### PR TITLE
migrate MD agents to unified LLM wrapper structure

### DIFF
--- a/scilink/agents/sim_agents/force_field_agent.py
+++ b/scilink/agents/sim_agents/force_field_agent.py
@@ -5,9 +5,15 @@ import json
 import tempfile
 import subprocess
 from typing import Dict, Any, List, Optional, Tuple, Union
-import google.generativeai as genai
 from MDAnalysis import Universe
 import numpy as np
+
+from ...auth import get_internal_proxy_key
+from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
+from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
+
+from ._deprecation import normalize_params
+
 
 class ForceFieldAgent:
     """
@@ -22,21 +28,27 @@ class ForceFieldAgent:
     The agent works in conjunction with other simulation agents in the pipeline.
     """
     
-    def __init__(self, working_dir: str, api_key: Optional[str] = None):
+    def __init__(self, 
+                 working_dir: str, 
+                 api_key: Optional[str] = None,
+                 model_name: str = "gemini-2.5-pro-preview-05-06",
+                 base_url: Optional[str] = None,
+                 # Legacy parameters
+                 local_model: Optional[str] = None,
+                 google_api_key: Optional[str] = None):
         """
         Initialize the ForceFieldAgent.
         
         Args:
             working_dir: Directory for output files and intermediate calculations
-            api_key: API key for Google Gemini API (optional if set in environment)
+            api_key: API key for the LLM provider
+            model_name: Model name to use
+            base_url: Optional base URL for internal proxy
+            local_model: Deprecated, use base_url instead
+            google_api_key: Deprecated, use api_key instead
         """
         self.working_dir = working_dir
         os.makedirs(working_dir, exist_ok=True)
-        
-        # Set up API access
-        self.api_key = api_key or os.getenv("GOOGLE_API_KEY")
-        genai.configure(api_key=self.api_key)
-        self.model = genai.GenerativeModel("gemini-2.5-pro-preview-05-06")
         
         # Configure logging
         self.logger = logging.getLogger(__name__)
@@ -46,6 +58,40 @@ class ForceFieldAgent:
             formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
             handler.setFormatter(formatter)
             self.logger.addHandler(handler)
+
+        # Normalize deprecated parameters
+        api_key, base_url = normalize_params(
+            api_key=api_key,
+            google_api_key=google_api_key,
+            base_url=base_url,
+            local_model=local_model,
+            source="ForceFieldAgent"
+        )
+        
+        # Initialize model using wrapper structure
+        if base_url:
+            # Internal Proxy
+            if api_key is None:
+                api_key = get_internal_proxy_key()
+            
+            if not api_key:
+                raise ValueError("API key required for internal proxy.")
+
+            self.logger.info(f"ForceFieldAgent using internal proxy: {base_url}")
+            self.model = OpenAIAsGenerativeModel(
+                model=model_name,
+                api_key=api_key,
+                base_url=base_url
+            )
+        else:
+            # Public / LiteLLM
+            self.logger.info(f"ForceFieldAgent using LiteLLM: {model_name}")
+            self.model = LiteLLMGenerativeModel(
+                model=model_name,
+                api_key=api_key
+            )
+        
+        self.generation_config = None
             
         # Force field databases and methods
         self.ff_databases = {
@@ -78,6 +124,61 @@ class ForceFieldAgent:
                 "strengths": ["Highest accuracy", "Novel molecules"]
             }
         }
