### PR TITLE
Add VASP wizard symmetric to LAMMPS + simulate-mode fixes

### DIFF
--- a/scilink/hpc/connection.py
+++ b/scilink/hpc/connection.py
@@ -73,6 +73,7 @@ class HPCConnection:
             )
             client.connect(**kw)
             self._client = client
+            self._enable_keepalive()
             return
     
         # Resolve all IPs and try each with a short per-IP timeout
@@ -109,6 +110,7 @@ class HPCConnection:
                 kw["timeout"] = 30
                 client.connect(**kw)
                 self._client = client
+                self._enable_keepalive()
                 return
             except Exception as exc:
                 last_err = exc
@@ -125,6 +127,20 @@ class HPCConnection:
             f"All IPs for {self.profile.hostname} failed. "
             f"Tried: {unique_ips}. Last error: {last_err}"
         )
+
+    def _enable_keepalive(self, interval: int = 30) -> None:
+        """Send an SSH keepalive every `interval` seconds so idle transports
+        don't get silently dropped by the server / firewall / NAT.
+
+        Without this, a transport can sit idle long enough that the remote
+        forgets the session; the next exec_command opens a channel that
+        never receives an exit status, and recv_exit_status blocks forever.
+        """
+        if self._client is None:
+            return
+        transport = self._client.get_transport()
+        if transport is not None:
+            transport.set_keepalive(interval)
 
     def disconnect(self) -> None:
         with self._lock:
@@ -156,7 +172,17 @@ class HPCConnection:
             raise ConnectionError("SSH session is not active")
         with self._lock:
             _, out, err = self._client.exec_command(cmd, timeout=timeout)
-            rc = out.channel.recv_exit_status()
+            channel = out.channel
+            # status_event.wait honors the timeout; recv_exit_status doesn't.
+            if not channel.status_event.wait(timeout):
+                try:
+                    channel.close()
+                except Exception:
+                    pass
+                raise TimeoutError(
+                    f"Command timed out after {timeout}s: {cmd!r}"
+                )
+            rc = channel.recv_exit_status()
             return (
                 out.read().decode(errors="replace"),
                 err.read().decode(errors="replace"),

--- a/scilink/hpc/probe.py
+++ b/scilink/hpc/probe.py
@@ -15,6 +15,8 @@ class HPCEnvironment:
     scratch: str = ""                         # $SCRATCH, $WORK, etc.
     lammps_binaries: list[str] = field(default_factory=list)
     lammps_modules: list[str] = field(default_factory=list)
+    vasp_binaries: list[str] = field(default_factory=list)
+    vasp_modules: list[str] = field(default_factory=list)
     container_runtimes: list[str] = field(default_factory=list)  # podman, singularity, …
     python_path: str = ""
     scheduler_name: str = ""
@@ -65,6 +67,34 @@ def probe_remote(conn: HPCConnection) -> HPCEnvironment:
             cleaned = tok.strip("()/")
             if "lammps" in cleaned.lower() and cleaned not in env.lammps_modules:
                 env.lammps_modules.append(cleaned)
+
+    # ── VASP binaries ─────────────────────────────────────
+    candidates = [
+        "vasp", "vasp_std", "vasp_gam", "vasp_ncl", "vasp_gpu",
+    ]
+    out, _, _ = conn.run(
+        " ; ".join(f'command -v {c} 2>/dev/null && echo "FOUND:{c}"' for c in candidates),
+        timeout=10,
+    )
+    for line in out.splitlines():
+        if line.startswith("FOUND:"):
+            env.vasp_binaries.append(line.split(":", 1)[1])
+
+    # ── VASP modules ──────────────────────────────────────
+    _, err, _ = conn.run(
+        'module avail vasp 2>&1 | grep -i vasp || true',
+        timeout=10,
+    )
+    out_combined = err
+    out2, _, _ = conn.run(
+        'module avail vasp 2>&1 | grep -i vasp || true',
+        timeout=10,
+    )
+    for text in (out_combined, out2):
+        for tok in text.split():
+            cleaned = tok.strip("()/")
+            if "vasp" in cleaned.lower() and cleaned not in env.vasp_modules:
+                env.vasp_modules.append(cleaned)
 
     # ── Container runtimes ────────────────────────────────
     for rt in ("podman", "docker", "singularity", "apptainer"):

--- a/scilink/hpc/probe.py
+++ b/scilink/hpc/probe.py
@@ -1,0 +1,80 @@
+"""Probe a remote HPC system for available tools and paths."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from scilink.hpc.connection import HPCConnection
+
+
+@dataclass
+class HPCEnvironment:
+    """Cached snapshot of what's available on the remote system."""
+    home: str = ""
+    scratch: str = ""                         # $SCRATCH, $WORK, etc.
+    lammps_binaries: list[str] = field(default_factory=list)
+    lammps_modules: list[str] = field(default_factory=list)
+    container_runtimes: list[str] = field(default_factory=list)  # podman, singularity, …
+    python_path: str = ""
+    scheduler_name: str = ""
+
+
+def probe_remote(conn: HPCConnection) -> HPCEnvironment:
+    """Probe the remote host for available tools. ~5 SSH round-trips."""
+    env = HPCEnvironment()
+
+    # ── Home + scratch ────────────────────────────────────
+    out, _, _ = conn.run(
+        'echo "$HOME"; '
+        'echo "${SCRATCH:-${WORK:-${CENTER_SCRATCH:-__none__}}}"',
+        timeout=10,
+    )
+    lines = out.strip().splitlines()
+    env.home = lines[0].strip() if lines else ""
+    if len(lines) > 1 and lines[1].strip() != "__none__":
+        env.scratch = lines[1].strip()
+
+    # ── LAMMPS binaries ───────────────────────────────────
+    candidates = [
+        "lmp", "lmp_mpi", "lmp_serial", "lmp_omp",
+        "lmp_gpu", "lmp_kokkos", "lmp_rocky9",
+    ]
+    out, _, _ = conn.run(
+        " ; ".join(f'command -v {c} 2>/dev/null && echo "FOUND:{c}"' for c in candidates),
+        timeout=10,
+    )
+    for line in out.splitlines():
+        if line.startswith("FOUND:"):
+            env.lammps_binaries.append(line.split(":", 1)[1])
+
+    # ── LAMMPS modules ────────────────────────────────────
+    # module avail output goes to stderr on most systems
+    _, err, _ = conn.run(
+        'module avail lammps 2>&1 | grep -i lammps || true',
+        timeout=10,
+    )
+    out_combined = err  # module avail writes to stderr
+    # Also try stdout
+    out2, _, _ = conn.run(
+        'module avail lammps 2>&1 | grep -i lammps || true',
+        timeout=10,
+    )
+    for text in (out_combined, out2):
+        for tok in text.split():
+            cleaned = tok.strip("()/")
+            if "lammps" in cleaned.lower() and cleaned not in env.lammps_modules:
+                env.lammps_modules.append(cleaned)
+
+    # ── Container runtimes ────────────────────────────────
+    for rt in ("podman", "docker", "singularity", "apptainer"):
+        _, _, rc = conn.run(f"command -v {rt}", timeout=5)
+        if rc == 0:
+            env.container_runtimes.append(rt)
+
+    # ── Python ────────────────────────────────────────────
+    out, _, rc = conn.run("command -v python3 || command -v python", timeout=5)
+    if rc == 0:
+        env.python_path = out.strip().splitlines()[0]
+
+    return env

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -418,7 +418,7 @@ if not st.session_state.agent_initialized:
             "LLM-powered agents for scientific research automation</p>",
             unsafe_allow_html=True,
         )
