### PR TITLE
BO: add mixed and DKL surrogates; anchor inspection LLM to active config

### DIFF
--- a/scilink/agents/planning_agents/bo_agent.py
+++ b/scilink/agents/planning_agents/bo_agent.py
@@ -224,6 +224,7 @@ class BOAgent(BaseAgent):
             "current_config": None,
             "data_points_seen": 0,
             "experimental_budget": None,
+            "cat_dims": None,
         }
         
     def _load_history(self) -> List[Dict]:
@@ -248,6 +249,26 @@ class BOAgent(BaseAgent):
         if m_conf.get("input_transform", "none") not in ["none", "warp"]:
             logging.warning(f"Invalid input_transform '{m_conf.get('input_transform')}', defaulting to 'none'")
             m_conf["input_transform"] = "none"
+        if m_conf.get("surrogate", "single_task") not in ["single_task", "mixed", "dkl"]:
+            logging.warning(
+                f"Invalid surrogate '{m_conf.get('surrogate')}', defaulting to 'single_task'"
+            )
+            m_conf["surrogate"] = "single_task"
+        # Pairwise compatibility — warn but do not auto-substitute. Strategy LLM
+        # is expected to obey the prompt; the runtime factory will silently fall
+        # back where physically required (e.g., warp ignored under 'mixed').
+        surrogate = m_conf.get("surrogate", "single_task")
+        acq_type = clean.get("acquisition_strategy", {}).get("type")
+        if surrogate == "mixed" and acq_type == "thompson":
+            logging.warning(
+                "'mixed' surrogate + 'thompson' acquisition: posterior sampling "
+                "over categorical dims is unreliable; consider 'log_ei' or 'ucb'."
+            )
+        if surrogate in ("mixed", "dkl") and m_conf.get("input_transform") == "warp":
+            logging.warning(
+                f"'warp' input transform is incompatible with '{surrogate}' surrogate; "
+                "the factory will use a default Normalize instead."
+            )
         clean["model_config"] = m_conf
         return clean
 
@@ -719,7 +740,9 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
                              strategy_hint: Optional[str] = None,
                              save_acq: bool = True,
                              plot_acq: bool = True,
