### PR TITLE
Tool registry image analysis

### DIFF
--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -1355,14 +1355,13 @@ class UnifiedImageProcessingController:
 
     Quality control features:
     - LLM-based quality verification of analysis results
-    - If quality is inadequate, automatically tries alternative pipelines (max_approach_retries)
-    - If still inadequate and human feedback enabled, asks for guidance
+    - Annealing-driven refinement loop inside the verification iterations
+    - If quality remains inadequate and human feedback is enabled, asks for guidance
     - Otherwise proceeds with best available result
     - For series: detects statistical outliers that may indicate interesting physics
     """
 
     MAX_ATTEMPTS = 5
-    DEFAULT_MAX_APPROACH_RETRIES = 1
     DEFAULT_OUTLIER_SIGMA = 2.0
     DEFAULT_MAX_VERIFICATION_ITERATIONS = 7
     DEFAULT_QUALITY_THRESHOLD = 0.7
@@ -1393,6 +1392,31 @@ class UnifiedImageProcessingController:
         "You have full freedom to suggest any pipeline or method change the data "
         "warrants. The only requirement is that you justify every deviation from "
         "the original plan based on what you observe in the images.\n",
+    )
+
+    # Tool-use constraint, graded with the same annealing ladder.
+    # At T=0 the verifier and refinement LLM must stay within the tool's
+    # documented parameters; at T=1 they prefer to but may replace the
+    # tool with justification; at T=2 there is no extra constraint because
+    # the main annealing directive already grants full pipeline freedom.
+    _TOOL_CONSTRAINT_SCHEDULE = (
+        # T=0 strict
+        "\n**Registered tool constraints:**\n"
+        "When the pipeline uses a registered tool (any function imported from "
+        "`scilink.tools.*`), your suggested fixes must be achievable via that "
+        "tool's documented parameters OR via preprocessing / postprocessing that "
+        "happens OUTSIDE the tool call. Do not suggest modifications to the "
+        "tool's internal algorithm. If the tool's documented parameters cannot "
+        "fix the issue, say so explicitly rather than inventing internal "
+        "modifications that would force the code generator to bypass the tool.\n",
+        # T=1 preferred
+        "\n**Registered tool constraints (eased):**\n"
+        "Prefer keeping registered tools in the pipeline and expressing fixes "
+        "through their documented parameters. If you must recommend replacing a "
+        "tool with custom code, briefly state why the tool's parameters could "
+        "not address the issue.\n",
+        # T=2 open — main annealing already grants full freedom
+        "",
     )
 
     # Same annealing applied to domain skill strictness during analysis.
@@ -1449,46 +1473,6 @@ more complete coverage), select it even if it is not perfect. Only return accept
 results are fundamentally flawed.
 '''
 
-    ALTERNATIVE_APPROACH_PROMPT = '''The current image analysis pipeline produced unsatisfactory results.
-
-**Current Pipeline:** {current_pipeline}
-**Quality Score:** {quality_score:.2f}
-**Quality Issues:** {quality_issues}
-
-**Image Statistics:**
-{image_stats}
-
-**Original Analysis Approach:** {analysis_approach}
-{previous_attempts_section}
-**IMPORTANT:** Examine the analysis visualization provided below carefully. Look for:
-1. False positives (artifacts incorrectly identified as features)
-2. Missed features (visible structures not captured)
-3. Incorrect segmentation (wrong boundaries, merged objects, split objects)
-4. Preprocessing issues (too much/too little filtering)
-
-Based on your visual inspection and the quality assessment, suggest an alternative analysis pipeline.
-
-**Required features:** Your alternative should extract these features for consistency with the rest of the series: {required_features}
-If a feature is physically unavailable (e.g., domains fully coalesced so individual count is meaningless), set its value to null and note the reason — do not fabricate values. You may add extra features.
-
-**Physics-first rule:** Before changing the pipeline drastically, first try improving the existing approach:
-1. Different thresholding method (e.g., adaptive instead of global, or different threshold level)
-2. Better preprocessing (different denoising, contrast enhancement)
-3. Morphological post-processing (opening/closing to clean up segmentation)
-4. Different feature extraction parameters
-
-Only switch to a fundamentally different approach if the current pipeline is clearly wrong for this
-type of image (e.g., using edge detection when segmentation is needed).
-
-Return JSON with:
-{{
-    "diagnosis": "specific description of what you observe is wrong with the current analysis based on the visualization",
-    "alternative_pipeline": "description of the new processing pipeline to try",
-    "analysis_approach": "updated analysis approach description",
-    "features_to_extract": ["list", "of", "features"]
-}}
-'''
-
     HUMAN_FEEDBACK_PROMPT = '''## Analysis Quality Issue
 
 The automated image analysis could not achieve adequate quality.
@@ -1517,7 +1501,6 @@ Your guidance: '''
         quality_instructions: str,
         output_dir: str,
         image_to_bytes_fn: Callable,
-        max_approach_retries: int = None,
         enable_human_feedback: bool = False,
         outlier_sigma: float = None,
         max_verification_iterations: int = None,
@@ -1534,7 +1517,6 @@ Your guidance: '''
         self.quality_instructions = quality_instructions
         self.output_dir = Path(output_dir)
         self.image_to_bytes_fn = image_to_bytes_fn
-        self.max_approach_retries = max_approach_retries if max_approach_retries is not None else self.DEFAULT_MAX_APPROACH_RETRIES
         self.enable_human_feedback = enable_human_feedback
         self.outlier_sigma = outlier_sigma if outlier_sigma is not None else self.DEFAULT_OUTLIER_SIGMA
         self.max_verification_iterations = max_verification_iterations if max_verification_iterations is not None else self.DEFAULT_MAX_VERIFICATION_ITERATIONS
@@ -1567,6 +1549,8 @@ Your guidance: '''
                     lines.append(f"- `{name}`{shape_str}")
                 context_parts.append("\n".join(lines))
 
+        from ....tools._registry import format_tool_inventory
+
         prompt = self.script_instructions.format(
             analysis_approach=config.get("analysis_approach", "Analyze the image"),
             processing_pipeline=config.get("processing_pipeline", "Standard processing"),
@@ -1577,6 +1561,7 @@ Your guidance: '''
             dtype=stats.get("dtype", "unknown"),
             intensity_min=stats.get("intensity_range", [0, 255])[0],
             intensity_max=stats.get("intensity_range", [0, 255])[1],
+            tool_inventory=format_tool_inventory("image_analysis"),
         )
 
         response = self.model.generate_content(prompt)
@@ -1597,11 +1582,14 @@ Your guidance: '''
             explanation of what went wrong and how it was fixed, or None.
         """
         config = state.get("locked_analysis_config", {})
+        from ....tools._registry import format_tool_inventory
+
         prompt = self.correction_instructions.format(
             analysis_approach=config.get("analysis_approach", ""),
             processing_pipeline=config.get("processing_pipeline", ""),
             failed_script=script,
             error_message=error_msg,
+            tool_inventory=format_tool_inventory("image_analysis"),
         )
         skill_sections = state.get("skill_sections")
         if skill_sections and skill_sections.get("analysis"):
@@ -1910,86 +1898,6 @@ Your guidance: '''
             "script_errors": script_errors,
         }
 
-    def _suggest_alternative_approach(
-        self, state: dict, current_result: dict,
-        previous_attempts: List[dict] = None,
-    ) -> Optional[dict]:
-        """Use LLM to suggest an alternative analysis pipeline, showing the actual poor result.
-
-        Args:
-            previous_attempts: List of dicts with keys 'pipeline', 'score',
-                'diagnosis', 'recommended_action' from prior alternative attempts.
-                Injected into the prompt so the LLM doesn't repeat failed approaches.
-        """
-        config = state.get("locked_analysis_config", {})
-        quality_issues = current_result.get("_quality_issues", "Quality below threshold")
-
-        # Build previous attempts section
-        prev_section = ""
-        if previous_attempts:
-            lines = [
-                "\n## PREVIOUSLY TRIED APPROACHES (do NOT repeat these)",
-                "The following approaches were already attempted and failed. "
-                "You MUST suggest something fundamentally different.\n",
-            ]
-            for i, prev in enumerate(previous_attempts, 1):
-                lines.append(f"### Attempt {i}")
-                lines.append(f"- Pipeline: {prev.get('pipeline', 'N/A')}")
-                lines.append(f"- Score: {prev.get('score', 'N/A')}")
-                if prev.get("diagnosis"):
-                    lines.append(f"- Diagnosis: {prev['diagnosis']}")
-                if prev.get("recommended_action"):
-                    lines.append(f"- Verifier recommended: {prev['recommended_action']}")
-                lines.append("")
-            prev_section = "\n".join(lines)
-
-        required_features = config.get("features_to_extract", [])
-        prompt_text = self.ALTERNATIVE_APPROACH_PROMPT.format(
-            current_pipeline=config.get("processing_pipeline", "Unknown"),
-            quality_score=current_result.get("_quality_score", 0.0),
-            quality_issues=quality_issues,
-            image_stats=json.dumps(current_result.get("statistics", {}), indent=2),
-            analysis_approach=config.get("analysis_approach", ""),
-            previous_attempts_section=prev_section,
-            required_features=", ".join(required_features) if required_features else "same as original plan",
-        )
-
-        prompt_parts = [prompt_text]
-
-        # Include the actual analysis visualization so LLM can see what went wrong
-        if current_result.get("visualization_bytes"):
-            prompt_parts.append("\n\n**CURRENT ANALYSIS VISUALIZATION (showing the poor result):**")
-            prompt_parts.append({
-                "mime_type": "image/png",
-                "data": current_result["visualization_bytes"]
-            })
-            prompt_parts.append(
-                "\nExamine this visualization carefully. Look at where the analysis "
-                "went wrong and suggest a better pipeline."
-            )
-
-        # Also include original image for comparison
-        if state.get("original_image_bytes"):
-            prompt_parts.append("\n\n**ORIGINAL IMAGE:**")
-            prompt_parts.append({
-                "mime_type": "image/jpeg",
-                "data": state["original_image_bytes"]
-            })
-
-        try:
-            response = self.model.generate_content(
-                contents=prompt_parts,
-                generation_config=self.generation_config,
-                safety_settings=self.safety_settings,
-            )
-            result, error = self._parse(response)
-            if error or not result:
-                return None
-            return result
-        except Exception as e:
-            self.logger.error(f"Failed to get alternative approach suggestion: {e}")
-            return None
-
     QUALITY_VERIFICATION_PROMPT = '''You are a scientific image analysis expert reviewing an analysis result.
 
 **TASK:** Compare the analysis visualization against the original image and score the result.
@@ -2063,6 +1971,10 @@ Estimate Completeness, Precision, and Plausibility separately, then average.
 
 ---
 
+{tool_constraint}
+
+---
+
 {plan_constraint}
 
 ---
