### PR TITLE
ui: gate simulate mode + HPC UI on [sim] extras

### DIFF
--- a/scilink/ui/_features.py
+++ b/scilink/ui/_features.py
@@ -1,0 +1,23 @@
+"""Feature-flag probes for the Streamlit UI.
+
+Today there is one flag: whether simulate mode (Simulate mode button,
+HPC sidebar, Simulations tab) is exposed. The flag is True iff the
+optional `[sim]` extras are installed — `paramiko` (HPC connectivity)
+and `ase` (structure handling).
+
+Without `[sim]`, the UI reverts to the analyze/plan-only shape that
+predates the simulate-mode work.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
+def simulate_enabled() -> bool:
+    try:
+        import paramiko  # noqa: F401
+        import ase  # noqa: F401
+    except ImportError:
+        return False
+    return True

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -14,7 +14,7 @@ from scilink.ui.components.chat_uploads import render_pre_chat_uploads
 from scilink.ui.components.file_viewer import render_file_preview
 from scilink.ui.components.tools_agents import render_tools_agents_tab
 from scilink.ui.components.skills import render_skills_tab
-from scilink.ui.components.simulations import render_simulations_tab
+from scilink.ui._features import simulate_enabled
 from scilink.ui.output_capture import AgentStoppedError, OutputCapture
 from scilink.ui.theme import inject_theme
 from scilink.ui.config import AVATAR_USER, AVATAR_AGENT, APP_MODES, SESSION_DIR_PREFIXES
@@ -355,9 +355,17 @@ if not st.session_state.agent_initialized:
         # Mode selector — centered above the logo
         if st.session_state.app_mode is None:
             st.session_state.app_mode = "analyze"
+        # Fall back if a stale session_state still says "simulate" but the
+        # [sim] extras are no longer installed.
+        if st.session_state.app_mode == "simulate" and not simulate_enabled():
+            st.session_state.app_mode = "analyze"
         _mode_map = {m["key"]: m for m in APP_MODES}
         st.markdown('<div class="mode-selector-anchor"></div>', unsafe_allow_html=True)
-        _, _mc1, _mc2, _mc3, _ = st.columns([1.5, 1, 1, 1, 1.5])
+        if simulate_enabled():
+            _, _mc1, _mc2, _mc3, _ = st.columns([1.5, 1, 1, 1, 1.5])
+        else:
+            _, _mc1, _mc2, _ = st.columns([1.5, 1.5, 1.5, 1.5])
+            _mc3 = None
         with _mc1:
             _atype = "primary" if st.session_state.app_mode == "analyze" else "secondary"
             if st.button("Analyze", type=_atype, use_container_width=True, key="mode_analyze"):
@@ -368,11 +376,12 @@ if not st.session_state.agent_initialized:
             if st.button("Plan", type=_ptype, use_container_width=True, key="mode_plan"):
                 st.session_state.app_mode = "plan"
                 st.rerun()
-        with _mc3:
-            _stype = "primary" if st.session_state.app_mode == "simulate" else "secondary"
-            if st.button("Simulate", type=_stype, use_container_width=True, key="mode_simulate"):
-                st.session_state.app_mode = "simulate"
-                st.rerun()
+        if _mc3 is not None:
+            with _mc3:
+                _stype = "primary" if st.session_state.app_mode == "simulate" else "secondary"
+                if st.button("Simulate", type=_stype, use_container_width=True, key="mode_simulate"):
+                    st.session_state.app_mode = "simulate"
+                    st.rerun()
         _cur_desc = _mode_map[st.session_state.app_mode]["description"]
         st.markdown(
             f'<p style="text-align:center;color:#6B7A8C;font-size:0.85em;'
@@ -451,8 +460,9 @@ if not st.session_state.agent_initialized:
 # Active session — Chat + File Explorer tabs
 # ══════════════════════════════════════════════════════════════════
 
-if st.session_state.app_mode == "simulate":
+if st.session_state.app_mode == "simulate" and simulate_enabled():
     # ── Simulate mode: no agent, just HPC UI ─────────────────
+    from scilink.ui.components.simulations import render_simulations_tab
     sim_tab, terminal_note = st.tabs(["Simulations", "About"])
     with sim_tab:
         render_simulations_tab()
@@ -466,9 +476,15 @@ if st.session_state.app_mode == "simulate":
         )
 else:
     # ── Analyze / Plan modes: full agent UI ──────────────────
-    chat_tab, files_tab, tools_tab, skills_tab, sim_tab = st.tabs(
-        ["Chat", "File Explorer", "Tools", "Skills", "Simulations"]
-    )
+    if simulate_enabled():
+        chat_tab, files_tab, tools_tab, skills_tab, sim_tab = st.tabs(
+            ["Chat", "File Explorer", "Tools", "Skills", "Simulations"]
+        )
+    else:
+        chat_tab, files_tab, tools_tab, skills_tab = st.tabs(
+            ["Chat", "File Explorer", "Tools", "Skills"]
+        )
+        sim_tab = None
 
     # ── Chat tab ─────────────────────────────────────────────────────
     with chat_tab:
@@ -780,7 +796,7 @@ else:
         new MutationObserver(fix).observe(doc.body,
             {childList:true, subtree:true, attributes:true, attributeFilter:['aria-checked','checked']});
     })();
-    </script>""", height=0)
+    </script>""", height=1)
                     if show:
                         import html as _html
     
@@ -990,5 +1006,7 @@ else:
         render_skills_tab()
     
     # ── Simulations tab ──────────────────────────────────────────────
-    with sim_tab:
-        render_simulations_tab()
+    if sim_tab is not None:
+        from scilink.ui.components.simulations import render_simulations_tab
+        with sim_tab:
+            render_simulations_tab()

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -209,7 +209,6 @@ def render_sidebar() -> None:
         else:
             st.title("SciLink")
         _locked = st.session_state.agent_initialized
-        _is_simulate = st.session_state.app_mode == "simulate"
         preset = st.selectbox(
             "Model",
             MODEL_OPTIONS + ["Custom"],
@@ -225,7 +224,9 @@ def render_sidebar() -> None:
         fh_api_key = st.text_input("FutureHouse API key (optional)", type="password", key="cfg_fh_api_key", disabled=_locked)
         mp_api_key = st.text_input("Materials Project API key (optional)", type="password", key="cfg_mp_api_key", disabled=_locked)
 
-        _render_hpc_connection()
+        from scilink.ui._features import simulate_enabled
+        if simulate_enabled():
+            _render_hpc_connection()
 
         # Planning mode: embedding model
         if st.session_state.app_mode == "plan":
@@ -411,7 +412,7 @@ def render_sidebar() -> None:
                 'height:100vh;font-family:sans-serif;color:#888;background:#0e1117;">'
                 '<h2>Server stopped. You can close this window.</h2></div>\';'
                 '</script>',
-                height=0,
+                height=1,
             )
             import time, signal
             time.sleep(1)
@@ -1012,43 +1013,3 @@ def _start_simulate_session(
     st.rerun()
 
 
-def _render_simulate_sidebar_status() -> None:
-    """Show HPC and simulation agent status in the sidebar."""
-    conn = st.session_state.get("hpc_connection")
-    if conn and conn.is_connected:
-        st.markdown(f"🟢 **{conn.profile.hostname}**")
-        sched = st.session_state.get("hpc_scheduler")
-        if sched:
-            st.caption(f"Scheduler: {sched.name}")
-    else:
-        st.caption("🔴 No HPC connection")
-        st.caption("Connect via the HPC section above, or work offline.")
-
-
-def _render_simulate_status() -> None:
-    """Show simulate-mode agent status metrics."""
-    agent = st.session_state.get("hpc_sim_agent")
-    result = st.session_state.get("hpc_gen_result")
-    conn = st.session_state.get("hpc_connection")
-
-    r1, r2 = st.columns(2)
-    with r1:
-        if agent and agent.skill_name:
-            st.metric("Engine", agent.skill_name)
-        else:
-            st.metric("Engine", "—")
-    with r2:
-        connected = conn is not None and conn.is_connected
-        st.metric("HPC", "Connected" if connected else "Offline")
-
-    if result:
-        sys_info = result.get("system_info", {})
-        st.metric("Last system", sys_info.get("system_category", "—"))
-        st.metric("Atoms", f"{sys_info.get('atom_count', '—'):,}")
-
-    tracked = st.session_state.get("hpc_tracked_jobs", {})
-    if tracked:
-        from scilink.hpc.scheduler import JobStatus
-        n_run = sum(1 for j in tracked.values() if j.status == JobStatus.RUNNING)
-        n_done = sum(1 for j in tracked.values() if j.status.is_terminal)
-        st.metric("Jobs", f"{n_run} running · {n_done} completed")

--- a/scilink/ui/theme.py
+++ b/scilink/ui/theme.py
@@ -1331,7 +1331,7 @@ def inject_theme() -> None:
         .observe(doc.body, {childList:true, subtree:true, attributes:true});
 })();
 </script>"""
