### PR TITLE
Custom agent support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,13 @@ scilink = "scilink.cli.main:main"
 scilink-workflows = "scilink.cli.workflows:main"
 scilink-agent = "scilink.cli.run_agent:main"
 
+# Third-party packages can advertise custom analysis agents here.
+# SciLink discovers these automatically on startup via importlib.metadata.
+# Example entry in a third-party pyproject.toml:
+#   [project.entry-points."scilink.agents"]
+#   my_xrd_agent = "my_package.agents:MyXRDAgent"
+[project.entry-points."scilink.agents"]
+
 [tool.setuptools]
 include-package-data = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scilink"
-version = "0.0.13"
+version = "0.0.14"
 authors = [
   { name="SciLink Team", email="maxim.ziatdinov@gmail.com" },
 ]

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -25,6 +25,35 @@ from .analysis_orchestrator_tools import AnalysisOrchestratorTools
 from ._deprecation import normalize_params
 
 
+# Built-in agent registry seed — classes are lazy-loaded on first use.
+_BUILTIN_AGENTS = {
+    0: {
+        "class_path": "scilink.agents.exp_agents.fft_microscopy_agent.FFTMicroscopyAnalysisAgent",
+        "name": "FFTMicroscopyAnalysisAgent",
+        "description": "Images: microstructure, grains, phases, atomic-resolution. Handles single images or image series.",
+        "short_name": "FFT",
+    },
+    1: {
+        "class_path": "scilink.agents.exp_agents.sam_microscopy_agent.SAMMicroscopyAnalysisAgent",
+        "name": "SAMMicroscopyAnalysisAgent",
+        "description": "Images: particle counting, segmentation. Handles single images or image series.",
+        "short_name": "SAM",
+    },
+    2: {
+        "class_path": "scilink.agents.exp_agents.hyperspectral_analysis_agent.HyperspectralAnalysisAgent",
+        "name": "HyperspectralAnalysisAgent",
+        "description": "3D datacubes: EELS-SI, EDS, Raman imaging.",
+        "short_name": "Hyperspectral",
+    },
+    3: {
+        "class_path": "scilink.agents.exp_agents.curve_fitting_agent.CurveFittingAgent",
+        "name": "CurveFittingAgent",
+        "description": "1D data: DSC, TGA, XRD, UV-Vis, Raman, PL, IV curves, kinetics. Handles single files or series.",
+        "short_name": "CurveFit",
+    },
+}
+
+
 class AnalysisMode(Enum):
     """
     Defines the level of autonomy for the analysis orchestrator.
@@ -98,7 +127,7 @@ _AUTONOMOUS_DIRECTIVE = """
 - Only provide a summary AFTER the entire pipeline is complete.
 """
 
-_SYSTEM_PROMPT_BODY = """
+_SYSTEM_PROMPT_BODY_PRE = """
 You are the **Analysis Agent**. Your goal is to coordinate experimental data analysis.
 
 **RESPONSE GUIDELINES (STRICT):**
@@ -123,11 +152,9 @@ You are the **Analysis Agent**. Your goal is to coordinate experimental data ana
 4. `select_agent`: Set the analysis agent. YOU decide based on data type and metadata.
    - Input: agent_id (integer), reasoning (string)
    - Available agents:
-     * 0: FFTMicroscopyAnalysisAgent - Images: microstructure, grains, phases, atomic-resolution
-     * 1: SAMMicroscopyAnalysisAgent - Images: particle counting, segmentation
-     * 2: HyperspectralAnalysisAgent - 3D datacubes: EELS-SI, EDS, Raman imaging
-     * 3: CurveFittingAgent - 1D data: DSC, TGA, XRD, UV-Vis, Raman, PL, IV curves, kinetics
+"""
 
+_SYSTEM_PROMPT_BODY_POST = """
 5. `preview_image`: Load image for visual inspection (for agent 0 vs 1 decision, or ambiguous 2D data).
 
 **ANALYSIS EXECUTION:**
@@ -190,14 +217,53 @@ examine_data returns data_type:
 """
 
 
