### PR TITLE
Fix image analysis two-tier pipeline and capture verification history

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -227,12 +227,10 @@ examine_data returns data_type:
 4. `select_agent`
 5. `run_analysis`
 6. Present results
-7. If `run_analysis` returns `tier2_suggested: true` (ImageAnalysisAgent only):
-   - Show the Tier 1 results and visualization to the user
-   - Ask: "Deeper analysis is recommended: [focus]. Proceed / Skip / Provide guidance?"
-   - If proceed: call `run_analysis` again with Tier 1 findings as `prior_knowledge`
-     and Tier 1 output directory path in `hints`
-   - If user provides guidance: include it in `hints` for the second call
+7. ImageAnalysisAgent handles Tier 2 deep analysis internally when warranted.
+   In interactive modes (CO_PILOT/SUPERVISED), the agent prompts the user directly
+   for Tier 2 approval. The result may include `tier2_ran: true` indicating
+   that deeper analysis was performed and merged into the results.
 
 **BEHAVIOR:**
 - If disambiguation_needed=true in examine_data result, ASK the user before selecting agent

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2019,16 +2019,11 @@ class AnalysisOrchestratorTools:
                     }
                     if viz_path:
                         response["visualization_path"] = viz_path
-                    if result.get("tier2_suggested"):
-                        response["tier2_suggested"] = True
-                        response["tier2_suggested_focus"] = result.get(
-                            "tier2_suggested_focus", "deeper analysis"
-                        )
-                        response["next_steps"] = (
-                            f"Deeper analysis recommended: {result.get('tier2_suggested_focus', '')}. "
-                            "Ask the user whether to proceed with Tier 2 analysis, skip it, or provide guidance. "
-                            "To run Tier 2, call run_analysis again on the same data with the Tier 1 findings "
-                            "as prior_knowledge and the output directory path in hints."
+                    if result.get("tier2_results"):
+                        response["tier2_ran"] = True
+                        t2 = result["tier2_results"]
+                        response["tier2_focus"] = t2.get(
+                            "analysis_approach", "deeper analysis"
                         )
                     return json.dumps(response)
                 else:

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -1498,8 +1498,15 @@ Your guidance: '''
 
         return result["script"]
 
-    def _correct_script(self, state: dict, script: str, error_msg: str) -> str:
-        """Generate a corrected script after an execution failure."""
+    def _correct_script(
+        self, state: dict, script: str, error_msg: str
+    ) -> tuple:
+        """Generate a corrected script after an execution failure.
+
+        Returns:
+            (corrected_script, diagnosis) — *diagnosis* is the LLM's
+            explanation of what went wrong and how it was fixed, or None.
+        """
         config = state.get("locked_analysis_config", {})
         prompt = self.correction_instructions.format(
             analysis_approach=config.get("analysis_approach", ""),
@@ -1522,10 +1529,11 @@ Your guidance: '''
         if error or not result or "script" not in result:
             raise ValueError(f"Correction failed: {error or 'no script'}")
 
-        if "diagnosis" in result:
-            self.logger.info(f"    Diagnosis: {result['diagnosis']}")
+        diagnosis = result.get("diagnosis")
+        if diagnosis:
+            self.logger.info(f"    Diagnosis: {diagnosis}")
 
-        return result["script"]
+        return result["script"], diagnosis
 
     def _check_conformance(self, state: dict, script: str) -> dict | None:
         """Use the LLM to verify a generated script implements the locked plan.
@@ -1646,6 +1654,8 @@ Your guidance: '''
         script = None
         last_error = ""
         exec_result = None
+        script_errors = []
+        last_diagnosis = None
 
         for attempt in range(1, self.MAX_ATTEMPTS + 1):
             try:
@@ -1680,7 +1690,9 @@ Your guidance: '''
                             "; ".join(conformance["justified_deviations"]),
                         )
                 else:
-                    script = self._correct_script(state, script, last_error)
+                    script, last_diagnosis = self._correct_script(
+                        state, script, last_error
+                    )
 
                 # Sanitize the script
                 script = self._sanitize_script(script)
@@ -1718,6 +1730,12 @@ Your guidance: '''
                             f"    Attempt {attempt}: Script ran but missing outputs: "
                             f"{', '.join(missing)}"
                         )
+                        script_errors.append({
+                            "attempt": attempt,
+                            "error": last_error[:300],
+                            "fix": (last_diagnosis or "")[:300] or None,
+                        })
+                        last_diagnosis = None
                         if attempt >= self.MAX_ATTEMPTS:
                             exec_result["status"] = "failed"
                             exec_result["message"] = last_error
@@ -1726,9 +1744,20 @@ Your guidance: '''
                     self.logger.warning(
                         f"    Attempt {attempt} failed: {last_error[:100]}"
                     )
+                    script_errors.append({
+                        "attempt": attempt,
+                        "error": last_error[:300],
+                        "fix": (last_diagnosis or "")[:300] or None,
+                    })
+                    last_diagnosis = None
             except Exception as e:
                 last_error = str(e)
                 self.logger.error(f"    Attempt {attempt} error: {e}")
+                script_errors.append({
+                    "attempt": attempt,
+                    "error": last_error[:300],
+                    "fix": None,
+                })
 
         # Clean up temp data file
         if temp_data_path.exists():
@@ -1746,6 +1775,7 @@ Your guidance: '''
                 "extracted_features": {},
                 "quality_metrics": {},
                 "script": script,
+                "script_errors": script_errors,
             }
 
         # Parse results from stdout
@@ -1789,6 +1819,7 @@ Your guidance: '''
             "visualization_bytes": viz_bytes,
             "statistics": stats,
             "script": script,
+            "script_errors": script_errors,
         }
 
     def _suggest_alternative_approach(
@@ -2315,6 +2346,8 @@ Return JSON with:
         4. If human feedback enabled: allow user to guide refinement
         """
         all_attempts = []
+        verification_history = []
+        judge_result = None
         best_result = None
         best_score = -1.0
         quality_threshold = self.quality_threshold
@@ -2357,7 +2390,6 @@ Return JSON with:
                     )
                 else:
                     verification_attempts = []
