### PR TITLE
gitignore: cover simulate-session dirs, _simulate_runs, Office temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,6 +185,7 @@ CoREMOF*/
 # Session outputs
 planning_session_*/
 analysis_*/
+simulate_session_*/
 campaign_outputs/
 image_analysis_output/
 kb_storage/
@@ -192,3 +193,7 @@ kb_storage/
 # Test outputs
 test_*/
 tests/_e2e_runs/
+tests/_simulate_runs/
+
+# Office autosave temp files (Word/Excel/PowerPoint)
+~$*


### PR DESCRIPTION
## Summary

Three small additions to `.gitignore`, analogous to existing session/test conventions, so `git status` stops nagging about untracked artifacts the agent (or Office) creates during normal use:

- **`simulate_session_*/`** — matches the existing `analysis_*/` pattern; agent creates these during simulation runs
- **`tests/_simulate_runs/`** — matches the existing `tests/_e2e_runs/` pattern
- **`~$*`** — Word/Excel/PowerPoint autosave temp files (the `~$<filename>` pattern)

User-authored `.docx`/`.md` files in the repo root are intentionally NOT ignored — those are content you may want to commit later.

## Test plan

- [x] `git status` before: 11 noise items per machine
- [x] `git status` after: only the genuine user-authored docs remain (none of the agent/test artifacts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)