-def get_system_prompt(analysis_mode: AnalysisMode) -> str:
-    """Returns the appropriate system prompt for the given analysis mode."""
+def _build_agent_list_section(agent_registry: dict) -> str:
+    """Build the agent list lines for the system prompt from the registry."""
+    lines = []
+    for aid in sorted(agent_registry.keys()):
+        entry = agent_registry[aid]
+        lines.append(f"     * {aid}: {entry['name']} - {entry['description']}")
+    return "\n".join(lines)
+
+
+def get_system_prompt(
+    analysis_mode: AnalysisMode,
+    agent_registry: dict = None,
+    external_tools: list = None,
+) -> str:
+    """Returns the appropriate system prompt for the given analysis mode.
+
+    Args:
+        analysis_mode: The autonomy level directive to prepend.
+        agent_registry: Live registry dict from AnalysisOrchestratorAgent.
+            When provided, the agent list in the prompt is built dynamically
+            so custom agents appear automatically. Falls back to the built-in
+            list if not provided.
+        external_tools: List of ``{"name": str, "description": str}`` dicts
+            for tools registered via register_tools(). When provided, a
+            "Custom tools" section is appended so the LLM knows they exist.
+    """
     directives = {
         AnalysisMode.CO_PILOT: _CO_PILOT_DIRECTIVE,
         AnalysisMode.SUPERVISED: _SUPERVISED_DIRECTIVE,
         AnalysisMode.AUTONOMOUS: _AUTONOMOUS_DIRECTIVE,
     }
-    return directives[analysis_mode] + _SYSTEM_PROMPT_BODY
+    if agent_registry:
+        agent_list = _build_agent_list_section(agent_registry)
+    else:
+        agent_list = "\n".join([
+            "     * 0: FFTMicroscopyAnalysisAgent - Images: microstructure, grains, phases, atomic-resolution",
+            "     * 1: SAMMicroscopyAnalysisAgent - Images: particle counting, segmentation",
+            "     * 2: HyperspectralAnalysisAgent - 3D datacubes: EELS-SI, EDS, Raman imaging",
+            "     * 3: CurveFittingAgent - 1D data: DSC, TGA, XRD, UV-Vis, Raman, PL, IV curves, kinetics",
+        ])
+    body = _SYSTEM_PROMPT_BODY_PRE + agent_list + _SYSTEM_PROMPT_BODY_POST
+    if external_tools:
+        lines = ["\n**CUSTOM TOOLS (registered externally, call directly by name):**"]
+        for t in external_tools:
+            lines.append(f"  * `{t['name']}` - {t['description']}")
+        body += "\n".join(lines) + "\n"
+    return directives[analysis_mode] + body
 
 
 class AnalysisOrchestratorAgent:
@@ -324,6 +390,14 @@ class AnalysisOrchestratorAgent:
         
         # Analysis run counter for unique IDs within same second
         self._analysis_run_counter = 0
+
+        # Cache for data loaded on behalf of external tools (keyed by data_path)
+        self._tool_data_cache: Dict[tuple, Any] = {}
+
+        # Registry of external tools added via register_tools(), used to keep
+        # the system prompt current so the LLM knows they exist.
+        # Each entry: {"name": str, "description": str}
+        self._external_tools: List[Dict[str, str]] = []
         
         self.message_count = 0
         self.last_checkpoint_message_count = 0
@@ -331,12 +405,16 @@ class AnalysisOrchestratorAgent:
         # Restore from checkpoint if requested
         if restore_checkpoint and self.checkpoint_path.exists():
             self._restore_checkpoint()
-        
-        # Initialize tools registry
+
+        # Build agent registry (built-ins + installed plugins)
+        self._agent_registry = self._build_registry()
+        self._discover_plugin_agents()
+
+        # Initialize tools registry (reads agent registry via _sync_from_registry)
         self.tools = AnalysisOrchestratorTools(self)
-        
-        # Get appropriate system prompt
-        system_prompt = get_system_prompt(self.analysis_mode)
+
+        # Get appropriate system prompt (agent list built from registry)
+        system_prompt = get_system_prompt(self.analysis_mode, self._agent_registry)
         
         # Initialize LLM
         if base_url:
@@ -386,10 +464,12 @@ class AnalysisOrchestratorAgent:
         self.analysis_mode = mode
         self._enable_human_feedback = self._should_enable_human_feedback()
         
-        # Update system prompt
-        new_system_prompt = get_system_prompt(mode)
+        # Update system prompt (preserve external tools if any are registered)
+        new_system_prompt = get_system_prompt(
+            mode, self._agent_registry, self._external_tools or None
+        )
         self._system_prompt = new_system_prompt
-        
+
         if self.messages and self.messages[0]["role"] == "system":
             self.messages[0]["content"] = new_system_prompt
         
@@ -399,6 +479,224 @@ class AnalysisOrchestratorAgent:
     def get_human_feedback_setting(self) -> bool:
         """Returns current human feedback setting for sub-agents."""
         return self._enable_human_feedback