+
+    def _generate_json(self, prompt: str) -> dict:
+        """Generate JSON response from LLM."""
+        self.logger.info("Sending request to LLM...")
+        
+        try:
+            response = self.model.generate_content(prompt, generation_config=self.generation_config)
+            
+            if not response or not response.text:
+                raise ValueError("Empty response from LLM")
+            
+            raw_text = response.text.strip()
+            
+            # Handle markdown code blocks if present
+            if raw_text.startswith("```"):
+                lines = raw_text.split("\n")
+                json_lines = []
+                in_block = False
+                for line in lines:
+                    if line.startswith("```"):
+                        in_block = not in_block
+                        continue
+                    if in_block:
+                        json_lines.append(line)
+                raw_text = "\n".join(json_lines)
+            
+            # Try to find JSON object if there's extra text
+            if not raw_text.startswith("{"):
+                start = raw_text.find("{")
+                end = raw_text.rfind("}") + 1
+                if start != -1 and end > start:
+                    raw_text = raw_text[start:end]
+            
+            return json.loads(raw_text)
+            
+        except json.JSONDecodeError as e:
+            self.logger.error(f"Failed to parse JSON response: {e}")
+            raise
+        except Exception as e:
+            self.logger.exception(f"Error during LLM content generation: {e}")
+            raise
+
+    def _generate_text(self, prompt: str) -> str:
+        """Generate text response from LLM."""
+        try:
+            response = self.model.generate_content(prompt, generation_config=self.generation_config)
+            
+            if not response or not response.text:
+                raise ValueError("Empty response from LLM")
+            
+            return response.text.strip()
+            
+        except Exception as e:
+            self.logger.exception(f"Error during LLM content generation: {e}")
+            raise
         
     def select_force_field(self, 
                          pdb_file: str, 
@@ -596,7 +697,6 @@ class ForceFieldAgent:
         5. Recent advancements in force field development
         
         Provide your response as JSON with this structure:
-        ```json
         {{
             "force_field": "Name of recommended force field",
             "compatible_water_model": "Recommended water model",
@@ -605,15 +705,11 @@ class ForceFieldAgent:
             "cautions": "Any limitations or issues to be aware of",
             "parameter_availability": "Ease of obtaining parameters (high/medium/low)"
         }}
-        ```
         Include only the JSON response with no additional text.
         """
         
         try:
-            # Generate response from LLM
-            generation_config = {"response_mime_type": "application/json"}
-            response = self.model.generate_content(prompt, generation_config=generation_config)
-            ff_selection = json.loads(response.text)
+            ff_selection = self._generate_json(prompt)
             
             # Ensure all expected fields are present
             ff_selection.setdefault("force_field", "AMBER ff14SB")
@@ -690,7 +786,6 @@ class ForceFieldAgent:
         5. Availability of QM-level parameterization tools if needed
         
         Provide your response as JSON with this structure:
-        ```json
         {{
             "method": "database|analogy|quantum",
             "justification": "Detailed scientific explanation for this choice",
@@ -700,15 +795,11 @@ class ForceFieldAgent:
                 "Detailed step-by-step approaches to obtain parameters"
             ]
         }}
-        ```
         Include only the JSON response with no additional text.
         """
         
         try:
-            # Generate response from LLM
-            generation_config = {"response_mime_type": "application/json"}
-            response = self.model.generate_content(prompt, generation_config=generation_config)
-            param_method = json.loads(response.text)
+            param_method = self._generate_json(prompt)
             
             # Ensure all expected fields are present
             param_method.setdefault("method", "database")
@@ -1125,7 +1216,6 @@ class ForceFieldAgent:
         For each parameter type, provide values compatible with LAMMPS syntax and the selected force field.
         
         Please provide parameters in the following JSON format:
-        ```json
         {{
             "atom_types": {{
                 "1": {{"name": "O", "mass": 15.9994, "description": "Water oxygen", "charge": -0.8476, "epsilon": 0.1553, "sigma": 3.166}},
@@ -1145,17 +1235,13 @@ class ForceFieldAgent:
                 "cutoff": 10.0
             }}
         }}
-        ```
         
         Include only parameters relevant to the system composition. The parameters should be scientifically accurate for the {force_field} force field.
         Include only the JSON response with no additional text.
         """
         
         try:
-            # Generate response from LLM
-            generation_config = {"response_mime_type": "application/json"}
-            response = self.model.generate_content(prompt, generation_config=generation_config)
-            parameters = json.loads(response.text)
+            parameters = self._generate_json(prompt)
             
             # Ensure all parameter categories exist
             for category in ["atom_types", "bonds", "angles", "dihedrals", "nonbonded_terms"]:
@@ -1218,7 +1304,6 @@ class ForceFieldAgent:
             Adjust parameters like bond lengths, angles, charges, and non-bonded terms based on chemical intuition and the force field paradigm.
             
             Please provide enhanced parameters in this JSON format:
-            ```json
             {{
                 "atom_types": {{
                     "1": {{"name": "O", "mass": 15.9994, "description": "Water oxygen", "charge": -0.8476, "epsilon": 0.1553, "sigma": 3.166}}
@@ -1230,7 +1315,6 @@ class ForceFieldAgent:
                     "1": {{"type": "harmonic", "atoms": ["H", "O", "H"], "k": 55.0, "theta0": 109.47, "description": "H-O-H angle in water"}}
                 }}
             }}
-            ```
             Include only the JSON response with no additional text.
             """
             
@@ -1253,7 +1337,6 @@ class ForceFieldAgent:
             and dihedral parameters that reflect the electronic structure of the molecules.
             
             Please provide quantum-derived parameters in this JSON format:
-            ```json
             {{
                 "atom_types": {{
                     "1": {{"name": "O", "mass": 15.9994, "description": "Water oxygen", "charge": -0.8476, "epsilon": 0.1553, "sigma": 3.166}}
@@ -1265,7 +1348,6 @@ class ForceFieldAgent:
                     "1": {{"type": "harmonic", "atoms": ["H", "O", "H"], "k": 55.0, "theta0": 109.47, "description": "H-O-H angle in water"}}
                 }}
             }}
-            ```
             Include only the JSON response with no additional text.
             """
             
@@ -1274,10 +1356,7 @@ class ForceFieldAgent:
             return parameters
             
         try:
-            # Generate response from LLM
-            generation_config = {"response_mime_type": "application/json"}
-            response = self.model.generate_content(prompt, generation_config=generation_config)
-            enhanced_params = json.loads(response.text)
+            enhanced_params = self._generate_json(prompt)
             
             # Merge enhanced parameters with original parameters
             for category in ["atom_types", "bonds", "angles", "dihedrals"]:
@@ -1531,7 +1610,6 @@ class ForceFieldAgent:
         10. kspace_style (allowed, as it defines long-range interaction handling) 
 
         Format the output as a JSON object with the main parameter file content and any additional files needed:
-        ```json
         {{
             "main": "# LAMMPS parameters for {force_field}\\n\\npair_style lj/cut/coul/long 10.0\\n...",
             "additional": {{
@@ -1539,17 +1617,13 @@ class ForceFieldAgent:
                 "other_file": "# Other parameters\\n\\n..."
             }}
         }}
-        ```
         
         Make sure the LAMMPS syntax is correct and all parameters are scientifically accurate for the {force_field} force field.
         Include only the JSON response with no additional text.
         """
         
         try:
-            # Generate response from LLM
-            generation_config = {"response_mime_type": "application/json"}
-            response = self.model.generate_content(prompt, generation_config=generation_config)
-            param_files = json.loads(response.text)
+            param_files = self._generate_json(prompt)
             
             # Ensure main content exists
             if "main" not in param_files:
@@ -1732,30 +1806,30 @@ class ForceFieldAgent:
             
         return "\n".join(lines)
 
-def _fix_lammps_syntax(self, lammps_text: str) -> str:
-    """
-    Fix common LAMMPS syntax issues in generated parameters.
-    
-    Args:
-        lammps_text: LAMMPS parameter text
+    def _fix_lammps_syntax(self, lammps_text: str) -> str:
+        """
+        Fix common LAMMPS syntax issues in generated parameters.
         
-    Returns:
-        Corrected LAMMPS parameter text
-    """
-    lines = lammps_text.split('\n')
-    fixed_lines = []
-    
-    for line in lines:
-        # Fix missing spaces after commas
-        line = re.sub(r',(?=\S)', ', ', line)
-        
-        # Fix incorrect comment syntax
-        line = re.sub(r'(//.+)$', r'#\1', line)
-        
-        # Fix invalid syntax in pair_coeff commands
-        if line.strip().startswith("pair_coeff") and re.search(r'pair_coeff\s+\*\s+\*\s+[\d\.]+\s*$', line):
-            line = line + " # Missing sigma parameter"
+        Args:
+            lammps_text: LAMMPS parameter text
             
-        fixed_lines.append(line)
+        Returns:
+            Corrected LAMMPS parameter text
+        """
+        lines = lammps_text.split('\n')
+        fixed_lines = []
         
-    return '\n'.join(fixed_lines)
+        for line in lines:
+            # Fix missing spaces after commas
+            line = re.sub(r',(?=\S)', ', ', line)
+            
+            # Fix incorrect comment syntax
+            line = re.sub(r'(//.+)$', r'#\1', line)
+            
+            # Fix invalid syntax in pair_coeff commands
+            if line.strip().startswith("pair_coeff") and re.search(r'pair_coeff\s+\*\s+\*\s+[\d\.]+\s*$', line):
+                line = line + " # Missing sigma parameter"
+                
+            fixed_lines.append(line)
+            
+        return '\n'.join(fixed_lines)

--- a/scilink/agents/sim_agents/lammps_agent.py
+++ b/scilink/agents/sim_agents/lammps_agent.py
@@ -4,25 +4,40 @@ import shutil
 import logging
 import json
 from typing import Dict, Any, Optional, List
-import google.generativeai as genai
+
 from ase import io
 from ase.io.lammpsdata import read_lammps_data
+
+from ...auth import get_internal_proxy_key
+from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
+from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
+
 from .instruct import LAMMPS_INPUT_GENERATION_TEMPLATE
+from ._deprecation import normalize_params
+
 
 class LAMMPSSimulationAgent:
-    def __init__(self, working_dir: str, api_key: Optional[str] = None):
+    def __init__(self, 
+                 working_dir: str, 
+                 api_key: Optional[str] = None,
+                 model_name: str = "gemini-2.5-pro-preview-05-06",
+                 base_url: Optional[str] = None,
+                 # Legacy parameters
+                 local_model: Optional[str] = None,
+                 google_api_key: Optional[str] = None):
         """
         Initialize the LAMMPS simulation agent.
         
         Args:
             working_dir: Directory for output files
-            api_key: API key for Google Gemini API (optional if set in environment)
+            api_key: API key for the LLM provider
+            model_name: Model name to use
+            base_url: Optional base URL for internal proxy
+            local_model: Deprecated, use base_url instead
+            google_api_key: Deprecated, use api_key instead
         """
         self.working_dir = working_dir
         os.makedirs(working_dir, exist_ok=True)
-        self.api_key = api_key or os.getenv("GOOGLE_API_KEY")
-        genai.configure(api_key=self.api_key)
-        self.model = genai.GenerativeModel("gemini-2.5-pro-preview-05-06")
         
         # Configure logging
         self.logger = logging.getLogger(__name__)
@@ -32,6 +47,95 @@ class LAMMPSSimulationAgent:
             formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
             handler.setFormatter(formatter)
             self.logger.addHandler(handler)
+
+        # Normalize deprecated parameters
+        api_key, base_url = normalize_params(
+            api_key=api_key,
+            google_api_key=google_api_key,
+            base_url=base_url,
+            local_model=local_model,
+            source="LAMMPSSimulationAgent"
+        )
+        
+        # Initialize model using wrapper structure
+        if base_url:
+            # Internal Proxy
+            if api_key is None:
+                api_key = get_internal_proxy_key()
+            
+            if not api_key:
+                raise ValueError("API key required for internal proxy.")
+
+            self.logger.info(f"LAMMPSSimulationAgent using internal proxy: {base_url}")
+            self.model = OpenAIAsGenerativeModel(
+                model=model_name,
+                api_key=api_key,
+                base_url=base_url
+            )
+        else:
+            # Public / LiteLLM
+            self.logger.info(f"LAMMPSSimulationAgent using LiteLLM: {model_name}")
+            self.model = LiteLLMGenerativeModel(
+                model=model_name,
+                api_key=api_key
+            )
+        
+        self.generation_config = None
+
+    def _generate_json(self, prompt: str) -> dict:
+        """Generate JSON response from LLM."""
+        self.logger.info("Sending request to LLM...")
+        
+        try:
+            response = self.model.generate_content(prompt, generation_config=self.generation_config)
+            
+            if not response or not response.text:
+                raise ValueError("Empty response from LLM")
+            
+            raw_text = response.text.strip()
+            
+            # Handle markdown code blocks if present
+            if raw_text.startswith("```"):
+                lines = raw_text.split("\n")
+                json_lines = []
+                in_block = False
+                for line in lines:
+                    if line.startswith("```"):
+                        in_block = not in_block
+                        continue
+                    if in_block:
+                        json_lines.append(line)
+                raw_text = "\n".join(json_lines)
+            
+            # Try to find JSON object if there's extra text
+            if not raw_text.startswith("{"):
+                start = raw_text.find("{")
+                end = raw_text.rfind("}") + 1
+                if start != -1 and end > start:
+                    raw_text = raw_text[start:end]
+            
+            return json.loads(raw_text)
+            
+        except json.JSONDecodeError as e:
+            self.logger.error(f"Failed to parse JSON response: {e}")
+            raise
+        except Exception as e:
+            self.logger.exception(f"Error during LLM content generation: {e}")
+            raise
+
+    def _generate_text(self, prompt: str) -> str:
+        """Generate text response from LLM."""
+        try:
+            response = self.model.generate_content(prompt, generation_config=self.generation_config)
+            
+            if not response or not response.text:
+                raise ValueError("Empty response from LLM")
+            
+            return response.text.strip()
+            
+        except Exception as e:
+            self.logger.exception(f"Error during LLM content generation: {e}")
+            raise
 
     def _integrate_force_field_files(self, script_text: str, force_field_files: Dict[str, str]) -> str:
         """
@@ -173,6 +277,7 @@ class LAMMPSSimulationAgent:
             "system_info": system_info,
             "simulation_parameters": simulation_params
         }    
+
     def analyze_system(self, data_file: str) -> Dict[str, Any]:
         """Analyze a LAMMPS data file using ASE to identify its components."""
         self.logger.info(f"Analyzing system from {data_file}")
@@ -325,7 +430,6 @@ class LAMMPSSimulationAgent:
         7. What specific analysis commands are needed in LAMMPS
         
         Respond with a JSON object with the following structure:
-        ```json
         {{
             "properties_to_calculate": ["list of properties"],
             "ensemble": "NPT",
@@ -340,16 +444,12 @@ class LAMMPSSimulationAgent:
                 "additional parameters as key-value pairs"
             }}
         }}
-        ```
         
         Include only the JSON response with no additional text.
         """
         
         try:
-            # Generate response from LLM
-            generation_config = {"response_mime_type": "application/json"}
-            response = self.model.generate_content(prompt, generation_config=generation_config)
-            params = json.loads(response.text)
+            params = self._generate_json(prompt)
             
             # Add default values if missing
             params.setdefault("ensemble", "NPT")
@@ -421,7 +521,7 @@ class LAMMPSSimulationAgent:
         # Generate outputs section based on required outputs
         output_commands = self._generate_output_commands(required_outputs, properties_to_calculate, system_info)
         
-       # Format the template with actual values
+        # Format the template with actual values
         prompt = LAMMPS_INPUT_GENERATION_TEMPLATE.format(
             research_goal=research_goal,
             system_description=system_description,
@@ -443,9 +543,10 @@ class LAMMPSSimulationAgent:
             equil_steps=equil_steps,
             prod_steps=prod_steps,
             data_filename=data_filename,
-            output_commands=output_commands) 
-        response = self.model.generate_content(prompt)
-        script_text = response.text
+            output_commands=output_commands
+        )
+        
+        script_text = self._generate_text(prompt)
         
         # Clean the script output
         script_text = self._clean_script(script_text)