-                    verification_history = []
                     analysis_was_approved = False
                     current_result = best_result  # track latest for verification
 
@@ -2546,6 +2578,11 @@ Return JSON with:
                             image_idx, all_attempts,
                         )
 
+                best_result["quality_history"] = self._build_quality_history(
+                    best_score, quality_threshold, all_attempts,
+                    verification_history, judge_result,
+                    best_result.get("script_errors"),
+                )
                 return best_result
             else:
                 self.logger.warning(
@@ -2893,6 +2930,11 @@ Return JSON with:
             if _is_anchor and best_result.get("_winning_config"):
                 state["locked_analysis_config"] = best_result["_winning_config"]
 
+            best_result["quality_history"] = self._build_quality_history(
+                best_score, quality_threshold, all_attempts,
+                verification_history, judge_result,
+                best_result.get("script_errors"),
+            )
             return best_result
         else:
             return {
@@ -2949,6 +2991,52 @@ Return JSON with:
                 self.logger.info(f"      {line}")
 
         self.logger.info("")
+
+    @staticmethod
+    def _build_quality_history(
+        best_score: float,
+        quality_threshold: float,
+        all_attempts: list,
+        verification_history: list,
+        judge_result: dict | None,
+        script_errors: list | None = None,
+    ) -> dict:
+        """Build a compact quality history dict for the best result.
+
+        Captures problem→solution pairs at every level: script errors,
+        verification iterations, alternative approaches, and judge reasoning.
+        """
+        return {
+            "final_score": best_score,
+            "threshold": quality_threshold,
+            "approved": best_score >= quality_threshold,
+            "verification_iterations": [
+                {
+                    "score": entry["quality_score"],
+                    "issues": [
+                        {
+                            "location": iss.get("location", ""),
+                            "problem": iss.get("problem", ""),
+                        }
+                        for iss in entry.get("issues_found", [])
+                    ],
+                    "fix_applied": entry.get("recommended_action", ""),
+                }
+                for entry in verification_history
+            ],
+            "alternative_approaches": [
+                {
+                    "pipeline": a["pipeline"],
+                    "score": a["score"],
+                    "diagnosis": a.get("diagnosis", ""),
+                }
+                for a in all_attempts[1:]
+            ],
+            "script_errors": script_errors or [],
+            "judge_reasoning": (
+                (judge_result or {}).get("reasoning")
+            ),
+        }
 
     def _apply_user_feedback(
         self,
@@ -3470,6 +3558,7 @@ Return JSON with:
                 "quality_metrics": first_result.get("quality_metrics", {}),
                 "summary": first_result.get("summary"),
                 "saved_arrays": first_result.get("saved_arrays", {}),
+                "quality_history": first_result.get("quality_history"),
             }
             state["final_script"] = first_result.get("script")
             state["final_viz_bytes"] = first_result.get("visualization_bytes")
@@ -4729,6 +4818,44 @@ Return JSON with:
                 "the best result achieved."
             )
 
+        qh = analysis_result.get("quality_history")
+        if qh:
+            qh_lines = ["## Analysis Quality Context"]
+            approved = qh.get("approved", True)
+            qh_lines.append(
+                f"- Final score: {qh.get('final_score', 'N/A')} "
+                f"({'approved' if approved else 'best available, below threshold'})"
+            )
+            iters = qh.get("verification_iterations", [])
+            alts = qh.get("alternative_approaches", [])
+            if len(iters) > 1 or alts:
+                qh_lines.append(
+                    f"- Verification iterations: {len(iters)}, "
+                    f"alternative pipelines tried: {len(alts)}"
+                )
+            # Remaining issues from last verification (known limitations)
+            if iters:
+                last_issues = iters[-1].get("issues", [])
+                if last_issues:
+                    qh_lines.append("- Known limitations in this result:")
+                    for iss in last_issues[:5]:
+                        qh_lines.append(
+                            f"  - {iss.get('location', '')}: "
+                            f"{iss.get('problem', '')}"
+                        )
+            # Script errors
+            se = qh.get("script_errors", [])
+            if se:
+                qh_lines.append(
+                    f"- {len(se)} script correction(s) needed: "
+                    + "; ".join(e["error"][:80] for e in se[:3])
+                )
+            qh_lines.append(
+                "\nNote these known limitations where relevant "
+                "in your interpretation."
+            )
+            prompt_parts.append("\n".join(qh_lines))
+
         if state.get("literature_context"):
             prompt_parts.extend([
                 "\n## Literature", state["literature_context"]
@@ -4781,6 +4908,10 @@ Return JSON with:
                 "key_features": r.get("extracted_features", {}),
                 "quality_metrics": r.get("quality_metrics", {}),
             }
+            vh = r.get("quality_history")
+            if vh:
+                summary["quality_score"] = vh.get("final_score")
+                summary["quality_approved"] = vh.get("approved")
             if r.get("flagged"):
                 summary["flagged"] = True
                 summary["flag_reason"] = r.get("flag_reason")
@@ -4843,6 +4974,32 @@ Return JSON with:
         )
 
         prompt_parts = [prompt]
+
+        # Aggregate quality verification summary
+        verified = [
+            r for r in successful_analyses
+            if r.get("quality_history")
+        ]
+        if verified:
+            scores = [
+                r["quality_history"]["final_score"]
+                for r in verified
+                if r["quality_history"].get("final_score") is not None
+            ]
+            approved_n = sum(
+                1 for r in verified if r["quality_history"].get("approved")
+            )
+            qv_lines = [
+                "\n**QUALITY VERIFICATION SUMMARY:**",
+                f"- Verified images: {len(verified)}/{len(successful_analyses)}",
+                f"- Approved: {approved_n}/{len(verified)}",
+            ]
+            if scores:
+                qv_lines.append(
+                    f"- Score range: {min(scores):.2f} - {max(scores):.2f} "
+                    f"(mean: {sum(scores)/len(scores):.2f})"
+                )
+            prompt_parts.append("\n".join(qv_lines))
 
         if flagged_images:
             prompt_parts.append("\n\n**FLAGGED IMAGE VISUALIZATIONS:**")

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -1784,6 +1784,7 @@ Your guidance: '''
             "extracted_features": analysis_results.get("extracted_features", {}),
             "quality_metrics": analysis_results.get("quality_metrics", {}),
             "summary": analysis_results.get("summary"),
+            "saved_arrays": analysis_results.get("saved_arrays", {}),
             "visualization_path": str(viz_path) if viz_path.exists() else None,
             "visualization_bytes": viz_bytes,
             "statistics": stats,
@@ -3468,6 +3469,7 @@ Return JSON with:
                 ),
                 "quality_metrics": first_result.get("quality_metrics", {}),
                 "summary": first_result.get("summary"),
+                "saved_arrays": first_result.get("saved_arrays", {}),
             }
             state["final_script"] = first_result.get("script")
             state["final_viz_bytes"] = first_result.get("visualization_bytes")

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -906,7 +906,24 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             f"- {c.get('claim', '')}" for c in claims[:5]
         ) or "No claims."
 
-        files_str = "\n".join(f"- {f}" for f in tier1_files[:20])
+        # Build file listing with array descriptions where available
+        saved_arrays = tier1_state.get("analysis_result", {}).get(
+            "saved_arrays", {}
+        )
+        file_lines = []
+        for f in tier1_files[:20]:
+            fname = Path(f).name
+            meta = saved_arrays.get(fname)
+            if meta:
+                desc = meta.get("description", "")
+                shape = meta.get("shape", "")
+                dtype = meta.get("dtype", "")
+                file_lines.append(
+                    f"- `{f}` — {desc} (shape={shape}, dtype={dtype})"
+                )
+            else:
+                file_lines.append(f"- {f}")
+        files_str = "\n".join(file_lines)
 
         # Build Tier 2 planning instructions
         tier2_instructions = IMAGE_ANALYSIS_TIER2_PLANNING_INSTRUCTIONS.format(

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -511,102 +511,51 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # ================================================================
         tier2_results = None
 
+        # Common args for _run_tier2 (avoids repeating in both branches)
+        _tier2_ctx = dict(
+            tier1_state=state, tier1_results=tier1_results,
+            first_image=first_image,
+            original_image_bytes=original_image_bytes,
+            image_statistics=image_statistics,
+            handled_system_info=handled_system_info,
+            series_metadata=series_metadata, hints=hints,
+            objective=objective, skill_state=skill_state,
+            aux_state=aux_state, image_paths=image_paths,
+            image_stack=image_stack, input_type=input_type,
+            num_images=num_images, is_single_image=is_single_image,
+            first_image_name=first_image_name,
+            effective_max_retries=effective_max_retries,
+            effective_outlier_sigma=effective_outlier_sigma,
+        )
+
         if self.analysis_depth == "auto" and tier1_results["status"] == "success":
-            # Evaluate whether Tier 2 is recommended — return suggestion
-            # to the caller (orchestrator) without running Tier 2
             tier2_decision = self._evaluate_tier2_needed(
                 tier1_results, objective
             )
             if tier2_decision and tier2_decision.get("tier2_needed"):
-                tier1_results["tier2_suggested"] = True
-                tier1_results["tier2_suggested_focus"] = tier2_decision.get(
-                    "suggested_focus", "deeper analysis"
-                )
-                self.logger.info(
-                    f"\n🔬 Tier 2 recommended: "
-                    f"{tier1_results['tier2_suggested_focus']}"
-                )
+                run_tier2 = True
+                if self.enable_human_feedback:
+                    run_tier2, user_guidance = self._prompt_tier2_approval(
+                        tier1_results, tier2_decision
+                    )
+                    if user_guidance:
+                        state["tier2_user_guidance"] = user_guidance
+
+                if run_tier2:
+                    self.logger.info("\n🔬 TIER 2: Running (auto, approved)")
+                    tier2_results = self._run_tier2(
+                        **_tier2_ctx, tier2_decision=tier2_decision,
+                    )
+                else:
+                    self.logger.info("\n📊 Tier 2: skipped by user")
             else:
-                tier1_results["tier2_suggested"] = False
                 self.logger.info(
                     "\n📊 Tier 2: not warranted by Tier 1 findings"
                 )
 
         elif self.analysis_depth == "deep" and tier1_results["status"] == "success":
-            # Run both tiers internally (autonomous/batch mode)
             self.logger.info("\n🔬 TIER 2: Running (analysis_depth='deep')")
-
-            # Preserve Tier 1 outputs
-            import shutil
-            tier1_dir = self.output_dir / "tier1"
-            tier1_dir.mkdir(exist_ok=True)
-            for item in self.output_dir.iterdir():
-                if item.name in ("tier1", "tier2") or item.name.startswith("."):
-                    continue
-                dst = tier1_dir / item.name
-                if item.is_dir():
-                    if dst.exists():
-                        shutil.rmtree(dst)
-                    shutil.copytree(item, dst)
-                elif item.is_file():
-                    shutil.copy2(item, dst)
-            self.logger.info(f"   📂 Tier 1 outputs preserved in {tier1_dir}")
-
-            # Build Tier 2 state and run
-            tier2_state = self._build_tier2_state(
-                state, tier1_results,
-                first_image, original_image_bytes, image_statistics,
-                handled_system_info, series_metadata, hints, objective,
-                skill_state, aux_state,
-                image_paths, image_stack, input_type,
-                num_images, is_single_image, first_image_name,
-            )
-
-            tier2_pipeline = create_unified_image_analysis_pipeline(
-                model=self.model,
-                logger=self.logger,
-                generation_config=self.generation_config,
-                safety_settings=self.safety_settings,
-                parse_fn=self._parse_llm_response,
-                store_fn=self._store_analysis_images,
-                image_to_bytes_fn=image_to_thumbnail_bytes,
-                montage_fn=create_image_montage,
-                executor=self.executor,
-                output_dir=str(self.output_dir),
-                literature_agent=self.literature_agent,
-                enable_human_feedback=self.enable_human_feedback,
-                max_approach_retries=effective_max_retries,
-                outlier_sigma=effective_outlier_sigma,
-                max_verification_iterations=self.max_verification_iterations,
-                num_plan_candidates=self.num_plan_candidates,
-            )
-
-            for i, controller in enumerate(tier2_pipeline, 1):
-                step_name = controller.__class__.__name__
-                self.logger.info(
-                    f"\n📍 TIER 2 STEP {i}: {step_name}\n"
-                )
-                try:
-                    tier2_state = controller.execute(tier2_state)
-                    if tier2_state.get("error_dict"):
-                        self.logger.error(
-                            f"❌ Tier 2 failed at {step_name}: "
-                            f"{tier2_state['error_dict']}"
-                        )
-                        break
-                except Exception as e:
-                    self.logger.error(
-                        f"❌ Tier 2 step {step_name} raised exception: {e}"
-                    )
-                    tier2_state["error_dict"] = {
-                        "error": f"Tier 2 step failed: {step_name}",
-                        "details": str(e),
-                    }
-                    break
-
-            if not tier2_state.get("error_dict"):
-                tier2_results = self._compile_results(tier2_state)
-                self._save_analysis_scripts(tier2_state)
+            tier2_results = self._run_tier2(**_tier2_ctx)
 
         # Merge results
         if tier2_results and tier2_results["status"] == "success":
@@ -786,6 +735,146 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         except Exception as e:
             self.logger.warning(f"Tier 2 decision error: {e}")
             return None
+
+    def _prompt_tier2_approval(
+        self, tier1_results: dict, tier2_decision: dict
+    ) -> tuple:
+        """Prompt the user for Tier 2 approval.
+
+        Returns:
+            (run_tier2, user_guidance) — *run_tier2* is True to proceed,
+            *user_guidance* is a string if the user provided guidance, else None.
+        """
+        focus = tier2_decision.get("suggested_focus", "deeper analysis")
+        reasoning = tier2_decision.get("reasoning", "")
+
+        print("\n" + "=" * 60)
+        print("TIER 2 ANALYSIS RECOMMENDATION")
+        print("=" * 60)
+
+        summary = tier1_results.get("detailed_analysis", "")
+        if summary:
+            lines = summary.strip().split("\n")[:10]
+            print(f"\nTier 1 Summary:\n   " + "\n   ".join(lines))
+
+        claims = tier1_results.get("scientific_claims", [])
+        if claims:
+            print(f"\nKey Claims:")
+            for c in claims[:5]:
+                print(f"   - {c.get('claim', '')}")
+
+        viz_paths = tier1_results.get("visualization_paths", [])
+        if viz_paths:
+            print(f"\nVisualizations:")
+            for p in viz_paths[:3]:
+                print(f"   {p}")
+
+        print(f"\nRecommendation: {focus}")
+        if reasoning:
+            print(f"   Reasoning: {reasoning}")
+
+        print("=" * 60)
+
+        try:
+            response = input(
+                "Proceed with deeper analysis? "
+                "(yes / skip / or provide guidance): "
+            ).strip()
+        except EOFError:
+            return True, None
+
+        if not response or response.lower() in ("yes", "y", "proceed"):
+            return True, None
+        if response.lower() in ("skip", "no", "n"):
+            return False, None
+        # Anything else is treated as guidance
+        return True, response
+
+    def _run_tier2(
+        self,
+        tier1_state, tier1_results,
+        first_image, original_image_bytes, image_statistics,
+        handled_system_info, series_metadata, hints, objective,
+        skill_state, aux_state,
+        image_paths, image_stack, input_type,
+        num_images, is_single_image, first_image_name,
+        effective_max_retries, effective_outlier_sigma,
+        tier2_decision=None,
+    ) -> Optional[dict]:
+        """Run Tier 2 pipeline and return compiled results, or None on failure."""
+        import shutil
+
+        # Preserve Tier 1 outputs
+        tier1_dir = self.output_dir / "tier1"
+        tier1_dir.mkdir(exist_ok=True)
+        for item in self.output_dir.iterdir():
+            if item.name in ("tier1", "tier2") or item.name.startswith("."):
+                continue
+            dst = tier1_dir / item.name
+            if item.is_dir():
+                if dst.exists():
+                    shutil.rmtree(dst)
+                shutil.copytree(item, dst)
+            elif item.is_file():
+                shutil.copy2(item, dst)
+        self.logger.info(f"   Tier 1 outputs preserved in {tier1_dir}")
+
+        tier2_state = self._build_tier2_state(
+            tier1_state, tier1_results,
+            first_image, original_image_bytes, image_statistics,
+            handled_system_info, series_metadata, hints, objective,
+            skill_state, aux_state,
+            image_paths, image_stack, input_type,
+            num_images, is_single_image, first_image_name,
+            tier2_decision=tier2_decision,
+        )
+
+        tier2_pipeline = create_unified_image_analysis_pipeline(
+            model=self.model,
+            logger=self.logger,
+            generation_config=self.generation_config,
+            safety_settings=self.safety_settings,
+            parse_fn=self._parse_llm_response,
+            store_fn=self._store_analysis_images,
+            image_to_bytes_fn=image_to_thumbnail_bytes,
+            montage_fn=create_image_montage,
+            executor=self.executor,
+            output_dir=str(self.output_dir),
+            literature_agent=self.literature_agent,
+            enable_human_feedback=self.enable_human_feedback,
+            max_approach_retries=effective_max_retries,
+            outlier_sigma=effective_outlier_sigma,
+            max_verification_iterations=self.max_verification_iterations,
+            num_plan_candidates=self.num_plan_candidates,
+        )
+
+        for i, controller in enumerate(tier2_pipeline, 1):
+            step_name = controller.__class__.__name__
+            self.logger.info(f"\n   TIER 2 STEP {i}: {step_name}\n")
+            try:
+                tier2_state = controller.execute(tier2_state)
+                if tier2_state.get("error_dict"):
+                    self.logger.error(
+                        f"Tier 2 failed at {step_name}: "
+                        f"{tier2_state['error_dict']}"
+                    )
+                    break
+            except Exception as e:
+                self.logger.error(
+                    f"Tier 2 step {step_name} raised exception: {e}"
+                )
+                tier2_state["error_dict"] = {
+                    "error": f"Tier 2 step failed: {step_name}",
+                    "details": str(e),
+                }
+                break
+
+        if not tier2_state.get("error_dict"):
+            tier2_results = self._compile_results(tier2_state)
+            self._save_analysis_scripts(tier2_state)
+            return tier2_results
+
+        return None
 
     def _build_tier2_state(
         self, tier1_state, tier1_results,

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -1046,6 +1046,8 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
 
             if series_results and series_results[0].get("quality_warning"):
                 results["quality_warning"] = series_results[0]["quality_warning"]
+            if series_results and series_results[0].get("quality_history"):
+                results["quality_history"] = series_results[0]["quality_history"]
 
         else:
             # Series: full structure with trends and flagged images
@@ -1084,6 +1086,10 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                     "flagged": r.get("flagged", False),
                     "flag_reason": r.get("flag_reason"),
                     "adaptively_refitted": r.get("adaptively_refitted", False),
+                    "verification_score": (
+                        r.get("quality_history", {}).get("final_score")
+                        if r.get("quality_history") else None
+                    ),
                 }
                 for r in series_results
             ]
@@ -1101,6 +1107,29 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             results["locked_analysis_config"] = state.get(
                 "locked_analysis_config"
             )
+
+            # Aggregate verification summary
+            vh_entries = [
+                r.get("quality_history") for r in series_results
+                if r.get("quality_history")
+            ]
+            if vh_entries:
+                scores = [
+                    v["final_score"] for v in vh_entries
+                    if v.get("final_score") is not None
+                ]
+                results["verification_summary"] = {
+                    "verified_count": len(vh_entries),
+                    "approved_count": sum(
+                        1 for v in vh_entries if v.get("approved")
+                    ),
+                    "score_range": (
+                        [min(scores), max(scores)] if scores else None
+                    ),
+                    "mean_score": (
+                        sum(scores) / len(scores) if scores else None
+                    ),
+                }
 
         return results
 

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2927,13 +2927,25 @@ For multi-channel images, show each channel as a separate grayscale subplot (do 
 display a 2-channel array directly with imshow). \
 All visualizations must be saved to the current working directory. Use `dpi=100` and limit \
 to 6 subplots max to keep file size manageable.
-4. Print results as JSON:
+4. Save key output arrays to the current working directory as `.npy` files. \
+At minimum save the primary detection/segmentation result (label map, binary \
+mask, or position array). Example: `np.save("analysis_labels.npy", label_map)`. \
+If you used SAM, build a combined integer label map from the per-particle masks \
+(background=0, particles labeled 1,2,3,...) and save that — do NOT save raw \
+per-particle boolean masks individually.
+5. Print results as JSON. Include a `saved_arrays` key describing every `.npy` \
+file you saved — each entry should have `description`, `shape`, and `dtype` so \
+follow-up analysis can load the right file without guessing. \
+Example entry: `"analysis_labels.npy": {{"description": "Integer label map, \
+23 grains labeled 1-23, background=0", "shape": [512, 512], "dtype": "int32"}}`. \
+The standard fields are:
 ```python
 results = {{{{
     "analysis_type": "description of what was done",
     "extracted_features": {{{{"feature_name": value, ...}}}},
     "quality_metrics": {{{{"metric_name": value, ...}}}},
-    "summary": "Key finding in one sentence"
+    "summary": "Key finding in one sentence",
+    "saved_arrays": {{{{...}}}}
 }}}}
 print(f"IMAGE_ANALYSIS_RESULTS_JSON:{{{{json.dumps(results)}}}}")
 ```

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2673,9 +2673,14 @@ interesting aspects of the data.
 **Available Tier 1 outputs in working directory:**
 {tier1_files}
 
-Your follow-up analysis can load and build on these outputs. Focus on
-the single most scientifically valuable analysis that the Tier 1
-results suggest — do not try to do everything.
+**CRITICAL: Re-use Tier 1 results.** Do NOT re-segment, re-detect, or
+re-measure features that Tier 1 already computed. Load the Tier 1
+output files listed above (masks, label maps, feature tables) and
+build on them. Tier 2 should perform *additional* analysis that Tier 1
+did not do — not repeat what it already did.
+
+Focus on the single most scientifically valuable follow-up analysis
+that the Tier 1 results suggest — do not try to do everything.
 
 **Output Format:**
 ```json

--- a/scilink/knowledge.py
+++ b/scilink/knowledge.py
@@ -114,6 +114,56 @@ def synthesize_knowledge(
         if status:
             analysis_texts.append(f"### Status ({label}): {status}")
 
+        # Collect quality history for failure/method synthesis.
+        # For tiered results, also check tier2_results.
+        qh_entries = []
+        t2 = result.get("tier2_results") or {}
+        if result.get("quality_history"):
+            tier_label = "Tier 1" if t2 else ""
+            qh_entries.append((tier_label, result["quality_history"]))
+        if isinstance(t2, dict) and t2.get("quality_history"):
+            qh_entries.append(("Tier 2", t2["quality_history"]))
+
+        for qh_label, qh in qh_entries:
+            if not (qh and synthesis_type in ("failure", "method")):
+                continue
+            section_label = f" — {qh_label}" if qh_label else ""
+            qh_lines = [f"### Quality History ({label}{section_label})"]
+
+            for se in qh.get("script_errors", []):
+                qh_lines.append(f"- Script error: {se.get('error', '')}")
+                if se.get("fix"):
+                    qh_lines.append(f"  Fix: {se['fix']}")
+
+            iterations = qh.get("verification_iterations", [])
+            for j, it in enumerate(iterations):
+                issues = [x.get("problem", "") for x in it.get("issues", [])]
+                qh_lines.append(
+                    f"- Verification {j + 1} (score={it.get('score', 0):.2f})"
+                    f": issues={issues}"
+                )
+                fix = it.get("fix_applied")
+                if fix:
+                    qh_lines.append(f"  Fix applied: {fix}")
+                    if j + 1 < len(iterations):
+                        next_score = iterations[j + 1].get("score", 0)
+                        improved = next_score > it.get("score", 0)
+                        qh_lines.append(
+                            f"  Outcome: score "
+                            f"{'improved' if improved else 'worsened'}"
+                            f" to {next_score:.2f}"
+                        )
+
+            for alt in qh.get("alternative_approaches", []):
+                qh_lines.append(
+                    f"- Alternative pipeline "
+                    f"(score={alt.get('score', 0):.2f}): "
+                    f"{alt.get('diagnosis', '')}"
+                )
+
+            if len(qh_lines) > 1:
+                analysis_texts.append("\n".join(qh_lines))
+
         # Collect human feedback
         hf = result.get("human_feedback", {})
         if isinstance(hf, dict):


### PR DESCRIPTION
## Summary

- Fix auto-mode Tier 2: run internally with human approval gate instead of broken orchestrator re-call
- Fix Tier 1 to Tier 2 data handoff: scripts save output arrays with metadata, Tier 2 loads them instead of re-running segmentation
- Capture "what didn't work and how it was fixed" at every level (script errors, verification issues, alternative approaches) and pass to knowledge synthesis

## Problem

Three related issues with the image analysis two-tier pipeline:

1. **Auto-mode Tier 2 never ran.** `analysis_depth="auto"` only set `tier2_suggested=True` in the return dict and relied on the orchestrator to call `run_analysis` again. But the second call created a fresh agent with Tier 1 instructions and no Tier 1 context, so Tier 2 effectively repeated Tier 1 or failed silently. Without the orchestrator, `auto` mode was identical to `basic`.

2. **Tier 2 couldn't access Tier 1 results.** Even in `deep` mode (which ran Tier 2 internally), Tier 1 scripts didn't save computed arrays to disk. Tier 2 received a file listing but the files were only PNGs and JSONs with feature values -- no masks, label maps, or position arrays. The Tier 2 planning prompt said "can load and build on these outputs" but there was nothing to load, so Tier 2 re-ran segmentation from scratch.

3. **Verification history was discarded.** The pipeline iteratively corrects failures at multiple levels (script execution errors, quality verification issues, alternative pipeline attempts), but the entire correction history was thrown away. Only a one-line `quality_warning` string survived to the synthesis controller, and the orchestrator's `synthesize_knowledge` tool had no access to what went wrong or how it was fixed.

## Changes

### Auto-mode Tier 2 fix (`image_analysis_agent.py`)

- `auto` mode now runs Tier 2 internally (like `deep`) with a gate: `enable_human_feedback=True` prompts the user with Tier 1 highlights before proceeding; AUTONOMOUS mode auto-runs if the LLM says Tier 2 is warranted
- Extracted `_run_tier2()` helper shared by both `auto` and `deep` code paths
- Added `_prompt_tier2_approval()` that displays Tier 1 summary, claims, and visualization paths before prompting

### Orchestrator updates (`analysis_orchestrator.py`, `analysis_orchestrator_tools.py`)

- Removed the "call `run_analysis` again for Tier 2" workflow from the system prompt
- Replaced `tier2_suggested` response with `tier2_ran` / `tier2_focus` report

### Tier 1 to Tier 2 data handoff (`instruct.py`, `image_analysis_controllers.py`, `image_analysis_agent.py`)

- Script generation instructions now require saving key output arrays as `.npy` files with a `saved_arrays` metadata dict in the JSON output (description, shape, dtype per file)
- `saved_arrays` is captured from script results and stored in `state["analysis_result"]`
- `_build_tier2_state()` annotates the Tier 2 file listing with array descriptions from `saved_arrays`
- Tier 2 planning instructions strengthened: "Do NOT re-segment, re-detect, or re-measure features that Tier 1 already computed. Load the Tier 1 output files."

### Quality history capture (`image_analysis_controllers.py`, `image_analysis_agent.py`, `knowledge.py`)

Captures problem-to-solution pairs at every level:

- **Script execution**: `_correct_script()` now returns `(script, diagnosis)` tuple; error+fix pairs collected in `script_errors` list on each per-image result
- **Quality verification**: `_build_quality_history()` helper builds a `quality_history` dict with per-iteration issues, recommended actions, and scores
- **Alternative approaches**: pipeline name, score, and diagnosis captured in `quality_history["alternative_approaches"]`
- **Judge reasoning**: preserved when judge selects best from failed attempts

Data flow:
- `quality_history` attached to per-image results in `_execute_and_verify()`
- Propagated to `state["analysis_result"]` for single images
- Single-image synthesis prompt gets "Analysis Quality Context" section with known limitations
- Series synthesis prompt gets aggregate quality verification summary
- `_compile_results()` passes `quality_history` through to final output dict
- Orchestrator's `full_result` storage automatically includes it
- `knowledge.py` extracts quality history for "failure" and "method" synthesis types, formatting problem-to-fix-to-outcome chains for both tiers