### PR TITLE
Fix custom code results not reaching hyperspectral synthesis stage

### DIFF
--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -707,7 +707,7 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                     "analysis_images": iteration_state.get("analysis_images", []),
                     "refinement_decision": iteration_state.get("refinement_decision", {}),
                     "depth": current_task["depth"],
-                    "custom_analysis_metadata": iteration_state.get("custom_analysis_metadata")
+                    "custom_analysis_metadata_list": iteration_state.get("custom_analysis_metadata_list")
                 }
                 all_completed_results.append(result_summary)
 


### PR DESCRIPTION
The result_summary dict used the key "custom_analysis_metadata" but the controller stores results under "custom_analysis_metadata_list" and the synthesis prompt builder reads from "custom_analysis_metadata_list". This mismatch silently dropped all custom code results, causing the LLM to interpret only NMF/PCA outputs.