--- a/scilink/agents/sim_agents/lammps_updater.py
+++ b/scilink/agents/sim_agents/lammps_updater.py
@@ -4,22 +4,36 @@ import logging
 import json
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple
-import google.generativeai as genai
+
+from ...auth import get_internal_proxy_key
+from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
+from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
+
 from .lammps_agent import LAMMPSSimulationAgent
+from ._deprecation import normalize_params
+
 
 class LAMMPSUpdater:
     """
     Self-evolving updater that analyzes LAMMPS errors and generates solutions.
     """
-    def __init__(self, api_key: Optional[str] = None, model_name: str = "gemini-2.5-pro-preview-05-06"):
-        if not api_key:
-            api_key = os.environ.get("GOOGLE_API_KEY")
-        if not api_key:
-            raise ValueError("API key required")
-        self.api_key = api_key
-        genai.configure(api_key=self.api_key)
-        self.model = genai.GenerativeModel(model_name)
+    def __init__(self, 
+                 api_key: Optional[str] = None, 
+                 model_name: str = "gemini-2.5-pro-preview-05-06",
+                 base_url: Optional[str] = None,
+                 # Legacy parameters
+                 local_model: Optional[str] = None,
+                 google_api_key: Optional[str] = None):
+        """
+        Initialize the LAMMPS updater.
         
+        Args:
+            api_key: API key for the LLM provider
+            model_name: Model name to use
+            base_url: Optional base URL for internal proxy
+            local_model: Deprecated, use base_url instead
+            google_api_key: Deprecated, use api_key instead
+        """
         # Configure logging
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.INFO)
@@ -28,6 +42,95 @@ class LAMMPSUpdater:
             formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
             handler.setFormatter(formatter)
             self.logger.addHandler(handler)
