### PR TITLE
Add HPC submission tools to SimulationOrchestratorAgent

### DIFF
--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -71,11 +71,13 @@ assistant focused on VASP. You help users build atomic structures and
 generate VASP input files (POSCAR, INCAR, KPOINTS) ready for calculation.
 
 **Scope (for now):**
-- VASP DFT input preparation only (LAMMPS support is a planned follow-up).
-- **Local prep only — you do NOT submit jobs to HPC clusters or run VASP
-  yourself.** The user runs VASP elsewhere; if they bring back output
-  files (OUTCAR, vasprun.xml, stdout/stderr logs), you can analyze them
-  for convergence and suggest INCAR fixes.
+- VASP DFT input preparation and HPC job submission (LAMMPS support is a
+  planned follow-up).
+- When an HPC connection is active (`submit_vasp_job` is available), you
+  can submit VASP jobs to the cluster, monitor their status, download
+  results, and generate a final report — all without leaving the session.
+- Without an HPC connection, prep is local only; the user runs VASP
+  elsewhere and brings back output files for analysis.
 
 **Workflow shape:**
 The session is iterative and structure-centric. Typical flow:
@@ -84,8 +86,10 @@ The session is iterative and structure-centric. Typical flow:
   2. (Optionally) validate it; refine if issues are found.
   3. Generate VASP inputs tailored to the scientific objective.
   4. (Optionally) validate INCAR against literature, apply improvements.
-  5. (After the user runs VASP) analyze the output, suggest fixes if
-     the run failed.
+  5. Submit the job to the HPC cluster (when connected), monitor status,
+     download results once complete.
+  6. Analyze the output, suggest INCAR fixes if the run failed.
+  7. Generate a final report summarizing the full workflow.
 
 Users often iterate on one structure, then ask for variants (different
 defect concentrations, supercell sizes, polymorphs, terminations). Reuse
@@ -224,6 +228,8 @@ class SimulationOrchestratorAgent:
         simulation_mode: SimulationMode = SimulationMode.CO_PILOT,
         mp_api_key: Optional[str] = None,
         futurehouse_api_key: Optional[str] = None,
+        hpc_connection=None,
+        hpc_scheduler=None,
         # Deprecated
         google_api_key: Optional[str] = None,
         local_model: Optional[str] = None,
@@ -262,6 +268,10 @@ class SimulationOrchestratorAgent:
         # transparency / restore_from_checkpoint).
         self.mp_api_key = mp_api_key
         self.futurehouse_api_key = futurehouse_api_key
+
+        # HPC backend — optional; tools degrade gracefully when None
+        self.hpc_connection = hpc_connection
+        self.hpc_scheduler = hpc_scheduler
 
         logging.info(f"🎛️  Simulation Mode: {simulation_mode.value.upper()}")
 

--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -1185,6 +1185,483 @@ class SimulationOrchestratorTools:
             required=["log_path", "original_request"],
         )
 