+
+    # =========================================================================
+    # Agent registry
+    # =========================================================================
+
+    def _build_registry(self) -> Dict[int, Dict]:
+        """Seed the registry with built-in agents (lazy class loading)."""
+        registry = {}
+        for agent_id, spec in _BUILTIN_AGENTS.items():
+            registry[agent_id] = {
+                "class_path": spec["class_path"],
+                "class": None,  # loaded on first use
+                "name": spec["name"],
+                "description": spec["description"],
+                "short_name": spec["short_name"],
+            }
+        return registry
+
+    def _discover_plugin_agents(self) -> None:
+        """Auto-register agents advertised via the 'scilink.agents' entry point group."""
+        try:
+            from importlib.metadata import entry_points
+            eps = entry_points(group="scilink.agents")
+        except Exception:
+            return
+
+        for ep in eps:
+            try:
+                cls = ep.load()
+                next_id = max(self._agent_registry.keys()) + 1 if self._agent_registry else 4
+                self.register_agent(next_id, cls)
+                logging.info(f"🔌 Plugin agent '{ep.name}' registered as ID {next_id}")
+            except Exception as e:
+                logging.warning(f"⚠️ Failed to load plugin agent '{ep.name}': {e}")
+
+    def register_agent(
+        self,
+        agent_id: int,
+        agent_class: type,
+        name: str = None,
+        description: str = None,
+        short_name: str = None,
+    ) -> None:
+        """Register a custom analysis agent with the orchestrator.
+
+        The agent class must inherit from BaseAnalysisAgent and implement
+        analyze(). The other BaseAnalysisAgent methods have sensible defaults
+        and do not need to be overridden.
+
+        Optional class-level attributes are used as fallbacks when name /
+        description / short_name are not passed explicitly:
+            AGENT_NAME        (str) display name
+            AGENT_DESCRIPTION (str) one-line capability description
+            AGENT_SHORT_NAME  (str) abbreviation used in output directory names
+
+        Args:
+            agent_id:    Integer ID used in select_agent / run_analysis calls.
+                         Must not collide with an existing ID you want to keep.
+            agent_class: The agent class (not an instance).
+            name:        Display name. Falls back to AGENT_NAME or class name.
+            description: Capability description. Falls back to AGENT_DESCRIPTION.
+            short_name:  Short label for directory names. Falls back to
+                         AGENT_SHORT_NAME or the first 8 chars of the class name.
+        """
+        resolved_name = name or getattr(agent_class, "AGENT_NAME", agent_class.__name__)
+        resolved_desc = description or getattr(agent_class, "AGENT_DESCRIPTION", "")
+        resolved_short = short_name or getattr(agent_class, "AGENT_SHORT_NAME", agent_class.__name__[:8])
+
+        self._agent_registry[agent_id] = {
+            "class_path": None,
+            "class": agent_class,
+            "name": resolved_name,
+            "description": resolved_desc,
+            "short_name": resolved_short,
+        }
+
+        # Keep the tools dicts and system prompt in sync.
+        if hasattr(self, "tools"):
+            self.tools._sync_from_registry()
+        self._system_prompt = get_system_prompt(self.analysis_mode, self._agent_registry)
+        if self.messages and self.messages[0]["role"] == "system":
+            self.messages[0]["content"] = self._system_prompt
+
+        logging.info(f"✅ Registered agent {agent_id}: {resolved_name}")
+
+    def register_tools(self, schemas: list, factory: callable) -> None:
+        """Register external tool functions into the orchestrator's LLM loop.
+
+        The ``factory`` callable is invoked lazily at tool-call time so it can
+        receive the loaded data (e.g. a NumPy image array) rather than a file
+        path.  The orchestrator inspects the *name* of the factory's first
+        positional parameter to decide what to pass:
+
+        * ``data_path`` / ``path`` / ``file`` / ``filepath`` / ``filename``
+          → the current data path is passed as a plain string.
+        * Any other name (e.g. ``image``, ``data``, ``array``)
+          → the file at the current data path is loaded (NumPy array for images
+          and .npy; pandas DataFrame for CSV; raw path string as fallback) and
+          that object is passed to the factory.
+
+        The factory must return a ``dict[str, callable]`` mapping tool names to
+        callables whose keyword arguments match the tool schema parameters.
+        Results are JSON-serialized if not already a string.
+
+        A per-path cache avoids reloading the file on every tool call.  The
+        cache is keyed by ``(data_path, id(factory))`` so it is invalidated
+        automatically when the user switches to a different data file.
+
+        Args:
+            schemas: List of OpenAI-format tool schemas
+                     (``[{"type": "function", "function": {...}}, ...]``).
+            factory: Callable that accepts data and returns bound tool functions.
+        """
+        import inspect
+
+        # Inspect factory signature once to decide calling convention.
+        sig = inspect.signature(factory)
+        params = list(sig.parameters.keys())
+        first_param = params[0] if params else None
+        _path_param_names = {'data_path', 'path', 'file', 'filepath', 'file_path', 'filename'}
+        factory_takes_path = first_param in _path_param_names
+        # If the factory declares an ``output_dir`` parameter, pass the session's
+        # custom-tools output directory so tools can save files and plots.
+        factory_takes_output_dir = 'output_dir' in params
+
+        registered = 0
+        for schema in schemas:
+            if schema.get("type") != "function":
+                continue
+            fn_info = schema["function"]
+            tool_name = fn_info["name"]
+            description = fn_info.get("description", "")
+            params_spec = fn_info.get("parameters", {})
+            properties = params_spec.get("properties", {})
+            required = params_spec.get("required", [])
+
+            def _make_wrapper(name, _factory, _takes_path, _takes_output_dir):
+                def wrapper(**kwargs):
+                    data_path = self.current_data_path
+                    if data_path is None:
+                        return json.dumps({
+                            "status": "error",
+                            "message": "No data loaded. Use examine_data first.",
+                        })
+                    # Resolve output directory for tools that save files / plots.
+                    output_dir = self.results_dir / "custom_tools"
+                    output_dir.mkdir(parents=True, exist_ok=True)
+                    cache_key = (data_path, id(_factory), str(output_dir))
+                    if cache_key not in self._tool_data_cache:
+                        if _takes_path:
+                            data = data_path
+                        else:
+                            data = self._load_data_as_array(data_path)
+                        if _takes_output_dir:
+                            self._tool_data_cache[cache_key] = _factory(data, output_dir=str(output_dir))
+                        else:
+                            self._tool_data_cache[cache_key] = _factory(data)
+                    bound_fns = self._tool_data_cache[cache_key]
+                    fn = bound_fns.get(name)
+                    if fn is None:
+                        return json.dumps({
+                            "status": "error",
+                            "message": (
+                                f"Tool '{name}' not found in factory output. "
+                                f"Available: {list(bound_fns.keys())}"
+                            ),
+                        })
+                    print(f"  ⚡ Tool: {name}...")
+                    result = fn(**kwargs)
+                    return result if isinstance(result, str) else json.dumps(result)
+                return wrapper
+
+            self.tools._register_tool(
+                func=_make_wrapper(tool_name, factory, factory_takes_path, factory_takes_output_dir),
+                name=tool_name,
+                description=description,
+                parameters=properties,
+                required=required,
+            )
+            self._external_tools.append({"name": tool_name, "description": description})
+            registered += 1
+
+        logging.info(f"✅ Registered {registered} external tool(s)")
+
+        # Keep the system prompt current so the LLM knows the new tools exist.
+        self._system_prompt = get_system_prompt(
+            self.analysis_mode, self._agent_registry, self._external_tools
+        )
+        if self.messages and self.messages[0]["role"] == "system":
+            self.messages[0]["content"] = self._system_prompt
+
+    def _load_data_as_array(self, data_path: str):
+        """Load a data file for use by external tool factories.
+
+        Returns a NumPy array for images and .npy files, a pandas DataFrame for
+        tabular files, or the path string itself as a fallback.
+        """
+        path = Path(data_path)
+        ext = path.suffix.lower()
+        if ext in {'.tif', '.tiff', '.png', '.jpg', '.jpeg', '.bmp'}:
+            from ...tools.image_processor import load_image
+            return load_image(str(path))
+        elif ext == '.npy':
+            import numpy as np
+            return np.load(str(path))
+        elif ext in {'.csv', '.txt', '.tsv'}:
+            try:
+                import pandas as pd
+                return pd.read_csv(str(path))
+            except ImportError:
+                import numpy as np
+                return np.genfromtxt(str(path), delimiter=',')
+        else:
+            self.logger.warning(
+                f"_load_data_as_array: unknown extension '{ext}' — "
+                "passing path string to factory."
+            )
+            return data_path
 
     def create_agent_for_analysis(self, agent_id: int, output_dir: str) -> Any:
         """
@@ -417,6 +715,13 @@ class AnalysisOrchestratorAgent:
         Raises:
             ValueError: If agent_id is invalid
         """