+
+        # Normalize deprecated parameters
+        api_key, base_url = normalize_params(
+            api_key=api_key,
+            google_api_key=google_api_key,
+            base_url=base_url,
+            local_model=local_model,
+            source="LAMMPSUpdater"
+        )
+        
+        # Initialize model using wrapper structure
+        if base_url:
+            # Internal Proxy
+            if api_key is None:
+                api_key = get_internal_proxy_key()
+            
+            if not api_key:
+                raise ValueError("API key required for internal proxy.")
+
+            self.logger.info(f"LAMMPSUpdater using internal proxy: {base_url}")
+            self.model = OpenAIAsGenerativeModel(
+                model=model_name,
+                api_key=api_key,
+                base_url=base_url
+            )
+        else:
+            # Public / LiteLLM
+            self.logger.info(f"LAMMPSUpdater using LiteLLM: {model_name}")
+            self.model = LiteLLMGenerativeModel(
+                model=model_name,
+                api_key=api_key
+            )
+        
+        self.generation_config = None
+
+    def _generate_json(self, prompt: str) -> dict:
+        """Generate JSON response from LLM."""
+        self.logger.info("Sending request to LLM...")
+        
+        try:
+            response = self.model.generate_content(prompt, generation_config=self.generation_config)
+            
+            if not response or not response.text:
+                raise ValueError("Empty response from LLM")
+            
+            raw_text = response.text.strip()
+            
+            # Handle markdown code blocks if present
+            if raw_text.startswith("```"):
+                lines = raw_text.split("\n")
+                json_lines = []
+                in_block = False
+                for line in lines:
+                    if line.startswith("```"):
+                        in_block = not in_block
+                        continue
+                    if in_block:
+                        json_lines.append(line)
+                raw_text = "\n".join(json_lines)
+            
+            # Try to find JSON object if there's extra text
+            if not raw_text.startswith("{"):
+                start = raw_text.find("{")
+                end = raw_text.rfind("}") + 1
+                if start != -1 and end > start:
+                    raw_text = raw_text[start:end]
+            
+            return json.loads(raw_text)
+            
+        except json.JSONDecodeError as e:
+            self.logger.error(f"Failed to parse JSON response: {e}")
+            raise
+        except Exception as e:
+            self.logger.exception(f"Error during LLM content generation: {e}")
+            raise
+
+    def _generate_text(self, prompt: str) -> str:
+        """Generate text response from LLM."""
+        try:
+            response = self.model.generate_content(prompt, generation_config=self.generation_config)
+            
+            if not response or not response.text:
+                raise ValueError("Empty response from LLM")
+            
+            return response.text.strip()
+            
+        except Exception as e:
+            self.logger.exception(f"Error during LLM content generation: {e}")
+            raise
 
     def _extract_errors(self, log_content: str) -> List[str]:
         """Extract all errors from LAMMPS output with the following line for context."""
