### PR TITLE
Add custom tools and MCP server support to planning mode

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -2289,7 +2289,76 @@ class OrchestratorTools:
         )
 
 
-        # 9. SAVE CHECKPOINT
+        # 9. SAVE FILE
+        def save_file(filename: str, content: str, subfolder: str = ""):
+            """
+            Save text content (code, protocols, notes) to a file in the session
+            directory.
+            """
+            print(f"  ⚡ Tool: Saving file '{filename}'...")
+
+            # Sanitise: strip path separators from filename to prevent traversal.
+            safe_name = Path(filename).name
+            if not safe_name:
+                return json.dumps({
+                    "status": "error",
+                    "message": "Invalid filename.",
+                })
+
+            target_dir = self.orch.base_dir
+            if subfolder:
+                safe_sub = Path(subfolder).name
+                target_dir = target_dir / safe_sub
+            target_dir.mkdir(parents=True, exist_ok=True)
+            dest = target_dir / safe_name
+
+            try:
+                dest.write_text(content, encoding="utf-8")
+                print(f"    💾 Saved: {dest}")
+                return json.dumps({
+                    "status": "success",
+                    "path": str(dest),
+                    "size_bytes": dest.stat().st_size,
+                })
+            except Exception as e:
+                logging.error(f"save_file failed: {e}")
+                return json.dumps({
+                    "status": "error",
+                    "message": str(e),
+                })
+
+        self._register_tool(
+            func=save_file,
+            name="save_file",
+            description=(
+                "Save text content (code, protocols, scripts, notes) to a file "
+                "in the session directory. Use this to persist generated code, "
+                "instrument protocols, or any text artifact."
+            ),
+            parameters={
+                "filename": {
+                    "type": "string",
+                    "description": (
+                        "Name of the file to create, e.g. 'extraction_protocol.py' "
+                        "or 'notes.txt'."
+                    ),
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The text content to write to the file.",
+                },
+                "subfolder": {
+                    "type": "string",
+                    "description": (
+                        "Optional subfolder within the session directory, "
+                        "e.g. 'protocols' or 'scripts'. Created if it doesn't exist."
+                    ),
+                },
+            },
+            required=["filename", "content"],
+        )
+
+        # 10. SAVE CHECKPOINT
         def save_checkpoint():
             """
             Saves complete orchestrator state including conversation and agent state.

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -377,14 +377,31 @@ Assume user runs agent from project directory. For example, when user says "file
 """
 
 
-def get_system_prompt(autonomy_level: AutonomyLevel) -> str:
-    """Returns the appropriate system prompt for the given autonomy level."""
+def get_system_prompt(
+    autonomy_level: AutonomyLevel,
+    external_tools: Optional[List[Dict[str, str]]] = None,
+) -> str:
+    """Returns the appropriate system prompt for the given autonomy level.
+
+    Args:
+        autonomy_level: Current autonomy level.
+        external_tools: Optional list of ``{"name": ..., "description": ...}``
+            dicts describing custom/MCP tools registered at runtime.
+    """
     directives = {
         AutonomyLevel.CO_PILOT: _CO_PILOT_DIRECTIVE,
         AutonomyLevel.SUPERVISED: _SUPERVISED_DIRECTIVE,
         AutonomyLevel.AUTONOMOUS: _AUTONOMOUS_DIRECTIVE,
     }
-    return directives[autonomy_level] + _SYSTEM_PROMPT_BODY
+    prompt = directives[autonomy_level] + _SYSTEM_PROMPT_BODY
+
+    if external_tools:
+        lines = ["\n\n**ADDITIONAL TOOLS (user-registered):**"]
+        for t in external_tools:
+            lines.append(f"- **{t['name']}**: {t.get('description', '')}")
+        prompt += "\n".join(lines)
+
+    return prompt
 
 
 
@@ -509,7 +526,12 @@ class PlanningOrchestratorAgent:
         self.expected_input_columns = None
         self.expected_target_columns = []
         self.latest_tea_results = None
