### PR TITLE
Skills: graduation frontmatter + content-audit fixes (overlapping_objects, atomic_stem)

### DIFF
--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2716,24 +2716,28 @@ KNOWLEDGE_TO_SKILL_INSTRUCTIONS = """You are an expert scientific data analyst. 
 {analysis_details}
 
 **Instructions:**
-Organize the knowledge into exactly five sections. Each section should contain actionable, specific guidance. Use markdown formatting.
+Begin the document with a YAML frontmatter block containing a single one-line `description:` field — a self-contained sentence that lets a downstream agent decide whether this skill is relevant. Do not end the description with a period. Then organize the knowledge into exactly five sections, each containing actionable, specific guidance. Use markdown formatting.
 
-# overview
+---
+description: <one-line, self-contained, no trailing period>
+---
+
+## overview
 Describe what domain/technique this skill covers, what types of data it applies to, and when to use it.
 
-# planning
+## planning
 List strategy constraints, recommended parameter ranges, and setup considerations. Include any user-specified corrections or preferences.
 
-# analysis
+## analysis
 Describe code patterns, workflows, or processing steps that have proven effective. Include specific parameter values that worked.
 
-# interpretation
+## interpretation
 Provide reference values, peak assignments, expected ranges, and how to interpret results. Include quantitative benchmarks from the key findings.
 
-# validation
+## validation
 Define quality criteria, acceptable tolerance ranges, failure indicators, and sanity checks. Include any corrections from user feedback.
 
-Output ONLY the skill document content in markdown, starting with `# overview`. Do not wrap in code blocks.
+Output ONLY the skill document content in markdown, starting with the `---` frontmatter block followed by `## overview`. Do not wrap in code blocks. Use level-2 headings (`##`) for the sections — level-1 (`#`) is not parsed by the loader.
 """
 
 SKILL_UPDATE_INSTRUCTIONS = """You are an expert scientific data analyst. You need to update an existing skill document with new knowledge while preserving what is already correct.
@@ -2751,10 +2755,11 @@ SKILL_UPDATE_INSTRUCTIONS = """You are an expert scientific data analyst. You ne
 2. Integrate the new findings into the appropriate sections.
 3. Do NOT remove existing content unless the new knowledge explicitly contradicts it.
 4. When there is a conflict, prefer the newer knowledge but note the discrepancy.
-5. Maintain the five-section structure (overview, planning, analysis, interpretation, validation).
+5. Maintain the five-section structure (overview, planning, analysis, interpretation, validation), each at level-2 (`##`) heading depth.
 6. Add new quantitative details, parameter ranges, or heuristics from the new knowledge.
+7. Preserve the YAML frontmatter at the top (the `---`-delimited block). If the new knowledge materially changes the skill's purpose, update the `description:` field; otherwise leave it intact. If the existing skill has no frontmatter, add one with a one-line `description:` synthesized from the overview.
 
