### PR TITLE
Toward Self-Improving Agents: Knowledge Synthesis Expansion & Skill Auto-Update

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -179,16 +179,28 @@ _SYSTEM_PROMPT_BODY_POST = """
 **CUSTOM PREPROCESSING:**
 13. `set_preprocessing_instruction`: Add custom preprocessing to loaded metadata.
    - Use when: user says "divide by baseline", "subtract dark reference", "normalize to peak", etc.
+   - This is for DATA PREPROCESSING ONLY (operations applied to raw data before fitting).
+   - Do NOT use for fitting model choices (e.g., "use Lorentzian", "fit with Fano").
+     Fitting model guidance goes in the `hints` parameter of `run_analysis`.
    - Requires: metadata already loaded
    - Example flow: load_metadata → set_preprocessing_instruction → run_analysis
 
 **KNOWLEDGE SYNTHESIS:**
 14. `synthesize_knowledge`: Distill findings from completed analyses into reusable knowledge.
    - Use when: user wants to learn from reference spectra, derive calibration, build a reference model, etc.
-   - Input: analysis_ids (list), focus (what to extract/learn)
+   - Input: analysis_ids (list), focus (what to extract/learn), synthesis_type (reference/trend/failure/method)
    - The synthesized knowledge is automatically injected into all subsequent run_analysis calls.
 15. `list_knowledge`: Show all active knowledge entries.
 16. `clear_knowledge`: Remove active knowledge (specific ID or all).
+
+**SKILL GRADUATION:**
+17. `graduate_to_skill`: Convert a knowledge entry into a reusable skill (.md file).
+   - Use when: user wants to make synthesized knowledge persistent and structured.
+   - Input: knowledge_id, skill_name, domain
+   - The skill is auto-registered for use in subsequent run_analysis calls.
+18. `update_skill`: Update a graduated skill with new knowledge.
+   - Use when: new knowledge has been synthesized and a linked graduated skill should be updated.
+   - Input: skill_name, knowledge_ids (optional — auto-detects if omitted)
 
 **AGENT SELECTION DECISION TREE:**
 
@@ -428,6 +440,9 @@ class AnalysisOrchestratorAgent:
 
         # Custom skills registered via register_skill() (name → path)
         self._custom_skills: Dict[str, str] = {}
+
+        # Graduated skill sources: skill_name → [source_knowledge_ids]
+        self._graduated_skill_sources: Dict[str, list] = {}
 
         # MCP server connections (keyed by server name)
         self._mcp_connections: Dict[str, Any] = {}
@@ -1015,6 +1030,7 @@ class AnalysisOrchestratorAgent:
             self.selected_agent_id = state.get("selected_agent_id")
             self.analysis_results = state.get("analysis_results", [])
             self.active_knowledge = state.get("active_knowledge", [])
+            self._graduated_skill_sources = state.get("graduated_skill_sources", {})
             self._analysis_run_counter = state.get("analysis_run_counter", 0)
             
             # Restore analysis mode if saved
@@ -1105,6 +1121,7 @@ class AnalysisOrchestratorAgent:
                 "message_count": self.message_count,
                 "analysis_mode": self.analysis_mode.value,
                 "active_knowledge": self.active_knowledge,
+                "graduated_skill_sources": self._graduated_skill_sources,
             }
 
             with open(self.checkpoint_path, 'w') as f:

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2157,6 +2157,7 @@ class AnalysisOrchestratorTools:
                     "message_count": self.orch.message_count,
                     "analysis_mode": self.orch.analysis_mode.value,
                     "active_knowledge": self.orch.active_knowledge,
+                    "graduated_skill_sources": self.orch._graduated_skill_sources,
                 }
 
                 with open(self.orch.checkpoint_path, 'w') as f:
@@ -2665,9 +2666,11 @@ class AnalysisOrchestratorTools:
             func=set_preprocessing_instruction,
             name="set_preprocessing_instruction",
             description=(
-                "Add or update a custom preprocessing instruction in the currently loaded metadata. "
-                "Use when the user wants custom preprocessing (e.g., baseline division, "
-                "background subtraction, normalization) on top of existing metadata. "
+                "Add or update a custom DATA PREPROCESSING instruction in the currently loaded metadata. "
+                "Use ONLY for raw data transformations BEFORE fitting: baseline division/subtraction, "
+                "background correction, normalization, dark reference subtraction, smoothing, etc. "
+                "Do NOT use for fitting model choices (e.g., 'use Lorentzian', 'fit with Fano', "
+                "'fit the peak with a Voigt') — those go in the `hints` parameter of `run_analysis`. "
                 "If metadata already has a preprocessing instruction, returns a conflict "
                 "for you to resolve with the user. When appending, an LLM check detects "
                 "redundant instructions to prevent double-processing. "
@@ -2700,7 +2703,7 @@ class AnalysisOrchestratorTools:
         # =====================================================================
         # 13. SYNTHESIZE KNOWLEDGE
         # =====================================================================
-        def synthesize_knowledge(analysis_ids: list, focus: str) -> str:
+        def synthesize_knowledge(analysis_ids: list, focus: str, synthesis_type: str = "reference") -> str:
             """
             Distill findings from completed analyses into reusable knowledge.
             The synthesized knowledge is automatically injected into all