-        
+
+        # Custom tools / MCP state
+        self._tool_data_cache: Dict[tuple, Any] = {}
+        self._external_tools: List[Dict[str, str]] = []
+        self._mcp_connections: Dict[str, Any] = {}
+
         self.message_count = 0
         self.last_checkpoint_message_count = 0
         
@@ -547,7 +569,9 @@ class PlanningOrchestratorAgent:
         self.tools = OrchestratorTools(self)
         
         # --- Get appropriate system prompt based on autonomy level ---
-        system_prompt = get_system_prompt(self.autonomy_level)
+        system_prompt = get_system_prompt(
+            self.autonomy_level, self._external_tools or None
+        )
         system_prompt += self._build_workspace_context()
         
         # --- LLM Initialization ---
@@ -634,9 +658,11 @@ class PlanningOrchestratorAgent:
         self._enable_human_feedback = self._should_enable_human_feedback()
         
         # Update system prompt
-        new_system_prompt = get_system_prompt(level)
+        new_system_prompt = get_system_prompt(
+            level, self._external_tools or None
+        )
         self._system_prompt = new_system_prompt
-        
+
         # Update system message in messages list (works for both OpenAI and LiteLLM now)
         if self.messages and self.messages[0]["role"] == "system":
             self.messages[0]["content"] = new_system_prompt
@@ -647,6 +673,250 @@ class PlanningOrchestratorAgent:
     def get_human_feedback_setting(self) -> bool:
         """Returns current human feedback setting for sub-agents."""
         return self._enable_human_feedback