@@ -57,7 +160,7 @@ class LAMMPSUpdater:
         4. Analyze how far the simulation progressed before the error
 
         ERRORS/WARNINGS:
-        {'\n'.join(errors)}
+        {chr(10).join(errors)}
 
         INPUT SCRIPT:
         {input_script}
@@ -94,9 +197,7 @@ class LAMMPSUpdater:
         """
         
         try:
-            generation_config = {"response_mime_type": "application/json"}
-            response = self.model.generate_content(analysis_prompt, generation_config=generation_config)
-            analysis = json.loads(response.text)
+            analysis = self._generate_json(analysis_prompt)
             self.logger.info(f"Analysis completed: {len(analysis.get('issues', []))} issues identified")
             return analysis
         except Exception as e:
@@ -302,8 +403,7 @@ class LAMMPSUpdater:
         
         # Step 3: Generate corrected script
         self.logger.info("Generating corrected LAMMPS script")
-        response = self.model.generate_content(correction_prompt)
-        corrected_script = response.text
+        corrected_script = self._generate_text(correction_prompt)
         
         # Step 4: Clean and format the script
         corrected_script = self._clean_script(corrected_script)

--- a/scilink/agents/sim_agents/packmol_agent.py
+++ b/scilink/agents/sim_agents/packmol_agent.py
@@ -6,14 +6,17 @@ import subprocess
 import re
 from typing import Dict, Any, List, Optional
 
-import google.generativeai as genai
-from google.generativeai.types import GenerationConfig
+from ...auth import get_internal_proxy_key
+from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
+from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
 
 from .instruct import (
     MOLECULE_EXTRACTION_TEMPLATE,
     SMILES_GENERATION_TEMPLATE,
     PACKMOL_SCRIPT_GENERATION_TEMPLATE
 )
+from ._deprecation import normalize_params
+
 from ase.build import molecule
 from ase.collections import g2
 from ase.io import write
@@ -36,21 +39,70 @@ class PackmolGeneratorAgent:
     4. Providing detailed, educational prompts for PACKMOL generation
     """
     