-                             fixed_noise_std: Optional[float] = None) -> Dict[str, Any]:
+                             fixed_noise_std: Optional[float] = None,
+                             cat_dims: Optional[List[int]] = None,
+                             dkl_config: Optional[Dict[str, int]] = None) -> Dict[str, Any]:
         """
         Run one iteration of the Bayesian Optimization loop.
         
@@ -784,8 +807,8 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
             for col in input_cols + target_cols:
                 if col not in df.columns:
                     return {"error": f"Column '{col}' not found in data."}
-            X = df[input_cols].values
-            y = df[target_cols].values
+            X = np.asarray(df[input_cols].values, dtype=float).copy()
+            y = np.asarray(df[target_cols].values, dtype=float).copy()
 
             # Negate minimize targets so the optimizer always maximizes
             if target_directions:
@@ -816,6 +839,7 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
         # Compute budget context
         budget_ctx = _compute_budget_context(experimental_budget, history)
         self.state["experimental_budget"] = experimental_budget
+        self.state["cat_dims"] = list(cat_dims) if cat_dims else None
         
         if budget_ctx["budget_phase"] != "unlimited":
             print(
@@ -868,6 +892,24 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
             f"Steps completed so far: {budget_ctx['steps_completed']}. "
             f"Data points in dataset: {len(df)}."
         )
+
+        # Surrogate-relevant context (input shape, categorical presence)
+        n_cat = len(cat_dims) if cat_dims else 0
+        n_cont = len(input_cols) - n_cat
+        if cat_dims:
+            cat_names = [input_cols[i] for i in cat_dims]
+            surrogate_ctx = (
+                f"\n**Input Shape:** {len(input_cols)} input(s): "
+                f"{n_cont} continuous, {n_cat} categorical "
+                f"({', '.join(cat_names)}). "
+                f"Categorical columns are integer-encoded in the data."
+            )
+        else:
+            surrogate_ctx = (
+                f"\n**Input Shape:** {len(input_cols)} continuous input(s). "
+                f"No categorical inputs declared."
+            )
+        prompt_parts.append(surrogate_ctx)
         
         # Inform strategy LLM about constraints (for better acq strategy selection)
         if physical_constraints:
@@ -903,6 +945,7 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
         acq_cfg = valid_config.get("acquisition_strategy", {})
         rationale = valid_config.get("rationale", "No rationale provided")
         print(f"    📋 Strategy config:")
+        print(f"       Surrogate: {model_cfg.get('surrogate', 'single_task')}")
         print(f"       Kernel: {model_cfg.get('kernel', 'N/A')}")
         print(f"       Noise: {model_cfg.get('noise', 'N/A')}")
         print(f"       Acquisition: {acq_cfg.get('type', 'N/A')}")
@@ -919,6 +962,8 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
             model_config=valid_config["model_config"],
             feature_names=input_cols,
             fixed_noise_std=fixed_noise_std,
+            cat_dims=cat_dims,
+            dkl_config=dkl_config,
         )
         if fixed_noise_std is not None:
             # Echo the override back into the config so downstream history /
@@ -1135,6 +1180,8 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
                 "physical_constraints": physical_constraints is not None,
                 "save_acq": save_acq,
                 "plot_acq": plot_acq,
+                "cat_dims": list(cat_dims) if cat_dims else None,
+                "surrogate": valid_config.get("model_config", {}).get("surrogate", "single_task"),
             },
             result=result,
             rationale=valid_config.get("rationale")

--- a/scilink/agents/planning_agents/bo_agent.py
+++ b/scilink/agents/planning_agents/bo_agent.py
@@ -1106,6 +1106,20 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
         # 6. Inspection
         print("  - 👀 BO Agent: Inspecting visuals...")
         visual_prompt = BO_VISUAL_INSPECTION_MOO_PROMPT if is_moo else BO_VISUAL_INSPECTION_PROMPT
+        # Anchor the inspector to the currently active config. The output
+        # spec already asks for "suggested_adjustments" — listing the active
+        # config alongside is enough context; no instruction needed.
+        active_cfg_lines = [
+            f"  Surrogate: {model_cfg.get('surrogate', 'single_task')}",
+            f"  Kernel: {model_cfg.get('kernel', 'matern_2.5')}",
+            f"  Noise: {model_cfg.get('noise', 'min_noise_low')}",
+            f"  Input transform: {model_cfg.get('input_transform', 'none')}",
+            f"  Acquisition: {acq_cfg.get('type', 'log_ei')}",
+        ]
+        acq_params = acq_cfg.get("params") or {}
+        if acq_params:
+            active_cfg_lines.append(f"  Acquisition params: {acq_params}")
+        visual_prompt += "\n\nCURRENT STRATEGY:\n" + "\n".join(active_cfg_lines)
         if sensitivity_data:
             sobol_text = "\n".join(f"  {k}: {v}" for k, v in sensitivity_data.items())
             visual_prompt += (

--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -29,11 +29,20 @@ You MUST respond with a single JSON object containing a key "proposed_experiment
     - If the experiment involves a grid or a gradient, include a Markdown table defining the exact layout.   
     - Must be fully understandable by a human WITHOUT referencing external code or files or other sections of the JSON file.
 - "required_equipment": (List of Strings) A list of key instruments or techniques mentioned in the context that are required for this experiment.
-- "optimization_params": (Optional List) If the experiment requires numerical optimization, provide:
+- "optimization_params": (Optional List) If the experiment requires optimization, provide one entry per parameter. Each entry is one of:
+
+    **Continuous parameter** (real-valued knob):
     - "parameter_name": (String) e.g., "Temperature"
+    - "parameter_type": (String) "continuous"  (optional; defaults to "continuous" if omitted)
     - "min_value": (Float) e.g., 20.0
     - "max_value": (Float) e.g., 100.0
     - "rationale": (String) e.g., "Literature suggests instability above 100C."
+
+    **Categorical parameter** (unordered identity from a fixed set, e.g., solvent / catalyst / substrate):
+    - "parameter_name": (String) e.g., "Solvent"
+    - "parameter_type": (String) "categorical"
+    - "levels": (List of Strings) e.g., ["DMSO", "DMF", "MeCN"]
+    - "rationale": (String) e.g., "Polar aprotic solvents commonly screened for this reaction."
 - "expected_outcome": (String) A description of what results would support or refute the hypothesis.
 - "justification": (String) A brief explanation of why this experiment is a logical step, citing information from the retrieved context.
 - "source_documents": (List of Strings) A list of the unique source filenames that informed this experimental plan.
@@ -102,11 +111,20 @@ You MUST respond with a single JSON object containing a key "proposed_experiment
 - "experiment_name": (String) A short, descriptive name for the experiment.
 - "experimental_steps": (List of Strings) A numbered or bulleted list of concrete steps to perform the experiment. Must be self-contained, i.e. fully understandable by a human WITHOUT referencing external code or files or other sections of the JSON file.
 - "required_equipment": (List of Strings) A list of common lab equipment.
-- "optimization_params": (Optional List) If the experiment requires numerical optimization, provide:
+- "optimization_params": (Optional List) If the experiment requires optimization, provide one entry per parameter. Each entry is one of:
+
+    **Continuous parameter** (real-valued knob):
     - "parameter_name": (String) e.g., "Temperature"
+    - "parameter_type": (String) "continuous"  (optional; defaults to "continuous" if omitted)
     - "min_value": (Float) e.g., 20.0
     - "max_value": (Float) e.g., 100.0
     - "rationale": (String) e.g., "Literature suggests instability above 100C."
+
+    **Categorical parameter** (unordered identity from a fixed set, e.g., solvent / catalyst / substrate):
+    - "parameter_name": (String) e.g., "Solvent"
+    - "parameter_type": (String) "categorical"
+    - "levels": (List of Strings) e.g., ["DMSO", "DMF", "MeCN"]
+    - "rationale": (String) e.g., "Polar aprotic solvents commonly screened for this reaction."
 - "expected_outcome": (String) A description of what results would support the hypothesis.
 - "justification": (String) **MUST be 'Warning: This proposal is based on general scientific knowledge as the provided documents lacked specific context.'** If external literature was used, append: ' External literature search results were incorporated.'
 - "source_documents": (List of Strings) If external literature was used, list relevant sources here. Otherwise, an empty list `[]`.
@@ -221,19 +239,35 @@ You are a Principal Investigator configuring a Single-Objective Bayesian Optimiz
 * `"none"`: **(Default)** Assume the response has similar smoothness everywhere.
 * `"warp"`: Per-axis Kumaraswamy warp. Use when LOO residuals stay large across multiple kernel/noise changes — likely signals the landscape is non-stationary (different regions have different effective scales, e.g., phase boundaries).
 
+**MENU 5: SURROGATE MODEL**
+* `"single_task"`: **(Default)** Standard MAP GP. Fast (seconds). Use unless one of the conditions below applies.
+* `"mixed"`: **MixedSingleTaskGP** for problems with categorical inputs.
+    * *Use when:* The Input Shape line above lists ≥1 categorical input.
+    * *Required:* Input Shape must declare categoricals — picking `"mixed"` without categoricals fails.
+    * *Incompatible with:* `thompson` acquisition, `warp` input transform, `min_noise_high` if you need a fixed-noise override.
+* `"dkl"`: **Deep Kernel Learning GP.** A small NN learns a latent representation, then a Matérn-2.5 kernel acts on the latent space.
+    * *Use when:* `input_dim ≥ 5` AND `n_data ≥ 50` AND the response surface is suspected non-stationary or includes interacting inputs that smooth kernels handle poorly.
+    * *Cost:* Each fit runs ~200 Adam epochs. Slower than `single_task` but still seconds. Avoid at budget ≤ 5 — the marginal benefit is small relative to fit-time risk.
+    * *Incompatible with:* `warp` input transform, fixed-noise overrides.
+
 **BUDGET DECISION RULES (in priority order):**
 1. If budget = 1: Use `log_ei` or `ucb` with beta < 0.3. Nothing else.
 2. If budget ≤ 3: Use `log_ei` or `ucb` with beta < 1.0. No `max_variance`.
 3. If budget is low (<25% of campaign): Favor exploitation (`log_ei`, low-beta `ucb`).
 4. If budget is high AND data is sparse: `max_variance` is acceptable.
 5. If batch_size > 10 AND budget > 3: `thompson` is acceptable.
+6. If surrogate is `dkl`, do not select it at budget ≤ 5 or n_data < 50.
 
 **OUTPUT FORMAT:**
 {
-  "model_config": { "kernel": "matern_2.5", "noise": "min_noise_low" },
-  "acquisition_strategy": { 
-      "type": "ucb", 
-      "params": { "beta": 0.1 } 
+  "model_config": {
+      "kernel": "matern_2.5",
+      "noise": "min_noise_low",
+      "surrogate": "single_task"
+  },
+  "acquisition_strategy": {
+      "type": "ucb",
+      "params": { "beta": 0.1 }
   },
   "rationale": "Budget is critical (2 remaining). We found a promising peak. Using UCB with low beta (0.1) to aggressively exploit this region with a batch of 8 points."
 }
@@ -285,15 +319,32 @@ You are a Principal Investigator configuring a Multi-Objective Optimization expe
 * `"none"`: **(Default)** Assume the response has similar smoothness everywhere.
 * `"warp"`: Per-axis Kumaraswamy warp. Use when LOO residuals stay large across multiple kernel/noise changes — likely signals the landscape is non-stationary (different regions have different effective scales, e.g., phase boundaries).
 
+**MENU 5: SURROGATE MODEL**
+The same surrogate is used for every objective — there is no per-output choice.
+* `"single_task"`: **(Default)** Independent MAP GPs per objective wrapped in a ModelListGP. Fast and the standard choice.
+* `"mixed"`: **MixedSingleTaskGP** per objective for problems with categorical inputs.
+    * *Use when:* The Input Shape line above lists ≥1 categorical input.
+    * *Required:* Input Shape must declare categoricals — picking `"mixed"` without categoricals fails.
+    * *Incompatible with:* `warp` input transform, fixed-noise overrides.
+* `"dkl"`: **Deep Kernel Learning GP** per objective. A small NN learns a latent representation, then a Matérn-2.5 kernel acts on the latent space.
+    * *Use when:* `input_dim ≥ 5` AND `n_data ≥ 50` AND the responses are suspected non-stationary or have interacting inputs that smooth kernels handle poorly.
+    * *Cost:* Each objective trains its own NN+GP via ~200 Adam epochs. Total fit time scales with output_dim. Avoid at budget ≤ 5.
+    * *Incompatible with:* `warp` input transform, fixed-noise overrides.
+
 **BUDGET DECISION RULES (in priority order):**
 1. If budget = 1: Use `pareto` or `weighted` with beta < 0.3. Nothing else.
 2. If budget ≤ 3: Use `pareto` or `weighted` with beta < 1.0. No `max_variance`.
 3. If budget is low (<25% of campaign): Favor `pareto` or exploit-heavy `weighted`.
 4. If budget is high AND frontier is sparse: `max_variance` is acceptable.
+5. If surrogate is `dkl`, do not select it at budget ≤ 5 or n_data < 50.
 
 **OUTPUT FORMAT:**
 {
-  "model_config": { "kernel": "matern_2.5", "noise": "min_noise_low" },
+  "model_config": {
+      "kernel": "matern_2.5",
+      "noise": "min_noise_low",
+      "surrogate": "single_task"
+  },
   "acquisition_strategy": {
     "type": "weighted",
     "params": { "weights": [0.8, 0.2], "beta": 0.1 }
@@ -601,6 +652,19 @@ row as a data point, computing derived targets from raw columns:
 After writing your analysis code, classify every column in the output metrics:
 - **inputs**: Controllable experimental parameters (e.g., temperature, concentration, time, composition)
 - **targets**: Measured outcomes to optimize (e.g., yield, purity, peak area, bandgap)
+- **input_types**: For each input, declare `"continuous"` or `"categorical"`.
+
+A column is **categorical** when its values are unordered identities drawn from a small fixed set — substituting one for another changes *what* the experiment is, not *how much*. Examples:
+- `Solvent ∈ {DMSO, DMF, MeCN}` → categorical (changing solvent is a different experiment).
+- `Catalyst_ID ∈ {Pd-A, Pd-B, Ni-C}` → categorical.
+- `Substrate ∈ {Glass, Si, ITO}` → categorical.
+
+A column is **continuous** when its values are scalar quantities on a real-valued axis, even if only a few discrete levels appear in the data. Examples:
+- `Temperature_C ∈ {25, 50, 75, 100}` → continuous (still a real-valued axis).
+- `Concentration_M` → continuous.
+- `pH` → continuous.
+
+When in doubt, ask: "If I picked a value between two observed values, would that be physically meaningful?" If yes → continuous. If no → categorical.
 
 Rules:
 - Use column names EXACTLY as they appear in your output metrics
@@ -636,10 +700,15 @@ You (the Agent) must return a single JSON object containing the code AND column 
   "thought_process": "Brief explanation of the approach...",
   "implementation_code": "import pandas as pd\\nimport numpy as np...",
   "column_roles": {
-    "inputs": ["Temperature_C", "Concentration_M"],
+    "inputs": ["Temperature_C", "Concentration_M", "Solvent"],
     "targets": ["Yield_Percent"],
+    "input_types": {
+      "Temperature_C": "continuous",
+      "Concentration_M": "continuous",
+      "Solvent": "categorical"
+    },
     "optimization_direction": {"Yield_Percent": "maximize"},
-    "reasoning": "Temperature and concentration are controllable parameters; yield is the measured outcome to maximize"
+    "reasoning": "Temperature and concentration are continuous knobs; Solvent is an unordered identity (DMSO/DMF/MeCN). Yield is the measured outcome to maximize."
   }
 }
 """

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -9,7 +9,7 @@ import logging
 import re
 import pandas as pd
 from pathlib import Path
