### PR TITLE
Fix subprocess using wrong Python on Windows with multiple environments

### DIFF
--- a/scilink/executors.py
+++ b/scilink/executors.py
@@ -305,7 +305,7 @@ class ScriptExecutor:
                 env['MP_API_KEY'] = self.mp_api_key
 
             proc = subprocess.Popen(
-                ['python', os.path.basename(temp_script_file)],
+                [sys.executable, os.path.basename(temp_script_file)],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 text=True, env=env,
             )


### PR DESCRIPTION
On Windows, when multiple Python installations exist simultaneously (e.g. a project virtual environment and a system-wide Python), subprocess.Popen with the bare string 'python' does not reliably resolve to the same interpreter that is currently running the parent process.

Observed on Windows with:
- Parent process: C:\...\SciLink\jarvis\Scripts\python.exe  (venv, has all deps)
- Subprocess:     C:\...\AppData\Local\Programs\Python\Python312\python.exe  (system Python, missing deps)

Even though the venv was active in the shell session, Windows PATH resolution in subprocess.Popen found the system Python first. This caused every LLM-generated fitting script to fail immediately with ModuleNotFoundError for packages like pandas that are installed in the venv but not in the system Python.

Fix: replace 'python' with sys.executable, which is the absolute path to the currently running interpreter. This guarantees the subprocess uses the exact same Python environment as the parent process, regardless of how many Python installations exist on the system or how PATH is ordered on Windows.

This is a no-op on Linux/Mac where 'python' typically resolves correctly, but is essential for Windows users running SciLink inside a virtual environment alongside a system Python installation.