### PR TITLE
plan conformance check

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -106,7 +106,14 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
     if not content:
         return
 
-    prompt.append(f"\n## Domain Skill: {skill_name} ({stage})")
+    prompt.append(f"\n## MANDATORY Domain Skill Rules: {skill_name} ({stage})")
+    prompt.append(
+        "The following rules are MANDATORY. Your analysis plan and implementation "
+        "MUST conform to these domain-specific requirements. These rules encode "
+        "validated domain expertise and take precedence over general-purpose defaults. "
+        "Do NOT substitute your own preferences where these rules specify a method, "
+        "treatment, or constraint."
+    )
     prompt.append(content)
 
     # Include validation rules during planning and interpretation
@@ -114,7 +121,7 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
     if stage in ("planning", "interpretation"):
         validation = sections.get("validation", "")
         if validation:
-            prompt.append(f"\n## Domain Validation Rules ({skill_name})")
+            prompt.append(f"\n## MANDATORY Domain Validation Rules ({skill_name})")
             prompt.append(validation)
 
 
@@ -1230,6 +1237,7 @@ Your guidance: '''
         outlier_sigma: float = None,
         max_verification_iterations: int = None,
         preprocessor: Any = None,
+        conformance_instructions: str = "",
     ):
         self.model = model
         self.logger = logger
@@ -1248,6 +1256,7 @@ Your guidance: '''
         self.outlier_sigma = outlier_sigma if outlier_sigma is not None else self.DEFAULT_OUTLIER_SIGMA
         self.max_verification_iterations = max_verification_iterations if max_verification_iterations is not None else self.DEFAULT_MAX_VERIFICATION_ITERATIONS
         self.preprocessor = preprocessor
+        self.conformance_instructions = conformance_instructions
 
     def _generate_fitting_script(self, state: dict, data_path: str, stats: dict) -> str:
         config = state.get("locked_fitting_config", {})
@@ -1257,7 +1266,9 @@ Your guidance: '''
         skill_sections = state.get("skill_sections")
         if skill_sections and skill_sections.get("fitting"):
             context_parts.append(
-                f"## Domain Skill Guidance ({state.get('skill_name', 'skill')})\n"
+                f"## MANDATORY Domain Skill Rules ({state.get('skill_name', 'skill')})\n"
+                "The following domain rules are MANDATORY and must be implemented exactly "
+                "as specified. They take precedence over general-purpose fitting defaults.\n\n"
                 + skill_sections["fitting"]
             )
 
@@ -1294,7 +1305,9 @@ Your guidance: '''
         skill_sections = state.get("skill_sections")
         if skill_sections and skill_sections.get("fitting"):
             prompt += (
-                f"\n\n## Domain Fitting Guidance ({state.get('skill_name', 'skill')})\n"
+                f"\n\n## MANDATORY Domain Skill Rules ({state.get('skill_name', 'skill')})\n"
+                "While fixing the error, you MUST continue to follow these domain rules. "
+                "Do not change the fitting model or workflow to deviate from these rules.\n\n"
                 + skill_sections["fitting"]
             )
 
