### PR TITLE
curve_fitting_agent: scale R² soft-band margin with threshold

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1328,6 +1328,23 @@ class UnifiedSeriesProcessingController:
     DEFAULT_MAX_MODEL_RETRIES = 1
     DEFAULT_OUTLIER_SIGMA = 2.0
     DEFAULT_MAX_VERIFICATION_ITERATIONS = 7
+    # Maximum width (in R² units) of the soft band below the acceptance
+    # threshold.  A flat 0.05 doesn't scale: at r2_threshold=0.999 it
+    # would put the hard-reject floor at 0.949, making 50× the gap-to-
+    # perfection eligible for soft-band acceptance.  See _r2_soft_margin.
+    SOFT_BAND_MAX_WIDTH = 0.05
+
+    @classmethod
+    def _r2_soft_margin(cls, r2_threshold: float) -> float:
+        """Width of the soft band below the acceptance threshold.
+
+        Width is capped at ``SOFT_BAND_MAX_WIDTH`` (0.05 — preserves
+        backward-compatible behavior at the default threshold of 0.95)
+        and at ``1 - r2_threshold`` (the gap to perfection — keeps the
+        band narrow when the user demands very high R², e.g. 0.999 for
+        XRD).  Always non-negative.
+        """
+        return max(min(cls.SOFT_BAND_MAX_WIDTH, 1.0 - r2_threshold), 0.0)
 
     JUDGE_PROMPT = '''You are a scientific data fitting expert acting as a judge.
 
@@ -2039,7 +2056,7 @@ Remember: Rejecting a good fit (R² > {accept_threshold:.2f}) to chase marginal 
             n_components=n_components,
             parameters=params_str,
             accept_threshold=self.r2_threshold,
-            reject_threshold=self.r2_threshold - 0.05,
+            reject_threshold=self.r2_threshold - self._r2_soft_margin(self.r2_threshold),
             prior_best_section=prior_best_section,
         )
 
@@ -2187,7 +2204,7 @@ Return JSON with the refined fitting approach:
             best_r2=best_result.get("fit_quality", {}).get("r_squared", 0),
             threshold=self.r2_threshold,
             models_tried=models_tried,
-            example_threshold=self.r2_threshold - 0.05,
+            example_threshold=self.r2_threshold - self._r2_soft_margin(self.r2_threshold),
         )
         print(prompt)
         
@@ -2422,7 +2439,7 @@ Return JSON with:
                     # Catastrophic regressions (script bugs, complete failure)
                     # are always rejected; small dips are admissible if the
                     # verifier signals physical improvement.
-                    R2_FLOOR = max(self.r2_threshold - 0.05, 0.0)
+                    R2_FLOOR = max(self.r2_threshold - self._r2_soft_margin(self.r2_threshold), 0.0)
 
                     for verification_iter in range(self.max_verification_iterations):
                         self.logger.info(f"   Verification {verification_iter + 1}/{self.max_verification_iterations} (annealing level {_annealing_level})...")
@@ -3139,10 +3156,10 @@ Return JSON with:
         self.logger.info("")
         self.logger.info(f"⚙️ FITTING: {mode_str}")
         _accept = float(self.r2_threshold)
-        _floor = max(_accept - 0.05, 0.0)
+        _floor = max(_accept - self._r2_soft_margin(_accept), 0.0)
         self.logger.info(
-            f"   R² targets: accept ≥ {_accept:.2f} (with clean residuals); "
-            f"hard-reject below {_floor:.2f}; soft band {_floor:.2f}–{_accept:.2f} "
+            f"   R² targets: accept ≥ {_accept:.3f} (with clean residuals); "
+            f"hard-reject below {_floor:.3f}; soft band {_floor:.3f}–{_accept:.3f} "
             f"(verifier may reject on physics)"
         )
         self.logger.info(f"   Max verification iterations: {self.max_verification_iterations}")

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -475,12 +475,13 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         
         self.logger.info("")
         self.logger.info(f"📈 CURVE FITTING ANALYSIS - {num_spectra} spectrum{'s' if num_spectra > 1 else ''}")
+        from .controllers.curve_fitting_controllers import UnifiedSeriesProcessingController as _USPC
         _accept = float(effective_r2_threshold)
-        _floor = max(_accept - 0.05, 0.0)
+        _floor = max(_accept - _USPC._r2_soft_margin(_accept), 0.0)
         self.logger.info(
-            f"   Quality: R² ≥ {_accept:.2f} accepts (with clean residuals); "
-            f"R² < {_floor:.2f} hard-rejects; "
-            f"{_floor:.2f}–{_accept:.2f} is a soft band where the verifier "
+            f"   Quality: R² ≥ {_accept:.3f} accepts (with clean residuals); "
+            f"R² < {_floor:.3f} hard-rejects; "
+            f"{_floor:.3f}–{_accept:.3f} is a soft band where the verifier "
             f"can reject on physics grounds (systematic residuals, missing features)"
         )
         if not is_single_spectrum:

--- a/tests/test_adaptive_annealing.py
+++ b/tests/test_adaptive_annealing.py
@@ -793,6 +793,114 @@ def test_hot_annealing_reached_when_best_stalls_above_threshold():
     print("  Hot annealing reached when best stalls: PASS")
 
 
+def test_soft_margin_scales_with_threshold():
+    """
+    Soft-band width must shrink as r2_threshold approaches 1, otherwise
+    a fixed 0.05 margin makes the floor absurdly far below the
+    acceptance bar (e.g. r2_threshold=0.999 → floor=0.949 with the old
+    rule, putting fits 50× the gap-to-perfection in the soft band).
+    """
+    from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+        UnifiedSeriesProcessingController as C,
+    )
+
+    # ≤ 0.95: backward-compatible pin at 0.05
+    assert C._r2_soft_margin(0.50) == 0.05
+    assert C._r2_soft_margin(0.85) == 0.05
+    assert C._r2_soft_margin(0.95) == 0.05
+
+    # > 0.95: scales to (1 - threshold)
+    assert abs(C._r2_soft_margin(0.99) - 0.01) < 1e-12
+    assert abs(C._r2_soft_margin(0.995) - 0.005) < 1e-12
+    assert abs(C._r2_soft_margin(0.999) - 0.001) < 1e-12
+
+    # At threshold == 1, no soft band
+    assert C._r2_soft_margin(1.0) == 0.0
+
+    # Never negative even if user passes something silly
+    assert C._r2_soft_margin(1.1) == 0.0
+    print("  Soft margin scales with threshold: PASS")
+
+
+def test_floor_uses_scaled_margin_at_high_threshold():
+    """
+    With r2_threshold=0.999 (XRD-style), an in-band refit at R²=0.96
+    must hard-reject (below the 0.998 floor), not get treated as a
+    soft-band candidate the way the old fixed-0.05 margin would have.
+    """
+    import numpy as np
+
+    ctrl = make_controller(
+        r2_threshold=0.999,           # XRD-like high bar
+        max_verification_iterations=3,
+        max_model_retries=0,
+    )
+
+    # Initial above threshold (good); refit drops to 0.96 — well below
+    # the new floor of 0.998 but above the OLD floor of 0.949.
+    r2_seq = iter([0.9995, 0.96])
+
+    def mock_fit(state, curve_data, data_path, spectrum_name, spectrum_idx,
+                 base_script=None, refine_from_script=None,
+                 refine_from_r2=0.0, refine_from_issues=None):
+        try:
+            r2 = next(r2_seq)
+        except StopIteration:
+            return {"success": False, "error": "exhausted",
+                    "fit_quality": {}, "parameters": {},
+                    "script": "", "script_errors": []}
+        return {
+            "success": True, "error": None,
+            "fit_quality": {"r_squared": r2},
+            "parameters": {}, "model_type": "test",
+            "visualization_path": None, "visualization_bytes": b"",
+            "statistics": {}, "script": f"# r2={r2:.4f}",
+            "script_errors": [],
+        }
+
+    # Verifier (mistakenly) signals physics improvement.  Floor must
+    # override regardless.
+    def mock_verify(state, fit_result, history=None,
+                    verification_iter=0, annealing_level=None,
+                    best_result=None, best_verification=None):
+        return {
+            "fit_acceptable": False,
+            "issues_found": [{"problem": "test"}],
+            "spurious_components": [], "missing_features": [],
+            "physically_better_than_best": True,
+            "comparison_note": "false positive — fit is well below floor",
+            "overall_assessment": "test", "recommended_action": "x",
+        }
+
+    config_counter = iter(range(100))
+    ctrl._fit_single_spectrum = mock_fit
+    ctrl._verify_fit_with_llm = mock_verify
+    ctrl._apply_llm_verification_feedback = (
+        lambda s, v: {**s.get("locked_fitting_config", {}), "_t": next(config_counter)}
+    )
+    ctrl._log_verification_issues = MagicMock()
+    ctrl._build_quality_history = MagicMock(return_value={})
+    ctrl._judge_select_best_fit = MagicMock(return_value={
+        "selected_index": None, "acceptable": False, "reasoning": "mock",
+    })
+
+    state = {"locked_fitting_config": {"physical_model": "test", "_t": -1}}
+    result = ctrl._fit_with_quality_control(
+        state=state,
+        curve_data=np.array([[0.0, 1.0], [1.0, 2.0]]),
+        data_path="/tmp/x", spectrum_name="x", spectrum_idx=0,
+        is_regime_anchor=True,
+    )
+
+    final_r2 = result.get("fit_quality", {}).get("r_squared")
+    print(f"  Final R² with threshold=0.999: {final_r2} (refit at 0.96 should be rejected)")
+    assert final_r2 == 0.9995, (
+        f"Expected initial 0.9995 to survive. Got {final_r2}.  "
+        f"Refit at 0.96 should be below the 0.998 floor for r2_threshold=0.999."
+    )
+    print("  Floor uses scaled margin at high threshold: PASS")
+
+
 def test_state_isolation_across_sequential_refits():
     """
     Series-context regression test.  AdaptiveRefitController calls
@@ -1047,6 +1155,8 @@ if __name__ == "__main__":
         test_hot_annealing_reached_when_best_stalls_above_threshold,
         test_floor_blocks_catastrophic_regression,
         test_state_isolation_across_sequential_refits,
+        test_soft_margin_scales_with_threshold,
+        test_floor_uses_scaled_margin_at_high_threshold,
     ])
     total_pass += p
     total_fail += f


### PR DESCRIPTION
## Summary

Closes a scaling bug in the R² soft-band that #147 introduced. The hardcoded `0.05` margin is fine at the default `r2_threshold=0.95` but breaks at high thresholds — at `0.999` (typical for XRD) it puts the hard-reject floor at `0.949`, making fits 50× the gap-to-perfection eligible for soft-band acceptance.

Adds `UnifiedSeriesProcessingController._r2_soft_margin(threshold)` returning `max(0, min(0.05, 1 - threshold))` so the band:
- **Stays at 0.05** for thresholds ≤ 0.95 (backward-compatible — no behavior change for the common case)
- **Scales to (1 − threshold)** at higher thresholds — the soft band shrinks with the gap to perfection
- **Caps at 0** so the band can never invert at `threshold=1.0`

| `r2_threshold` | floor (old) | floor (new) |
|---|---|---|
| 0.95 | 0.90 | 0.90 |
| 0.99 | 0.94 | 0.98 |
| 0.999 | 0.949 | 0.998 |
| 0.9999 | 0.9499 | 0.9998 |

Replaces 4 hardcoded sites: verifier prompt's `reject_threshold`, the in-loop `R2_FLOOR`, human-feedback example threshold, and both user-facing log lines (also bumped log precision to `.3f` so floors are legible at high thresholds).

## Test plan

- [x] `python tests/test_adaptive_annealing.py` — 18/18 pass (2 new tests)
- [x] `test_soft_margin_scales_with_threshold` — table check across thresholds 0.50→1.0
- [x] `test_floor_uses_scaled_margin_at_high_threshold` — end-to-end at `r2_threshold=0.999`: a refit at R²=0.96 must be rejected by the floor even when the verifier mistakenly signals physics improvement
- [x] All 16 existing tests still pass (default threshold 0.95 → margin unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)