@@ -2708,7 +2711,7 @@ class AnalysisOrchestratorTools:
             """
             from scilink.knowledge import synthesize_knowledge as _synthesize
 
-            print(f"  ⚡ Tool: Synthesizing knowledge from {len(analysis_ids)} analyses...")
+            print(f"  ⚡ Tool: Synthesizing knowledge ({synthesis_type}) from {len(analysis_ids)} analyses...")
 
             # Collect result dicts by analysis ID
             results = []
@@ -2738,6 +2741,7 @@ class AnalysisOrchestratorTools:
                     results, focus,
                     model=self.orch.model,
                     knowledge_id=f"knowledge_{counter:03d}",
+                    synthesis_type=synthesis_type,
                 )
             except (ValueError, RuntimeError) as e:
                 return json.dumps({"status": "error", "message": str(e)})
@@ -2752,15 +2756,35 @@ class AnalysisOrchestratorTools:
             with open(knowledge_file, 'w') as f:
                 json.dump(entry, f, indent=2)
 
-            return json.dumps({
+            response = {
                 "status": "success",
                 "knowledge_id": entry["id"],
                 "focus": focus,
+                "synthesis_type": synthesis_type,
                 "summary": entry["summary"],
                 "key_findings": entry["key_findings"],
                 "saved_to": str(knowledge_file),
                 "note": "This knowledge will be automatically injected into all subsequent run_analysis calls."
-            })
+            }
+
+            # Check if any graduated skill is linked to knowledge with same focus
+            for skill_name, source_ids in self.orch._graduated_skill_sources.items():
+                for kid in source_ids:
+                    for k in self.orch.active_knowledge:
+                        if k.get("id") == kid and k.get("focus", "").lower() == focus.lower():
+                            response["skill_update_suggested"] = skill_name
+                            response["skill_update_note"] = (
+                                f"Graduated skill '{skill_name}' is linked to knowledge "
+                                f"with the same focus area. Consider calling update_skill "
+                                f"to incorporate the new findings."
+                            )
+                            break
+                    if "skill_update_suggested" in response:
+                        break
+                if "skill_update_suggested" in response:
+                    break
+
+            return json.dumps(response)
 
         self._register_tool(
             func=synthesize_knowledge,
@@ -2768,7 +2792,8 @@ class AnalysisOrchestratorTools:
             description=(
                 "Distill findings from completed analyses into reusable knowledge. "
                 "Use when the user wants to learn from reference spectra, derive calibration, "
-                "build a reference model, etc. The synthesized knowledge is automatically "
+                "build a reference model, detect trends, learn from failures, or compare methods. "
+                "The synthesized knowledge is automatically "
                 "injected into all subsequent run_analysis calls as prior knowledge context."
             ),
             parameters={
@@ -2780,6 +2805,16 @@ class AnalysisOrchestratorTools:
                 "focus": {
                     "type": "string",
                     "description": "What to extract/learn (e.g., 'peak assignments for Ti 2p XPS', 'baseline behavior in DSC curves')"
+                },
+                "synthesis_type": {
+                    "type": "string",
+                    "enum": ["reference", "trend", "failure", "method"],
+                    "description": (
+                        "Type of synthesis: 'reference' (calibration/reference extraction, default), "
+                        "'trend' (cross-sample trend detection), "
+                        "'failure' (failure pattern learning), "
+                        "'method' (method selection heuristics)"
+                    )
                 }
             },
             required=["analysis_ids", "focus"]
@@ -2879,7 +2914,252 @@ class AnalysisOrchestratorTools:
         )
 
         # =====================================================================
-        # 16. SAVE FILE
+        # 16. GRADUATE TO SKILL
+        # =====================================================================
+        def graduate_to_skill(knowledge_id: str, skill_name: str, domain: str = "curve_fitting") -> str:
+            """
+            Convert a knowledge entry into a reusable skill (.md file).
+            The skill is automatically registered for use in subsequent analyses.
+            """
+            from scilink.agents.exp_agents.instruct import KNOWLEDGE_TO_SKILL_INSTRUCTIONS
+
+            print(f"  ⚡ Tool: Graduating knowledge '{knowledge_id}' to skill '{skill_name}'...")
+
+            # Find the knowledge entry
+            knowledge_entry = None
+            for entry in self.orch.active_knowledge:
+                if entry.get("id") == knowledge_id:
+                    knowledge_entry = entry
+                    break
+
+            if knowledge_entry is None:
+                return json.dumps({
+                    "status": "error",
+                    "message": f"Knowledge ID not found: {knowledge_id}"
+                })
+
+            # Build knowledge text
+            knowledge_text = f"**Focus:** {knowledge_entry.get('focus', '')}\n"
+            knowledge_text += f"**Summary:** {knowledge_entry.get('summary', '')}\n"
+            knowledge_text += "**Key Findings:**\n"
+            for finding in knowledge_entry.get("key_findings", []):
+                knowledge_text += f"- {finding}\n"
+
+            # Collect source analysis details
+            analysis_details_parts = []
+            source_ids = knowledge_entry.get("source_analyses", [])
+            for aid in source_ids:
+                for record in self.orch.analysis_results:
+                    if record.get("analysis_id") == aid:
+                        full_result = record.get("full_result", {})
+                        parts = [f"### Analysis: {aid}"]
+
+                        da = full_result.get("detailed_analysis", "")
+                        if da:
+                            parts.append(da[:2000])  # Truncate for prompt size
+
+                        fp = full_result.get("fitting_parameters")
+                        if fp:
+                            parts.append(f"Fitting parameters: {json.dumps(fp, indent=2, default=str)}")
+
+                        hf = full_result.get("human_feedback", {})
+                        if isinstance(hf, dict) and hf.get("user_feedback"):
+                            parts.append(f"User feedback: {hf['user_feedback']}")
+
+                        analysis_details_parts.append("\n".join(parts))
+                        break
+
+            analysis_details = "\n\n".join(analysis_details_parts) if analysis_details_parts else "No source analysis details available."
+
+            # Call LLM to generate skill content
+            prompt = KNOWLEDGE_TO_SKILL_INSTRUCTIONS.format(
+                skill_name=skill_name,
+                domain=domain,
+                knowledge_text=knowledge_text,
+                analysis_details=analysis_details,
+            )
+
+            try:
+                response = self.orch.model.generate_content(
+                    contents=[prompt],
+                    generation_config=None,
+                    safety_settings=None,
+                )
+                skill_content = response.text if hasattr(response, "text") else str(response)
+            except Exception as e:
+                return json.dumps({"status": "error", "message": f"LLM call failed: {e}"})
+
+            # Save skill file
+            skill_dir = self.orch.base_dir / "graduated_skills"
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            skill_path = skill_dir / f"{skill_name}.md"
+            skill_path.write_text(skill_content)
+
+            # Register the skill
+            self.orch.register_skill(str(skill_path))
+
+            # Track the link
+            self.orch._graduated_skill_sources[skill_name] = [knowledge_id]
+
+            return json.dumps({
+                "status": "success",
+                "skill_name": skill_name,
+                "skill_path": str(skill_path),
+                "source_knowledge_id": knowledge_id,
+                "note": f"Skill '{skill_name}' has been registered and will be available in run_analysis."
+            })
+
+        self._register_tool(
+            func=graduate_to_skill,
+            name="graduate_to_skill",
+            description=(
+                "Convert a knowledge entry into a reusable skill (.md file). "
+                "The skill is organized into 5 sections (overview, planning, analysis, "
+                "interpretation, validation) and automatically registered for use in "
+                "subsequent analyses."
+            ),
+            parameters={
+                "knowledge_id": {
+                    "type": "string",
+                    "description": "ID of the knowledge entry to graduate"
+                },
+                "skill_name": {
+                    "type": "string",
+                    "description": "Name for the new skill (used as filename and reference)"
+                },
+                "domain": {
+                    "type": "string",
+                    "description": "Domain/technique area (e.g., 'curve_fitting', 'xps', 'raman'). Default: 'curve_fitting'"
+                }
+            },
+            required=["knowledge_id", "skill_name"]
+        )
+
+        # =====================================================================
+        # 17. UPDATE SKILL
+        # =====================================================================
+        def update_skill(skill_name: str, knowledge_ids: list = None) -> str:
+            """
+            Update a graduated skill with new knowledge entries.
+            Preserves the old version as {name}.prev.md.
+            """
+            from scilink.agents.exp_agents.instruct import SKILL_UPDATE_INSTRUCTIONS
+
+            print(f"  ⚡ Tool: Updating skill '{skill_name}'...")
+
+            # Find the existing skill file
+            skill_dir = self.orch.base_dir / "graduated_skills"
+            skill_path = skill_dir / f"{skill_name}.md"
+            if not skill_path.exists():
+                return json.dumps({
+                    "status": "error",
+                    "message": f"Graduated skill not found: {skill_name}"
+                })
+
+            existing_skill = skill_path.read_text()
+
+            # Determine source knowledge IDs
+            tracked_ids = self.orch._graduated_skill_sources.get(skill_name, [])
+            if knowledge_ids:
+                new_ids = knowledge_ids
+            else:
+                # Use all knowledge entries with matching focus
+                focus_areas = set()
+                for kid in tracked_ids:
+                    for k in self.orch.active_knowledge:
+                        if k.get("id") == kid:
+                            focus_areas.add(k.get("focus", "").lower())
+                new_ids = [
+                    k["id"] for k in self.orch.active_knowledge
+                    if k["id"] not in tracked_ids and k.get("focus", "").lower() in focus_areas
+                ]
+
+            if not new_ids:
+                return json.dumps({
+                    "status": "error",
+                    "message": "No new knowledge entries found to update the skill with."
+                })
+
+            # Collect new knowledge texts
+            new_knowledge_parts = []
+            for kid in new_ids:
+                for k in self.orch.active_knowledge:
+                    if k.get("id") == kid:
+                        part = f"### {kid}\n**Focus:** {k.get('focus', '')}\n"
+                        part += f"**Summary:** {k.get('summary', '')}\n"
+                        part += "**Key Findings:**\n"
+                        for f in k.get("key_findings", []):
+                            part += f"- {f}\n"
+                        new_knowledge_parts.append(part)
+                        break
+
+            new_knowledge = "\n\n".join(new_knowledge_parts)
+
+            # Call LLM to produce updated skill
+            prompt = SKILL_UPDATE_INSTRUCTIONS.format(
+                skill_name=skill_name,
+                existing_skill=existing_skill,
+                new_knowledge=new_knowledge,
+            )
+
+            try:
+                response = self.orch.model.generate_content(
+                    contents=[prompt],
+                    generation_config=None,
+                    safety_settings=None,
+                )
+                updated_content = response.text if hasattr(response, "text") else str(response)
+            except Exception as e:
+                return json.dumps({"status": "error", "message": f"LLM call failed: {e}"})
+
+            # Save previous version
+            prev_path = skill_dir / f"{skill_name}.prev.md"
+            prev_path.write_text(existing_skill)
+
+            # Write updated skill
+            skill_path.write_text(updated_content)
+
+            # Update source tracking
+            all_ids = list(set(tracked_ids + new_ids))
+            self.orch._graduated_skill_sources[skill_name] = all_ids
+
+            # Re-register the skill
+            self.orch.register_skill(str(skill_path))
+
+            return json.dumps({
+                "status": "success",
+                "skill_name": skill_name,
+                "skill_path": str(skill_path),
+                "previous_version": str(prev_path),
+                "new_knowledge_ids": new_ids,
+                "total_source_ids": all_ids,
+                "note": f"Skill '{skill_name}' has been updated. Previous version saved as {prev_path.name}."
+            })
+
+        self._register_tool(
+            func=update_skill,
+            name="update_skill",
+            description=(
+                "Update a graduated skill with new knowledge entries. "
+                "Use when new knowledge has been synthesized and a linked skill "
+                "should incorporate the new findings. The old version is preserved."
+            ),
+            parameters={
+                "skill_name": {
+                    "type": "string",
+                    "description": "Name of the graduated skill to update"
+                },
+                "knowledge_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Specific knowledge IDs to incorporate (omit to auto-detect from matching focus area)"
+                }
+            },
+            required=["skill_name"]
+        )
+
+        # =====================================================================
+        # 18. SAVE FILE
         # =====================================================================
         def save_file(filename: str, content: str, subfolder: str = "") -> str:
             """

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2402,5 +2402,148 @@ You MUST output a valid JSON object with exactly two keys:
 Ensure the final output is ONLY the JSON object and nothing else.
 """
 
+KNOWLEDGE_TREND_INSTRUCTIONS = """You are an expert scientific data analyst. You have been given detailed results from multiple analyses of related datasets. Your task is to identify systematic trends and correlations across these results.
+
+**Focus Area:** {focus}
+
+**Analysis Results:**
+{analysis_texts}
+
+{human_feedback_section}
+
+**Instructions:**
+1. Compare results across all analyses to find systematic trends.
+2. Identify correlations between experimental parameters and outcomes.
+3. Note turning points, thresholds, or transitions in the data.
+4. Quantitative relationships (slopes, ratios, critical values) are highly valued.
+5. Distinguish robust trends from noise or single-sample artifacts.
+
+You MUST output a valid JSON object with exactly two keys:
+
+{{
+    "summary": "A concise paragraph describing the systematic trends discovered across the analyses, focused on {focus}.",
+    "key_findings": [
+        "Finding 1: specific trend or correlation with quantitative detail",
+        "Finding 2: another systematic observation",
+        "..."
+    ]
+}}
+
+Ensure the final output is ONLY the JSON object and nothing else.
+"""
+
+KNOWLEDGE_FAILURE_INSTRUCTIONS = """You are an expert scientific data analyst. You have been given detailed results from analyses, some of which may have failed or produced suboptimal results. Your task is to identify failure patterns and learn from them.
+
+**Focus Area:** {focus}
+
+**Analysis Results:**
+{analysis_texts}
+
+{human_feedback_section}
+
+**Instructions:**
+1. Identify common failure modes across the analyses.
+2. Look for data characteristics that predict failures (noise levels, missing features, artifacts).
+3. Note which analysis approaches or parameter choices led to poor outcomes.
+4. Suggest mitigations or early-warning indicators.
+5. Distinguish systematic issues from one-off failures.
+
+You MUST output a valid JSON object with exactly two keys:
+
+{{
+    "summary": "A concise paragraph describing the failure patterns discovered, focused on {focus}.",
+    "key_findings": [
+        "Finding 1: failure mode with predictive characteristics",
+        "Finding 2: mitigation strategy or early warning sign",
+        "..."
+    ]
+}}
+
+Ensure the final output is ONLY the JSON object and nothing else.
+"""
+
+KNOWLEDGE_METHOD_INSTRUCTIONS = """You are an expert scientific data analyst. You have been given detailed results from analyses that used different methods or parameter settings. Your task is to compare method effectiveness and build selection heuristics.
+
+**Focus Area:** {focus}
+
+**Analysis Results:**
+{analysis_texts}
+
+{human_feedback_section}
+
+**Instructions:**
+1. Compare which methods or parameter choices worked best for different data types.
+2. Identify when each method is most appropriate (data characteristics, sample type, etc.).
+3. Build concrete selection heuristics: "If X, use method Y with parameters Z."
+4. Note parameter ranges that consistently produce good results.
+5. Include quantitative performance comparisons where available.
+
+You MUST output a valid JSON object with exactly two keys:
+
+{{
+    "summary": "A concise paragraph describing method effectiveness comparisons, focused on {focus}.",
+    "key_findings": [
+        "Finding 1: method selection heuristic with conditions",
+        "Finding 2: optimal parameter range for a specific scenario",
+        "..."
+    ]
+}}
+
+Ensure the final output is ONLY the JSON object and nothing else.
+"""
+
+KNOWLEDGE_TO_SKILL_INSTRUCTIONS = """You are an expert scientific data analyst. You need to convert accumulated knowledge into a structured, reusable skill document.
+
+**Skill Name:** {skill_name}
+**Domain:** {domain}
+
+**Source Knowledge:**
+{knowledge_text}
+
+**Source Analysis Details:**
+{analysis_details}
+
+**Instructions:**
+Organize the knowledge into exactly five sections. Each section should contain actionable, specific guidance. Use markdown formatting.
+
+# overview
+Describe what domain/technique this skill covers, what types of data it applies to, and when to use it.
+
+# planning
+List strategy constraints, recommended parameter ranges, and setup considerations. Include any user-specified corrections or preferences.
+
+# analysis
+Describe code patterns, workflows, or processing steps that have proven effective. Include specific parameter values that worked.
+
+# interpretation
+Provide reference values, peak assignments, expected ranges, and how to interpret results. Include quantitative benchmarks from the key findings.
+
+# validation
+Define quality criteria, acceptable tolerance ranges, failure indicators, and sanity checks. Include any corrections from user feedback.
+
+Output ONLY the skill document content in markdown, starting with `# overview`. Do not wrap in code blocks.
+"""
+
+SKILL_UPDATE_INSTRUCTIONS = """You are an expert scientific data analyst. You need to update an existing skill document with new knowledge while preserving what is already correct.
+
+**Skill Name:** {skill_name}
+
+**Existing Skill Content:**
+{existing_skill}
+
+**New Knowledge to Incorporate:**
+{new_knowledge}
+
+**Instructions:**
+1. Review the existing skill content carefully.
+2. Integrate the new findings into the appropriate sections.
+3. Do NOT remove existing content unless the new knowledge explicitly contradicts it.
+4. When there is a conflict, prefer the newer knowledge but note the discrepancy.
+5. Maintain the five-section structure (overview, planning, analysis, interpretation, validation).
+6. Add new quantitative details, parameter ranges, or heuristics from the new knowledge.
+
+Output ONLY the updated skill document content in markdown, starting with `# overview`. Do not wrap in code blocks.
+"""
+
 # Backwards compatibility
 FITTING_RESULTS_INTERPRETATION_INSTRUCTIONS = FITTING_INTERPRETATION_INSTRUCTIONS

--- a/scilink/knowledge.py
+++ b/scilink/knowledge.py
@@ -7,6 +7,14 @@ import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+# Map synthesis_type to prompt template names
+_SYNTHESIS_PROMPT_MAP = {
+    "reference": "KNOWLEDGE_SYNTHESIS_INSTRUCTIONS",
+    "trend": "KNOWLEDGE_TREND_INSTRUCTIONS",
+    "failure": "KNOWLEDGE_FAILURE_INSTRUCTIONS",
+    "method": "KNOWLEDGE_METHOD_INSTRUCTIONS",
+}
+
 
 def synthesize_knowledge(
     analysis_results: List[Dict[str, Any]],
@@ -16,6 +24,7 @@ def synthesize_knowledge(
     model_name: str = "gemini-3.1-pro-preview",
     api_key: Optional[str] = None,
     knowledge_id: Optional[str] = None,
+    synthesis_type: str = "reference",
 ) -> Dict[str, Any]:
     """Distill findings from completed analyses into reusable prior knowledge.
 