+        # =====================================================================
+        # 12. SUBMIT VASP JOB
+        # =====================================================================
+        def submit_vasp_job(
+            structure_slug: str,
+            remote_dir: str,
+            job_name: str = "vasp",
+            partition: str = "",
+            n_nodes: int = 1,
+            n_tasks: int = 16,
+            time_limit: str = "04:00:00",
+            vasp_command: str = "vasp_std",
+            modules: str = "",
+            extra_directives: str = "",
+        ) -> str:
+            conn = self.orch.hpc_connection
+            sched = self.orch.hpc_scheduler
+            if conn is None or sched is None:
+                return json.dumps({
+                    "status": "error",
+                    "message": (
+                        "No HPC connection active. Construct "
+                        "SimulationOrchestratorAgent with hpc_connection= "
+                        "and hpc_scheduler= to enable job submission."
+                    ),
+                })
+            if not conn.is_connected:
+                return json.dumps({
+                    "status": "error",
+                    "message": "HPC connection is not active. Reconnect and retry.",
+                })
+
+            record = next(
+                (s for s in (self.orch.generated_structures or [])
+                 if s.get("slug") == structure_slug),
+                None,
+            )
+            if record is None:
+                return json.dumps({
+                    "status": "error",
+                    "message": (
+                        f"Structure '{structure_slug}' not found in this "
+                        "session. Call list_generated_structures to see "
+                        "available slugs."
+                    ),
+                })
+
+            poscar = record.get("poscar_path")
+            incar = record.get("incar_path")
+            kpoints = record.get("kpoints_path")
+            missing = [
+                n for n, p in [("POSCAR", poscar), ("INCAR", incar), ("KPOINTS", kpoints)]
+                if not p or not Path(p).exists()
+            ]
+            if missing:
+                return json.dumps({
+                    "status": "error",
+                    "message": (
+                        f"Missing local files before upload: {missing}. "
+                        "Run generate_vasp_inputs first."
+                    ),
+                })
+
+            try:
+                conn.mkdir_p(remote_dir)
+                for local_path, remote_name in [
+                    (poscar, "POSCAR"),
+                    (incar, "INCAR"),
+                    (kpoints, "KPOINTS"),
+                ]:
+                    conn.upload(local_path, f"{remote_dir}/{remote_name}")
+
+                script_content = self._generate_job_script(
+                    sched=sched,
+                    job_name=job_name,
+                    n_nodes=n_nodes,
+                    n_tasks=n_tasks,
+                    time_limit=time_limit,
+                    partition=partition,
+                    vasp_command=vasp_command,
+                    modules=modules,
+                    extra_directives=extra_directives,
+                )
+                local_script = Path(record["structure_dir"]) / "job.sh"
+                local_script.write_text(script_content)
+                remote_script = f"{remote_dir}/job.sh"
+                conn.upload(str(local_script), remote_script)
+
+                job_id = sched.submit(remote_script, work_dir=remote_dir)
+            except Exception as e:
+                return json.dumps({"status": "error", "message": str(e)})
+
+            record["hpc_job_id"] = job_id
+            record["hpc_remote_dir"] = remote_dir
+            record["hpc_results_dir"] = None
+
+            return json.dumps({
+                "status": "success",
+                "job_id": job_id,
+                "scheduler": sched.name,
+                "remote_dir": remote_dir,
+                "next_steps": (
+                    f"Monitor with get_job_status('{job_id}'). "
+                    "When status is Completed, call "
+                    f"download_vasp_results('{job_id}') to retrieve outputs."
+                ),
+            })
+
+        self._register_tool(
+            func=submit_vasp_job,
+            name="submit_vasp_job",
+            description=(
+                "Upload VASP input files (POSCAR, INCAR, KPOINTS) to a remote "
+                "HPC cluster and submit a job via the active scheduler "
+                "(SLURM / PBS / LSF). Requires hpc_connection and hpc_scheduler "
+                "to be set on the orchestrator. Call generate_vasp_inputs first "
+                "to ensure local inputs exist."
+            ),
+            parameters={
+                "structure_slug": {
+                    "type": "string",
+                    "description": "Session slug of the structure to submit (from list_generated_structures).",
+                },
+                "remote_dir": {
+                    "type": "string",
+                    "description": "Absolute remote path for the job working directory (e.g. /scratch/user/run1).",
+                },
+                "job_name": {
+                    "type": "string",
+                    "description": "Scheduler job name (default: 'vasp').",
+                },
+                "partition": {
+                    "type": "string",
+                    "description": "Scheduler partition / queue. Omit to use the cluster default.",
+                },
+                "n_nodes": {
+                    "type": "integer",
+                    "description": "Number of nodes (default: 1).",
+                },
+                "n_tasks": {
+                    "type": "integer",
+                    "description": "Number of MPI tasks / CPUs (default: 16).",
+                },
+                "time_limit": {
+                    "type": "string",
+                    "description": "Wall-time limit in HH:MM:SS (default: '04:00:00').",
+                },
+                "vasp_command": {
+                    "type": "string",
+                    "description": "VASP executable name on the cluster (default: 'vasp_std').",
+                },
+                "modules": {
+                    "type": "string",
+                    "description": (
+                        "Shell commands to load the VASP environment, written "
+                        "verbatim into the job script "
+                        "(e.g. 'module load vasp/6.3.2 intel/2023'). Omit if "
+                        "the user's .bashrc already loads VASP."
+                    ),
+                },
+                "extra_directives": {
+                    "type": "string",
+                    "description": (
+                        "Additional scheduler directives to inject into the "
+                        "job script header, one per line "
+                        "(e.g. '#SBATCH --gres=gpu:1')."
+                    ),
+                },
+            },
+            required=["structure_slug", "remote_dir"],
+        )
+
+        # =====================================================================
+        # 13. GET JOB STATUS
+        # =====================================================================
+        def get_job_status(job_id: str) -> str:
+            conn = self.orch.hpc_connection
+            sched = self.orch.hpc_scheduler
+            if conn is None or sched is None:
+                return json.dumps({
+                    "status": "error",
+                    "message": "No HPC connection active.",
+                })
+            if not conn.is_connected:
+                return json.dumps({
+                    "status": "error",
+                    "message": "HPC connection is not active. Reconnect and retry.",
+                })
+            try:
+                job = sched.status(job_id)
+            except Exception as e:
+                return json.dumps({"status": "error", "message": str(e)})
+
+            return json.dumps({
+                "status": "success",
+                "job_id": job.job_id,
+                "job_status": job.status.value,
+                "is_terminal": job.status.is_terminal,
+                "raw_status": job.raw_status,
+                "partition": job.partition,
+                "nodes": job.nodes,
+                "ntasks": job.ntasks,
+                "time_limit": job.time_limit,
+                "time_used": job.time_used,
+                "work_dir": job.work_dir,
+                "start_time": job.start_time,
+                "end_time": job.end_time,
+                "exit_code": job.exit_code,
+                "node_list": job.node_list,
+                "next_steps": (
+                    f"download_vasp_results('{job_id}') to retrieve outputs."
+                    if job.status.is_terminal and job.status.value == "Completed"
+                    else (
+                        f"Call get_job_status('{job_id}') again to check progress."
+                        if not job.status.is_terminal
+                        else "Job ended in a non-success state. Use analyze_vasp_output or suggest_incar_fixes."
+                    )
+                ),
+            })
+
+        self._register_tool(
+            func=get_job_status,
+            name="get_job_status",
+            description=(
+                "Poll the HPC scheduler for the current status of a submitted "
+                "job. Returns job_status (Pending / Running / Completed / "
+                "Failed / Cancelled / Timeout), time used, and whether the "
+                "job has reached a terminal state. Use after submit_vasp_job "
+                "to check progress."
+            ),
+            parameters={
+                "job_id": {
+                    "type": "string",
+                    "description": "Scheduler job ID returned by submit_vasp_job.",
+                },
+            },
+            required=["job_id"],
+        )
+
+        # =====================================================================
+        # 14. DOWNLOAD VASP RESULTS
+        # =====================================================================
+        def download_vasp_results(job_id: str, local_dir: str = "") -> str:
+            conn = self.orch.hpc_connection
+            if conn is None:
+                return json.dumps({
+                    "status": "error",
+                    "message": "No HPC connection active.",
+                })
+            if not conn.is_connected:
+                return json.dumps({
+                    "status": "error",
+                    "message": "HPC connection is not active. Reconnect and retry.",
+                })
+
+            record = self._find_structure_by_job_id(job_id)
+            if record is None:
+                return json.dumps({
+                    "status": "error",
+                    "message": (
+                        f"No session record found for job_id='{job_id}'. "
+                        "Only jobs submitted via submit_vasp_job in this "
+                        "session can be downloaded automatically."
+                    ),
+                })
+
+            remote_dir = record.get("hpc_remote_dir")
+            if not remote_dir:
+                return json.dumps({
+                    "status": "error",
+                    "message": "No remote_dir recorded for this job.",
+                })
+
+            dest = Path(local_dir) if local_dir else Path(record["structure_dir"]) / "hpc_results"
+            dest.mkdir(parents=True, exist_ok=True)
+
+            target_files = [
+                "vasprun.xml", "OUTCAR", "CONTCAR", "OSZICAR",
+                "EIGENVAL", "DOSCAR", "vasp.stdout", "vasp.stderr",
+            ]
+
+            downloaded, skipped = [], []
+            for fname in target_files:
+                remote_path = f"{remote_dir}/{fname}"
+                local_path = dest / fname
+                try:
+                    conn.download(remote_path, str(local_path))
+                    downloaded.append(fname)
+                except Exception:
+                    skipped.append(fname)
+
+            if not downloaded:
+                return json.dumps({
+                    "status": "error",
+                    "message": (
+                        f"No output files found in {remote_dir}. "
+                        "The job may not have produced output yet."
+                    ),
+                })
+
+            record["hpc_results_dir"] = str(dest)
+            return json.dumps({
+                "status": "success",
+                "local_dir": str(dest),
+                "downloaded": downloaded,
+                "skipped": skipped,
+                "next_steps": (
+                    f"analyze_vasp_output('{dest}') to parse results, or "
+                    f"generate_final_report('{record['slug']}') for a full summary."
+                ),
+            })
+
+        self._register_tool(
+            func=download_vasp_results,
+            name="download_vasp_results",
+            description=(
+                "Download VASP output files (vasprun.xml, OUTCAR, CONTCAR, "
+                "OSZICAR, etc.) from the remote HPC directory to a local "
+                "directory. Skips files that don't exist (e.g. DOSCAR for "
+                "a plain relaxation). Call after get_job_status confirms "
+                "the job is Completed."
+            ),
+            parameters={
+                "job_id": {
+                    "type": "string",
+                    "description": "Scheduler job ID returned by submit_vasp_job.",
+                },
+                "local_dir": {
+                    "type": "string",
+                    "description": (
+                        "Local directory to save results. Defaults to "
+                        "<structure_dir>/hpc_results/ when omitted."
+                    ),
+                },
+            },
+            required=["job_id"],
+        )
+
+        # =====================================================================
+        # 15. GENERATE FINAL REPORT
+        # =====================================================================
+        def generate_final_report(
+            structure_slug: str,
+            output_path: str = "",
+        ) -> str:
+            record = next(
+                (s for s in (self.orch.generated_structures or [])
+                 if s.get("slug") == structure_slug),
+                None,
+            )
+            if record is None:
+                return json.dumps({
+                    "status": "error",
+                    "message": (
+                        f"Structure '{structure_slug}' not found. "
+                        "Call list_generated_structures to see available slugs."
+                    ),
+                })
+
+            # Run post-run analysis if results are available
+            vasp_analysis = None
+            results_dir = record.get("hpc_results_dir") or record.get("structure_dir")
+            if results_dir and (Path(results_dir) / "vasprun.xml").exists():
+                try:
+                    from .post_run_analysis import analyze_run_directory
+                    vasp_analysis = analyze_run_directory(results_dir)
+                except Exception as e:
+                    vasp_analysis = {"error": str(e)}
+
+            lines = [
+                "# VASP DFT Simulation Report",
+                f"\n## Structure: {record.get('description', structure_slug)}",
+                f"- **Slug:** `{structure_slug}`",
+                f"- **Created:** {record.get('created_at', 'unknown')}",
+                f"- **POSCAR:** `{record.get('poscar_path', 'N/A')}`",
+            ]
+
+            n_atoms = self._count_atoms(record.get("poscar_path", ""))
+            if n_atoms is not None:
+                lines.append(f"- **Atoms:** {n_atoms}")
+
+            val = record.get("validation") or {}
+            if val:
+                lines += [
+                    "\n## Structure Validation",
+                    f"- **Status:** {val.get('status', 'unknown')}",
+                    f"- **Assessment:** {val.get('overall_assessment', '')}",
+                ]
+                issues = val.get("all_identified_issues") or []
+                if issues:
+                    lines.append("- **Issues:**")
+                    for iss in issues:
+                        lines.append(f"  - {iss}")
+
+            if record.get("incar_path") and Path(record["incar_path"]).exists():
+                lines += [
+                    "\n## VASP Inputs",
+                    f"- **INCAR:** `{record['incar_path']}`",
+                    f"- **KPOINTS:** `{record.get('kpoints_path', 'N/A')}`",
+                ]
+                if record.get("vasp_summary"):
+                    lines.append(f"- **Summary:** {record['vasp_summary']}")
+
+            if record.get("hpc_job_id"):
+                sched_name = (
+                    self.orch.hpc_scheduler.name
+                    if self.orch.hpc_scheduler else "unknown"
+                )
+                lines += [
+                    "\n## HPC Job",
+                    f"- **Scheduler:** {sched_name}",
+                    f"- **Job ID:** {record['hpc_job_id']}",
+                    f"- **Remote dir:** `{record.get('hpc_remote_dir', 'N/A')}`",
+                    f"- **Local results:** `{record.get('hpc_results_dir', 'N/A')}`",
+                ]
+
+            if vasp_analysis:
+                lines.append("\n## Calculation Results")
+                if "error" in vasp_analysis:
+                    lines.append(f"- **Parse error:** {vasp_analysis['error']}")
+                else:
+                    vr = vasp_analysis.get("vasprun") or {}
+                    oc = vasp_analysis.get("outcar") or {}
+                    lines += [
+                        f"- **Convergence:** {vasp_analysis.get('convergence_status', 'unknown')}",
+                        f"- **Final energy:** {vr.get('final_energy_eV', 'N/A')} eV",
+                        f"- **Ionic steps:** {vr.get('n_ionic_steps', 'N/A')}",
+                        f"- **Max force (last step):** {oc.get('max_force_eV_per_A', 'N/A')} eV/Å",
+                    ]
+                    hints = vasp_analysis.get("error_hints") or []
+                    if hints:
+                        lines.append("- **Error hints:**")
+                        for h in hints:
+                            lines.append(f"  - {h}")
+
+            report_text = "\n".join(lines) + "\n"
+            out_path = (
+                Path(output_path) if output_path
+                else Path(record["structure_dir"]) / "final_report.md"
+            )
+            try:
+                out_path.write_text(report_text)
+            except Exception as e:
+                return json.dumps({"status": "error", "message": f"Failed to write report: {e}"})
+
+            return json.dumps({
+                "status": "success",
+                "report_path": str(out_path),
+                "report": report_text,
+            })
+
+        self._register_tool(
+            func=generate_final_report,
+            name="generate_final_report",
+            description=(
+                "Generate a Markdown summary report for a completed simulation "
+                "workflow: structure description, validation outcome, VASP input "
+                "settings, HPC job info, and parsed results (energy, convergence, "
+                "error hints). Saves to <structure_dir>/final_report.md by default. "
+                "Call after download_vasp_results to include calculation outcomes."
+            ),
+            parameters={
+                "structure_slug": {
+                    "type": "string",
+                    "description": "Session slug of the structure to report on.",
+                },
+                "output_path": {
+                    "type": "string",
+                    "description": (
+                        "Full local path for the report file. Defaults to "
+                        "<structure_dir>/final_report.md when omitted."
+                    ),
+                },
+            },
+            required=["structure_slug"],
+        )
+
         # ↓↓↓ CLI flesh-out (step 5), run_task (step 6), tests (step 7).
 
     # ------------------------------------------------------------------