+
+    # ── Custom tools ──────────────────────────────────────────────────
+
+    def _rebuild_system_prompt(self) -> None:
+        """Rebuild the system prompt and update the message history."""
+        self._system_prompt = get_system_prompt(
+            self.autonomy_level, self._external_tools or None
+        )
+        self._system_prompt += self._build_workspace_context()
+        if self.messages and self.messages[0]["role"] == "system":
+            self.messages[0]["content"] = self._system_prompt
+
+    def _load_data_for_factory(self, data_path: str):
+        """Load a data file for use by external tool factories.
+
+        Returns a pandas DataFrame for tabular files, a NumPy array for .npy,
+        or the path string itself as a fallback.
+        """
+        path = Path(data_path)
+        ext = path.suffix.lower()
+        if ext in {'.csv', '.txt', '.tsv', '.xlsx', '.xls'}:
+            try:
+                if ext in {'.xlsx', '.xls'}:
+                    return pd.read_excel(str(path))
+                return pd.read_csv(str(path))
+            except Exception:
+                return data_path
+        elif ext == '.npy':
+            import numpy as np
+            return np.load(str(path))
+        else:
+            logging.warning(
+                f"_load_data_for_factory: unknown extension '{ext}' — "
+                "passing path string to factory."
+            )
+            return data_path
+
+    def register_tools(self, schemas: list, factory: callable) -> None:
+        """Register external tool functions into the orchestrator's LLM loop.
+
+        The ``factory`` callable is invoked lazily at tool-call time.  The
+        orchestrator inspects the *name* of the factory's first positional
+        parameter to decide what to pass:
+
+        * ``data_path`` / ``path`` / ``file`` / ``filepath`` / ``filename``
+          → the current optimization CSV path (or data directory) as a string.
+        * Any other name (e.g. ``data``, ``df``, ``dataframe``)
+          → the optimization CSV is loaded as a pandas DataFrame and passed.
+
+        If the factory declares an ``output_dir`` parameter the orchestrator
+        passes ``<base_dir>/custom_tools/``.
+
+        Args:
+            schemas: List of OpenAI-format tool schemas.
+            factory: Callable that accepts data and returns a dict mapping tool
+                names to callables.
+        """
+        import inspect
+
+        sig = inspect.signature(factory)
+        params = list(sig.parameters.keys())
+        first_param = params[0] if params else None
+        _path_param_names = {
+            'data_path', 'path', 'file', 'filepath', 'file_path', 'filename',
+        }
+        factory_takes_path = first_param in _path_param_names
+        factory_takes_output_dir = 'output_dir' in params
+
+        registered = 0
+        for schema in schemas:
+            if schema.get("type") != "function":
+                continue
+            fn_info = schema["function"]
+            tool_name = fn_info["name"]
+            description = fn_info.get("description", "")
+            params_spec = fn_info.get("parameters", {})
+            properties = params_spec.get("properties", {})
+            required = params_spec.get("required", [])
+
+            def _make_wrapper(name, _factory, _takes_path, _takes_output_dir):
+                def wrapper(**kwargs):
+                    # Determine what data source to pass.
+                    data_path = str(self.bo_data_path) if self.bo_data_path.exists() else None
+                    if data_path is None and self.data_dir is not None:
+                        data_path = str(self.data_dir)
+                    if data_path is None:
+                        return json.dumps({
+                            "status": "error",
+                            "message": (
+                                "No data available. Load experimental data "
+                                "or provide --data-dir first."
+                            ),
+                        })
+                    output_dir = self.base_dir / "custom_tools"
+                    output_dir.mkdir(parents=True, exist_ok=True)
+                    cache_key = (data_path, id(_factory), str(output_dir))
+                    if cache_key not in self._tool_data_cache:
+                        if _takes_path:
+                            data = data_path
+                        else:
+                            data = self._load_data_for_factory(data_path)
+                        if _takes_output_dir:
+                            self._tool_data_cache[cache_key] = _factory(
+                                data, output_dir=str(output_dir)
+                            )
+                        else:
+                            self._tool_data_cache[cache_key] = _factory(data)
+                    bound_fns = self._tool_data_cache[cache_key]
+                    fn = bound_fns.get(name)
+                    if fn is None:
+                        return json.dumps({
+                            "status": "error",
+                            "message": (
+                                f"Tool '{name}' not found in factory output. "
+                                f"Available: {list(bound_fns.keys())}"
+                            ),
+                        })
+                    print(f"  ⚡ Tool: {name}...")
+                    result = fn(**kwargs)
+                    return result if isinstance(result, str) else json.dumps(result)
+                return wrapper
+
+            self.tools._register_tool(
+                func=_make_wrapper(
+                    tool_name, factory,
+                    factory_takes_path, factory_takes_output_dir,
+                ),
+                name=tool_name,
+                description=description,
+                parameters=properties,
+                required=required,
+            )
+            self._external_tools.append({
+                "name": tool_name, "description": description,
+            })
+            registered += 1
+
+        logging.info(f"✅ Registered {registered} external tool(s)")
+        self._rebuild_system_prompt()
+
+    # ── MCP server integration ────────────────────────────────────────
+
+    def connect_mcp_server(
+        self,
+        server_name: str,
+        *,
+        command: list = None,
+        url: str = None,
+        env: dict = None,
+    ) -> int:
+        """Connect to an MCP server and register its tools.
+
+        Args:
+            server_name: Human-readable label for this server.
+            command: Command + args for stdio transport.
+            url: URL for SSE transport.
+            env: Optional environment variables for the subprocess.
+
+        Returns:
+            Number of tools registered from this server.
+        """
+        from ...mcp_client import MCPConnection
+
+        if server_name in self._mcp_connections:
+            logging.warning(
+                f"MCP server '{server_name}' already connected — "
+                "disconnect first to reconnect."
+            )
+            return 0
+
+        conn = MCPConnection(server_name, command=command, url=url, env=env)
+        schemas = conn.connect()
+
+        existing_names = {t["name"] for t in self._external_tools}
+        registered = 0
+        for schema in schemas:
+            fn_info = schema.get("function", {})
+            tool_name = fn_info.get("name", "")
+            if not tool_name:
+                continue
+
+            display_name = tool_name
+            if tool_name in self.tools.functions_map or tool_name in existing_names:
+                tool_name = f"{server_name}_{tool_name}"
+                logging.info(
+                    f"MCP tool renamed to '{tool_name}' to avoid collision"
+                )
+
+            description = fn_info.get("description", "")
+            params_spec = fn_info.get("parameters", {})
+            properties = params_spec.get("properties", {})
+            required = params_spec.get("required", [])
+
+            def _make_mcp_wrapper(_conn, _name):
+                def wrapper(**kwargs):
+                    return _conn.call_tool(_name, kwargs)
+                return wrapper
+
+            self.tools._register_tool(
+                func=_make_mcp_wrapper(conn, display_name),
+                name=tool_name,
+                description=f"[MCP:{server_name}] {description}",
+                parameters=properties,
+                required=required,
+            )
+            self._external_tools.append({
+                "name": tool_name,
+                "description": f"[MCP:{server_name}] {description}",
+            })
+            registered += 1
+
+        self._mcp_connections[server_name] = conn
+        logging.info(f"✅ MCP '{server_name}': registered {registered} tool(s)")
+        self._rebuild_system_prompt()
+        return registered
+
+    def disconnect_mcp_server(self, server_name: str) -> None:
+        """Disconnect from an MCP server and unregister its tools."""
+        conn = self._mcp_connections.pop(server_name, None)
+        if conn is None:
+            logging.warning(f"MCP server '{server_name}' not found.")
+            return
+
+        conn.disconnect()
+
+        prefix = f"[MCP:{server_name}]"
+        names_to_remove = {
+            s.get("function", {}).get("name")
+            for s in self.tools.openai_schemas
+            if s.get("function", {}).get("description", "").startswith(prefix)
+        }
+        self._external_tools = [
+            t for t in self._external_tools
+            if not t["description"].startswith(prefix)
+        ]
+        self.tools.openai_schemas = [
+            s for s in self.tools.openai_schemas
+            if s.get("function", {}).get("name") not in names_to_remove
+        ]
+        for name in names_to_remove:
+            self.tools.functions_map.pop(name, None)
+
+        logging.info(f"🔌 Disconnected MCP server '{server_name}'")
+        self._rebuild_system_prompt()
 
     def _restore_checkpoint(self):
         """Restore campaign state from checkpoint."""

