### PR TITLE
feat: Add Novita provider integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ export OPENAI_API_KEY="your-key"
 # Anthropic
 export ANTHROPIC_API_KEY="your-key"
 
+# Novita (OpenAI-compatible)
+export NOVITA_API_KEY="your-key"
+
 # OpenAI-compatible proxy (if applicable)
 export SCILINK_API_KEY="your-key"
 ```

--- a/scilink/auth.py
+++ b/scilink/auth.py
@@ -14,6 +14,7 @@ ENV_VARS = {
     'google': ['GEMINI_API_KEY', 'GOOGLE_API_KEY'],
     'openai': ['OPENAI_API_KEY'],
     'anthropic': ['ANTHROPIC_API_KEY'],
+    'novita': ['NOVITA_API_KEY'],
     
     # Other Services
     'futurehouse': ['FUTUREHOUSE_API_KEY'],
@@ -47,6 +48,7 @@ def infer_provider(model_name: str) -> Optional[str]:
             'google': 'google',
             'openai': 'openai',
             'anthropic': 'anthropic',
+            'novita': 'novita',
         }
         if prefix in prefix_map:
             return prefix_map[prefix]
@@ -58,6 +60,9 @@ def infer_provider(model_name: str) -> Optional[str]:
         return 'anthropic'
     if 'gemini' in model_lower:
         return 'google'
+    # Novita models use / separator (e.g., deepseek/deepseek-v3.2)
+    if 'novita' in model_lower or model_lower.startswith('deepseek/') or model_lower.startswith('zai-org/') or model_lower.startswith('minimax/'):
+        return 'novita'
     
     return None
 

--- a/scilink/wrappers/__init__.py
+++ b/scilink/wrappers/__init__.py
@@ -4,24 +4,38 @@ API Wrappers for Multi-Backend LLM Support
 Two deployment modes:
 1. Internal (Incubator) - OpenAI-compatible proxy endpoint
    → Uses OpenAIAsGenerativeModel, OpenAIAsEmbeddingModel
-   
+
 2. Public - Direct provider access via LiteLLM
    → Uses LiteLLMGenerativeModel, LiteLLMEmbeddingModel
    → Supports: Google, OpenAI, Anthropic, Cohere, and 100+ providers
+
+3. Novita - OpenAI-compatible provider with fixed endpoint
+   → Uses NovitaGenerativeModel
+   → Supports: deepseek/deepseek-v3.2, zai-org/glm-5, minimax/minimax-m2.5
 
 Usage:
     # Internal proxy
     from wrappers import OpenAIAsGenerativeModel
     model = OpenAIAsGenerativeModel("model-name", api_key="...", base_url="https://proxy/v1")
-    
+
     # Public (multi-provider)
     from wrappers import LiteLLMGenerativeModel
     model = LiteLLMGenerativeModel("gemini/gemini-2.0-flash", api_key="...")
+
+    # Novita
+    from wrappers import NovitaGenerativeModel
+    model = NovitaGenerativeModel("deepseek/deepseek-v3.2", api_key="...")
 """
 
 # Internal/Incubator - OpenAI-compatible endpoints
 from .openai_wrapper import OpenAIAsGenerativeModel
 from .openai_wrapper_embeddings import OpenAIAsEmbeddingModel
+
+# Novita - OpenAI-compatible provider with fixed endpoint
+try:
+    from .novita_wrapper import NovitaGenerativeModel
+except ImportError:
+    NovitaGenerativeModel = None
 
 # Public - Multi-provider via LiteLLM
 try:
@@ -39,11 +53,13 @@ except ImportError:
 
 __all__ = [
     # Internal proxy
-    'OpenAIAsGenerativeModel',
-    'OpenAIAsEmbeddingModel',
+    "OpenAIAsGenerativeModel",
+    "OpenAIAsEmbeddingModel",
+    # Novita provider
+    "NovitaGenerativeModel",
     # Public multi-provider
-    'LiteLLMGenerativeModel',
-    'LiteLLMEmbeddingModel',
-    'LiteLLMChatSession',
-    'LITELLM_AVAILABLE',
+    "LiteLLMGenerativeModel",
+    "LiteLLMEmbeddingModel",
+    "LiteLLMChatSession",
+    "LITELLM_AVAILABLE",
 ]

--- a/scilink/wrappers/novita_wrapper.py
+++ b/scilink/wrappers/novita_wrapper.py
@@ -1,0 +1,94 @@
+"""
+Novita provider wrapper using OpenAI-compatible API.
+
+Novita provides an OpenAI-compatible API endpoint at:
+    https://api.novita.ai/openai
+
+This wrapper extends OpenAIAsGenerativeModel to hardcode the Novita endpoint
+while maintaining the same interface contract:
+    response = model.generate_content(prompt_parts)
+    text = response.text
+
+Usage:
+    from wrappers import NovitaGenerativeModel
+    model = NovitaGenerativeModel("deepseek/deepseek-v3.2", api_key="...")
+    response = model.generate_content(["Hello!"])
+    print(response.text)
+"""
+
+import openai
+
+from .openai_wrapper import OpenAIAsGenerativeModel
+
+# Novita's OpenAI-compatible endpoint
+NOVITA_BASE_URL = "https://api.novita.ai/openai"
+
+# Default model IDs for Novita
+# Use '/' separator as per Novita's naming convention
+DEFAULT_MODELS = [
+    "deepseek/deepseek-v3.2",  # Default model
+    "zai-org/glm-5",  # GLM-5 from Zhipu AI
+    "minimax/minimax-m2.5",  # MiniMax M2.5
+]
+
+
+class NovitaGenerativeModel(OpenAIAsGenerativeModel):
+    """
+    Unified LLM interface backed by Novita's OpenAI-compatible API.
+
+    Novita is an OpenAI-compatible provider that supports multiple models
+    through a unified endpoint. This wrapper configures the Novita endpoint
+    while maintaining the same interface as OpenAIAsGenerativeModel.
+
+    All SciLink agents interact with LLMs through a single contract:
+        response = model.generate_content(prompt_parts)
+        text = response.text
+
+    This wrapper implements that contract for Novita, using the OpenAI-compatible
+    Chat Completions API.
+
+    Input:  A flat list of mixed-content parts — strings and image dicts
+            ({mime_type, data}) — so callers never deal with provider-specific
+            message/role nesting.
+    Output: A SimpleNamespace with .text and .candidates, giving callers a
+            uniform accessor regardless of backend.
+
+    Usage:
+        # Novita with default model
+        model = NovitaGenerativeModel(api_key="...")
+        response = model.generate_content(["Hello!"])
+        print(response.text)
+
+        # Novita with specific model
+        model = NovitaGenerativeModel("deepseek/deepseek-v3.2", api_key="...")
+        response = model.generate_content(["Analyze this..."])
+        print(response.text)
+
+    Model IDs (use '/' separator):
+        - deepseek/deepseek-v3.2 (default)
+        - zai-org/glm-5
+        - minimax/minimax-m2.5
+    """
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODELS[0],
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: int | None = None,
+    ):
+        """
+        Initialize Novita model with OpenAI-compatible endpoint.
+
+        Args:
+            model: Model ID (default: deepseek/deepseek-v3.2). Use '/' separator.
+            api_key: Novita API key (NOVITA_API_KEY environment variable)
+            base_url: Override Novita endpoint (rarely needed)
+            timeout: Request timeout in seconds (default: 300)
+        """
+        # Use Novita's default endpoint unless overridden
+        effective_base_url = base_url or NOVITA_BASE_URL
+
+        super().__init__(
+            model=model, api_key=api_key, base_url=effective_base_url, timeout=timeout
+        )


### PR DESCRIPTION
## Summary

This PR introduces Novita provider support for SciLink, a new OpenAI-compatible LLM provider.

## Changes

### New Files
- `scilink/wrappers/novita_wrapper.py` - Provides `NovitaGenerativeModel` class for Novita's OpenAI-compatible API

### Modified Files
- `scilink/auth.py` - Added NOVITA_API_KEY support and model inference for Novita models
- `scilink/wrappers/__init__.py` - Exported `NovitaGenerativeModel`
- `README.md` - Documented NOVITA_API_KEY environment variable

## Implementation Details

- **API Endpoint**: `https://api.novita.ai/openai` (OpenAI-compatible)
- **Default Models**: `deepseek/deepseek-v3.2`, `zai-org/glm-5`, `minimax/minimax-m2.5`
- **Model ID Format**: Uses `/` separator (e.g., `deepseek/deepseek-v3.2`)
- **API Key**: Configured via `NOVITA_API_KEY` environment variable

## Usage

```python
from scilink.wrappers import NovitaGenerativeModel

model = NovitaGenerativeModel(deepseek/deepseek-v3.2, api_key=your-key)
response = model.generate_content([Hello!])
print(response.text)
```

## Checklist
- [x] Implementation follows existing provider patterns
- [x] Backward compatible (no existing provider modifications)
- [x] Minimal diff approach
- [x] Documentation updated