@@ -1308,6 +1321,60 @@ Your guidance: '''
             self.logger.info(f"    Diagnosis: {result['diagnosis']}")
 
         return result["script"]
+
+    def _check_plan_conformance(self, state: dict, script: str) -> dict | None:
+        """Use the LLM to verify a generated script implements the locked plan.
+
+        Returns a dict with ``conformant``, ``justified_deviations``,
+        ``unjustified_deviations``, and ``summary`` keys, or ``None`` if the
+        check cannot be performed (missing config, LLM error, etc.).
+        """
+        config = state.get("locked_fitting_config", {})
+        if not config or not config.get("physical_model"):
+            return None
+        if not self.conformance_instructions:
+            return None
+
+        # Build skill rules text for conformance checking
+        skill_rules_text = ""
+        skill_sections = state.get("skill_sections")
+        if skill_sections:
+            skill_name = state.get("skill_name", "domain skill")
+            rules_parts = []
+            for stage in ("planning", "fitting", "validation"):
+                content = skill_sections.get(stage, "")
+                if content:
+                    rules_parts.append(f"### {stage.title()} rules\n{content}")
+            if rules_parts:
+                skill_rules_text = (
+                    f"\n**MANDATORY Domain Skill Rules ({skill_name}):**\n"
+                    + "\n".join(rules_parts)
+                    + "\n"
+                )
+
+        prompt = self.conformance_instructions.format(
+            analysis_approach=config.get("analysis_approach", ""),
+            physical_model=config.get("physical_model", ""),
+            parameters_to_extract=", ".join(
+                config.get("parameters_to_extract", [])
+            ),
+            fitting_strategy=config.get("fitting_strategy", ""),
+            skill_rules=skill_rules_text,
+            script=script,
+        )
+
+        try:
+            response = self.model.generate_content(contents=[prompt])
+            result, error = self._parse(response)
+            if error or not result:
+                self.logger.debug(
+                    "Plan conformance check parse failed: %s", error
+                )
+                return None
+            return result
+        except Exception as exc:
+            self.logger.debug("Plan conformance check failed: %s", exc)
+            return None
 
     def _adapt_script_for_spectrum(self, base_script: str, data_path: str, output_prefix: str) -> str:
         adapted = base_script
@@ -1431,6 +1498,30 @@ Your guidance: '''
                     script = self._adapt_script_for_spectrum(base_script, str(temp_data_path), output_prefix)
                 elif attempt == 1:
                     script = self._generate_fitting_script(state, str(temp_data_path), stats)
+                    # Check conformance with locked plan on fresh generation
+                    conformance = self._check_plan_conformance(state, script)
+                    if conformance and not conformance.get("conformant", True):
+                        issues = "; ".join(
+                            conformance.get("unjustified_deviations", [])
+                        )
+                        self.logger.warning(
+                            "    \u26a0\ufe0f Plan conformance issue: %s", issues
+                        )
+                        last_error = (
+                            "PLAN CONFORMANCE: Script deviates from the "
+                            "locked plan without justification. Issues: "
+                            f"{issues}. Plan model: "
+                            f"{state.get('locked_fitting_config', {}).get('physical_model', '')}. "
+                            "Either fix the script to match the plan, or if "
+                            "the plan cannot work, implement the closest "
+                            "viable alternative and explain why in the summary."
+                        )
+                        continue
+                    if conformance and conformance.get("justified_deviations"):
+                        self.logger.info(
+                            "    \u2139\ufe0f Justified plan deviations: %s",
+                            "; ".join(conformance["justified_deviations"]),
+                        )
                 else:
                     script = self._correct_script(state, script, last_error)
 
@@ -2918,6 +3009,7 @@ class AdaptiveRefitController:
         max_verification_iterations: int = 3,
         preprocessor: Any = None,
         enable_human_feedback: bool = False,
+        conformance_instructions: str = "",
     ):
         self.logger = logger
         self.output_dir = Path(output_dir)
@@ -2943,6 +3035,7 @@ class AdaptiveRefitController:
             enable_human_feedback=False,
             max_verification_iterations=max_verification_iterations,
             preprocessor=preprocessor,
+            conformance_instructions=conformance_instructions,
         )
 
     def _load_spectrum(self, idx, spectrum_paths, spectrum_stack):

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -2645,7 +2645,22 @@ Return JSON with:
             # Apply preprocessing with locking support for series consistency
             if self.preprocessor is not None:
                 try:
