### PR TITLE
Add directory database query support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,16 @@ cython_debug/
 *.tar.gz
 *.err
 *.out
+
+# External databases
+CoREMOF*/
+
+# Session outputs
+planning_session_*/
+analysis_*/
+campaign_outputs/
+image_analysis_output/
+kb_storage/
+
+# Test outputs
+test_*/

--- a/scilink/agents/planning_agents/ingestor.py
+++ b/scilink/agents/planning_agents/ingestor.py
@@ -55,13 +55,35 @@ def ingest_files(file_paths: List[str], is_code_mode: bool, code_chunk_size: int
             else:
                 expanded_paths.append(f_path)
 
+    # 1b. Detect directory databases — skip files that belong to large
+    #     uniform collections (e.g., 4764 JSON records). These are queried
+    #     structurally via query_knowledge_data, not embedded as text chunks.
+    from collections import Counter
+    _dir_ext_counts: Dict[str, Counter] = {}
+    for f_path in expanded_paths:
+        p = Path(f_path)
+        parent_key = str(p.parent)
+        if parent_key not in _dir_ext_counts:
+            _dir_ext_counts[parent_key] = Counter()
+        _dir_ext_counts[parent_key][p.suffix.lower()] += 1
+    _skip_dir_ext = set()
+    for dir_path, ext_counts in _dir_ext_counts.items():
+        for ext, count in ext_counts.items():
+            if count >= 10:
+                _skip_dir_ext.add((dir_path, ext))
+                print(f"  - 📁 Skipping {count} {ext} files in {Path(dir_path).name} (directory database, queryable via query_knowledge_data)")
+
     # 2. Process each file
     for f_path in expanded_paths:
         path = Path(f_path)
         if not path.exists():
             print(f"  - ⚠️ File not found: {f_path}")
             continue
-        
+
+        # Skip files belonging to detected directory databases
+        if (str(path.parent), path.suffix.lower()) in _skip_dir_ext:
+            continue
+
         file_ext = path.suffix.lower()
         
         # --- ROUTE A: PDF Documents ---

--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -727,7 +727,7 @@ FIRST 10 ROWS:
 
 QUESTION: {query}
 
-Complete ONLY the middle section (marked TODO) of this script. Output just the pandas code, nothing else.
+Complete ONLY the middle section (marked TODO) of this script.
 
 ```
 import pandas as pd, json
@@ -739,7 +739,9 @@ print(json.dumps({{"answer": answer, "summary": summary}}))
 ```
 
 Your output must define two variables: `answer` (the result) and `summary` (a one-sentence string description).
-Output ONLY the TODO lines, no imports, no print, no explanation."""
+Return a JSON object with a single key "code" containing ONLY the TODO lines as a string.
+No imports, no print, no explanation.
+Example: {{"code": "answer = df['col'].mean()\\nsummary = \\"Average value is \\" + str(answer)"}}"""
 
 
 KNOWLEDGE_QUERY_DIRECTORY_CODEGEN_PROMPT = """Complete the TODO section of the script below to answer a question about a directory of files.

--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -740,3 +740,32 @@ print(json.dumps({{"answer": answer, "summary": summary}}))
 
 Your output must define two variables: `answer` (the result) and `summary` (a one-sentence string description).
 Output ONLY the TODO lines, no imports, no print, no explanation."""
+
+
+KNOWLEDGE_QUERY_DIRECTORY_CODEGEN_PROMPT = """Complete the TODO section of the script below to answer a question about a directory of files.
+
+DIRECTORY: {directory}
+CONTENTS: {files_by_extension}
+TOTAL FILES: {total_files}
+
+SAMPLE FILENAMES (first 20): {filenames}
+
+{sample_sections}
+
+QUESTION: {query}
+
+The script below provides imports, file discovery, and reader functions.
+Complete ONLY the TODO section (query logic).
+
+```
+{scaffold}
+# --- TODO: write query logic using the file lists and reader functions above ---
+
+# --- END TODO ---
+print(json.dumps({{"answer": answer, "summary": summary}}))
+```
+
+Your output must define two variables: `answer` (the result) and `summary` (a one-sentence string description).
+
+Return a JSON object with a single key "code" containing ONLY the TODO lines as a string.
+Example: {{"code": "data = [read_json(f) for f in json_files[:5]]\\nanswer = len(data)\\nsummary = \\"Found 5 records\\""}}"""

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -3734,11 +3734,16 @@ class OrchestratorTools:
                         [current_prompt],
                         generation_config={"max_output_tokens": 1024, "temperature": 0.0},
                     )