--- a/scilink/cli/plan.py
+++ b/scilink/cli/plan.py
@@ -124,6 +124,41 @@ Supported Models:
         help='Path to code/API documentation directory (optional)'
     )
     
+    # Custom tool arguments
+    parser.add_argument(
+        '--tools',
+        type=str,
+        nargs='+',
+        dest='tool_files',
+        metavar='TOOL_FILE',
+        help=(
+            'Path(s) to Python files containing domain-specific tool functions to '
+            'expose directly to the orchestrator\'s LLM loop. '
+            'Each file must define: (1) a list of OpenAI-format tool schemas named '
+            '\'tool_schemas\', \'openai_schemas\', or any top-level list of '
+            'OpenAI function dicts; (2) a factory function named '
+            '\'create_tool_functions\' (or any function ending in \'_tool_functions\') '
+            'that accepts data and returns a dict mapping tool names to callables. '
+            'Example: scilink plan --tools ./custom_stats_tools.py'
+        )
+    )
+
+    # MCP server arguments
+    parser.add_argument(
+        '--mcp',
+        type=str,
+        nargs='+',
+        dest='mcp_servers',
+        metavar='MCP_CONFIG',
+        help=(
+            'MCP server configurations. Each entry can be:\n'
+            '  - A JSON config file ({"name":"...", "command":["..."], "env":{}})\n'
+            '  - stdio shorthand:  stdio:name:command,arg1,arg2\n'
+            '  - SSE shorthand:    sse:name:http://host:port/sse\n'
+            'Example: scilink plan --mcp stdio:fs:npx,-y,@modelcontextprotocol/server-filesystem,/tmp'
+        )
+    )
+
     # Deprecated arguments (hidden but functional)
     parser.add_argument(
         '--local-model',
@@ -192,6 +227,8 @@ Supported Models:
         'data_dir': args.data_dir,
         'knowledge_dir': args.knowledge_dir,
         'code_dir': args.code_dir,
+        'tool_files': args.tool_files,
+        'mcp_servers': args.mcp_servers,
     }
     
     # Run the interactive orchestrator