@@ -2125,6 +2037,8 @@ Return JSON:
             max_iter = max(self.max_verification_iterations, 1)
             level = min(verification_iter * n_levels // max_iter, n_levels - 1)
         plan_constraint = schedule[level]
+        tool_schedule = self._TOOL_CONSTRAINT_SCHEDULE
+        tool_constraint = tool_schedule[min(level, len(tool_schedule) - 1)]
 
         prompt_text = self.QUALITY_VERIFICATION_PROMPT.format(
             analysis_approach=config.get("analysis_approach", "Unknown"),
@@ -2134,6 +2048,7 @@ Return JSON:
             metrics=metrics_str,
             quality_threshold=self.quality_threshold,
             plan_constraint=plan_constraint,
+            tool_constraint=tool_constraint,
         )
 
         # Add history context
@@ -2220,6 +2135,10 @@ Return JSON:
         annealing_level = state.get("_annealing_level", 0)
         schedule = self._CONSTRAINT_ANNEALING_SCHEDULE
         constraint_text = schedule[min(annealing_level, len(schedule) - 1)]
+        tool_schedule = self._TOOL_CONSTRAINT_SCHEDULE
+        tool_constraint = tool_schedule[
+            min(annealing_level, len(tool_schedule) - 1)
+        ]
 
         refinement_prompt = f"""Refine the image analysis approach based on automated verification feedback.
 
@@ -2227,6 +2146,7 @@ Return JSON:
 - Pipeline: {config.get('processing_pipeline', 'Unknown')}
 - Approach: {config.get('analysis_approach', 'Unknown')}
 {constraint_text}
+{tool_constraint}
 **VERIFICATION FINDINGS:**
 {chr(10).join(issues_summary) if issues_summary else 'No specific issues listed'}
 
@@ -2271,9 +2191,8 @@ Return JSON with the refined analysis approach:
         """Ask user for guidance when automated quality is poor."""
         # Build concise summary grouped by attempt type
         lines = []
-        initial = [a for a in all_attempts if not str(a["pipeline"]).startswith(("Verification", "Alternative", "User"))]
+        initial = [a for a in all_attempts if not str(a["pipeline"]).startswith(("Verification", "User"))]
         verifications = [a for a in all_attempts if str(a["pipeline"]).startswith("Verification")]
-        alternatives = [a for a in all_attempts if not str(a["pipeline"]).startswith(("Verification", "User")) and a not in initial]
         user_guided = [a for a in all_attempts if str(a["pipeline"]).startswith("User")]
 
         if initial:
@@ -2281,8 +2200,6 @@ Return JSON with the refined analysis approach:
         if verifications:
             scores = [f"{v['score']:.2f}" for v in verifications]
             lines.append(f"  Verification refinements ({len(verifications)}): scores = {', '.join(scores)}")
-        for i, a in enumerate(alternatives, 1):
-            lines.append(f"  Alternative {i}: score = {a['score']:.2f}")
         for a in user_guided:
             lines.append(f"  User-guided: score = {a['score']:.2f}")
 
@@ -2812,205 +2729,6 @@ Return JSON with:
                 "result": result,
             })
 
-        # --- Alternative approach retries ---
-        current_config = state.get("locked_analysis_config", {}).copy()
-        alternative_history = []
-
-        # Seed history with the initial locked approach
-        initial_verification = (
-            all_attempts[-1].get("result", {}) if all_attempts else {}
-        )
-        alternative_history.append({
-            "pipeline": initial_pipeline,
-            "score": best_score,
-            "diagnosis": "Initial locked approach",
-            "recommended_action": initial_verification.get(
-                "_last_recommended_action", ""
-            ),
-        })
-
-        for retry in range(self.max_approach_retries):
-            self.logger.info(
-                f"   Alternative approach {retry + 1}/"
-                f"{self.max_approach_retries}..."
-            )
-
-            alternative = self._suggest_alternative_approach(
-                state, best_result or result,
-                previous_attempts=alternative_history,
-            )
-
-            if not alternative:
-                self.logger.warning(
-                    "   Could not generate alternative approach suggestion"
-                )
-                break
-
-            print("\n" + "=" * 60)
-            print(f"📋 ALTERNATIVE APPROACH {retry + 1}/{self.max_approach_retries}")
-            print("=" * 60)
-            print(f"\n🔍 Diagnosis:\n   {alternative.get('diagnosis', 'N/A')}")
-            print(f"\n📊 Approach:\n   {alternative.get('analysis_approach', 'N/A')}")
-            _pipeline = alternative.get("alternative_pipeline", "N/A")
-            if isinstance(_pipeline, list):
-                _pipeline = " -> ".join(str(s) for s in _pipeline)
-            _pipeline = re.sub(r"\. (\d+)\. ", r".\n   \1. ", _pipeline)
-            print(f"\n⚙️  Pipeline:\n   {_pipeline}")
-            print(f"\n🎯 Features:\n   {', '.join(alternative.get('features_to_extract', []))}")
-            print("=" * 60)
-
-            temp_config = current_config.copy()
-            temp_config["processing_pipeline"] = alternative.get(
-                "alternative_pipeline",
-                temp_config.get("processing_pipeline"),
-            )
-            temp_config["analysis_approach"] = alternative.get(
-                "analysis_approach",
-                temp_config.get("analysis_approach"),
-            )
-            temp_config["features_to_extract"] = alternative.get(
-                "features_to_extract",
-                temp_config.get("features_to_extract", []),
-            )
-
-            original_config = state.get("locked_analysis_config")
-            state["locked_analysis_config"] = temp_config
-
-            alt_result = self._process_single_image(
-                state=state, image_data=image_data, data_path=data_path,
-                image_name=image_name, image_idx=image_idx, base_script=None,
-            )
-
-            state["locked_analysis_config"] = original_config
-
-            if alt_result["success"]:
-                # Verify and allow one re-analysis if fixable
-                alt_verification = self._verify_quality(state, alt_result)
-                if alt_verification:
-                    alt_score = alt_verification.get("quality_score", 0.0)
-                    if isinstance(alt_score, str):
-                        try:
-                            alt_score = float(alt_score)
-                        except (ValueError, TypeError):
-                            alt_score = 0.0
-
-                    # One re-analysis chance if below threshold
-                    if alt_score < quality_threshold:
-                        self.logger.info(
-                            f"   Score = {alt_score:.2f}, attempting one re-analysis..."
-                        )
-                        refined = self._apply_verification_feedback(
-                            state, alt_verification
-                        )
-                        refined.pop("_refinement_error", None)
-                        if refined != temp_config:
-                            state["locked_analysis_config"] = refined
-                            reanalysis = self._process_single_image(
-                                state=state, image_data=image_data,
-                                data_path=data_path,
-                                image_name=image_name,
-                                image_idx=image_idx, base_script=None,
-                            )
-                            state["locked_analysis_config"] = original_config
-                            if reanalysis["success"]:
-                                re_verif = self._verify_quality(
-                                    state, reanalysis
-                                )
-                                if re_verif:
-                                    re_score = re_verif.get(
-                                        "quality_score", 0.0
-                                    )
-                                    if isinstance(re_score, str):
-                                        try:
-                                            re_score = float(re_score)
-                                        except (ValueError, TypeError):
-                                            re_score = 0.0
-                                    if re_score > alt_score:
-                                        alt_score = re_score
-                                        alt_result = reanalysis
-                                        temp_config = refined
-                                        self.logger.info(
-                                            f"   Re-analysis improved: {re_score:.2f}"
-                                        )
-                else:
-                    alt_score = 0.0
-                alt_result["_quality_score"] = alt_score
-                all_attempts.append({
-                    "pipeline": alternative.get(
-                        "alternative_pipeline",
-                        f"Alternative {retry + 1}",
-                    ),
-                    "score": alt_score,
-                    "result": alt_result,
-                    "config": temp_config,
-                })
-
-                if alt_score > best_score:
-                    best_score = alt_score
-                    best_result = alt_result
-                    best_config = temp_config.copy()
-                    best_result["_winning_config"] = temp_config
-
-                if alt_score >= quality_threshold:
-                    self.logger.info(
-                        f"Quality score = {alt_score:.2f} "
-                        f"(meets threshold with alternative pipeline)"
-                    )
-                    if _is_anchor:
-                        state["locked_analysis_config"] = temp_config
-
-                        if (
-                            self.enable_human_feedback
-                            and alt_result.get("visualization_bytes")
-                        ):
-                            user_feedback = self._get_user_feedback_on_result(
-                                state, alt_result, alt_score
-                            )
-                            if user_feedback:
-                                alt_result, alt_score = self._apply_user_feedback(
-                                    state, user_feedback, alt_result, alt_score,
-                                    image_data, data_path, image_name,
-                                    image_idx, all_attempts,
-                                )
-
-                    return alt_result
-                else:
-                    self.logger.warning(
-                        f"   Score = {alt_score:.2f} (still below threshold)"
-                    )
-
-                # Record this attempt for cross-attempt memory
-                alternative_history.append({
-                    "pipeline": alternative.get("alternative_pipeline", "N/A"),
-                    "score": alt_score,
-                    "diagnosis": alternative.get("diagnosis", ""),
-                    "recommended_action": (
-                        alt_verification.get("recommended_action", "")
-                        if alt_verification else ""
-                    ),
-                })
-            else:
-                self.logger.warning(
-                    f"   Alternative pipeline failed: "
-                    f"{alt_result.get('error', 'Unknown')[:50]}"
-                )
-                all_attempts.append({
-                    "pipeline": alternative.get(
-                        "alternative_pipeline",
-                        f"Alternative {retry + 1}",
-                    ),
-                    "score": 0,
-                    "result": alt_result,
-                })
-
-                # Record failed attempt too
-                alternative_history.append({
-                    "pipeline": alternative.get("alternative_pipeline", "N/A"),
-                    "score": 0,
-                    "diagnosis": alternative.get("diagnosis", ""),
-                    "recommended_action": "Script execution failed",
-                })
-
         # --- Human feedback for poor quality (if enabled) ---
         if self.enable_human_feedback and _is_anchor:
             feedback_result = self._get_human_feedback_for_poor_quality(
@@ -3090,37 +2808,29 @@ Return JSON with:
                     ][:500]
 
         # --- Summarize plan history ---
-        used_alternative = best_result and best_result.get("_winning_config")
-        if used_alternative or len(all_attempts) > 1:
+        multiple_attempts = len(all_attempts) > 1
+        if multiple_attempts:
             summary_lines = []
             summary_lines.append(
                 f"Original plan: {initial_pipeline[:100]}"
             )
-            if len(all_attempts) > 1:
+            summary_lines.append(
+                f"Original plan score: "
+                f"{all_attempts[0].get('score', 'N/A')}"
+            )
+            for a in all_attempts[1:]:
                 summary_lines.append(
-                    f"Original plan score: "
-                    f"{all_attempts[0].get('score', 'N/A')}"
+                    f"{a.get('pipeline', 'N/A')[:80]} "
+                    f"(score: {a.get('score', 'N/A')})"
                 )
-                for i, a in enumerate(all_attempts[1:], 1):
-                    summary_lines.append(
-                        f"Alternative {i}: "
-                        f"{a.get('pipeline', 'N/A')[:80]} "
-                        f"(score: {a.get('score', 'N/A')})"
-                    )
-            if used_alternative:
-                winning = best_result["_winning_config"]
-                summary_lines.append(
-                    f"Selected: {winning.get('processing_pipeline', 'N/A')[:80]}"
-                )
-            else:
-                summary_lines.append(
-                    f"Selected: original plan (best available)"
-                )
+            summary_lines.append(
+                "Selected: original plan (best available)"
+            )
 
             plan_summary = "\n".join(summary_lines)
 
             print("\n" + "=" * 60)
-            print("📋 PLAN DEVIATION SUMMARY")
+            print("📋 REFINEMENT HISTORY")
             print("=" * 60)
             for line in summary_lines:
                 print(f"   {line}")
@@ -3135,7 +2845,7 @@ Return JSON with:
             best_result["attempted_pipelines"] = [
                 a["pipeline"] for a in all_attempts
             ]
-            if used_alternative or len(all_attempts) > 1:
+            if multiple_attempts:
                 best_result["plan_deviation_summary"] = plan_summary
             self.logger.warning(
                 f"Proceeding with best available result "
@@ -3239,14 +2949,6 @@ Return JSON with:
                     "fix_applied": entry.get("recommended_action", ""),
                 }
                 for entry in verification_history
-            ],
-            "alternative_approaches": [
-                {
-                    "pipeline": a["pipeline"],
-                    "score": a["score"],
-                    "diagnosis": a.get("diagnosis", ""),
-                }
-                for a in all_attempts[1:]
             ],
             "script_errors": script_errors or [],
             "judge_reasoning": (
@@ -3809,7 +3511,6 @@ Return JSON: {{"diagnosis": "what you changed and why", "script": "full Python s
         mode_str = "SINGLE IMAGE" if is_single else f"SERIES ({num_images} images)"
         self.logger.info("")
         self.logger.info(f"IMAGE ANALYSIS: {mode_str}")
-        self.logger.info(f"   Max approach retries: {self.max_approach_retries}")
         if not is_single:
             self.logger.info(
                 f"   Outlier detection: {self.outlier_sigma} sigma"
@@ -4047,7 +3748,6 @@ Return JSON: {{"diagnosis": "what you changed and why", "script": "full Python s
                 "is_single_image": is_single,
                 "series_metadata": state.get("series_metadata", {}),
                 "quality_settings": {
-                    "max_approach_retries": self.max_approach_retries,
                     "outlier_sigma": self.outlier_sigma,
                 },
                 "locked_config": state.get("locked_analysis_config"),
@@ -4218,7 +3918,6 @@ class ImageAdaptiveRefitController:
         quality_instructions: str,
         output_dir: str,
         image_to_bytes_fn: Callable,
-        max_approach_retries: int = 1,
         max_verification_iterations: int = 7,
         enable_human_feedback: bool = False,
         conformance_instructions: str = "",
@@ -4241,7 +3940,6 @@ class ImageAdaptiveRefitController:
             quality_instructions=quality_instructions,
             output_dir=output_dir,
             image_to_bytes_fn=image_to_bytes_fn,
-            max_approach_retries=max_approach_retries,
             enable_human_feedback=False,
             max_verification_iterations=max_verification_iterations,
             conformance_instructions=conformance_instructions,
@@ -5261,8 +4959,8 @@ Return JSON with:
         if quality_warning:
             prompt_parts.append(
                 f"\n## Quality Warning\n{quality_warning}\n"
-                "Note: Alternative pipelines were attempted but this was "
-                "the best result achieved."
+                "Note: this is the best result achieved after verification "
+                "refinement — quality remained below the threshold."
             )
 
         qh = analysis_result.get("quality_history")
@@ -5274,11 +4972,9 @@ Return JSON with:
                 f"({'approved' if approved else 'best available, below threshold'})"
             )
             iters = qh.get("verification_iterations", [])
-            alts = qh.get("alternative_approaches", [])
-            if len(iters) > 1 or alts:
+            if len(iters) > 1:
                 qh_lines.append(
-                    f"- Verification iterations: {len(iters)}, "
-                    f"alternative pipelines tried: {len(alts)}"
+                    f"- Verification iterations: {len(iters)}"
                 )
             # Remaining issues from last verification (known limitations)
             if iters:

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -180,6 +180,38 @@ def _append_auxiliary_context(prompt: list, state: dict) -> None:
     })
 
 
+def _append_tool_inventory(prompt: list, agent: str = "image_analysis") -> None:
+    """Append the registered tool inventory and library list for ``agent``.
+
+    Tools come from ``scilink.tools._registry.get_tools_for(agent)``; libraries
+    come from ``IMAGE_ANALYSIS_LIBRARIES``. Injected before skill context so
+    skill prose can reference tools introduced here by name.
+    """
+    from ....tools._registry import (
+        format_library_inventory,
+        get_tools_for,
+    )
+
+    specs = get_tools_for(agent)
+    if specs:
+        prompt.append("\n## Available Tools")
+        prompt.append(
+            "The following tools are registered and callable from generated scripts. "
+            "Prefer a tool when it fits; combine with custom numpy/scipy/skimage/cv2 "
+            "code for post-processing. A tool call anchoring the hard step followed "
+            "by custom code is usually more reliable than an all-custom pipeline."
+        )
+        for spec in specs:
+            prompt.append(spec.to_prompt())
+
+    prompt.append("\n## Available Libraries")
+    prompt.append(
+        "These libraries are importable in the execution sandbox. Use them for "
+        "custom code when no registered tool fits."
+    )
+    prompt.append(format_library_inventory())
+
+
 def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
     """Append domain skill knowledge to an LLM prompt for the given stage.
 
@@ -693,6 +725,7 @@ class ImagePlanningController:
             prompt.append(f"\n## User Guidance\n{state['analysis_hints']}")
 
         _append_auxiliary_context(prompt, state)
+        _append_tool_inventory(prompt, agent="image_analysis")
         _append_skill_context(prompt, state, "planning")
         _append_prior_knowledge_context(prompt, state)
         _append_subagent_context(prompt, state)
@@ -995,6 +1028,7 @@ class ImagePlanningController:
             prompt.append(f"\n## Original Guidance\n{state['analysis_hints']}")
 
         _append_auxiliary_context(prompt, state)
+        _append_tool_inventory(prompt, agent="image_analysis")
         _append_skill_context(prompt, state, "planning")
         _append_prior_knowledge_context(prompt, state)
         _append_subagent_context(prompt, state)
@@ -2546,6 +2580,22 @@ Return JSON with:
                                     f"{_annealing_level}"
                                 )
                         _prev_best_score = best_score
+
+                        # Iteration-based floor: guarantees progression when
+                        # noisy quality scores keep resetting the stall
+                        # counter. Each level gets ~max_iter/n_levels slots
+                        # before the floor forces the next one.
+                        _floor = min(
+                            verification_iter // 2,
+                            _n_anneal_levels - 1,
+                        )
+                        if _floor > _annealing_level:
+                            self.logger.info(
+                                f"   Annealing: iteration floor lifting "
+                                f"level {_annealing_level} -> {_floor}"
+                            )
+                            _annealing_level = _floor
+                            _stall_count = 0
 
                         _cur_level = _annealing_level
 

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -1366,6 +1366,15 @@ class UnifiedImageProcessingController:
     DEFAULT_MAX_VERIFICATION_ITERATIONS = 7
     DEFAULT_QUALITY_THRESHOLD = 0.7
 
+    # Quality verification is rubric-based scoring — not generative work.
+    # Using a deterministic config (T=0) so the same visualization gets the
+    # same sub-scores across iterations, which the annealing /
+    # stall-counter logic depends on. Other LLM calls (planner, refiner,
+    # code-gen) continue to use provider-default temperature.
+    # Note: only temperature is set — Anthropic's Messages API rejects
+    # temperature and top_p together.
+    _VERIFIER_GEN_CONFIG = {"temperature": 0.0}
+
     # Constraint annealing: gradually raise the "temperature" so the
     # verifier can explore more of the pipeline space when early iterations
     # fail to produce an adequate result.  Like simulated annealing
@@ -2093,7 +2102,7 @@ Return JSON:
         try:
             response = self.model.generate_content(
                 contents=prompt_parts,
-                generation_config=self.generation_config,
+                generation_config=self._VERIFIER_GEN_CONFIG,
                 safety_settings=self.safety_settings,
             )
             result_parsed, error = self._parse(response)

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -1514,6 +1514,7 @@ Your guidance: '''
         outlier_sigma: float = None,
         max_verification_iterations: int = None,
         conformance_instructions: str = "",
+        refinement_instructions: str = "",
     ):
         self.model = model
         self.logger = logger
@@ -1523,6 +1524,7 @@ Your guidance: '''
         self.executor = executor
         self.script_instructions = script_instructions
         self.correction_instructions = correction_instructions
+        self.refinement_instructions = refinement_instructions
         self.quality_instructions = quality_instructions
         self.output_dir = Path(output_dir)
         self.image_to_bytes_fn = image_to_bytes_fn