-        components.html(_LIGHT_WIDGET_JS, height=0)
+        components.html(_LIGHT_WIDGET_JS, height=1)
     else:
         # Keep DOM slot count stable; also undo any inline styles
         # left by the light-mode observer on the stop button.
@@ -1351,7 +1351,7 @@ def inject_theme() -> None:
     new MutationObserver(cleanup)
         .observe(doc.body, {childList:true, subtree:true});
 })();
-</script>""", height=0)
+</script>""", height=1)
 
     vibe = st.session_state.get("vibe_theme", "Professional")
 
@@ -1380,5 +1380,5 @@ def inject_theme() -> None:
     # Slot 2: collision JS (always present, no-op script when inactive)
     components.html(
         _COLLISION_JS if use_collision_js else "<script>/* noop */</script>",
-        height=0,
+        height=1,
     )


### PR DESCRIPTION
## Summary

- Add `scilink/ui/_features.py` with a single `simulate_enabled()` probe (`paramiko` + `ase`, cached). Without `[sim]` installed, the UI reverts to the analyze/plan-only shape that predates recent simulate-mode work: no Simulate mode button, no HPC sidebar expander, no Simulations tab anywhere, no module-load pulls of paramiko/ase. Flipping the flag (e.g. to a hard `False` during a transitional period when sim isn't production-ready, even with deps installed) is one function in one file.
- Drive-by cleanup in `sidebar.py`: drop dead `_is_simulate` local + two never-called renderers (`_render_simulate_sidebar_status`, `_render_simulate_status`) left over from earlier refactors.
- Drive-by fix: restore `height=1` for invisible script-injection iframes in 5 sites across `app.py`, `sidebar.py`, and `theme.py`. The original fix in 9080f9b only covered one call site; later UI work re-introduced `height=0` elsewhere, which a recent Streamlit version rejects with `StreamlitInvalidHeightError` — manifested as a crash when switching to light mode.

## Test plan

- [x] All three modified Python modules compile (`py_compile`)
- [x] `simulate_enabled()` returns `True` with `paramiko` + `ase` present, `False` otherwise (verified via mock)
- [x] `sidebar.py` imports cleanly with `simulate_enabled` mocked to `False`
- [x] Removed symbols (`_is_simulate`, two renderers) confirmed gone; preserved symbols (`render_sidebar`, `start_session`, `_start_simulate_session`, `_render_hpc_connection`) confirmed present
- [x] No remaining `height=0` instances anywhere under `scilink/ui/`
- [x] Audited UI fix commits since Feb 2026 — only the `height=0` site regressed; all other fixes intact or intentionally evolved
- [x] Manual: visual verification with `[sim]` installed (current dev env) — Simulate button, HPC sidebar, Simulations tab all present as before
- [x] Manual: visual verification with `[sim]` absent — 2-button mode selector, 4-tab analyze/plan view, no HPC expander
- [x] Manual: light-mode toggle no longer crashes