+        entry = self._agent_registry.get(agent_id)
+        if entry is None:
+            raise ValueError(
+                f"Unknown agent ID: {agent_id}. "
+                f"Valid IDs: {sorted(self._agent_registry.keys())}"
+            )
+
         common_kwargs = {
             "api_key": self.api_key,
             "model_name": self.model_name,
@@ -424,25 +729,19 @@ class AnalysisOrchestratorAgent:
             "output_dir": output_dir,
             "enable_human_feedback": self._enable_human_feedback,
         }
-        
-        if agent_id == 0:
-            from .fft_microscopy_agent import FFTMicroscopyAnalysisAgent
-            agent = FFTMicroscopyAnalysisAgent(**common_kwargs)
-        elif agent_id == 1:
-            from .sam_microscopy_agent import SAMMicroscopyAnalysisAgent
-            agent = SAMMicroscopyAnalysisAgent(**common_kwargs)
-        elif agent_id == 2:
-            from .hyperspectral_analysis_agent import HyperspectralAnalysisAgent
-            agent = HyperspectralAnalysisAgent(**common_kwargs)
-        elif agent_id == 3:
-            from .curve_fitting_agent import CurveFittingAgent
-            agent = CurveFittingAgent(**common_kwargs)
-        else:
-            raise ValueError(f"Unknown agent ID: {agent_id}. Valid IDs: 0-3")
-        
+
+        # Lazy-load built-in agents; custom agents already carry their class.
+        cls = entry.get("class")
+        if cls is None:
+            import importlib
+            module_path, class_name = entry["class_path"].rsplit(".", 1)
+            module = importlib.import_module(module_path)
+            cls = getattr(module, class_name)
+            entry["class"] = cls  # cache for subsequent calls
+
+        agent = cls(**common_kwargs)
         logging.info(f"   Created agent {agent_id}: {type(agent).__name__}")
         logging.info(f"   Output directory: {output_dir}")