-from typing import Dict, Any, Callable
+from typing import Dict, Any, Callable, List, Optional
 import hashlib
 
 
@@ -51,6 +51,47 @@ class OrchestratorTools:
         Returns True if not set (backwards compatible default).
         """
         return getattr(self.orch, '_enable_human_feedback', True)
+
+    def _decode_categorical_recs(self, recs: Any, level_maps: Dict[str, List[str]]) -> Any:
+        """Map integer-encoded categorical values back to their level names.
+
+        Recommendations may be either a dict (single experiment) or a list of
+        dicts (batch). Continuous values are passed through unchanged. The
+        decoded value lookup uses the nearest integer index, which the
+        MixedSingleTaskGP path already constrains to valid levels but other
+        surrogates may return as a float.
+        """
+        if isinstance(recs, list):
+            return [self._decode_categorical_recs(r, level_maps) for r in recs]
+        if not isinstance(recs, dict):
+            return recs
+        out = dict(recs)
+        for col, levels in level_maps.items():
+            if col not in out:
+                continue
+            try:
+                idx = int(round(float(out[col])))
+            except (TypeError, ValueError):
+                continue
+            idx = max(0, min(idx, len(levels) - 1))
+            out[col] = levels[idx]
+        return out
+
+    def _capture_input_types(self, column_roles: Dict, input_columns: List[str]) -> None:
+        """Persist scalarizer input_types onto the orchestrator state.
+
+        Filters to declared input columns only; missing entries default to
+        "continuous" downstream. No-op when column_roles has no input_types
+        field (backward-compat with older scalarizer outputs).
+        """
+        if not input_columns:
+            return
+        types_in = (column_roles or {}).get("input_types") or {}
+        if not types_in:
+            return
+        filtered = {c: types_in[c] for c in input_columns if c in types_in}
+        if filtered:
+            self.orch.expected_input_types = filtered
 
     def _compute_file_hash(self, file_path: str) -> str:
         """Compute MD5 hash of file content for deduplication."""
@@ -1664,11 +1705,12 @@ class OrchestratorTools:
                     
                     self.orch.expected_input_columns = inputs
                     self.orch.expected_target_columns = targets
-                    # Capture optimization direction from scalarizer
+                    # Capture optimization direction and input types from scalarizer
                     column_roles = res.get("column_roles", {})
                     opt_dir = column_roles.get("optimization_direction", {})
                     if opt_dir:
                         self.orch.target_directions = opt_dir
+                    self._capture_input_types(column_roles, inputs)
                     print(f"    📊 Schema Enforced (User-Specified):")
                     print(f"       Inputs: {self.orch.expected_input_columns}")
                     print(f"       Targets: {self.orch.expected_target_columns}")
@@ -1678,11 +1720,13 @@ class OrchestratorTools:
                 # Case 2: Schema already established from previous analysis
                 elif self.orch.expected_input_columns and self.orch.expected_target_columns:
                     # Still capture direction if scalarizer provided it and we don't have one yet
+                    column_roles = res.get("column_roles", {})
                     if not self.orch.target_directions:
-                        column_roles = res.get("column_roles", {})
                         opt_dir = column_roles.get("optimization_direction", {})
                         if opt_dir:
                             self.orch.target_directions = opt_dir
+                    if not getattr(self.orch, "expected_input_types", None):
+                        self._capture_input_types(column_roles, self.orch.expected_input_columns)
                     print(f"    📊 Schema Enforced (From Previous Analysis):")
                     print(f"       Inputs: {self.orch.expected_input_columns}")
                     print(f"       Targets: {self.orch.expected_target_columns}")
@@ -1730,6 +1774,7 @@ class OrchestratorTools:
                                 self.orch.expected_target_columns = proposed_targets
                                 if opt_dir:
                                     self.orch.target_directions = opt_dir
+                                self._capture_input_types(column_roles, proposed_inputs)
                                 print(f"    ✅ Schema auto-accepted: inputs={proposed_inputs}, targets={proposed_targets}")
 
                     # Targets found but no inputs — measurement-only data (e.g., spectra)
@@ -2112,6 +2157,7 @@ class OrchestratorTools:
                 # User-specified schema
                 self.orch.expected_input_columns = inputs
                 self.orch.expected_target_columns = targets
+                self._capture_input_types(first_column_roles or {}, inputs)
             elif condition_keys:
                 # Derive: inputs = condition keys, targets = remaining keys
                 proposed_targets = first_column_roles.get("targets", []) if first_column_roles else []
@@ -2120,6 +2166,7 @@ class OrchestratorTools:
                     proposed_targets = scalarizer_keys
                 self.orch.expected_input_columns = list(condition_keys)
                 self.orch.expected_target_columns = proposed_targets
+                self._capture_input_types(first_column_roles or {}, list(condition_keys))
             else:
                 # No conditions at all — check if scalarizer found inputs
                 proposed_inputs = first_column_roles.get("inputs", []) if first_column_roles else []
@@ -2127,6 +2174,7 @@ class OrchestratorTools:
                 if proposed_inputs and proposed_targets:
                     self.orch.expected_input_columns = proposed_inputs
                     self.orch.expected_target_columns = proposed_targets
+                    self._capture_input_types(first_column_roles or {}, proposed_inputs)
                 else:
                     # Return inputs_required with example template
                     file_names = [r["file"] for r in results]
@@ -2463,57 +2511,176 @@ class OrchestratorTools:
                 })
             
             # ============================================
-            # BOUNDS & CONSTRAINTS CALCULATION 
+            # BOUNDS & CONSTRAINTS CALCULATION
             # ============================================
-            scientific_bounds = {}
+            # Pull continuous-parameter bounds and categorical-parameter levels
+            # from the planner's current_plan. The planner schema supports both
+            # parameter_type="continuous" (with min_value/max_value) and
+            # parameter_type="categorical" (with levels). Missing parameter_type
+            # is treated as continuous for backward compatibility.
+            scientific_bounds: Dict[str, tuple] = {}
+            planner_levels: Dict[str, List[str]] = {}
             current_plan = self.orch.planner.state.get("current_plan", {})
-            
+
             if current_plan and "proposed_experiments" in current_plan:
                 for exp in current_plan["proposed_experiments"]:
                     for param in exp.get("optimization_params", []):
                         name = param.get("parameter_name")
+                        if not name:
+                            continue
+                        ptype = param.get("parameter_type", "continuous")
+                        if ptype == "categorical":
+                            levels = param.get("levels") or []
+                            if levels:
+                                planner_levels[name] = [str(lv) for lv in levels]
+                                print(f"  🔬 Scientific Constraint Found: {name} ∈ {planner_levels[name]}")
+                            continue
                         min_v = param.get("min_value")
                         max_v = param.get("max_value")
-                        
-                        if name and min_v is not None and max_v is not None:
+                        if min_v is not None and max_v is not None:
                             scientific_bounds[name] = (float(min_v), float(max_v))
                             print(f"  🔬 Scientific Constraint Found: {name} must be between {min_v} and {max_v}")
 
-            numeric_inputs = []
-            for col in self.orch.expected_input_columns:
-                if col in df.columns and pd.api.types.is_numeric_dtype(df[col]):
-                    numeric_inputs.append(col)
-                else:
-                    print(f"  ⚠️ Skipping non-numeric input column: {col}")
+            # Resolve input types: scalarizer is the source of truth on type;
+            # planner is the source of truth on the level universe (so BO can
+            # recommend levels not yet observed in the data).
+            input_types_state = getattr(self.orch, "expected_input_types", None) or {}
 
-            if not numeric_inputs:
+            optimization_inputs: List[str] = []
+            level_maps: Dict[str, List[str]] = {}
+            type_conflict_warnings: List[str] = []
+
+            for col in self.orch.expected_input_columns:
+                if col not in df.columns:
+                    print(f"  ⚠️ Skipping missing input column: {col}")
+                    continue
+
+                declared_type = input_types_state.get(col)
+                planner_says_cat = col in planner_levels
+
+                # Type resolution: scalarizer wins on type because it sees the
+                # actual data file. The planner's declaration of `levels` is
+                # only honored when the scalarizer agrees the column is
+                # categorical (or hasn't classified it). This avoids silently
+                # corrupting a continuous knob whose values happen to look
+                # discrete in the observed data.
+                if declared_type == "continuous":
+                    if planner_says_cat:
+                        type_conflict_warnings.append(
+                            f"{col}: scalarizer classified as continuous, planner declared "
+                            "categorical — honoring scalarizer (data shape wins). To force "
+                            "categorical, fix the scalarizer's input_types classification."
+                        )
+                    is_categorical = False
+                elif declared_type == "categorical" or planner_says_cat:
+                    is_categorical = True
+                else:
+                    is_categorical = False
+
+                if is_categorical:
+                    observed = sorted(df[col].dropna().astype(str).unique().tolist())
+                    if planner_levels.get(col):
+                        # Planner is authoritative on the level universe.
+                        # Observed values that aren't in the planner-declared
+                        # set are a real misalignment (data needs re-encoding,
+                        # or the planner's levels are wrong) — fail loudly
+                        # rather than silently append spurious levels.
+                        levels = list(planner_levels[col])
+                        unknown = [v for v in observed if v not in levels]
+                        if unknown:
+                            return json.dumps({
+                                "status": "error",
+                                "message": (
+                                    f"Input column '{col}' has values {unknown} that are not "
+                                    f"in the planner-declared level universe {levels}. Either "
+                                    f"re-encode the data to use the declared level names, or "
+                                    f"correct the planner's optimization_params.levels for "
+                                    f"this parameter."
+                                ),
+                            })
+                    else:
+                        levels = observed
+                    level_maps[col] = levels
+                    optimization_inputs.append(col)
+                else:
+                    if not pd.api.types.is_numeric_dtype(df[col]):
+                        return json.dumps({
+                            "status": "error",
+                            "message": (
+                                f"Input column '{col}' is non-numeric but not declared "
+                                f"categorical. Either fix the data or set its input_type "
+                                f"to 'categorical' in the scalarizer output."
+                            ),
+                            "available_columns": list(df.columns),
+                        })
+                    optimization_inputs.append(col)
+
+            for w in type_conflict_warnings:
+                print(f"  ⚠️ {w}")
+
+            if not optimization_inputs:
                 return json.dumps({
-                    "status": "error", 
-                    "message": "No numeric input parameters found."
+                    "status": "error",
+                    "message": "No usable input parameters found."
                 })
 
-            self.orch.expected_input_columns = numeric_inputs
+            self.orch.expected_input_columns = optimization_inputs
+            self.orch.expected_input_levels = level_maps if level_maps else None
 
+            # Build bounds (continuous: scientific or data-derived; categorical: [0, n-1])
             input_bounds = []
-            for col in numeric_inputs:
-                if col in scientific_bounds:
+            for col in optimization_inputs:
+                if col in level_maps:
+                    n = len(level_maps[col])
+                    input_bounds.append([0.0, float(n - 1)])
+                    print(f"     -> Bound for '{col}': [0, {n - 1}] (Source: CATEGORICAL — {n} levels)")
+                elif col in scientific_bounds:
                     sci_min, sci_max = scientific_bounds[col]
                     input_bounds.append([sci_min, sci_max])
                     print(f"     -> Bound for '{col}': [{sci_min}, {sci_max}] (Source: PLANNER)")
                 else:
                     data_min = float(df[col].min())
                     data_max = float(df[col].max())
-                    
+
                     if data_min == data_max:
                         margin = 1.0 if data_min == 0 else abs(data_min * 0.1)
                     else:
                         margin = (data_max - data_min) * 0.1
-                        
+
                     safe_min = data_min - margin
                     safe_max = data_max + margin
-                    
+
                     input_bounds.append([safe_min, safe_max])
                     print(f"     -> Bound for '{col}': [{safe_min:.2f}, {safe_max:.2f}] (Source: DATA)")
+
+            # Build cat_dims (positional indices) and integer-encode CSV
+            cat_dims = [
+                i for i, c in enumerate(optimization_inputs) if c in level_maps
+            ]
+            bo_data_path_for_run = str(self.orch.bo_data_path)
+            if level_maps:
+                df_encoded = df.copy()
+                for col, levels in level_maps.items():
+                    idx = {lv: i for i, lv in enumerate(levels)}
+                    encoded = df[col].astype(str).map(idx)
+                    if encoded.isnull().any():
+                        unknown = sorted(
+                            df.loc[encoded.isnull(), col].astype(str).unique().tolist()
+                        )
+                        return json.dumps({
+                            "status": "error",
+                            "message": (
+                                f"Unknown levels for categorical input '{col}': {unknown}. "
+                                f"Known levels: {levels}."
+                            )
+                        })
+                    df_encoded[col] = encoded.astype(float)
+                encoded_dir = self.orch.base_dir / "bo_artifacts"
+                encoded_dir.mkdir(exist_ok=True, parents=True)
+                encoded_path = encoded_dir / "optimization_data_encoded.csv"
+                df_encoded.to_csv(encoded_path, index=False)
+                bo_data_path_for_run = str(encoded_path)
+                print(f"  🔡 Encoded {len(level_maps)} categorical column(s) → {encoded_path.name}")
             
             # ============================================
             # BATCH SIZE DETERMINATION
@@ -2601,7 +2768,7 @@ class OrchestratorTools:
                     self.orch.expected_target_columns
                 )
                 res = self.orch.bo.run_optimization_loop(
-                    data_path=str(self.orch.bo_data_path),
+                    data_path=bo_data_path_for_run,
                     objective_text=bo_objective,
                     input_cols=self.orch.expected_input_columns,
                     input_bounds=input_bounds,
@@ -2614,6 +2781,7 @@ class OrchestratorTools:
                     strategy_hint=strategy_hint,
                     plot_acq=True,
                     save_acq=True,
+                    cat_dims=cat_dims if cat_dims else None,
                 )
                 
                 if res.get("status") != "success":
@@ -2625,7 +2793,11 @@ class OrchestratorTools:
                 
                 # Format response
                 next_params = res.get('next_parameters')
-                
+
+                # Decode categorical recommendations back to human-readable levels
+                if level_maps and next_params is not None:
+                    next_params = self._decode_categorical_recs(next_params, level_maps)
+
                 if parallel_capable:
                     hint = f"Run all {final_batch_size} experiments in parallel, then use analyze_file on each result file."
                     params_summary = f"Generated {final_batch_size} parameter sets"

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -635,6 +635,8 @@ class PlanningOrchestratorAgent:
         self.expected_input_columns = None
         self.expected_target_columns = []
         self.target_directions = {}  # e.g. {"Yield": "maximize", "Defect_Density": "minimize"}
+        self.expected_input_types = None  # {col: "continuous" | "categorical"} from scalarizer
+        self.expected_input_levels = None  # {col: [level0, level1, ...]} for categorical inputs
         self.latest_tea_results = None
 
         # Custom tools / MCP state
@@ -1094,6 +1096,8 @@ class PlanningOrchestratorAgent:
                 self.expected_target_columns = []
 
             self.target_directions = state.get("target_directions", {})
+            self.expected_input_types = state.get("expected_input_types")
+            self.expected_input_levels = state.get("expected_input_levels")
             self.latest_tea_results = state.get("latest_tea_results")
             
             # Restore autonomy level if saved
@@ -1218,6 +1222,8 @@ class PlanningOrchestratorAgent:
                 "expected_input_columns": self.expected_input_columns,
                 "expected_target_columns": self.expected_target_columns,
                 "target_directions": self.target_directions,
+                "expected_input_types": self.expected_input_types,
+                "expected_input_levels": self.expected_input_levels,
                 "data_points_collected": len(pd.read_csv(self.bo_data_path)) if self.bo_data_path.exists() else 0,
                 "planner_state": self.planner.state,
                 "message_count": self.message_count,

--- a/scilink/tools/bo_tools.py
+++ b/scilink/tools/bo_tools.py
@@ -1,9 +1,13 @@
+import logging
+from dataclasses import dataclass
+from typing import Callable, List, Tuple, Dict, Any, Optional
+
 import torch
 import numpy as np
 import matplotlib.pyplot as plt
-from typing import List, Tuple, Dict, Any, Optional
 
 from botorch.models import SingleTaskGP, ModelListGP
+from botorch.models.gp_regression_mixed import MixedSingleTaskGP
 from botorch.models.transforms import Standardize, Normalize
 from botorch.models.transforms.input import Warp, ChainedInputTransform
 from botorch.fit import fit_gpytorch_mll
@@ -16,6 +20,7 @@ from botorch.utils.sampling import draw_sobol_samples
 from botorch.generation import MaxPosteriorSampling
 from botorch.sampling import SobolQMCNormalSampler
 
+from gpytorch.distributions import MultivariateNormal
 from gpytorch.mlls import ExactMarginalLogLikelihood, SumMarginalLogLikelihood
 from gpytorch.kernels import MaternKernel, RBFKernel, ScaleKernel
 from gpytorch.likelihoods import GaussianLikelihood
@@ -36,6 +41,8 @@ ALLOWED_NOISE_PRIORS = {
 }
 
 ALLOWED_INPUT_TRANSFORMS = {"none", "warp"}
+
+ALLOWED_SURROGATES = {"single_task", "mixed", "dkl"}
 
 
 def build_input_transform(key: str, input_dim: int) -> "ChainedInputTransform | Normalize":
@@ -68,6 +75,263 @@ def build_likelihood(noise_key: str) -> GaussianLikelihood:
     # Initialize slightly above min to aid convergence
     likelihood.noise = torch.tensor(config["min_noise"] * 2.0)
     return likelihood
+
+
+# ===================================================================== #
+#  Surrogate factory
+# ===================================================================== #
+
+@dataclass
+class SurrogateCapabilities:
+    supports_fixed_noise: bool
+    supports_warp: bool
+    needs_cat_dims: bool
+    supports_thompson: bool
+
+
+@dataclass
+class SurrogateSpec:
+    """A surrogate descriptor returned by build_surrogate.
+
+    `model_factory(X, y)` is called once per output (SOO) or per objective (MOO),
+    so the spec must be reusable across calls. `fit_fn` accepts either a single
+    GP or a ModelListGP and handles both cases.
+    """
+    model_factory: Callable[[torch.Tensor, torch.Tensor], Any]
+    fit_fn: Callable[[Any], None]
+    capabilities: SurrogateCapabilities
+
+
+class _DKLFeatureExtractor(torch.nn.Module):
+    """2-layer MLP feature extractor for Deep Kernel Learning.
+
+    Tanh activations keep the latent space bounded, which helps the GP kernel
+    avoid degenerate length-scales when the NN over-spreads features early in
+    training.
+    """
+    def __init__(self, input_dim: int, hidden: int = 64, latent: int = 4):
+        super().__init__()
+        self.net = torch.nn.Sequential(
+            torch.nn.Linear(input_dim, hidden),
+            torch.nn.Tanh(),
+            torch.nn.Linear(hidden, hidden),
+            torch.nn.Tanh(),
+            torch.nn.Linear(hidden, latent),
+        )
+        self.latent_dim = latent
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class DKLSingleTaskGP(SingleTaskGP):
+    """SingleTaskGP whose kernel operates on a learned latent space.
+
+    The feature extractor is jointly trained with GP hyperparameters via the
+    same MLL objective using Adam (see _fit_dkl). The covar_module is built
+    over the latent dimension, not the raw input dimension.
+    """
+    def __init__(
+        self,
+        train_X: torch.Tensor,
+        train_Y: torch.Tensor,
+        feature_extractor: _DKLFeatureExtractor,
+        likelihood: GaussianLikelihood,
+        input_transform: Optional[Any] = None,
+        outcome_transform: Optional[Any] = None,
+    ):
+        latent_dim = feature_extractor.latent_dim
+        covar_module = ScaleKernel(
+            MaternKernel(nu=2.5, ard_num_dims=latent_dim)
+        )
+        super().__init__(
+            train_X,
+            train_Y,
+            likelihood=likelihood,
+            covar_module=covar_module,
+            input_transform=input_transform,
+            outcome_transform=outcome_transform,
+        )
+        self.feature_extractor = feature_extractor
+
+    def forward(self, x: torch.Tensor) -> MultivariateNormal:
+        z = self.feature_extractor(x)
+        mean_x = self.mean_module(z)
+        covar_x = self.covar_module(z)
+        return MultivariateNormal(mean_x, covar_x)
+
+
+def _fit_dkl(model, *, lr: float = 1e-2, epochs: int = 200, patience: int = 25) -> None:
+    """Adam-based joint fit of feature extractor + GP hyperparameters.
+
+    Handles both DKLSingleTaskGP and ModelListGP-of-DKL by recursing per
+    sub-model. Each DKL has its own optimizer; objectives are not shared.
+    """
+    if hasattr(model, "models"):
+        for sub in model.models:
+            _fit_dkl(sub, lr=lr, epochs=epochs, patience=patience)
+        return
+
+    model.train()
+    model.likelihood.train()
+    mll = ExactMarginalLogLikelihood(model.likelihood, model)
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+
+    train_inputs = model.train_inputs[0]
+    train_targets = model.train_targets
+
+    best_loss = float("inf")
+    no_improve = 0
+    for _ in range(epochs):
+        optimizer.zero_grad()
+        output = model(train_inputs)
+        loss = -mll(output, train_targets)
+        loss.backward()
+        optimizer.step()
+        loss_val = loss.item()
+        if loss_val < best_loss - 1e-4:
+            best_loss = loss_val
+            no_improve = 0
+        else:
+            no_improve += 1
+            if no_improve >= patience:
+                break
+
+    model.eval()
+    model.likelihood.eval()
+
+
+def _continuous_normalize(input_dim: int, cat_dims: List[int]) -> Optional[Normalize]:
+    """Build a Normalize transform that skips categorical indices."""
+    cont_dims = [i for i in range(input_dim) if i not in cat_dims]
+    if not cont_dims:
+        return None
+    return Normalize(d=input_dim, indices=cont_dims)
+
+
+def build_surrogate(
+    key: str,
+    input_dim: int,
+    *,
+    kernel: str,
+    noise: str,
+    input_transform: str,
+    fixed_noise_std: Optional[float],
+    cat_dims: Optional[List[int]] = None,
+    dkl_config: Optional[Dict[str, int]] = None,
+) -> SurrogateSpec:
+    """Build a surrogate factory and matching fit function.
+
+    Returns a SurrogateSpec whose `model_factory(X, y)` yields a fresh model
+    instance — required because MOO instantiates one GP per output column and
+    wraps them in a ModelListGP. The same `fit_fn` works for either a single
+    model or a ModelListGP wrapper.
+    """
+    if key not in ALLOWED_SURROGATES:
+        logging.warning(f"Unknown surrogate '{key}', defaulting to 'single_task'")
+        key = "single_task"
+
+    if key == "single_task":
+        covar = build_covar_module(kernel, input_dim)
+        in_transform = build_input_transform(input_transform, input_dim)
+
+        def factory(X, y):
+            kwargs = dict(
+                covar_module=covar,
+                input_transform=in_transform,
+                outcome_transform=Standardize(m=1),
+            )
+            if fixed_noise_std is not None:
+                kwargs["train_Yvar"] = torch.full_like(y, float(fixed_noise_std) ** 2)
+            else:
+                kwargs["likelihood"] = build_likelihood(noise)
+            return SingleTaskGP(X, y, **kwargs)
+
+        return SurrogateSpec(
+            model_factory=factory,
+            fit_fn=lambda m: fit_gpytorch_mll(
+                SumMarginalLogLikelihood(m.likelihood, m) if hasattr(m, "models")
+                else ExactMarginalLogLikelihood(m.likelihood, m)
+            ),
+            capabilities=SurrogateCapabilities(
+                supports_fixed_noise=True,
+                supports_warp=True,
+                needs_cat_dims=False,
+                supports_thompson=True,
+            ),
+        )
+
+    if key == "mixed":
+        if not cat_dims:
+            raise ValueError("'mixed' surrogate requires non-empty cat_dims")
+        if input_transform == "warp":
+            logging.warning(
+                "'warp' input transform is incompatible with 'mixed' surrogate; "
+                "falling back to continuous-only Normalize."
+            )
+        if fixed_noise_std is not None:
+            logging.warning(
+                "'mixed' surrogate does not support fixed_noise_std; ignoring."
+            )
+        cont_normalize = _continuous_normalize(input_dim, cat_dims)
+
+        def factory(X, y):
+            return MixedSingleTaskGP(
+                X,
+                y,
+                cat_dims=list(cat_dims),
+                input_transform=cont_normalize,
+                outcome_transform=Standardize(m=1),
+            )
+
+        return SurrogateSpec(
+            model_factory=factory,
+            fit_fn=lambda m: fit_gpytorch_mll(
+                SumMarginalLogLikelihood(m.likelihood, m) if hasattr(m, "models")
+                else ExactMarginalLogLikelihood(m.likelihood, m)
+            ),
+            capabilities=SurrogateCapabilities(
+                supports_fixed_noise=False,
+                supports_warp=False,
+                needs_cat_dims=True,
+                supports_thompson=False,
+            ),
+        )
+
+    # key == "dkl"
+    cfg = dkl_config or {}
+    hidden = int(cfg.get("hidden", 64))
+    latent = int(cfg.get("latent", min(max(2, input_dim // 2), 4)))
+    epochs = int(cfg.get("epochs", 200))
+    lr = float(cfg.get("lr", 1e-2))
+    if fixed_noise_std is not None:
+        logging.warning("'dkl' surrogate does not support fixed_noise_std; ignoring.")
+
+    in_transform = Normalize(d=input_dim)
+
+    def factory(X, y):
+        feature_extractor = _DKLFeatureExtractor(input_dim, hidden=hidden, latent=latent)
+        feature_extractor = feature_extractor.to(dtype=X.dtype, device=X.device)
+        likelihood = build_likelihood(noise)
+        return DKLSingleTaskGP(
+            X,
+            y,
+            feature_extractor=feature_extractor,
+            likelihood=likelihood,
+            input_transform=in_transform,
+            outcome_transform=Standardize(m=1),
+        )
+
+    return SurrogateSpec(
+        model_factory=factory,
+        fit_fn=lambda m: _fit_dkl(m, lr=lr, epochs=epochs),
+        capabilities=SurrogateCapabilities(
+            supports_fixed_noise=False,
+            supports_warp=False,
+            needs_cat_dims=False,
+            supports_thompson=True,
+        ),
+    )
 
 
 def _acq_contour_levels(acq_map: np.ndarray, n_levels: int = 30) -> np.ndarray:
@@ -114,13 +378,18 @@ class SingleObjectiveOptimizer:
 
     def fit(self, X: np.ndarray, y: np.ndarray, bounds: List[Tuple[float, float]],
             model_config: Dict[str, str], feature_names: List[str] = None,
-            fixed_noise_std: Optional[float] = None):
-        """Fits the SingleTaskGP.
+            fixed_noise_std: Optional[float] = None,
+            cat_dims: Optional[List[int]] = None,
+            dkl_config: Optional[Dict[str, int]] = None):
+        """Fits the surrogate selected by ``model_config['surrogate']``.
 
-        If ``fixed_noise_std`` is provided, uses a FixedNoiseGaussianLikelihood
-        (via ``train_Yvar``) with noise variance = fixed_noise_std**2 applied
-        uniformly to all training points. In this case the ``noise`` entry in
-        ``model_config`` is ignored.
+        Default surrogate is ``"single_task"`` (vanilla SingleTaskGP). ``"mixed"``
+        uses MixedSingleTaskGP with the supplied ``cat_dims``. ``"dkl"`` uses a
+        Deep Kernel Learning GP fit with Adam over the joint MLL.
+
+        If ``fixed_noise_std`` is provided, the single_task surrogate uses a
+        FixedNoise likelihood (via ``train_Yvar``); other surrogates ignore it
+        with a warning.
         """
         self.X_train = torch.tensor(X, dtype=torch.double, device=self.device)
         self.y_train = torch.tensor(y, dtype=torch.double, device=self.device)