@@ -37,6 +46,11 @@ def synthesize_knowledge(
         api_key: API key used when *model* is *None*.
         knowledge_id: Optional identifier for the entry.  Defaults to
             ``"knowledge_001"``.
+        synthesis_type: Type of synthesis to perform. One of:
+            ``"reference"`` (default) — calibration/reference extraction,
+            ``"trend"`` — cross-sample trend detection,
+            ``"failure"`` — failure pattern learning,
+            ``"method"`` — method selection heuristics.
 
     Returns:
         A knowledge entry dict::
@@ -44,13 +58,15 @@ def synthesize_knowledge(
             {
                 "id": "knowledge_001",
                 "focus": "...",
+                "synthesis_type": "reference",
                 "summary": "...",
                 "key_findings": ["...", ...],
                 "timestamp": "..."
             }
 
     Raises:
-        ValueError: If no ``detailed_analysis`` text is found in any result.
+        ValueError: If no ``detailed_analysis`` text is found in any result,
+            or if *synthesis_type* is not recognized.
         RuntimeError: If the LLM call fails or returns unparseable output.
 
     Example::
@@ -69,26 +85,89 @@ def synthesize_knowledge(
             prior_knowledge=[knowledge],
         )
     """
+    if synthesis_type not in _SYNTHESIS_PROMPT_MAP:
+        raise ValueError(
+            f"Unknown synthesis_type '{synthesis_type}'. "
+            f"Must be one of: {list(_SYNTHESIS_PROMPT_MAP.keys())}"
+        )
+
     # ── Collect detailed_analysis texts ──────────────────────────────────
     analysis_texts: list[str] = []
+    human_feedback_texts: list[str] = []
     for i, result in enumerate(analysis_results):
+        label = result.get("analysis_id", f"analysis_{i}")
+
         text = result.get("detailed_analysis", "")
         if text:
-            label = result.get("analysis_id", f"analysis_{i}")
             analysis_texts.append(f"### Analysis: {label}\n{text}")
+
+        # Collect fitting parameters if present
+        fitting_params = result.get("fitting_parameters")
+        if fitting_params:
+            params_str = json.dumps(fitting_params, indent=2, default=str)
+            analysis_texts.append(
+                f"### Fitting Parameters ({label}):\n```json\n{params_str}\n```"
+            )
+
+        # Collect status for failure-pattern learning
+        status = result.get("status")
+        if status:
+            analysis_texts.append(f"### Status ({label}): {status}")
+
+        # Collect human feedback
+        hf = result.get("human_feedback", {})
+        if isinstance(hf, dict):
+            user_fb = hf.get("user_feedback", "")
+            if user_fb:
+                human_feedback_texts.append(
+                    f"### User Feedback ({label}):\n{user_fb}"
+                )
 
     if not analysis_texts:
         raise ValueError(
             "No detailed_analysis text found in the provided results."
         )
 
-    # ── Build LLM prompt ─────────────────────────────────────────────────
-    from scilink.agents.exp_agents.instruct import KNOWLEDGE_SYNTHESIS_INSTRUCTIONS
+    # ── Build human feedback section ──────────────────────────────────────
+    if human_feedback_texts:
+        human_feedback_section = (
+            "**Human Feedback / Domain Corrections:**\n"
+            + "\n\n".join(human_feedback_texts)
+            + "\n\nIncorporate these corrections and domain expertise into your findings."
+        )
+    else:
+        human_feedback_section = ""
 
-    prompt_text = KNOWLEDGE_SYNTHESIS_INSTRUCTIONS.format(
-        focus=focus,
-        analysis_texts="\n\n".join(analysis_texts),
+    # ── Build LLM prompt ─────────────────────────────────────────────────
+    from scilink.agents.exp_agents.instruct import (
+        KNOWLEDGE_SYNTHESIS_INSTRUCTIONS,
+        KNOWLEDGE_TREND_INSTRUCTIONS,
+        KNOWLEDGE_FAILURE_INSTRUCTIONS,
+        KNOWLEDGE_METHOD_INSTRUCTIONS,
     )
+
+    prompt_map = {
+        "reference": KNOWLEDGE_SYNTHESIS_INSTRUCTIONS,
+        "trend": KNOWLEDGE_TREND_INSTRUCTIONS,
+        "failure": KNOWLEDGE_FAILURE_INSTRUCTIONS,
+        "method": KNOWLEDGE_METHOD_INSTRUCTIONS,
+    }
+
+    template = prompt_map[synthesis_type]
+
+    format_kwargs = {
+        "focus": focus,
+        "analysis_texts": "\n\n".join(analysis_texts),
+    }
+    # The reference template doesn't have a human_feedback_section placeholder
+    if synthesis_type != "reference":
+        format_kwargs["human_feedback_section"] = human_feedback_section
+    else:
+        # For reference type, append human feedback to analysis texts if present
+        if human_feedback_section:
+            format_kwargs["analysis_texts"] += "\n\n" + human_feedback_section
+
+    prompt_text = template.format(**format_kwargs)
 
     # ── Resolve model ────────────────────────────────────────────────────
     if model is None:
@@ -117,6 +196,7 @@ def synthesize_knowledge(
     return {
         "id": knowledge_id or "knowledge_001",
         "focus": focus,
+        "synthesis_type": synthesis_type,
         "summary": llm_output.get("summary", ""),
         "key_findings": llm_output.get("key_findings", []),
         "timestamp": datetime.now().isoformat(),


### PR DESCRIPTION
Analysis sessions now accumulate richer knowledge and can convert it into persistent, auto-updating skills.

- **Enhanced knowledge synthesis**: The `synthesize_knowledge` tool is improved in two ways. First, it now collects richer inputs from analysis results — user corrections (from the human feedback loop), fitting parameters, and success/failure status — in addition to the existing `detailed_analysis` text. Second, a new `synthesis_type` parameter controls what kind of findings are extracted: `"reference"` (default, calibration/peak assignments), `"trend"` (cross-sample correlations), `"failure"` (predictive failure patterns and mitigations), or `"method"` (model/approach selection heuristics). The output schema consumed by `_append_prior_knowledge_context` is unchanged, though the knowledge entry now includes a `synthesis_type` field for tracking.

- **Skill graduation**: New `graduate_to_skill` tool converts a knowledge entry into a structured 5-section `.md` skill file (overview / planning / analysis / interpretation / validation), auto-registers it, and tracks source knowledge IDs.

- **Living skill updates**: New `update_skill` tool merges new knowledge into graduated skills with `.prev.md` backup. When `synthesize_knowledge` detects a linked graduated skill with matching focus, it auto-suggests an update in the response.

- **Checkpoint persistence**: `_graduated_skill_sources` mapping is included in checkpoint save/restore.