-        
         return agent
 
     def generate_analysis_id(self, data_path: str, agent_id: int) -> str:
@@ -477,14 +776,8 @@ class AnalysisOrchestratorAgent:
         if len(dataset_name) > 30:
             dataset_name = dataset_name[:30]
         
-        # Get short agent name
-        agent_short_names = {
-            0: "FFT",
-            1: "SAM",
-            2: "Hyperspectral",
-            3: "CurveFit"
-        }
-        agent_short = agent_short_names.get(agent_id, f"agent{agent_id}")
+        # Get short agent name from registry
+        agent_short = self._agent_registry.get(agent_id, {}).get("short_name", f"agent{agent_id}")
         
         # Generate timestamp
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -19,6 +19,7 @@ from typing import Dict, Any, Callable
 
 from .metadata_converter import generate_metadata_json_from_text, METADATA_SCHEMA_DICT
 from ..lit_agents import OwlLiteratureAgent, NoveltyScorer
+from ...skills.loader import list_skills
 
 
 class AnalysisOrchestratorTools:
@@ -1000,7 +1001,11 @@ class AnalysisOrchestratorTools:
                 },
                 "skill": {
                     "type": "string",
-                    "description": "Domain skill name (e.g. 'xps', 'xrd') or path to .md skill file for CurveFitting agent"
+                    "description": (
+                        "Domain skill name or path to .md skill file for CurveFitting agent. "
+                        f"Available built-in skills: {list_skills('curve_fitting')}. "
+                        "Use show_available_agents to check for updates."
+                    )
                 }
             },
             required=[]
@@ -1159,10 +1164,17 @@ class AnalysisOrchestratorTools:
                     "description": self.AGENT_DESCRIPTIONS[agent_id]
                 })
 
+            available_skills = {}
+            for domain in ["curve_fitting"]:
+                skills = list_skills(domain)
+                if skills:
+                    available_skills[domain] = skills
+
             result = {
                 "status": "success",
                 "agents": agents,
                 "current_selection": self.orch.selected_agent_id,
+                "available_skills": available_skills,
             }
 
             external_tools = getattr(self.orch, "_external_tools", [])

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -25,22 +25,7 @@ class AnalysisOrchestratorTools:
     """
     Manages tool definitions, schemas, and execution for the AnalysisOrchestratorAgent.
     """
-    
-    # Agent name mapping for display
-    AGENT_NAMES = {
-        0: "FFTMicroscopyAnalysisAgent",
-        1: "SAMMicroscopyAnalysisAgent", 
-        2: "HyperspectralAnalysisAgent",
-        3: "CurveFittingAgent"
-    }
-    
-    AGENT_DESCRIPTIONS = {
-        0: "Microstructure analysis via FFT/NMF - grains, phases, domains, atomic-resolution images. Handles single images or image series.",
-        1: "Particle/object segmentation - counting, size distributions, morphology. Handles single images or image series.",
-        2: "Hyperspectral/spectral imaging data - 3D datacubes (x, y, spectral). EELS-SI, EDS mapping, Raman imaging.",
-        3: "1D data fitting - curves, spectra, time series. DSC, TGA, XRD, UV-Vis, Raman, PL, IV curves, kinetics. Handles single files or series."
-    }
-    
+
     def __init__(self, orchestrator_instance):
         """
         Args:
@@ -48,12 +33,24 @@ class AnalysisOrchestratorTools:
         """
         self.orch = orchestrator_instance
         self.logger = logging.getLogger(self.__class__.__name__)
