### PR TITLE
Add MCP server to expose SciLink tools to external clients

### DIFF
--- a/docs/claude_code_integration.md
+++ b/docs/claude_code_integration.md
@@ -7,7 +7,9 @@ SciLink can run as an MCP (Model Context Protocol) server, making its analysis a
 ### 1. Install SciLink with MCP support
 
 ```bash
-pip install -e ".[mcp]"
+pip install -e ".[mcp]"          # MCP server only
+pip install -e ".[ui,mcp]"       # MCP server + Streamlit UI
+pip install -e ".[all]"          # everything (UI + MCP + simulation)
 ```
 
 ### 2a. Claude Code — register the MCP server

--- a/docs/claude_code_integration.md
+++ b/docs/claude_code_integration.md
@@ -1,0 +1,173 @@
+# Using SciLink with Claude Code
+
+SciLink can run as an MCP (Model Context Protocol) server, making its analysis and planning tools available directly inside Claude Code. This lets you analyze experimental data through natural conversation — Claude calls SciLink's tools automatically based on your requests.
+
+## Setup
+
+### 1. Install SciLink with MCP support
+
+```bash
+pip install -e ".[mcp]"
+```
+
+### 2. Register the MCP server
+
+```bash
+claude mcp add scilink -s user \
+  -e GEMINI_API_KEY=your-gemini-key \
+  -e UNSAFE_EXECUTION_OK=true \
+  -e "PATH=$(dirname $(which python)):$PATH" \
+  -- $(which scilink) serve --mode analyze
+```
+
+**Flags explained:**
+- `-s user` — available from any directory (use `-s project` to limit to one repo)
+- `-e GEMINI_API_KEY=...` — API key for the LLM backend (also supports `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`)
+- `-e UNSAFE_EXECUTION_OK=true` — allows code execution without a sandbox prompt (required since there's no terminal to approve interactively)
+- `-e PATH=...` — ensures the `python` command is found during code execution
+- `--mode analyze` — expose analysis tools (use `plan` for planning tools, or `both` for all)
+
+### 3. Restart Claude Code
+
+Start a new Claude Code session. You should see the SciLink MCP server connecting on startup.
+
+## Available tools
+
+Once connected, Claude Code has access to these SciLink tools:
+
+| Tool | Description |
+|------|-------------|
+| `scilink_examine_data` | Inspect a data file (type, shape, suggested agents) |
+| `scilink_convert_metadata` | Convert a text description to structured metadata |
+| `scilink_load_metadata` | Load metadata from a JSON file or directory |
+| `scilink_select_agent` | Choose an analysis agent (FFT, SAM, Hyperspectral, CurveFitting) |
+| `scilink_preview_image` | Preview a microscopy image |
+| `scilink_run_analysis` | Run analysis with the selected agent |
+| `scilink_list_results` | List completed analyses in the session |
+| `scilink_get_recommendations` | Get follow-up experiment suggestions |
+| `scilink_assess_novelty` | Literature search for novelty of findings |
+| `scilink_synthesize_knowledge` | Build reusable knowledge from results |
+| `scilink_save_checkpoint` | Save session state |
+| `scilink_show_available_agents` | List available analysis agents |
+
+## Usage examples
+
+Just chat naturally with Claude Code. It will call the SciLink tools as needed.
+
+### Analyze a spectrum
+
+```
+Examine /path/to/xps_data.csv and tell me what kind of data it is
+```
+
+### Set metadata and run analysis
+
+```
+This is XPS Ti 2p data from a TiO2 thin film collected with Al K-alpha at 1486.6 eV.
+Load the metadata, select the curve fitting agent, and analyze with the xps skill.
+```
+
+### Analyze a microscopy image
+
+```
+Examine /path/to/sem_image.tif, preview it, and run particle segmentation
+```
+
+### Batch analysis
+
+```
+Examine the directory /path/to/spectra/ and run a series analysis
+with temperature as the control variable
+```
+
+### Get follow-up suggestions
+
+```
+List my analysis results and get measurement recommendations for the most recent one
+```
+
+## Server options
+
+The `scilink serve` command accepts several flags:
+
+```bash
+scilink serve --help
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--model` | `gemini-3.1-pro-preview` | LLM model for analysis agents |
+| `--mode` | `both` | `analyze`, `plan`, or `both` |
+| `--autonomy` | `autonomous` | `autonomous`, `supervised`, or `co-pilot` |
+| `--session-dir` | auto-generated | Directory for session outputs |
+| `--api-key` | from env vars | Override API key |
+| `--base-url` | none | OpenAI-compatible endpoint |
+
+## Planning tools
+
+When using `--mode plan` or `--mode both`, additional planning tools are available:
+
+| Tool | Description |
+|------|-------------|
+| `scilink_list_workspace_files` | List files in the session directory |
+| `scilink_generate_initial_plan` | Generate an experimental plan |
+| `scilink_generate_implementation_code` | Add implementation code to a plan |
+| `scilink_run_economic_analysis` | Techno-economic analysis |
+| `scilink_refine_plan_with_results` | Refine plan based on results |
+| `scilink_refine_implementation_code` | Update implementation code |
+| `scilink_analyze_file` | Analyze a result file for optimization |
+| `scilink_analyze_batch` | Batch analysis for optimization |
+| `scilink_reset_analysis_logic` | Reset the scalarizer |
+| `scilink_run_optimization` | Run Bayesian optimization |
+| `scilink_plan_save_checkpoint` | Save planning session state |
+| `scilink_discard_plan` | Discard the current plan |
+| `scilink_show_directory_guide` | Show project directory structure |
+
+## Autonomy modes
+
+Control how much approval SciLink requires before executing actions:
+
+```bash
+scilink serve --autonomy autonomous   # default — all tools run immediately
+scilink serve --autonomy supervised   # high-impact tools pause for approval
+scilink serve --autonomy co-pilot     # most tools pause for approval
+```
+
+In **supervised** and **co-pilot** modes, high-impact tools (like `run_analysis`, `run_optimization`) return a `needs_input` response instead of executing. The MCP client then shows the proposed action to the user and calls `scilink_respond` with `"yes"` to approve or `"no"` to cancel.
+
+Tools that require approval:
+- **Co-pilot**: `run_analysis`, `select_agent`, `assess_novelty`, `get_recommendations`, `run_optimization`, `generate_initial_plan`, `generate_implementation_code`, `run_economic_analysis`, `discard_plan`
+- **Supervised**: `run_analysis`, `run_optimization`, `discard_plan`
+
+## Session outputs
+
+Analysis results are saved to `~/scilink_mcp_sessions/session_<timestamp>/`. Each analysis run creates a subdirectory with:
+- Fitted curves and plots
+- `analysis_results.json` with detailed findings
+- Scientific claims and recommendations
+
+## Troubleshooting
+
+### Server not connecting
+Verify the server works standalone:
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | scilink serve --mode analyze 2>/dev/null
+```
+
+### `python` not found during analysis
+Ensure the `PATH` env var in the MCP config includes the directory containing `python`. Use:
+```bash
+-e "PATH=$(dirname $(which python)):$PATH"
+```
+
+### Tools not appearing
+- Run `claude mcp list` to verify the server is registered
+- Make sure `scilink serve` is available (the feature branch must be installed)
+- Restart Claude Code after adding the MCP server
+
+### Managing the server
+```bash
+claude mcp list              # list configured servers
+claude mcp get scilink       # show config details
+claude mcp remove scilink    # remove the server
+```

--- a/docs/claude_code_integration.md
+++ b/docs/claude_code_integration.md
@@ -1,6 +1,6 @@
-# Using SciLink with Claude Code
+# Using SciLink as an MCP Server
 
-SciLink can run as an MCP (Model Context Protocol) server, making its analysis and planning tools available directly inside Claude Code. This lets you analyze experimental data through natural conversation — Claude calls SciLink's tools automatically based on your requests.
+SciLink can run as an MCP (Model Context Protocol) server, making its analysis and planning tools available to any MCP client — Claude Code, Claude Desktop, Cursor, or any other compatible tool.
 
 ## Setup
 
@@ -10,7 +10,7 @@ SciLink can run as an MCP (Model Context Protocol) server, making its analysis a
 pip install -e ".[mcp]"
 ```
 
-### 2. Register the MCP server
+### 2a. Claude Code — register the MCP server
 
 ```bash
 claude mcp add scilink -s user \
@@ -27,13 +27,53 @@ claude mcp add scilink -s user \
 - `-e PATH=...` — ensures the `python` command is found during code execution
 - `--mode analyze` — expose analysis tools (use `plan` for planning tools, or `both` for all)
 
-### 3. Restart Claude Code
+Restart Claude Code after adding.
 
-Start a new Claude Code session. You should see the SciLink MCP server connecting on startup.
+### 2b. Claude Desktop — edit config
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "scilink": {
+      "command": "/path/to/scilink",
+      "args": ["serve", "--mode", "analyze"],
+      "env": {
+        "GEMINI_API_KEY": "your-key",
+        "UNSAFE_EXECUTION_OK": "true",
+        "PATH": "/path/to/python/bin:/usr/local/bin:/usr/bin:/bin"
+      }
+    }
+  }
+}
+```
+
+Replace `/path/to/scilink` with the full path (find it with `which scilink`).
+Restart Claude Desktop after editing.
+
+### 2c. SSE transport — any MCP client
+
+Start the server as a long-lived HTTP service:
+
+```bash
+scilink serve --mode analyze --transport sse --port 8000
+```
+
+Then connect your MCP client to `http://127.0.0.1:8000/sse`.
+
+### 2d. Direct command
+
+SciLink also installs a `scilink-mcp` entry point that goes directly to the server:
+
+```bash
+scilink-mcp --mode analyze                         # stdio (default)
+scilink-mcp --mode both --transport sse --port 8000  # SSE
+```
 
 ## Available tools
 
-Once connected, Claude Code has access to these SciLink tools:
+### Analysis tools
 
 | Tool | Description |
 |------|-------------|
@@ -49,10 +89,43 @@ Once connected, Claude Code has access to these SciLink tools:
 | `scilink_synthesize_knowledge` | Build reusable knowledge from results |
 | `scilink_save_checkpoint` | Save session state |
 | `scilink_show_available_agents` | List available analysis agents |
+| `scilink_set_preprocessing_instruction` | Add custom preprocessing steps |
+| `scilink_get_metadata_schema` | View required/optional metadata fields |
+| `scilink_list_knowledge` | List active knowledge entries |
+| `scilink_clear_knowledge` | Remove knowledge entries |
+
+### Planning tools
+
+Available with `--mode plan` or `--mode both`:
+
+| Tool | Description |
+|------|-------------|
+| `scilink_list_workspace_files` | List files in the session directory |
+| `scilink_generate_initial_plan` | Generate an experimental plan |
+| `scilink_generate_implementation_code` | Add implementation code to a plan |
+| `scilink_run_economic_analysis` | Techno-economic analysis |
+| `scilink_refine_plan_with_results` | Refine plan based on results |
+| `scilink_refine_implementation_code` | Update implementation code |
+| `scilink_analyze_file` | Analyze a result file for optimization |
+| `scilink_analyze_batch` | Batch analysis for optimization |
+| `scilink_reset_analysis_logic` | Reset the scalarizer |
+| `scilink_run_optimization` | Run Bayesian optimization |
+| `scilink_plan_save_checkpoint` | Save planning session state |
+| `scilink_discard_plan` | Discard the current plan |
+| `scilink_show_directory_guide` | Show project directory structure |
+
+### Session management tools
+
+| Tool | Description |
+|------|-------------|
+| `scilink_set_autonomy` | Switch between autonomous/supervised/co-pilot modes at runtime |
+| `scilink_respond` | Approve or reject a pending action (co-pilot/supervised modes) |
+| `scilink_job_status` | Check status of a background job |
+| `scilink_job_result` | Retrieve result of a completed background job |
 
 ## Usage examples
 
-Just chat naturally with Claude Code. It will call the SciLink tools as needed.
+Just chat naturally. The LLM calls SciLink tools automatically.
 
 ### Analyze a spectrum
 
@@ -66,6 +139,14 @@ Examine /path/to/xps_data.csv and tell me what kind of data it is
 This is XPS Ti 2p data from a TiO2 thin film collected with Al K-alpha at 1486.6 eV.
 Load the metadata, select the curve fitting agent, and analyze with the xps skill.
 ```
+
+### Run analysis in background (avoids timeouts)
+
+```
+Run analysis on the current data with background=true
+```
+
+Then the LLM will poll with `scilink_job_status` and retrieve with `scilink_job_result`.
 
 ### Analyze a microscopy image
 
@@ -88,8 +169,6 @@ List my analysis results and get measurement recommendations for the most recent
 
 ## Server options
 
-The `scilink serve` command accepts several flags:
-
 ```bash
 scilink serve --help
 ```
@@ -99,33 +178,17 @@ scilink serve --help
 | `--model` | `gemini-3.1-pro-preview` | LLM model for analysis agents |
 | `--mode` | `both` | `analyze`, `plan`, or `both` |
 | `--autonomy` | `autonomous` | `autonomous`, `supervised`, or `co-pilot` |
+| `--transport` | `stdio` | `stdio` or `sse` |
+| `--host` | `127.0.0.1` | Bind address (SSE only) |
+| `--port` | `8000` | Bind port (SSE only) |
 | `--session-dir` | auto-generated | Directory for session outputs |
 | `--api-key` | from env vars | Override API key |
 | `--base-url` | none | OpenAI-compatible endpoint |
-
-## Planning tools
-
-When using `--mode plan` or `--mode both`, additional planning tools are available:
-
-| Tool | Description |
-|------|-------------|
-| `scilink_list_workspace_files` | List files in the session directory |
-| `scilink_generate_initial_plan` | Generate an experimental plan |
-| `scilink_generate_implementation_code` | Add implementation code to a plan |
-| `scilink_run_economic_analysis` | Techno-economic analysis |
-| `scilink_refine_plan_with_results` | Refine plan based on results |
-| `scilink_refine_implementation_code` | Update implementation code |
-| `scilink_analyze_file` | Analyze a result file for optimization |
-| `scilink_analyze_batch` | Batch analysis for optimization |
-| `scilink_reset_analysis_logic` | Reset the scalarizer |
-| `scilink_run_optimization` | Run Bayesian optimization |
-| `scilink_plan_save_checkpoint` | Save planning session state |
-| `scilink_discard_plan` | Discard the current plan |
-| `scilink_show_directory_guide` | Show project directory structure |
+| `--futurehouse-key` | from env vars | FutureHouse/Edison API key |
 
 ## Autonomy modes
 
-Control how much approval SciLink requires before executing actions:
+Control how much approval SciLink requires:
 
 ```bash
 scilink serve --autonomy autonomous   # default — all tools run immediately
@@ -133,15 +196,32 @@ scilink serve --autonomy supervised   # high-impact tools pause for approval
 scilink serve --autonomy co-pilot     # most tools pause for approval
 ```
 
-In **supervised** and **co-pilot** modes, high-impact tools (like `run_analysis`, `run_optimization`) return a `needs_input` response instead of executing. The MCP client then shows the proposed action to the user and calls `scilink_respond` with `"yes"` to approve or `"no"` to cancel.
+You can also switch at runtime by asking the LLM to call `scilink_set_autonomy`.
+
+In **supervised** and **co-pilot** modes, high-impact tools return a `needs_input` response instead of executing. The MCP client calls `scilink_respond` with `"yes"` to approve or `"no"` to cancel.
 
 Tools that require approval:
 - **Co-pilot**: `run_analysis`, `select_agent`, `assess_novelty`, `get_recommendations`, `run_optimization`, `generate_initial_plan`, `generate_implementation_code`, `run_economic_analysis`, `discard_plan`
 - **Supervised**: `run_analysis`, `run_optimization`, `discard_plan`
 
+## Background execution
+
+Long-running tools (`run_analysis`, `run_optimization`) support an optional `background=true` parameter that returns a job ID immediately instead of blocking. This avoids timeouts in clients like Claude Desktop.
+
+```
+run_analysis(data_path="...", background=true)
+→ {"status": "started", "job_id": "job_20260308_130923_001"}
+
+job_status(job_id="job_20260308_130923_001")
+→ {"status": "running"} or {"status": "completed"}
+
+job_result(job_id="job_20260308_130923_001")
+→ full analysis result
+```
+
 ## Session outputs
 
-Analysis results are saved to `~/scilink_mcp_sessions/session_<timestamp>/`. Each analysis run creates a subdirectory with:
+Results are saved to `~/scilink_mcp_sessions/session_<timestamp>/`. Each analysis run creates a subdirectory with:
 - Fitted curves and plots
 - `analysis_results.json` with detailed findings
 - Scientific claims and recommendations
@@ -155,17 +235,20 @@ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":
 ```
 
 ### `python` not found during analysis
-Ensure the `PATH` env var in the MCP config includes the directory containing `python`. Use:
+Ensure the `PATH` env var in the MCP config includes the directory containing `python`:
 ```bash
 -e "PATH=$(dirname $(which python)):$PATH"
 ```
 
+### Analysis times out (Claude Desktop)
+Claude Desktop has a ~4 minute timeout on tool calls. Use `background=true` for long-running analyses, or use Claude Code which has no timeout.
+
 ### Tools not appearing
 - Run `claude mcp list` to verify the server is registered
-- Make sure `scilink serve` is available (the feature branch must be installed)
-- Restart Claude Code after adding the MCP server
+- Make sure `scilink serve` is available (`pip install -e .`)
+- Restart the client after adding the MCP server
 
-### Managing the server
+### Managing the server (Claude Code)
 ```bash
 claude mcp list              # list configured servers
 claude mcp get scilink       # show config details

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ scilink = "scilink.cli.main:main"
 scilink-workflows = "scilink.cli.workflows:main"
 scilink-agent = "scilink.cli.run_agent:main"
 scilink-ui = "scilink.cli.ui:main"
+scilink-mcp = "scilink.cli.serve:main"
 
 # Third-party packages can advertise custom analysis agents here.
 # SciLink discovers these automatically on startup via importlib.metadata.

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -518,15 +518,18 @@ class PlanningOrchestratorAgent:
         
         # --- Init Sub-Agents ---
         print("🤖 Agent: Hiring sub-agents...")
-        self.planner = PlanningAgent(
+        planner_kwargs = dict(
             api_key=api_key,
             model_name=model_name,
             base_url=base_url,
             embedding_model=embedding_model,
             embedding_api_key=embedding_api_key,
             futurehouse_api_key=futurehouse_api_key,
-            output_dir=str(self.base_dir)
+            output_dir=str(self.base_dir),
         )
+        if self.knowledge_dir:
+            planner_kwargs["kb_base_path"] = str(self.knowledge_dir / "default_kb")
+        self.planner = PlanningAgent(**planner_kwargs)
         self.scalarizer = ScalarizerAgent(
             api_key=api_key,
             model_name=model_name,

--- a/scilink/cli/main.py
+++ b/scilink/cli/main.py
@@ -113,9 +113,15 @@ def print_gradient_logo():
 def main():
     """Main CLI entry point with subcommands"""
     
+    # Skip logo for MCP server mode (stdout is the transport)
+    if len(sys.argv) >= 2 and sys.argv[1] == 'serve':
+        from scilink.cli.serve import main as serve_main
+        sys.argv = [sys.argv[0] + ' serve'] + sys.argv[2:]
+        return serve_main()
+
     # Always show logo first
     print_gradient_logo()
-    
+
     if len(sys.argv) < 2:
         print()  # Spacing after logo
         print_usage()
@@ -143,6 +149,11 @@ def main():
         from scilink.cli.ui import main as ui_main
         sys.argv = [sys.argv[0] + ' ui'] + sys.argv[2:]
         return ui_main()
+
+    elif command == 'serve':
+        from scilink.cli.serve import main as serve_main
+        sys.argv = [sys.argv[0] + ' serve'] + sys.argv[2:]
+        return serve_main()
 
     elif command in ['-h', '--help', 'help']:
         print()  # Spacing after logo
@@ -179,6 +190,10 @@ Available Commands:
 
   ui            Launch the Streamlit web interface for interactive
                 analysis (requires: pip install scilink[ui])
+
+  serve         Start SciLink as an MCP tool server so external clients
+                (Claude Desktop, Cursor) can use SciLink's tools
+                (requires: pip install scilink[mcp])
 
 Examples:
   scilink plan                              # Start planning orchestrator

--- a/scilink/cli/serve.py
+++ b/scilink/cli/serve.py
@@ -1,0 +1,134 @@
+"""CLI entry point for the SciLink MCP server.
+
+Usage::
+
+    scilink serve                                      # defaults
+    scilink serve --model gemini-3.1-pro-preview       # specific model
+    scilink serve --mode analyze                       # analysis tools only
+    scilink serve --autonomy co-pilot                  # require approval
+    scilink serve --transport sse --port 8000           # SSE transport
+"""
+
+import argparse
+import os
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="scilink serve",
+        description="Start SciLink as an MCP tool server.",
+    )
+
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=os.environ.get("SCILINK_MODEL", "gemini-3.1-pro-preview"),
+        help="LLM model name (default: gemini-3.1-pro-preview)",
+    )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help="API key (default: auto-detect from env vars)",
+    )
+    parser.add_argument(
+        "--base-url",
+        type=str,
+        default=None,
+        help="OpenAI-compatible endpoint URL",
+    )
+    parser.add_argument(
+        "--mode",
+        type=str,
+        choices=["analyze", "plan", "both"],
+        default="both",
+        help="Which tool sets to expose (default: both)",
+    )
+    parser.add_argument(
+        "--autonomy",
+        type=str,
+        choices=["autonomous", "supervised", "co-pilot"],
+        default="autonomous",
+        help="Autonomy level (default: autonomous)",
+    )
+    parser.add_argument(
+        "--session-dir",
+        type=str,
+        default=None,
+        help="Session directory for outputs (default: auto-generated)",
+    )
+    parser.add_argument(
+        "--transport",
+        type=str,
+        choices=["stdio"],
+        default="stdio",
+        help="MCP transport (default: stdio)",
+    )
+    parser.add_argument(
+        "--futurehouse-key",
+        type=str,
+        default=None,
+        help="FutureHouse/Edison API key for novelty assessment",
+    )
+
+    args = parser.parse_args()
+
+    # Resolve API key
+    api_key = args.api_key
+    if api_key is None:
+        for env_var in [
+            "SCILINK_API_KEY",
+            "GEMINI_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ]:
+            api_key = os.environ.get(env_var)
+            if api_key:
+                break
+
+    # The MCP stdio transport reads sys.stdin.buffer and writes
+    # sys.stdout.buffer.  Save the real stdout before redirecting
+    # Python-level sys.stdout to stderr, so print() calls from
+    # orchestrator init / tool execution go to stderr instead of
+    # corrupting the JSON-RPC stream.
+    import logging
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(levelname)s: %(message)s",
+        stream=sys.stderr,
+    )
+    _real_stdout = sys.stdout
+    sys.stdout = sys.stderr
+
+    try:
+        from scilink.mcp_server import create_server, run_stdio
+    except ImportError as exc:
+        print(
+            f"Error: {exc}\n"
+            "Install MCP support with: pip install scilink[mcp]",
+            file=sys.stderr,
+        )
+        return 1
+
+    server = create_server(
+        api_key=api_key,
+        model_name=args.model,
+        base_url=args.base_url,
+        mode=args.mode,
+        session_dir=args.session_dir,
+        analysis_mode=args.autonomy,
+        futurehouse_api_key=args.futurehouse_key,
+    )
+
+    # Initialize orchestrators eagerly so tools/list responds instantly.
+    # Claude Desktop times out after ~5 seconds.
+    server.eager_init()
+
+    import asyncio
+    asyncio.run(run_stdio(server, real_stdout=_real_stdout))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scilink/cli/serve.py
+++ b/scilink/cli/serve.py
@@ -61,9 +61,21 @@ def main():
     parser.add_argument(
         "--transport",
         type=str,
-        choices=["stdio"],
+        choices=["stdio", "sse"],
         default="stdio",
         help="MCP transport (default: stdio)",
+    )
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help="Bind address for SSE transport (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Bind port for SSE transport (default: 8000)",
     )
     parser.add_argument(
         "--futurehouse-key",
@@ -102,7 +114,7 @@ def main():
     sys.stdout = sys.stderr
 
     try:
-        from scilink.mcp_server import create_server, run_stdio
+        from scilink.mcp_server import create_server, run_stdio, run_sse
     except ImportError as exc:
         print(
             f"Error: {exc}\n"
@@ -125,8 +137,18 @@ def main():
     # Claude Desktop times out after ~5 seconds.
     server.eager_init()
 
-    import asyncio
-    asyncio.run(run_stdio(server, real_stdout=_real_stdout))
+    if args.transport == "sse":
+        # SSE doesn't need stdout redirection — it's HTTP, not stdio.
+        print(
+            f"Starting SciLink MCP server (SSE) on "
+            f"http://{args.host}:{args.port}/sse",
+            file=sys.stderr,
+        )
+        run_sse(server, host=args.host, port=args.port)
+    else:
+        import asyncio
+        asyncio.run(run_stdio(server, real_stdout=_real_stdout))
+
     return 0
 
 

--- a/scilink/mcp_server.py
+++ b/scilink/mcp_server.py
@@ -17,10 +17,12 @@ Requires the ``mcp`` optional dependency::
 """
 
 import asyncio
+import concurrent.futures
 import contextlib
 import io
 import json
 import logging
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 try:
@@ -53,6 +55,11 @@ _SUPERVISED_APPROVAL_TOOLS = {
     "run_analysis", "run_optimization", "discard_plan",
 }
 
+# Tools that support optional background execution via ``background=true``.
+_BACKGROUND_CAPABLE_TOOLS = {
+    "run_analysis", "run_optimization",
+}
+
 
 # ── Schema conversion ───────────────────────────────────────────────────
 
@@ -60,10 +67,25 @@ def _openai_to_mcp_tool(schema: dict, prefix: str = "scilink") -> types.Tool:
     """Convert an OpenAI function-calling schema to an MCP Tool object."""
     fn = schema.get("function", schema)
     name = fn.get("name", "")
+    input_schema = fn.get("parameters", {"type": "object", "properties": {}})
+
+    # Add optional ``background`` parameter for long-running tools.
+    if name in _BACKGROUND_CAPABLE_TOOLS:
+        schema_copy = json.loads(json.dumps(input_schema))
+        schema_copy.setdefault("properties", {})["background"] = {
+            "type": "boolean",
+            "description": (
+                "If true, run in the background and return a job_id "
+                "immediately. Use scilink_job_status and scilink_job_result "
+                "to poll and retrieve results. Default: false (blocking)."
+            ),
+        }
+        input_schema = schema_copy
+
     return types.Tool(
         name=f"{prefix}_{name}" if prefix else name,
         description=fn.get("description", ""),
-        inputSchema=fn.get("parameters", {"type": "object", "properties": {}}),
+        inputSchema=input_schema,
     )
 
 
@@ -149,11 +171,16 @@ def create_server(
     server = Server("scilink")
 
     # ── State (initialized lazily on first tool list) ────────────────
+    # Thread pool for background jobs
+    _executor = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+
     state: Dict[str, Any] = {
         "analysis_orch": None,
         "planning_orch": None,
         "pending_action": None,
         "initialized": False,
+        "jobs": {},
+        "job_counter": 0,
         "config": {
             "api_key": api_key,
             "model_name": model_name,
@@ -228,29 +255,66 @@ def create_server(
                     prefix = "scilink"
                 tools.append(_openai_to_mcp_tool(schema, prefix=prefix))
 
-        # Add the respond tool for co-pilot/supervised modes
-        if state["config"]["analysis_mode"] != "autonomous":
-            tools.append(types.Tool(
-                name="scilink_respond",
-                description=(
-                    "Send a response to a pending SciLink action that requires "
-                    "human approval. Call this after receiving a 'needs_input' "
-                    "status from another tool."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "response": {
-                            "type": "string",
-                            "description": (
-                                "User's response: 'yes'/'approve' to proceed, "
-                                "'no'/'reject' to cancel, or free-text feedback."
-                            ),
-                        },
+        # Always include scilink_respond so it's available if the user
+        # switches to co-pilot/supervised mode mid-session via
+        # scilink_set_autonomy (MCP clients only call tools/list once).
+        tools.append(types.Tool(
+            name="scilink_respond",
+            description=(
+                "Send a response to a pending SciLink action that requires "
+                "human approval. Only needed in co-pilot or supervised mode. "
+                "Call this after receiving a 'needs_input' status from another tool."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "response": {
+                        "type": "string",
+                        "description": (
+                            "User's response: 'yes'/'approve' to proceed, "
+                            "'no'/'reject' to cancel, or free-text feedback."
+                        ),
                     },
-                    "required": ["response"],
                 },
-            ))
+                "required": ["response"],
+            },
+        ))
+
+        # Background job management tools
+        tools.append(types.Tool(
+            name="scilink_job_status",
+            description=(
+                "Check the status of a background job started with "
+                "background=true. Returns 'running', 'completed', or 'failed'."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "job_id": {
+                        "type": "string",
+                        "description": "The job ID returned by the original tool call.",
+                    },
+                },
+                "required": ["job_id"],
+            },
+        ))
+        tools.append(types.Tool(
+            name="scilink_job_result",
+            description=(
+                "Retrieve the full result of a completed background job. "
+                "Returns an error if the job is still running."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "job_id": {
+                        "type": "string",
+                        "description": "The job ID returned by the original tool call.",
+                    },
+                },
+                "required": ["job_id"],
+            },
+        ))
 
         # Always add the set_autonomy tool
         tools.append(types.Tool(
@@ -293,6 +357,12 @@ def create_server(
         if name == "scilink_set_autonomy":
             return _handle_set_autonomy(state, arguments)
 
+        # Handle background job status/result
+        if name == "scilink_job_status":
+            return _handle_job_status(state, arguments)
+        if name == "scilink_job_result":
+            return _handle_job_result(state, arguments)
+
         # Look up which orchestrator owns this tool
         if name not in tool_map:
             return [types.TextContent(
@@ -323,6 +393,39 @@ def create_server(
                     "message": prompt,
                     "tool": original_name,
                     "arguments": arguments,
+                }),
+            )]
+
+        # Background execution: if background=true and tool supports it,
+        # submit to thread pool and return job_id immediately.
+        run_in_background = arguments.pop("background", False)
+        if run_in_background and original_name in _BACKGROUND_CAPABLE_TOOLS:
+            state["job_counter"] += 1
+            ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+            job_id = f"job_{ts}_{state['job_counter']:03d}"
+
+            future = _executor.submit(
+                _execute_tool_captured, orch.tools, original_name, arguments
+            )
+            state["jobs"][job_id] = {
+                "future": future,
+                "tool": original_name,
+                "started_at": ts,
+                "status": "running",
+                "result": None,
+            }
+
+            return [types.TextContent(
+                type="text",
+                text=json.dumps({
+                    "status": "started",
+                    "job_id": job_id,
+                    "tool": original_name,
+                    "message": (
+                        f"Analysis running in background (job {job_id}). "
+                        "Use scilink_job_status to check progress, "
+                        "then scilink_job_result to retrieve the result."
+                    ),
                 }),
             )]
 
@@ -518,6 +621,86 @@ def _init_orchestrators(state: dict, config: dict) -> None:
             )
         except Exception as exc:
             logging.warning(f"Planning orchestrator not available: {exc}")
+
+
+# ── Background job handlers ──────────────────────────────────────────────
+
+def _handle_job_status(
+    state: dict, arguments: dict
+) -> List["types.TextContent"]:
+    """Check the status of a background job."""
+    job_id = arguments.get("job_id", "")
+    job = state["jobs"].get(job_id)
+    if job is None:
+        return [types.TextContent(
+            type="text",
+            text=json.dumps({
+                "status": "error",
+                "message": f"Unknown job_id: {job_id}",
+            }),
+        )]
+
+    future = job["future"]
+    if future.done():
+        try:
+            result = future.result()
+            job["status"] = "completed"
+            job["result"] = result
+        except Exception as exc:
+            job["status"] = "failed"
+            job["result"] = json.dumps({
+                "status": "error", "message": str(exc),
+            })
+
+    return [types.TextContent(
+        type="text",
+        text=json.dumps({
+            "job_id": job_id,
+            "status": job["status"],
+            "tool": job["tool"],
+            "started_at": job["started_at"],
+        }),
+    )]
+
+
+def _handle_job_result(
+    state: dict, arguments: dict
+) -> List["types.TextContent"]:
+    """Retrieve the result of a completed background job."""
+    job_id = arguments.get("job_id", "")
+    job = state["jobs"].get(job_id)
+    if job is None:
+        return [types.TextContent(
+            type="text",
+            text=json.dumps({
+                "status": "error",
+                "message": f"Unknown job_id: {job_id}",
+            }),
+        )]
+
+    future = job["future"]
+    if not future.done():
+        return [types.TextContent(
+            type="text",
+            text=json.dumps({
+                "status": "running",
+                "job_id": job_id,
+                "message": "Job is still running. Check again later with scilink_job_status.",
+            }),
+        )]
+
+    # Ensure result is captured
+    if job["result"] is None:
+        try:
+            job["result"] = future.result()
+            job["status"] = "completed"
+        except Exception as exc:
+            job["result"] = json.dumps({
+                "status": "error", "message": str(exc),
+            })
+            job["status"] = "failed"
+
+    return [types.TextContent(type="text", text=job["result"])]
 
 
 # ── Autonomy mode switch ─────────────────────────────────────────────────

--- a/scilink/mcp_server.py
+++ b/scilink/mcp_server.py
@@ -40,6 +40,20 @@ def _require_mcp():
         )
 
 
+# Tools that require user approval in co-pilot / supervised modes.
+# In co-pilot mode ALL of these pause; in supervised mode only the
+# high-impact subset (run_analysis, run_optimization) pauses.
+_COPILOT_APPROVAL_TOOLS = {
+    "run_analysis", "select_agent", "assess_novelty",
+    "get_recommendations", "run_optimization", "generate_initial_plan",
+    "generate_implementation_code", "run_economic_analysis",
+    "discard_plan",
+}
+_SUPERVISED_APPROVAL_TOOLS = {
+    "run_analysis", "run_optimization", "discard_plan",
+}
+
+
 # ── Schema conversion ───────────────────────────────────────────────────
 
 def _openai_to_mcp_tool(schema: dict, prefix: str = "scilink") -> types.Tool:
@@ -78,6 +92,30 @@ class PendingAction:
         self.kwargs = kwargs
         self.prompt = prompt
         self.context = context or {}
+
+
+def _needs_approval(tool_name: str, mode: str) -> bool:
+    """Check whether a tool requires user approval given the autonomy mode."""
+    if mode == "autonomous":
+        return False
+    if mode in ("co-pilot", "co_pilot", "copilot"):
+        return tool_name in _COPILOT_APPROVAL_TOOLS
+    if mode == "supervised":
+        return tool_name in _SUPERVISED_APPROVAL_TOOLS
+    return False
+
+
+def _build_approval_prompt(tool_name: str, kwargs: dict) -> str:
+    """Build a human-readable description of the pending action."""
+    parts = [f"SciLink wants to execute: {tool_name}"]
+    if kwargs:
+        for k, v in kwargs.items():
+            val = str(v)
+            if len(val) > 100:
+                val = val[:100] + "..."
+            parts.append(f"  {k}: {val}")
+    parts.append("\nCall scilink_respond with 'yes' to approve or 'no' to cancel.")
+    return "\n".join(parts)
 
 
 # ── Server factory ──────────────────────────────────────────────────────
@@ -143,19 +181,18 @@ def create_server(
         if log:
             logging.info(f"[init] {log}")
 
-        # Build tool map
+        # Build tool map — analysis tools first, then planning with
+        # collision avoidance (prefix colliding names with "plan_").
         if state["analysis_orch"]:
             for schema in state["analysis_orch"].tools.openai_schemas:
                 fn_name = schema.get("function", {}).get("name", "")
                 if fn_name:
-                    mcp_name = f"scilink_{fn_name}"
-                    tool_map[mcp_name] = ("analysis_orch", fn_name)
+                    tool_map[f"scilink_{fn_name}"] = ("analysis_orch", fn_name)
 
         if state["planning_orch"]:
             for schema in state["planning_orch"].tools.openai_schemas:
                 fn_name = schema.get("function", {}).get("name", "")
                 if fn_name:
-                    # Avoid collisions with analysis tools
                     mcp_name = f"scilink_{fn_name}"
                     if mcp_name in tool_map:
                         mcp_name = f"scilink_plan_{fn_name}"
@@ -179,15 +216,12 @@ def create_server(
 
         if state["analysis_orch"]:
             for schema in state["analysis_orch"].tools.openai_schemas:
-                fn_name = schema.get("function", {}).get("name", "")
-                mcp_name = f"scilink_{fn_name}"
                 tools.append(_openai_to_mcp_tool(schema, prefix="scilink"))
 
         if state["planning_orch"]:
             for schema in state["planning_orch"].tools.openai_schemas:
                 fn_name = schema.get("function", {}).get("name", "")
                 mcp_name = f"scilink_{fn_name}"
-                # Use the same collision-avoidance as tool_map
                 if mcp_name in tool_map and tool_map[mcp_name][0] != "planning_orch":
                     prefix = "scilink_plan"
                 else:
@@ -244,6 +278,26 @@ def create_server(
 
         orch_key, original_name = tool_map[name]
         orch = state[orch_key]
+        autonomy = state["config"]["analysis_mode"]
+
+        # Co-pilot / supervised: intercept tools that need approval
+        if _needs_approval(original_name, autonomy):
+            prompt = _build_approval_prompt(original_name, arguments)
+            state["pending_action"] = PendingAction(
+                tool_name=original_name,
+                kwargs=arguments,
+                prompt=prompt,
+                context={"orch_key": orch_key},
+            )
+            return [types.TextContent(
+                type="text",
+                text=json.dumps({
+                    "status": "needs_input",
+                    "message": prompt,
+                    "tool": original_name,
+                    "arguments": arguments,
+                }),
+            )]
 
         result = await asyncio.to_thread(
             _execute_tool_captured, orch.tools, original_name, arguments
@@ -259,24 +313,42 @@ def create_server(
         resources = []
 
         if state["analysis_orch"]:
-            resources.append(types.Resource(
-                uri="scilink://session/status",
-                name="Session Status",
-                description="Current analysis session state",
-                mimeType="application/json",
-            ))
-            resources.append(types.Resource(
-                uri="scilink://session/metadata",
-                name="Current Metadata",
-                description="Loaded sample/experiment metadata",
-                mimeType="application/json",
-            ))
-            resources.append(types.Resource(
-                uri="scilink://session/agents",
-                name="Available Agents",
-                description="Registered analysis agents",
-                mimeType="application/json",
-            ))
+            resources.extend([
+                types.Resource(
+                    uri="scilink://analysis/status",
+                    name="Analysis Session Status",
+                    description="Current analysis session state",
+                    mimeType="application/json",
+                ),
+                types.Resource(
+                    uri="scilink://analysis/metadata",
+                    name="Current Metadata",
+                    description="Loaded sample/experiment metadata",
+                    mimeType="application/json",
+                ),
+                types.Resource(
+                    uri="scilink://analysis/agents",
+                    name="Available Agents",
+                    description="Registered analysis agents",
+                    mimeType="application/json",
+                ),
+            ])
+
+        if state["planning_orch"]:
+            resources.extend([
+                types.Resource(
+                    uri="scilink://planning/status",
+                    name="Planning Session Status",
+                    description="Current planning session state",
+                    mimeType="application/json",
+                ),
+                types.Resource(
+                    uri="scilink://planning/plan",
+                    name="Current Plan",
+                    description="Active experimental plan",
+                    mimeType="application/json",
+                ),
+            ])
 
         return resources
 
@@ -285,24 +357,26 @@ def create_server(
     @server.read_resource()
     async def read_resource(uri: str) -> str:
         _ensure_initialized()
-        orch = state.get("analysis_orch")
 
-        if uri == "scilink://session/status":
-            data = {
-                "current_data_path": getattr(orch, "current_data_path", None),
-                "current_data_type": getattr(orch, "current_data_type", None),
-                "selected_agent_id": getattr(orch, "selected_agent_id", None),
-                "analysis_count": len(getattr(orch, "analysis_results", [])),
-                "message_count": getattr(orch, "message_count", 0),
-            }
-            return json.dumps(data, indent=2)
+        # Analysis resources
+        a_orch = state.get("analysis_orch")
+        if uri == "scilink://analysis/status" and a_orch:
+            return json.dumps({
+                "current_data_path": getattr(a_orch, "current_data_path", None),
+                "current_data_type": getattr(a_orch, "current_data_type", None),
+                "selected_agent_id": getattr(a_orch, "selected_agent_id", None),
+                "analysis_count": len(getattr(a_orch, "analysis_results", [])),
+                "message_count": getattr(a_orch, "message_count", 0),
+                "autonomy_mode": state["config"]["analysis_mode"],
+            }, indent=2)
 
-        elif uri == "scilink://session/metadata":
-            meta = getattr(orch, "current_metadata", None)
-            return json.dumps(meta or {}, indent=2)
+        if uri == "scilink://analysis/metadata" and a_orch:
+            return json.dumps(
+                getattr(a_orch, "current_metadata", None) or {}, indent=2
+            )
 
-        elif uri == "scilink://session/agents":
-            registry = getattr(orch, "_agent_registry", {})
+        if uri == "scilink://analysis/agents" and a_orch:
+            registry = getattr(a_orch, "_agent_registry", {})
             agents = {}
             for aid, entry in registry.items():
                 agents[str(aid)] = {
@@ -311,6 +385,30 @@ def create_server(
                     "short_name": entry.get("short_name", ""),
                 }
             return json.dumps(agents, indent=2)
+
+        # Planning resources
+        p_orch = state.get("planning_orch")
+        if uri == "scilink://planning/status" and p_orch:
+            return json.dumps({
+                "has_plan": getattr(p_orch, "current_plan", None) is not None,
+                "iteration": getattr(p_orch, "current_iteration", 0),
+                "message_count": len(getattr(p_orch, "messages", [])),
+                "autonomy_level": str(getattr(p_orch, "autonomy_level", "unknown")),
+            }, indent=2)
+
+        if uri == "scilink://planning/plan" and p_orch:
+            plan = getattr(p_orch, "current_plan", None)
+            if plan and hasattr(plan, "to_dict"):
+                return json.dumps(plan.to_dict(), indent=2)
+            return json.dumps(plan or {}, indent=2)
+
+        # Backward compatibility with Phase 1 URIs
+        if uri == "scilink://session/status" and a_orch:
+            return await read_resource("scilink://analysis/status")
+        if uri == "scilink://session/metadata" and a_orch:
+            return await read_resource("scilink://analysis/metadata")
+        if uri == "scilink://session/agents" and a_orch:
+            return await read_resource("scilink://analysis/agents")
 
         return json.dumps({"error": f"Unknown resource: {uri}"})
 
@@ -331,19 +429,6 @@ def _init_orchestrators(state: dict, config: dict) -> None:
         session_dir = str(Path.home() / "scilink_mcp_sessions" / f"session_{ts}")
     Path(session_dir).mkdir(parents=True, exist_ok=True)
 
-    # Resolve analysis mode enum
-    from scilink.agents.exp_agents.analysis_orchestrator import AnalysisMode
-    mode_map = {
-        "co-pilot": AnalysisMode.CO_PILOT,
-        "co_pilot": AnalysisMode.CO_PILOT,
-        "copilot": AnalysisMode.CO_PILOT,
-        "supervised": AnalysisMode.SUPERVISED,
-        "autonomous": AnalysisMode.AUTONOMOUS,
-    }
-    analysis_mode = mode_map.get(
-        config["analysis_mode"].lower(), AnalysisMode.AUTONOMOUS
-    )
-
     api_key = config["api_key"]
     model_name = config["model_name"]
     base_url = config["base_url"]
@@ -351,7 +436,17 @@ def _init_orchestrators(state: dict, config: dict) -> None:
 
     if config["mode"] in ("analyze", "both"):
         from scilink.agents.exp_agents.analysis_orchestrator import (
-            AnalysisOrchestratorAgent,
+            AnalysisOrchestratorAgent, AnalysisMode,
+        )
+        mode_map = {
+            "co-pilot": AnalysisMode.CO_PILOT,
+            "co_pilot": AnalysisMode.CO_PILOT,
+            "copilot": AnalysisMode.CO_PILOT,
+            "supervised": AnalysisMode.SUPERVISED,
+            "autonomous": AnalysisMode.AUTONOMOUS,
+        }
+        analysis_mode = mode_map.get(
+            config["analysis_mode"].lower(), AnalysisMode.AUTONOMOUS
         )
         state["analysis_orch"] = AnalysisOrchestratorAgent(
             base_dir=session_dir,
@@ -365,13 +460,29 @@ def _init_orchestrators(state: dict, config: dict) -> None:
     if config["mode"] in ("plan", "both"):
         try:
             from scilink.agents.planning_agents.planning_orchestrator import (
-                PlanningOrchestratorAgent,
+                PlanningOrchestratorAgent, AutonomyLevel,
             )
+            autonomy_map = {
+                "co-pilot": AutonomyLevel.CO_PILOT,
+                "co_pilot": AutonomyLevel.CO_PILOT,
+                "copilot": AutonomyLevel.CO_PILOT,
+                "supervised": AutonomyLevel.SUPERVISED,
+                "autonomous": AutonomyLevel.AUTONOMOUS,
+            }
+            autonomy_level = autonomy_map.get(
+                config["analysis_mode"].lower(), AutonomyLevel.AUTONOMOUS
+            )
+            # Planning orchestrator needs data_dir in autonomous mode
+            data_dir = str(Path(session_dir) / "data")
+            Path(data_dir).mkdir(parents=True, exist_ok=True)
             state["planning_orch"] = PlanningOrchestratorAgent(
                 base_dir=session_dir,
                 api_key=api_key,
                 model_name=model_name,
                 base_url=base_url,
+                futurehouse_api_key=fh_key,
+                autonomy_level=autonomy_level,
+                data_dir=data_dir,
             )
         except Exception as exc:
             logging.warning(f"Planning orchestrator not available: {exc}")
@@ -397,13 +508,15 @@ async def _handle_respond(
     state["pending_action"] = None
 
     if response in ("yes", "y", "approve", "ok", "proceed"):
-        # Execute the pending tool
         orch_key = pending.context.get("orch_key", "analysis_orch")
         orch = state.get(orch_key)
         if orch is None:
             return [types.TextContent(
                 type="text",
-                text=json.dumps({"status": "error", "message": "Orchestrator not found."}),
+                text=json.dumps({
+                    "status": "error",
+                    "message": "Orchestrator not found.",
+                }),
             )]
 
         result = await asyncio.to_thread(

--- a/scilink/mcp_server.py
+++ b/scilink/mcp_server.py
@@ -1,0 +1,450 @@
+"""MCP server that exposes SciLink's analysis and planning tools.
+
+Allows any MCP client (Claude Desktop, Cursor, etc.) to use SciLink as a
+tool provider.  Start with::
+
+    scilink serve --model gemini-3.1-pro-preview
+
+Supports three autonomy modes:
+- **autonomous** (default) — tools execute without human approval.
+- **supervised** — tools run but return key decisions for review.
+- **co-pilot** — tools that need approval return a ``needs_input``
+  response; the MCP client must call ``scilink_respond`` to continue.
+
+Requires the ``mcp`` optional dependency::
+
+    pip install scilink[mcp]
+"""
+
+import asyncio
+import contextlib
+import io
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+try:
+    from mcp.server.lowlevel import Server
+    from mcp.server.stdio import stdio_server
+    from mcp import types
+    HAS_MCP = True
+except ImportError:
+    HAS_MCP = False
+
+
+def _require_mcp():
+    if not HAS_MCP:
+        raise ImportError(
+            "MCP server support requires the 'mcp' package. "
+            "Install with: pip install scilink[mcp]"
+        )
+
+
+# ── Schema conversion ───────────────────────────────────────────────────
+
+def _openai_to_mcp_tool(schema: dict, prefix: str = "scilink") -> types.Tool:
+    """Convert an OpenAI function-calling schema to an MCP Tool object."""
+    fn = schema.get("function", schema)
+    name = fn.get("name", "")
+    return types.Tool(
+        name=f"{prefix}_{name}" if prefix else name,
+        description=fn.get("description", ""),
+        inputSchema=fn.get("parameters", {"type": "object", "properties": {}}),
+    )
+
+
+# ── Stdout capture ──────────────────────────────────────────────────────
+
+def _execute_tool_captured(tools, tool_name: str, kwargs: dict) -> str:
+    """Execute a tool while capturing stdout so it doesn't corrupt stdio MCP transport."""
+    captured = io.StringIO()
+    with contextlib.redirect_stdout(captured):
+        result = tools.execute_tool(tool_name, **kwargs)
+
+    log_output = captured.getvalue().strip()
+    if log_output:
+        logging.info(f"[tool:{tool_name}] {log_output}")
+
+    return result
+
+
+# ── Pending action support (co-pilot / supervised) ──────────────────────
+
+class PendingAction:
+    """Holds a pending tool call that needs user approval before execution."""
+
+    def __init__(self, tool_name: str, kwargs: dict, prompt: str, context: dict = None):
+        self.tool_name = tool_name
+        self.kwargs = kwargs
+        self.prompt = prompt
+        self.context = context or {}
+
+
+# ── Server factory ──────────────────────────────────────────────────────
+
+def create_server(
+    *,
+    api_key: str = None,
+    model_name: str = "gemini-3.1-pro-preview",
+    base_url: str = None,
+    mode: str = "both",
+    session_dir: str = None,
+    analysis_mode: str = "autonomous",
+    futurehouse_api_key: str = None,
+) -> "Server":
+    """Create and return a configured MCP Server instance.
+
+    Args:
+        api_key: LLM API key.
+        model_name: Model identifier.
+        base_url: Optional OpenAI-compatible endpoint.
+        mode: ``"analyze"``, ``"plan"``, or ``"both"``.
+        session_dir: Directory for session outputs.
+        analysis_mode: ``"autonomous"``, ``"supervised"``, or ``"co-pilot"``.
+        futurehouse_api_key: Optional FutureHouse/Edison API key.
+
+    Returns:
+        A configured ``mcp.server.lowlevel.Server``.
+    """
+    _require_mcp()
+
+    server = Server("scilink")
+
+    # ── State (initialized lazily on first tool list) ────────────────
+    state: Dict[str, Any] = {
+        "analysis_orch": None,
+        "planning_orch": None,
+        "pending_action": None,
+        "initialized": False,
+        "config": {
+            "api_key": api_key,
+            "model_name": model_name,
+            "base_url": base_url,
+            "mode": mode,
+            "session_dir": session_dir,
+            "analysis_mode": analysis_mode,
+            "futurehouse_api_key": futurehouse_api_key,
+        },
+    }
+
+    # Tool name → (orchestrator_key, original_name) mapping
+    tool_map: Dict[str, tuple] = {}
+
+    def _ensure_initialized():
+        if state["initialized"]:
+            return
+
+        config = state["config"]
+        captured = io.StringIO()
+        with contextlib.redirect_stdout(captured):
+            _init_orchestrators(state, config)
+
+        log = captured.getvalue().strip()
+        if log:
+            logging.info(f"[init] {log}")
+
+        # Build tool map
+        if state["analysis_orch"]:
+            for schema in state["analysis_orch"].tools.openai_schemas:
+                fn_name = schema.get("function", {}).get("name", "")
+                if fn_name:
+                    mcp_name = f"scilink_{fn_name}"
+                    tool_map[mcp_name] = ("analysis_orch", fn_name)
+
+        if state["planning_orch"]:
+            for schema in state["planning_orch"].tools.openai_schemas:
+                fn_name = schema.get("function", {}).get("name", "")
+                if fn_name:
+                    # Avoid collisions with analysis tools
+                    mcp_name = f"scilink_{fn_name}"
+                    if mcp_name in tool_map:
+                        mcp_name = f"scilink_plan_{fn_name}"
+                    tool_map[mcp_name] = ("planning_orch", fn_name)
+
+        state["initialized"] = True
+
+    # ── Eager init (call before starting transport) ────────────────
+
+    def _eager_init():
+        _ensure_initialized()
+
+    server.eager_init = _eager_init
+
+    # ── tools/list ───────────────────────────────────────────────────
+
+    @server.list_tools()
+    async def list_tools() -> List[types.Tool]:
+        _ensure_initialized()
+        tools = []
+
+        if state["analysis_orch"]:
+            for schema in state["analysis_orch"].tools.openai_schemas:
+                fn_name = schema.get("function", {}).get("name", "")
+                mcp_name = f"scilink_{fn_name}"
+                tools.append(_openai_to_mcp_tool(schema, prefix="scilink"))
+
+        if state["planning_orch"]:
+            for schema in state["planning_orch"].tools.openai_schemas:
+                fn_name = schema.get("function", {}).get("name", "")
+                mcp_name = f"scilink_{fn_name}"
+                # Use the same collision-avoidance as tool_map
+                if mcp_name in tool_map and tool_map[mcp_name][0] != "planning_orch":
+                    prefix = "scilink_plan"
+                else:
+                    prefix = "scilink"
+                tools.append(_openai_to_mcp_tool(schema, prefix=prefix))
+
+        # Add the respond tool for co-pilot/supervised modes
+        if state["config"]["analysis_mode"] != "autonomous":
+            tools.append(types.Tool(
+                name="scilink_respond",
+                description=(
+                    "Send a response to a pending SciLink action that requires "
+                    "human approval. Call this after receiving a 'needs_input' "
+                    "status from another tool."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": (
+                                "User's response: 'yes'/'approve' to proceed, "
+                                "'no'/'reject' to cancel, or free-text feedback."
+                            ),
+                        },
+                    },
+                    "required": ["response"],
+                },
+            ))
+
+        return tools
+
+    # ── tools/call ───────────────────────────────────────────────────
+
+    @server.call_tool()
+    async def call_tool(
+        name: str, arguments: dict
+    ) -> List[types.TextContent]:
+        _ensure_initialized()
+
+        # Handle the respond tool
+        if name == "scilink_respond":
+            return await _handle_respond(state, arguments)
+
+        # Look up which orchestrator owns this tool
+        if name not in tool_map:
+            return [types.TextContent(
+                type="text",
+                text=json.dumps({
+                    "status": "error",
+                    "message": f"Unknown tool: {name}",
+                }),
+            )]
+
+        orch_key, original_name = tool_map[name]
+        orch = state[orch_key]
+
+        result = await asyncio.to_thread(
+            _execute_tool_captured, orch.tools, original_name, arguments
+        )
+
+        return [types.TextContent(type="text", text=result)]
+
+    # ── resources/list ───────────────────────────────────────────────
+
+    @server.list_resources()
+    async def list_resources() -> List[types.Resource]:
+        _ensure_initialized()
+        resources = []
+
+        if state["analysis_orch"]:
+            resources.append(types.Resource(
+                uri="scilink://session/status",
+                name="Session Status",
+                description="Current analysis session state",
+                mimeType="application/json",
+            ))
+            resources.append(types.Resource(
+                uri="scilink://session/metadata",
+                name="Current Metadata",
+                description="Loaded sample/experiment metadata",
+                mimeType="application/json",
+            ))
+            resources.append(types.Resource(
+                uri="scilink://session/agents",
+                name="Available Agents",
+                description="Registered analysis agents",
+                mimeType="application/json",
+            ))
+
+        return resources
+
+    # ── resources/read ───────────────────────────────────────────────
+
+    @server.read_resource()
+    async def read_resource(uri: str) -> str:
+        _ensure_initialized()
+        orch = state.get("analysis_orch")
+
+        if uri == "scilink://session/status":
+            data = {
+                "current_data_path": getattr(orch, "current_data_path", None),
+                "current_data_type": getattr(orch, "current_data_type", None),
+                "selected_agent_id": getattr(orch, "selected_agent_id", None),
+                "analysis_count": len(getattr(orch, "analysis_results", [])),
+                "message_count": getattr(orch, "message_count", 0),
+            }
+            return json.dumps(data, indent=2)
+
+        elif uri == "scilink://session/metadata":
+            meta = getattr(orch, "current_metadata", None)
+            return json.dumps(meta or {}, indent=2)
+
+        elif uri == "scilink://session/agents":
+            registry = getattr(orch, "_agent_registry", {})
+            agents = {}
+            for aid, entry in registry.items():
+                agents[str(aid)] = {
+                    "name": entry.get("name", ""),
+                    "description": entry.get("description", ""),
+                    "short_name": entry.get("short_name", ""),
+                }
+            return json.dumps(agents, indent=2)
+
+        return json.dumps({"error": f"Unknown resource: {uri}"})
+
+    return server
+
+
+# ── Orchestrator initialization ──────────────────────────────────────────
+
+def _init_orchestrators(state: dict, config: dict) -> None:
+    """Initialize orchestrator(s) based on config."""
+    import os
+    from datetime import datetime
+    from pathlib import Path
+
+    session_dir = config["session_dir"]
+    if not session_dir:
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        session_dir = str(Path.home() / "scilink_mcp_sessions" / f"session_{ts}")
+    Path(session_dir).mkdir(parents=True, exist_ok=True)
+
+    # Resolve analysis mode enum
+    from scilink.agents.exp_agents.analysis_orchestrator import AnalysisMode
+    mode_map = {
+        "co-pilot": AnalysisMode.CO_PILOT,
+        "co_pilot": AnalysisMode.CO_PILOT,
+        "copilot": AnalysisMode.CO_PILOT,
+        "supervised": AnalysisMode.SUPERVISED,
+        "autonomous": AnalysisMode.AUTONOMOUS,
+    }
+    analysis_mode = mode_map.get(
+        config["analysis_mode"].lower(), AnalysisMode.AUTONOMOUS
+    )
+
+    api_key = config["api_key"]
+    model_name = config["model_name"]
+    base_url = config["base_url"]
+    fh_key = config["futurehouse_api_key"] or os.environ.get("FUTUREHOUSE_API_KEY")
+
+    if config["mode"] in ("analyze", "both"):
+        from scilink.agents.exp_agents.analysis_orchestrator import (
+            AnalysisOrchestratorAgent,
+        )
+        state["analysis_orch"] = AnalysisOrchestratorAgent(
+            base_dir=session_dir,
+            api_key=api_key,
+            model_name=model_name,
+            base_url=base_url,
+            analysis_mode=analysis_mode,
+            futurehouse_api_key=fh_key,
+        )
+
+    if config["mode"] in ("plan", "both"):
+        try:
+            from scilink.agents.planning_agents.planning_orchestrator import (
+                PlanningOrchestratorAgent,
+            )
+            state["planning_orch"] = PlanningOrchestratorAgent(
+                base_dir=session_dir,
+                api_key=api_key,
+                model_name=model_name,
+                base_url=base_url,
+            )
+        except Exception as exc:
+            logging.warning(f"Planning orchestrator not available: {exc}")
+
+
+# ── Respond handler (co-pilot / supervised) ──────────────────────────────
+
+async def _handle_respond(
+    state: dict, arguments: dict
+) -> List["types.TextContent"]:
+    """Handle user response to a pending action."""
+    pending = state.get("pending_action")
+    if pending is None:
+        return [types.TextContent(
+            type="text",
+            text=json.dumps({
+                "status": "error",
+                "message": "No pending action to respond to.",
+            }),
+        )]
+
+    response = arguments.get("response", "").strip().lower()
+    state["pending_action"] = None
+
+    if response in ("yes", "y", "approve", "ok", "proceed"):
+        # Execute the pending tool
+        orch_key = pending.context.get("orch_key", "analysis_orch")
+        orch = state.get(orch_key)
+        if orch is None:
+            return [types.TextContent(
+                type="text",
+                text=json.dumps({"status": "error", "message": "Orchestrator not found."}),
+            )]
+
+        result = await asyncio.to_thread(
+            _execute_tool_captured, orch.tools, pending.tool_name, pending.kwargs
+        )
+        return [types.TextContent(type="text", text=result)]
+
+    else:
+        return [types.TextContent(
+            type="text",
+            text=json.dumps({
+                "status": "cancelled",
+                "message": f"Action cancelled by user: {response}",
+                "tool": pending.tool_name,
+            }),
+        )]
+
+
+# ── Server runner ────────────────────────────────────────────────────────
+
+async def run_stdio(server: Server, real_stdout=None) -> None:
+    """Run the MCP server over stdio transport.
+
+    Args:
+        server: The configured MCP Server.
+        real_stdout: The original ``sys.stdout`` before redirection.
+            Needed because the CLI redirects ``sys.stdout`` to stderr
+            to protect the JSON-RPC stream from stray ``print()`` calls.
+    """
+    _require_mcp()
+    import anyio
+    from io import TextIOWrapper
+
+    stdout_arg = None
+    if real_stdout is not None:
+        stdout_arg = anyio.wrap_file(
+            TextIOWrapper(real_stdout.buffer, encoding="utf-8")
+        )
+
+    async with stdio_server(stdout=stdout_arg) as (read_stream, write_stream):
+        await server.run(
+            read_stream, write_stream,
+            server.create_initialization_options(),
+        )

--- a/scilink/mcp_server.py
+++ b/scilink/mcp_server.py
@@ -856,10 +856,21 @@ def run_sse(server: Server, host: str = "127.0.0.1", port: int = 8000) -> None:
             )
         return Response()
 
+    from starlette.middleware import Middleware
+    from starlette.middleware.cors import CORSMiddleware
+
     app = Starlette(
         routes=[
             Route("/sse", endpoint=handle_sse, methods=["GET"]),
             Mount("/messages/", app=sse_transport.handle_post_message),
+        ],
+        middleware=[
+            Middleware(
+                CORSMiddleware,
+                allow_origins=["*"],
+                allow_methods=["*"],
+                allow_headers=["*"],
+            ),
         ],
     )
 

--- a/scilink/mcp_server.py
+++ b/scilink/mcp_server.py
@@ -815,3 +815,53 @@ async def run_stdio(server: Server, real_stdout=None) -> None:
             read_stream, write_stream,
             server.create_initialization_options(),
         )
+
+
+def run_sse(server: Server, host: str = "127.0.0.1", port: int = 8000) -> None:
+    """Run the MCP server over SSE (Server-Sent Events) transport.
+
+    Starts an HTTP server with two endpoints:
+
+    - ``GET /sse`` — SSE stream for client connections
+    - ``POST /messages/`` — message submission endpoint
+
+    Args:
+        server: The configured MCP Server.
+        host: Bind address (default: ``127.0.0.1``).
+        port: Bind port (default: ``8000``).
+    """
+    _require_mcp()
+
+    try:
+        from mcp.server.sse import SseServerTransport
+        from starlette.applications import Starlette
+        from starlette.routing import Route, Mount
+        from starlette.responses import Response
+        import uvicorn
+    except ImportError as exc:
+        raise ImportError(
+            f"SSE transport requires additional packages: {exc}\n"
+            "Install with: pip install uvicorn starlette sse-starlette"
+        ) from exc
+
+    sse_transport = SseServerTransport("/messages/")
+
+    async def handle_sse(request):
+        async with sse_transport.connect_sse(
+            request.scope, request.receive, request._send
+        ) as streams:
+            await server.run(
+                streams[0], streams[1],
+                server.create_initialization_options(),
+            )
+        return Response()
+
+    app = Starlette(
+        routes=[
+            Route("/sse", endpoint=handle_sse, methods=["GET"]),
+            Mount("/messages/", app=sse_transport.handle_post_message),
+        ],
+    )
+
+    logging.info(f"SciLink MCP server (SSE) at http://{host}:{port}/sse")
+    uvicorn.run(app, host=host, port=port, log_level="warning")

--- a/scilink/mcp_server.py
+++ b/scilink/mcp_server.py
@@ -252,6 +252,29 @@ def create_server(
                 },
             ))
 
+        # Always add the set_autonomy tool
+        tools.append(types.Tool(
+            name="scilink_set_autonomy",
+            description=(
+                "Change the autonomy mode at runtime. In 'autonomous' mode "
+                "all tools execute immediately. In 'supervised' mode high-impact "
+                "tools (run_analysis, run_optimization) pause for approval. "
+                "In 'co-pilot' mode most action tools pause for approval. "
+                "Returns the new mode and whether scilink_respond is now needed."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "mode": {
+                        "type": "string",
+                        "enum": ["autonomous", "supervised", "co-pilot"],
+                        "description": "The autonomy mode to switch to.",
+                    },
+                },
+                "required": ["mode"],
+            },
+        ))
+
         return tools
 
     # ── tools/call ───────────────────────────────────────────────────
@@ -265,6 +288,10 @@ def create_server(
         # Handle the respond tool
         if name == "scilink_respond":
             return await _handle_respond(state, arguments)
+
+        # Handle autonomy mode switch
+        if name == "scilink_set_autonomy":
+            return _handle_set_autonomy(state, arguments)
 
         # Look up which orchestrator owns this tool
         if name not in tool_map:
@@ -472,9 +499,13 @@ def _init_orchestrators(state: dict, config: dict) -> None:
             autonomy_level = autonomy_map.get(
                 config["analysis_mode"].lower(), AutonomyLevel.AUTONOMOUS
             )
-            # Planning orchestrator needs data_dir in autonomous mode
+            # Planning orchestrator needs data_dir and knowledge_dir
+            # to avoid creating directories with relative paths
+            # (fails when Claude Desktop runs from /).
             data_dir = str(Path(session_dir) / "data")
+            knowledge_dir = str(Path(session_dir) / "kb_storage")
             Path(data_dir).mkdir(parents=True, exist_ok=True)
+            Path(knowledge_dir).mkdir(parents=True, exist_ok=True)
             state["planning_orch"] = PlanningOrchestratorAgent(
                 base_dir=session_dir,
                 api_key=api_key,
@@ -483,9 +514,49 @@ def _init_orchestrators(state: dict, config: dict) -> None:
                 futurehouse_api_key=fh_key,
                 autonomy_level=autonomy_level,
                 data_dir=data_dir,
+                knowledge_dir=knowledge_dir,
             )
         except Exception as exc:
             logging.warning(f"Planning orchestrator not available: {exc}")
+
+
+# ── Autonomy mode switch ─────────────────────────────────────────────────
+
+def _handle_set_autonomy(
+    state: dict, arguments: dict
+) -> List["types.TextContent"]:
+    """Switch autonomy mode at runtime."""
+    new_mode = arguments.get("mode", "").strip().lower()
+    valid = {"autonomous", "supervised", "co-pilot"}
+    if new_mode not in valid:
+        return [types.TextContent(
+            type="text",
+            text=json.dumps({
+                "status": "error",
+                "message": f"Invalid mode '{new_mode}'. Use: {', '.join(sorted(valid))}",
+            }),
+        )]
+
+    old_mode = state["config"]["analysis_mode"]
+    state["config"]["analysis_mode"] = new_mode
+
+    # Clear any pending action from the previous mode
+    state["pending_action"] = None
+
+    return [types.TextContent(
+        type="text",
+        text=json.dumps({
+            "status": "success",
+            "previous_mode": old_mode,
+            "current_mode": new_mode,
+            "approval_required_for": sorted(
+                _COPILOT_APPROVAL_TOOLS if new_mode == "co-pilot"
+                else _SUPERVISED_APPROVAL_TOOLS if new_mode == "supervised"
+                else set()
+            ),
+            "scilink_respond_needed": new_mode != "autonomous",
+        }),
+    )]
 
 
 # ── Respond handler (co-pilot / supervised) ──────────────────────────────


### PR DESCRIPTION
## Summary

- Add `scilink serve` command and `scilink-mcp` entry point that runs SciLink as an MCP (Model Context Protocol) server, exposing all analysis and planning tools to external clients (Claude Code, Claude Desktop, Cursor, etc.)
- Support stdio and SSE transports, three autonomy modes (autonomous/supervised/co-pilot with runtime switching), and background job execution for long-running analyses
- Tested with Claude Code and Claude Desktop

## What's included

- **`scilink/mcp_server.py`** — Core MCP server: tools/list, tools/call, resources, schema conversion, stdout capture, co-pilot approval flow, background job management
- **`scilink/cli/serve.py`** — CLI entry point with config for model, mode, autonomy, transport
- **`scilink/cli/main.py`** — `serve` command routing (before logo print to protect stdio)
- **`pyproject.toml`** — `scilink-mcp` entry point
- **`docs/claude_code_integration.md`** — Setup guide for Claude Code, Claude Desktop, and SSE
- **Planning orchestrator fix** — propagate `kb_base_path` to inner PlanningAgent (fixes read-only filesystem in Claude Desktop)

## Key features

- 30 tools exposed (16 analysis + 13 planning + set_autonomy)
- Background execution via `background=true` parameter (avoids Claude Desktop's 4-min timeout)
- Runtime autonomy switching via `scilink_set_autonomy` tool
- Session state exposed as MCP resources
- Eager initialization to beat Claude Desktop's 5-second tools/list timeout

## Test plan

- [x] Stdio transport with Claude Code
- [x] Stdio transport with Claude Desktop
- [x] Full analysis pipeline (examine → metadata → select agent → run_analysis)
- [x] Background job execution (start → poll → retrieve)
- [x] Co-pilot mode approval flow
- [x] Planning tools in `--mode both`
- [x] SSE transport starts and responds
- [ ] SSE transport with an MCP client end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)