### PR TITLE
Add two-tier metadata normalization for analysis pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ result = agent.analyze("sample.tif", system_info=metadata)
 # Batch/series
 result = agent.analyze(
     ["frame_001.tif", "frame_002.tif"],
-    series_metadata={"series_type": "time", "values": [0, 10], "unit": "s"}
+    series_metadata={"variable": "time", "values": [0, 10], "unit": "s"}
 )
 
 # Get recommendations
@@ -505,7 +505,7 @@ print(f"R²: {result['fit_quality']['r_squared']:.4f}")
 # Series with trend analysis
 result = agent.analyze(
     ["pl_300K.csv", "pl_350K.csv", "pl_400K.csv"],
-    series_metadata={"series_type": "temperature", "values": [300, 350, 400], "unit": "K"}
+    series_metadata={"variable": "temperature", "values": [300, 350, 400], "unit": "K"}
 )
 ```
 

--- a/scilink/agents/exp_agents/__init__.py
+++ b/scilink/agents/exp_agents/__init__.py
@@ -5,7 +5,12 @@ from .hyperspectral_analysis_agent import HyperspectralAnalysisAgent
 from .orchestrator_agent import OrchestratorAgent, AGENT_MAP
 from .curve_fitting_agent import CurveFittingAgent
 from .analysis_orchestrator import AnalysisOrchestratorAgent, AnalysisMode
-from .metadata_converter import generate_metadata_json_from_text
+from .metadata_converter import (
+    generate_metadata_json_from_text,
+    check_schema_conformance,
+    normalize_metadata_dict,
+    normalize_metadata_dict_with_llm,
+)
 
 
 __all__ = [
@@ -23,4 +28,7 @@ __all__ = [
     'AnalysisMode',
     # Metadata utilities
     'generate_metadata_json_from_text',
+    'check_schema_conformance',
+    'normalize_metadata_dict',
+    'normalize_metadata_dict_with_llm',
 ]

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -17,7 +17,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, Any, Callable
 
-from .metadata_converter import generate_metadata_json_from_text, METADATA_SCHEMA_DICT
+from .metadata_converter import (
+    generate_metadata_json_from_text,
+    METADATA_SCHEMA_DICT,
+    check_schema_conformance,
+    normalize_metadata_dict,
+    normalize_metadata_dict_with_llm,
+)
 from ..lit_agents import OwlLiteratureAgent, NoveltyScorer
 from ...skills.loader import list_skills
 
@@ -530,13 +536,37 @@ class AnalysisOrchestratorTools:
                 with open(path, 'r') as f:
                     metadata = json.load(f)
                 
-                # Always store metadata first
+                # Normalize metadata to canonical schema if needed
+                is_conformant, issues = check_schema_conformance(metadata)
+                if not is_conformant:
+                    normalized, was_modified = normalize_metadata_dict(metadata)  # Tier 1
+                    re_ok, _ = check_schema_conformance(normalized)
+                    if not re_ok:
+                        # Tier 2: LLM normalization for remaining gaps
+                        try:
+                            llm_result = normalize_metadata_dict_with_llm(
+                                metadata, self.orch.model, self.logger
+                            )
+                            if llm_result:
+                                # Preserve non-schema keys from the original
+                                for k, v in metadata.items():
+                                    if k not in llm_result:
+                                        llm_result[k] = v
+                                metadata = llm_result
+                        except Exception as e:
+                            self.logger.warning(f"LLM metadata normalization failed: {e}")
+                            if was_modified:
+                                metadata = normalized
+                    else:
+                        metadata = normalized
+
+                # Always store metadata (possibly normalized)
                 self.orch.current_metadata = metadata
-                
+
                 # Validate basic structure
                 required_fields = ["experiment_type", "experiment", "sample"]
                 missing = [f for f in required_fields if f not in metadata]
-                
+
                 if missing:
                     return json.dumps({
                         "status": "warning",

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -810,6 +810,18 @@ class AnalysisOrchestratorTools:
             the analysis without fitting/unmixing it. Supported by CurveFitting
             and Hyperspectral agents.
 
+            series_metadata is a JSON string describing the independent variable
+            across spectra in a series. When ``values`` is a dict mapping
+            filenames to values, files are automatically sorted by value for
+            correct physical ordering and the dict is converted to a sorted
+            list before passing to the agent. Expected format::
+
+                {"variable": "temperature", "values": {"spec_5K.csv": 5, ...}, "unit": "K"}
+
+            If multiple data files are detected and no series_metadata is
+            provided, returns a ``needs_series_metadata`` status prompting the
+            caller to supply it.
+
             Output directory format: results/analysis_{dataset_name}_{timestamp}_{counter}/
             """
             print(f"  ⚡ Tool: Running analysis...")
@@ -977,7 +989,7 @@ class AnalysisOrchestratorTools:
                         ),
                         "num_spectra": num_files,
                         "expected_format": {
-                            "series_type": "<variable name, e.g. temperature>",
+                            "variable": "<variable name, e.g. temperature>",
                             "values": {"<filename>": "<value>", "...": "..."},
                             "unit": "<unit string, e.g. K, mM, V>"
                         },
@@ -1148,8 +1160,8 @@ class AnalysisOrchestratorTools:
                         "spectra in a series. Required for series analysis (multiple spectra). "
                         "Values is a dict mapping each filename to its value — files are "
                         "automatically sorted by value for correct trend analysis. "
-                        "Format: {\"series_type\": \"<variable>\", \"values\": {\"<filename>\": <value>, ...}, \"unit\": \"<units>\"}. "
-                        "Example: {\"series_type\": \"temperature\", \"values\": {\"spec_5K.csv\": 5, \"spec_10K.csv\": 10, \"spec_20K.csv\": 20}, \"unit\": \"K\"}"
+                        "Format: {\"variable\": \"<variable>\", \"values\": {\"<filename>\": <value>, ...}, \"unit\": \"<units>\"}. "
+                        "Example: {\"variable\": \"temperature\", \"values\": {\"spec_5K.csv\": 5, \"spec_10K.csv\": 10, \"spec_20K.csv\": 20}, \"unit\": \"K\"}"
                     )
                 }
             },

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -791,7 +791,8 @@ class AnalysisOrchestratorTools:
             hints: str = None,
             auxiliary_data: str = None,
             auxiliary_label: str = None,
-            skill: str = None
+            skill: str = None,
+            series_metadata: str = None
         ) -> str:
             """
             Execute analysis with the selected or specified agent.
@@ -942,6 +943,75 @@ class AnalysisOrchestratorTools:
                         if len(actual_data_input) > 3:
                             print(f"      ... and {len(actual_data_input) - 3} more")
                 
+                # === Handle series metadata ===
+                is_series = isinstance(actual_data_input, list) and len(actual_data_input) > 1
+                has_series_meta = (
+                    isinstance(self.orch.current_metadata, dict)
+                    and "series" in self.orch.current_metadata
+                )
+
+                if series_metadata is not None:
+                    # Parse and inject series metadata from the tool call
+                    try:
+                        parsed_series = json.loads(series_metadata) if isinstance(series_metadata, str) else series_metadata
+                        self.orch.current_metadata["series"] = parsed_series
+                        has_series_meta = True
+                    except (json.JSONDecodeError, TypeError) as e:
+                        self.logger.warning(f"Failed to parse series_metadata: {e}")
+
+                if is_series and not has_series_meta:
+                    num_files = len(actual_data_input)
+                    return json.dumps({
+                        "status": "needs_series_metadata",
+                        "message": (
+                            f"Detected {num_files} spectra (series mode) but no series metadata found. "
+                            "Series metadata describes the experimental variable that changes across spectra "
+                            "(e.g. temperature, concentration, voltage). "
+                            "Ask the user what variable changes across the spectra, the range or "
+                            "values, and the units. The user can describe this naturally — e.g. "
+                            "'temperature from 300 to 500 K in 50 K steps' or 'concentration: "
+                            "0.1, 0.2, 0.5 mM'. Use the filenames and the user's response to "
+                            "build the values dict mapping each filename to its value, then "
+                            "re-call run_analysis with the series_metadata parameter. "
+                            "Files will be sorted by value automatically for correct trend analysis."
+                        ),
+                        "num_spectra": num_files,
+                        "expected_format": {
+                            "series_type": "<variable name, e.g. temperature>",
+                            "values": {"<filename>": "<value>", "...": "..."},
+                            "unit": "<unit string, e.g. K, mM, V>"
+                        },
+                        "files": [Path(f).name for f in actual_data_input],
+                    })
+
+                # Sort files by series values for correct physical ordering
+                if is_series and has_series_meta:
+                    series_info = self.orch.current_metadata.get("series", {})
+                    values = series_info.get("values")
+                    if isinstance(values, dict):
+                        # Map filenames to full paths
+                        name_to_path = {Path(f).name: f for f in actual_data_input}
+                        # Build sorted (path, value) pairs by value
+                        paired = []
+                        for fname, val in values.items():
+                            full_path = name_to_path.get(fname)
+                            if full_path is not None:
+                                try:
+                                    paired.append((full_path, float(val)))
+                                except (TypeError, ValueError):
+                                    paired.append((full_path, val))
+                        # Sort by value (numeric sort when possible)
+                        try:
+                            paired.sort(key=lambda x: x[1])
+                        except TypeError:
+                            pass  # mixed types, keep original order
+                        if paired:
+                            actual_data_input = [p[0] for p in paired]
+                            sorted_values = [p[1] for p in paired]
+                            # Replace dict with sorted list for agent consumption
+                            series_info["values"] = sorted_values
+                            self.orch.current_metadata["series"] = series_info
+
                 # === Run analysis ===
                 analyze_kwargs = {
                     "data": actual_data_input,
@@ -1069,6 +1139,17 @@ class AnalysisOrchestratorTools:
                         "Supported by CurveFitting and Hyperspectral agents. "
                         f"Built-in curve_fitting skills: {list_skills('curve_fitting')}. "
                         f"Built-in hyperspectral skills: {list_skills('hyperspectral')}."
+                    )
+                },
+                "series_metadata": {
+                    "type": "string",
+                    "description": (
+                        "JSON string describing the experimental variable that changes across "
+                        "spectra in a series. Required for series analysis (multiple spectra). "
+                        "Values is a dict mapping each filename to its value — files are "
+                        "automatically sorted by value for correct trend analysis. "
+                        "Format: {\"series_type\": \"<variable>\", \"values\": {\"<filename>\": <value>, ...}, \"unit\": \"<units>\"}. "
+                        "Example: {\"series_type\": \"temperature\", \"values\": {\"spec_5K.csv\": 5, \"spec_10K.csv\": 10, \"spec_20K.csv\": 20}, \"unit\": \"K\"}"
                     )
                 }
             },

--- a/scilink/agents/exp_agents/base_agent.py
+++ b/scilink/agents/exp_agents/base_agent.py
@@ -315,6 +315,14 @@ class LLMAgentMixin:
         Returns the (possibly modified) *system_info* and the resolved
         *series_metadata*.  If *series_metadata* was already provided it
         takes precedence and *system_info* is returned unchanged.
+
+        The expected series_metadata structure is::
+
+            {
+                "variable": "temperature",  # independent variable name
+                "values": [300, 350, 400],  # one value per data point
+                "unit": "K"                 # unit for values
+            }
         """
         if not series_metadata and isinstance(system_info, dict) and "series" in system_info:
             system_info = dict(system_info)          # shallow copy to avoid mutating caller's dict

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -2446,7 +2446,7 @@ with open('series_fit_results.json', 'r') as f:
 
 results = data['results']
 series_metadata = data.get('series_metadata', {{}})
-# series_metadata has: series_type, values (one per spectrum), unit
+# series_metadata has: variable, values (one per spectrum), unit
 
 # Extract series variable and parameters...
 # Create figure with subplots...
@@ -3122,7 +3122,7 @@ class UnifiedCurveReportController:
         <div class="metadata-box">
             <p><strong>Date:</strong> {timestamp}</p>
             <p><strong>Spectra Processed:</strong> {successful}/{num_spectra}</p>
-            <p><strong>Series Type:</strong> {series_metadata.get('series_type', 'N/A')}</p>
+            <p><strong>Series Variable:</strong> {series_metadata.get('variable', 'N/A')}</p>
             <p><strong>Fitting Model:</strong> {locked_config.get('physical_model', 'N/A')}</p>
             <p><strong>Quality Status:</strong> {quality_indicator}</p>
         </div>

--- a/scilink/agents/exp_agents/controllers/sam_microscopy_controllers.py
+++ b/scilink/agents/exp_agents/controllers/sam_microscopy_controllers.py
@@ -1256,7 +1256,7 @@ class ConditionalCustomAnalysisController:
             "successful": sum(1 for r in batch_results if r["success"]),
             "particle_counts": particle_counts,
             "mean_areas": mean_areas,
-            "series_type": series_metadata.get("series_type", "unknown"),
+            "variable": series_metadata.get("variable", "unknown"),
             "time_points": time_points,
         }
         
@@ -1817,7 +1817,7 @@ class UnifiedReportGenerationController:
         <p><strong>Date:</strong> {timestamp}</p>
         <p><strong>Images Processed:</strong> {successful}/{num_images}</p>
         <p><strong>Analysis Approach:</strong> {custom_results.get("approach", "time_series")}</p>
-        <p><strong>Series Type:</strong> {series_metadata.get("series_type", "unknown")}</p>{quality_info}
+        <p><strong>Series Variable:</strong> {series_metadata.get("variable", "unknown")}</p>{quality_info}
     </div>
 
     <h2>Scientific Analysis</h2>

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -106,7 +106,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         result = agent.analyze(
             spectra_paths,
             series_metadata={
-                "series_type": "temperature",
+                "variable": "temperature",
                 "values": [300, 350, 400, 450, 500],
                 "unit": "K"
             }
@@ -273,7 +273,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 ``series_metadata`` takes precedence. Expected structure::
 
                     {
-                        "series_type": "temperature",   # or "time", "concentration", …
+                        "variable": "temperature",   # or "time", "concentration", …
                         "values": [300, 350, 400],      # one value per spectrum, in file order
                         "unit": "K"                      # unit for values
                     }
@@ -284,7 +284,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 the dict to a list before passing to the agent::
 
                     {
-                        "series_type": "temperature",
+                        "variable": "temperature",
                         "values": {"spec_5K.csv": 5, "spec_20K.csv": 20, "spec_10K.csv": 10},
                         "unit": "K"
                     }
@@ -322,7 +322,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             result = agent.analyze(
                 ["temp_300K.csv", "temp_350K.csv", "temp_400K.csv"],
                 series_metadata={
-                    "series_type": "temperature",
+                    "variable": "temperature",
                     "values": [300, 350, 400],
                     "unit": "K"
                 }
@@ -335,7 +335,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                     "sample": "Boron-doped silicon",
                     "instrument": "Raman spectrometer, 532 nm",
                     "series": {
-                        "series_type": "concentration",
+                        "variable": "concentration",
                         "values": [0.1, 0.2, 0.3],
                         "unit": "mol/L"
                     }
@@ -864,7 +864,9 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             spectrum_paths: List of file paths to spectra
             spectrum_stack: 3D numpy array (n_spectra x 2 x n_points)
             system_info: System/sample metadata
-            series_metadata: Metadata about the series
+            series_metadata: Dict with ``"variable"`` (str), ``"values"``
+                (list), and ``"unit"`` (str) describing the independent
+                variable across the series
             objective: High-level scientific objective
             hints: Analysis guidance
 

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -274,9 +274,22 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
 
                     {
                         "series_type": "temperature",   # or "time", "concentration", …
-                        "values": [300, 350, 400],      # one value per spectrum
+                        "values": [300, 350, 400],      # one value per spectrum, in file order
                         "unit": "K"                      # unit for values
                     }
+
+                When calling through the orchestrator, ``values`` can be a dict
+                mapping filenames to values instead of a list. The orchestrator
+                sorts files by value for correct physical ordering and converts
+                the dict to a list before passing to the agent::
+
+                    {
+                        "series_type": "temperature",
+                        "values": {"spec_5K.csv": 5, "spec_20K.csv": 20, "spec_10K.csv": 10},
+                        "unit": "K"
+                    }
+                    # → files sorted to [spec_5K, spec_10K, spec_20K]
+                    # → values converted to [5, 10, 20]
             auxiliary_data: Optional path to an auxiliary dataset (1D curve file
                 or 2D image) from the same sample/experiment. Not fitted or
                 analyzed in detail, but provided to the LLM as context for

--- a/scilink/agents/exp_agents/fft_microscopy_agent.py
+++ b/scilink/agents/exp_agents/fft_microscopy_agent.py
@@ -145,8 +145,18 @@ class FFTMicroscopyAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 - str: Single image path
                 - List[str]: Multiple image paths
                 - np.ndarray: 2D (single) or 3D (stack) array
-            system_info: System/sample information
-            series_metadata: Optional metadata about the series
+            system_info: System/sample information. May include a ``"series"``
+                key with series metadata; it will be extracted automatically.
+            series_metadata: Optional metadata describing the experimental
+                variable that changes across images in a series. Can also
+                be provided inside ``system_info["series"]``. Expected
+                structure::
+
+                    {
+                        "variable": "temperature",  # independent variable name
+                        "values": [300, 350, 400],   # one value per image, in file order
+                        "unit": "K"                  # unit for values
+                    }
             preset_params: Skip first-frame analysis, use these params directly
             feedback_callback: Optional function for custom feedback
         

--- a/scilink/agents/exp_agents/metadata_converter.py
+++ b/scilink/agents/exp_agents/metadata_converter.py
@@ -164,6 +164,257 @@ Ensure the output JSON accurately reflects the information present in the text d
 """
 
 
+# =====================================================================
+# Alias mappings for deterministic normalization (Tier 1)
+# =====================================================================
+# Each canonical field maps to a list of common aliases (case-insensitive)
+_TECHNIQUE_ALIASES = [
+    "technique", "method", "experimental technique", "measurement_type",
+    "experimental_technique", "measurement_method",
+]
+_MATERIAL_ALIASES = [
+    "material", "sample_material", "composition", "formula",
+    "sample_name", "compound",
+]
+_EXPERIMENT_TYPE_ALIASES = [
+    "type", "data_type", "exp_type", "experiment_type",
+]
+_ENERGY_START_ALIASES = [
+    "energy_start", "spectral_start", "range_start", "start_wavelength",
+    "start_energy", "x_start",
+]
+_ENERGY_END_ALIASES = [
+    "energy_end", "spectral_end", "range_end", "end_wavelength",
+    "end_energy", "x_end",
+]
+_ENERGY_UNITS_ALIASES = [
+    "energy_units", "spectral_units", "x_units", "wavelength_units",
+]
+_SPATIAL_FOV_ALIASES = ["field_of_view", "fov"]
+_PIXEL_SIZE_ALIASES = [
+    "pixel_size", "pixel_size_nm", "nm_per_pixel",
+    "scale_nm_per_pixel", "pixelSize", "pixel_scale", "resolution_nm",
+]
+_PIXEL_SIZE_UNIT_ALIASES = [
+    "pixel_size_unit", "pixel_size_units", "spatial_units",
+]
+
+
+def _ci_pop(d: dict, aliases: list[str]):
+    """Case-insensitive pop: find the first matching alias in *d* and remove it."""
+    lower_map = {k.lower(): k for k in d}
+    for alias in aliases:
+        real_key = lower_map.get(alias.lower())
+        if real_key is not None and d[real_key] is not None:
+            return d.pop(real_key)
+    return None
+
+
+def check_schema_conformance(metadata: dict) -> tuple[bool, list[str]]:
+    """Check whether *metadata* conforms to the canonical schema.
+
+    Returns ``(is_conformant, issues)`` where *issues* is a list of
+    human-readable strings describing what is missing or wrong.
+    Fast-path: returns ``(True, [])`` for already-conformant dicts.
+    """
+    issues: list[str] = []
+
+    # Required top-level keys
+    for key in ("experiment_type", "experiment", "sample"):
+        if key not in metadata:
+            issues.append(f"Missing required top-level key: '{key}'")
+
+    # Nested required keys
+    exp = metadata.get("experiment")
+    if isinstance(exp, dict):
+        if "technique" not in exp:
+            issues.append("Missing 'experiment.technique'")
+    elif exp is not None:
+        issues.append("'experiment' should be a dict")
+
+    sample = metadata.get("sample")
+    if isinstance(sample, dict):
+        if "material" not in sample:
+            issues.append("Missing 'sample.material'")
+    elif sample is not None:
+        issues.append("'sample' should be a dict")
+
+    # Type checks for optional nested objects
+    for key in ("energy_range", "spatial_info"):
+        val = metadata.get(key)
+        if val is not None and not isinstance(val, dict):
+            issues.append(f"'{key}' should be a dict or null")
+
+    return (len(issues) == 0, issues)
+
+
+def normalize_metadata_dict(metadata: dict) -> tuple[dict, bool]:
+    """Tier 1 deterministic normalizer — map common aliases to canonical form.
+
+    Returns ``(normalized_dict, was_modified)``.  If no changes were needed
+    the *same* dict object is returned with ``was_modified=False``.
+    All unrecognized keys are preserved at the top level.
+    """
+    # Fast-path: already conformant → no-op
+    is_ok, _ = check_schema_conformance(metadata)
+    if is_ok:
+        return metadata, False
+
+    # Work on a shallow copy so the original is not mutated
+    d = dict(metadata)
+    modified = False
+
+    # --- experiment_type ---
+    if "experiment_type" not in d:
+        val = _ci_pop(d, _EXPERIMENT_TYPE_ALIASES)
+        if val is not None:
+            d["experiment_type"] = val
+            modified = True
+
+    # --- experiment.technique ---
+    exp = d.get("experiment")
+    if not isinstance(exp, dict):
+        exp = {}
+    if "technique" not in exp:
+        val = _ci_pop(d, _TECHNIQUE_ALIASES)
+        if val is not None:
+            exp = dict(exp)  # copy if we're modifying
+            exp["technique"] = val
+            d["experiment"] = exp
+            modified = True
+    if exp and "experiment" not in d:
+        d["experiment"] = exp
+        modified = True
+
+    # --- sample.material ---
+    sample = d.get("sample")
+    if not isinstance(sample, dict):
+        sample = {}
+    if "material" not in sample:
+        val = _ci_pop(d, _MATERIAL_ALIASES)
+        if val is not None:
+            sample = dict(sample)
+            sample["material"] = val
+            d["sample"] = sample
+            modified = True
+    if sample and "sample" not in d:
+        d["sample"] = sample
+        modified = True
+
+    # --- energy_range ---
+    er = d.get("energy_range")
+    if not isinstance(er, dict):
+        er = {}
+    er_modified = False
+    if "start" not in er:
+        val = _ci_pop(d, _ENERGY_START_ALIASES)
+        if val is not None:
+            er["start"] = val
+            er_modified = True
+    if "end" not in er:
+        val = _ci_pop(d, _ENERGY_END_ALIASES)
+        if val is not None:
+            er["end"] = val
+            er_modified = True
+    if "units" not in er:
+        val = _ci_pop(d, _ENERGY_UNITS_ALIASES)
+        if val is not None:
+            er["units"] = val
+            er_modified = True
+    if er_modified:
+        d["energy_range"] = er
+        modified = True
+
+    # --- spatial_info ---
+    si = d.get("spatial_info")
+    if not isinstance(si, dict):
+        si = {}
+    si_modified = False
+
+    # field_of_view → field_of_view_x (scalar fov treated as x)
+    if "field_of_view_x" not in si:
+        val = _ci_pop(d, _SPATIAL_FOV_ALIASES)
+        if val is not None:
+            if isinstance(val, dict):
+                # e.g. {"x": 100, "y": 100, "units": "nm"}
+                si.update({
+                    "field_of_view_x": val.get("x"),
+                    "field_of_view_y": val.get("y"),
+                    "field_of_view_units": val.get("units"),
+                })
+            else:
+                si["field_of_view_x"] = val
+            si_modified = True
+
+    # pixel_size → nm_per_pixel at top level (kept for spatial_info enrichment)
+    ps_val = _ci_pop(d, _PIXEL_SIZE_ALIASES)
+    if ps_val is not None:
+        si["nm_per_pixel"] = ps_val
+        ps_unit = _ci_pop(d, _PIXEL_SIZE_UNIT_ALIASES)
+        if ps_unit is not None:
+            si["pixel_size_unit"] = ps_unit
+        si_modified = True
+
+    if si_modified:
+        d["spatial_info"] = si
+        modified = True
+
+    return (d, True) if modified else (metadata, False)
+
+
+def _run_metadata_llm(text: str, model) -> dict | None:
+    """Shared LLM call + JSON parsing for metadata generation.
+
+    Sends *text* through the ``METADATA_GENERATION_PROMPT`` using *model*
+    and returns the parsed dict, or ``None`` on failure.
+    """
+    prompt_parts = [
+        METADATA_GENERATION_PROMPT,
+        "\n--- Plain Text Description ---",
+        text,
+        "\n--- Extracted JSON Metadata ---",
+    ]
+
+    try:
+        response = model.generate_content(contents=prompt_parts)
+
+        if not hasattr(response, "text"):
+            if hasattr(response, "candidates"):
+                raw_text = response.candidates[0].content.parts[0].text
+            else:
+                raw_text = str(response)
+        else:
+            raw_text = response.text
+
+        # Clean markdown fences
+        if "```json" in raw_text:
+            raw_text = raw_text.split("```json")[1].split("```")[0]
+        elif "```" in raw_text:
+            raw_text = raw_text.split("```")[1].split("```")[0]
+
+        return json.loads(raw_text.strip())
+
+    except Exception as e:
+        logger.error(f"Error in LLM metadata generation: {e}", exc_info=True)
+        return None
+
+
+def normalize_metadata_dict_with_llm(
+    metadata: dict,
+    model,
+    ext_logger=None,
+) -> dict | None:
+    """Tier 2 LLM normalizer — serialize dict as JSON text and run through LLM.
+
+    Reuses the existing ``METADATA_GENERATION_PROMPT``.  Returns the
+    normalized dict or ``None`` on failure.
+    """
+    log = ext_logger or logger
+    text = json.dumps(metadata, indent=2, default=str)
+    log.info("Running LLM-based metadata normalization")
+    return _run_metadata_llm(text, model)
+
+
 def generate_metadata_json_from_text(
     input_text_filepath: str,           
     api_key: str | None = None,
@@ -222,40 +473,18 @@ def generate_metadata_json_from_text(
         logger.info(f"☁️ Using LiteLLM agent: {model_name}")
         model = LiteLLMGenerativeModel(model=model_name, api_key=api_key)
 
-    # 4. Prepare Prompt
-    prompt_parts = [
-        METADATA_GENERATION_PROMPT,
-        "\n--- Plain Text Description ---",
-        text_description, 
-        "\n--- Extracted JSON Metadata ---"
-    ]
+    # 4. Generate via shared helper
+    metadata_dict = _run_metadata_llm(text_description, model)
 
-    # 5. Generate
+    if metadata_dict is None:
+        return None
+
+    # 5. Save
     try:
-        response = model.generate_content(contents=prompt_parts)
-        
-        # 6. Parse
-        if not hasattr(response, 'text'):
-            if hasattr(response, 'candidates'): raw_text = response.candidates[0].content.parts[0].text
-            else: raw_text = str(response)
-        else:
-             raw_text = response.text
-
-        # Clean markdown
-        if "```json" in raw_text:
-            raw_text = raw_text.split("```json")[1].split("```")[0]
-        elif "```" in raw_text:
-            raw_text = raw_text.split("```")[1].split("```")[0]
-            
-        metadata_dict = json.loads(raw_text.strip())
-        
-        # Save
         with open(output_json_filepath, 'w', encoding='utf-8') as f:
             json.dump(metadata_dict, f, indent=4)
         logger.info(f"Saved metadata to: {output_json_filepath}")
-        
-        return metadata_dict
-
     except Exception as e:
-        logger.error(f"Error generating metadata: {e}", exc_info=True)
-        return None
+        logger.error(f"Error saving metadata file: {e}", exc_info=True)
+
+    return metadata_dict

--- a/scilink/agents/exp_agents/sam_microscopy_agent.py
+++ b/scilink/agents/exp_agents/sam_microscopy_agent.py
@@ -214,9 +214,19 @@ class SAMMicroscopyAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 - str: Single image path
                 - List[str]: Multiple image paths
                 - np.ndarray: 2D (single) or 3D (stack) array
-            system_info: System/sample information
-            series_metadata: Optional metadata about the series
-        
+            system_info: System/sample information. May include a ``"series"``
+                key with series metadata; it will be extracted automatically.
+            series_metadata: Optional metadata describing the experimental
+                variable that changes across images in a series. Can also
+                be provided inside ``system_info["series"]``. Expected
+                structure::
+
+                    {
+                        "variable": "temperature",  # independent variable name
+                        "values": [300, 350, 400],   # one value per image, in file order
+                        "unit": "K"                  # unit for values
+                    }
+
         Returns:
             Dict with status, detailed_analysis, scientific_claims,
             summary, output_directory, and SAM-specific fields
@@ -509,8 +519,16 @@ class SAMMicroscopyAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
     ) -> Dict[str, Any]:
         """
         Analyze a series of images.
-        
+
         BACKWARD COMPATIBLE: Delegates to unified analyze() method.
+
+        Args:
+            image_paths: List of file paths to images
+            image_stack: 3D numpy array (n_images x height x width)
+            system_info: System/sample metadata
+            series_metadata: Dict with ``"variable"`` (str), ``"values"``
+                (list), and ``"unit"`` (str) describing the independent
+                variable across the series
         """
         if image_paths is not None:
             return self.analyze(


### PR DESCRIPTION
Users can pass metadata in flat dicts, with different key names, or with non-canonical nesting. Downstream code (e.g. hyperspectral energy axis computation at energy_range["start"/"end"]) assumes the canonical schema from METADATA_SCHEMA_DICT and crashes or silently loses context when the structure doesn't match.

This PR adds a two-tier normalization system:

#### Tier 1. Deterministic alias mapping (no LLM, pure Python):
- `check_schema_conformance()` validates a dict against the canonical schema (experiment_type, experiment.technique, sample.material, etc.)
- `normalize_metadata_dict()` maps common aliases to canonical form via case-insensitive lookup (e.g. "technique" -> experiment.technique, "energy_start" -> energy_range.start, "material" -> sample.material)
- Fast-path: already-conformant dicts are returned as-is (same object)
- Additive: unrecognized keys are preserved as is

#### Tier 2. LLM-powered normalization (only when Tier 1 leaves gaps):
- `normalize_metadata_dict_with_llm()` serializes the dict as JSON and passes it through the existing METADATA_GENERATION_PROMPT
- Only runs in `load_metadata()` (once per session at metadata load time), never in the agent hot path
- LLM result is merged back with the original dict so that non-schema keys (e.g. custom calibration data, lab notebook refs) are never silently dropped -- LLM output takes priority for schema fields, original keys are preserved for everything else

Both tiers run automatically in the orchestrator's `load_metadata()` tool. For programmatic use, all three functions are exported from `scilink.agents.exp_agents` alongside `generate_metadata_json_from_text`, so users can call them directly on arbitrary metadata dicts:

```python
from scilink.agents.exp_agents import (
    check_schema_conformance, normalize_metadata_dict
  )

flat = {"technique": "Raman", "material": "TiO2",
          "energy_start": 200, "energy_end": 800, "energy_units": "cm^-1",
          "lab_notebook": "NB-42"}

ok, issues = check_schema_conformance(flat)
# ok=False, issues=["Missing required top-level key: 'experiment_type'", ...]

 normalized, was_modified = normalize_metadata_dict(flat)
 # was_modified=True
 # normalized = {
 #     "experiment": {"technique": "Raman"},
 #     "sample": {"material": "TiO2"},
 #     "energy_range": {"start": 200, "end": 800, "units": "cm^-1"},
 #     "lab_notebook": "NB-42",   # non-schema keys preserved
 # }
```

#### Refactoring

Extracts a shared `_run_metadata_llm()` helper from `generate_metadata_json_from_text()`, reused by both the original text-to-JSON function and the new LLM dict normalizer. Public signature unchanged.

**Minor behavior change:** file save errors are now caught separately from LLM errors, so the function returns the parsed dict even if writing the JSON file to disk fails (previously returned `None` for both cases).

#### Files changed

- **`scilink/agents/exp_agents/metadata_converter.py`**
  - New: `check_schema_conformance()`, `normalize_metadata_dict()`, `normalize_metadata_dict_with_llm()`, `_run_metadata_llm()`, `_ci_pop()`
  - New: alias mapping constants (`_TECHNIQUE_ALIASES`, `_MATERIAL_ALIASES`, etc.)
  - Refactored: `generate_metadata_json_from_text()` now delegates to `_run_metadata_llm()`
- **`scilink/agents/exp_agents/__init__.py`**
  - Export `check_schema_conformance`, `normalize_metadata_dict`, `normalize_metadata_dict_with_llm`
- **`scilink/agents/exp_agents/analysis_orchestrator_tools.py`**
  - `load_metadata()`: Tier 1 + Tier 2 normalization before required-fields check, with non-schema key preservation on Tier 2 results

This also automatically addresses #28.