-                    if idx == 0:
+                    if idx == 0 and state.get("first_spectrum_preprocessed"):
+                        # Reuse preprocessing from analyze() — avoid redundant LLM call
+                        curve_data = state.get("curve_data", curve_data)
+                        preprocess_quality = state.get(
+                            "first_spectrum_preprocess_quality", {}
+                        ) or {}
+                        locked_preprocessing_strategy = preprocess_quality.get("strategy")
+                        if locked_preprocessing_strategy:
+                            state["locked_preprocessing_strategy"] = locked_preprocessing_strategy
+                            self.logger.info(
+                                "📝 Preprocessing strategy locked (from planning stage): "
+                                f"{locked_preprocessing_strategy.get('reasoning', 'N/A')[:60]}"
+                            )
+                        else:
+                            self.logger.info("Preprocessed (reused from planning stage)")
+                    elif idx == 0:
                         curve_data, preprocess_quality = self.preprocessor.run_preprocessing(
                             curve_data, state.get("system_info", {})
                         )

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -45,7 +45,14 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
     if not content:
         return
 
-    prompt.append(f"\n## Domain Skill: {skill_name} ({stage})")
+    prompt.append(f"\n## MANDATORY Domain Skill Rules: {skill_name} ({stage})")
+    prompt.append(
+        "The following rules are MANDATORY. Your analysis plan and implementation "
+        "MUST conform to these domain-specific requirements. These rules encode "
+        "validated domain expertise and take precedence over general-purpose defaults. "
+        "Do NOT substitute your own preferences where these rules specify a method, "
+        "treatment, or constraint."
+    )
     prompt.append(content)
 
     # Include validation rules during planning and interpretation
@@ -53,7 +60,7 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
     if stage in ("planning", "interpretation"):
         validation = sections.get("validation", "")
         if validation:
-            prompt.append(f"\n## Domain Validation Rules ({skill_name})")
+            prompt.append(f"\n## MANDATORY Domain Validation Rules ({skill_name})")
             prompt.append(validation)
 
 

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -477,10 +477,13 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         
         # Optional preprocessing of first spectrum
         processed_first_spectrum = first_spectrum
+        first_spectrum_preprocess_quality = None
         if self.preprocessor is not None:
             try:
