### PR TITLE
Fix hardcoded R² threshold in LLM verification prompt

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1724,7 +1724,7 @@ Return JSON:
 }}
 
 
-Remember: Rejecting a good fit (R² > 0.98) to chase marginal improvements often makes things WORSE through overfitting or convergence failures.
+Remember: Rejecting a good fit (R² > {accept_threshold:.3f}) to chase marginal improvements often makes things WORSE through overfitting or convergence failures.
 '''
 
     def _verify_fit_with_llm(self, state: dict, fit_result: dict, history: List[dict] = None) -> Optional[dict]:


### PR DESCRIPTION
The FIT_VERIFICATION_PROMPT contained a hardcoded 0.98 value in the closing reminder line, which caused the LLM to approve fits above R²=0.98 regardless of the parameterized accept_threshold. This overrode the user-specified threshold (e.g. 0.995) and prevented retries from triggering.

Replaced hardcoded 0.98 with {accept_threshold:.3f} to match the parameterization already applied to the accept/reject criteria above.