### PR TITLE
Fix Windows UTF-8 encoding failures in LLM-generated scripts

### DIFF
--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2210,15 +2210,13 @@ plan as specified and let the retry pipeline handle actual runtime failures.
 - Y: [{y_min:.6g}, {y_max:.6g}]
 
 **Available Libraries:** numpy, pandas, scipy, lmfit, matplotlib, json
-Note: use `np.trapezoid` (not `np.trapz`, which was removed in NumPy 2.0).
 
 **Requirements:**
-1. Start the script with `# -*- coding: utf-8 -*-` as the very first line to avoid Unicode errors on Windows.
-2. Load data (handle .npy, .csv, .txt)
-3. Implement your fitting approach
-4. Compute R² and RMSE
-5. Save `fit_visualization.png` (data + fit + residuals; show components if multiple peaks)
-6. Print results as JSON:
+1. Load data (handle .npy, .csv, .txt)
+2. Implement your fitting approach
+3. Compute R² and RMSE
+4. Save `fit_visualization.png` (data + fit + residuals; show components if multiple peaks)
+5. Print results as JSON:
 ```python
 results = {{
     "model_type": "description",
@@ -2248,10 +2246,8 @@ FITTING_SCRIPT_CORRECTION_INSTRUCTIONS = """Fix this failed script.
 ```
 
 **Available Libraries:** numpy, pandas, scipy, lmfit, matplotlib, json
-Note: use `np.trapezoid` (not `np.trapz`, which was removed in NumPy 2.0).
 
 **CRITICAL:** Fix only the execution error. Do NOT change the fitting model, its parameters, or the overall analysis approach. The model is locked for series consistency.
-Also ensure the script starts with `# -*- coding: utf-8 -*-` as the first line.
 
 **Response:** Return only `{{"diagnosis": "...", "script": "..."}}`
 """


### PR DESCRIPTION
Two related issues cause script execution failures on Windows:

1. executors.py: NamedTemporaryFile opens with mode='w' and no encoding, defaulting to cp1252 on Windows. LLM-generated scripts often contain Unicode characters (e.g. minus sign U+2212 from lmfit parameter output, degree symbol from DSC axis labels). This causes UnicodeEncodeError when writing the script to disk, wasting a retry slot before execution even starts. Fix: add encoding='utf-8' to NamedTemporaryFile.

2. instruct.py: FITTING_SCRIPT_INSTRUCTIONS and FITTING_SCRIPT_CORRECTION_INSTRUCTIONS did not instruct the LLM to declare UTF-8 encoding or use NumPy 2.0-compatible functions. Fix: add requirement to start scripts with # -*- coding: utf-8 -*- and note that np.trapezoid must be used instead of the removed np.trapz.