-                    # LLM returns only the computation lines; wrap in scaffold
-                    body = _extract_code_block(response.text) or response.text.strip()
-                    # Strip any markdown fences the LLM may have added
-                    body = re.sub(r'^```\w*\s*', '', body)
-                    body = re.sub(r'\s*```$', '', body)
+                    # LLM returns JSON: {"code": "...TODO lines..."}
+                    from .parser_utils import parse_json_from_response
+                    result, parse_error = parse_json_from_response(response)
+                    if parse_error or not result or "code" not in result:
+                        # Fallback: treat response as raw code
+                        body = _extract_code_block(response.text) or response.text.strip()
+                        body = re.sub(r'^```\w*\s*', '', body)
+                        body = re.sub(r'\s*```$', '', body)
+                    else:
+                        body = result["code"]
                     code = (
                         f"import pandas as pd, json\n"
                         f"df = {info['read_instruction']}\n"

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -18,7 +18,11 @@ def _natural_sort_key(s):
     return [int(c) if c.isdigit() else c.lower() for c in re.split(r'(\d+)', str(s))]
 
 from .parser_utils import write_experiments_to_disk
-from .instruct import BO_OBJECTIVE_DISTILL_PROMPT, KNOWLEDGE_QUERY_CODEGEN_PROMPT
+from .instruct import (
+    BO_OBJECTIVE_DISTILL_PROMPT,
+    KNOWLEDGE_QUERY_CODEGEN_PROMPT,
+    KNOWLEDGE_QUERY_DIRECTORY_CODEGEN_PROMPT,
+)
 from ..lit_agents.optimize_query import optimize_search_query, is_molecule_design_objective
 
 
@@ -3190,6 +3194,126 @@ class OrchestratorTools:
 
         QUERYABLE_EXTENSIONS = {'.xlsx', '.xls', '.csv'}
 
+        DIR_DB_MIN_FILES = 10  # minimum same-extension files to treat as database
+
+        def _summarize_json_value(value, max_str_len=200):
+            """Return a compact string representation of a JSON value."""
+            if value is None:
+                return "null"
+            if isinstance(value, bool):
+                return str(value).lower()
+            if isinstance(value, (int, float)):
+                return str(value)
+            if isinstance(value, str):
+                if len(value) > max_str_len:
+                    return json.dumps(value[:100]) + f"... ({len(value)} chars)"
+                return json.dumps(value)
+            if isinstance(value, list):
+                if len(value) == 0:
+                    return "list (0 items)"
+                first = _summarize_json_value(value[0], max_str_len=80)
+                return f"list ({len(value)} items, first: {first})"
+            if isinstance(value, dict):
+                keys = list(value.keys())
+                return f"dict ({len(keys)} keys: {keys[:5]})"
+            return repr(value)[:100]
+
+        def _summarize_json_file(file_path: str) -> str:
+            """Parse a JSON file and return a compact summary showing all keys."""
+            with open(file_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                lines = ["{"]
+                for k, v in data.items():
+                    lines.append(f"  {json.dumps(k)}: {_summarize_json_value(v)},")
+                lines.append("}")
+                return "\n".join(lines)
+            elif isinstance(data, list):
+                if len(data) == 0:
+                    return "[]  (empty list)"
+                summary = f"list of {len(data)} items\n"
+                if isinstance(data[0], dict):
+                    summary += "First item:\n"
+                    lines = ["{"]
+                    for k, v in data[0].items():
+                        lines.append(f"  {json.dumps(k)}: {_summarize_json_value(v)},")
+                    lines.append("}")
+                    summary += "\n".join(lines)
+                else:
+                    summary += f"First item: {_summarize_json_value(data[0])}"
+                return summary
+            return repr(data)[:2000]
+
+        def _inspect_directory(dir_path: str) -> dict:
+            """Summarize directory contents for LLM-driven querying."""
+            from collections import Counter
+
+            p = Path(dir_path)
+            files_by_ext = Counter()
+            all_files = {}  # ext -> sorted list of filenames
+
+            for f in p.iterdir():
+                if f.is_file() and not f.name.startswith('.'):
+                    ext = f.suffix.lower()
+                    files_by_ext[ext] += 1
+                    all_files.setdefault(ext, []).append(f.name)
+
+            # Sort filenames for each extension
+            for ext in all_files:
+                all_files[ext].sort()
+
+            total = sum(files_by_ext.values())
+
+            # Pick dominant extension for sampling
+            if not files_by_ext:
+                return {
+                    "directory": str(p),
+                    "files_by_extension": {},
+                    "total_files": 0,
+                    "sample_files": [],
+                    "all_filenames_sample": [],
+                }
+
+            # Sample files from each extension that has >= DIR_DB_MIN_FILES
+            # For smaller groups, sample one file; this gives the LLM visibility
+            # into all file types in the directory.
+            sample_files = []  # list of {"name", "content", "ext"}
+            sampled_exts = []
+            for ext, count in files_by_ext.most_common():
+                if count < DIR_DB_MIN_FILES:
+                    continue
+                sampled_exts.append(ext)
+                names_for_ext = all_files[ext]
+                # Pick one representative file per extension
+                sample_name = names_for_ext[len(names_for_ext) // 2]
+                fp = p / sample_name
+                try:
+                    if ext == '.json':
+                        content = _summarize_json_file(str(fp))
+                    else:
+                        size = fp.stat().st_size
+                        with open(fp, 'r', encoding='utf-8', errors='replace') as fh:
+                            if size > 50_000:
+                                content = fh.read(50_000)
+                                content += f"\n... (truncated, {size} bytes total)"
+                            else:
+                                content = fh.read()
+                except Exception as e:
+                    content = f"(error reading file: {e})"
+                sample_files.append({"name": sample_name, "content": content, "ext": ext})
+
+            # Collect first 20 filenames from the most common extension
+            dominant_ext = files_by_ext.most_common(1)[0][0]
+
+            return {
+                "directory": str(p),
+                "files_by_extension": dict(files_by_ext.most_common()),
+                "total_files": total,
+                "extensions": sampled_exts,
+                "sample_files": sample_files,
+                "all_filenames_sample": all_files[dominant_ext][:20],
+            }
+
         def _inspect_knowledge_file(file_path: str) -> dict:
             """Return a format-agnostic diagnostic snapshot of a data file."""
             p = Path(file_path)
@@ -3229,7 +3353,9 @@ class OrchestratorTools:
             }
 
         def _discover_queryable_files() -> list:
-            """Scan knowledge directories for queryable data files."""
+            """Scan knowledge directories for queryable data files and directory databases."""
+            from collections import Counter
+
             search_dirs = set()
             # User-specified knowledge folder (or kb_storage/ default)
             if self.orch.knowledge_dir and Path(self.orch.knowledge_dir).exists():
@@ -3241,34 +3367,79 @@ class OrchestratorTools:
 
             if not search_dirs:
                 return []
+
             found = {}
+            dir_db_dirs = set()  # directories detected as databases
+
+            # --- Detect directory databases ---
+            # Check each search dir and its immediate subdirectories
+            dirs_to_check = list(search_dirs)
+            for kdir in search_dirs:
+                for child in kdir.iterdir():
+                    if child.is_dir() and not child.name.startswith('.'):
+                        dirs_to_check.append(child)
+
+            for d in dirs_to_check:
+                ext_counts = Counter()
+                for f in d.iterdir():
+                    if f.is_file() and not f.name.startswith('.'):
+                        ext_counts[f.suffix.lower()] += 1
+                # If any extension has enough files, treat whole directory as database
+                db_exts = {ext: count for ext, count in ext_counts.items()
+                           if count >= DIR_DB_MIN_FILES}
+                if db_exts:
+                    parts = ", ".join(f"{c} {e}" for e, c in sorted(db_exts.items()))
+                    display_name = f"{d.name} ({parts} files)"
+                    found[display_name] = {
+                        "name": display_name,
+                        "path": str(d),
+                        "type": "directory",
+                    }
+                    dir_db_dirs.add(d)
+
+            # --- Discover single queryable files ---
             for kdir in search_dirs:
                 for f in kdir.rglob("*"):
                     if f.is_file() and f.suffix.lower() in QUERYABLE_EXTENSIONS:
-                        found[f.name] = {"name": f.name, "path": str(f)}
+                        # Skip files inside a detected database directory
+                        if any(f.parent == dd for dd in dir_db_dirs):
+                            continue
+                        found[f.name] = {"name": f.name, "path": str(f), "type": "file"}
+
             return sorted(found.values(), key=lambda x: x["name"])
 
         def _resolve_knowledge_data_file(file_name: str):
-            """Resolve a file name to a path in the knowledge directory."""
+            """Resolve a file name to a path in the knowledge directory.
+
+            Returns (target, error) where target is either:
+            - a file path string (for single files)
+            - a dict with "type": "directory" (for directory databases)
+            """
             from difflib import get_close_matches
             candidates = _discover_queryable_files()
             if not candidates:
                 return None, json.dumps({
                     "status": "error",
-                    "message": "No queryable data files found in knowledge directory."
+                    "message": "No queryable data files or directories found in knowledge directory."
                 })
             names = [c["name"] for c in candidates]
-            path_map = {c["name"]: c["path"] for c in candidates}
+            entry_map = {c["name"]: c for c in candidates}
+
+            def _return_entry(name):
+                entry = entry_map[name]
+                if entry.get("type") == "directory":
+                    return entry, None
+                return entry["path"], None
 
             # Exact match
-            if file_name in path_map:
-                return path_map[file_name], None
+            if file_name in entry_map:
+                return _return_entry(file_name)
 
-            # Stem match (without extension)
+            # Stem match (without extension) — only for file entries
             stem = Path(file_name).stem
             for n in names:
                 if Path(n).stem == stem:
-                    return path_map[n], None
+                    return _return_entry(n)
 
             # Fuzzy match
             matches = get_close_matches(file_name, names, n=3, cutoff=0.5)
@@ -3276,13 +3447,13 @@ class OrchestratorTools:
                 suggestion = ", ".join(matches)
                 return None, json.dumps({
                     "status": "error",
-                    "message": f"File '{file_name}' not found. Did you mean: {suggestion}?",
+                    "message": f"'{file_name}' not found. Did you mean: {suggestion}?",
                     "available_files": names
                 })
 
             return None, json.dumps({
                 "status": "error",
-                "message": f"File '{file_name}' not found.",
+                "message": f"'{file_name}' not found.",
                 "available_files": names
             })
 
@@ -3313,35 +3484,218 @@ class OrchestratorTools:
                 return re.sub(r'\n```\s*$', '', text.strip())
             return ""
 
+        def _build_directory_scaffold(info: dict) -> str:
+            """Build scaffold code with readers for each file type."""
+            dir_path = info["directory"]
+            lines = [
+                "import json, glob, os",
+                "from pathlib import Path",
+                "",
+                f"directory = {json.dumps(dir_path)}",
+            ]
+            # Add file lists and readers per extension
+            reader_map = {
+                '.json': (
+                    "def read_json(filepath):\n"
+                    "    with open(filepath, 'r') as f:\n"
+                    "        return json.load(f)"
+                ),
+                '.csv': (
+                    "import pandas as pd\n"
+                    "def read_csv(filepath):\n"
+                    "    return pd.read_csv(filepath)"
+                ),
+                '.tsv': (
+                    "import pandas as pd\n"
+                    "def read_tsv(filepath):\n"
+                    "    return pd.read_csv(filepath, sep='\\t')"
+                ),
+            }
+            default_reader = (
+                "def read_text(filepath):\n"
+                "    with open(filepath, 'r', encoding='utf-8', errors='replace') as f:\n"
+                "        return f.read()"
+            )
+
+            for ext in info["extensions"]:
+                count = info["files_by_extension"].get(ext, 0)
+                var_name = ext.lstrip('.') + "_files"
+                lines.append(f'{var_name} = sorted(glob.glob(os.path.join(directory, "*{ext}")))')
+                lines.append(f"# {count} {ext} files")
+            lines.append("")
+
+            added_readers = set()
+            for ext in info["extensions"]:
+                if ext in reader_map and ext not in added_readers:
+                    lines.append(reader_map[ext])
+                    added_readers.add(ext)
+                elif ext not in added_readers:
+                    lines.append(default_reader)
+                    added_readers.add('_text')
+            lines.append("")
+
+            return "\n".join(lines)
+
+        def _query_directory(dir_entry: dict, query: str) -> str:
+            """Query a directory database using LLM-generated code."""
+            import subprocess
+
+            dir_path = dir_entry["path"]
+            print(f"    - Inspecting directory: {dir_entry['name']}")
+
+            try:
+                info = _inspect_directory(dir_path)
+            except Exception as e:
+                return json.dumps({"status": "error", "message": f"Failed to inspect directory: {e}"})
+
+            if not info["sample_files"]:
+                return json.dumps({"status": "error", "message": "Directory is empty or unreadable."})
+
+            # Build scaffold and sample sections for prompt
+            scaffold = _build_directory_scaffold(info)
+            sample_sections = []
+            for s in info["sample_files"]:
+                sample_sections.append(f"--- {s['name']} ({s['ext']}) ---\n{s['content']}")
+            sample_text = "\nSAMPLE FILE CONTENTS:\n" + "\n\n".join(sample_sections) if sample_sections else ""
+
+            prompt = KNOWLEDGE_QUERY_DIRECTORY_CODEGEN_PROMPT.format(
+                directory=info["directory"],
+                files_by_extension=info["files_by_extension"],
+                total_files=info["total_files"],
+                filenames=info["all_filenames_sample"],
+                sample_sections=sample_text,
+                scaffold=scaffold,
+                query=query,
+            )
+
+            scripts_dir = Path(self.orch.base_dir) / "knowledge_query_scripts"
+            scripts_dir.mkdir(parents=True, exist_ok=True)
+
+            last_error = None
+            for attempt in range(2):
+                current_prompt = prompt
+                if last_error:
+                    current_prompt += f"\n\n**PREVIOUS ERROR:** {last_error}\nFix the script."
+
+                try:
+                    from .parser_utils import parse_json_from_response
+                    response = self.orch.planner.model.generate_content(
+                        [current_prompt],
+                        generation_config={"max_output_tokens": 8192, "temperature": 0.0},
+                    )
+                    # Log raw response for debugging
+                    raw_log_path = scripts_dir / f"kq_dir_raw_{abs(hash(query)) % 10000:04d}_a{attempt}.txt"
+                    raw_log_path.write_text(response.text)
+                    # LLM returns JSON: {"code": "...TODO lines..."}
+                    result, parse_error = parse_json_from_response(response)
+                    if parse_error or not result or "code" not in result:
+                        # Fallback: treat response as raw code
+                        body = _extract_code_block(response.text) or response.text.strip()
+                        body = re.sub(r'^```\w*\s*', '', body)
+                        body = re.sub(r'\s*```$', '', body)
+                    else:
+                        body = result["code"]
+                    code = (
+                        f"{scaffold}\n"
+                        f"{body}\n"
+                        f"print(json.dumps({{\"answer\": answer, \"summary\": summary}}))\n"
+                    )
+                except Exception as e:
+                    return json.dumps({"status": "error", "message": f"Code generation failed: {e}"})
+
+                script_path = scripts_dir / f"kq_dir_{Path(dir_path).name}_{abs(hash(query)) % 10000:04d}.py"
+                script_path.write_text(code)
+                print(f"    - Running: {script_path.name} (attempt {attempt + 1})")
+
+                try:
+                    result = subprocess.run(
+                        ["python", str(script_path)],
+                        capture_output=True, text=True, timeout=120,
+                    )
+                    if result.returncode != 0:
+                        last_error = result.stderr.strip()[-500:]
+                        continue
+
+                    # Parse the last valid JSON object from stdout
+                    # (LLM may print extra output before the json.dumps line)
+                    answer_data = None
+                    for line in reversed(result.stdout.strip().splitlines()):
+                        line = line.strip()
+                        if line.startswith('{') and line.endswith('}'):
+                            try:
+                                answer_data = json.loads(line)
+                                if "answer" in answer_data or "summary" in answer_data:
+                                    break
+                            except json.JSONDecodeError:
+                                continue
+                    if not answer_data:
+                        last_error = f"No valid JSON in output: {result.stdout[-300:]}"
+                        continue
+
+                    answer_str = json.dumps(answer_data.get("answer", ""))
+                    if len(answer_str) > 5000:
+                        answer_data["answer"] = str(answer_data["answer"])[:5000] + "... (truncated)"
+
+                    print(f"    - ✅ Directory query answered successfully.")
+                    return json.dumps({
+                        "status": "success",
+                        "query": query,
+                        "file": dir_entry["name"],
+                        "answer": answer_data.get("answer"),
+                        "summary": answer_data.get("summary", ""),
+                        "details": answer_data.get("details"),
+                        "script_path": str(script_path),
+                    })
+
+                except subprocess.TimeoutExpired:
+                    last_error = "Script timed out (120s limit)."
+                    continue
+                except json.JSONDecodeError as e:
+                    last_error = f"Invalid JSON in output: {e}"
+                    continue
+
+            return json.dumps({
+                "status": "error",
+                "message": "Directory query failed after 2 attempts.",
+                "last_error": last_error,
+            })
+
         def query_knowledge_data(query: str, file_name: str = None) -> str:
-            """Query a knowledge data file with natural language."""
+            """Query a knowledge data file or directory database with natural language."""
             import subprocess
 
             print(f"  ⚡ Tool: Querying knowledge data: '{query[:80]}...'")
 
-            # 1. Discover queryable files
+            # 1. Discover queryable files and directory databases
             queryable = _discover_queryable_files()
             if not queryable:
                 return json.dumps({
                     "status": "error",
-                    "message": "No queryable data files (.csv, .xlsx) found in knowledge directory."
+                    "message": "No queryable data files or directories found in knowledge directory."
                 })
 
-            # 2. Resolve target file
+            # 2. Resolve target
             if file_name is None:
                 if len(queryable) == 1:
-                    target_path = queryable[0]["path"]
-                    print(f"    - Auto-selected: {queryable[0]['name']}")
+                    target = queryable[0]
+                    print(f"    - Auto-selected: {target['name']}")
                 else:
                     return json.dumps({
                         "status": "file_selection_needed",
-                        "message": "Multiple data files found. Specify file_name.",
+                        "message": "Multiple queryable sources found. Specify file_name.",
                         "available_files": [f["name"] for f in queryable]
                     })
             else:
-                target_path, error = _resolve_knowledge_data_file(file_name)
+                target, error = _resolve_knowledge_data_file(file_name)
                 if error:
                     return error
+
+            # 2b. Branch: directory database vs single file
+            if isinstance(target, dict) and target.get("type") == "directory":
+                return _query_directory(target, query)
+
+            # Single file path — extract path string
+            target_path = target if isinstance(target, str) else target["path"]
 
             # 3. Inspect file
             try:
@@ -3448,9 +3802,10 @@ class OrchestratorTools:
             func=query_knowledge_data,
             name="query_knowledge_data",
             description=(
-                "Query a knowledge data file with natural language. "
-                "Generates and executes a Python script to answer questions about "
-                "reference datasets loaded as knowledge files."
+                "Query knowledge data with natural language. Works with single "
+                "data files (CSV, XLSX) and directory databases (folders of "
+                "uniformly-structured files like JSON records). Generates and "
+                "executes a Python script to answer questions about the data."
             ),
             parameters={
                 "query": {

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -296,14 +296,21 @@ to explore it BEFORE generating a plan: check what fields exist, query value ran
 distributions of key numeric fields, and identify available categories or labels.
 
 If the objective involves screening, filtering, ranking, or analyzing the knowledge data,
-design and execute a comprehensive screening strategy BEFORE calling `generate_initial_plan`:
-1. Based on the objective, the data exploration, and any literature context, outline a
-   multi-step screening approach (filters, scoring criteria, ranking metrics).
-2. Execute each screening step via `query_knowledge_data` calls.
-3. Pass the complete screening results as `additional_context` to `generate_initial_plan`,
-   clearly stating: "The following screening/analysis has already been completed: [results].
-   The plan should only cover steps that require resources beyond database queries
-   (e.g., new simulations, synthesis, characterization, experimental validation)."
+you MUST execute the screening yourself BEFORE calling `generate_initial_plan`. Do NOT
+delegate screening to the plan — anything you can answer by querying the database must be
+done now. Specifically:
+1. Based on the objective, the data exploration, and any literature context, decide on a
+   comprehensive suite of screening criteria that goes beyond summarizing basic stats —
+   include multi-step filters, composite scoring formulas, and ranking metrics.
+2. Execute each filter and ranking step via `query_knowledge_data` calls.
+3. Save the screening results to a file using `save_file` (e.g., a CSV of ranked candidates
+   with all relevant properties) so the results persist for downstream use.
+4. Pass the screening summary as `additional_context` to `generate_initial_plan`, clearly
+   stating: "The following database screening has already been completed and produced [N]
+   candidates (saved to [filename]): [summary of filters applied and results].
+   The plan should NOT repeat any database screening steps. It should only cover steps
+   that require resources beyond the database (e.g., new simulations, synthesis,
+   characterization, experimental validation)."
 
 When data files are provided, use `read_file` FIRST to inspect the contents. Based on what you see:
 - **Clean, straightforward tabular data** (clear column names, consistent units, no preprocessing needed)

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -300,6 +300,8 @@ When data files are provided, use `read_file` FIRST to inspect the contents. Bas
   to extract and clean the relevant data, then pass the answer as `additional_context`.
 - **Non-tabular data** (.txt, .json) → TEA/planning only parse CSV/Excel. If the content
   is short, pass the relevant data as `additional_context`. If too complex, ask the user for guidance.
+- **Directory databases** (folders with many files of the same type, e.g., JSON records) →
+  `query_knowledge_data` auto-detects these and lets you query across all files with natural language.
 - **Multi-run experimental results** (many rows of varying conditions, needs metric extraction
   for Bayesian optimization or plan refinement) → use `analyze_file` to extract scalar metrics.
 
@@ -337,17 +339,18 @@ To inspect or query data files before deciding on a workflow, use `read_file` an
     - Use instead of calling `analyze_file` in a loop when files share the same data structure.
 9. `reset_analysis_logic`: Destroys all analysis data, scripts, and BO history. Use ONLY when the
     user explicitly asks to start over. Do NOT use as error recovery — use `force_regenerate=True` instead.
-9b. `query_knowledge_data`: Query knowledge data files with natural language.
-    - For reference databases loaded as knowledge files (composition tables, property databases).
+9b. `query_knowledge_data`: Query knowledge data with natural language.
+    - Works with single data files (CSV, XLSX) AND directory databases (folders with many
+      uniformly-structured files, e.g., JSON record collections).
     - Generates a Python script, executes it, returns the answer.
     - NOT for experimental results feeding optimization — use analyze_file for that.
-    - If file_name omitted, lists available queryable files.
+    - If file_name omitted, lists available queryable files and detected directory databases.
     - **IMPORTANT**: Query answers are only visible to YOU (the orchestrator).
       Downstream tools (TEA, planning, refinement) cannot see them unless you pass
       them via `additional_context`.
     - Examples:
       * query_knowledge_data(query="average Li concentration in Permian Basin", file_name="PWSdatabase.xlsx")
-      * query_knowledge_data(query="top 10 samples by TDS")
+      * query_knowledge_data(query="find all MOFs with void fraction > 0.8")
       * query_knowledge_data(query="how many unique basins are represented?")
 
 **OPTIMIZATION TOOLS:**

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -291,6 +291,12 @@ Do NOT run TEA for purely scientific exploration (e.g., "study phase transitions
 **DATA TOOLS:**
 
 **DATA INSPECTION WORKFLOW:**
+When knowledge data is available (CSV, XLSX, or directory databases), use `query_knowledge_data`
+to explore it BEFORE generating a plan: check what fields exist, query value ranges and
+distributions of key numeric fields, and identify available categories or labels. Pass these
+findings as `additional_context` to `generate_initial_plan` so that screening criteria and
+thresholds are grounded in the actual data, not assumed values.
+
 When data files are provided, use `read_file` FIRST to inspect the contents. Based on what you see:
 - **Clean, straightforward tabular data** (clear column names, consistent units, no preprocessing needed)
   → pass directly to `run_economic_analysis` or `generate_initial_plan` as `primary_data_set`.

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -296,11 +296,14 @@ to explore it BEFORE generating a plan: check what fields exist, query value ran
 distributions of key numeric fields, and identify available categories or labels.
 
 If the objective involves screening, filtering, ranking, or analyzing the knowledge data,
-execute those steps directly using `query_knowledge_data` — do not defer them to the plan.
-The plan should only contain steps that require resources beyond the available data (e.g.,
-new experiments, external simulations, synthesis, characterization). Pass both the data
-exploration findings AND the screening/analysis results as `additional_context` to
-`generate_initial_plan`.
+design and execute a comprehensive screening strategy BEFORE calling `generate_initial_plan`:
+1. Based on the objective, the data exploration, and any literature context, outline a
+   multi-step screening approach (filters, scoring criteria, ranking metrics).
+2. Execute each screening step via `query_knowledge_data` calls.
+3. Pass the complete screening results as `additional_context` to `generate_initial_plan`,
+   clearly stating: "The following screening/analysis has already been completed: [results].
+   The plan should only cover steps that require resources beyond database queries
+   (e.g., new simulations, synthesis, characterization, experimental validation)."
 
 When data files are provided, use `read_file` FIRST to inspect the contents. Based on what you see:
 - **Clean, straightforward tabular data** (clear column names, consistent units, no preprocessing needed)

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -293,9 +293,14 @@ Do NOT run TEA for purely scientific exploration (e.g., "study phase transitions
 **DATA INSPECTION WORKFLOW:**
 When knowledge data is available (CSV, XLSX, or directory databases), use `query_knowledge_data`
 to explore it BEFORE generating a plan: check what fields exist, query value ranges and
-distributions of key numeric fields, and identify available categories or labels. Pass these
-findings as `additional_context` to `generate_initial_plan` so that screening criteria and
-thresholds are grounded in the actual data, not assumed values.
+distributions of key numeric fields, and identify available categories or labels.
+
+If the objective involves screening, filtering, ranking, or analyzing the knowledge data,
+execute those steps directly using `query_knowledge_data` — do not defer them to the plan.
+The plan should only contain steps that require resources beyond the available data (e.g.,
+new experiments, external simulations, synthesis, characterization). Pass both the data
+exploration findings AND the screening/analysis results as `additional_context` to
+`generate_initial_plan`.
 
 When data files are provided, use `read_file` FIRST to inspect the contents. Based on what you see:
 - **Clean, straightforward tabular data** (clear column names, consistent units, no preprocessing needed)

--- a/scilink/cli/plan.py
+++ b/scilink/cli/plan.py
@@ -114,7 +114,7 @@ Supported Models:
         '--knowledge-dir',
         type=str,
         dest='knowledge_dir',
-        help='Path to papers/literature directory (optional)'
+        help='Path to papers/literature or file-based database directory (optional)'
     )
     
     parser.add_argument(

--- a/scilink/ui/components/chat_uploads.py
+++ b/scilink/ui/components/chat_uploads.py
@@ -126,7 +126,7 @@ def _render_planning_uploads(start_task_fn) -> None:
         knowledge_folder = st.text_input(
             "or paste folder path",
             key="knowledge_folder_path",
-            placeholder="/path/to/papers/",
+            placeholder="/path/to/papers/ or /path/to/database/",
             label_visibility="collapsed",
         )
 

--- a/scilink/ui/config.py
+++ b/scilink/ui/config.py
@@ -33,7 +33,7 @@ SUPPORTED_DATA_EXTENSIONS = (
 
 SUPPORTED_METADATA_EXTENSIONS = (".json", ".txt")
 
-SUPPORTED_KNOWLEDGE_EXTENSIONS = (".pdf", ".txt", ".md", ".docx", ".png", ".jpg", ".jpeg", ".tif", ".tiff", ".csv", ".xlsx", ".tsv")
+SUPPORTED_KNOWLEDGE_EXTENSIONS = (".pdf", ".txt", ".md", ".docx", ".png", ".jpg", ".jpeg", ".tif", ".tiff", ".csv", ".xlsx", ".tsv", ".json")
 SUPPORTED_CODE_EXTENSIONS = (".py", ".txt", ".md", ".json", ".yaml", ".yml")
 SUPPORTED_PLANNING_DATA_EXTENSIONS = (".csv", ".xlsx", ".tsv", ".txt", ".npy", ".json")
 


### PR DESCRIPTION
## Summary

- Extends `query_knowledge_data` to support querying across directories of uniformly-structured files (e.g., thousands of JSON records from CoREMOF). The system auto-detects directories with 10+ files of the same extension as queryable collections, inspects sample files, and generates query code via scaffold + LLM pattern.
- Adds format-aware file inspection: JSON files are parsed into compact schema summaries (avoiding blob fields dominating previews), non-JSON files read as full text (up to 50KB).
- Uses JSON response pattern (`{"code": "..."}`) for both directory and single-file codegen, matching the scalarizer's established pattern and preventing `_clean_text` from mangling Python code containing dict literals.
- Skips directory database files during RAG ingestion to avoid embedding thousands of structured records as text chunks.
- Updates orchestrator system prompt to instruct the agent to explore knowledge data, execute screening/filtering, and save results BEFORE generating a plan -- so plans only contain steps requiring resources beyond database queries.
- Adds `.json` to supported knowledge upload extensions and updates UI/CLI help text.

## Files changed

| File | Changes |
|------|---------|
| `orchestrator_tools.py` | `_inspect_directory()`, `_build_directory_scaffold()`, `_query_directory()`; modified `_discover_queryable_files()`, `_resolve_knowledge_data_file()`, `query_knowledge_data()`; JSON response extraction for single-file codegen |
| `instruct.py` | `KNOWLEDGE_QUERY_DIRECTORY_CODEGEN_PROMPT`; updated `KNOWLEDGE_QUERY_CODEGEN_PROMPT` to use JSON response pattern |
| `ingestor.py` | Skip files belonging to detected directory databases during RAG ingestion |
| `planning_orchestrator.py` | System prompt: explore data before planning, execute screening via queries, save results |
| `config.py` | `.json` added to `SUPPORTED_KNOWLEDGE_EXTENSIONS` |
| `chat_uploads.py` | Updated folder path placeholder |
| `cli/plan.py` | Updated `--knowledge-dir` help text |
| `.gitignore` | Added CoREMOF*, planning_session_*, test_*, session outputs |

## Backward compatibility

- Single-file CSV/XLSX query path is untouched
- `_discover_queryable_files()` adds `type` field to entries; no existing code checks this
- Tool signature `query_knowledge_data(query, file_name)` is unchanged
- JSON response extraction includes fallback to raw code extraction for models that don't follow the JSON instruction