-    def __init__(self, api_key: str, model_name: str = "gemini-2.5-flash-preview-05-20", 
-                 working_dir: str = "packmol_run"):
+    def __init__(self, 
+                 api_key: Optional[str] = None, 
+                 model_name: str = "gemini-2.5-flash-preview-05-20", 
+                 working_dir: str = "packmol_run",
+                 base_url: Optional[str] = None,
+                 # Legacy parameters
+                 local_model: Optional[str] = None,
+                 google_api_key: Optional[str] = None):
+        """
+        Initialize the PACKMOL generator agent.
         
-        # Initialize LLM model directly (replaces LLMClient)
-        if not api_key:
-            raise ValueError("API key not provided to PackmolGeneratorAgent.")
-        
-        genai.configure(api_key=api_key)
-        self.model = genai.GenerativeModel(model_name)
-        self.model_name = model_name
-        self.generation_config = GenerationConfig()
-        
+        Args:
+            api_key: API key for the LLM provider
+            model_name: Model name to use
+            working_dir: Working directory for output files
+            base_url: Optional base URL for internal proxy
+            local_model: Deprecated, use base_url instead
+            google_api_key: Deprecated, use api_key instead
+        """
         self.working_dir = working_dir
+        
+        # Configure logging
         self.logger = logging.getLogger(__name__)