@@ -130,32 +399,20 @@ class SingleObjectiveOptimizer:
         self.bounds = torch.tensor(bounds, dtype=torch.double, device=self.device).T
         self.feature_names = feature_names or [f"x{i}" for i in range(self.input_dim)]
 
-        kernel_choice = model_config.get("kernel", "matern_2.5")
-        noise_choice = model_config.get("noise", "min_noise_low")
-        input_transform_choice = model_config.get("input_transform", "none")
-
-        covar = build_covar_module(kernel_choice, self.input_dim)
-        input_transform = build_input_transform(input_transform_choice, self.input_dim)
-
-        gp_kwargs = dict(
-            covar_module=covar,
-            input_transform=input_transform,
-            outcome_transform=Standardize(m=1),
+        spec = build_surrogate(
+            key=model_config.get("surrogate", "single_task"),
+            input_dim=self.input_dim,
+            kernel=model_config.get("kernel", "matern_2.5"),
+            noise=model_config.get("noise", "min_noise_low"),
+            input_transform=model_config.get("input_transform", "none"),
+            fixed_noise_std=fixed_noise_std,
+            cat_dims=cat_dims,
+            dkl_config=dkl_config,
         )
-        if fixed_noise_std is not None:
-            # train_Yvar activates the fixed-noise path internally; do NOT pass
-            # a likelihood alongside it.
-            gp_kwargs["train_Yvar"] = torch.full_like(
-                self.y_train, float(fixed_noise_std) ** 2
-            )
-        else:
-            gp_kwargs["likelihood"] = build_likelihood(noise_choice)
-
-        self.model = SingleTaskGP(self.X_train, self.y_train, **gp_kwargs)
-
+        self.model = spec.model_factory(self.X_train, self.y_train)
+        spec.fit_fn(self.model)
         self.mll = ExactMarginalLogLikelihood(self.model.likelihood, self.model)
-        fit_gpytorch_mll(self.mll)
-        
+
         # Clear stale acquisition function from previous fit
         self.acq_func = None
         self.acq_strategy_name = None
@@ -866,36 +1123,37 @@ class MultiObjectiveOptimizer:
 
     def fit(self, X: np.ndarray, y: np.ndarray, bounds: List[Tuple[float, float]],
             model_config: Dict[str, str], feature_names: List[str] = None,
-            fixed_noise_std: Optional[float] = None):
+            fixed_noise_std: Optional[float] = None,
+            cat_dims: Optional[List[int]] = None,
+            dkl_config: Optional[Dict[str, int]] = None):
+        """Fits independent surrogates per objective and wraps them in a
+        ModelListGP. Same surrogate kind is used for every objective.
+        """
         self.X_train = torch.tensor(X, dtype=torch.double, device=self.device)
         self.y_train = torch.tensor(y, dtype=torch.double, device=self.device)
         self.input_dim = self.X_train.shape[-1]
         self.output_dim = self.y_train.shape[-1]
         self.bounds = torch.tensor(bounds, dtype=torch.double, device=self.device).T
         self.feature_names = feature_names or [f"x{i}" for i in range(self.input_dim)]