-                processed_first_spectrum, _ = self.preprocessor.run_preprocessing(
-                    first_spectrum, self._handle_system_info(system_info)
+                processed_first_spectrum, first_spectrum_preprocess_quality = (
+                    self.preprocessor.run_preprocessing(
+                        first_spectrum, self._handle_system_info(system_info)
+                    )
                 )
             except Exception as e:
                 self.logger.warning(f"Preprocessing failed: {e}, using raw data")
@@ -509,9 +512,14 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # Load skill if provided
         skill_state = {"skill_name": None, "skill_sections": None}
         if skill:
-            parsed = load_skill(skill, domain="curve_fitting")
-            skill_state = {"skill_name": parsed["name"], "skill_sections": parsed}
-            self.logger.info(f"   Skill loaded: {parsed['name']}")
+            try:
+                parsed = load_skill(skill, domain="curve_fitting")
+                skill_state = {"skill_name": parsed["name"], "skill_sections": parsed}
+                self.logger.info(f"   Skill loaded: {parsed['name']}")
+            except FileNotFoundError:
+                self.logger.warning(
+                    f"   Skill '{skill}' not found — proceeding without domain skill"
+                )
 
         # Extract series metadata from system_info if not provided explicitly
         handled_system_info = self._handle_system_info(system_info)
@@ -548,6 +556,8 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "curve_data": processed_first_spectrum,
             "original_plot_bytes": original_plot_bytes,
             "data_statistics": data_statistics,
+            "first_spectrum_preprocessed": first_spectrum_preprocess_quality is not None,
+            "first_spectrum_preprocess_quality": first_spectrum_preprocess_quality,
 
             # Pipeline state
             "analysis_images": [{"label": "First Spectrum", "data": original_plot_bytes}],

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -167,7 +167,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         use_literature: bool = False,
         run_preprocessing: bool = True,
         enable_human_feedback: bool = True,
-        executor_timeout: int = 60,
+        executor_timeout: int = 300,
         max_wait_time: int = 1000,
         # Quality control settings
         r2_threshold: float = 0.95,

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -264,9 +264,14 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # Load skill if provided
         skill_state = {"skill_name": None, "skill_sections": None}
         if skill:
-            parsed = load_skill(skill, domain="hyperspectral")
-            skill_state = {"skill_name": parsed["name"], "skill_sections": parsed}
-            self.logger.info(f"   Skill loaded: {parsed['name']}")
+            try:
+                parsed = load_skill(skill, domain="hyperspectral")
+                skill_state = {"skill_name": parsed["name"], "skill_sections": parsed}
+                self.logger.info(f"   Skill loaded: {parsed['name']}")
+            except FileNotFoundError:
+                self.logger.warning(
+                    f"   Skill '{skill}' not found — proceeding without domain skill"
+                )
 
         # Load auxiliary data if provided
         auxiliary_state = {

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2083,6 +2083,14 @@ meaning is always preferred over a complex model with marginally better fit stat
 - If residuals show systematic structure, first reconsider the baseline or peak shape
   (e.g., Voigt vs Gaussian) before adding more peaks.
 
+**Domain Skill Rules (when provided):** If a "MANDATORY Domain Skill Rules" section appears \
+below, its rules are MANDATORY constraints on your analysis plan. These rules encode validated \
+domain expertise and override general-purpose defaults. For example, if the skill specifies a \
+particular baseline treatment (e.g., "Shirley background"), you MUST use that treatment — do \
+not substitute your own preference. If the skill specifies line shapes, component constraints, \
+or fitting workflow steps, follow them exactly. Violations of skill rules are treated as errors, \
+not style preferences.
+
 **Common Analysis Approaches** (for reference):
 - Peak fitting (Gaussian, Lorentzian, Voigt, Pseudo-Voigt, Pearson VII, asymmetric profiles)
 - Peak deconvolution (overlapping features with constraints)
@@ -2092,12 +2100,20 @@ meaning is always preferred over a complex model with marginally better fit stat
 - Derivative spectroscopy
 - Peak detection and integration
 
+**Commit to specific choices — do NOT hedge:**
+- State ONE model type, not alternatives (write "Voigt profiles" not "Gaussian or Voigt")
+- State the exact number of components, not a range (write "3 peaks" not "3-4 peaks")
+- Specify the exact baseline/background treatment (write "linear baseline" not "polynomial or linear")
+- If you are unsure between options, pick the one best supported by the data and physics —
+  the user can refine before the plan is locked
+- This plan will be translated directly into code; any ambiguity forces the code generator to guess
+
 **Output Format:**
 ```json
 {
     "observations": "What you see in the data",
     "analysis_approach": "What you will do",
-    "physical_model": "Mathematical form",
+    "physical_model": "Mathematical form — be specific: state the exact profile/function type, exact number of components, and baseline treatment",
     "parameters_to_extract": ["param1", "param2"],
     "fitting_strategy": "How you will fit (initial guesses, constraints, method)",
     "literature_query": "Question for literature search to help with fitting, or null if not needed"
@@ -2170,6 +2186,21 @@ FITTING_SCRIPT_INSTRUCTIONS = """Write a curve fitting script for spectroscopic 
 - Parameters: {parameters_to_extract}
 - Strategy: {fitting_strategy}
 
+**CONFORMANCE REQUIREMENT:** Your script MUST implement exactly what the plan specifies:
+- Use the exact mathematical model described (e.g., if the plan says "Voigt profiles", implement Voigt — not Gaussian, not Lorentzian)
+- Match the exact number of components (e.g., "3 peaks" means 3, not 2 or 4)
+- Match the baseline/background treatment described
+- If the plan specifies exponential decay, implement exponential decay — not a polynomial fit
+- If the Context section below contains "MANDATORY Domain Skill Rules", those rules are \
+binding constraints that MUST be followed in your implementation. Skill rules specify required \
+methods (e.g., Shirley background, Voigt line shapes, spin-orbit constraints) that cannot be \
+substituted with alternatives.
+Deviations are acceptable ONLY when they are obvious from the data dimensions provided \
+(e.g., more parameters than data points). In such cases, implement the closest viable model \
+and document the deviation and reasoning in the results "summary" field. \
+Do NOT preemptively deviate because you think the plan might not converge — implement the \
+plan as specified and let the retry pipeline handle actual runtime failures.
+
 **Context:** {context}
 
 **Data:**
@@ -2219,6 +2250,50 @@ FITTING_SCRIPT_CORRECTION_INSTRUCTIONS = """Fix this failed script.
 **CRITICAL:** Fix only the execution error. Do NOT change the fitting model, its parameters, or the overall analysis approach. The model is locked for series consistency.
 
 **Response:** Return only `{{"diagnosis": "...", "script": "..."}}`
+"""
+
+
+PLAN_CONFORMANCE_CHECK_INSTRUCTIONS = """You are verifying that a Python script correctly implements a scientific analysis plan.
+
+**ANALYSIS PLAN (authoritative specification):**
+- Approach: {analysis_approach}
+- Model: {physical_model}
+- Parameters to extract: {parameters_to_extract}
+- Strategy: {fitting_strategy}
+{skill_rules}
+**GENERATED SCRIPT:**
+```python
+{script}
+```
+
+Compare the script against the plan and determine if the script faithfully implements \
+what the plan describes.
+
+Check:
+1. **Mathematical model**: Does the script implement the same type of model? \
+(e.g., if the plan says "Voigt profiles", does the script use Voigt — not Gaussian? \
+If "bi-exponential decay", does it use two exponentials — not a stretched exponential?)
+2. **Number of components**: Does the script create the number of model components \
+the plan specifies?
+3. **Background/baseline treatment**: Does the script handle the baseline as the plan \
+describes?
+4. **Parameters**: Does the script compute and report the parameters the plan lists?
+5. **Domain skill compliance**: If MANDATORY Domain Skill Rules are listed above, does \
+the script follow ALL of them? (e.g., if the skill requires Shirley background, does \
+the script implement Shirley — not linear or polynomial? If the skill specifies Voigt \
+line shapes, does the script use Voigt — not Gaussian?)
+
+Allow reasonable implementation-level variation (variable naming, optimization algorithm, \
+library choice). A deviation is **justified** only if it is obvious from the data dimensions \
+that the plan cannot work (e.g., more components than data points). In that case the script's \
+"summary" field should explain the deviation. Justified deviations should be marked conformant.
+
+Mark as non-conformant when the script implements a different model or structure than the plan \
+describes without clear justification (e.g., plan says "3 Voigt peaks" but script uses \
+2 Gaussians with no explanation), OR when the script violates mandatory domain skill rules.
+
+Return JSON:
+{{"conformant": true/false, "justified_deviations": ["deviations with stated reasoning, if any"], "unjustified_deviations": ["deviations with no explanation"], "summary": "one sentence"}}
 """
 
 

--- a/scilink/agents/exp_agents/pipelines/curve_fitting_pipelines.py
+++ b/scilink/agents/exp_agents/pipelines/curve_fitting_pipelines.py
@@ -41,6 +41,7 @@ from ..instruct import (
     FITTING_SCRIPT_CORRECTION_INSTRUCTIONS,
     FIT_QUALITY_ASSESSMENT_INSTRUCTIONS,
     FITTING_INTERPRETATION_INSTRUCTIONS,
+    PLAN_CONFORMANCE_CHECK_INSTRUCTIONS,
 )
 
 
@@ -185,7 +186,8 @@ def create_unified_curve_fitting_pipeline(
             enable_human_feedback=enable_human_feedback,
             outlier_sigma=outlier_sigma,
             max_verification_iterations=max_verification_iterations,
-            preprocessor=preprocessor
+            preprocessor=preprocessor,
+            conformance_instructions=PLAN_CONFORMANCE_CHECK_INSTRUCTIONS,
         )
     )
 
@@ -208,6 +210,7 @@ def create_unified_curve_fitting_pipeline(
             max_verification_iterations=max_verification_iterations,
             preprocessor=preprocessor,
             enable_human_feedback=enable_human_feedback,
+            conformance_instructions=PLAN_CONFORMANCE_CHECK_INSTRUCTIONS,
         )
     )
 

--- a/scilink/agents/exp_agents/preprocess.py
+++ b/scilink/agents/exp_agents/preprocess.py
@@ -34,9 +34,9 @@ class HyperspectralPreprocessingAgent(BaseUtilityAgent):
 
     MAX_SCRIPT_ATTEMPTS = 3
 
-    def __init__(self, *args, 
-                 output_dir: str = "preprocessing_output", 
-                 executor_timeout: int = 120,
+    def __init__(self, *args,
+                 output_dir: str = "preprocessing_output",
+                 executor_timeout: int = 300,
                  **kwargs):
         """Initialize the pre-processing agent."""
 
@@ -425,9 +425,9 @@ class CurvePreprocessingAgent(BaseUtilityAgent):
     MAX_SCRIPT_ATTEMPTS = 5
     MAX_MODEL_ATTEMPTS = 5
 
-    def __init__(self, *args, 
-                 output_dir: str = "preprocessing_output", 
-                 executor_timeout: int = 120,
+    def __init__(self, *args,
+                 output_dir: str = "preprocessing_output",
+                 executor_timeout: int = 300,
                  **kwargs):
         """Initialize the 1D pre-processing agent."""
         # Pass output_dir to BaseAnalysisAgent for state management

--- a/scilink/executors.py
+++ b/scilink/executors.py
@@ -10,7 +10,7 @@ import threading
 
 from .auth import get_api_key
 
-DEFAULT_TIMEOUT = 120
+DEFAULT_TIMEOUT = 300
 
 # Global registry of active subprocesses, keyed by thread ID.
 # Accessible from any thread so the UI stop handler can kill them.
@@ -349,7 +349,7 @@ class ExecutionTimeout:
        ``TimeoutError`` into the target thread after *seconds* elapse.
     """
 
-    def __init__(self, seconds: int = 120):
+    def __init__(self, seconds: int = 300):
         self.seconds = seconds
         self._old_handler = None
         self._watchdog: threading.Timer | None = None

--- a/scilink/workflows/dft_workflow.py
+++ b/scilink/workflows/dft_workflow.py
@@ -41,7 +41,7 @@ class DFTWorkflow:
                  local_model: str = None,
                  output_dir: str = "dft_workflow_output",
                  max_refinement_cycles: int = 4,
-                 script_timeout: int = 180,
+                 script_timeout: int = 300,
                  vasp_generator_method: str = "llm"):
         """
         Initializes the DFT workflow and its constituent agents.


### PR DESCRIPTION
Add plan-conformance check, fix redundant preprocessing, and handle missing skills gracefully

- Add LLM-based conformance check that verifies generated fitting scripts
  match the locked analysis plan (model type, component count, baseline)
- Strengthen planning prompt to require unambiguous model choices
  (no hedging like "Gaussian or Voigt")
- Strengthen script-generation prompt with explicit conformance requirement
- Allow justified deviations when plan is obviously incompatible with data
- Skip redundant preprocessing for spectrum 0 when already done in planning stage
- Handle missing domain skills gracefully (warn and continue) instead of
  crashing the entire analysis (affects CurveFitting and Hyperspectral agents)
- Recognize elapsed time as a legitimate series control variable for
  in-situ/time-resolved experiments