-        self.logger.info(f"PackmolGeneratorAgent initialized with model: {self.model_name}")
+        self.logger.setLevel(logging.INFO)
+        if not self.logger.handlers:
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+
+        # Normalize deprecated parameters
+        api_key, base_url = normalize_params(
+            api_key=api_key,
+            google_api_key=google_api_key,
+            base_url=base_url,
+            local_model=local_model,
+            source="PackmolGeneratorAgent"
+        )
+        
+        # Initialize model using wrapper structure
+        if base_url:
+            # Internal Proxy
+            if api_key is None:
+                api_key = get_internal_proxy_key()
+            
+            if not api_key:
+                raise ValueError("API key required for internal proxy.")
+
+            self.logger.info(f"PackmolGeneratorAgent using internal proxy: {base_url}")
+            self.model = OpenAIAsGenerativeModel(
+                model=model_name,
+                api_key=api_key,
+                base_url=base_url
+            )
+        else:
+            # Public / LiteLLM
+            self.logger.info(f"PackmolGeneratorAgent using LiteLLM: {model_name}")
+            self.model = LiteLLMGenerativeModel(
+                model=model_name,
+                api_key=api_key
+            )
+        
+        self.model_name = model_name
+        self.generation_config = None
         
         # Initialize available molecule sources
         self.ase_molecules = set(g2.names)