-        
+
+        # Agent display dicts — populated from the orchestrator's live registry
+        # so that custom agents registered via register_agent() appear here too.
+        self.AGENT_NAMES: Dict[int, str] = {}
+        self.AGENT_DESCRIPTIONS: Dict[int, str] = {}
+        self._sync_from_registry()
+
         # Build function map and schemas
         self.functions_map: Dict[str, Callable] = {}
         self.openai_schemas: list = []
-        
+
         self._register_all_tools()
+
+    def _sync_from_registry(self) -> None:
+        """Rebuild AGENT_NAMES and AGENT_DESCRIPTIONS from the orchestrator's registry."""
+        registry = getattr(self.orch, "_agent_registry", {})
+        self.AGENT_NAMES = {aid: e["name"] for aid, e in registry.items()}
+        self.AGENT_DESCRIPTIONS = {aid: e["description"] for aid, e in registry.items()}
 
     def _get_human_feedback_enabled(self) -> bool:
         """Get current human feedback setting from orchestrator."""
@@ -1149,10 +1146,11 @@ class AnalysisOrchestratorTools:
         # =====================================================================
         def show_available_agents() -> str:
             """
-            Show list of available analysis agents and their capabilities.
+            Show list of available analysis agents and their capabilities,
+            plus any custom tools registered via register_tools().
             """
             print(f"  ⚡ Tool: Showing available agents...")
-            
+
             agents = []
             for agent_id in sorted(self.AGENT_NAMES.keys()):
                 agents.append({
@@ -1160,17 +1158,30 @@ class AnalysisOrchestratorTools:
                     "name": self.AGENT_NAMES[agent_id],
                     "description": self.AGENT_DESCRIPTIONS[agent_id]
                 })
-            
-            return json.dumps({
+
+            result = {
                 "status": "success",
                 "agents": agents,
-                "current_selection": self.orch.selected_agent_id
-            })
-        
+                "current_selection": self.orch.selected_agent_id,
+            }
+
+            external_tools = getattr(self.orch, "_external_tools", [])
+            if external_tools:
+                result["custom_tools"] = external_tools
+                result["custom_tools_note"] = (
+                    "These tools are callable directly by name and operate on "
+                    "the current data file (set via examine_data)."
+                )
+
+            return json.dumps(result)
+
         self._register_tool(
             func=show_available_agents,
             name="show_available_agents",
-            description="Show list of available analysis agents and their capabilities.",
+            description=(
+                "Show list of available analysis agents and their capabilities, "
+                "plus any custom tools registered for the current session."
+            ),
             parameters={},
             required=[]
         )

--- a/scilink/agents/exp_agents/base_agent.py
+++ b/scilink/agents/exp_agents/base_agent.py
@@ -693,15 +693,25 @@ class BaseAnalysisAgent(LLMAgentMixin, ABC):
     # ABSTRACT METHODS
     # =========================================================================
     
-    @abstractmethod
     def _get_claims_instruction_prompt(self) -> str:
-        """Return the instruction prompt for claims generation."""
-        raise NotImplementedError
-    
-    @abstractmethod
+        """Return the instruction prompt for claims generation.
+
+        Override in subclasses to provide domain-specific guidance for the
+        LLM when generating scientific claims and refining analysis with
+        human feedback. Returning "" is valid — the LLM will still produce
+        claims based on the data alone.
+        """
+        return ""
+
     def _get_measurement_recommendations_prompt(self) -> str:
-        """Return the instruction prompt for measurement recommendations."""
-        raise NotImplementedError
+        """Return the instruction prompt for measurement recommendations.
+
+        Override in subclasses to provide domain-specific guidance for the
+        LLM when generating follow-up measurement suggestions. Returning ""
+        is valid — the LLM will generate generic recommendations from the
+        analysis results.
+        """
+        return ""
 
     # =========================================================================
     # INTERNAL RECOMMENDATION GENERATION

--- a/scilink/cli/analyze.py
+++ b/scilink/cli/analyze.py
@@ -113,6 +113,39 @@ Metadata Options:
         help='Path to metadata file (.json or .txt)'
     )
     