-        # Independent GPs
-        models = []
-        for i in range(self.output_dim):
-            kernel_choice = model_config.get("kernel", "matern_2.5")
-            noise_choice = model_config.get("noise", "min_noise_low")
-            input_transform_choice = model_config.get("input_transform", "none")
 
-            y_i = self.y_train[:, i : i + 1]
-            gp_kwargs = dict(
-                covar_module=build_covar_module(kernel_choice, self.input_dim),
-                input_transform=build_input_transform(input_transform_choice, self.input_dim),
-                outcome_transform=Standardize(m=1),
-            )
-            if fixed_noise_std is not None:
-                gp_kwargs["train_Yvar"] = torch.full_like(y_i, float(fixed_noise_std) ** 2)
-            else:
-                gp_kwargs["likelihood"] = build_likelihood(noise_choice)
-
-            models.append(SingleTaskGP(self.X_train, y_i, **gp_kwargs))
+        spec = build_surrogate(
+            key=model_config.get("surrogate", "single_task"),
+            input_dim=self.input_dim,
+            kernel=model_config.get("kernel", "matern_2.5"),
+            noise=model_config.get("noise", "min_noise_low"),
+            input_transform=model_config.get("input_transform", "none"),
+            fixed_noise_std=fixed_noise_std,
+            cat_dims=cat_dims,
+            dkl_config=dkl_config,
+        )
+        models = [
+            spec.model_factory(self.X_train, self.y_train[:, i : i + 1])
+            for i in range(self.output_dim)
+        ]
         self.model = ModelListGP(*models)