@@ -1532,8 +1534,20 @@ Your guidance: '''
         self.quality_threshold = self.DEFAULT_QUALITY_THRESHOLD
         self.conformance_instructions = conformance_instructions
 
-    def _generate_analysis_script(self, state: dict, data_path: str, stats: dict) -> str:
-        """Generate an image analysis script using the locked config."""
+    def _generate_analysis_script(
+        self,
+        state: dict,
+        data_path: str,
+        stats: dict,
+        base_script: str | None = None,
+    ) -> str:
+        """Generate an image analysis script using the locked config.
+
+        When ``base_script`` is provided (non-empty), uses the refinement
+        prompt to adapt the previous attempt's script to the refined plan
+        rather than regenerating from scratch. When ``None`` or empty,
+        falls back to fresh generation via ``self.script_instructions``.
+        """
         config = state.get("locked_analysis_config", {})
         context_parts = []
         if state.get("literature_context"):
@@ -1560,7 +1574,7 @@ Your guidance: '''
 
         from ....tools._registry import format_tool_inventory
 
-        prompt = self.script_instructions.format(
+        format_kwargs = dict(
             analysis_approach=config.get("analysis_approach", "Analyze the image"),
             processing_pipeline=config.get("processing_pipeline", "Standard processing"),
             features_to_extract=", ".join(config.get("features_to_extract", [])) or "relevant features",
@@ -1572,6 +1586,14 @@ Your guidance: '''
             intensity_max=stats.get("intensity_range", [0, 255])[1],
             tool_inventory=format_tool_inventory("image_analysis"),
         )
+
+        if base_script and self.refinement_instructions:
+            prompt = self.refinement_instructions.format(
+                base_script=base_script,
+                **format_kwargs,
+            )
+        else:
+            prompt = self.script_instructions.format(**format_kwargs)
 
         response = self.model.generate_content(prompt)
         result, error = self._parse(response)
@@ -1712,8 +1734,26 @@ Your guidance: '''
         image_name: str,
         image_idx: int,
         base_script: Optional[str] = None,
+        refine_from_script: Optional[str] = None,
     ) -> dict:
-        """Execute analysis pipeline on a single image with retry logic."""
+        """Execute analysis pipeline on a single image with retry logic.
+
+        Two independent ways to carry a previous script forward:
+
+        - ``base_script`` — series-level adaptation. When provided, the first
+          attempt substitutes data paths / output names via
+          ``_adapt_script_for_image`` without invoking the LLM. Used to
+          keep pipeline consistent across images in a series.
+        - ``refine_from_script`` — refinement-iteration adaptation. When
+          provided, the first attempt calls ``_generate_analysis_script``
+          with ``base_script=refine_from_script`` so the refinement prompt
+          is used (LLM adapts the previous script to the refined plan).
+          Used when carrying a working script forward across verification
+          refinement iterations at lower annealing levels.
+
+        ``base_script`` wins if both are supplied (series consistency takes
+        precedence over refinement adaptation).
+        """
         stats = compute_image_statistics(image_data)
 
         # Create working directory for this image
@@ -1749,7 +1789,12 @@ Your guidance: '''
                         base_script, str(temp_data_path), output_prefix
                     )
                 elif attempt == 1:
-                    script = self._generate_analysis_script(state, str(temp_data_path), stats)
+                    script = self._generate_analysis_script(
+                        state,
+                        str(temp_data_path),
+                        stats,
+                        base_script=refine_from_script,
+                    )
                     # Check conformance with locked plan on fresh generation
                     conformance = self._check_conformance(state, script)
                     if conformance and not conformance.get("conformant", True):
@@ -1977,6 +2022,7 @@ Estimate Completeness, Precision, and Plausibility separately, then average.
 - Minor imperfections in segmentation boundaries
 - A few missed small or ambiguous features if the majority are captured
 - Slight over- or under-segmentation if the overall result is scientifically usable
+- An abundance map or decomposition component that does not delineate every visible region of the image. Data-driven decompositions (NMF, PCA, ICA, FFT-NMF) produce basis patterns, not semantic segmentations — they are not required to match what you would segment by eye. If the output is coherent and faithful to the image content, score it on that basis, not on whether it matched the regions you visually identified.
 
 ---
 
@@ -2516,6 +2562,7 @@ Return JSON with:
                     # LLM-assigned and noisy, so we use a patience counter
                     # instead of a rate-based formula.
                     _annealing_level = 0
+                    _previous_annealing_level = 0
                     _stall_count = 0
                     _PATIENCE = 2
                     _prev_best_score = best_score
@@ -2687,6 +2734,23 @@ Return JSON with:
                         # Sync skill strictness with adaptive annealing level
                         state["_annealing_level"] = _annealing_level
 
+                        # Carry the previous attempt's script forward so the
+                        # code generator can adapt rather than regenerate
+                        # from scratch — except on the single iteration
+                        # where the annealing level escalates from < 2 to
+                        # = 2 (hot). That escalation step deliberately
+                        # gets fresh generation so the code generator can
+                        # restructure without anchor bias from the
+                        # structure that prompted the escalation.
+                        _just_escalated_to_hot = (
+                            _annealing_level >= 2
+                            and _previous_annealing_level < 2
+                        )
+                        _refine_from_script = (
+                            None if _just_escalated_to_hot
+                            else (current_result or {}).get("script")
+                        )
+
                         # Re-analyze with refined config
                         self.logger.info(
                             "   Re-analyzing with verification feedback..."
@@ -2695,7 +2759,9 @@ Return JSON with:
                             state=state, image_data=image_data,
                             data_path=data_path, image_name=image_name,
                             image_idx=image_idx, base_script=None,
+                            refine_from_script=_refine_from_script,
                         )
+                        _previous_annealing_level = _annealing_level
 
                         if verified_result["success"]:
                             verified_result["_quality_score"] = 0.0
@@ -4028,6 +4094,7 @@ class ImageAdaptiveRefitController:
         max_verification_iterations: int = 7,
         enable_human_feedback: bool = False,
         conformance_instructions: str = "",
+        refinement_instructions: str = "",
     ):
         self.logger = logger
         self.output_dir = Path(output_dir)
@@ -4050,6 +4117,7 @@ class ImageAdaptiveRefitController:
             enable_human_feedback=False,
             max_verification_iterations=max_verification_iterations,
             conformance_instructions=conformance_instructions,
+            refinement_instructions=refinement_instructions,
         )
 
     def _load_image(self, idx, image_paths, image_stack):

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -2108,10 +2108,72 @@ Return JSON:
             self.logger.error(f"      LLM verification failed: {e}")
             return None
 
-    def _apply_verification_feedback(self, state: dict, verification: dict) -> dict:
+    def _format_refinement_history(self, history: list) -> str:
+        """Compact per-iteration trajectory for the refinement LLM.
+
+        Gives the refiner visibility into prior scores and pipelines so it
+        can recognize when a recent change regressed and consider backing
+        off toward a better-scoring earlier config. Leaner than
+        ``build_verification_prompt_with_history`` (used by the verifier) —
+        the refiner needs scores + pipeline summaries, not full issue lists.
+        """
+        if not history:
+            return ""
+
+        # Cap at the most recent 6 entries to bound token cost.
+        recent = history[-6:]
+        scores = [h.get("quality_score", 0.0) for h in recent]
+        if not scores:
+            return ""
+        best = max(scores)
+
+        lines = [
+            "**ITERATION HISTORY (oldest first, current last):**",
+            "Use this trajectory to decide whether the current pipeline is "
+            "improving or has regressed from an earlier version. If a recent "
+            "change dropped the score, consider reverting toward the "
+            "better-scoring config and making a smaller adjustment rather "
+            "than piling on further changes. You may still accept a temporary "
+            "regression if your reasoning supports it.",
+            "",
+        ]
+        n = len(recent)
+        for i, h in enumerate(recent):
+            score = h.get("quality_score", 0.0)
+            cfg = h.get("config_used", {}) or {}
+            pipeline = (cfg.get("processing_pipeline", "") or "").strip()
+            if len(pipeline) > 200:
+                pipeline = pipeline[:200] + "..."
+            markers = []
+            if abs(score - best) < 1e-6:
+                markers.append("BEST")
+            if i == n - 1:
+                markers.append("CURRENT")
+            tag = f" [{', '.join(markers)}]" if markers else ""
+            lines.append(
+                f"- score={score:.2f}{tag}: "
+                f"{pipeline or '(no pipeline captured)'}"
+            )
+        return "\n".join(lines)
+
+    def _apply_verification_feedback(
+        self,
+        state: dict,
+        verification: dict,
+        history: list | None = None,
+    ) -> dict:
         """Apply LLM verification feedback to refine the analysis configuration.
 
-        Returns updated config.
+        Args:
+            state: Pipeline state dict.
+            verification: Latest verifier output (scores, issues, recommended_action).
+            history: Optional list of prior ``verification_history`` entries. When
+                provided, a compact trajectory is included in the refinement prompt
+                so the LLM can reason about regressions. Leave ``None`` to preserve
+                previous behavior (no history injected).
+
+        Returns:
+            Updated analysis config dict.
         """
         config = state.get("locked_analysis_config", {}).copy()
 
@@ -2140,6 +2202,9 @@ Return JSON:
             min(annealing_level, len(tool_schedule) - 1)
         ]
 
+        history_text = self._format_refinement_history(history or [])
+        history_section = f"\n{history_text}\n" if history_text else ""
+
         refinement_prompt = f"""Refine the image analysis approach based on automated verification feedback.
 
 **CURRENT APPROACH:**
@@ -2147,6 +2212,7 @@ Return JSON:
 - Approach: {config.get('analysis_approach', 'Unknown')}
 {constraint_text}
 {tool_constraint}
+{history_section}
 **VERIFICATION FINDINGS:**
 {chr(10).join(issues_summary) if issues_summary else 'No specific issues listed'}
 
@@ -2560,9 +2626,13 @@ Return JSON with:
                                 verification.get("recommended_action", "")
                             )
 
-                        # Apply LLM's recommended fixes
+                        # Apply LLM's recommended fixes. Pass the
+                        # accumulated verification_history so the refiner
+                        # can see prior scores/pipelines and recognize
+                        # regressions instead of iterating blindly on the
+                        # previous (possibly degraded) config.
                         refined_config = self._apply_verification_feedback(
-                            state, verification
+                            state, verification, history=verification_history
                         )
 
                         # If the refinement LLM call failed (transient
@@ -2969,15 +3039,20 @@ Return JSON with:
 - Approach: {analysis_approach}
 - Pipeline: {processing_pipeline}
 
-Decide how to address the user's feedback:
-- If the feedback is about visualization, colormaps, labels, fonts, or display only → modify the relevant plotting sections of the existing script. Keep all analysis logic untouched.
-- If the feedback requires minor analysis changes (parameters, thresholds, filters) → modify the relevant parts of the existing script.
-- If the feedback requires a fundamentally different analysis approach → write a new script from scratch.
+Decide how to address the user's feedback and classify the change:
+- **cosmetic** — visualization, colormaps, labels, fonts, legend, axis ranges, \
+subplot layout, or other display-only changes. Modify the plotting sections \
+only; keep all analysis logic and extracted values untouched.
+- **analytical** — parameter / threshold / filter changes, or any change that \
+affects the extracted values. Modify the relevant parts of the script.
+- **rewrite** — the feedback demands a fundamentally different analysis \
+approach. Write a new script from scratch.
 
 In all cases, preserve the output contract: the script must print \
 'IMAGE_ANALYSIS_RESULTS_JSON:{{...}}' and save a visualization PNG.
 
-Return JSON: {{"diagnosis": "what you changed and why", "script": "full Python script"}}
+Return JSON: {{"change_type": "cosmetic" | "analytical" | "rewrite", \
+"diagnosis": "what you changed and why", "script": "full Python script"}}
 '''
 
     def _apply_user_feedback(
@@ -3020,8 +3095,13 @@ Return JSON: {{"diagnosis": "what you changed and why", "script": "full Python s
 
                 if not error and result and result.get("script"):
                     diagnosis = result.get("diagnosis", "")
+                    change_type = (
+                        result.get("change_type", "").strip().lower()
+                    )
                     if diagnosis:
                         self.logger.info(f"    Diagnosis: {diagnosis}")
+                    if change_type:
+                        self.logger.info(f"    Change type: {change_type}")
                     patched_script = result["script"]
 
                     # Execute the patched script
@@ -3088,7 +3168,6 @@ Return JSON: {{"diagnosis": "what you changed and why", "script": "full Python s
                                     pass
 
                         if analysis_results and viz_bytes:
-                            # Verify the user-guided result with the LLM
                             user_guided_result = {
                                 "index": image_idx,
                                 "name": image_name,
@@ -3111,6 +3190,25 @@ Return JSON: {{"diagnosis": "what you changed and why", "script": "full Python s
                                 "script_errors": [],
                             }
 
+                            # Cosmetic-only changes: the analysis outputs did
+                            # not change, so skip re-verification and keep the
+                            # previous best_score. Accept the patched script
+                            # and new visualization as the final result.
+                            if change_type == "cosmetic":
+                                user_guided_result["_quality_score"] = best_score
+                                self.logger.info(
+                                    "   Cosmetic change applied — skipping "
+                                    "re-verification, keeping existing score "
+                                    f"({best_score:.2f})"
+                                )
+                                all_attempts.append({
+                                    "pipeline": "User-guided (cosmetic)",
+                                    "score": best_score,
+                                    "result": user_guided_result,
+                                })
+                                return user_guided_result, best_score
+
+                            # Analytical / rewrite changes: verify quality.
                             verification = self._verify_quality(
                                 state, user_guided_result
                             )

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -95,7 +95,6 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         analysis_depth: "auto" (default), "basic", or "deep"
         enable_human_feedback: Enable feedback loop
         executor_timeout: Script timeout in seconds
-        max_approach_retries: Max alternative approaches to try (default: 1)
         outlier_sigma: Sigma threshold for outlier detection (default: 2.0)
         max_verification_iterations: Max LLM verification iterations (default: 7)
 
@@ -153,7 +152,6 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # Analysis depth
         analysis_depth: str = "auto",
         # Quality control settings
-        max_approach_retries: int = 1,
         outlier_sigma: float = 2.0,
         max_verification_iterations: int = 7,
         # Planning settings
@@ -188,7 +186,6 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         self.output_dir = Path(self.output_dir).resolve()
 
         # Quality control settings
-        self.max_approach_retries = max_approach_retries
         self.outlier_sigma = outlier_sigma
         self.max_verification_iterations = max_verification_iterations
         self.num_plan_candidates = num_plan_candidates
@@ -232,7 +229,6 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         skill: Optional[str] = None,
         prior_knowledge: Optional[List[Dict[str, Any]]] = None,
         # Quality control overrides
-        max_approach_retries: Optional[int] = None,
         outlier_sigma: Optional[float] = None,
         **kwargs,
     ) -> Dict[str, Any]:
@@ -263,7 +259,6 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             auxiliary_label: Description of auxiliary data
             skill: Domain skill name or path to .md skill file
             prior_knowledge: Reference findings from previous analyses
-            max_approach_retries: Override default max retries
             outlier_sigma: Override default outlier sigma
 
         Returns:
@@ -274,11 +269,6 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             for traceability.
         """
         # Use provided overrides or fall back to instance defaults
-        effective_max_retries = (
-            max_approach_retries
-            if max_approach_retries is not None
-            else self.max_approach_retries
-        )
         effective_outlier_sigma = (
             outlier_sigma if outlier_sigma is not None else self.outlier_sigma
         )
@@ -345,7 +335,7 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
 
         self.logger.info("")
         self.logger.info(f"🖼️  IMAGE ANALYSIS - {num_images} image{'s' if num_images > 1 else ''}")
-        self.logger.info(f"   Quality: max_retries={effective_max_retries}, depth={self.analysis_depth}")
+        self.logger.info(f"   Quality: depth={self.analysis_depth}")
         if not is_single_image:
             self.logger.info(f"   Outlier detection: {effective_outlier_sigma}σ")
 
@@ -459,7 +449,6 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             output_dir=str(self.output_dir),
             literature_agent=self.literature_agent,
             enable_human_feedback=self.enable_human_feedback,
-            max_approach_retries=effective_max_retries,
             outlier_sigma=effective_outlier_sigma,
             max_verification_iterations=self.max_verification_iterations,
             num_plan_candidates=self.num_plan_candidates,
@@ -524,7 +513,6 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             image_stack=image_stack, input_type=input_type,
             num_images=num_images, is_single_image=is_single_image,
             first_image_name=first_image_name,
-            effective_max_retries=effective_max_retries,
             effective_outlier_sigma=effective_outlier_sigma,
         )
 
@@ -800,7 +788,7 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         skill_state, aux_state,
         image_paths, image_stack, input_type,
         num_images, is_single_image, first_image_name,
-        effective_max_retries, effective_outlier_sigma,
+        effective_outlier_sigma,
         tier2_decision=None,
     ) -> Optional[dict]:
         """Run Tier 2 pipeline and return compiled results, or None on failure."""
@@ -864,7 +852,6 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             output_dir=str(self.output_dir),
             literature_agent=self.literature_agent,
             enable_human_feedback=self.enable_human_feedback,
-            max_approach_retries=effective_max_retries,
             outlier_sigma=effective_outlier_sigma,
             max_verification_iterations=self.max_verification_iterations,
             num_plan_candidates=self.num_plan_candidates,

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2819,7 +2819,7 @@ sections below):
     "analysis_approach": "Overall strategy in one sentence",
     "processing_pipeline": "Step-by-step sequence: e.g., 'Gaussian blur (sigma=2) -> Otsu threshold -> morphological opening (disk r=3) -> connected component labeling -> region property extraction'",
     "features_to_extract": ["feature1", "feature2"],
-    "quality_criteria": "How to verify the analysis worked — specific, measurable where possible (e.g., 'segmentation should capture >90% of visible grains', 'detected edge map should trace visible boundaries')",
+    "quality_criteria": "How to verify the analysis produced usable output. Match criteria specificity to the objective. Targeted objective (e.g. count grains, measure lattice spacing, find specific defects): set concrete measurable criteria that check those features are extracted and physically plausible — e.g. 'grain count within 10% of visual estimate', 'lattice spacing matches known bulk value'. Exploratory / open-ended objective (or no objective provided): keep criteria descriptive — 'outputs are coherent (not pure noise or all NaN)', 'features correspond to real image content rather than artifacts'. Avoid baking in specific expectations the data may not actually support — the analysis should discover what is there, not confirm a hypothesis.",
     "expected_outputs": ["output_visualization_1.png", "output_visualization_2.png"],
     "literature_query": "Question for literature search to help with analysis, or null if not needed"
 }}
@@ -3157,6 +3157,92 @@ file you saved — each entry should have `description`, `shape`, and `dtype` so
 follow-up analysis can load the right file without guessing. \
 Example entry: `"analysis_labels.npy": {{"description": "Integer label map, \
 23 grains labeled 1-23, background=0", "shape": [512, 512], "dtype": "int32"}}`. \
+The standard fields are:
+```python
+results = {{{{
+    "analysis_type": "description of what was done",
+    "extracted_features": {{{{"feature_name": value, ...}}}},
+    "quality_metrics": {{{{"metric_name": value, ...}}}},
+    "summary": "Key finding in one sentence",
+    "saved_arrays": {{{{...}}}}
+}}}}
+print(f"IMAGE_ANALYSIS_RESULTS_JSON:{{{{json.dumps(results)}}}}")
+```
+
+**Response:** Return only `{{"script": "..."}}`
+"""
+
+
+IMAGE_ANALYSIS_SCRIPT_REFINEMENT_PROMPT = """Refine an existing image analysis script to match a refined plan.
+
+**Your Plan (refined by verification feedback):**
+- Approach: {analysis_approach}
+- Pipeline: {processing_pipeline}
+- Features to extract: {features_to_extract}
+
+**CONFORMANCE:** Your updated script should implement the plan's methods and \
+extract the listed features. You may adjust numerical parameters (thresholds, \
+window sizes, sigma values) to produce reasonable results — document adjustments \
+in the "summary" field. Do not change the analysis methods themselves (e.g., \
+don't replace Otsu with adaptive thresholding) unless the refined plan \
+explicitly demands it.
+
+**REGISTERED TOOLS:** If the plan names a registered tool, you MUST import and call it \
+by its exact import line and signature. Do not reimplement the tool's internals inline, \
+even when you believe you can write "equivalent logic" — a hand-written variant cannot \
+be verified as equivalent to the registered implementation. Two narrow exceptions: \
+(1) the tool fails at runtime due to a major infrastructure issue (model weights \
+cannot be downloaded, a required dependency is not installed, model files are missing \
+or corrupted); (2) the tool runs but produces clearly unacceptable output that cannot \
+be fixed by tuning its documented parameters — and you have actually tried tuning \
+them first. In either case: try the tool first (and for case 2, attempt reasonable \
+parameter adjustments before giving up), catch the failure or inadequate result, \
+document the specific issue in the "summary" field, and only then fall back to custom \
+code.
+
+**Context:** {context}
+
+**Data:**
+- Path: `{data_path}`
+- Shape: {shape}
+- dtype: {dtype}
+- Intensity range: [{intensity_min}, {intensity_max}]
+
+{tool_inventory}
+
+**PREVIOUS SCRIPT (working baseline):**
+```python
+{base_script}
+```
+
+**How to adapt the previous script:**
+The previous script produced a partial result that the verifier wants improved. \
+The refined plan above reflects the verifier's feedback. Modify the previous script \
+to implement the refined plan — **preserve pipeline choices and custom implementations \
+that still apply** (e.g., a handwritten per-window processing loop that was matching \
+the plan's intent). Only change the parts the refinement actually requires. \
+If the refined plan demands fundamentally different methods (e.g., switching from \
+intensity thresholding to edge detection, or from one registered tool to another), \
+rewrite the analysis portion accordingly — but do not rewrite more than the \
+refined plan calls for.
+
+**Requirements:**
+1. Load image: use `np.load(path)` for .npy, or `cv2.imread(path, cv2.IMREAD_UNCHANGED)` \
+for standard formats (remember cv2 loads BGR — convert to RGB if 3-channel color). \
+Check the image shape — it may have 2 or more channels that are not RGB. Access channels \
+via `image[:,:,0]`, `image[:,:,1]`, etc. Do not assume grayscale or RGB.
+2. Implement the refined analysis pipeline.
+3. Save visualization(s): `analysis_visualization.png` showing original image alongside \
+key analysis results. Use subplots with clear labels. All visualizations must be saved \
+to the current working directory. Use `dpi=100`.
+4. Save key output arrays to the current working directory as `.npy` files. \
+At minimum save the primary detection/segmentation result.
+5. NumPy / Python scalar conversions: values pulled out of numpy arrays (via indexing, \
+reductions, or tool outputs) are numpy scalars, not Python scalars. Before passing them \
+to Python builtins (`round()`, f-string width/precision), `json.dumps`, or any code that \
+expects a native Python `int`/`float`, wrap with `float(...)` or `int(...)`.
+6. Print results as JSON. Include a `saved_arrays` key describing every `.npy` \
+file you saved — each entry should have `description`, `shape`, and `dtype`. \
 The standard fields are:
 ```python
 results = {{{{

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2784,31 +2784,16 @@ channel for what it measures, and consider whether cross-channel relationships a
 meaningful (e.g., do features in one channel correspond to or predict features in another).
 Access channels via `image[:,:,0]`, `image[:,:,1]`, etc.
 
-**Common Analysis Approaches** (for reference):
+**Common Analysis Approaches** (for reference — callable tools and available \
+libraries are listed in the `## Available Tools` and `## Available Libraries` \
+sections below):
 - Segmentation (Otsu, adaptive threshold, watershed, morphological)
 - Edge/boundary detection (Canny, Sobel, Laplacian of Gaussian)
-- Feature extraction (connected components, region properties, contour analysis)
+- Feature extraction (connected components, region properties, contour analysis).
   Note: connected component labeling cannot separate touching or overlapping objects —
-  they will be merged into single blobs. If objects touch or overlap, use SAM instance
-  segmentation or add a splitting step (e.g., distance transform → watershed).
-- SAM instance segmentation — for images with touching/overlapping objects.
-  Use `from scilink.tools.sam import run_sam_analysis` in your script.
-  SAM detects individual object instances directly, even when they overlap.
-  Usage: `result = run_sam_analysis(image_array, params={"sam_parameters": "default",
-    "min_area": <set_from_image>, "max_area": <set_from_image>,
-    "pruning_iou_threshold": <set_from_image>})`
-  First arg accepts a 2D grayscale numpy array or an HxWx3 RGB uint8 array. \
-For RGB images, passing the array directly is often preferable because SAM can leverage \
-color contrast, but extracting a single channel is also valid when one channel carries the \
-most relevant contrast. For non-RGB multi-channel images (e.g., 2-channel or 4-channel), \
-pass a single channel (e.g., `image[:,:,0]`).
-  Choose min_area/max_area based on expected object sizes in the image.
-  Always start with sam_parameters='default'. Only escalate to 'sensitive' in a retry if
-  'default' misses visible objects.
-  Parameters: min_area/max_area (pixel area filters), use_clahe (contrast enhancement, default False),
-    pruning_iou_threshold (masks with IoU above this are removed; lower = stricter, higher = keeps more overlapping objects; default 0.5).
-  Returns dict with "particles" (list with "mask", "area" per particle), "total_count", "masks".
-  Avoid Gaussian blur before SAM unless noise is very high.
+  they will be merged into single blobs. For touching or overlapping objects, reach for
+  a registered instance-segmentation tool from `## Available Tools` or add a splitting
+  step (e.g., distance transform → watershed).
 - Texture analysis (GLCM, local binary patterns, Gabor filters)
 - Morphological measurements (area, perimeter, circularity, aspect ratio, solidity)
 - Phase identification (intensity clustering, color-space segmentation)
@@ -2818,27 +2803,6 @@ pass a single channel (e.g., `image[:,:,0]`).
   Prefer FFT-based methods for atomically resolved images where it is more meaningful
   to learn about periodic structures, symmetries, or electronic patterns rather than
   find every atom.
-- Sliding FFT/NMF decomposition — for images with periodic or quasi-periodic structures.
-  Use `from scilink.tools.fft_nmf import run_fft_nmf_analysis` in your script.
-  Procedure: slides a window across the image, computes the FFT power spectrum of each
-  patch (with Hamming windowing, log-magnitude, and central zoom), then runs NMF on the
-  stacked spectra to factorize them into a small set of spectral components (dominant
-  frequency patterns) and their spatial abundance maps (where each pattern is present).
-  Usage: `result = run_fft_nmf_analysis(image_array, params={"n_components": 4})`
-  First arg must be a 2D grayscale numpy array.
-  Parameters: window_size (pixels, default: auto), n_components (default: 4),
-    step_fraction (window overlap, default: 0.25).
-  Returns dict with "components" shape (n_components, fft_h, fft_w) — each component is
-    a 2D FFT power spectrum representing a dominant frequency pattern; "abundances" shape
-    (n_components, grid_h, grid_w) — spatial maps showing where each component is present
-    in the image; plus "n_components", "window_size", "grid_shape".
-  Choose window_size and n_components based on the physics of the problem — the spatial
-  scale of repeating features and the number of distinct patterns expected in the image
-  based on the material system and imaging conditions.
-  Always save components and abundances as .npy files (e.g.,
-  `np.save("nmf_components.npy", result["components"])` and
-  `np.save("abundance_maps.npy", result["abundances"])`) and include them in
-  `saved_arrays` so follow-up analysis can reuse them.
 
 **Commit to specific choices — do NOT hedge:**
 - State ONE segmentation method, not alternatives (write "Otsu thresholding" not "Otsu or adaptive")
@@ -2876,6 +2840,14 @@ your findings.
 Keep the pipeline simple and robust. A successful basic analysis that
 captures the main features is more valuable than an ambitious pipeline
 that fails.
+
+When a registered tool already does the hard step (e.g. `run_fft_nmf_analysis`
+with a window size tuned to the spatial scale of the features of interest for
+disorder / defect / multi-phase analysis, or `run_sam_analysis` for instance
+segmentation), a single tool call followed by a simple post-processing step is
+already a complete Tier 1 pipeline. Do not pad it with additional processing
+steps for the sake of thoroughness — the tool output plus a focused
+interpretation is the deliverable.
 
 If a specific analysis objective was provided, ensure your foundational
 analysis captures the features most relevant to that objective —
@@ -2947,25 +2919,37 @@ IMAGE_ANALYSIS_TIER2_DECISION_INSTRUCTIONS = """You are evaluating whether a fou
 
 **Analysis Objective:** {objective}
 
-Based on the Tier 1 findings, decide whether a deeper follow-up
-analysis would produce scientifically meaningful additional insights.
+**Default answer is NO.** Tier 1 is typically sufficient. Only answer YES when
+Tier 2 would deliver a *specific, concrete* scientific insight that Tier 1 did
+not and cannot produce. Interesting-looking features or possibilities do not
+justify Tier 2 — there must be a clear follow-up analysis with a clear outcome.
 
-Answer YES if the Tier 1 results reveal:
-- Multiple distinct feature populations worth separating (e.g., bimodal intensity suggesting sublattices)
-- Spatial patterns or gradients worth quantifying (e.g., size gradient, intensity variation)
-- Anomalous regions worth characterizing (e.g., dark bands, displaced features)
-- The stated objective requires analysis beyond basic detection and measurement
+**Answer NO if any of the following is true:**
+- Tier 1 already addresses the stated objective (even partially — if the core
+  question is answered, stop).
+- The image is uniform or featureless.
+- Tier 1 quality is poor or unreliable — building deeper analysis on a weak
+  foundation is worse than stopping.
+- The additional insight from Tier 2 would be incremental or speculative rather
+  than a distinct new finding.
+- You cannot name a specific follow-up analysis that would produce a specific
+  new measurable outcome.
 
-Answer NO if:
-- Tier 1 already fully addresses the objective
-- The image shows uniform, featureless structure with nothing to investigate further
-- Tier 1 quality is too poor to build on (detection failed, lattice fit unreliable)
+**Answer YES only if all of the following are true:**
+- The stated objective requires analysis that Tier 1 demonstrably did not
+  perform (e.g., objective mentions sublattice-resolved measurement, strain
+  mapping, or phase-resolved quantification, and Tier 1 did not produce it).
+- Tier 1 findings *clearly* indicate a follow-up with a concrete, bounded
+  outcome — not "investigate further," but "measure X using Y."
+- Tier 1 results are reliable enough to serve as input to the follow-up.
+
+If you are uncertain, answer NO.
 
 Return JSON:
 {{
     "tier2_needed": true/false,
-    "reasoning": "why deeper analysis is or isn't warranted",
-    "suggested_focus": "what the follow-up should investigate (if needed)"
+    "reasoning": "Concrete justification. If YES: name the specific follow-up analysis and the specific outcome it will produce that Tier 1 did not.",
+    "suggested_focus": "Specific follow-up analysis if YES; empty string if NO."
 }}
 """
 

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -3108,6 +3108,19 @@ features. You may adjust numerical parameters (thresholds, window sizes, sigma v
 to produce reasonable results — document adjustments in the "summary" field. Do not \
 change the analysis methods themselves (e.g., don't replace Otsu with adaptive thresholding).
 
+**REGISTERED TOOLS:** If the plan names a registered tool, you MUST import and call it \
+by its exact import line and signature. Do not reimplement the tool's internals inline, \
+even when you believe you can write "equivalent logic" — a hand-written variant cannot \
+be verified as equivalent to the registered implementation. Two narrow exceptions: \
+(1) the tool fails at runtime due to a major infrastructure issue (model weights \
+cannot be downloaded, a required dependency is not installed, model files are missing \
+or corrupted); (2) the tool runs but produces clearly unacceptable output that cannot \
+be fixed by tuning its documented parameters — and you have actually tried tuning \
+them first. In either case: try the tool first (and for case 2, attempt reasonable \
+parameter adjustments before giving up), catch the failure or inadequate result, \
+document the specific issue in the "summary" field, and only then fall back to custom \
+code.
+
 **Context:** {context}
 
 **Data:**
@@ -3116,29 +3129,7 @@ change the analysis methods themselves (e.g., don't replace Otsu with adaptive t
 - dtype: {dtype}
 - Intensity range: [{intensity_min}, {intensity_max}]
 
-**Available Libraries:** numpy, scipy (ndimage, signal, optimize), scikit-image (skimage), \
-opencv-python (cv2), matplotlib, Pillow (PIL), scikit-learn (sklearn), pandas, json, \
-scilink.tools.sam — SAM instance segmentation for touching/overlapping objects. \
-`from scilink.tools.sam import run_sam_analysis`; \
-usage: `result = run_sam_analysis(image_array, params={{"sam_parameters": "default", \
-"min_area": <set_from_plan>, "max_area": <set_from_plan>, \
-"pruning_iou_threshold": <set_from_plan>}})`. \
-First arg must be a 2D grayscale numpy array or an HxWx3 RGB uint8 array. \
-For multi-channel images that are not RGB (e.g., 2-channel or 4-channel), pass a single \
-channel (e.g., `image[:,:,0]`). True RGB images can be passed directly. \
-Choose min_area/max_area based on expected object sizes in the image. \
-sam_parameters MUST be 'default' on the first attempt — only switch to 'sensitive' in a retry \
-after 'default' has been tried and missed objects. \
-Parameters: \
-min_area/max_area (pixel area filters), use_clahe (contrast enhancement, default False), \
-pruning_iou_threshold (masks with IoU above this are removed; lower = stricter, higher = keeps more overlapping objects; default 0.5). \
-Returns dict with "particles" (list with "mask", "area" per particle), "total_count", "masks". \
-For RGB input, each particle also includes "mean_color_rgb". \
-Avoid Gaussian blur before SAM unless noise is very high. \
-scilink.tools.atom_finding_tools — atomic column detection for STEM images. \
-`from scilink.tools.atom_finding_tools import detect_atoms, detect_atoms_dcnn, refine_positions, find_zone_axes, find_missing_atoms, subtract_atoms`; \
-detect_atoms uses classical peak detection; detect_atoms_dcnn uses a DCNN ensemble and requires fov_nm (field of view in nm). \
-Use only when the domain skill or plan calls for atom-finding tools.
+{tool_inventory}
 
 **Requirements:**
 1. Load image: use `np.load(path)` for .npy, or `cv2.imread(path, cv2.IMREAD_UNCHANGED)` \
@@ -3196,29 +3187,7 @@ IMAGE_ANALYSIS_SCRIPT_CORRECTION_INSTRUCTIONS = """Fix this failed image analysi
 {error_message}
 ```
 
-**Available Libraries:** numpy, scipy (ndimage, signal, optimize), scikit-image (skimage), \
-opencv-python (cv2), matplotlib, Pillow (PIL), scikit-learn (sklearn), pandas, json, \
-scilink.tools.sam — SAM instance segmentation for touching/overlapping objects. \
-`from scilink.tools.sam import run_sam_analysis`; \
-usage: `result = run_sam_analysis(image_array, params={{"sam_parameters": "default", \
-"min_area": <set_from_plan>, "max_area": <set_from_plan>, \
-"pruning_iou_threshold": <set_from_plan>}})`. \
-First arg must be a 2D grayscale numpy array or an HxWx3 RGB uint8 array. \
-For multi-channel images that are not RGB (e.g., 2-channel or 4-channel), pass a single \
-channel (e.g., `image[:,:,0]`). True RGB images can be passed directly. \
-Choose min_area/max_area based on expected object sizes in the image. \
-sam_parameters MUST be 'default' on the first attempt — only switch to 'sensitive' in a retry \
-after 'default' has been tried and missed objects. \
-Parameters: \
-min_area/max_area (pixel area filters), use_clahe (contrast enhancement, default False), \
-pruning_iou_threshold (masks with IoU above this are removed; lower = stricter, higher = keeps more overlapping objects; default 0.5). \
-Returns dict with "particles" (list with "mask", "area" per particle), "total_count", "masks". \
-For RGB input, each particle also includes "mean_color_rgb". \
-Avoid Gaussian blur before SAM unless noise is very high. \
-scilink.tools.atom_finding_tools — atomic column detection for STEM images. \
-`from scilink.tools.atom_finding_tools import detect_atoms, detect_atoms_dcnn, refine_positions, find_zone_axes, find_missing_atoms, subtract_atoms`; \
-detect_atoms uses classical peak detection; detect_atoms_dcnn uses a DCNN ensemble and requires fov_nm (field of view in nm). \
-Use only when the domain skill or plan calls for atom-finding tools.
+{tool_inventory}
 
 **CRITICAL:** Fix only the execution error. Do NOT change the analysis pipeline, feature \
 extraction approach, or the overall analysis strategy. The approach is locked for series consistency.
@@ -3264,6 +3233,16 @@ implementation-level decision, not a method change.
 The script's "summary" field should explain any adjustment.
 Changing the analysis method (e.g., replacing LoG with Hough circles) is NOT a justified \
 deviation — that requires a new plan via the retry pipeline.
+
+Reimplementing a registered tool inline instead of calling it is NOT a justified \
+deviation, even when the script claims "equivalent logic" or "same parameters". The \
+registered tool is the single source of truth for that operation. The only valid \
+exceptions are (1) the tool actually failed at runtime due to a major infrastructure \
+issue (model download failed, required dependency not installed, model files missing), \
+or (2) the tool ran but produced clearly unacceptable output that could not be fixed by \
+tuning its documented parameters and the script documents the attempted tuning. Both \
+exceptions must be explicitly documented in the script's "summary" field — mere \
+assertion of equivalence is not sufficient.
 
 Return JSON:
 {{"conformant": true/false, "justified_deviations": ["deviations with stated reasoning, if any"], "unjustified_deviations": ["deviations with no explanation"], "summary": "one sentence"}}

--- a/scilink/agents/exp_agents/pipelines/image_analysis_pipelines.py
+++ b/scilink/agents/exp_agents/pipelines/image_analysis_pipelines.py
@@ -57,7 +57,6 @@ def create_unified_image_analysis_pipeline(
     output_dir: str,
     literature_agent: Any | None = None,
     enable_human_feedback: bool = False,
-    max_approach_retries: int = 1,
     outlier_sigma: float = 2.0,
     max_verification_iterations: int = 7,
     num_plan_candidates: int = 1,
@@ -117,7 +116,6 @@ def create_unified_image_analysis_pipeline(
         output_dir: Output directory path
         literature_agent: Optional literature search agent
         enable_human_feedback: Enable human-in-the-loop refinement
-        max_approach_retries: Max alternative approaches to try (default: 1)
         outlier_sigma: Sigma threshold for outlier detection in series (default: 2.0)
         max_verification_iterations: Max LLM verification iterations (default: 7)
 
@@ -188,7 +186,6 @@ def create_unified_image_analysis_pipeline(
             quality_instructions=IMAGE_ANALYSIS_QUALITY_ASSESSMENT_INSTRUCTIONS,
             output_dir=output_dir,
             image_to_bytes_fn=image_to_bytes_fn,
-            max_approach_retries=max_approach_retries,
             enable_human_feedback=enable_human_feedback,
             outlier_sigma=outlier_sigma,
             max_verification_iterations=max_verification_iterations,
@@ -210,7 +207,6 @@ def create_unified_image_analysis_pipeline(
             quality_instructions=IMAGE_ANALYSIS_QUALITY_ASSESSMENT_INSTRUCTIONS,
             output_dir=output_dir,
             image_to_bytes_fn=image_to_bytes_fn,
-            max_approach_retries=max_approach_retries,
             max_verification_iterations=max_verification_iterations,
             enable_human_feedback=enable_human_feedback,
             conformance_instructions=IMAGE_ANALYSIS_PLAN_CONFORMANCE_CHECK_INSTRUCTIONS,
@@ -255,10 +251,7 @@ def create_unified_image_analysis_pipeline(
     )
 
     logger.info(f"Unified image analysis pipeline created: {len(pipeline)} steps")
-    logger.info(
-        f"  Quality settings: max_retries={max_approach_retries}, "
-        f"outlier_sigma={outlier_sigma}"
-    )
+    logger.info(f"  Outlier sigma: {outlier_sigma}")
     logger.info(f"  Verification iterations: {max_verification_iterations}")
 
     return pipeline

--- a/scilink/agents/exp_agents/pipelines/image_analysis_pipelines.py
+++ b/scilink/agents/exp_agents/pipelines/image_analysis_pipelines.py
@@ -38,6 +38,7 @@ from ..instruct import (
     IMAGE_ANALYSIS_PLANNING_INSTRUCTIONS,
     IMAGE_ANALYSIS_SCRIPT_INSTRUCTIONS,
     IMAGE_ANALYSIS_SCRIPT_CORRECTION_INSTRUCTIONS,
+    IMAGE_ANALYSIS_SCRIPT_REFINEMENT_PROMPT,
     IMAGE_ANALYSIS_QUALITY_ASSESSMENT_INSTRUCTIONS,
     IMAGE_ANALYSIS_INTERPRETATION_INSTRUCTIONS,
     IMAGE_ANALYSIS_PLAN_CONFORMANCE_CHECK_INSTRUCTIONS,
@@ -190,6 +191,7 @@ def create_unified_image_analysis_pipeline(
             outlier_sigma=outlier_sigma,
             max_verification_iterations=max_verification_iterations,
             conformance_instructions=IMAGE_ANALYSIS_PLAN_CONFORMANCE_CHECK_INSTRUCTIONS,
+            refinement_instructions=IMAGE_ANALYSIS_SCRIPT_REFINEMENT_PROMPT,
         )
     )
 
@@ -210,6 +212,7 @@ def create_unified_image_analysis_pipeline(
             max_verification_iterations=max_verification_iterations,
             enable_human_feedback=enable_human_feedback,
             conformance_instructions=IMAGE_ANALYSIS_PLAN_CONFORMANCE_CHECK_INSTRUCTIONS,
+            refinement_instructions=IMAGE_ANALYSIS_SCRIPT_REFINEMENT_PROMPT,
         )
     )
 

--- a/scilink/agents/exp_agents/utils.py
+++ b/scilink/agents/exp_agents/utils.py
@@ -348,7 +348,7 @@ def download_file_with_gdown(file_id, output_path):
             os.makedirs(parent_dir, exist_ok=True)
 
         # gdown.download handles the direct download link construction and large file quirks
-        gdown.download(id=file_id, output=output_path, quiet=False, fuzzy=True) # fuzzy=True for slightly more relaxed ID matching
+        gdown.download(id=file_id, output=output_path, quiet=False)
         
         print(f"File downloaded to: {output_path}")
         return output_path

--- a/scilink/executors.py
+++ b/scilink/executors.py
@@ -287,7 +287,7 @@ class ScriptExecutor:
 
     def execute_script(self, script_content: str, working_dir: str = None) -> dict:
         """Execute a Python script."""
-        logging.info("Executing Python script...")
+        logging.info("   Executing Python script...")
         
         original_cwd = os.getcwd()
         if working_dir:

--- a/scilink/knowledge.py
+++ b/scilink/knowledge.py
@@ -154,13 +154,6 @@ def synthesize_knowledge(
                             f" to {next_score:.2f}"
                         )
 
-            for alt in qh.get("alternative_approaches", []):
-                qh_lines.append(
-                    f"- Alternative pipeline "
-                    f"(score={alt.get('score', 0):.2f}): "
-                    f"{alt.get('diagnosis', '')}"
-                )
-
             if len(qh_lines) > 1:
                 analysis_texts.append("\n".join(qh_lines))
 

--- a/scilink/skills/image_analysis/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem.md
@@ -11,6 +11,18 @@ identification, and structural variation analysis.
 ## planning
 
 ### foundational
+**When to use `run_fft_nmf_analysis` instead of atom-resolved detection:**
+inspect the image for pattern-level heterogeneity — visible textures or
+phase-like regions, disorder or defects at a scale coarser than
+individual atoms, or atomic detail that is noisy or low-contrast (where
+peak finding would be unreliable). If any of these is present,
+`run_fft_nmf_analysis` with a window size tuned to the feature scale is
+a complete Tier 1 pipeline. The same applies when the objective
+explicitly targets disorder, defects, or phase separation. Use
+atom-resolved detection (below) when the image is clean and uniform and
+per-column measurements are needed — which is also the default when no
+objective is provided and the image looks well-resolved.
+
 Before running detection, estimate the expected number of **visible**
 atomic columns from the image dimensions, pixel calibration (if
 available), and known lattice parameters for the material. Count all
@@ -45,10 +57,15 @@ from scilink.tools.atom_finding_tools import (
 Two detection methods are available: `detect_atoms_dcnn` (AtomNet3
 DCNN ensemble, requires `fov_nm` from metadata) and `detect_atoms`
 (classical peak detection, works in pixel space). Both return the same
-dict format so downstream tools work with either. Try `detect_atoms_dcnn`
-first when spatial calibration is available. If DCNN detection fails or
-produces poor results, fall back to `detect_atoms`. Use `detect_atoms`
-directly when `fov_nm` cannot be determined from metadata.
+dict format so downstream tools work with either. Choose between them
+based on material and image quality:
+- The AtomNet3 works best for transition-metal oxides (including
+  perovskites, layered perovskites, and cuprate superconductors) and
+  graphene. For these materials, try `detect_atoms_dcnn` first when
+  spatial calibration is available.
+- For materials outside that list, when `fov_nm` cannot be determined,
+  or when DCNN results look poor on inspection, use `detect_atoms`
+  directly — it is the more general-purpose baseline.
 
 Plan the pipeline around the chosen detector, then use `find_zone_axes` to identify
 lattice vectors, `find_missing_atoms` to predict weaker sublattice

--- a/scilink/skills/image_analysis/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem.md
@@ -252,6 +252,13 @@ image area and unit cell) should be within 0.90-1.10.
 **Unit cell sanity:** Measured lattice parameters should be close to
 known bulk values when spatial calibration is available.
 
+**Do not recommend preprocessing on the input to `detect_atoms_dcnn`**
+(CLAHE, contrast normalization, background subtraction, etc.). The
+AtomNet3 model is trained on raw images and handles intensity
+gradients internally; added preprocessing can degrade detection. If
+weak columns are missed, recommend adjusting the tool's `threshold`
+parameter instead.
+
 ### advanced
 **Sublattice populations:** Should match expected stoichiometry for
 the material. Heavy doping can shift intensities between clusters.

--- a/scilink/skills/image_analysis/overlapping_objects.md
+++ b/scilink/skills/image_analysis/overlapping_objects.md
@@ -12,6 +12,31 @@ to which object).
 ## planning
 
 ### foundational
+**Check first whether the problem actually needs instance segmentation.**
+Several common cases resolve with simple classical methods before
+reaching for a heavy model like SAM:
+
+- **Well-separated objects** → Otsu + connected components is enough.
+- **Objects separated by a visible boundary feature** (dark grain
+  boundaries in etched metal, stained cell walls, bright domain
+  edges) → use the boundary itself to separate the objects. Extract
+  the boundary first — the method depends on how the boundary looks
+  in the pixel data (thresholding for clean dark/bright lines, edge
+  detection such as Canny/Sobel for gradient edges, gradient magnitude
+  or texture filters for softer boundaries; add morphological closing
+  if the boundary is broken). Once you have the boundary map, the two
+  classical ways to turn it into labeled objects are (a) invert and
+  run connected components on the interiors, or (b) use the boundary
+  map as a watershed landscape. Usually sharper and faster than SAM
+  for these images — SAM does not know to treat a thin boundary
+  feature as an object separator.
+- **Clean foreground-background intensity separation** → Otsu +
+  connected components + morphological cleanup.
+
+Only reach for SAM when objects genuinely touch or overlap AND no
+visible boundary feature delineates them — the case where classical
+approaches would merge adjacent objects into single blobs.
+
 Connected component labeling on a binary mask merges all touching pixels
 into one object. If the image shows touching or overlapping objects, the
 pipeline must include a splitting step between mask creation and

--- a/scilink/skills/image_analysis/stm_cafm.md
+++ b/scilink/skills/image_analysis/stm_cafm.md
@@ -1,0 +1,44 @@
+# STM & Conductive AFM (low-bias) Imaging Skill
+
+## overview
+
+Scanning tunneling microscopy (STM) and conductive atomic force
+microscopy at low bias (cAFM) produce images whose features reflect
+local density of states or local conductance. Apparent "atoms" can
+shift with bias voltage, tip condition, or contact geometry. Use this
+skill for LDOS heterogeneity, conductance domain mapping, and
+pattern-level analysis of electronic imaging data.
+
+## planning
+
+### foundational
+The primary signal is electronic. Set the plan's `quality_criteria`
+to match electronic features — LDOS heterogeneity, conductance
+variation, domain structure, coherence of abundance maps. Atomic-like
+periodic patterns may still be present, but include lattice-related
+criteria only when the objective explicitly calls for lattice
+characterization.
+
+The right Tier 1 tool depends on what the image shows. For
+heterogeneous textures or phase domains (quantum materials,
+crystalline patches, spatially varying electronic order),
+`run_fft_nmf_analysis` with a feature-scale window is typically
+appropriate. For discrete features on a surface (molecular
+adsorbates, clusters, individual defects), peak/blob detection
+(`skimage.feature`) or instance segmentation (SAM) is more natural —
+count, measure, and map the spatial distribution of individual
+features rather than looking for periodicity that isn't there.
+
+Classical atom-detection tools (`detect_atoms`, `detect_atoms_dcnn`)
+are designed for STEM-style atomic columns and typically not the
+right default for electronic imaging — apparent atoms can shift with
+bias, tip state, and contact geometry. Use them when the objective
+explicitly calls for lattice characterization and the image is
+genuinely atomic-resolution and stable.
+
+## validation
+
+### foundational
+Validate against the electronic signal — spatial coherence of
+detected domains, physical plausibility of conductance / LDOS values,
+agreement between independent electronic descriptors.

--- a/scilink/skills/image_analysis/stm_cafm.md
+++ b/scilink/skills/image_analysis/stm_cafm.md
@@ -36,9 +36,39 @@ bias, tip state, and contact geometry. Use them when the objective
 explicitly calls for lattice characterization and the image is
 genuinely atomic-resolution and stable.
 
+**Do not try to pre-filter LDOS modulations out of the lattice
+signal.** In STM/cAFM the lattice contrast is genuinely modulated by
+the LDOS envelope — that modulation is real signal, not noise. Avoid
+aggressive high-pass filtering, mean subtraction within windows, or
+bandpass design aimed at "isolating the pure lattice": these remove
+physically meaningful variation and may leave only noise where the
+lattice contrast was weakest. Let the decomposition see both scales;
+interpret the resulting components rather than engineering the
+pipeline to force a separation the physics doesn't support.
+
+**Visualizing FFT-NMF results.** When `n_components` ≤ 3, display all
+FFT components and all abundance maps. For `n_components` > 3, show
+the major ones (top by total abundance). Pair each abundance map with
+its corresponding FFT component so the viewer can match them — an
+abundance map alone is uninterpretable. Preserve true aspect ratios;
+don't stretch or squash images to fill subplot shapes.
+
 ## validation
 
 ### foundational
 Validate against the electronic signal — spatial coherence of
 detected domains, physical plausibility of conductance / LDOS values,
 agreement between independent electronic descriptors.
+
+For FFT-NMF-based analyses: acceptable output has non-noise frequency
+content in the components and spatially coherent abundance maps.
+Semantic labeling of components (e.g. "this is the crystalline
+component") requires post-hoc interpretation and depends on the data —
+don't treat it as a hard quality criterion.
+
+Do not penalize a decomposition for "not isolating the pure lattice"
+or for being dominated by the LDOS envelope rather than lattice-scale
+peaks: envelope and lattice contrast are physically coupled in these
+techniques, and the envelope is real signal — not contamination the
+decomposition should have suppressed. Accept coherent, data-faithful
+outputs whether or not they produce a pure-lattice component.

--- a/scilink/tools/_registry.py
+++ b/scilink/tools/_registry.py
@@ -1,0 +1,83 @@
+"""Auto-discovery registry for ``scilink.tools`` modules.
+
+Walks ``scilink/tools/`` once, collects ``TOOL_SPEC`` (single) or
+``TOOL_SPECS`` (list) attributes from each public module, filters by agent
+tag, and caches the result.
+
+Adding a new tool:
+    1. Write the function in a module under ``scilink/tools/``.
+    2. Add ``TOOL_SPEC = ToolSpec(...)`` (or append to ``TOOL_SPECS``) with
+       ``agents=["image_analysis", ...]``.
+    3. Done — no central list to edit.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import pkgutil
+from functools import lru_cache
+
+from ._spec import ToolSpec
+
+_logger = logging.getLogger(__name__)
+
+
+# Libraries available in the execution sandbox (verified against the host
+# Python environment, which the sandbox shares via subprocess.Popen in
+# scilink.executors).
+IMAGE_ANALYSIS_LIBRARIES: list[tuple[str, str]] = [
+    ("numpy", "array ops, FFT, linear algebra"),
+    ("scipy", "signal / image processing (ndimage), optimize, stats, spatial"),
+    ("skimage", "segmentation, morphology, feature, measure, filters, transform"),
+    ("cv2", "OpenCV — thresholding, contours, morphology, template matching"),
+    ("sklearn", "clustering, PCA, classifiers for pixel / region classification"),
+    ("matplotlib", "plotting"),
+    ("pandas", "tabular output (particle lists, atom position tables)"),
+]
+
+
+def format_library_inventory() -> str:
+    """Render ``IMAGE_ANALYSIS_LIBRARIES`` as a compact markdown list."""
+    lines = [f"- `{name}` — {desc}" for name, desc in IMAGE_ANALYSIS_LIBRARIES]
+    return "\n".join(lines)
+
+
+def _collect_specs_from_module(mod) -> list[ToolSpec]:
+    """Return ToolSpec list declared by a module (supports TOOL_SPEC and TOOL_SPECS)."""
+    specs: list[ToolSpec] = []
+    single = getattr(mod, "TOOL_SPEC", None)
+    if isinstance(single, ToolSpec):
+        specs.append(single)
+    multi = getattr(mod, "TOOL_SPECS", None)
+    if isinstance(multi, (list, tuple)):
+        specs.extend(s for s in multi if isinstance(s, ToolSpec))
+    return specs
+
+
+@lru_cache(maxsize=None)
+def _all_specs() -> tuple[ToolSpec, ...]:
+    """Walk scilink.tools once and collect every declared ToolSpec.
+
+    Cached for the life of the process. Module import failures are logged
+    and skipped — an optional heavy dependency should not prevent discovery
+    of the other tools.
+    """
+    from . import __path__ as _tools_path  # local import to avoid cycles
+
+    collected: list[ToolSpec] = []
+    for info in pkgutil.iter_modules(_tools_path):
+        if info.name.startswith("_"):
+            continue
+        try:
+            mod = importlib.import_module(f"scilink.tools.{info.name}")
+        except Exception as exc:
+            _logger.debug("Skipping scilink.tools.%s: %s", info.name, exc)
+            continue
+        collected.extend(_collect_specs_from_module(mod))
+    return tuple(collected)
+
+
+def get_tools_for(agent: str) -> list[ToolSpec]:
+    """Return every registered ToolSpec tagged for ``agent``."""
+    return [spec for spec in _all_specs() if agent in spec.agents]

--- a/scilink/tools/_registry.py
+++ b/scilink/tools/_registry.py
@@ -43,6 +43,37 @@ def format_library_inventory() -> str:
     return "\n".join(lines)
 
 
+def format_tool_inventory(agent: str = "image_analysis") -> str:
+    """Render the full tool + library inventory for ``agent`` as one string.
+
+    Used by prompts that need a drop-in ``{tool_inventory}`` substitution
+    (code-gen, script-correction) — complements ``_append_tool_inventory``
+    which is list-based for multi-part prompts. Both draw from the same
+    registry so there is a single source of truth.
+    """
+    parts: list[str] = []
+    specs = get_tools_for(agent)
+    if specs:
+        parts.append("## Available Tools")
+        parts.append(
+            "The following tools are registered and callable from generated scripts. "
+            "Prefer a tool when it fits; combine with custom numpy/scipy/skimage/cv2 "
+            "code for post-processing. A tool call anchoring the hard step followed "
+            "by custom code is usually more reliable than an all-custom pipeline."
+        )
+        for spec in specs:
+            parts.append(spec.to_prompt())
+
+    parts.append("## Available Libraries")
+    parts.append(
+        "These libraries are importable in the execution sandbox. Use them for "
+        "custom code when no registered tool fits."
+    )
+    parts.append(format_library_inventory())
+
+    return "\n\n".join(parts)
+
+
 def _collect_specs_from_module(mod) -> list[ToolSpec]:
     """Return ToolSpec list declared by a module (supports TOOL_SPEC and TOOL_SPECS)."""
     specs: list[ToolSpec] = []

--- a/scilink/tools/_spec.py
+++ b/scilink/tools/_spec.py
@@ -1,0 +1,83 @@
+"""Structured tool spec for agent prompt injection and function-call schemas.
+
+A ``ToolSpec`` describes *what* a tool is (bare mechanics: name, signature,
+parameters, returns). Domain-specific usage recipes (how to combine tools for
+a particular analysis) belong in skill files, not here.
+
+Tool modules in ``scilink/tools/`` declare their spec at module level:
+
+    # single-function module
+    TOOL_SPEC = ToolSpec(...)
+
+    # multi-function module
+    TOOL_SPECS = [ToolSpec(...), ToolSpec(...)]
+
+The walker in ``scilink.tools._registry`` discovers these and filters by the
+``agents`` tag.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ToolSpec:
+    """Metadata for a single callable tool.
+
+    Field vocabulary mirrors ``AnalysisOrchestratorTools._register_tool`` so
+    the same spec can produce both a prompt block (``to_prompt``) and an
+    OpenAI function-call schema (``to_openai_schema``).
+    """
+
+    name: str
+    description: str
+    parameters: dict[str, Any] = field(default_factory=dict)
+    required: list[str] = field(default_factory=list)
+    import_line: str = ""
+    signature: str = ""
+    agents: list[str] = field(default_factory=list)
+    when_to_use: str = ""
+    returns: str = ""
+    example: str = ""
+
+    def to_prompt(self) -> str:
+        """Render as a markdown block for injection into planner / code-gen prompts."""
+        lines = [f"### `{self.name}`"]
+        if self.description:
+            lines.append(self.description)
+        if self.when_to_use:
+            lines.append(f"**When to use:** {self.when_to_use}")
+        if self.import_line:
+            lines.append(f"**Import:** `{self.import_line}`")
+        if self.signature:
+            lines.append(f"**Signature:** `{self.signature}`")
+        if self.parameters:
+            lines.append("**Parameters:**")
+            for pname, pinfo in self.parameters.items():
+                pdesc = pinfo.get("description", "") if isinstance(pinfo, dict) else str(pinfo)
+                ptype = pinfo.get("type", "") if isinstance(pinfo, dict) else ""
+                req_marker = " *(required)*" if pname in self.required else ""
+                type_str = f" ({ptype})" if ptype else ""
+                lines.append(f"- `{pname}`{type_str}{req_marker}: {pdesc}")
+        if self.returns:
+            lines.append(f"**Returns:** {self.returns}")
+        if self.example:
+            lines.append(f"**Example:**\n```python\n{self.example}\n```")
+        return "\n".join(lines)
+
+    def to_openai_schema(self) -> dict:
+        """Render as an OpenAI function-call schema (matches ``_register_tool`` output)."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": self.parameters,
+                    "required": self.required,
+                },
+            },
+        }

--- a/scilink/tools/atom_finding_tools.py
+++ b/scilink/tools/atom_finding_tools.py
@@ -736,3 +736,251 @@ def _empty_result():
         "amplitude": None,
         "rotation": None,
     }
+
+
+# ---------------------------------------------------------------------------
+# Tool specs
+# ---------------------------------------------------------------------------
+
+from ._spec import ToolSpec
+
+TOOL_SPECS = [
+    ToolSpec(
+        name="detect_atoms",
+        description=(
+            "Classical atom-column detection: peak detection plus optional 2D Gaussian "
+            "refinement. Returns sub-pixel positions and per-atom Gaussian parameters."
+        ),
+        import_line="from scilink.tools.atom_finding_tools import detect_atoms",
+        signature=(
+            "detect_atoms(image, separation, threshold_rel=0.02, refine=True, "
+            "percent_to_nn=0.40, subtract_background=False, normalize_intensity=True) -> dict"
+        ),
+        agents=["image_analysis"],
+        when_to_use=(
+            "Atomic-resolution STEM/HAADF images where atoms appear as bright peaks on a "
+            "darker background and the approximate atom separation in pixels is known "
+            "(from metadata or by measurement). A good general-purpose baseline across "
+            "materials — no training-data dependence."
+        ),
+        parameters={
+            "image": {"type": "ndarray", "description": "2D grayscale array."},
+            "separation": {
+                "type": "int",
+                "description": "Minimum atom spacing in pixels.",
+            },
+            "threshold_rel": {
+                "type": "float",
+                "description": "Relative peak threshold (default 0.02).",
+            },
+            "refine": {
+                "type": "bool",
+                "description": "Fit a 2D Gaussian per peak for sub-pixel precision (default True).",
+            },
+            "percent_to_nn": {
+                "type": "float",
+                "description": "Gaussian mask radius as fraction of nearest-neighbor distance (default 0.40).",
+            },
+            "subtract_background": {
+                "type": "bool",
+                "description": "Gaussian-blur background subtraction before peak finding (default False).",
+            },
+            "normalize_intensity": {
+                "type": "bool",
+                "description": "Normalize to 0-1 before peak finding (default True).",
+            },
+        },
+        required=["image", "separation"],
+        returns=(
+            "dict with 'positions' (N,2 array of (x,y) sub-pixel coordinates), "
+            "'sigma_x', 'sigma_y', 'amplitude', 'rotation' (each length-N arrays, or "
+            "None when refine=False)."
+        ),
+    ),
+    ToolSpec(
+        name="detect_atoms_dcnn",
+        description=(
+            "AtomNet3 deep-CNN ensemble detection. Produces atom positions and a "
+            "probability heatmap."
+        ),
+        import_line="from scilink.tools.atom_finding_tools import detect_atoms_dcnn",
+        signature=(
+            "detect_atoms_dcnn(image, fov_nm, model_dir=None, "
+            "target_pixel_size=0.25, threshold=0.8, refine=True) -> dict"
+        ),
+        agents=["image_analysis"],
+        when_to_use=(
+            "Relatively clean atomic-resolution images. Known to work well on "
+            "transition-metal oxides — simple perovskites, layered perovskites, and "
+            "cuprate superconductors (e.g. YBCO, BSCCO) — and on graphene. Preferred "
+            "over classical peak finding for these material systems. Requires the "
+            "field of view in nanometers (from metadata/calibration). Requires the "
+            "atomai package; models auto-download on first call."
+        ),
+        parameters={
+            "image": {"type": "ndarray", "description": "2D grayscale array."},
+            "fov_nm": {
+                "type": "float",
+                "description": "Field of view in nanometers (from metadata or calibration).",
+            },
+            "model_dir": {
+                "type": "str | None",
+                "description": "Path to directory with atomnet3*.tar files. None auto-discovers/downloads.",
+            },
+            "target_pixel_size": {
+                "type": "float",
+                "description": "Target pixel size in Angstroms (default 0.25).",
+            },
+            "threshold": {
+                "type": "float",
+                "description": "Detection confidence 0-1 (default 0.8).",
+            },
+            "refine": {
+                "type": "bool",
+                "description": "Sub-pixel refinement on detected peaks (default True).",
+            },
+        },
+        required=["image", "fov_nm"],
+        returns=(
+            "dict with 'positions' (N,2 array (x,y) in original image pixels), "
+            "'heatmap' (2D probability map in original image space), and "
+            "'sigma_x', 'sigma_y', 'amplitude', 'rotation' (None — call refine_positions "
+            "to obtain Gaussian parameters)."
+        ),
+    ),
+    ToolSpec(
+        name="refine_positions",
+        description=(
+            "Fit 2D Gaussians at known atom positions to obtain sub-pixel coordinates "
+            "and per-atom sigma, amplitude, and rotation values."
+        ),
+        import_line="from scilink.tools.atom_finding_tools import refine_positions",
+        signature="refine_positions(image, positions, percent_to_nn=0.40) -> dict",
+        agents=["image_analysis"],
+        when_to_use=(
+            "After detect_atoms_dcnn (or any source that returns positions without "
+            "Gaussian parameters), when downstream tools like subtract_atoms need "
+            "sigma / amplitude per atom."
+        ),
+        parameters={
+            "image": {"type": "ndarray", "description": "2D grayscale array."},
+            "positions": {
+                "type": "ndarray",
+                "description": "(N, 2) array of (x, y) atom positions.",
+            },
+            "percent_to_nn": {
+                "type": "float",
+                "description": "Gaussian mask radius as fraction of nearest-neighbor distance (default 0.40).",
+            },
+        },
+        required=["image", "positions"],
+        returns=(
+            "dict with 'positions' (refined N,2 (x,y)), 'sigma_x', 'sigma_y', "
+            "'amplitude', 'rotation' (each length-N arrays)."
+        ),
+    ),
+    ToolSpec(
+        name="find_zone_axes",
+        description=(
+            "Detect lattice translation vectors from a set of atom positions. Returns "
+            "the unique shortest lattice vectors."
+        ),
+        import_line="from scilink.tools.atom_finding_tools import find_zone_axes",
+        signature="find_zone_axes(positions, n_neighbors=9, distance_tolerance=None) -> list",
+        agents=["image_analysis"],
+        when_to_use=(
+            "Once atom positions are known (detect_atoms or detect_atoms_dcnn), to "
+            "recover lattice periodicity and pass a zone vector to find_missing_atoms."
+        ),
+        parameters={
+            "positions": {
+                "type": "ndarray",
+                "description": "(N, 2) array of atom positions (x, y).",
+            },
+            "n_neighbors": {
+                "type": "int",
+                "description": "Neighbors per atom to examine (default 9).",
+            },
+            "distance_tolerance": {
+                "type": "float | None",
+                "description": "Clustering tolerance in pixels. Default: median NN distance / 3.",
+            },
+        },
+        required=["positions"],
+        returns="List of (dx, dy) tuples — unique lattice vectors, shortest first.",
+    ),
+    ToolSpec(
+        name="find_missing_atoms",
+        description=(
+            "Predict atom positions at fractional lattice sites along a zone vector "
+            "(e.g. midpoints for a second sublattice)."
+        ),
+        import_line="from scilink.tools.atom_finding_tools import find_missing_atoms",
+        signature="find_missing_atoms(positions, zone_vector, fraction=0.5, min_distance=3.0) -> ndarray",
+        agents=["image_analysis"],
+        when_to_use=(
+            "Multi-sublattice materials where a second (weaker) sublattice sits at "
+            "fractional positions between detected atoms. Pair with subtract_atoms to "
+            "reveal the weaker sublattice, then re-detect."
+        ),
+        parameters={
+            "positions": {
+                "type": "ndarray",
+                "description": "(N, 2) array of detected atoms (x, y).",
+            },
+            "zone_vector": {
+                "type": "tuple",
+                "description": "(dx, dy) lattice vector from find_zone_axes.",
+            },
+            "fraction": {
+                "type": "float",
+                "description": "Fractional position along the vector (0.5 = midpoint).",
+            },
+            "min_distance": {
+                "type": "float",
+                "description": "Minimum distance from existing atoms (pixels, default 3.0).",
+            },
+        },
+        required=["positions", "zone_vector"],
+        returns="(M, 2) ndarray of predicted positions (x, y).",
+    ),
+    ToolSpec(
+        name="subtract_atoms",
+        description=(
+            "Subtract fitted 2D Gaussians from an image to produce a residual that "
+            "reveals weaker sublattices or features."
+        ),
+        import_line="from scilink.tools.atom_finding_tools import subtract_atoms",
+        signature=(
+            "subtract_atoms(image, positions, sigma_x, sigma_y, amplitude, "
+            "rotation=None) -> ndarray"
+        ),
+        agents=["image_analysis"],
+        when_to_use=(
+            "Revealing weaker sublattices in multi-sublattice materials after the "
+            "primary sublattice is fit with detect_atoms (or detect_atoms_dcnn + "
+            "refine_positions). Feed the residual back into a detector for the second "
+            "sublattice."
+        ),
+        parameters={
+            "image": {"type": "ndarray", "description": "2D array."},
+            "positions": {
+                "type": "ndarray",
+                "description": "(N, 2) atom positions (x, y).",
+            },
+            "sigma_x": {"type": "ndarray", "description": "Per-atom sigma_x (length N)."},
+            "sigma_y": {"type": "ndarray", "description": "Per-atom sigma_y (length N)."},
+            "amplitude": {
+                "type": "ndarray",
+                "description": "Per-atom Gaussian amplitude (length N).",
+            },
+            "rotation": {
+                "type": "ndarray | None",
+                "description": "Per-atom rotation in radians. Default 0 for all.",
+            },
+        },
+        required=["image", "positions", "sigma_x", "sigma_y", "amplitude"],
+        returns="2D residual image (clipped to >= 0).",
+    ),
+]
+

--- a/scilink/tools/atomistic_tools.py
+++ b/scilink/tools/atomistic_tools.py
@@ -380,7 +380,7 @@ def download_file_with_gdown(file_id, output_path, logger):
         parent_dir = os.path.dirname(output_path)
         if parent_dir:
             os.makedirs(parent_dir, exist_ok=True)
-        gdown.download(id=file_id, output=output_path, quiet=False, fuzzy=True)
+        gdown.download(id=file_id, output=output_path, quiet=False)
         logger.info(f"File downloaded to: {output_path}")
         return output_path
     except Exception as e:

--- a/scilink/tools/fft_nmf.py
+++ b/scilink/tools/fft_nmf.py
@@ -299,3 +299,62 @@ def run_fft_nmf_analysis(image_array, params=None):
             analyzer.grid_shape[2],
         ),
     }
+
+
+# =============================================================================
+# TOOL SPEC
+# =============================================================================
+
+from ._spec import ToolSpec
+
+TOOL_SPEC = ToolSpec(
+    name="run_fft_nmf_analysis",
+    description=(
+        "Sliding-window FFT + NMF decomposition. Factorizes local frequency patterns "
+        "across an image into a small set of basis spectra and their spatial abundance maps."
+    ),
+    import_line="from scilink.tools.fft_nmf import run_fft_nmf_analysis",
+    signature="run_fft_nmf_analysis(image_array, params=None) -> dict",
+    agents=["image_analysis"],
+    when_to_use=(
+        "Materials with defects, disorder, multiple phases, or spatially varying "
+        "structure — or when the objective involves characterizing disorder, phase "
+        "separation, or local symmetry variations. Also useful for any image where "
+        "the goal is periodic patterns, symmetries, or electronic/lattice patterns "
+        "rather than individual atom positions.\n"
+        "\n"
+        "With a window size tuned to the spatial scale of the repeating features and a "
+        "simple post-processing step (e.g. inspecting components and abundance maps, "
+        "thresholding or clustering abundances to localize distinct regions), this is "
+        "already a complete Tier 1 pipeline — no extra processing steps are required."
+    ),
+    parameters={
+        "image_array": {
+            "type": "ndarray",
+            "description": "2D grayscale numpy array.",
+        },
+        "params": {
+            "type": "dict",
+            "description": (
+                "Optional. Keys: "
+                "window_size (int pixels, default auto — pick based on the spatial scale "
+                "of repeating features), "
+                "n_components (int, default 4 — number of distinct patterns expected), "
+                "step_fraction (float, default 0.25 — window step as a fraction of window "
+                "size; 0.25 = 75%% overlap)."
+            ),
+        },
+    },
+    required=["image_array"],
+    returns=(
+        "dict with 'components' shape (n_components, fft_h, fft_w) — each is a 2D FFT "
+        "power spectrum for one dominant frequency pattern; 'abundances' shape "
+        "(n_components, grid_h, grid_w) — spatial maps of where each component is "
+        "present; plus 'n_components', 'window_size', 'grid_shape'."
+    ),
+    example=(
+        "result = run_fft_nmf_analysis(image_array, params={'n_components': 4})\n"
+        "np.save('nmf_components.npy', result['components'])\n"
+        "np.save('abundance_maps.npy', result['abundances'])"
+    ),
+)

--- a/scilink/tools/fft_nmf.py
+++ b/scilink/tools/fft_nmf.py
@@ -341,16 +341,17 @@ TOOL_SPEC = ToolSpec(
                 "of repeating features), "
                 "n_components (int, default 4 — number of distinct patterns expected), "
                 "step_fraction (float, default 0.25 — window step as a fraction of window "
-                "size; 0.25 = 75%% overlap)."
+                "size; 0.25 = 75% overlap)."
             ),
         },
     },
     required=["image_array"],
     returns=(
-        "dict with 'components' shape (n_components, fft_h, fft_w) — each is a 2D FFT "
-        "power spectrum for one dominant frequency pattern; 'abundances' shape "
-        "(n_components, grid_h, grid_w) — spatial maps of where each component is "
-        "present; plus 'n_components', 'window_size', 'grid_shape'."
+        "dict with 'components' (ndarray, shape (n_components, fft_h, fft_w)) — each "
+        "is a 2D FFT power spectrum for one dominant frequency pattern; 'abundances' "
+        "(ndarray, shape (n_components, grid_h, grid_w)) — spatial maps of where each "
+        "component is present; 'n_components' (int); 'window_size' (tuple of two ints, "
+        "(width, height)); 'grid_shape' (tuple of two ints, (grid_h, grid_w))."
     ),
     example=(
         "result = run_fft_nmf_analysis(image_array, params={'n_components': 4})\n"

--- a/scilink/tools/fft_nmf.py
+++ b/scilink/tools/fft_nmf.py
@@ -326,7 +326,21 @@ TOOL_SPEC = ToolSpec(
         "With a window size tuned to the spatial scale of the repeating features and a "
         "simple post-processing step (e.g. inspecting components and abundance maps, "
         "thresholding or clustering abundances to localize distinct regions), this is "
-        "already a complete Tier 1 pipeline — no extra processing steps are required."
+        "already a complete Tier 1 pipeline — no extra processing steps are required.\n"
+        "\n"
+        "**What the method guarantees vs. does not:** FFT-NMF is a data-driven "
+        "non-negative decomposition. It reliably produces (a) non-negative spectral "
+        "components with low reconstruction error, (b) spatially coherent abundance "
+        "maps when the image contains spatial variation, and (c) visually distinct "
+        "components when the image contains distinct patterns. It does NOT assign "
+        "semantic labels to components (e.g. one component = 'crystalline', another "
+        "= 'disordered') — that is for the user to interpret. Plan's quality_criteria "
+        "should target coherent, non-noise outputs rather than idealized textbook "
+        "patterns or strict semantic separation the method cannot deliver. "
+        "When signals co-vary spatially (lattice × LDOS envelope, topography × "
+        "composition, etc.), components typically mix these signals rather than "
+        "isolating each — interpret components as basis patterns, not "
+        "physics-separated modes."
     ),
     parameters={
         "image_array": {

--- a/scilink/tools/sam.py
+++ b/scilink/tools/sam.py
@@ -460,3 +460,58 @@ def merge_sam_results(results: List[dict]) -> dict:
         'masks': [p.get('mask') for p in all_particles if p.get('mask') is not None],
         'merged_from': len(results)
     }
+
+
+# =============================================================================
+# TOOL SPEC
+# =============================================================================
+
+from ._spec import ToolSpec
+
+TOOL_SPEC = ToolSpec(
+    name="run_sam_analysis",
+    description=(
+        "Segment Anything Model (SAM) instance segmentation. Detects individual "
+        "object instances even when they touch or overlap."
+    ),
+    import_line="from scilink.tools.sam import run_sam_analysis",
+    signature="run_sam_analysis(image_array, params) -> dict",
+    agents=["image_analysis"],
+    when_to_use=(
+        "2D images where discrete objects touch or overlap (particles, cells, pores, "
+        "grains). Accepts a 2D grayscale array or an HxWx3 RGB uint8 array. For non-RGB "
+        "multi-channel images, pass a single channel (e.g. image[:, :, 0]). "
+        "For objects that do not touch, plain connected-component labeling is usually "
+        "sufficient."
+    ),
+    parameters={
+        "image_array": {
+            "type": "ndarray",
+            "description": "2D grayscale array or HxWx3 RGB uint8 array.",
+        },
+        "params": {
+            "type": "dict",
+            "description": (
+                "Analysis parameters. Keys: "
+                "sam_parameters ('default' | 'sensitive' | 'ultra-permissive', "
+                "always start with 'default'), "
+                "min_area and max_area (pixel area filters, set from expected object size), "
+                "pruning_iou_threshold (float, default 0.5 — lower is stricter, higher keeps "
+                "more overlapping masks), "
+                "use_clahe (bool, default False — contrast enhancement)."
+            ),
+        },
+    },
+    required=["image_array", "params"],
+    returns=(
+        "dict with 'particles' (list with 'mask' and 'area' per particle), "
+        "'total_count' (int), 'masks' (list of binary arrays), 'areas' (list of ints)."
+    ),
+    example=(
+        "result = run_sam_analysis(image_array, params={\n"
+        "    'sam_parameters': 'default',\n"
+        "    'min_area': 50, 'max_area': 5000,\n"
+        "    'pruning_iou_threshold': 0.5,\n"
+        "})"
+    ),
+)


### PR DESCRIPTION
# Tool registry for ImageAnalysisAgent + tighter feedback loops

## Summary

- Structured tool registry auto-discovered from `scilink/tools/`, injected into the planner, code-generator, script-correction, and verifier prompts as a single source of truth.
- Tier 2 gating made conservative: default NO, fires only when the objective demonstrably requires analysis Tier 1 did not do and the follow-up has a specific bounded outcome.
- More aggressive annealing escalation in the verification loop: an iteration-based floor guarantees reaching the maximum-freedom level (T=2) by iteration 5 in the worst case, previously only at the final iteration.
- Removed the alternative-approach outer retry loop; refinement at T=2 already covers that role.
- Refinement LLM now receives a compact iteration history so it can recognize score regressions instead of iterating blindly on the latest (possibly degraded) config.
- Verification-refinement **script carry-forward**: the code generator adapts the previous iteration's script instead of regenerating from scratch, gated by annealing level (fresh generation only at the T=2 escalation step, then carried forward again in sustained T=2 iterations).
- Verifier **sampling pinned to `temperature=0.0`** for reproducible scoring across iterations (reduces spurious patience-counter escalation from LLM-score noise).
- New **`stm_cafm` skill** for STM / conductive-AFM (low-bias) imaging, steering the planner toward LDOS/conductance-appropriate pipelines instead of atom-resolved STEM recipes.
- `overlapping_objects` skill gains a preventive "check first" block: classical methods beat SAM when objects are well-separated, delineated by visible boundaries (etched grain boundaries, cell walls), or cleanly thresholdable.
- Planning prompt's `quality_criteria` schema split into **targeted vs exploratory** branches — discourages baking observed features into requirements the analysis should discover on its own.
- Verifier rubric explicitly notes that **data-driven decompositions produce basis patterns, not semantic segmentations** — stops penalizing FFT-NMF / NMF / PCA / ICA for not delineating every visible region by eye.
- Cosmetic user feedback on the final visualization (colormap, labels, layout) skips re-verification and keeps the existing score.
- Assorted tool-spec corrections and a gdown `fuzzy` compatibility fix.


## What changed

### 1. Tool registry (`scilink/tools/_spec.py`, `scilink/tools/_registry.py`)

- `ToolSpec` dataclass with the same field vocabulary the existing `AnalysisOrchestratorTools._register_tool` uses (`name`, `description`, `parameters`, `required`) plus image-analysis extras (`import_line`, `signature`, `agents`, `when_to_use`, `returns`, `example`).
- Auto-discovery walker `get_tools_for(agent)` using `pkgutil.iter_modules` over `scilink/tools/`; discovers `TOOL_SPEC` (single) or `TOOL_SPECS` (list) on each module, filters by an `agents` tag, caches the result.
- Adding a new tool = add `TOOL_SPEC` to its module with `agents=["image_analysis"]`. No central list to edit.
- `format_tool_inventory(agent)` renders the registry + library inventory as a string drop-in for `.format()`-based templates; `_append_tool_inventory` does the same for list-based prompts.

### 2. Prompt integration

- Planning (`_build_planning_prompt`) and code-gen / script-correction (`IMAGE_ANALYSIS_SCRIPT_INSTRUCTIONS`, `IMAGE_ANALYSIS_SCRIPT_CORRECTION_INSTRUCTIONS`) now receive the registry-rendered inventory instead of hand-written tool prose. Single source of truth.
- Tool-first rules added to code-gen and conformance prompts: a registered tool referenced in the plan must be imported and called; reimplementation is not a justified deviation. Two narrow exceptions: runtime infrastructure failure (model download / dep missing), or unacceptable tool output that cannot be fixed by tuning documented parameters (and tuning was actually attempted).
- Graded tool constraint `_TOOL_CONSTRAINT_SCHEDULE` mirrors `_CONSTRAINT_ANNEALING_SCHEDULE`: strict (T=0), preferred (T=1), empty (T=2). Applied to both the verifier (`QUALITY_VERIFICATION_PROMPT`) and the refinement prompt in `_apply_verification_feedback`.

### 3. Refinement history for the refiner (`_format_refinement_history`)

- The refinement LLM previously saw only the current (possibly degraded) config and the latest verifier feedback. It now receives a compact trajectory: score + pipeline summary for the last 6 iterations, with `[BEST]` and `[CURRENT]` markers, plus framing guidance ("if a recent change regressed, consider reverting toward the better-scoring config").
- Backward-compatible: the `history` parameter defaults to `None`, in which case behavior is identical to before.

### 4. Cosmetic feedback short-circuit

- `USER_FEEDBACK_SCRIPT_PROMPT` now requires the LLM to classify its patch as `cosmetic` / `analytical` / `rewrite`.
- For `cosmetic` changes, `_apply_user_feedback` executes the patched script but skips `_verify_quality` and keeps the existing score. Visualization-only patches no longer burn a verifier call.
- Analytical and rewrite changes retain the full verify-and-score flow. Execution failures still fall through to the existing re-analysis fallback.

### 5. Alternative-approach loop removal

- Deleted the outer `_suggest_alternative_approach` loop, `ALTERNATIVE_APPROACH_PROMPT`, `max_approach_retries` kwargs across the agent / pipeline / controller stack, and downstream consumers (`quality_history.alternative_approaches`, knowledge-synthesis reader, report generator mentions).
- Rationale: T=2 refinement already carries the "full freedom to change the pipeline" role, and the alternative path was a leak point where the tool-first rules didn't apply.

### 6. Tier 2 decision + Tier 1 sufficiency

- `IMAGE_ANALYSIS_TIER2_DECISION_INSTRUCTIONS` now defaults to NO. YES requires all of: the objective demonstrably requires analysis Tier 1 did not do, the follow-up has a specific bounded outcome, and Tier 1 results are reliable enough to build on. Interesting-looking features do not justify Tier 2. Tie-breaker: "if uncertain, answer NO."
- Tier 1 suffix notes that a registered-tool call plus simple post-processing is already a complete Tier 1 pipeline — discourages "pad with more steps for thoroughness."

### 7. Tool-spec corrections

- `detect_atoms_dcnn.when_to_use`: narrowed to clean images of transition-metal oxides (perovskites, cuprates e.g. YBCO / BSCCO) and graphene — materials the AtomNet3 model is actually good at — and positioned as the preferred choice for those. Prior wording was an overclaim.
- `detect_atoms.when_to_use`: reframed as the general-purpose baseline (no training-data dependence).
- `run_fft_nmf_analysis.when_to_use`: leads with defects / disorder / multi-phase / spatially-varying structure; explicitly states that tool call + simple post-processing is a complete Tier 1 pipeline.
- `run_fft_nmf_analysis.returns`: clarified that `window_size` and `grid_shape` are tuples, not scalars (the previous phrasing triggered `float(window_size)` crashes in generated code).
- Dropped the `not_for` field from `ToolSpec` entirely — it was a persistent source of overclaims; `when_to_use` carries the positive framing and the planner can compare across tools.

### 8. Annealing floor

- The verification loop's annealing escalation previously reached the hot level (T=2) only in the final iteration of a 7-iteration loop in bad cases. Added an iteration-based floor `verification_iter // 2` that guarantees T=2 by iteration 5 in the worst case, giving 3+ iterations at maximum freedom. Patience-based escalation still works as before in the noise-free case.

### 9. Skill alignment

- `atomic_stem.md`: DCNN preference narrowed to the materials it's actually good at (replacing the blanket "try DCNN first whenever FOV is available"), matching the tool registry. Added guidance that `run_fft_nmf_analysis` is the simpler Tier 1 pathway when the image shows pattern-level heterogeneity or the objective targets disorder — image-first triggers, not just objective-gated.

### 10. gdown compatibility

- `download_file_with_gdown` helpers in `scilink/tools/atomistic_tools.py` and `scilink/agents/exp_agents/utils.py` no longer pass `fuzzy=True`. The argument was redundant when `id=` is used (it only matters when parsing a URL), and newer gdown versions have removed it. Forward-compatible with both old and new gdown.

### 11. Script carry-forward across refinement iterations

- New `IMAGE_ANALYSIS_SCRIPT_REFINEMENT_PROMPT` in `instruct.py` adapts a previous attempt's script to a refined plan rather than regenerating from scratch. Preserves custom pipeline choices that matched the plan's intent (e.g. a handwritten per-window FFT + preprocessing loop) while letting the LLM restructure when the refined plan requires a fundamentally different method.
- `_generate_analysis_script` gains an optional `base_script` parameter; `_process_single_image` gains a `refine_from_script` kwarg (distinct from the existing series-level `base_script` adaptation path).
- Annealing-gated in the verification loop: the previous script is carried forward at every iteration **except** the single iteration where annealing escalates from `< 2` to `= 2` (fresh generation at that "escape" step so the code generator isn't anchored to the structure that prompted escalation). Sustained-T=2 iterations resume carrying the script forward.
- Applies uniformly to both Tier 1 and Tier 2 verification loops via the shared controller.

### 12. Verifier sampling determinism

- New class constant `UnifiedImageProcessingController._VERIFIER_GEN_CONFIG = {"temperature": 0.0}`, used by `_verify_quality`. Same visualization now gets the same sub-scores across iterations, which the annealing patience counter and best-score tracking depend on.
- Only `temperature` is set; Anthropic's Messages API rejects combining `temperature` and `top_p` — `top_p` left at provider default.
- Other LLM calls (planner, refiner, code-gen, conformance, user-feedback) unchanged — they keep default temperature where exploration is healthy.

### 13. STM / conductive-AFM skill

- New `scilink/skills/image_analysis/stm_cafm.md` covers STM and conductive AFM at low bias — imaging modes where the dominant signal is electronic (LDOS, conductance) rather than structural. Described on its own terms, no cross-references to STEM.
- Planning guidance: FFT-NMF as typical Tier 1 for pattern/domain analysis; peak/blob detection or SAM for discrete features (molecular adsorbates, clusters, defects); classical atom-detection (`detect_atoms`, `detect_atoms_dcnn`) reserved for genuine clean atomic-resolution cases where the objective explicitly calls for lattice characterization.
- **Don't pre-filter LDOS out of the lattice signal:** aggressive high-pass / bandpass / per-window mean subtraction removes physically meaningful variation and may leave only noise where the lattice contrast was weakest.
- **Visualization:** when `n_components ≤ 3` display all FFT components + abundance maps; for `>3` show the major ones. Pair each abundance map with its corresponding FFT component (side-by-side, matching grid, or inset). Preserve true aspect ratios.
- **Validation (verifier-facing):** accept coherent, data-faithful outputs even when they don't produce a "pure lattice" component or are dominated by the LDOS envelope — the envelope is real signal, not contamination.

### 14. Overlapping-objects skill preventive branch

- `overlapping_objects.md` gains a "check first" paragraph at the top of planning. Three classical-method cases where SAM is overkill or wrong:
  - Well-separated objects → Otsu + connected components.
  - Objects separated by a visible boundary feature (dark grain boundaries, stained cell walls, bright domain edges) → detect the boundary and use it as a watershed landscape or invert + CC.
  - Clean foreground-background threshold → Otsu + CC + morphological cleanup.
- Reach for SAM only when objects genuinely touch/overlap AND no visible boundary delineates them — the case where classical approaches merge adjacent objects.

### 15. `quality_criteria` schema — targeted vs exploratory

- Rewrote the `quality_criteria` field explanation in `IMAGE_ANALYSIS_PLANNING_INSTRUCTIONS` to split by objective type:
  - **Targeted objective** (count grains, measure lattice spacing, find specific defects) → concrete measurable criteria as before.
  - **Exploratory / open-ended / no objective** → descriptive criteria focused on pipeline integrity: *"outputs are coherent (not pure noise or all NaN)", "features correspond to real image content rather than artifacts"*. Avoid baking in expectations the data may not actually support — the analysis should discover what is there, not confirm a hypothesis.

### 16. FFT-NMF expectations in the tool spec

- `run_fft_nmf_analysis.when_to_use` gained a *"What the method guarantees vs. does not"* paragraph. The tool reliably produces non-negative components with low reconstruction error and spatially coherent abundance maps; it **does not** assign semantic labels to components (one ≠ "crystalline", another ≠ "disordered") and **does not** cleanly separate physically coupled or multiplicative signals (lattice × LDOS envelope, topography × composition). Interpret components as basis patterns, not physics-separated modes.
- `run_fft_nmf_analysis.returns` clarified to note `window_size` and `grid_shape` are tuples — previously caused `float(window_size)` crashes in generated code.

### 17. Verifier rubric guardrail

- `QUALITY_VERIFICATION_PROMPT` "Do NOT reject for" list extended with one clause: an abundance map or decomposition component that does not delineate every visible region of the image is not a failure. Data-driven decompositions (NMF, PCA, ICA, FFT-NMF) produce basis patterns, not semantic segmentations; if the output is coherent and faithful to the image content, score it on that basis, not on whether it matched the regions a human would draw by eye.

### 18. Log alignment (cosmetic)

- `"Executing Python script..."` in `scilink/executors.py` now uses the same three-space indent as surrounding controller log lines, aligning visually in run output.

## Key files

| Path | Change |
|---|---|
| `scilink/tools/_spec.py` | **new** — `ToolSpec` dataclass |
| `scilink/tools/_registry.py` | **new** — auto-discovery walker + library inventory + string formatter |
| `scilink/tools/sam.py`, `fft_nmf.py`, `atom_finding_tools.py` | `TOOL_SPEC` / `TOOL_SPECS` declarations; `fft_nmf` expectations paragraph; `detect_atoms_dcnn` scope |
| `scilink/agents/exp_agents/controllers/image_analysis_controllers.py` | tool-inventory injection helper; graded tool constraint; refinement history; cosmetic-feedback short-circuit; alternative-approach loop removed; annealing floor; **script carry-forward plumbing** (new `base_script`/`refine_from_script` params, annealing-gated); **verifier `temperature=0.0`**; **rubric "Do NOT reject" guardrail** |
| `scilink/agents/exp_agents/instruct.py` | prompt migrations to `{tool_inventory}` placeholder; tool-first enforcement; tighter Tier 2 gate; Tier 1 sufficiency note; **new `IMAGE_ANALYSIS_SCRIPT_REFINEMENT_PROMPT`**; **`quality_criteria` targeted-vs-exploratory schema** |
| `scilink/agents/exp_agents/pipelines/image_analysis_pipelines.py` | `max_approach_retries` removed; wires the new refinement prompt into both controllers |
| `scilink/agents/exp_agents/image_analysis_agent.py` | `max_approach_retries` removed |
| `scilink/skills/image_analysis/atomic_stem.md` | DCNN scope alignment; FFT-NMF pointer |
| `scilink/skills/image_analysis/stm_cafm.md` | **new** — STM / cAFM skill: planning guidance, visualization requirements, validation-side LDOS-envelope acceptance |
| `scilink/skills/image_analysis/overlapping_objects.md` | **preventive "check first" block**: three classical-method cases before reaching for SAM |
| `scilink/tools/atomistic_tools.py`, `scilink/agents/exp_agents/utils.py` | gdown `fuzzy=True` removed |
| `scilink/knowledge.py` | alternative-approaches reader removed |
| `scilink/executors.py` | `"Executing Python script..."` log line indented to align with controller logs |
