### PR TITLE
Add constraint annealing to image analysis agent

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -2224,6 +2224,14 @@ Return JSON with:
                             self.logger.warning(f"   Verification failed, skipping")
                             break
                         
+                        # Compute the annealing level actually used by the
+                        # verification prompt (not the stale state value).
+                        _n_lvl = len(self._CONSTRAINT_ANNEALING_SCHEDULE)
+                        _max_it = max(self.max_verification_iterations, 1)
+                        _cur_level = min(
+                            verification_iter * _n_lvl // _max_it, _n_lvl - 1
+                        )
+
                         # Store in history for next iteration's context
                         verification_history.append({
                             "r_squared": best_r2,
@@ -2231,6 +2239,7 @@ Return JSON with:
                             "issues_found": verification.get("issues_found", []),
                             "overall_assessment": verification.get("overall_assessment", ""),
                             "recommended_action": verification.get("recommended_action", ""),
+                            "annealing_level": _cur_level,
                         })
 
                         if verification.get("fit_acceptable", True):
@@ -3053,6 +3062,7 @@ Return JSON with:
             "verification_iterations": [
                 {
                     "r_squared": entry.get("r_squared"),
+                    "annealing_level": entry.get("annealing_level", 0),
                     "issues": [
                         {
                             "location": iss.get("location", ""),

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -2212,21 +2212,37 @@ Return JSON with the refined analysis approach:
         self, state: dict, best_result: dict, all_attempts: List[dict]
     ) -> Optional[dict]:
         """Ask user for guidance when automated quality is poor."""
-        pipelines_tried = "\n".join([
-            f"  - {a['pipeline']}: score = {a['score']:.2f}"
-            for a in all_attempts
-        ])
+        # Build concise summary grouped by attempt type
+        lines = []
+        initial = [a for a in all_attempts if not str(a["pipeline"]).startswith(("Verification", "Alternative", "User"))]
+        verifications = [a for a in all_attempts if str(a["pipeline"]).startswith("Verification")]
+        alternatives = [a for a in all_attempts if not str(a["pipeline"]).startswith(("Verification", "User")) and a not in initial]
+        user_guided = [a for a in all_attempts if str(a["pipeline"]).startswith("User")]
 
-        print("")
-        print("=" * 60)
-        print("ANALYSIS QUALITY BELOW THRESHOLD")
-        print("=" * 60)
+        if initial:
+            lines.append(f"  Initial pipeline: score = {initial[0]['score']:.2f}")
+        if verifications:
+            scores = [f"{v['score']:.2f}" for v in verifications]
+            lines.append(f"  Verification refinements ({len(verifications)}): scores = {', '.join(scores)}")
+        for i, a in enumerate(alternatives, 1):
+            lines.append(f"  Alternative {i}: score = {a['score']:.2f}")
+        for a in user_guided:
+            lines.append(f"  User-guided: score = {a['score']:.2f}")
+
+        pipelines_tried = "\n".join(lines)
+
+        print("\n\n")
+        print("─" * 60)
+        print()
+        print("⚠️  ANALYSIS QUALITY BELOW THRESHOLD")
+        print()
+        print("─" * 60)
 
         if best_result.get("visualization_bytes"):
             viz_path = self.output_dir / "quality_review_analysis.png"
             with open(viz_path, 'wb') as f:
                 f.write(best_result["visualization_bytes"])
-            print(f"[Best result visualization saved to: {viz_path}]")
+            print(f"\n📊 [Best result saved to: {viz_path}]")
 
         prompt = self.HUMAN_FEEDBACK_PROMPT.format(
             best_score=best_result.get("_quality_score", 0.0),

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -1319,8 +1319,53 @@ class UnifiedImageProcessingController:
     MAX_ATTEMPTS = 5
     DEFAULT_MAX_APPROACH_RETRIES = 3
     DEFAULT_OUTLIER_SIGMA = 2.0
-    DEFAULT_MAX_VERIFICATION_ITERATIONS = 3
+    DEFAULT_MAX_VERIFICATION_ITERATIONS = 5
     DEFAULT_QUALITY_THRESHOLD = 0.7
+
+    # Constraint annealing: gradually raise the "temperature" so the
+    # verifier can explore more of the pipeline space when early iterations
+    # fail to produce an adequate result.  Like simulated annealing
+    # (P ∝ exp(−ΔE/kT)), low T keeps the system near the locked plan
+    # while high T lets it explore freely.
+    #
+    # NOTE: Image analysis starts softer than curve fitting — the baseline
+    # (T=0) is "guidance", not "mandatory", because image analysis pipelines
+    # are inherently more flexible than parametric curve models.
+    _CONSTRAINT_ANNEALING_SCHEDULE = (
+        # T=0  guidance: prefer the locked pipeline, suggest parameter tweaks.
+        "\n**Plan-aware constraint:**\n"
+        "The processing pipeline listed above is the analysis plan. "
+        "Your suggested fixes should work within the planned method — recommend "
+        "parameter adjustments, preprocessing improvements, or cleanup steps. "
+        "Do not recommend replacing the core analysis method with a different one.\n",
+        # T=1  warm: allow pipeline modifications if justified.
+        "\n**Plan-aware constraint (eased — earlier fixes did not resolve the issues):**\n"
+        "Prefer the smallest change that could fix the remaining issues. "
+        "If you believe a pipeline change is necessary, suggest it, but explain "
+        "why a parameter-level fix is insufficient.\n",
+        # T=2  hot: full freedom, justify from what you see in the images.
+        "\n**Plan constraint (open — previous iterations could not fix the analysis):**\n"
+        "You have full freedom to suggest any pipeline or method change the data "
+        "warrants. The only requirement is that you justify every deviation from "
+        "the original plan based on what you observe in the images.\n",
+    )
+
+    # Same annealing applied to domain skill strictness during analysis.
+    # Planning and interpretation stages always keep skills at T=0 (guidance).
+    _SKILL_STRICTNESS_SCHEDULE = (
+        # T=0: guidance (default for image analysis — softer than curve fitting's "mandatory")
+        "## Domain Expertise Guidance ({name})\n"
+        "The following guidance is from validated domain expertise. "
+        "Use it to inform your implementation.\n\n",
+        # T=1: light reference
+        "## Domain Expertise Reference ({name})\n"
+        "Use as reference. If the data clearly requires a different approach, "
+        "deviate and explain why.\n\n",
+        # T=2: context only
+        "## Domain Expertise Context ({name})\n"
+        "Use as background context only. Override any guidance if the data "
+        "warrants it — explain the deviation.\n\n",
+    )
 
     JUDGE_PROMPT = '''You are a scientific image analysis expert acting as a judge.
 
@@ -1459,12 +1504,11 @@ Your guidance: '''
             context_parts.append(state["literature_context"])
         skill_sections = state.get("skill_sections")
         if skill_sections and skill_sections.get("analysis"):
-            context_parts.append(
-                f"## Domain Expertise ({state.get('skill_name', 'skill')})\n"
-                "The following guidance is from validated domain expertise. "
-                "Use it to inform your implementation.\n\n"
-                + skill_sections["analysis"]
-            )
+            level = state.get("_annealing_level", 0)
+            preamble = self._SKILL_STRICTNESS_SCHEDULE[
+                min(level, len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
+            ].format(name=state.get("skill_name", "skill"))
+            context_parts.append(preamble + skill_sections["analysis"])
 
         # Add sub-agent preprocessing array paths
         for key in ("fft_preprocessing", "sam_preprocessing"):
@@ -1516,12 +1560,11 @@ Your guidance: '''
         )
         skill_sections = state.get("skill_sections")
         if skill_sections and skill_sections.get("analysis"):
-            prompt += (
-                f"\n\n## Domain Expertise ({state.get('skill_name', 'skill')})\n"
-                "The following guidance is from validated domain expertise. "
-                "Use it to inform your implementation.\n\n"
-                + skill_sections["analysis"]
-            )
+            level = state.get("_annealing_level", 0)
+            preamble = self._SKILL_STRICTNESS_SCHEDULE[
+                min(level, len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
+            ].format(name=state.get("skill_name", "skill"))
+            prompt += "\n\n" + preamble + skill_sections["analysis"]
 
         response = self.model.generate_content(prompt)
         result, error = self._parse(response)
@@ -1975,12 +2018,7 @@ Estimate Completeness, Precision, and Plausibility separately, then average.
 
 ---
 
-## PLAN AWARENESS
-
-The processing pipeline listed above is the LOCKED analysis plan. \
-Your suggested fixes should work within the planned method — recommend \
-parameter adjustments, preprocessing improvements, or cleanup steps. \
-Do not recommend replacing the core analysis method with a different one.
+{plan_constraint}
 
 ---
 
@@ -2013,6 +2051,7 @@ Return JSON:
         state: dict,
         result: dict,
         history: List[dict] = None,
+        verification_iter: int = 0,
     ) -> Optional[dict]:
         """Use LLM to verify analysis quality by examining the visualization.
 
@@ -2030,6 +2069,13 @@ Return JSON:
         features_str = json.dumps(features, indent=2) if features else "No features extracted"
         metrics_str = json.dumps(metrics, indent=2) if metrics else "No metrics available"
 
+        # Constraint annealing: spread temperature levels evenly across iterations.
+        schedule = self._CONSTRAINT_ANNEALING_SCHEDULE
+        n_levels = len(schedule)
+        max_iter = max(self.max_verification_iterations, 1)
+        level = min(verification_iter * n_levels // max_iter, n_levels - 1)
+        plan_constraint = schedule[level]
+
         prompt_text = self.QUALITY_VERIFICATION_PROMPT.format(
             analysis_approach=config.get("analysis_approach", "Unknown"),
             processing_pipeline=config.get("processing_pipeline", "Unknown"),
@@ -2037,6 +2083,7 @@ Return JSON:
             features=features_str,
             metrics=metrics_str,
             quality_threshold=self.quality_threshold,
+            plan_constraint=plan_constraint,
         )
 
         # Add history context
@@ -2355,6 +2402,9 @@ Return JSON with:
         # Anchor = first image overall OR first in a regime; gets full QC
         _is_anchor = image_idx == 0 or is_regime_anchor
 
+        # --- Initial analysis (skills at T=0 — guidance) ---
+        state["_annealing_level"] = 0
+
         # --- Initial analysis ---
         initial_pipeline = state.get(
             'locked_analysis_config', {}
@@ -2400,7 +2450,8 @@ Return JSON with:
                         )
 
                         verification = self._verify_quality(
-                            state, current_result, history=verification_history
+                            state, current_result, history=verification_history,
+                            verification_iter=verification_iter,
                         )
 
                         if verification is None:
@@ -2429,6 +2480,15 @@ Return JSON with:
                             "score": v_score,
                         })
 
+                        # Compute the annealing level that was actually used
+                        # by _verify_quality for this iteration (not the stale
+                        # state value, which is updated after re-analysis).
+                        _n_lvl = len(self._CONSTRAINT_ANNEALING_SCHEDULE)
+                        _max_it = max(self.max_verification_iterations, 1)
+                        _cur_level = min(
+                            verification_iter * _n_lvl // _max_it, _n_lvl - 1
+                        )
+
                         verification_history.append({
                             "quality_score": v_score,
                             "config_used": state.get("locked_analysis_config", {}),
@@ -2439,6 +2499,7 @@ Return JSON with:
                             "recommended_action": verification.get(
                                 "recommended_action", ""
                             ),
+                            "annealing_level": _cur_level,
                         })
 
                         # Log sub-scores if available
@@ -2487,6 +2548,14 @@ Return JSON with:
 
                         state["locked_analysis_config"] = refined_config
 
+                        # Sync skill strictness with annealing temperature
+                        n_levels = len(self._SKILL_STRICTNESS_SCHEDULE)
+                        max_iter = max(self.max_verification_iterations, 1)
+                        state["_annealing_level"] = min(
+                            verification_iter * n_levels // max_iter,
+                            n_levels - 1,
+                        )
+
                         # Re-analyze with refined config
                         self.logger.info(
                             "   Re-analyzing with verification feedback..."
@@ -2520,7 +2589,8 @@ Return JSON with:
                         # Loop exhausted without approval - verify final result
                         self.logger.info("   Verifying final re-analysis...")
                         final_verification = self._verify_quality(
-                            state, current_result
+                            state, current_result,
+                            verification_iter=self.max_verification_iterations,
                         )
 
                         if final_verification:
@@ -3013,6 +3083,7 @@ Return JSON with:
             "verification_iterations": [
                 {
                     "score": entry["quality_score"],
+                    "annealing_level": entry.get("annealing_level", 0),
                     "issues": [
                         {
                             "location": iss.get("location", ""),
@@ -3038,6 +3109,30 @@ Return JSON with:
             ),
         }
 
+    USER_FEEDBACK_SCRIPT_PROMPT = '''You have a working image analysis script and user feedback requesting changes.
+
+**USER FEEDBACK:** {user_feedback}
+
+**CURRENT WORKING SCRIPT:**
+```python
+{current_script}
+```
+
+**CURRENT ANALYSIS CONFIG:**
+- Approach: {analysis_approach}
+- Pipeline: {processing_pipeline}
+
+Decide how to address the user's feedback:
+- If the feedback is about visualization, colormaps, labels, fonts, or display only → modify the relevant plotting sections of the existing script. Keep all analysis logic untouched.
+- If the feedback requires minor analysis changes (parameters, thresholds, filters) → modify the relevant parts of the existing script.
+- If the feedback requires a fundamentally different analysis approach → write a new script from scratch.
+
+In all cases, preserve the output contract: the script must print \
+'IMAGE_ANALYSIS_RESULTS_JSON:{{...}}' and save a visualization PNG.
+
+Return JSON: {{"diagnosis": "what you changed and why", "script": "full Python script"}}
+'''
+
     def _apply_user_feedback(
         self,
         state: dict,
@@ -3052,11 +3147,158 @@ Return JSON with:
     ) -> tuple:
         """Apply user feedback to refine the analysis.
 
+        Gives the LLM the existing script and lets it decide whether to
+        patch it or rewrite from scratch based on the feedback.
+
         Returns:
             Tuple of (best_result, best_score) after applying feedback
         """
+        existing_script = best_result.get("script", "")
+        original_config = state.get("locked_analysis_config", {})
+
+        if existing_script:
+            # Let the LLM decide: patch existing script or rewrite
+            self.logger.info("   Applying user feedback to existing script...")
+            config = state.get("locked_analysis_config", {})
+            prompt = self.USER_FEEDBACK_SCRIPT_PROMPT.format(
+                user_feedback=user_feedback,
+                current_script=existing_script,
+                analysis_approach=config.get("analysis_approach", ""),
+                processing_pipeline=config.get("processing_pipeline", ""),
+            )
+
+            try:
+                response = self.model.generate_content(prompt)
+                result, error = self._parse(response)
+
+                if not error and result and result.get("script"):
+                    diagnosis = result.get("diagnosis", "")
+                    if diagnosis:
+                        self.logger.info(f"    Diagnosis: {diagnosis}")
+                    patched_script = result["script"]
+
+                    # Execute the patched script
+                    working_dir = self.output_dir / f"image_{image_idx:04d}"
+                    working_dir.mkdir(parents=True, exist_ok=True)
+                    temp_data_path = working_dir / f"temp_image_{image_idx}.npy"
+                    np.save(temp_data_path, image_data)
+                    output_prefix = f"image_{image_idx:04d}"
+
+                    patched_script = self._sanitize_script(patched_script)
+                    exec_result = self.executor.execute_script(
+                        patched_script, working_dir=str(working_dir)
+                    )
+
+                    if temp_data_path.exists():
+                        try:
+                            os.remove(temp_data_path)
+                        except Exception:
+                            pass
+
+                    if exec_result.get("status") == "success":
+                        stdout = exec_result.get("stdout", "")
+                        analysis_results = {}
+                        for line in stdout.splitlines():
+                            if line.startswith("IMAGE_ANALYSIS_RESULTS_JSON:"):
+                                try:
+                                    analysis_results = json.loads(
+                                        line.replace(
+                                            "IMAGE_ANALYSIS_RESULTS_JSON:", ""
+                                        ).strip()
+                                    )
+                                except json.JSONDecodeError:
+                                    pass
+                                break
+
+                        viz_path = working_dir / f"{output_prefix}_analysis.png"
+                        if not viz_path.exists():
+                            viz_path = working_dir / "analysis_visualization.png"
+
+                        viz_bytes = None
+                        if viz_path.exists():
+                            with open(viz_path, "rb") as f:
+                                viz_bytes = f.read()
+
+                        if analysis_results and viz_bytes:
+                            # Verify the user-guided result with the LLM
+                            user_guided_result = {
+                                "index": image_idx,
+                                "name": image_name,
+                                "data_path": data_path,
+                                "success": True,
+                                "error": None,
+                                "analysis_type": analysis_results.get(
+                                    "analysis_type"
+                                ),
+                                "extracted_features": analysis_results.get(
+                                    "extracted_features", {}
+                                ),
+                                "quality_metrics": analysis_results.get(
+                                    "quality_metrics", {}
+                                ),
+                                "summary": analysis_results.get("summary"),
+                                "visualization_bytes": viz_bytes,
+                                "visualization_path": str(viz_path),
+                                "script": patched_script,
+                                "script_errors": [],
+                            }
+
+                            verification = self._verify_quality(
+                                state, user_guided_result
+                            )
+                            if verification:
+                                user_score = verification.get(
+                                    "quality_score", 0.5
+                                )
+                                if not isinstance(user_score, (int, float)):
+                                    user_score = 0.5
+                            else:
+                                user_score = user_guided_result.get(
+                                    "quality_metrics", {}
+                                ).get("quality_score", 0.5)
+                                if isinstance(user_score, str):
+                                    try:
+                                        user_score = float(user_score)
+                                    except (ValueError, TypeError):
+                                        user_score = 0.5
+
+                            user_guided_result["_quality_score"] = user_score
+                            self.logger.info(
+                                f"   User-guided result: score = {user_score:.2f}"
+                            )
+                            all_attempts.append({
+                                "pipeline": "User-guided",
+                                "score": user_score,
+                                "result": user_guided_result,
+                            })
+
+                            if user_score >= best_score:
+                                return user_guided_result, user_score
+                            else:
+                                if viz_bytes:
+                                    review_path = (
+                                        self.output_dir
+                                        / "first_image_analysis_review.png"
+                                    )
+                                    with open(review_path, "wb") as f:
+                                        f.write(viz_bytes)
+                                keep = self._ask_keep_user_guided_result(
+                                    user_score, best_score
+                                )
+                                if keep:
+                                    return user_guided_result, user_score
+                                return best_result, best_score
+
+                    self.logger.warning(
+                        "   Patched script failed, falling back to full re-analysis"
+                    )
+            except Exception as e:
+                self.logger.warning(
+                    f"   Script patching failed ({e}), falling back to full re-analysis"
+                )
+
+        # Fallback: full re-analysis (original behavior)
         refined_config = self._refine_config_from_feedback(state, user_feedback)
-        original_config = state.get("locked_analysis_config")
         state["locked_analysis_config"] = refined_config
 
         # Clean up old visualization
@@ -3074,14 +3316,20 @@ Return JSON with:
         )
 
         if user_guided_result["success"]:
-            user_score = user_guided_result.get(
-                "quality_metrics", {}
-            ).get("quality_score", 0.5)
-            if isinstance(user_score, str):
-                try:
-                    user_score = float(user_score)
-                except (ValueError, TypeError):
+            verification = self._verify_quality(state, user_guided_result)
+            if verification:
+                user_score = verification.get("quality_score", 0.5)
+                if not isinstance(user_score, (int, float)):
                     user_score = 0.5
+            else:
+                user_score = user_guided_result.get(
+                    "quality_metrics", {}
+                ).get("quality_score", 0.5)
+                if isinstance(user_score, str):
+                    try:
+                        user_score = float(user_score)
+                    except (ValueError, TypeError):
+                        user_score = 0.5
             user_guided_result["_quality_score"] = user_score
             self.logger.info(f"   User-guided result: score = {user_score:.2f}")
             all_attempts.append({
@@ -3090,12 +3338,14 @@ Return JSON with:
                 "result": user_guided_result,
             })
 
-            if user_score > best_score:
+            if user_score >= best_score:
                 return user_guided_result, user_score
             else:
                 if user_guided_result.get("visualization_bytes"):
-                    review_viz_path = self.output_dir / "first_image_analysis_review.png"
-                    with open(review_viz_path, 'wb') as f:
+                    review_viz_path = (
+                        self.output_dir / "first_image_analysis_review.png"
+                    )
+                    with open(review_viz_path, "wb") as f:
                         f.write(user_guided_result["visualization_bytes"])
                 keep_user = self._ask_keep_user_guided_result(
                     user_score, best_score

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -806,7 +806,8 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         """Run Tier 2 pipeline and return compiled results, or None on failure."""
         import shutil
 
-        # Preserve Tier 1 outputs
+        # Preserve Tier 1 outputs — move to tier1/ subdirectory so the
+        # main output dir only contains Tier 2 results + the tier1/ archive.
         tier1_dir = self.output_dir / "tier1"
         tier1_dir.mkdir(exist_ok=True)
         for item in self.output_dir.iterdir():
@@ -816,9 +817,9 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             if item.is_dir():
                 if dst.exists():
                     shutil.rmtree(dst)
-                shutil.copytree(item, dst)
+                shutil.move(str(item), str(dst))
             elif item.is_file():
-                shutil.copy2(item, dst)
+                shutil.move(str(item), str(dst))
         self.logger.info(f"   Tier 1 outputs preserved in {tier1_dir}")
 
         tier2_state = self._build_tier2_state(
@@ -852,7 +853,7 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
 
         for i, controller in enumerate(tier2_pipeline, 1):
             step_name = controller.__class__.__name__
-            self.logger.info(f"\n   TIER 2 STEP {i}: {step_name}\n")
+            self.logger.info(f"\n📍 TIER 2 STEP {i}: {step_name}\n")
             try:
                 tier2_state = controller.execute(tier2_state)
                 if tier2_state.get("error_dict"):

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -748,32 +748,34 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         focus = tier2_decision.get("suggested_focus", "deeper analysis")
         reasoning = tier2_decision.get("reasoning", "")
 
-        print("\n" + "=" * 60)
-        print("TIER 2 ANALYSIS RECOMMENDATION")
-        print("=" * 60)
+        # Clear visual break so the recommendation starts fresh
+        print("\n\n")
+        print("─" * 60)
+        print()
+        print("🔬 TIER 2 — DEEP ANALYSIS RECOMMENDATION")
+        print()
+        print("─" * 60)
 
-        summary = tier1_results.get("detailed_analysis", "")
+        # Brief Tier 1 summary — first 3 lines only
+        summary = tier1_results.get("summary", "")
+        if not summary:
+            summary = tier1_results.get("detailed_analysis", "")
         if summary:
-            lines = summary.strip().split("\n")[:10]
-            print(f"\nTier 1 Summary:\n   " + "\n   ".join(lines))
+            lines = summary.strip().split("\n")[:3]
+            print(f"\n📋 Tier 1 summary:\n   "
+                  + " ".join(l.strip() for l in lines)[:300])
 
-        claims = tier1_results.get("scientific_claims", [])
-        if claims:
-            print(f"\nKey Claims:")
-            for c in claims[:5]:
-                print(f"   - {c.get('claim', '')}")
-
-        viz_paths = tier1_results.get("visualization_paths", [])
-        if viz_paths:
-            print(f"\nVisualizations:")
-            for p in viz_paths[:3]:
-                print(f"   {p}")
-
-        print(f"\nRecommendation: {focus}")
+        # Concise Tier 2 proposal
+        print(f"\n🎯 Proposed analysis:\n   {focus}")
         if reasoning:
-            print(f"   Reasoning: {reasoning}")
+            # Keep reasoning to first sentence or 200 chars
+            short_reason = reasoning.split(". ")[0].rstrip(".") + "."
+            if len(short_reason) > 200:
+                short_reason = short_reason[:200] + "..."
+            print(f"\n💡 Why: {short_reason}")
 
-        print("=" * 60)
+        print()
+        print("─" * 60)
 
         try:
             response = input(

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2646,7 +2646,27 @@ For multi-channel images, pass a single channel (e.g., `image[:,:,0]`).
 - Phase identification (intensity clustering, color-space segmentation)
 - Defect detection (template matching, anomaly detection, local contrast)
 - Spatial statistics (nearest-neighbor distances, pair correlation, Voronoi tessellation)
-- Frequency analysis (FFT, bandpass filtering)
+- Frequency analysis (FFT, bandpass filtering, power spectral density).
+  Prefer FFT-based methods for atomically resolved images where it is more meaningful
+  to learn about periodic structures, symmetries, or electronic patterns rather than
+  find every atom.
+- Sliding FFT/NMF decomposition — for images with periodic or quasi-periodic structures.
+  Use `from scilink.tools.fft_nmf import run_fft_nmf_analysis` in your script.
+  Procedure: slides a window across the image, computes the FFT power spectrum of each
+  patch (with Hamming windowing, log-magnitude, and central zoom), then runs NMF on the
+  stacked spectra to factorize them into a small set of spectral components (dominant
+  frequency patterns) and their spatial abundance maps (where each pattern is present).
+  Usage: `result = run_fft_nmf_analysis(image_array, params={"n_components": 4})`
+  First arg must be a 2D grayscale numpy array.
+  Parameters: window_size (pixels, default: auto), n_components (default: 4),
+    step_fraction (window overlap, default: 0.25).
+  Returns dict with "components" shape (n_components, fft_h, fft_w) — each component is
+    a 2D FFT power spectrum representing a dominant frequency pattern; "abundances" shape
+    (n_components, grid_h, grid_w) — spatial maps showing where each component is present
+    in the image; plus "n_components", "window_size", "grid_shape".
+  Choose window_size and n_components based on the physics of the problem — the spatial
+  scale of repeating features and the number of distinct patterns expected in the image
+  based on the material system and imaging conditions.
 
 **Commit to specific choices — do NOT hedge:**
 - State ONE segmentation method, not alternatives (write "Otsu thresholding" not "Otsu or adaptive")
@@ -2682,8 +2702,15 @@ fields) — that will be handled in a follow-up step if warranted by
 your findings.
 
 Keep the pipeline simple and robust. A successful basic analysis that
-captures all features is more valuable than an ambitious pipeline that
-fails.
+captures the main features is more valuable than an ambitious pipeline
+that fails.
+
+If no specific analysis objective was provided, focus on basic
+characterization: identify what structures are present, measure their
+primary properties (count, size, spacing, intensity), and report what
+you observe. Do not attempt to answer every possible scientific
+question about the image — Tier 2 can follow up on the most
+interesting findings.
 """
 
 

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2667,6 +2667,10 @@ For multi-channel images, pass a single channel (e.g., `image[:,:,0]`).
   Choose window_size and n_components based on the physics of the problem — the spatial
   scale of repeating features and the number of distinct patterns expected in the image
   based on the material system and imaging conditions.
+  Always save components and abundances as .npy files (e.g.,
+  `np.save("nmf_components.npy", result["components"])` and
+  `np.save("abundance_maps.npy", result["abundances"])`) and include them in
+  `saved_arrays` so follow-up analysis can reuse them.
 
 **Commit to specific choices — do NOT hedge:**
 - State ONE segmentation method, not alternatives (write "Otsu thresholding" not "Otsu or adaptive")

--- a/scilink/tools/fft_nmf.py
+++ b/scilink/tools/fft_nmf.py
@@ -244,3 +244,58 @@ class SlidingFFTNMF:
             print(f"Saved results to {output_dir}")
             
         return components, abundances
+
+
+def run_fft_nmf_analysis(image_array, params=None):
+    """Run sliding FFT + NMF decomposition on an image.
+
+    Convenience wrapper around :class:`SlidingFFTNMF` that mirrors the
+    ``run_sam_analysis`` API so generated scripts can call it directly.
+
+    Args:
+        image_array: 2D numpy array (grayscale image).
+        params: Optional dict with:
+            - window_size (int): Side length in pixels (default: auto).
+            - n_components (int): Number of NMF components (default: 4).
+            - step_fraction (float): Window step as fraction of window
+              size — 0.25 means 75 % overlap (default: 0.25).
+
+    Returns:
+        dict with ``components`` (n, h, w), ``abundances`` (n, gh, gw),
+        ``n_components``, ``window_size``, and ``grid_shape``.
+    """
+    params = params or {}
+    window_size = params.get("window_size")
+    n_components = params.get("n_components", 4)
+    step_fraction = params.get("step_fraction", 0.25)
+
+    kwargs = {"components": n_components}
+    if window_size is not None:
+        kwargs["window_size_x"] = window_size
+        kwargs["window_size_y"] = window_size
+        step = max(1, int(window_size * step_fraction))
+        kwargs["window_step_x"] = step
+        kwargs["window_step_y"] = step
+
+    analyzer = SlidingFFTNMF(**kwargs)
+
+    # Call pipeline steps directly to avoid stdout prints and
+    # unwanted file saves that analyze() does by default.
+    data = image_array.astype(float)
+    d_min, d_max = data.min(), data.max()
+    if d_max > d_min:
+        data = (data - d_min) / (d_max - d_min)
+    windows = analyzer.make_windows(data)
+    fft_data = analyzer.process_fft(windows)
+    components, abundances = analyzer.run_nmf(fft_data)
+
+    return {
+        "components": components,
+        "abundances": abundances,
+        "n_components": int(components.shape[0]),
+        "window_size": (analyzer.window_size_x, analyzer.window_size_y),
+        "grid_shape": (
+            analyzer.grid_shape[1],
+            analyzer.grid_shape[2],
+        ),
+    }


### PR DESCRIPTION
## Summary
- **Constraint annealing for image analysis**: Adds a temperature-based schedule (`_CONSTRAINT_ANNEALING_SCHEDULE`) that gradually relaxes plan constraints during verification iterations — starts at "guidance" (prefer the locked pipeline) and opens to full freedom if earlier fixes fail, mirroring the curve-fitting approach but softer by default.
- **Skill strictness annealing**: Domain expertise preambles (`_SKILL_STRICTNESS_SCHEDULE`) also relax with temperature during analysis, while planning/interpretation stages stay at T=0.
- **FFT/NMF as callable tool**: Adds `run_fft_nmf_analysis()` convenience wrapper and updates Tier 1 planning guidance with detailed usage instructions for sliding FFT/NMF decomposition.
- **Smarter user feedback**: `_apply_user_feedback` now gives the LLM the existing working script so it can patch it (visualization tweaks, parameter changes) instead of always doing a full re-analysis from scratch.
- **Cleaner UI**: Concise Tier 2 recommendation output, better formatted quality-review prompts, removed duplicate Tier 1 report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)