-        # ── Simulate mode: direct launch ─────────────────
+        # ── Simulate mode: pre-session connection status ─────────
         if st.session_state.app_mode == "simulate":
             st.markdown(
                 '<p style="text-align:center;color:#6B7A8C;font-size:0.95em;'
@@ -428,7 +428,6 @@ if not st.session_state.agent_initialized:
                 '</p>',
                 unsafe_allow_html=True,
             )
-            # Show connection status as a visual cue
             _conn = st.session_state.get("hpc_connection")
             if _conn and _conn.is_connected:
                 st.markdown(
@@ -440,33 +439,11 @@ if not st.session_state.agent_initialized:
                 st.markdown(
                     '<p style="text-align:center;color:#6B7A8C;font-size:0.85em;'
                     'margin-bottom:16px">'
-                    '🔴 No HPC connection — you can connect via the sidebar, '
-                    'or work offline.'
+                    '🔴 No HPC connection — connect via the sidebar before '
+                    'starting, or work offline.'
                     '</p>',
                     unsafe_allow_html=True,
                 )
-            _, _lc, _ = st.columns([1, 1, 1])
-            with _lc:
-                # Reuse the sidebar's start logic
-                if st.button(
-                    "🖥️ Launch Simulations",
-                    type="primary",
-                    use_container_width=True,
-                    key="launch_simulate",
-                ):
-                    from scilink.ui.components.sidebar import _start_simulate_session
-                    _sim_preset = st.session_state.get("cfg_model_preset", "")
-                    _sim_model = (
-                        st.session_state.get("cfg_model_custom", "")
-                        if _sim_preset == "Custom" else _sim_preset
-                    )
-                    _start_simulate_session(
-                        model=_sim_model,
-                        api_key=st.session_state.get("cfg_api_key", ""),
-                        base_url=st.session_state.get("cfg_base_url", ""),
-                        mode=st.session_state.get("cfg_mode", "co-pilot"),
-                        fh_api_key=st.session_state.get("cfg_fh_api_key", ""),
-                    )
             st.stop()
     st.stop()
 

--- a/scilink/ui/components/engines.py
+++ b/scilink/ui/components/engines.py
@@ -1,0 +1,63 @@
+"""Engine registry for the Generate tab in the simulations UI.
+
+Each entry maps to a Streamlit-rendering callback that owns its own
+configure -> review -> submit workflow inside the Generate tab. The list
+is hardcoded today; a future capability-inventory agent (see CLAUDE.md,
+"the meta agent" section) will populate it from declared software +
+introspected agents/skills/tools, replacing the static list without
+changing the consumer (`simulations.py`).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Callable, List, Tuple
+
+
+@dataclass(frozen=True)
+class Engine:
+    """An engine the Generate tab can drive.
+
+    `render_workflow` is a no-arg Streamlit-rendering callback that owns
+    the Generate-tab content for this engine, typically a state machine
+    over configure -> review -> monitoring -> results phases.
+    """
+    key: str
+    label: str
+    icon: str
+    render_workflow: Callable[[], None]
+
+
+@lru_cache(maxsize=1)
+def _engines() -> Tuple[Engine, ...]:
+    # Imports are local to dodge any future circulars (sim_workflow /
+    # vasp_workflow have no dependency on this module today).
+    from scilink.ui.components import sim_workflow, vasp_workflow
+
+    return (
+        Engine(
+            key="lammps",
+            label="LAMMPS",
+            icon="🧪",
+            render_workflow=sim_workflow.render_agent_workflow,
+        ),
+        Engine(
+            key="vasp",
+            label="VASP",
+            icon="⚛️",
+            render_workflow=vasp_workflow.render_agent_workflow,
+        ),
+    )
+
+
+def get_engines() -> List[Engine]:
+    """Registered engines in display order."""
+    return list(_engines())
+
+
+def get_engine(key: str) -> Engine:
+    """Look up by key. Raises KeyError if not registered."""
+    for e in _engines():
+        if e.key == key:
+            return e
+    raise KeyError(f"Unknown engine: {key!r}")

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -547,6 +547,11 @@ def start_session(model: str, api_key: str, base_url: str, mode: str, fh_api_key
         scilink.set_api_key('materials_project', mp_api_key)
 
     app_mode = st.session_state.app_mode or "analyze"
+
+    if app_mode == "simulate":
+        _start_simulate_session(model, api_key, base_url, mode, fh_api_key)
+        return
+
     prefix = SESSION_DIR_PREFIXES.get(app_mode, "session")
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     session_dir = Path(f"{prefix}_{ts}").resolve()

--- a/scilink/ui/components/sim_workflow.py
+++ b/scilink/ui/components/sim_workflow.py
@@ -1017,7 +1017,7 @@ def _render_review_scripts() -> None:
                         conn, slurm_script,
                         f"{remote_dir}/submit.sh",
                     )
-                    conn.run(f"chmod +x {_q(remote_dir + '/submit.sh')}")
+                    conn.run(f"chmod +x {_q(remote_dir + '/submit.sh')}", timeout=30)
 
                     # Submit
                     job_id = sched.submit(f"{remote_dir}/submit.sh", work_dir=remote_dir)

--- a/scilink/ui/components/sim_workflow.py
+++ b/scilink/ui/components/sim_workflow.py
@@ -12,6 +12,11 @@ from typing import Any, Dict, List, Optional, Set
 
 import streamlit as st
 
+from scilink.ui.components.wizard_state import (
+    apply_lammps_defaults,
+    save_lammps,
+)
+
 
 # ══════════════════════════════════════════════════════════════
 # Script templates
@@ -534,6 +539,10 @@ def _show_path_mapping(
         st.warning("Add a volume mount that covers the unmapped paths.")
 
 def _render_configure() -> None:
+    # Pre-fill infrastructure fields from the last successful Prepare Scripts
+    # before any widget is created.
+    apply_lammps_defaults()
+
     st.subheader("🧪 LAMMPS Simulation")
 
     cfg = st.session_state.get("agent_config", {})
@@ -890,6 +899,7 @@ def _render_configure() -> None:
         disabled=not can_proceed,
         key="hpc_prepare_btn",
     ):
+        save_lammps()
         # ── Build path mapping for container mode ─────────
         data_exec_path = remote_data_path  # direct mode: same path
         work_exec_path = remote_work_dir

--- a/scilink/ui/components/sim_workflow.py
+++ b/scilink/ui/components/sim_workflow.py
@@ -1179,8 +1179,9 @@ def _render_monitoring() -> None:
         with t_files:
             _render_remote_output_files(_conn, _job)
 
-        # ── Transition to results when terminal ───────────
-        if _job.status.is_terminal and not old_status.is_terminal:
+        # Rerun the parent on any status change so the connection-bar
+        # job counts (rendered outside this fragment) stay fresh.
+        if _job.status != old_status:
             st.rerun(scope="app")
 
     _monitor_fragment()

--- a/scilink/ui/components/simulations.py
+++ b/scilink/ui/components/simulations.py
@@ -24,7 +24,7 @@ from scilink.hpc.scheduler import (
     detect_scheduler,
 )
 
-from scilink.ui.components.sim_workflow import render_agent_workflow
+from scilink.ui.components.engines import get_engine, get_engines
 
 import logging
 
@@ -134,7 +134,7 @@ def render_simulations_tab() -> None:
         submit = monitor = terminal = files = None
 
     with gen:
-        render_agent_workflow()
+        _render_engine_selector_and_dispatch()
 
     with dash:
         if has_hpc:
@@ -160,6 +160,52 @@ def render_simulations_tab() -> None:
     if files is not None:
         with files:
             _render_remote_files()
+
+# ── Engine selector ───────────────────────────────────────────
+
+# Phase / artifact keys cleared when the user switches engines, to avoid
+# bleeding LAMMPS state into a VASP run (and vice versa).
+_PHASE_KEYS_TO_CLEAR_ON_ENGINE_CHANGE = (
+    "hpc_workflow_phase",
+    "hpc_gen_run_script",
+    "hpc_gen_slurm_script",
+    "hpc_gen_remote_work_dir",
+    "hpc_gen_job_name",
+    "hpc_gen_vasp_files",
+)
+
+
+def _render_engine_selector_and_dispatch() -> None:
+    engines = get_engines()
+    if not engines:
+        st.error("No simulation engines registered.")
+        return
+
+    keys = [e.key for e in engines]
+    current = st.session_state.get("hpc_engine", keys[0])
+    if current not in keys:
+        current = keys[0]
+
+    sel_col, _ = st.columns([1, 4])
+    with sel_col:
+        chosen = st.selectbox(
+            "Engine",
+            keys,
+            index=keys.index(current),
+            format_func=lambda k: f"{get_engine(k).icon} {get_engine(k).label}",
+            key="hpc_engine_select",
+        )
+
+    if chosen != current:
+        for k in _PHASE_KEYS_TO_CLEAR_ON_ENGINE_CHANGE:
+            st.session_state.pop(k, None)
+        st.session_state.hpc_engine = chosen
+        st.rerun()
+    else:
+        st.session_state.hpc_engine = chosen
+
+    get_engine(chosen).render_workflow()
+
 
 # ── Connection bar ────────────────────────────────────────────
 

--- a/scilink/ui/components/simulations.py
+++ b/scilink/ui/components/simulations.py
@@ -550,8 +550,9 @@ def _render_monitor() -> None:
                 if v:
                     st.text(f"{k:>14}: {v}")
 
-        # Trigger full rerun when job transitions to terminal
-        if fresh.status.is_terminal and not old_status.is_terminal:
+        # Rerun the parent on any status change so the connection-bar
+        # job counts (rendered outside this fragment) stay fresh.
+        if fresh.status != old_status:
             st.rerun(scope="app")
 
     _live_output()

--- a/scilink/ui/components/vasp_workflow.py
+++ b/scilink/ui/components/vasp_workflow.py
@@ -1,0 +1,564 @@
+"""VASP DFT wizard — Configure -> Review -> Submit -> Monitor.
+
+Symmetric to the LAMMPS wizard in `sim_workflow.py`, but drives
+`SimulationOrchestratorAgent.run_task()` to generate VASP inputs
+(POSCAR, INCAR, KPOINTS) instead of building a self-contained run
+script around `LAMMPSOrchestrator`. Submission, monitoring, and results
+phases reuse the engine-agnostic implementations from `sim_workflow.py`.
+"""
+from __future__ import annotations
+
+import os
+import textwrap
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import streamlit as st
+
+from scilink.ui.components.sim_workflow import (
+    _render_monitoring,
+    _render_results,
+    _upload_text,
+    _q,
+)
+
+
+# ══════════════════════════════════════════════════════════════
+# SLURM template
+# ══════════════════════════════════════════════════════════════
+
+def _build_slurm_script(
+    *,
+    job_name: str,
+    account: str,
+    partition: str,
+    time_limit: str,
+    nodes: int,
+    ntasks_per_node: int,
+    extra_sbatch: str,
+    work_dir: str,
+    module_commands: str,
+    pseudo_dir: str,
+    elements: List[str],
+    vasp_command: str,
+) -> str:
+    """Construct the SLURM script: SBATCH directives, module loads,
+    POTCAR assembly from `pseudo_dir`, then `vasp_command`."""
+    sbatch_lines = [
+        "#!/bin/bash",
+        f"#SBATCH --job-name={job_name}",
+        f"#SBATCH --time={time_limit}",
+        f"#SBATCH --nodes={int(nodes)}",
+        f"#SBATCH --ntasks-per-node={int(ntasks_per_node)}",
+        f"#SBATCH --output={job_name}_%j.out",
+        f"#SBATCH --error={job_name}_%j.err",
+    ]
+    if account.strip():
+        sbatch_lines.append(f"#SBATCH --account={account.strip()}")
+    if partition.strip():
+        sbatch_lines.append(f"#SBATCH --partition={partition.strip()}")
+    for line in (extra_sbatch or "").splitlines():
+        line = line.strip()
+        if line:
+            sbatch_lines.append(f"#SBATCH {line}")
+
+    elements_arr = " ".join(_q(e) for e in elements) if elements else ""
+
+    body = textwrap.dedent(f"""\
+
+        set -e
+        cd {_q(work_dir)}
+
+        # ---- Module environment ----
+        {module_commands.strip() or "# (no modules specified)"}
+
+        # ---- Assemble POTCAR from pseudo dir ----
+        PSEUDO_DIR={_q(pseudo_dir)}
+        ELEMENTS=({elements_arr})
+        if [ ${{#ELEMENTS[@]}} -eq 0 ]; then
+            echo "No elements parsed from POSCAR; aborting." >&2
+            exit 1
+        fi
+        : > POTCAR
+        for e in "${{ELEMENTS[@]}}"; do
+            if [ ! -f "$PSEUDO_DIR/$e/POTCAR" ]; then
+                echo "Missing POTCAR for element $e at $PSEUDO_DIR/$e/POTCAR" >&2
+                exit 1
+            fi
+            cat "$PSEUDO_DIR/$e/POTCAR" >> POTCAR
+        done
+
+        # ---- Run VASP ----
+        {vasp_command}
+    """)
+
+    return "\n".join(sbatch_lines) + body
+
+
+def _elements_from_poscar(poscar_text: str) -> List[str]:
+    """Parse the element symbols from a VASP-5+ POSCAR (line 6)."""
+    lines = poscar_text.splitlines()
+    if len(lines) < 6:
+        return []
+    return lines[5].split()
+
+
+# ══════════════════════════════════════════════════════════════
+# Workflow state machine
+# ══════════════════════════════════════════════════════════════
+
+def render_agent_workflow() -> None:
+    """Main entry point — dispatches to the current workflow phase."""
+    phase = st.session_state.get("hpc_workflow_phase", "configure")
+
+    if phase == "configure":
+        _render_configure()
+    elif phase == "review":
+        _render_review_inputs()
+    elif phase == "monitoring":
+        _render_monitoring()
+    elif phase == "results":
+        _render_results()
+    else:
+        st.session_state.hpc_workflow_phase = "configure"
+        st.rerun()
+
+
+# ══════════════════════════════════════════════════════════════
+# Phase 1: Configure
+# ══════════════════════════════════════════════════════════════
+
+def _render_configure() -> None:
+    st.subheader("⚛️ VASP DFT Simulation")
+
+    cfg = st.session_state.get("agent_config", {})
+    _model = cfg.get("model", "")
+    _has_key = bool(
+        cfg.get("api_key")
+        or os.environ.get("SCILINK_API_KEY")
+        or os.environ.get("OPENAI_API_KEY")
+        or os.environ.get("ANTHROPIC_API_KEY")
+        or os.environ.get("GOOGLE_API_KEY")
+    )
+    conn = st.session_state.get("hpc_connection")
+    has_hpc = conn is not None and conn.is_connected
+
+    if not _has_key:
+        st.warning(
+            "No LLM API key detected. Launch a simulate session from the "
+            "sidebar with a key set, or export SCILINK_API_KEY before starting."
+        )
+
+    # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    # Scientific objective
+    # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    st.markdown("**Scientific objective**")
+    structure_description = st.text_area(
+        "Structure description",
+        height=80,
+        key="vasp_structure_description",
+        placeholder="e.g. rutile TiO2, 2x2x2 supercell with one oxygen vacancy",
+    )
+    research_goal = st.text_area(
+        "Research goal",
+        height=100,
+        key="vasp_research_goal",
+        placeholder="e.g. Compute the band structure with HSE06 and the GGA+U formation energy of the oxygen vacancy.",
+    )
+
+    # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    # INCAR generation
+    # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    st.markdown("---")
+    st.markdown("**INCAR generation**")
+    incar_method = st.selectbox(
+        "Method",
+        ["llm", "atomate2"],
+        key="vasp_incar_method",
+        help="`llm` uses the orchestrator's LLM-driven INCAR builder; `atomate2` uses atomate2 templates when applicable.",
+    )
+    with st.expander("Advanced (optional)"):
+        futurehouse_key = st.text_input(
+            "FutureHouse API key (for INCAR validation)",
+            type="password",
+            key="vasp_fh_key",
+            help="When set, the agent will validate the generated INCAR against literature and apply suggested fixes.",
+        )
+        incar_overrides = st.text_area(
+            "Manual INCAR additions / overrides",
+            height=80,
+            key="vasp_incar_overrides",
+            placeholder="ENCUT = 520\nISMEAR = 0\nSIGMA = 0.05",
+            help="Free-text INCAR snippets to fold into the agent's request. Leave blank to let the agent decide.",
+        )
+
+    # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    # HPC environment
+    # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    st.markdown("---")
+    st.markdown("**HPC environment**")
+    if not has_hpc:
+        st.info(
+            "No HPC connection. You can still generate inputs; submission "
+            "will be unavailable until you connect via the sidebar."
+        )
+    vasp_command = st.text_input(
+        "VASP command",
+        value="mpirun vasp_std",
+        key="vasp_command",
+        help="The exact command that runs VASP after POTCAR is assembled.",
+    )
+    module_commands = st.text_area(
+        "Module setup",
+        height=80,
+        key="vasp_module_commands",
+        placeholder="module purge\nmodule load vasp/6.4.2 intel-mpi/2021",
+    )
+    pseudo_dir = st.text_input(
+        "PSEUDO_DIR (remote)",
+        key="vasp_pseudo_dir",
+        placeholder="/path/to/potpaw_PBE.54",
+        help="Remote directory containing element subdirs (e.g. Si/POTCAR, O/POTCAR). The submit script `cat`s these to build POTCAR.",
+    )
+
+    # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    # Remote layout
+    # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    st.markdown("---")
+    remote_work_dir = st.text_input(
+        "Remote working directory",
+        key="vasp_remote_work_dir",
+        placeholder="/scratch/$USER/scilink/vasp_runs",
+        help="Base directory; a per-job subdirectory will be created at submit time.",
+    )
+
+    # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    # SLURM
+    # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    st.markdown("---")
+    st.markdown("**SLURM settings**")
+    sc1, sc2, sc3 = st.columns(3)
+    with sc1:
+        account = st.text_input("Account (-A)", key="vasp_slurm_account")
+        time_limit = st.text_input(
+            "Time limit (-t)", value="04:00:00", key="vasp_slurm_time"
+        )
+    with sc2:
+        nodes = st.number_input(
+            "Nodes (-N)", value=1, min_value=1, key="vasp_slurm_nodes"
+        )
+        ntasks = st.number_input(
+            "Tasks/node", value=16, min_value=1, key="vasp_slurm_ntasks"
+        )
+    with sc3:
+        job_name = st.text_input(
+            "Job name (-J)", value="scilink_vasp", key="vasp_slurm_jname"
+        )
+        partition = st.text_input(
+            "Partition (-p, optional)", key="vasp_slurm_partition"
+        )
+    extra_sbatch = st.text_area(
+        "Extra SBATCH directives (one per line, without `#SBATCH`)",
+        key="vasp_extra_sbatch",
+        height=60,
+        placeholder="--exclusive\n--mem=0",
+    )
+
+    # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    # Generate
+    # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    st.markdown("---")
+    can_proceed = bool(
+        structure_description.strip()
+        and research_goal.strip()
+        and remote_work_dir.strip()
+        and pseudo_dir.strip()
+        and _has_key
+    )
+    if not can_proceed:
+        missing: list[str] = []
+        if not structure_description.strip():
+            missing.append("structure description")
+        if not research_goal.strip():
+            missing.append("research goal")
+        if not pseudo_dir.strip():
+            missing.append("PSEUDO_DIR")
+        if not remote_work_dir.strip():
+            missing.append("remote working directory")
+        if not _has_key:
+            missing.append("LLM API key")
+        st.info(f"Still needed: {', '.join(missing)}")
+
+    err_slot = st.empty()
+
+    if st.button(
+        "⚛️ Generate VASP inputs",
+        type="primary",
+        disabled=not can_proceed,
+        key="vasp_generate_btn",
+    ):
+        try:
+            with st.spinner(
+                "Asking SimulationOrchestratorAgent to build POSCAR / INCAR / KPOINTS…"
+            ):
+                structure = _run_generation(
+                    structure_description=structure_description.strip(),
+                    research_goal=research_goal.strip(),
+                    incar_method=incar_method,
+                    incar_overrides=incar_overrides.strip(),
+                    futurehouse_key=futurehouse_key or None,
+                )
+        except Exception as exc:
+            err_slot.error(f"Generation failed: {exc}")
+            return
+
+        if structure is None:
+            err_slot.error(
+                "Agent returned no structure. Check the orchestrator logs for "
+                "the agent's reply (it may have asked a clarifying question)."
+            )
+            return
+
+        # Stash files + draft SLURM script in session state.
+        try:
+            poscar_text = Path(structure["poscar_path"]).read_text()
+            incar_text = Path(structure["incar_path"]).read_text()
+            kpoints_text = Path(structure["kpoints_path"]).read_text()
+        except Exception as exc:
+            err_slot.error(f"Could not read generated files: {exc}")
+            return
+
+        elements = _elements_from_poscar(poscar_text)
+        slurm_script = _build_slurm_script(
+            job_name=job_name,
+            account=account,
+            partition=partition,
+            time_limit=time_limit,
+            nodes=int(nodes),
+            ntasks_per_node=int(ntasks),
+            extra_sbatch=extra_sbatch,
+            work_dir=remote_work_dir.rstrip("/") + f"/{structure['slug']}",
+            module_commands=module_commands,
+            pseudo_dir=pseudo_dir.strip(),
+            elements=elements,
+            vasp_command=vasp_command.strip(),
+        )
+
+        st.session_state.hpc_gen_vasp_files = {
+            "POSCAR": poscar_text,
+            "INCAR": incar_text,
+            "KPOINTS": kpoints_text,
+        }
+        st.session_state.hpc_gen_slurm_script = slurm_script
+        st.session_state.hpc_gen_remote_work_dir = (
+            remote_work_dir.rstrip("/") + f"/{structure['slug']}"
+        )
+        st.session_state.hpc_gen_job_name = job_name
+        st.session_state.vasp_last_slug = structure["slug"]
+        st.session_state.hpc_workflow_phase = "review"
+        st.rerun()
+
+
+def _get_or_create_agent():
+    """Lazily build SimulationOrchestratorAgent and cache it in session state.
+
+    The simulate-mode session is otherwise "lightweight" (no agent) — see
+    `sidebar.py:_start_simulate_session`. We only spin up the agent when
+    the user actually clicks Generate, so LAMMPS-only users never pay the cost.
+    """
+    if "hpc_vasp_agent" in st.session_state and st.session_state.hpc_vasp_agent is not None:
+        agent = st.session_state.hpc_vasp_agent
+        # Refresh HPC plumbing in case the user (re)connected after agent build.
+        agent.hpc_connection = st.session_state.get("hpc_connection")
+        agent.hpc_scheduler = st.session_state.get("hpc_scheduler")
+        return agent
+
+    from scilink.agents.sim_agents.simulation_orchestrator import (
+        SimulationOrchestratorAgent,
+        SimulationMode,
+    )
+
+    cfg = st.session_state.get("agent_config", {})
+    api_key = cfg.get("api_key") or None
+    base_url = cfg.get("base_url") or None
+
+    agent = SimulationOrchestratorAgent(
+        base_dir=st.session_state.get("session_dir", "./simulate_session"),
+        api_key=api_key,
+        model_name=cfg.get("model") or "claude-opus-4-6",
+        base_url=base_url,
+        simulation_mode=SimulationMode.CO_PILOT,
+        futurehouse_api_key=st.session_state.get("vasp_fh_key") or None,
+        hpc_connection=st.session_state.get("hpc_connection"),
+        hpc_scheduler=st.session_state.get("hpc_scheduler"),
+    )
+    st.session_state.hpc_vasp_agent = agent
+    return agent
+
+
+def _run_generation(
+    *,
+    structure_description: str,
+    research_goal: str,
+    incar_method: str,
+    incar_overrides: str,
+    futurehouse_key: Optional[str],
+) -> Optional[dict]:
+    """Call agent.run_task() with a focused prompt; return the new structure
+    record (or None if the agent produced no structure)."""
+    agent = _get_or_create_agent()
+
+    overrides_block = ""
+    if incar_overrides:
+        overrides_block = (
+            "\nUser-supplied INCAR additions/overrides to fold into the request:\n"
+            f"```\n{incar_overrides}\n```\n"
+        )
+    fh_step = ""
+    if futurehouse_key:
+        fh_step = (
+            "3. Validate the generated INCAR with `validate_incar` and apply "
+            "improvements if validation flags substantive issues.\n"
+        )
+
+    task = textwrap.dedent(f"""\
+        Build VASP inputs for the following research objective.
+
+        Structure: {structure_description}
+        Research goal: {research_goal}
+        INCAR generation method: {incar_method}
+        {overrides_block}
+        Steps:
+        1. Generate the structure (use `generate_structure`).
+        2. Generate VASP inputs (use `generate_vasp_inputs` with method={incar_method!r}).
+        {fh_step}
+        Return when POSCAR, INCAR, and KPOINTS are written. Do NOT submit
+        the job — the wizard handles HPC submission separately in a later
+        step where the user reviews and edits the inputs.
+    """)
+
+    n_before = len(agent.generated_structures)
+    result = agent.run_task(task)
+
+    new = agent.generated_structures[n_before:]
+    if not new:
+        return None
+    # Use the most recent record (the call may have produced multiple if the
+    # agent decided to refine; the wizard always uses the latest).
+    candidate = new[-1]
+    if not (
+        candidate.get("poscar_path")
+        and candidate.get("incar_path")
+        and candidate.get("kpoints_path")
+    ):
+        return None
+    return candidate
+
+
+# ══════════════════════════════════════════════════════════════
+# Phase 2: Review & Submit
+# ══════════════════════════════════════════════════════════════
+
+def _render_review_inputs() -> None:
+    st.subheader("📝 Review & Submit VASP Inputs")
+    st.caption("Edit the generated files if needed, then submit to the cluster.")
+
+    remote_dir = st.session_state.get("hpc_gen_remote_work_dir", "")
+    st.info(f"**Remote working directory:** `{remote_dir}`")
+
+    files = st.session_state.get("hpc_gen_vasp_files", {})
+    poscar = files.get("POSCAR", "")
+    incar = files.get("INCAR", "")
+    kpoints = files.get("KPOINTS", "")
+    slurm = st.session_state.get("hpc_gen_slurm_script", "")
+
+    tab_poscar, tab_incar, tab_kpoints, tab_submit = st.tabs(
+        ["POSCAR", "INCAR", "KPOINTS", "submit.sh"]
+    )
+    with tab_poscar:
+        poscar_edit = st.text_area(
+            "POSCAR", value=poscar, height=350, key="vasp_edit_poscar",
+        )
+    with tab_incar:
+        incar_edit = st.text_area(
+            "INCAR", value=incar, height=350, key="vasp_edit_incar",
+        )
+    with tab_kpoints:
+        kpoints_edit = st.text_area(
+            "KPOINTS", value=kpoints, height=200, key="vasp_edit_kpoints",
+        )
+    with tab_submit:
+        slurm_edit = st.text_area(
+            "submit.sh", value=slurm, height=350, key="vasp_edit_slurm",
+        )
+
+    st.markdown("---")
+    err_slot = st.empty()
+
+    c_back, c_submit = st.columns(2)
+    with c_back:
+        if st.button(
+            "← Back to configure",
+            key="vasp_review_back",
+            use_container_width=True,
+        ):
+            st.session_state.hpc_workflow_phase = "configure"
+            st.rerun()
+
+    with c_submit:
+        if st.button(
+            "🚀 Upload & Submit",
+            type="primary",
+            key="vasp_review_submit",
+            use_container_width=True,
+        ):
+            conn = st.session_state.get("hpc_connection")
+            sched = st.session_state.get("hpc_scheduler")
+            if not conn or not conn.is_connected:
+                err_slot.error("HPC connection lost. Reconnect via sidebar.")
+                return
+            if sched is None:
+                err_slot.error("No scheduler detected on this cluster.")
+                return
+
+            try:
+                with st.spinner("Uploading inputs and submitting job…"):
+                    conn.run(f"mkdir -p {_q(remote_dir)}")
+                    _upload_text(conn, poscar_edit, f"{remote_dir}/POSCAR")
+                    _upload_text(conn, incar_edit, f"{remote_dir}/INCAR")
+                    _upload_text(conn, kpoints_edit, f"{remote_dir}/KPOINTS")
+                    _upload_text(conn, slurm_edit, f"{remote_dir}/submit.sh")
+                    conn.run(f"chmod +x {_q(remote_dir + '/submit.sh')}")
+
+                    job_id = sched.submit(
+                        f"{remote_dir}/submit.sh", work_dir=remote_dir,
+                    )
+
+                from scilink.hpc.scheduler import HPCJob, JobStatus
+
+                job_name = st.session_state.get("hpc_gen_job_name", "scilink_vasp")
+                job = HPCJob(
+                    job_id=job_id,
+                    name=job_name,
+                    status=JobStatus.PENDING,
+                    work_dir=remote_dir,
+                    script_path=f"{remote_dir}/submit.sh",
+                    stdout_file=f"{remote_dir}/{job_name}_{job_id}.out",
+                    stderr_file=f"{remote_dir}/{job_name}_{job_id}.err",
+                )
+
+                tracked = st.session_state.get("hpc_tracked_jobs", {})
+                tracked[job_id] = job
+                st.session_state.hpc_tracked_jobs = tracked
+                st.session_state.hpc_monitored_job_id = job_id
+                st.session_state.hpc_mon_known_files = set()
+                st.session_state.hpc_mon_downloaded_images = {}
+                st.session_state.hpc_workflow_phase = "monitoring"
+
+                st.success(f"✅ Submitted job **{job_id}**")
+                st.balloons()
+                st.rerun()
+
+            except Exception as exc:
+                err_slot.error(f"Submission failed: {exc}")

--- a/scilink/ui/components/vasp_workflow.py
+++ b/scilink/ui/components/vasp_workflow.py
@@ -560,12 +560,12 @@ def _render_review_inputs() -> None:
 
             try:
                 with st.spinner("Uploading inputs and submitting job…"):
-                    conn.run(f"mkdir -p {_q(remote_dir)}")
+                    conn.run(f"mkdir -p {_q(remote_dir)}", timeout=30)
                     _upload_text(conn, poscar_edit, f"{remote_dir}/POSCAR")
                     _upload_text(conn, incar_edit, f"{remote_dir}/INCAR")
                     _upload_text(conn, kpoints_edit, f"{remote_dir}/KPOINTS")
                     _upload_text(conn, slurm_edit, f"{remote_dir}/submit.sh")
-                    conn.run(f"chmod +x {_q(remote_dir + '/submit.sh')}")
+                    conn.run(f"chmod +x {_q(remote_dir + '/submit.sh')}", timeout=30)
 
                     job_id = sched.submit(
                         f"{remote_dir}/submit.sh", work_dir=remote_dir,

--- a/scilink/ui/components/vasp_workflow.py
+++ b/scilink/ui/components/vasp_workflow.py
@@ -22,6 +22,10 @@ from scilink.ui.components.sim_workflow import (
     _upload_text,
     _q,
 )
+from scilink.ui.components.wizard_state import (
+    apply_vasp_defaults,
+    save_vasp,
+)
 
 
 # ══════════════════════════════════════════════════════════════
@@ -130,6 +134,10 @@ def render_agent_workflow() -> None:
 # ══════════════════════════════════════════════════════════════
 
 def _render_configure() -> None:
+    # Pre-fill infrastructure fields from the last successful Generate
+    # before any widget is created.
+    apply_vasp_defaults()
+
     st.subheader("⚛️ VASP DFT Simulation")
 
     cfg = st.session_state.get("agent_config", {})
@@ -334,6 +342,7 @@ def _render_configure() -> None:
         disabled=not can_proceed,
         key="vasp_generate_btn",
     ):
+        save_vasp()
         try:
             with st.spinner(
                 "Asking SimulationOrchestratorAgent to build POSCAR / INCAR / KPOINTS…"

--- a/scilink/ui/components/vasp_workflow.py
+++ b/scilink/ui/components/vasp_workflow.py
@@ -150,6 +150,42 @@ def _render_configure() -> None:
             "sidebar with a key set, or export SCILINK_API_KEY before starting."
         )
 
+    if has_hpc:
+        if _model:
+            st.caption(
+                f"Model: **{_model}** · HPC: 🟢 **{conn.profile.hostname}**"
+            )
+
+        env = st.session_state.get("hpc_env_probe")
+        if env is None:
+            from scilink.hpc.probe import probe_remote
+            with st.spinner("Probing remote environment…"):
+                env = probe_remote(conn)
+            st.session_state.hpc_env_probe = env
+
+        with st.expander("🔍 Detected environment"):
+            det_c1, det_c2 = st.columns(2)
+            with det_c1:
+                st.caption(f"**Home:** `{env.home}`")
+                if env.scratch:
+                    st.caption(f"**Scratch:** `{env.scratch}`")
+                if env.vasp_binaries:
+                    st.caption(
+                        f"**VASP binaries:** "
+                        f"{', '.join(f'`{b}`' for b in env.vasp_binaries)}"
+                    )
+                else:
+                    st.caption("**VASP binaries:** none found in PATH")
+            with det_c2:
+                if env.vasp_modules:
+                    st.caption(
+                        f"**VASP modules:** "
+                        f"{', '.join(f'`{m}`' for m in env.vasp_modules)}"
+                    )
+            if st.button("🔄 Re-probe", key="vasp_reprobe"):
+                st.session_state.hpc_env_probe = None
+                st.rerun()
+
     # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
     # Scientific objective
     # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/scilink/ui/components/wizard_state.py
+++ b/scilink/ui/components/wizard_state.py
@@ -1,0 +1,116 @@
+"""Cross-restart persistence for the LAMMPS / VASP wizards' infrastructure
+fields (HPC env, SLURM settings, paths, etc.).
+
+Scientific fields (structure description, research goal) are deliberately
+not persisted -- they change per simulation. Secrets (FutureHouse key,
+LLM API key) live in the sidebar config, not in wizard state, and are
+also not saved here. The state file is a plain JSON cache; corruption,
+schema drift, or missing files all fall back to widget defaults.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+import streamlit as st
+
+
+_STATE_PATH = Path.home() / ".scilink" / "wizard_state.json"
+
+# Widget keys persisted per wizard. Anything not listed here is treated
+# as scientific / one-off / secret and intentionally not saved.
+_LAMMPS_KEYS: tuple[str, ...] = (
+    "hpc_exec_mode",
+    "hpc_module_cmds",
+    "hpc_lammps_cmd",
+    "hpc_python_cmd",
+    "hpc_container_runtime",
+    "hpc_container_image",
+    "hpc_image_tar",
+    "hpc_extra_runtime_flags",
+    "_hpc_mounts",
+    "hpc_struct_source",
+    "hpc_ff_source",
+    "hpc_work_dir",
+    "hpc_slurm_account",
+    "hpc_slurm_time",
+    "hpc_slurm_nodes",
+    "hpc_slurm_ntasks",
+    "hpc_slurm_jname",
+    "hpc_slurm_partition",
+    "hpc_extra_sbatch",
+    "hpc_api_key_env",
+    "hpc_max_attempts",
+    "hpc_stage_timeout",
+)
+
+_VASP_KEYS: tuple[str, ...] = (
+    "vasp_incar_method",
+    "vasp_command",
+    "vasp_module_commands",
+    "vasp_pseudo_dir",
+    "vasp_remote_work_dir",
+    "vasp_slurm_account",
+    "vasp_slurm_time",
+    "vasp_slurm_nodes",
+    "vasp_slurm_ntasks",
+    "vasp_slurm_jname",
+    "vasp_slurm_partition",
+    "vasp_extra_sbatch",
+)
+
+
+def _load() -> Dict[str, Dict[str, Any]]:
+    if not _STATE_PATH.exists():
+        return {}
+    try:
+        return json.loads(_STATE_PATH.read_text())
+    except Exception as exc:
+        logging.warning("Could not read %s: %s", _STATE_PATH, exc)
+        return {}
+
+
+def _save(data: Dict[str, Dict[str, Any]]) -> None:
+    try:
+        _STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _STATE_PATH.write_text(json.dumps(data, indent=2))
+    except Exception as exc:
+        logging.warning("Could not write %s: %s", _STATE_PATH, exc)
+
+
+def _apply(scope: str) -> None:
+    """Pre-fill st.session_state with saved values for `scope`. Safe to call
+    on every Configure render; only sets keys that aren't already in
+    session state, so it never clobbers a value the user has typed during
+    the current session."""
+    saved = _load().get(scope, {})
+    for key, value in saved.items():
+        if key not in st.session_state:
+            st.session_state[key] = value
+
+
+def _save_current(scope: str, keys: Iterable[str]) -> None:
+    snap = {key: st.session_state[key] for key in keys if key in st.session_state}
+    if not snap:
+        return
+    data = _load()
+    data[scope] = snap
+    _save(data)
+
+
+def apply_lammps_defaults() -> None:
+    _apply("lammps")
+
+
+def apply_vasp_defaults() -> None:
+    _apply("vasp")
+
+
+def save_lammps() -> None:
+    _save_current("lammps", _LAMMPS_KEYS)
+
+
+def save_vasp() -> None:
+    _save_current("vasp", _VASP_KEYS)


### PR DESCRIPTION
 ## Summary
  
  This is the follow-up called out in the review of the LAMMPS-only wizard PR:

  > A symmetric VASP wizard that drives `SimulationOrchestratorAgent` (#144 + #151) is a natural follow-up — out of scope here.

  While building it, real-cluster testing on a cluster surfaced several pre-existing latent bugs in the simulate-mode flow that were blocking validation. They're bundled here because each was needed to actually exercise the wizard end-to-end - without them, simulate mode doesn't work.

  ## What's in scope

  **Main feature**
  - *Adds VASP wizard symmetric to LAMMPS in the Generate tab* — engine registry split (`engines.py`); VASP wizard (`vasp_workflow.py`) drives `SimulationOrchestratorAgent.run_task` to produce POSCAR/INCAR/KPOINTS, wraps a SLURM script that assembles POTCAR from `PSEUDO_DIR` and runs the user's `vasp_command`. Reuses the engine-agnostic monitor/results/upload helpers from `sim_workflow.py`. Also lands `scilink/hpc/probe.py`, which the already-merged LAMMPS wizard imports lazily but was missing from main (latent runtime bug there too).

  **Polish**
  - *Show Model/HPC caption + Detected environment in VASP wizard* — orientation parity with LAMMPS; extends `probe_remote` with VASP binary/module detection.
  - *Drop redundant "Launch Simulations" button on welcome screen* — workaround for the now-fixed simulate dispatch bug.
  - *Add wizard form persistence across app restarts* — pre-fills HPC/SLURM/path fields from `~/.scilink/wizard_state.json`. Scientific fields (description, research goal) and secrets are deliberately not persisted.

  **Latent bug fixes surfaced during real-cluster testing**
  - *Wire simulate-mode dispatch in `start_session`* — `start_session` only branched on `app_mode == "plan"`; simulate fell through to `_init_analysis_agent`, and `agent_config["api_key"]` never got populated, so the wizards couldn't find the LLM key. `_start_simulate_session` existed but was never called.
  - *Add timeouts to `conn.run` in submit path* — defense-in-depth so a stalled SSH channel surfaces as a real error rather than locking the spinner.
  - *`HPCConnection`: SSH keepalive + real exec timeout* — the actual root-cause fix. Idle transports were silently dropped (no keepalive), and the existing `timeout=` arg on `conn.run` did nothing because `recv_exit_status()` ignores it. Set `transport.set_keepalive(30)` on every successful connect, and use `channel.status_event.wait(timeout)` so the documented timeout is actually enforced.
  - *Refresh connection-bar job counts on any status change* — monitor fragments only triggered a parent rerun on terminal transitions, so the connection bar's "N running · M pending" stayed stale through PENDING → RUNNING.