-Output ONLY the updated skill document content in markdown, starting with `# overview`. Do not wrap in code blocks.
+Output ONLY the updated skill document content in markdown, starting with the `---` frontmatter block followed by `## overview`. Do not wrap in code blocks.
 """
 
 # Backwards compatibility

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -44,16 +44,25 @@ is a complete pipeline by itself. Otherwise pick atom-resolved
 detection.
 
 **For atom-resolved detection — choose the detector:**
+
+Default to `detect_atoms_dcnn` when the material is in its training set
+**and** `fov_nm` is available from metadata; otherwise use the
+classical `detect_atoms`.
+
 - `detect_atoms_dcnn` (AtomNet3 DCNN ensemble): best for transition-
   metal oxides (perovskites, layered perovskites, cuprate
-  superconductors) and graphene; needs `fov_nm` from metadata. Pass
-  the raw image without preprocessing — the model handles intensity
-  gradients internally.
+  superconductors) and graphene; needs `fov_nm` from metadata.
+  **Pass the raw image without preprocessing** — no CLAHE, no contrast
+  normalization, no background subtraction, no bandpass filtering. The
+  model is trained on raw images and handles intensity gradients
+  internally; added preprocessing degrades detection. If weak columns
+  are missed, lower the `threshold` parameter; do not preprocess.
 - `detect_atoms` (classical peak detection): more general-purpose
   baseline; use when material is outside the DCNN's training set, when
-  `fov_nm` is unknown, or when DCNN results look poor. Background
-  subtraction or bandpass filtering before detection helps with
-  non-uniform illumination.
+  `fov_nm` is unknown, or when DCNN results look poor. **Preprocessing
+  applies here, not to the DCNN path** — background subtraction or
+  bandpass filtering before detection helps with non-uniform
+  illumination.
 
 Refine detected positions with 2D Gaussian fitting (built into
 `detect_atoms`, available via `refine_positions` after
@@ -102,12 +111,18 @@ goal you picked above:
   not built in), and a focused interpretation is the complete pipeline.
   Do not add FFT, zone-axis analysis, or sublattice clustering to the
   same step.
-- *If goal is sublattice separation:* intensity-based clustering alone
-  is insufficient for complex structures — combine intensity with
-  position within the unit cell, or use local-environment GMM (see the
-  `analysis` section). Verify stoichiometric ratios. Detected positions
-  from a prior detection step should come from `prior_analysis_paths`,
-  not be re-detected here.
+- *If goal is sublattice separation:* three approaches, choose based
+  on the data — see the `analysis` section for code:
+  (a) **iterative detect-subtract-detect** when sublattices have
+  noticeably different intensities (the classical Z-contrast case);
+  (b) **local-environment GMM** when intensity alone is ambiguous and
+  the neighborhood arrangement disambiguates the species;
+  (c) **intensity + positional clustering** when both intensity and
+  fractional position within the unit cell carry signal.
+  Intensity-based clustering alone is insufficient for complex
+  structures. Verify stoichiometric ratios in all cases. Detected
+  positions from a prior detection step should come from
+  `prior_analysis_paths`, not be re-detected here.
 - *If goal is lattice parameter / zone axis:* use FFT for periodicity
   (NN distance is not the lattice parameter for multi-sublattice
   structures — true unit cell may be 2× or more of the shortest column
@@ -126,9 +141,21 @@ goal you picked above:
 ## analysis
 
 ### foundational
-Column detection typically involves: normalization, background
-subtraction or bandpass filtering, blob/peak detection, and 2D
-Gaussian refinement. Measure basic statistics: column count, intensity
+**Workflow shape depends on the detector chosen in planning** (see
+`## planning` for the decision):
+
+- **DCNN path** (`detect_atoms_dcnn`): pass the raw image as-is →
+  built-in detection → `refine_positions` for sub-pixel coordinates and
+  Gaussian parameters → measure basic statistics. **No preprocessing
+  step.** The model handles intensity gradients internally; CLAHE,
+  contrast normalization, background subtraction, and bandpass
+  filtering on the input degrade detection.
+- **Classical path** (`detect_atoms`): normalization → optional
+  background subtraction or bandpass filtering for non-uniform
+  illumination → built-in peak detection → 2D Gaussian refinement
+  (built into `detect_atoms` via `refine=True`).
+
+Both paths end with the same statistics: column count, intensity
 distribution, nearest-neighbor distances, and lattice parameters from
 FFT.
 
@@ -290,12 +317,12 @@ failure. Hard checks should be self-consistency: ratio of measured
 spacings (b/a) matching the expected ratio, or FFT peaks forming a
 consistent reciprocal lattice.
 
-**Do not recommend preprocessing on the input to `detect_atoms_dcnn`**
-(CLAHE, contrast normalization, background subtraction, etc.). The
-AtomNet3 model is trained on raw images and handles intensity
-gradients internally; added preprocessing can degrade detection. If
-weak columns are missed, recommend adjusting the tool's `threshold`
-parameter instead.
+**DCNN preprocessing check:** if the step uses `detect_atoms_dcnn`,
+flag any pipeline step that preprocesses the image before the DCNN
+call (CLAHE, contrast normalization, background subtraction, bandpass
+filtering, etc.) — these belong only on the classical
+`detect_atoms` path. See the planning-section detector selection for
+the rationale.
 
 ### advanced
 The following only apply when the step explicitly targets the named

--- a/scilink/skills/image_analysis/overlapping_objects/overlapping_objects.md
+++ b/scilink/skills/image_analysis/overlapping_objects/overlapping_objects.md
@@ -49,24 +49,27 @@ Only reach for SAM when objects genuinely touch or overlap AND no
 visible boundary feature delineates them — the case where classical
 approaches would merge adjacent objects into single blobs.
 
-Connected component labeling on a binary mask merges all touching pixels
-into one object. If the image shows touching or overlapping objects, the
-pipeline must include a splitting step between mask creation and
-measurement. The main approaches, in order of preference:
+### genuinely-overlapping case (no visible boundary)
 
-1. **SAM instance segmentation** (preferred): Use `run_sam_analysis`
-   from `scilink.skills._shared.sam`. SAM detects individual object instances
-   directly, even when they overlap, without requiring thresholding
-   or binary masks. Works for any object shape. Tune via
-   `sam_parameters` preset and `min_area`/`pruning_iou_threshold`.
-   Avoid Gaussian blur before SAM unless noise is very high.
+When the foundational checks above rule out classical methods —
+i.e. objects genuinely touch with no boundary feature you can extract —
+connected component labeling on a binary mask will merge all touching
+pixels into one object, so the pipeline must include a dedicated
+splitting step. Within this case, in order of preference:
+
+1. **SAM instance segmentation**: Use `run_sam_analysis` from
+   `scilink.skills._shared.sam`. SAM detects individual object instances
+   directly, even when they overlap, without requiring thresholding or
+   binary masks. Works for any object shape. Tune via `sam_parameters`
+   preset and `min_area` / `pruning_iou_threshold`. Avoid Gaussian blur
+   before SAM unless noise is very high.
 
 2. **Watershed splitting**: Create binary mask (any method) → distance
    transform → find markers (local maxima of distance transform) →
-   watershed on inverted distance transform. Best for roughly convex
-   objects when SAM is unavailable or produces poor results. Key
-   parameter: `min_distance` in `peak_local_max` should approximate
-   the object radius.
+   watershed on inverted distance transform. Use when objects are
+   roughly convex and SAM produces poor results (over-merged or
+   over-split for the size scale). Key parameter: `min_distance` in
+   `peak_local_max` should approximate the object radius.
 
 3. **Instance detection**: Detect individual objects directly from
    the image without relying on a binary mask. For elliptical objects:
@@ -90,13 +93,64 @@ boundaries follow real inter-object edges.
 
 ## analysis
 
-### foundational
-**SAM implementation (preferred):**
+Implementations match the cases laid out in `## planning`. Pick the
+case first via the foundational decision tree there, then use the
+matching implementation below.
+
+### classical: visible boundary feature (etched grains, stained walls, …)
+
+Extract the boundary, invert, and label the interiors. Default to
+global Otsu unless illumination varies noticeably across the field of
+view.
+
+```
+import numpy as np
+from skimage.filters import threshold_otsu
+from skimage.morphology import binary_closing, disk
+from scipy.ndimage import label
+
+# 1. Boundary mask. Dark boundaries → True where image < threshold.
+thr = threshold_otsu(image_array)
+boundary = image_array < thr          # flip the comparison if boundaries are bright
+
+# 2. Close small gaps in the boundary so it fully encloses interiors.
+boundary = binary_closing(boundary, disk(1))
+
+# 3. binary_mask = inverse of the boundary; True where the objects are.
+binary_mask = ~boundary
+labels, n = label(binary_mask)
+props = skimage.measure.regionprops(labels, intensity_image=image_array)
+```
+
+Use adaptive thresholding (`cv2.adaptiveThreshold` /
+`skimage.filters.threshold_local`) only as a substitute for the Otsu
+line above when illumination drifts across the image. Block size and
+offset add tuning surface area that doesn't pay rent on uniformly lit
+images.
+
+### classical: well-separated or clean foreground/background
+
+```
+import numpy as np
+from skimage.filters import threshold_otsu
+from skimage.morphology import binary_opening, disk
+from scipy.ndimage import label
+
+thr = threshold_otsu(image_array)
+binary_mask = image_array > thr       # flip if foreground is dark
+binary_mask = binary_opening(binary_mask, disk(1))   # cleanup small specks
+labels, n = label(binary_mask)
+props = skimage.measure.regionprops(labels, intensity_image=image_array)
+```
+
+### genuinely-overlapping: SAM
+
 Pass a 2D grayscale array or an HxWx3 RGB uint8 array. For multi-channel
 images that are not RGB (e.g., 2-channel or 4-channel), pass a single
-channel (e.g., `image[:,:,0]`).
-**Tune all numeric parameters to the image** — the values below are
-syntax examples only, not recommended defaults.
+channel (e.g., `image[:,:,0]`). **Tune all numeric parameters to the
+image** — the values below are syntax examples only, not recommended
+defaults.
+
 ```
 from scilink.skills._shared.sam import run_sam_analysis
 result = run_sam_analysis(image_array, params={
@@ -112,16 +166,20 @@ for i, p in enumerate(result["particles"]):
 props = skimage.measure.regionprops(labeled, intensity_image=image_array)
 ```
 
-**Watershed implementation (fallback):**
+Avoid Gaussian blur before SAM unless noise is very high.
+
+### genuinely-overlapping: watershed
+
 ```
-binary_mask = threshold(image)
+# binary_mask comes from one of the classical thresholding blocks above
 distance = scipy.ndimage.distance_transform_edt(binary_mask)
 markers = skimage.feature.peak_local_max(distance, min_distance=estimated_radius)
 labeled_markers = scipy.ndimage.label(markers)[0]
 labels = skimage.segmentation.watershed(-distance, labeled_markers, mask=binary_mask)
 ```
 
-**Ellipse detection implementation:**
+### genuinely-overlapping: ellipse detection (specific shapes only)
+
 ```
 contours, _ = cv2.findContours(binary_mask, cv2.RETR_LIST, cv2.CHAIN_APPROX_NONE)
 for contour in contours:

--- a/scilink/skills/image_analysis/overlapping_objects/overlapping_objects.md
+++ b/scilink/skills/image_analysis/overlapping_objects/overlapping_objects.md
@@ -24,15 +24,24 @@ reaching for a heavy model like SAM:
   boundaries in etched metal, stained cell walls, bright domain
   edges) → use the boundary itself to separate the objects. Extract
   the boundary first — the method depends on how the boundary looks
-  in the pixel data (thresholding for clean dark/bright lines, edge
-  detection such as Canny/Sobel for gradient edges, gradient magnitude
-  or texture filters for softer boundaries; add morphological closing
-  if the boundary is broken). Once you have the boundary map, the two
-  classical ways to turn it into labeled objects are (a) invert and
-  run connected components on the interiors, or (b) use the boundary
-  map as a watershed landscape. Usually sharper and faster than SAM
-  for these images — SAM does not know to treat a thin boundary
-  feature as an object separator.
+  in the pixel data:
+    - **Default: global Otsu thresholding** (`skimage.filters.threshold_otsu`)
+      for clean dark/bright lines on a uniformly illuminated image.
+      Simpler and usually sharper than adaptive variants; tune nothing.
+    - **Adaptive thresholding** (`cv2.adaptiveThreshold` or
+      `skimage.filters.threshold_local`) only when illumination varies
+      noticeably across the field of view — block size and offset add
+      tuning surface area that doesn't pay rent on evenly lit images.
+    - **Edge detection** (Canny/Sobel) for gradient edges where there's
+      no clean intensity step.
+    - **Gradient magnitude or texture filters** for softer / textured
+      boundaries.
+    - Add **morphological closing** afterward if the boundary is broken.
+  Once you have the boundary map, the two classical ways to turn it
+  into labeled objects are (a) invert and run connected components on
+  the interiors, or (b) use the boundary map as a watershed landscape.
+  Usually sharper and faster than SAM for these images — SAM does not
+  know to treat a thin boundary feature as an object separator.
 - **Clean foreground-background intensity separation** → Otsu +
   connected components + morphological cleanup.
 


### PR DESCRIPTION
## Summary

Follow-up to #153. Four small fixes — three skill-content audits surfaced when LLM behavior on shipped skills was less reliable than expected, plus the analysis-side graduation pipeline counterpart of the frontmatter work that landed on the planning side in #153.

- **`overlapping_objects`** — pinned Otsu as the default for boundary-feature thresholding (was generic "thresholding for clean dark/bright lines"; LLMs reliably defaulted to over-elaborate adaptive thresholding) and resolved two real contradictions between the foundational decision tree and the numbered "main approaches" list (SAM was framed as both "last resort" and "globally preferred"; watershed was mis-framed as a SAM fallback when it's a classical method).
- **`atomic_stem`** — three audit findings: analysis foundational said "Column detection typically involves: normalization, background subtraction…" while planning + validation tell the LLM to pass raw images to `detect_atoms_dcnn`; sublattice-separation guidance in planning omitted the iterative detect-subtract-detect approach (the one with concrete reference code in the analysis section); and the "no preprocessing for DCNN" rule was misplaced in validation rather than next to the detector choice in planning.
- **Graduation pipeline** — `KNOWLEDGE_TO_SKILL_INSTRUCTIONS` and `SKILL_UPDATE_INSTRUCTIONS` in `scilink/agents/exp_agents/instruct.py` now emit/preserve YAML frontmatter (matching the planning-side counterparts updated in #153), and the heading level was bumped from `# overview` (level 1, silently dropped by the loader's `^##\s+` parser) to `## overview`. Pre-existing latent bug — analysis-side graduated skills were rendering as effectively empty bundles.

## Commits

```
e039b84 skill: resolve atomic_stem contradictions (preprocessing + sublattice)
76cbf1c skill: resolve contradictions in overlapping_objects guidance
1fb0fd6 skill: pin Otsu as default for boundary-feature thresholding
6ad4678 graduation: add frontmatter and fix heading level in analysis-side templates
```

## What changed in each skill

### `image_analysis/overlapping_objects`

Boundary-feature path now pins **global Otsu as the default** with adaptive thresholding scoped to "only when illumination varies noticeably across the field of view." The numbered preference list (SAM → watershed → Hough → contour decomposition) is now scoped under a new `### genuinely-overlapping case (no visible boundary)` subsection so it doesn't conflict with the foundational "try classical first" guidance. Watershed reframed as "use when objects are roughly convex and SAM produces poor results" instead of the misleading "when SAM is unavailable." Analysis section gained explicit code blocks for both classical paths (Otsu → close → invert → connected components for the etched-grain case; Otsu → opening → connected components for the well-separated case), which the LLM was previously inventing from scratch every run. Variable naming unified to `binary_mask` across all blocks.

### `image_analysis/atomic_stem`

Analysis foundational split into **DCNN path (no preprocessing)** vs **classical path (preprocessing applies)** workflows so the "typically involves: normalization…" line no longer contradicts the DCNN guidance. The "no preprocessing for DCNN" rule moved from validation into planning next to the detector choice (where it's actionable during script generation). Planning sublattice-separation bullet now lists all three approaches that have working code in the analysis section: iterative detect-subtract-detect, local-environment GMM, intensity + positional clustering. DCNN-first hierarchy made explicit ("Default to `detect_atoms_dcnn` when material is in its training set AND `fov_nm` is available; otherwise classical").

### Graduation pipeline (analysis-side templates)

`KNOWLEDGE_TO_SKILL_INSTRUCTIONS` now emits a `---`-delimited frontmatter block with a one-line `description:` field. `SKILL_UPDATE_INSTRUCTIONS` preserves existing frontmatter and backfills it on legacy graduated skills. Both templates switched from `# overview` to `## overview` to match the loader's section vocabulary.

## Behavior change worth flagging

Graduated skills emitted by `analysis_orchestrator.tools.graduate_to_skill` will now have populated section content (previously: the loader silently dropped level-1 headings, leaving the section dict empty for analysis-side graduated skills). This is a fix, not a regression — but if anything downstream was unexpectedly working with empty graduated skills, it'll start seeing real content.

## Test plan

- [x] `pytest tests/ --ignore=tests/_e2e_runs --ignore=tests/_simulate_runs --ignore=tests/test_mp_resolver.py --ignore=tests/test_simulation_orchestrator.py` → 54 passed, 6 skipped (baseline preserved).
- [x] Live skill suite (gated on `ANTHROPIC_API_KEY`) → 27 passed against `claude-opus-4-6` in ~67s.
- [x] All seven shipped skills load via `load_skill()` with frontmatter parsed and no section content silently dropped to `extras`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)