+        spec.fit_fn(self.model)
         self.mll = SumMarginalLogLikelihood(self.model.likelihood, self.model)
-        fit_gpytorch_mll(self.mll)
-        
+
         # Clear stale acquisition function from previous fit
         self.acq_func = None
         self.acq_strategy_name = None


### PR DESCRIPTION
## Summary

Extends the BO surrogate menu beyond vanilla GP and fixes a related visual-inspection LLM bug surfaced by live tracing.

- **MENU 5 (SURROGATE)** added to BO config prompts. Three options: \`single_task\` (default, current behavior), \`mixed\` (\`MixedSingleTaskGP\` for problems with categorical inputs), \`dkl\` (Deep Kernel Learning GP for high-dim non-stationary problems with sufficient data). Same surrogate kind is used for every objective in MOO.
- **Categorical input pipeline**: scalarizer prompt declares \`input_types\` per input; planner schema accepts \`parameter_type: \"continuous\" | \"categorical\"\` with \`levels\`. Orchestrator integer-encodes categoricals into \`optimization_data_encoded.csv\`, computes \`cat_dims\`, and decodes recommendations back to level names. Backward-compat: missing \`parameter_type\` defaults to continuous; missing \`input_types\` defaults to all-continuous.
- **Conflict resolution** (planner ↔ scalarizer): scalarizer wins on type (it sees the actual data), planner wins on level universe (so BO can recommend unobserved levels). Loud error on data values that don't match the planner's declared level set.
- **Visual inspection fix**: the inspection LLM was echoing the running config back as a \"suggested adjustment\" because it had no anchor for what was currently active. Now injects a \`CURRENT STRATEGY\` listing into the prompt at call time. No instruction/rule needed in the prompt template — the listing alone is sufficient context.
- **Drive-by**: \`bo_agent\` data load now copies X/y arrays defensively before in-place negation for minimization targets — pre-existing pandas-2.x read-only-view bug surfaced by the live tests.

## Architecture choices worth flagging

- **No \`BaseChatOrchestrator\` refactor.** Per CLAUDE.md, the three orchestrators stay duplicated until the duplication actually hurts.
- **Surrogate factory** in \`bo_tools\` returns \`(model_factory, fit_fn, capabilities)\` rather than a finished model. MOO calls \`model_factory(X, y)\` once per output column and wraps in \`ModelListGP\`; same \`fit_fn\` handles either a single GP or a \`ModelListGP\`.
- **DKL fits via Adam loop** (joint NN + GP MLL with early stopping), not \`fit_gpytorch_mll\`. Capability map encodes which surrogates support \`fixed_noise_std\`, \`warp\`, \`thompson\` — no auto-downgrade for prompt rule violations; LLM is expected to obey MENU 5.
- **Encoded data path is separate** (\`optimization_data_encoded.csv\`) — original \`optimization_data.csv\` is untouched.

## Files

| File | Change |
|---|---|
| \`scilink/tools/bo_tools.py\` | Surrogate factory, \`DKLSingleTaskGP\`, \`MixedSingleTaskGP\` wiring (SOO + MOO) |
| \`scilink/agents/planning_agents/bo_agent.py\` | \`cat_dims\`/\`dkl_config\` plumbing; validator extension; defensive \`.copy()\` on data load; current-config injection into inspection prompt |
| \`scilink/agents/planning_agents/instruct.py\` | MENU 5 in BO config prompts; \`input_types\` in scalarizer; categorical schema in planner |
| \`scilink/agents/planning_agents/orchestrator_tools.py\` | Type-aware encoding, level\_maps, decode helper, conflict resolution |
| \`scilink/agents/planning_agents/planning_orchestrator.py\` | \`expected_input_types\` / \`expected_input_levels\` state + checkpoint |

## Test plan

- [x] \`bo_tools\` factory smoke: \`single_task\` SOO/MOO, \`mixed\` SOO/MOO, \`dkl\` SOO — all fit/recommend cleanly
- [x] Live LLM regression (claude-opus-4-6): \`bo_agent_returns_valid_structure\`, \`bo_agent_batch_mode\`, \`llm_exploits_on_final_budget\`, \`llm_avoids_exploration_on_low_budget\`
- [x] Live LLM stress (claude-opus-4-6): MOO+mixed picks \`mixed\` + \`pareto\`; high-dim 8D/n=80 picks \`dkl\` quoting the gate rules; small-data 5D/n=10 avoids \`dkl\`; multi-step convergence on mixed; large-batch + cat correctly substitutes \`ucb\` for incompatible \`thompson\`
- [x] Planner→BO transfer: continuous-only, mixed (continuous + categorical), backward-compat (no \`parameter_type\`), scalarizer-only categorical, conflict (scalarizer continuous beats planner categorical), matched data + planner levels, mismatched data triggers loud error
- [x] Visual inspection regression: on the user's reported trace pattern (9 sparse 2D points with one outlier), inspection no longer echoes active kernel — status changed from \`fail\` with \`{kernel: matern_2.5}\` to \`pass\` with no suggestion