@@ -1455,6 +1932,74 @@ class SimulationOrchestratorTools:
             except Exception:
                 continue
         return None
+
+    def _find_structure_by_job_id(self, job_id: str) -> Optional[Dict[str, Any]]:
+        """Find the session record that was submitted as the given HPC job."""
+        for record in self.orch.generated_structures or []:
+            if record.get("hpc_job_id") == job_id:
+                return record
+        return None
+
+    @staticmethod
+    def _generate_job_script(
+        sched,
+        job_name: str,
+        n_nodes: int,
+        n_tasks: int,
+        time_limit: str,
+        partition: str,
+        vasp_command: str,
+        modules: str,
+        extra_directives: str,
+    ) -> str:
+        """Generate a scheduler job script for VASP."""
+        sname = getattr(sched, "name", "SLURM").upper()
+        lines = ["#!/bin/bash"]
+
+        if sname == "PBS":
+            lines += [
+                f"#PBS -N {job_name}",
+                f"#PBS -l nodes={n_nodes}:ppn={n_tasks}",
+                f"#PBS -l walltime={time_limit}",
+                f"#PBS -o vasp.stdout",
+                f"#PBS -e vasp.stderr",
+            ]
+            if partition:
+                lines.append(f"#PBS -q {partition}")
+            if extra_directives:
+                lines.append(extra_directives)
+            lines.append("\ncd $PBS_O_WORKDIR")
+        elif sname == "LSF":
+            lines += [
+                f"#BSUB -J {job_name}",
+                f"#BSUB -n {n_tasks}",
+                f"#BSUB -W {time_limit}",
+                f"#BSUB -o vasp.stdout",
+                f"#BSUB -e vasp.stderr",
+            ]
+            if partition:
+                lines.append(f"#BSUB -q {partition}")
+            if extra_directives:
+                lines.append(extra_directives)
+        else:  # SLURM (default)
+            lines += [
+                f"#SBATCH --job-name={job_name}",
+                f"#SBATCH --nodes={n_nodes}",
+                f"#SBATCH --ntasks={n_tasks}",
+                f"#SBATCH --time={time_limit}",
+                f"#SBATCH --output=vasp.stdout",
+                f"#SBATCH --error=vasp.stderr",
+            ]
+            if partition:
+                lines.append(f"#SBATCH --partition={partition}")
+            if extra_directives:
+                lines.append(extra_directives)
+
+        if modules:
+            lines += ["", modules]
+
+        lines += ["", f"mpirun -np {n_tasks} {vasp_command}", ""]
+        return "\n".join(lines)
 
     # ------------------------------------------------------------------
     # Registration + dispatch primitives (mirror analyze-mode shapes)