+    # Custom agent arguments
+    parser.add_argument(
+        '--agents',
+        type=str,
+        nargs='+',
+        dest='agent_files',
+        metavar='AGENT_FILE',
+        help=(
+            'Path(s) to Python files containing custom BaseAnalysisAgent subclasses. '
+            'All subclasses found in each file are registered automatically. '
+            'Example: scilink analyze --agents ./my_xrd_agent.py'
+        )
+    )
+
+    # Custom tool arguments
+    parser.add_argument(
+        '--tools',
+        type=str,
+        nargs='+',
+        dest='tool_files',
+        metavar='TOOL_FILE',
+        help=(
+            'Path(s) to Python files containing domain-specific tool functions to '
+            'expose directly to the orchestrator\'s LLM loop. '
+            'Each file must define: (1) a list of OpenAI-format tool schemas named '
+            '\'tool_schemas\', \'openai_schemas\', or any top-level list of '
+            'OpenAI function dicts; (2) a factory function named '
+            '\'create_tool_functions\' (or any function ending in \'_tool_functions\') '
+            'that accepts data and returns a dict mapping tool names to callables. '
+            'Example: scilink analyze --tools ./image_analysis_tools.py'
+        )
+    )
+
     # Session arguments
     parser.add_argument(
         '--session-dir',
@@ -175,6 +208,22 @@ Metadata Options:
     if args.metadata_path and not Path(args.metadata_path).exists():
         parser.error(f"--metadata path does not exist: {args.metadata_path}")
     
+    # Validate custom agent files if provided
+    if args.agent_files:
+        for af in args.agent_files:
+            if not Path(af).exists():
+                parser.error(f"--agents path does not exist: {af}")
+            if not af.endswith('.py'):
+                parser.error(f"--agents file must be a .py file: {af}")
+
+    # Validate custom tool files if provided
+    if args.tool_files:
+        for tf in args.tool_files:
+            if not Path(tf).exists():
+                parser.error(f"--tools path does not exist: {tf}")
+            if not tf.endswith('.py'):
+                parser.error(f"--tools file must be a .py file: {tf}")
+
     # Build config dict
     config = {
         'model_name': args.model,
@@ -185,6 +234,8 @@ Metadata Options:
         'metadata_path': args.metadata_path,
         'session_dir': args.session_dir,
         'restore': args.restore,
+        'agent_files': args.agent_files or [],
+        'tool_files': args.tool_files or [],
     }
     
     # Run the interactive orchestrator
@@ -266,9 +317,11 @@ class AnalysisPlayground:
         session_dir = self.config.get('session_dir')
         restore = self.config.get('restore', False)
         
-        # Store initial paths for later use in run()
+        # Store initial paths and agent/tool files for later use in run()
         self._initial_data_path = data_path
         self._initial_metadata_path = metadata_path
+        self._agent_files = self.config.get('agent_files', [])
+        self._tool_files = self.config.get('tool_files', [])
         
         # Convert mode string to enum
         mode_map = {
@@ -364,12 +417,20 @@ Supported data types:
                 futurehouse_api_key=futurehouse_key
             )
             print("✅ Agent ready!")
-            
+
         except Exception as e:
             print(f"❌ Failed to initialize agent: {e}")
             import traceback
             traceback.print_exc()
             sys.exit(1)
+
+        # === LOAD CUSTOM AGENT FILES ===
+        if self._agent_files:
+            self._load_custom_agents(self._agent_files)
+
+        # === LOAD CUSTOM TOOL FILES ===
+        if self._tool_files:
+            self._load_custom_tools(self._tool_files)
         
         # === SHOW SESSION INFO ===
         print("\n" + "="*60)
@@ -398,6 +459,119 @@ Supported data types:
         if self._initial_metadata_path:
             print(f"📋 Initial metadata: {self._initial_metadata_path}")
         
+    def _load_custom_agents(self, agent_files: list) -> None:
+        """Load BaseAnalysisAgent subclasses from user-supplied .py files and register them."""
+        import importlib.util
+        import inspect
+        from scilink.agents.exp_agents.base_agent import BaseAnalysisAgent
+
+        for file_path in agent_files:
+            path = Path(file_path).resolve()
+            print(f"\n🔌 Loading custom agents from: {path}")
+            try:
+                spec = importlib.util.spec_from_file_location(path.stem, path)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+            except Exception as e:
+                print(f"   ❌ Failed to load {path.name}: {e}")
+                continue
+
+            found = 0
+            for _, cls in inspect.getmembers(module, inspect.isclass):
+                if (
+                    issubclass(cls, BaseAnalysisAgent)
+                    and cls is not BaseAnalysisAgent
+                    and cls.__module__ == module.__name__
+                ):
+                    next_id = max(self.agent._agent_registry.keys()) + 1
+                    self.agent.register_agent(next_id, cls)
+                    print(f"   ✅ Registered '{cls.__name__}' as agent ID {next_id}")
+                    found += 1
+
+            if found == 0:
+                print(f"   ⚠️  No BaseAnalysisAgent subclasses found in {path.name}")
+
+    def _load_custom_tools(self, tool_files: list) -> None:
+        """Load external tool functions from user-supplied .py files and register them.
+
+        Each file must expose:
+          1. A list of OpenAI-format tool schemas — discovered by looking for a
+             module-level variable named ``tool_schemas`` or ``openai_schemas``
+             first, then falling back to any top-level list whose first element is
+             a dict with ``type == "function"``.
+          2. A factory function that accepts data and returns a dict mapping tool
+             names to callables.  The factory is discovered by looking for
+             ``create_tool_functions`` first, then any module-level function whose
+             name ends with ``_tool_functions``.
+
+        The orchestrator's ``register_tools()`` method decides at call-time whether
+        to pass the current data path or a loaded NumPy/DataFrame object to the
+        factory, based on the name of the factory's first parameter.
+        """
+        import importlib.util
+        import inspect
+
+        for file_path in tool_files:
+            path = Path(file_path).resolve()
+            print(f"\n🔧 Loading custom tools from: {path}")
+            try:
+                spec = importlib.util.spec_from_file_location(path.stem, path)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+            except Exception as e:
+                print(f"   ❌ Failed to load {path.name}: {e}")
+                continue
+
+            # ── Discover schemas ──────────────────────────────────────────────
+            schemas = (
+                getattr(module, 'tool_schemas', None)
+                or getattr(module, 'openai_schemas', None)
+            )
+            if schemas is None:
+                # Auto-detect: any top-level list of OpenAI function dicts
+                for attr_name in dir(module):
+                    obj = getattr(module, attr_name, None)
+                    if (
+                        isinstance(obj, list)
+                        and obj
+                        and isinstance(obj[0], dict)
+                        and obj[0].get('type') == 'function'
+                    ):
+                        schemas = obj
+                        print(f"   📋 Auto-detected schemas in '{attr_name}'")
+                        break
+
+            if not schemas:
+                print(
+                    f"   ⚠️  No tool schemas found in {path.name}.\n"
+                    "       Define 'tool_schemas' as a list of OpenAI-format tool dicts."
+                )
+                continue
+
+            # ── Discover factory ──────────────────────────────────────────────
+            factory = getattr(module, 'create_tool_functions', None)
+            if factory is None:
+                for name, fn in inspect.getmembers(module, inspect.isfunction):
+                    if (
+                        name.endswith('_tool_functions')
+                        and fn.__module__ == module.__name__
+                    ):
+                        factory = fn
+                        print(f"   🏭 Auto-detected factory '{name}'")
+                        break
+
+            if factory is None:
+                print(
+                    f"   ⚠️  No factory function found in {path.name}.\n"
+                    "       Define 'create_tool_functions(data)' returning "
+                    "a dict mapping tool names to callables."
+                )
+                continue
+
+            self.agent.register_tools(schemas, factory)
+            count = sum(1 for s in schemas if s.get('type') == 'function')
+            print(f"   ✅ Registered {count} tool(s) from {path.name}")
+
     def print_help(self):
         """Print available commands."""
         print("\n" + "="*60)

--- a/scilink/skills/loader.py
+++ b/scilink/skills/loader.py
@@ -15,6 +15,21 @@ _SKILLS_DIR = Path(__file__).parent
 _KNOWN_SECTIONS = {"overview", "planning", "fitting", "interpretation", "validation"}
 
 
+def list_skills(domain: str = "curve_fitting") -> list:
+    """Return names of available built-in skills for a domain.
+
+    Args:
+        domain: Skill domain subdirectory (default: "curve_fitting").
+
+    Returns:
+        Sorted list of skill name strings (file stems).
+    """
+    skills_dir = _SKILLS_DIR / domain
+    if not skills_dir.is_dir():
+        return []
+    return sorted(p.stem for p in skills_dir.glob("*.md"))
+
+
 def load_skill(skill: str, domain: str = "curve_fitting") -> Dict[str, str]:
     """Load and parse a skill markdown file.
 


### PR DESCRIPTION
Add custom agent and tool support to `scilink analyze`:
- `register_agent()`: plug in `BaseAnalysisAgent` subclasses at runtime;
  auto-discovered from entry points or loaded via new --agents CLI flag
- `register_tools()`: expose domain functions directly to the LLM loop
  via new `--tools` CLI flag; factory receives loaded data (NumPy array
  or path) and optional output_dir for saving plots/reports
- De-abstract two `BaseAnalysisAgent `methods so only `analyze()` is required
- System prompt and show_available_agents tool update dynamically when
  custom agents or tools are registered