@@ -59,11 +111,57 @@ class PackmolGeneratorAgent:
         if not shutil.which("packmol"):
             raise FileNotFoundError("PACKMOL executable not found in PATH")
 
-    def _generate_content(self, prompt: str) -> str:
-        """Generate content from LLM and return raw text."""
+    def _generate_json(self, prompt: str) -> dict:
+        """Generate JSON response from LLM."""
+        self.logger.info("Sending request to LLM...")
+        
         try:
             response = self.model.generate_content(prompt, generation_config=self.generation_config)
-            return response.text
+            
+            if not response or not response.text:
+                raise ValueError("Empty response from LLM")
+            
+            raw_text = response.text.strip()
+            
+            # Handle markdown code blocks if present
+            if raw_text.startswith("```"):
+                lines = raw_text.split("\n")
+                json_lines = []
+                in_block = False
+                for line in lines:
+                    if line.startswith("```"):
+                        in_block = not in_block
+                        continue
+                    if in_block:
+                        json_lines.append(line)
+                raw_text = "\n".join(json_lines)
+            
+            # Try to find JSON object if there's extra text
+            if not raw_text.startswith("{"):
+                start = raw_text.find("{")
+                end = raw_text.rfind("}") + 1
+                if start != -1 and end > start:
+                    raw_text = raw_text[start:end]
+            
+            return json.loads(raw_text)
+            
+        except json.JSONDecodeError as e:
+            self.logger.error(f"Failed to parse JSON response: {e}")
+            raise
+        except Exception as e:
+            self.logger.exception(f"Error during LLM content generation: {e}")
+            raise
+
+    def _generate_text(self, prompt: str) -> str:
+        """Generate text response from LLM."""
+        try:
+            response = self.model.generate_content(prompt, generation_config=self.generation_config)
+            
+            if not response or not response.text:
+                raise ValueError("Empty response from LLM")
+            
+            return response.text.strip()
+            
         except Exception as e:
             self.logger.exception(f"Error during LLM content generation: {e}")
             raise
@@ -74,13 +172,7 @@ class PackmolGeneratorAgent:
         extraction_prompt = MOLECULE_EXTRACTION_TEMPLATE.format(description=description)
 
         try:
-            raw_text = self._generate_content(extraction_prompt)
-            
-            start_brace = raw_text.find('{')
-            end_brace = raw_text.rfind('}')
-            json_string = raw_text[start_brace:end_brace+1]
-            
-            analysis = json.loads(json_string)
+            analysis = self._generate_json(extraction_prompt)
             self.logger.info(f"LLM extracted molecules: {[mol['identifier'] for mol in analysis['molecules']]}")
             return analysis['molecules']
             
@@ -267,7 +359,7 @@ class PackmolGeneratorAgent:
         smiles_prompt = SMILES_GENERATION_TEMPLATE.format(molecule_identifier=molecule_identifier)
 
         try:
-            smiles = self._generate_content(smiles_prompt).strip()
+            smiles = self._generate_text(smiles_prompt).strip()
             
             if smiles == "UNKNOWN" or len(smiles) > 200:  # Sanity check
                 return None
@@ -334,12 +426,7 @@ class PackmolGeneratorAgent:
             prompt = self._create_comprehensive_packmol_prompt(description, built_molecules)
             
             try:
-                raw_text = self._generate_content(prompt)
-                
-                start_brace = raw_text.find('{')
-                end_brace = raw_text.rfind('}')
-                json_string = raw_text[start_brace:end_brace+1]
-                llm_response = json.loads(json_string)
+                llm_response = self._generate_json(prompt)
                 
             except Exception as e:
                 return {"status": "error", "message": f"LLM script generation failed: {str(e)}"}


### PR DESCRIPTION
Update `force_field_agent`, l`ammps_agent`, `lammps_updater`, and `packmol_agent` to use `OpenAIAsGenerativeModel/LiteLLMGenerativeModel` wrappers instead of direct `google.generativeai` imports, matching the pattern used by DFT agents.

- Add support for internal proxy (`base_url`) and public LiteLLM backends
- Add `_generate_json()` and `_generate_text()` helper methods
- Maintain backwards compatibility via `normalize_params()` for deprecated `google_api_key` and `local_model` parameters
- Standardize model initialization across all simulation agents