--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -1196,7 +1196,7 @@ class SimulationOrchestratorTools:
             n_nodes: int = 1,
             n_tasks: int = 16,
             time_limit: str = "04:00:00",
-            vasp_command: str = "vasp_std",
+            vasp_command: str = "srun vasp_std",
             modules: str = "",
             extra_directives: str = "",
         ) -> str:
@@ -1334,7 +1334,11 @@ class SimulationOrchestratorTools:
                 },
                 "vasp_command": {
                     "type": "string",
-                    "description": "VASP executable name on the cluster (default: 'vasp_std').",
+                    "description": (
+                        "Full run command including MPI launcher "
+                        "(e.g. 'srun vasp_std', 'mpirun -np 16 vasp_std'). "
+                        "Written verbatim into the job script. Default: 'srun vasp_std'."
+                    ),
                 },
                 "modules": {
                     "type": "string",
@@ -1998,7 +2002,7 @@ class SimulationOrchestratorTools:
         if modules:
             lines += ["", modules]
 
-        lines += ["", f"mpirun -np {n_tasks} {vasp_command}", ""]
+        lines += ["", vasp_command, ""]
         return "\n".join(lines)
 
     # ------------------------------------------------------------------

--- a/tests/test_simulation_orchestrator.py
+++ b/tests/test_simulation_orchestrator.py
@@ -50,6 +50,19 @@ def _require_env(*names):
         sys.exit(2)
 
 
+def _get_api_key(allow_dummy: bool = False) -> str:
+    """Return whichever LLM key is set, preferring SCILINK_API_KEY."""
+    key = (os.environ.get("SCILINK_API_KEY")
+           or os.environ.get("ANTHROPIC_API_KEY"))
+    if key:
+        return key
+    if allow_dummy:
+        return "dummy-not-used"
+    raise RuntimeError(
+        "Set SCILINK_API_KEY or ANTHROPIC_API_KEY to run live-LLM tests."
+    )
+
+
 def _make_orch(model_name: str, base_dir: str, autonomy: str = "co-pilot"):
     """Construct a fresh SimulationOrchestratorAgent for a test."""
     from scilink.agents.sim_agents import (
@@ -62,7 +75,7 @@ def _make_orch(model_name: str, base_dir: str, autonomy: str = "co-pilot"):
     }
     return SimulationOrchestratorAgent(
         base_dir=base_dir,
-        api_key=os.environ.get("ANTHROPIC_API_KEY", "dummy-not-used"),
+        api_key=_get_api_key(allow_dummy=True),
         model_name=model_name,
         simulation_mode=mode_map[autonomy],
         mp_api_key=os.environ.get("MP_API_KEY"),
@@ -608,7 +621,7 @@ def stress_5_hpc_workflow_mocked(model_name: str):
 
     orch = SimulationOrchestratorAgent(
         base_dir=str(workdir / "sim"),
-        api_key=os.environ["ANTHROPIC_API_KEY"],
+        api_key=_get_api_key(),
         model_name=model_name,
         simulation_mode=SimulationMode.AUTONOMOUS,
         hpc_connection=mock_conn,
@@ -705,10 +718,18 @@ def integration_1_hpc_slurm(model_name: str):
     from scilink.hpc.scheduler import SlurmScheduler, JobStatus
     from scilink.agents.sim_agents import SimulationOrchestratorAgent, SimulationMode
 
-    host      = os.environ["HPC_HOST"]
-    user      = os.environ["HPC_USER"]
-    key_path  = os.environ.get("HPC_KEY_PATH", "")
+    host        = os.environ["HPC_HOST"]
+    user        = os.environ["HPC_USER"]
+    key_path    = os.environ.get("HPC_KEY_PATH", "")
+    password    = os.environ.get("HPC_PASSWORD", "")
     remote_base = os.environ["HPC_REMOTE_DIR"].rstrip("/")
+
+    # Default: password auth if no key path given, key auth if key path given
+    auth_method = os.environ.get("HPC_AUTH_METHOD", "key" if key_path else "password")
+
+    if auth_method == "password" and not password:
+        import getpass
+        password = getpass.getpass(f"   Password for {user}@{host}: ")
 
     workdir = RUN_DIR / "integration_hpc"
     if workdir.exists():
@@ -730,11 +751,11 @@ def integration_1_hpc_slurm(model_name: str):
         name="test",
         hostname=host,
         username=user,
-        auth_method="key" if key_path else "key",
+        auth_method=auth_method,
         key_path=key_path,
     )
     conn = HPCConnection(profile)
-    conn.connect()
+    conn.connect(password=password)
     assert conn.is_connected, "SSH connection failed"
     print(f"   ✅ Connected to {user}@{host}")
 
@@ -766,13 +787,13 @@ def integration_1_hpc_slurm(model_name: str):
         "created_at": datetime.now().isoformat(),
     })
 
