### PR TITLE
Add `scilink/hpc/` backend: HPCConnection, Scheduler, detect_scheduler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ sim = [
     "aimsgb>=1.1.1",
     "atomate2>=0.0.21",
     "mdanalysis>=2.9.0",
+    "paramiko>=3.0.0",
 ]
 ui = [
     "streamlit>=1.37.0",

--- a/scilink/hpc/__init__.py
+++ b/scilink/hpc/__init__.py
@@ -1,0 +1,22 @@
+from scilink.hpc.connection import HPCConnection, HPCProfile
+from scilink.hpc.scheduler import (
+    HPCJob,
+    JobStatus,
+    Scheduler,
+    SlurmScheduler,
+    PBSScheduler,
+    LSFScheduler,
+    detect_scheduler,
+)
+
+__all__ = [
+    "HPCConnection",
+    "HPCProfile",
+    "HPCJob",
+    "JobStatus",
+    "Scheduler",
+    "SlurmScheduler",
+    "PBSScheduler",
+    "LSFScheduler",
+    "detect_scheduler",
+]

--- a/scilink/hpc/connection.py
+++ b/scilink/hpc/connection.py
@@ -1,0 +1,225 @@
+"""Thread-safe SSH connection manager for HPC resources."""
+from __future__ import annotations
+
+import io
+import threading
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import paramiko
+import logging
+import socket
+
+@dataclass
+class HPCProfile:
+    """Storable connection profile (no secrets)."""
+    name: str
+    hostname: str
+    username: str
+    port: int = 22
+    auth_method: str = "key"        # "key" | "password"
+    key_path: str = ""
+    proxy_jump: str = ""            # e.g. "user@bastion.example.edu"
+
+class HPCConnection:
+    """Wraps a single Paramiko SSHClient with SFTP helpers.
+
+    Stored in ``st.session_state`` — persists across reruns within
+    the same Streamlit browser session.  NOT picklable, so it cannot
+    survive a server restart.
+    """
+
+    def __init__(self, profile: HPCProfile) -> None:
+        self.profile = profile
+        self._client: Optional[paramiko.SSHClient] = None
+        self._sftp: Optional[paramiko.SFTPClient] = None
+        self._lock = threading.RLock()
+
+    # ── lifecycle ─────────────────────────────────────────────
+
+    def connect(
+        self,
+        password: str = "",
+        key_passphrase: str = "",
+    ) -> None:
+        """Open an SSH connection, trying all resolved IPs."""
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    
+        kw: dict = dict(
+            hostname=self.profile.hostname,
+            port=self.profile.port,
+            username=self.profile.username,
+            timeout=30,
+            banner_timeout=30,
+            auth_timeout=30,
+        )
+    
+        if self.profile.auth_method == "key":
+            if self.profile.key_path:
+                kw["key_filename"] = self.profile.key_path
+            if key_passphrase:
+                kw["passphrase"] = key_passphrase
+            kw["look_for_keys"] = True
+            kw["allow_agent"] = True
+        else:
+            kw["password"] = password
+            kw["look_for_keys"] = False
+            kw["allow_agent"] = False
+    
+        if self.profile.proxy_jump:
+            kw["sock"] = paramiko.ProxyCommand(
+                f"ssh -W %h:%p {self.profile.proxy_jump}"
+            )
+            client.connect(**kw)
+            self._client = client
+            return
+    
+        # Resolve all IPs and try each with a short per-IP timeout
+        addrs = socket.getaddrinfo(
+            self.profile.hostname, self.profile.port,
+            family=socket.AF_INET,
+            type=socket.SOCK_STREAM,
+        )
+        # Deduplicate while preserving order
+        seen = set()
+        unique_ips = []
+        for info in addrs:
+            ip = info[4][0]
+            if ip not in seen:
+                seen.add(ip)
+                unique_ips.append(ip)
+    
+        if not unique_ips:
+            raise ConnectionError(
+                f"Cannot resolve {self.profile.hostname}"
+            )
+    
+        per_ip_timeout = 5  # seconds — fail fast, try next
+        last_err = None
+    
+        for ip in unique_ips:
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(per_ip_timeout)
+                sock.connect((ip, self.profile.port))
+    
+                # Socket connected — hand to Paramiko
+                kw["sock"] = sock
+                kw["timeout"] = 30
+                client.connect(**kw)
+                self._client = client
+                return
+            except Exception as exc:
+                last_err = exc
+                try:
+                    sock.close()
+                except Exception:
+                    pass
+                # Reset client for next attempt
+                client = paramiko.SSHClient()
+                client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                continue
+    
+        raise ConnectionError(
+            f"All IPs for {self.profile.hostname} failed. "
+            f"Tried: {unique_ips}. Last error: {last_err}"
+        )
+
+    def disconnect(self) -> None:
+        with self._lock:
+            for res in (self._sftp, self._client):
+                if res is not None:
+                    try:
+                        res.close()
+                    except Exception:
+                        pass
+            self._client = None
+            self._sftp = None
+
+    @property
+    def is_connected(self) -> bool:
+        if self._client is None:
+            return False
+        t = self._client.get_transport()
+        return t is not None and t.is_active()
+
+    # ── command execution ─────────────────────────────────────
+
+    def run(
+        self,
+        cmd: str,
+        timeout: float = 300,
+    ) -> tuple[str, str, int]:
+        """Execute *cmd*, return ``(stdout, stderr, exit_code)``."""
+        if not self.is_connected:
+            raise ConnectionError("SSH session is not active")
+        with self._lock:
+            _, out, err = self._client.exec_command(cmd, timeout=timeout)
+            rc = out.channel.recv_exit_status()
+            return (
+                out.read().decode(errors="replace"),
+                err.read().decode(errors="replace"),
+                rc,
+            )
+
+# ── SFTP helpers ──────────────────────────────────────────
+
+    @property
+    def sftp(self) -> paramiko.SFTPClient:
+        with self._lock:
+            if self._sftp is None or self._sftp.get_channel().closed:
+                if self._client is None:
+                    raise ConnectionError("Not connected")
+                self._sftp = self._client.open_sftp()
+            return self._sftp
+
+    def listdir(self, path: str) -> list[paramiko.SFTPAttributes]:
+        return self.sftp.listdir_attr(path)
+
+    def read_text(self, path: str, tail: int = 0) -> str:
+        """Read a remote text file.  *tail* > 0 → last N lines only."""
+        if tail > 0:
+            out, _, _ = self.run(f"tail -n {tail} {_q(path)}", timeout=15)
+            return out
+        with self.sftp.open(path, "r") as fh:
+            return fh.read().decode(errors="replace")
+
+    def read_bytes(self, path: str) -> bytes:
+        """Read a remote file into memory as bytes."""
+        buf = io.BytesIO()
+        self.sftp.getfo(path, buf)
+        buf.seek(0)
+        return buf.read()
+
+    def upload(
+        self,
+        local: str,
+        remote: str,
+        callback: Optional[Callable] = None,
+    ) -> None:
+        self.sftp.put(local, remote, callback=callback)
+
+    def download(
+        self,
+        remote: str,
+        local: str,
+        callback: Optional[Callable] = None,
+    ) -> None:
+        self.sftp.get(remote, local, callback=callback)
+
+    def stat(self, path: str) -> paramiko.SFTPAttributes:
+        return self.sftp.stat(path)
+
+    def mkdir_p(self, path: str) -> None:
+        """Remote equivalent of ``mkdir -p``."""
+        self.run(f"mkdir -p {_q(path)}")
+
+    def home_dir(self) -> str:
+        out, _, _ = self.run("echo $HOME", timeout=10)
+        return out.strip() or "~"
+
+
+def _q(s: str) -> str:
+    """Shell-quote a path."""
+    return "'" + s.replace("'", "'\\''") + "'"

--- a/scilink/hpc/scheduler.py
+++ b/scilink/hpc/scheduler.py
@@ -1,0 +1,504 @@
+"""Job-scheduler abstraction: SLURM, PBS/Torque, LSF."""
+from __future__ import annotations
+
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from scilink.hpc.connection import HPCConnection
+
+
+# ── data model ────────────────────────────────────────────────
+
+class JobStatus(Enum):
+    PENDING = "Pending"
+    RUNNING = "Running"
+    COMPLETED = "Completed"
+    FAILED = "Failed"
+    CANCELLED = "Cancelled"
+    TIMEOUT = "Timeout"
+    UNKNOWN = "Unknown"
+
+    @property
+    def emoji(self) -> str:
+        return {
+            JobStatus.PENDING: "🟡",
+            JobStatus.RUNNING: "🔵",
+            JobStatus.COMPLETED: "🟢",
+            JobStatus.FAILED: "🔴",
+            JobStatus.CANCELLED: "⚫",
+            JobStatus.TIMEOUT: "🟠",
+            JobStatus.UNKNOWN: "⚪",
+        }[self]
+
+    @property
+    def is_terminal(self) -> bool:
+        return self in (
+            JobStatus.COMPLETED,
+            JobStatus.FAILED,
+            JobStatus.CANCELLED,
+            JobStatus.TIMEOUT,
+        )
+
+@dataclass
+class HPCJob:
+    job_id: str
+    name: str = ""
+    status: JobStatus = JobStatus.UNKNOWN
+    raw_status: str = ""
+    partition: str = ""
+    nodes: int = 1
+    ntasks: int = 1
+    time_limit: str = ""
+    time_used: str = ""
+    work_dir: str = ""
+    stdout_file: str = ""
+    stderr_file: str = ""
+    script_path: str = ""
+    submit_time: str = ""
+    start_time: str = ""
+    end_time: str = ""
+    exit_code: Optional[int] = None
+    node_list: str = ""
+
+
+# ── abstract base ─────────────────────────────────────────────
+
+class Scheduler(ABC):
+    name: str = "unknown"
+
+    def __init__(self, conn: HPCConnection) -> None:
+        self.conn = conn
+
+    @abstractmethod
+    def detect(self) -> bool: ...
+
+    @abstractmethod
+    def submit(self, script: str, work_dir: str = "") -> str: ...
+
+    @abstractmethod
+    def cancel(self, job_id: str) -> bool: ...
+
+    @abstractmethod
+    def status(self, job_id: str) -> HPCJob: ...
+
+    @abstractmethod
+    def queue(self, user: Optional[str] = None) -> list[HPCJob]: ...
+
+    @abstractmethod
+    def partitions(self) -> list[dict]: ...
+
+    def tail_output(
+        self,
+        job: HPCJob,
+        stream: str = "stdout",
+        lines: int = 200,
+    ) -> str:
+        path = job.stdout_file if stream == "stdout" else job.stderr_file
+        if not path:
+            # SLURM default naming
+            default = f"slurm-{job.job_id}.out" if stream == "stdout" else ""
+            path = f"{job.work_dir}/{default}" if job.work_dir and default else ""
+        if not path:
+            return ""
+        try:
+            return self.conn.read_text(path, tail=lines)
+        except Exception as exc:
+            return f"(cannot read {path}: {exc})"
+
+# ══════════════════════════════════════════════════════════════
+# SLURM
+# ══════════════════════════════════════════════════════════════
+
+class SlurmScheduler(Scheduler):
+    name = "SLURM"
+
+    _MAP: dict[str, JobStatus] = {
+        "PD": JobStatus.PENDING,
+        "PENDING": JobStatus.PENDING,
+        "CF": JobStatus.PENDING,
+        "CONFIGURING": JobStatus.PENDING,
+        "R": JobStatus.RUNNING,
+        "RUNNING": JobStatus.RUNNING,
+        "CG": JobStatus.RUNNING,
+        "COMPLETING": JobStatus.RUNNING,
+        "CD": JobStatus.COMPLETED,
+        "COMPLETED": JobStatus.COMPLETED,
+        "F": JobStatus.FAILED,
+        "FAILED": JobStatus.FAILED,
+        "NF": JobStatus.FAILED,
+        "NODE_FAIL": JobStatus.FAILED,
+        "OOM": JobStatus.FAILED,
+        "OUT_OF_MEMORY": JobStatus.FAILED,
+        "CA": JobStatus.CANCELLED,
+        "CANCELLED": JobStatus.CANCELLED,
+        "TO": JobStatus.TIMEOUT,
+        "TIMEOUT": JobStatus.TIMEOUT,
+    }
+
+    def detect(self) -> bool:
+        _, _, rc = self.conn.run("command -v squeue", timeout=10)
+        return rc == 0
+
+    def submit(self, script: str, work_dir: str = "") -> str:
+        pre = f"cd {_q(work_dir)} && " if work_dir else ""
+        out, err, rc = self.conn.run(f"{pre}sbatch {_q(script)}")
+        if rc != 0:
+            raise RuntimeError(f"sbatch failed (rc={rc}):\n{err}")
+        m = re.search(r"Submitted batch job (\d+)", out)
+        if not m:
+            raise RuntimeError(f"Cannot parse job ID:\n{out}")
+        return m.group(1)
+
+    def cancel(self, job_id: str) -> bool:
+        _, _, rc = self.conn.run(f"scancel {job_id}")
+        return rc == 0
+
+    # ── status ────────────────────────────────────────────────
+
+    def status(self, job_id: str) -> HPCJob:
+        # scontrol for live jobs
+        out, _, rc = self.conn.run(
+            f"scontrol show job {job_id}", timeout=15,
+        )
+        if rc == 0 and out.strip():
+            return self._parse_scontrol(out, job_id)
+        # sacct for finished jobs
+        out, _, rc = self.conn.run(
+            f"sacct -j {job_id} -P --noheader "
+            f"--format=JobID,JobName,State,ExitCode,Start,End,"
+            f"Elapsed,Partition,NodeList,WorkDir",
+            timeout=15,
+        )
+        if rc == 0 and out.strip():
+            return self._parse_sacct(out, job_id)
+        return HPCJob(job_id=job_id)
+
+    def _parse_scontrol(self, raw: str, jid: str) -> HPCJob:
+        kv: dict[str, str] = {}
+        for tok in raw.split():
+            if "=" in tok:
+                k, _, v = tok.partition("=")
+                kv[k] = v
+        rs = kv.get("JobState", "UNKNOWN").split()[0]
+        ec = _parse_exit_code(kv.get("ExitCode", ""))
+        return HPCJob(
+            job_id=jid,
+            name=kv.get("JobName", ""),
+            status=self._MAP.get(rs, JobStatus.UNKNOWN),
+            raw_status=rs,
+            partition=kv.get("Partition", ""),
+            nodes=_int(kv.get("NumNodes"), 1),
+            ntasks=_int(kv.get("NumCPUs"), 1),
+            time_limit=kv.get("TimeLimit", ""),
+            time_used=kv.get("RunTime", ""),
+            work_dir=kv.get("WorkDir", ""),
+            stdout_file=kv.get("StdOut", ""),
+            stderr_file=kv.get("StdErr", ""),
+            submit_time=kv.get("SubmitTime", ""),
+            start_time=kv.get("StartTime", ""),
+            end_time=kv.get("EndTime", ""),
+            node_list=kv.get("NodeList", ""),
+            exit_code=ec,
+        )
+
+    def _parse_sacct(self, raw: str, jid: str) -> HPCJob:
+        # First non-empty line = main job record (skip .batch, .extern)
+        for line in raw.strip().splitlines():
+            p = line.split("|")
+            if len(p) >= 10 and not ("." in p[0]):
+                break
+        else:
+            return HPCJob(job_id=jid)
+        rs = p[2].split()[0]
+        return HPCJob(
+            job_id=jid,
+            name=p[1],
+            status=self._MAP.get(rs, JobStatus.UNKNOWN),
+            raw_status=rs,
+            exit_code=_parse_exit_code(p[3]),
+            start_time=p[4],
+            end_time=p[5],
+            time_used=p[6],
+            partition=p[7],
+            node_list=p[8],
+            work_dir=p[9],
+        )
+
+# ── queue ─────────────────────────────────────────────────
+
+    def queue(self, user: Optional[str] = None) -> list[HPCJob]:
+        uf = f"-u {user}" if user else "-u $USER"
+        out, _, rc = self.conn.run(
+            f'squeue {uf} -o "%i|%j|%T|%P|%D|%C|%l|%M|%V|%S|%R" --noheader',
+            timeout=15,
+        )
+        if rc != 0:
+            return []
+        jobs: list[HPCJob] = []
+        for line in out.strip().splitlines():
+            if not line.strip():
+                continue
+            p = [x.strip() for x in line.split("|")]
+            if len(p) < 11:
+                continue
+            rs = p[2]
+            jobs.append(HPCJob(
+                job_id=p[0],
+                name=p[1],
+                status=self._MAP.get(rs, JobStatus.UNKNOWN),
+                raw_status=rs,
+                partition=p[3],
+                nodes=_int(p[4], 1),
+                ntasks=_int(p[5], 1),
+                time_limit=p[6],
+                time_used=p[7],
+                submit_time=p[8],
+                start_time=p[9],
+                node_list=p[10],
+            ))
+        return jobs
+
+ # ── partitions ────────────────────────────────────────────
+
+    def partitions(self) -> list[dict]:
+        out, _, rc = self.conn.run(
+            'sinfo -o "%P|%a|%l|%D|%T|%c|%m|%G" --noheader',
+            timeout=15,
+        )
+        if rc != 0:
+            return []
+        parts: list[dict] = []
+        for line in out.strip().splitlines():
+            p = [x.strip() for x in line.split("|")]
+            if len(p) < 8:
+                continue
+            parts.append(dict(
+                name=p[0].rstrip("*"),
+                avail=p[1],
+                timelimit=p[2],
+                nodes=p[3],
+                state=p[4],
+                cpus=p[5],
+                mem_MB=p[6],
+                gres=p[7],
+                default="*" in p[0],
+            ))
+        return parts
+
+
+# ══════════════════════════════════════════════════════════════
+# PBS / Torque
+# ══════════════════════════════════════════════════════════════
+
+class PBSScheduler(Scheduler):
+    name = "PBS"
+
+    _MAP: dict[str, JobStatus] = {
+        "Q": JobStatus.PENDING,
+        "H": JobStatus.PENDING,
+        "W": JobStatus.PENDING,
+        "R": JobStatus.RUNNING,
+        "E": JobStatus.RUNNING,
+        "C": JobStatus.COMPLETED,
+        "F": JobStatus.FAILED,
+    }
+
+    def detect(self) -> bool:
+        _, _, rc = self.conn.run("command -v qsub", timeout=10)
+        return rc == 0
+
+    def submit(self, script: str, work_dir: str = "") -> str:
+        pre = f"cd {_q(work_dir)} && " if work_dir else ""
+        out, err, rc = self.conn.run(f"{pre}qsub {_q(script)}")
+        if rc != 0:
+            raise RuntimeError(f"qsub failed:\n{err}")
+        return out.strip().split(".")[0]
+
+    def cancel(self, job_id: str) -> bool:
+        _, _, rc = self.conn.run(f"qdel {job_id}")
+        return rc == 0
+
+    def status(self, job_id: str) -> HPCJob:
+        out, _, rc = self.conn.run(f"qstat -f {job_id}", timeout=15)
+        if rc != 0:
+            return HPCJob(job_id=job_id)
+        kv: dict[str, str] = {}
+        for line in out.splitlines():
+            if " = " in line:
+                k, _, v = line.strip().partition(" = ")
+                kv[k.strip()] = v.strip()
+        rs = kv.get("job_state", "U")
+        return HPCJob(
+            job_id=job_id,
+            name=kv.get("Job_Name", ""),
+            status=self._MAP.get(rs, JobStatus.UNKNOWN),
+            raw_status=rs,
+            partition=kv.get("queue", ""),
+            stdout_file=kv.get("Output_Path", "").rsplit(":", 1)[-1],
+            stderr_file=kv.get("Error_Path", "").rsplit(":", 1)[-1],
+            node_list=kv.get("exec_host", ""),
+        )
+
+    def queue(self, user: Optional[str] = None) -> list[HPCJob]:
+        uf = f"-u {user}" if user else ""
+        out, _, rc = self.conn.run(f"qstat {uf}", timeout=15)
+        if rc != 0:
+            return []
+        jobs: list[HPCJob] = []
+        for line in out.strip().splitlines()[2:]:  # skip header
+            p = line.split()
+            if len(p) < 6:
+                continue
+            rs = p[4]
+            jobs.append(HPCJob(
+                job_id=p[0].split(".")[0],
+                name=p[1],
+                status=self._MAP.get(rs, JobStatus.UNKNOWN),
+                raw_status=rs,
+                time_used=p[3],
+                partition=p[5],
+            ))
+        return jobs
+
+    def partitions(self) -> list[dict]:
+        out, _, rc = self.conn.run("qstat -Q", timeout=15)
+        if rc != 0:
+            return []
+        return [
+            {"name": line.split()[0], "avail": "yes"}
+            for line in out.strip().splitlines()[2:]
+            if line.split()
+        ]
+
+
+# ══════════════════════════════════════════════════════════════
+# IBM Spectrum LSF
+# ══════════════════════════════════════════════════════════════
+
+class LSFScheduler(Scheduler):
+    name = "LSF"
+
+    _MAP: dict[str, JobStatus] = {
+        "PEND": JobStatus.PENDING,
+        "RUN": JobStatus.RUNNING,
+        "DONE": JobStatus.COMPLETED,
+        "EXIT": JobStatus.FAILED,
+        "USUSP": JobStatus.PENDING,
+        "SSUSP": JobStatus.PENDING,
+    }
+
+    def detect(self) -> bool:
+        _, _, rc = self.conn.run("command -v bsub", timeout=10)
+        return rc == 0
+
+    def submit(self, script: str, work_dir: str = "") -> str:
+        pre = f"cd {_q(work_dir)} && " if work_dir else ""
+        out, err, rc = self.conn.run(f"{pre}bsub < {_q(script)}")
+        if rc != 0:
+            raise RuntimeError(f"bsub failed:\n{err}")
+        m = re.search(r"Job <(\d+)>", out)
+        if not m:
+            raise RuntimeError(f"Cannot parse job ID:\n{out}")
+        return m.group(1)
+
+    def cancel(self, job_id: str) -> bool:
+        _, _, rc = self.conn.run(f"bkill {job_id}")
+        return rc == 0
+
+    def status(self, job_id: str) -> HPCJob:
+        out, _, rc = self.conn.run(
+            f"bjobs -o 'jobid stat job_name queue exec_host' "
+            f"-noheader {job_id}",
+            timeout=15,
+        )
+        if rc != 0:
+            return HPCJob(job_id=job_id)
+        p = out.strip().split()
+        rs = p[1] if len(p) > 1 else "UNKNOWN"
+        return HPCJob(
+            job_id=job_id,
+            status=self._MAP.get(rs, JobStatus.UNKNOWN),
+            raw_status=rs,
+            name=p[2] if len(p) > 2 else "",
+            partition=p[3] if len(p) > 3 else "",
+            node_list=p[4] if len(p) > 4 else "",
+        )
+
+    def queue(self, user: Optional[str] = None) -> list[HPCJob]:
+        uf = f"-u {user}" if user else ""
+        out, _, rc = self.conn.run(
+            f"bjobs {uf} -o 'jobid stat job_name queue' -noheader",
+            timeout=15,
+        )
+        if rc != 0:
+            return []
+        jobs: list[HPCJob] = []
+        for line in out.strip().splitlines():
+            p = line.split()
+            if len(p) < 2:
+                continue
+            rs = p[1]
+            jobs.append(HPCJob(
+                job_id=p[0],
+                status=self._MAP.get(rs, JobStatus.UNKNOWN),
+                raw_status=rs,
+                name=p[2] if len(p) > 2 else "",
+                partition=p[3] if len(p) > 3 else "",
+            ))
+        return jobs
+
+    def partitions(self) -> list[dict]:
+        out, _, rc = self.conn.run(
+            "bqueues -o 'queue_name status' -noheader", timeout=15,
+        )
+        if rc != 0:
+            return []
+        return [
+            {"name": line.split()[0], "avail": line.split()[1] if len(line.split()) > 1 else ""}
+            for line in out.strip().splitlines()
+            if line.strip()
+        ]
+
+# ── helpers ───────────────────────────────────────────────────
+
+def _q(s: str) -> str:
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+def _int(s: Optional[str], default: int = 0) -> int:
+    try:
+        return int(s)  # type: ignore[arg-type]
+    except (ValueError, TypeError):
+        return default
+
+
+def _parse_exit_code(raw: str) -> Optional[int]:
+    if not raw:
+        return None
+    try:
+        return int(raw.split(":")[0])
+    except (ValueError, IndexError):
+        return None
+
+
+_SCHEDULER_CLASSES: list[type[Scheduler]] = [
+    SlurmScheduler,
+    PBSScheduler,
+    LSFScheduler,
+]
+
+
+def detect_scheduler(conn: HPCConnection) -> Optional[Scheduler]:
+    """Probe the remote host and return the first detected scheduler."""
+    for cls in _SCHEDULER_CLASSES:
+        sched = cls(conn)
+        try:
+            if sched.detect():
+                return sched
+        except Exception:
+            continue
+    return None


### PR DESCRIPTION
# Summary
Provider-agnostic HPC backend built on Paramiko. No UI changes — this is the focused backend-only split requested in review of [#140](https://github.com/sarah-allec/SciLink/issues/140).

# What's in it:

- `HPCConnection` — thread-safe SSH/SFTP client; resolves all IPs for a hostname and fails over automatically; supports password, SSH key, and ProxyJump auth
- `HPCProfile` — lightweight dataclass for saveable connection profiles (no secrets stored)
- `Scheduler` ABC with concrete `SlurmScheduler`, `PBSScheduler`, and `LSFScheduler` implementations
- `detect_scheduler(conn)` — probes the remote host and returns the matching scheduler

**Dependencies:** `paramiko` (optional; callers should guard with `try/except ImportError`)

# Known limitations (documented in docstrings):

- `HPCConnection` is not picklable — does not survive a Streamlit server restart
- `AutoAddPolicy` for host keys (acceptable for interactive use)
- PBS and LSF implementations not yet tested (only SLURM)

**Sequencing:** This lands first → HPC submission tools (`submit_vasp_job`, etc.) wrap this in a follow-up branch on top of [#144](https://github.com/sarah-allec/SciLink/issues/144) → UI wizard (`hpc_ui_integration`) lands last.