@@ -225,6 +262,8 @@ class OrchestratorPlayground:
         self.data_dir = None
         self.knowledge_dir = None
         self.code_dir = None
+        self._tool_files = self.config.get('tool_files')
+        self._mcp_servers = self.config.get('mcp_servers')
         
     def _infer_provider(self, model_name: str) -> tuple:
         """
@@ -397,7 +436,7 @@ class OrchestratorPlayground:
                 code_dir=self.code_dir,
             )
             print("✅ Agent ready!")
-            
+
         except Exception as e:
             print(f"❌ Failed to initialize agent: {e}")
             import traceback
@@ -408,7 +447,15 @@ class OrchestratorPlayground:
             print("   3. Check your API key is valid")
             print("   4. For supervised/autonomous: ensure directories exist")
             sys.exit(1)
-        
+
+        # === LOAD CUSTOM TOOL FILES ===
+        if self._tool_files:
+            self._load_custom_tools(self._tool_files)
+
+        # === CONNECT MCP SERVERS ===
+        if self._mcp_servers:
+            self._connect_mcp_servers(self._mcp_servers)
+
         # === SHOW SESSION INFO ===
         print("\n" + "="*60)
         print("SESSION INFO")
@@ -444,6 +491,117 @@ class OrchestratorPlayground:
         else:
             print(f"  {', '.join(tool_names)}")
         
+    def _load_custom_tools(self, tool_files: list) -> None:
+        """Load external tool functions from user-supplied .py files."""
+        import importlib.util
+        import inspect
+
+        for file_path in tool_files:
+            path = Path(file_path).resolve()
+            print(f"\n🔧 Loading custom tools from: {path}")
+            try:
+                spec = importlib.util.spec_from_file_location(path.stem, path)
+                module = importlib.util.module_from_spec(spec)
+                _prev = sys.dont_write_bytecode
+                sys.dont_write_bytecode = True
+                try:
+                    spec.loader.exec_module(module)
+                finally:
+                    sys.dont_write_bytecode = _prev
+            except Exception as e:
+                print(f"   ❌ Failed to load {path.name}: {e}")
+                continue
+
+            # Discover schemas
+            schemas = (
+                getattr(module, 'tool_schemas', None)
+                or getattr(module, 'openai_schemas', None)
+            )
+            if schemas is None:
+                for attr_name in dir(module):
+                    obj = getattr(module, attr_name, None)
+                    if (
+                        isinstance(obj, list)
+                        and obj
+                        and isinstance(obj[0], dict)
+                        and obj[0].get('type') == 'function'
+                    ):
+                        schemas = obj
+                        print(f"   📋 Auto-detected schemas in '{attr_name}'")
+                        break
+
+            if not schemas:
+                print(
+                    f"   ⚠️  No tool schemas found in {path.name}.\n"
+                    "       Define 'tool_schemas' as a list of OpenAI-format tool dicts."
+                )
+                continue
+
+            # Discover factory
+            factory = getattr(module, 'create_tool_functions', None)
+            if factory is None:
+                for name, fn in inspect.getmembers(module, inspect.isfunction):
+                    if (
+                        name.endswith('_tool_functions')
+                        and fn.__module__ == module.__name__
+                    ):
+                        factory = fn
+                        print(f"   🏭 Auto-detected factory '{name}'")
+                        break
+
+            if factory is None:
+                print(
+                    f"   ⚠️  No factory function found in {path.name}.\n"
+                    "       Define 'create_tool_functions(data)' returning "
+                    "a dict mapping tool names to callables."
+                )
+                continue
+
+            self.agent.register_tools(schemas, factory)
+            count = sum(1 for s in schemas if s.get('type') == 'function')
+            print(f"   ✅ Registered {count} tool(s) from {path.name}")
+
+    def _connect_mcp_servers(self, mcp_configs: list) -> None:
+        """Parse MCP server configs and connect to each."""
+        import json as _json
+
+        for entry in mcp_configs:
+            try:
+                if entry.startswith("stdio:"):
+                    parts = entry[len("stdio:"):].split(":", 1)
+                    name = parts[0]
+                    command = parts[1].split(",") if len(parts) > 1 else []
+                    print(f"\n🔌 Connecting to MCP server '{name}' (stdio)...")
+                    count = self.agent.connect_mcp_server(
+                        name, command=command
+                    )
+                    print(f"   ✅ Registered {count} tool(s) from '{name}'")
+
+                elif entry.startswith("sse:"):
+                    parts = entry[len("sse:"):].split(":", 1)
+                    name = parts[0]
+                    url = parts[1] if len(parts) > 1 else ""
+                    print(f"\n🔌 Connecting to MCP server '{name}' (SSE)...")
+                    count = self.agent.connect_mcp_server(name, url=url)
+                    print(f"   ✅ Registered {count} tool(s) from '{name}'")
+
+                else:
+                    path = Path(entry).resolve()
+                    with open(path) as f:
+                        cfg = _json.load(f)
+                    name = cfg.get("name", path.stem)
+                    print(f"\n🔌 Connecting to MCP server '{name}'...")
+                    count = self.agent.connect_mcp_server(
+                        name,
+                        command=cfg.get("command"),
+                        url=cfg.get("url"),
+                        env=cfg.get("env"),
+                    )
+                    print(f"   ✅ Registered {count} tool(s) from '{name}'")
+
+            except Exception as e:
+                print(f"   ❌ Failed to connect MCP server '{entry}': {e}")
+
     def print_help(self):
         """Print available commands."""
         print("\n" + "="*60)

--- a/scilink/ui/components/file_viewer.py
+++ b/scilink/ui/components/file_viewer.py
@@ -69,6 +69,25 @@ def render_file_preview(file_path: Path) -> None:
             st.error(f"Could not load .npy file: {exc}")
         return
 
+    # Source code
+    _code_langs = {
+        ".py": "python",
+        ".js": "javascript",
+        ".ts": "typescript",
+        ".sh": "bash",
+        ".yaml": "yaml",
+        ".yml": "yaml",
+        ".toml": "toml",
+        ".xml": "xml",
+        ".html": "html",
+        ".css": "css",
+        ".r": "r",
+        ".jl": "julia",
+    }
+    if suffix in _code_langs:
+        st.code(file_path.read_text()[:10000], language=_code_langs[suffix])
+        return
+
     # Plain text fallback
     if suffix in (".txt", ".md", ".log"):
         st.code(file_path.read_text()[:10000], language="text")

--- a/scilink/ui/components/tools_agents.py
+++ b/scilink/ui/components/tools_agents.py
@@ -28,44 +28,42 @@ def render_tools_agents_tab() -> None:
 
 def _render_tools_section(agent, app_mode: str) -> None:
     """Upload custom tool files and list registered tools."""
-    # Custom tool upload — only for analyze mode (planning doesn't support it yet)
-    if app_mode == "analyze":
-        st.subheader("Custom Tools")
-        uploaded = st.file_uploader(
-            "Upload a custom tool file (.py)",
-            type=["py"],
-            key="tool_file_uploader",
-            accept_multiple_files=True,
-            help=(
-                "Python file with tool_schemas (OpenAI-format list) "
-                "and create_tool_functions(data) factory."
-            ),
-        )
+    st.subheader("Custom Tools")
+    uploaded = st.file_uploader(
+        "Upload a custom tool file (.py)",
+        type=["py"],
+        key="tool_file_uploader",
+        accept_multiple_files=True,
+        help=(
+            "Python file with tool_schemas (OpenAI-format list) "
+            "and create_tool_functions(data) factory."
+        ),
+    )
 
-        if uploaded:
-            for f in uploaded:
-                upload_key = ("custom_tool", f.name)
-                if upload_key in st.session_state._processed_uploads:
-                    continue
-                _load_tool_file(agent, f)
-                st.session_state._processed_uploads.add(upload_key)
+    if uploaded:
+        for f in uploaded:
+            upload_key = ("custom_tool", f.name)
+            if upload_key in st.session_state._processed_uploads:
+                continue
+            _load_tool_file(agent, f)
+            st.session_state._processed_uploads.add(upload_key)
 
-        # List registered external tools
-        external_tools = getattr(agent, "_external_tools", [])
-        if external_tools:
-            st.markdown("**Registered custom tools:**")
-            for t in external_tools:
-                with st.expander(t["name"], expanded=False):
-                    st.markdown(t.get("description", "No description."))
-        else:
-            st.caption("No custom tools registered yet.")
+    # List registered external tools
+    external_tools = getattr(agent, "_external_tools", [])
+    if external_tools:
+        st.markdown("**Registered custom tools:**")
+        for t in external_tools:
+            with st.expander(t["name"], expanded=False):
+                st.markdown(t.get("description", "No description."))
+    else:
+        st.caption("No custom tools registered yet.")
 
-        st.divider()
+    st.divider()
 
-        # MCP server connections
-        _render_mcp_section(agent)
+    # MCP server connections
+    _render_mcp_section(agent)
 
-        st.divider()
+    st.divider()
 
     # List built-in orchestrator tools
     st.subheader("Built-in Tools")
@@ -346,12 +344,18 @@ def _render_mcp_section(agent) -> None:
         for name, conn in list(mcp_connections.items()):
             with st.expander(f"MCP: {name}", expanded=False):
                 tool_count = len(conn.tool_schemas) if hasattr(conn, "tool_schemas") else 0
-                st.caption(
-                    f"Transport: {'stdio' if conn.command else 'sse'} · "
-                    f"{tool_count} tool(s)"
-                )
-                if st.button(f"Disconnect", key=f"mcp_disconnect_{name}"):
-                    agent.disconnect_mcp_server(name)
-                    st.rerun()
+                col_info, col_btn = st.columns([5, 1])
+                with col_info:
+                    st.caption(
+                        f"Transport: {'stdio' if conn.command else 'sse'} · "
+                        f"{tool_count} tool(s)"
+                    )
+                with col_btn:
+                    if st.button(
+                        "\u2715", key=f"mcp_disconnect_{name}",
+                        help=f"Disconnect {name}",
+                    ):
+                        agent.disconnect_mcp_server(name)
+                        st.rerun()
     else:
         st.caption("No MCP servers connected.")


### PR DESCRIPTION
## Summary
- **Custom tools**: `register_tools()` on `PlanningOrchestratorAgent` + `--tools` CLI flag + UI upload — same factory pattern as analysis mode, adapted for planning data (optimization CSV / data directory)
- **MCP servers**: `connect_mcp_server()` / `disconnect_mcp_server()` on `PlanningOrchestratorAgent` + `--mcp` CLI flag + UI connect/disconnect — tested with OpentronsAI MCP server (3 tools registered successfully)
- **`save_file` tool**: New built-in tool so the agent can persist generated code, protocols, and text artifacts to the session directory
- **UI improvements**: Custom tools & MCP sections now available in both analyze and plan modes; disconnect button replaced with compact ✕ symbol; source code preview (.py, .js, .sh, etc.) enabled in File Explorer

## Test plan
- [x] `python -c "import scilink"` passes
- [x] `PlanningOrchestratorAgent` has all new methods (`register_tools`, `connect_mcp_server`, `disconnect_mcp_server`)
- [x] `scilink plan --help` shows `--tools` and `--mcp` flags
- [x] End-to-end test: connected to OpentronsAI MCP server, registered 3 tools, verified system prompt updated, disconnected cleanly
- [x] `save_file` tool writes files to session directory with subfolder support
- [x] Manual UI test: upload custom tool .py in plan mode, connect MCP server via Tools & Agents tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)