-    # Submit — use "sleep 10 && write fake outputs" instead of vasp_std
+    # Submit — use a plain bash command that writes fake VASP output files
     remote_dir = f"{remote_base}/scilink_integration_test"
     fake_vasp = (
-        "sleep 10 && "
-        "echo 'running on 1 core' > vasp.stdout && "
-        "printf 'Total CPU time used (sec): 10\\n' > OUTCAR && "
-        "cp POSCAR CONTCAR && "
+        "sleep 5\n"
+        "echo 'running on 1 core' > vasp.stdout\n"
+        "printf 'Total CPU time used (sec): 10\\n' > OUTCAR\n"
+        "cp POSCAR CONTCAR\n"
         "echo '  1 F= -.100E+03 E0= -.100E+03 d E =0.000' > OSZICAR"
     )
     r = json.loads(orch.tools.execute_tool(
@@ -873,7 +894,9 @@ def main():
 
     needs_keys = args.stress or args.e2e
     if needs_keys:
-        _require_env("ANTHROPIC_API_KEY")
+        if not (os.environ.get("SCILINK_API_KEY") or os.environ.get("ANTHROPIC_API_KEY")):
+            print("❌ Set SCILINK_API_KEY or ANTHROPIC_API_KEY for live-LLM tests")
+            sys.exit(2)
     if args.integration:
         _require_env("HPC_HOST", "HPC_USER", "HPC_REMOTE_DIR")
 

--- a/tests/test_simulation_orchestrator.py
+++ b/tests/test_simulation_orchestrator.py
@@ -86,11 +86,16 @@ EXPECTED_TOOLS = {
     "list_generated_structures",
     "analyze_vasp_output",
     "suggest_incar_fixes",
+    # HPC tools
+    "submit_vasp_job",
+    "get_job_status",
+    "download_vasp_results",
+    "generate_final_report",
 }
 
 
 def test_1_orchestrator_constructs(model_name: str):
-    """Orchestrator builds without an LLM call; all 12 tools registered."""
+    """Orchestrator builds without an LLM call; all 16 tools registered."""
     with tempfile.TemporaryDirectory() as td:
         orch = _make_orch(model_name, td + "/sim")
         assert set(orch.tools.functions_map.keys()) == EXPECTED_TOOLS
@@ -295,6 +300,134 @@ def test_6_session_persistence(model_name: str):
     print("   ✅ Checkpoint round-trips structures + sticky params")
 
 
+def test_7_hpc_tools_no_connection(model_name: str):
+    """All 4 HPC tools return structured error JSON when no connection is set."""
+    with tempfile.TemporaryDirectory() as td:
+        orch = _make_orch(model_name, td + "/sim")
+
+        for tool, kwargs in [
+            ("submit_vasp_job",       {"structure_slug": "x", "remote_dir": "/tmp"}),
+            ("get_job_status",        {"job_id": "12345"}),
+            ("download_vasp_results", {"job_id": "12345"}),
+            ("generate_final_report", {"structure_slug": "x"}),
+        ]:
+            r = json.loads(orch.tools.execute_tool(tool, **kwargs))
+            assert r["status"] == "error", f"{tool} should error without a connection"
+
+        print("   ✅ All 4 HPC tools return structured error when no connection set")
+
+
+def test_8_hpc_tools_mock_connection(model_name: str):
+    """Full offline HPC flow: submit → status → download → report (all mocked)."""
+    from unittest.mock import MagicMock, patch
+    from scilink.agents.sim_agents import SimulationOrchestratorAgent, SimulationMode
+    from scilink.hpc.scheduler import HPCJob, JobStatus
+
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+
+        # Build minimal local VASP input files
+        struct_dir = td / "structures" / "si_bulk_001"
+        struct_dir.mkdir(parents=True)
+        poscar = struct_dir / "POSCAR"
+        incar  = struct_dir / "INCAR"
+        kpoints = struct_dir / "KPOINTS"
+        poscar.write_text("Si\n1.0\n3 0 0\n0 3 0\n0 0 3\nSi\n1\nDirect\n0 0 0\n")
+        incar.write_text("ENCUT = 400\nISMEAR = 0\n")
+        kpoints.write_text("Automatic\n0\nGamma\n4 4 4\n0 0 0\n")
+
+        # Mock HPC connection
+        mock_conn = MagicMock()
+        mock_conn.is_connected = True
+        mock_conn.mkdir_p = MagicMock()
+        mock_conn.upload = MagicMock()
+
+        # Mock scheduler — submit returns "99999", status returns Completed
+        mock_sched = MagicMock()
+        mock_sched.name = "SLURM"
+        mock_sched.submit = MagicMock(return_value="99999")
+        completed_job = HPCJob(job_id="99999", status=JobStatus.COMPLETED,
+                               raw_status="COMPLETED", work_dir="/scratch/test")
+        mock_sched.status = MagicMock(return_value=completed_job)
+
+        orch = SimulationOrchestratorAgent(
+            base_dir=str(td / "sim"),
+            api_key="dummy",
+            model_name=model_name,
+            simulation_mode=SimulationMode.AUTONOMOUS,
+            hpc_connection=mock_conn,
+            hpc_scheduler=mock_sched,
+        )
+
+        # Seed a structure record
+        slug = "si_bulk_001"
+        orch.generated_structures.append({
+            "slug": slug,
+            "description": "bulk silicon",
+            "structure_dir": str(struct_dir),
+            "poscar_path": str(poscar),
+            "incar_path": str(incar),
+            "kpoints_path": str(kpoints),
+            "hpc_job_id": None,
+            "hpc_remote_dir": None,
+            "hpc_results_dir": None,
+            "validation": {"status": "success", "overall_assessment": "Looks good.",
+                           "all_identified_issues": []},
+            "vasp_summary": "Static SCF, ENCUT=400",
+            "created_at": datetime.now().isoformat(),
+        })
+
+        # 1. submit_vasp_job
+        r = json.loads(orch.tools.execute_tool(
+            "submit_vasp_job",
+            structure_slug=slug,
+            remote_dir="/scratch/test",
+            job_name="si_test",
+            n_nodes=1,
+            n_tasks=8,
+            time_limit="01:00:00",
+        ))
+        assert r["status"] == "success", f"submit failed: {r}"
+        assert r["job_id"] == "99999"
+        mock_conn.upload.assert_called()
+        mock_sched.submit.assert_called_once()
+        print("   ✅ submit_vasp_job: uploaded files, submitted job, got job_id=99999")
+
+        # 2. get_job_status
+        r = json.loads(orch.tools.execute_tool("get_job_status", job_id="99999"))
+        assert r["status"] == "success"
+        assert r["job_status"] == "Completed"
+        assert r["is_terminal"] is True
+        print("   ✅ get_job_status: Completed, is_terminal=True")
+
+        # 3. download_vasp_results — mock conn.download to write real files
+        results_dir = struct_dir / "hpc_results"
+        def fake_download(remote, local, **kw):
+            fname = Path(remote).name
+            if fname in ("OUTCAR", "vasprun.xml", "vasp.stdout"):
+                Path(local).write_text(f"fake {fname} content")
+        mock_conn.download = MagicMock(side_effect=fake_download)
+
+        r = json.loads(orch.tools.execute_tool("download_vasp_results", job_id="99999"))
+        assert r["status"] == "success", f"download failed: {r}"
+        assert "OUTCAR" in r["downloaded"] or "vasp.stdout" in r["downloaded"]
+        print(f"   ✅ download_vasp_results: got {r['downloaded']}")
+
+        # 4. generate_final_report
+        r = json.loads(orch.tools.execute_tool(
+            "generate_final_report", structure_slug=slug
+        ))
+        assert r["status"] == "success", f"report failed: {r}"
+        assert Path(r["report_path"]).exists()
+        report = r["report"]
+        assert "bulk silicon" in report
+        assert "99999" in report  # job ID in report
+        assert "VASP DFT Simulation Report" in report
+        print(f"   ✅ generate_final_report: written to {r['report_path']}")
+
+    print("   ✅ Full offline HPC flow: submit → status → download → report")
+
+
 # ---------------------------------------------------------------------------
 # Stress tests — live LLM, exercise individual tools
 # ---------------------------------------------------------------------------
@@ -433,6 +566,94 @@ def stress_4_aimsgb_skill_loaded(model_name: str):
           f"{len(atoms)} Fe atoms produced.")
 
 
+def stress_5_hpc_workflow_mocked(model_name: str):
+    """Live LLM drives submit → status → download → report with mocked HPC.
+
+    Pre-seeds a structure record with real local files so the agent can
+    find POSCAR/INCAR/KPOINTS without needing to run generate_structure.
+    """
+    from unittest.mock import MagicMock
+    from scilink.agents.sim_agents import SimulationOrchestratorAgent, SimulationMode
+    from scilink.hpc.scheduler import HPCJob, JobStatus
+
+    workdir = RUN_DIR / "stress_hpc_mocked"
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir(parents=True)
+
+    struct_dir = workdir / "structures" / "si_bulk_001"
+    struct_dir.mkdir(parents=True)
+    poscar  = struct_dir / "POSCAR"
+    incar   = struct_dir / "INCAR"
+    kpoints = struct_dir / "KPOINTS"
+    poscar.write_text("Si\n1.0\n5.43 0 0\n0 5.43 0\n0 0 5.43\nSi\n2\nDirect\n0 0 0\n0.25 0.25 0.25\n")
+    incar.write_text("ENCUT = 520\nISMEAR = 0\nSIGMA = 0.05\n")
+    kpoints.write_text("Automatic\n0\nGamma\n6 6 6\n0 0 0\n")
+
+    mock_conn = MagicMock()
+    mock_conn.is_connected = True
+    mock_sched = MagicMock()
+    mock_sched.name = "SLURM"
+    mock_sched.submit = MagicMock(return_value="55555")
+
+    results_dir = struct_dir / "hpc_results"
+    completed_job = HPCJob(job_id="55555", status=JobStatus.COMPLETED,
+                           raw_status="COMPLETED", work_dir="/scratch/run1")
+    mock_sched.status = MagicMock(return_value=completed_job)
+
+    def fake_download(remote, local, **kw):
+        Path(local).parent.mkdir(parents=True, exist_ok=True)
+        Path(local).write_text(f"fake {Path(remote).name}")
+    mock_conn.download = MagicMock(side_effect=fake_download)
+
+    orch = SimulationOrchestratorAgent(
+        base_dir=str(workdir / "sim"),
+        api_key=os.environ["ANTHROPIC_API_KEY"],
+        model_name=model_name,
+        simulation_mode=SimulationMode.AUTONOMOUS,
+        hpc_connection=mock_conn,
+        hpc_scheduler=mock_sched,
+    )
+    orch.generated_structures.append({
+        "slug": "si_bulk_001",
+        "description": "2x2x2 bulk silicon supercell",
+        "structure_dir": str(struct_dir),
+        "poscar_path": str(poscar),
+        "incar_path": str(incar),
+        "kpoints_path": str(kpoints),
+        "hpc_job_id": None,
+        "hpc_remote_dir": None,
+        "hpc_results_dir": None,
+        "vasp_summary": "Static SCF, ENCUT=520",
+        "validation": {"status": "success", "overall_assessment": "Structure looks correct.",
+                       "all_identified_issues": []},
+        "created_at": datetime.now().isoformat(),
+    })
+
+    response = orch.chat(
+        "I have a bulk silicon structure ready (slug: si_bulk_001, POSCAR/INCAR/KPOINTS "
+        "are on disk). Please: 1) submit it to the HPC cluster at remote dir "
+        "/scratch/si_run, using 1 node, 16 tasks, 2-hour wall time; "
+        "2) check the job status; 3) download the results; 4) generate a final report."
+    )
+    print("   --- agent response (last 600 chars) ---")
+    print("   " + response[-600:].replace("\n", "\n   "))
+
+    mock_sched.submit.assert_called_once()
+    mock_sched.status.assert_called()
+    mock_conn.download.assert_called()
+
+    record = orch.generated_structures[0]
+    assert record.get("hpc_job_id") == "55555", "Job ID not recorded on structure"
+    assert record.get("hpc_results_dir"), "Results dir not recorded after download"
+
+    report_path = struct_dir / "final_report.md"
+    assert report_path.exists(), "Final report not written to disk"
+    report_text = report_path.read_text()
+    assert "55555" in report_text, "Job ID missing from report"
+    print("   ✅ LLM drove full HPC workflow; report written with correct job ID")
+
+
 # ---------------------------------------------------------------------------
 # E2E — full run_task call producing files on disk
 # ---------------------------------------------------------------------------
@@ -464,6 +685,142 @@ def e2e_1_run_task_minimal_structure(model_name: str):
 
 
 # ---------------------------------------------------------------------------
+# Integration tests — real SLURM cluster, no LLM required
+#
+# Required env vars:
+#   HPC_HOST        hostname of the SLURM cluster
+#   HPC_USER        SSH username
+#   HPC_KEY_PATH    path to SSH private key (optional — uses ssh-agent if unset)
+#   HPC_REMOTE_DIR  remote scratch directory for test jobs (e.g. /scratch/user/scilink_test)
+# ---------------------------------------------------------------------------
+
+def integration_1_hpc_slurm(model_name: str):
+    """Real SLURM cluster: submit a fake VASP job, poll until done, download results.
+
+    Uses a tiny job script that writes VASP-shaped output files instead of
+    running actual VASP, so no VASP license is required.
+    """
+    import time
+    from scilink.hpc.connection import HPCConnection, HPCProfile
+    from scilink.hpc.scheduler import SlurmScheduler, JobStatus
+    from scilink.agents.sim_agents import SimulationOrchestratorAgent, SimulationMode
+
+    host      = os.environ["HPC_HOST"]
+    user      = os.environ["HPC_USER"]
+    key_path  = os.environ.get("HPC_KEY_PATH", "")
+    remote_base = os.environ["HPC_REMOTE_DIR"].rstrip("/")
+
+    workdir = RUN_DIR / "integration_hpc"
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir(parents=True)
+
+    # Build local VASP input files
+    struct_dir = workdir / "structures" / "si_integration_001"
+    struct_dir.mkdir(parents=True)
+    poscar  = struct_dir / "POSCAR"
+    incar   = struct_dir / "INCAR"
+    kpoints = struct_dir / "KPOINTS"
+    poscar.write_text("Si\n1.0\n5.43 0 0\n0 5.43 0\n0 0 5.43\nSi\n2\nDirect\n0 0 0\n0.25 0.25 0.25\n")
+    incar.write_text("ENCUT = 520\nISMEAR = 0\nSIGMA = 0.05\n")
+    kpoints.write_text("Automatic\n0\nGamma\n6 6 6\n0 0 0\n")
+
+    # Connect
+    profile = HPCProfile(
+        name="test",
+        hostname=host,
+        username=user,
+        auth_method="key" if key_path else "key",
+        key_path=key_path,
+    )
+    conn = HPCConnection(profile)
+    conn.connect()
+    assert conn.is_connected, "SSH connection failed"
+    print(f"   ✅ Connected to {user}@{host}")
+
+    sched = SlurmScheduler(conn)
+    assert sched.detect(), "SLURM not detected on remote host"
+    print("   ✅ SLURM detected")
+
+    orch = SimulationOrchestratorAgent(
+        base_dir=str(workdir / "sim"),
+        api_key="dummy",
+        model_name=model_name,
+        simulation_mode=SimulationMode.AUTONOMOUS,
+        hpc_connection=conn,
+        hpc_scheduler=sched,
+    )
+    slug = "si_integration_001"
+    orch.generated_structures.append({
+        "slug": slug,
+        "description": "bulk silicon integration test",
+        "structure_dir": str(struct_dir),
+        "poscar_path": str(poscar),
+        "incar_path": str(incar),
+        "kpoints_path": str(kpoints),
+        "hpc_job_id": None,
+        "hpc_remote_dir": None,
+        "hpc_results_dir": None,
+        "vasp_summary": "Static SCF, ENCUT=520",
+        "validation": None,
+        "created_at": datetime.now().isoformat(),
+    })
+
+    # Submit — use "sleep 10 && write fake outputs" instead of vasp_std
+    remote_dir = f"{remote_base}/scilink_integration_test"
+    fake_vasp = (
+        "sleep 10 && "
+        "echo 'running on 1 core' > vasp.stdout && "
+        "printf 'Total CPU time used (sec): 10\\n' > OUTCAR && "
+        "cp POSCAR CONTCAR && "
+        "echo '  1 F= -.100E+03 E0= -.100E+03 d E =0.000' > OSZICAR"
+    )
+    r = json.loads(orch.tools.execute_tool(
+        "submit_vasp_job",
+        structure_slug=slug,
+        remote_dir=remote_dir,
+        job_name="scilink_test",
+        n_nodes=1,
+        n_tasks=1,
+        time_limit="00:05:00",
+        vasp_command=fake_vasp,
+    ))
+    assert r["status"] == "success", f"submit failed: {r}"
+    job_id = r["job_id"]
+    print(f"   ✅ Job submitted: {job_id}")
+
+    # Poll until terminal (max 5 min)
+    deadline = time.time() + 300
+    final_status = None
+    while time.time() < deadline:
+        sr = json.loads(orch.tools.execute_tool("get_job_status", job_id=job_id))
+        assert sr["status"] == "success", f"status poll failed: {sr}"
+        final_status = sr["job_status"]
+        print(f"   ... job {job_id} status: {final_status}")
+        if sr["is_terminal"]:
+            break
+        time.sleep(15)
+
+    assert final_status == "Completed", f"Job did not complete: {final_status}"
+    print(f"   ✅ Job {job_id} completed")
+
+    # Download
+    r = json.loads(orch.tools.execute_tool("download_vasp_results", job_id=job_id))
+    assert r["status"] == "success", f"download failed: {r}"
+    assert r["downloaded"], "No files downloaded"
+    print(f"   ✅ Downloaded: {r['downloaded']}")
+
+    # Report
+    r = json.loads(orch.tools.execute_tool("generate_final_report", structure_slug=slug))
+    assert r["status"] == "success", f"report failed: {r}"
+    assert Path(r["report_path"]).exists()
+    assert job_id in r["report"]
+    print(f"   ✅ Final report written to {r['report_path']}")
+
+    conn.disconnect()
+
+
+# ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 
@@ -474,6 +831,8 @@ TARGETED_TESTS = [
     ("Mode switching",                         test_4_mode_switching),
     ("run_task without LLM",                   test_5_run_task_without_llm),
     ("Session persistence (checkpoint)",       test_6_session_persistence),
+    ("HPC tools: no connection errors",        test_7_hpc_tools_no_connection),
+    ("HPC tools: full offline mock flow",      test_8_hpc_tools_mock_connection),
 ]
 
 STRESS_TESTS = [
@@ -481,10 +840,15 @@ STRESS_TESTS = [
     ("STRESS: post-run failure analysis",      stress_2_post_run_analysis_failure),
     ("STRESS: session_status call",            stress_3_session_status_called),
     ("STRESS: aimsgb skill auto-loaded",       stress_4_aimsgb_skill_loaded),
+    ("STRESS: HPC workflow (mocked cluster)",  stress_5_hpc_workflow_mocked),
 ]
 
 E2E_TESTS = [
     ("E2E: run_task minimal structure",        e2e_1_run_task_minimal_structure),
+]
+
+INTEGRATION_TESTS = [
+    ("INTEGRATION: SLURM submit/poll/download/report", integration_1_hpc_slurm),
 ]
 
 
@@ -494,6 +858,9 @@ def main():
                         help="Also run live-LLM stress tests")
     parser.add_argument("--e2e", action="store_true",
                         help="Also run live-LLM end-to-end run_task tests")
+    parser.add_argument("--integration", action="store_true",
+                        help="Run real-cluster integration tests (requires HPC_HOST, "
+                             "HPC_USER, HPC_REMOTE_DIR env vars)")
     parser.add_argument("--model", default=DEFAULT_MODEL)
     parser.add_argument("--verbose", action="store_true")
     args = parser.parse_args()
@@ -507,6 +874,8 @@ def main():
     needs_keys = args.stress or args.e2e
     if needs_keys:
         _require_env("ANTHROPIC_API_KEY")
+    if args.integration:
+        _require_env("HPC_HOST", "HPC_USER", "HPC_REMOTE_DIR")
 
     print(f"🔧 SimulationOrchestratorAgent tests against model: {args.model}")
     print("=" * 72)
@@ -516,6 +885,8 @@ def main():
         tests.extend(STRESS_TESTS)
     if args.e2e:
         tests.extend(E2E_TESTS)
+    if args.integration:
+        tests.extend(INTEGRATION_TESTS)
 
     passed, failed = [], []
     for name, fn in tests:


### PR DESCRIPTION
# Summary
Wraps `scilink/hpc/` (from [#145](https://github.com/sarah-allec/SciLink/issues/145)) as four new tools on `SimulationOrchestratorAgent`, completing the end-to-end pipeline: structure description → VASP inputs → HPC submission → results → report.

- `submit_vasp_job` — uploads POSCAR/INCAR/KPOINTS to the cluster, generates a SLURM/PBS/LSF job script, and submits via `Scheduler.submit()`
-  `get_job_status` — polls `Scheduler.status()` for a submitted job ID
- `download_vasp_results` — pulls vasprun.xml, OUTCAR, CONTCAR, etc. back locally
- `generate_final_report` — assembles a Markdown report covering structure, inputs, HPC job metadata, and parsed VASP results
- `SimulationOrchestratorAgent.__init__` gains `hpc_connection=` and `hpc_scheduler= kwargs` (both default to `None`; all four tools degrade gracefully with a clear error when no connection is set). System prompt updated to reflect HPC submission availability.

Job script generation supports SLURM, PBS, and LSF. The `vasp_command` parameter is the full run command written verbatim (e.g. `srun vasp_std, mpirun -np 16 vasp_std`) — no hardcoded MPI launcher.

# Tests
Targeted (8 tests, no LLM/cluster): tool registration (16 tools), error paths, full offline mock flow (submit → status → download → report)
Stress (5 tests, live LLM): LLM drives the full HPC workflow against a mocked cluster with pre-seeded structure
Integration (1 test, real SLURM): submits a fake job to a live cluster, polls until complete, downloads results, generates report. Triggered with `--integration` flag + `HPC_HOST`, `HPC_USER`, `HPC_REMOTE_DIR` env vars.

All tests green (targeted + stress + integration on PNNL Deception cluster).

# Relationship to other PRs
Depends on: [#145](https://github.com/sarah-allec/SciLink/issues/145) (scilink/hpc/ backend) — already merged
Depends on: [#144](https://github.com/sarah-allec/SciLink/issues/144) (SimulationOrchestratorAgent) — already merged
Followed by: [#140](https://github.com/sarah-allec/SciLink/issues/140) (wizard UI) — will be rebased on top of this