### PR TITLE
analyze: lit search as orchestrator tool + multimodal optimizer

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -157,6 +157,14 @@ You are the **Analysis Agent**. Your goal is to coordinate experimental data ana
 _SYSTEM_PROMPT_BODY_POST = """
 5. `preview_image`: Load image for visual inspection (for agent 0 vs 1 decision, or ambiguous 2D data).
 
+**LITERATURE CONTEXT (optional, before analysis):**
+5b. `search_literature`: Fetch external literature to inform an upcoming analysis.
+   - Input: `query` (a focused research question).
+   - Action: queries the FutureHouse Edison API; saves results to a markdown file.
+   - Output: `file_path`. Pass it as `literature_file` to the next `run_analysis` so the planner produces a literature-informed plan the user reviews.
+   - When to use: the user asks for literature support, or the analysis objective is one where domain context would meaningfully shape method/parameter choice. Skip for routine measurement-quality analyses.
+   - Note: in curve-fitting `task_mode="identification"` the planner withholds lit context (to keep the fit unbiased); the literature still informs Stage-2 candidate enumeration.
+
 **ANALYSIS EXECUTION:**
 6. `run_analysis`: Execute analysis. Handles single files AND series automatically.
    - Each analysis run creates a unique output directory for traceability.

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -33,6 +33,7 @@ from .metadata_converter import (
     normalize_metadata_dict_with_llm,
 )
 from ..lit_agents import OwlLiteratureAgent, NoveltyScorer, FittingModelLiteratureAgent
+from ..lit_agents.optimize_query_for_analysis import optimize_query_for_analysis
 from .recommendation_agent import RecommendationAgent
 from ...skills.loader import list_skills, list_all_skills, load_skill
 # Note: DFTOrchestrator is imported lazily inside `run_dft_workflow` to avoid
@@ -2977,8 +2978,24 @@ class AnalysisOrchestratorTools:
             except Exception as e:
                 return json.dumps({"status": "error", "message": f"Failed to init Literature Agent: {e}"})
 
+            # Refine the orchestrator-LLM's draft query using the loaded data
+            # preview + metadata (visual + experimental specifics). Best-effort:
+            # falls back to the raw query on any failure.
+            refined_query = optimize_query_for_analysis(
+                raw_query=query,
+                data_type=getattr(self.orch, "current_data_type", None),
+                data_path=getattr(self.orch, "current_data_path", None),
+                metadata=getattr(self.orch, "current_metadata", None),
+                model=self.orch.model,
+            )
+            if refined_query != query:
+                print(f"  🔍 Refined query: {refined_query}")
+                logging.info(f"search_literature: refined query → {refined_query}")
+            else:
+                print(f"  🔍 Using raw query (no refinement applied)")
+
             try:
-                result = lit_agent.query_for_models(query)
+                result = lit_agent.query_for_models(refined_query)
             except Exception as e:
                 logging.error(f"Literature search error: {e}", exc_info=True)
                 return json.dumps({"status": "error", "message": str(e)})
@@ -2991,12 +3008,15 @@ class AnalysisOrchestratorTools:
 
             content = result.get("formatted_answer", "") or ""
 
-            # Hash the query for an idempotent, collision-free filename:
-            # same query → same file (re-runnable), different queries → different files.
+            # Hash the raw query for an idempotent, collision-free filename:
+            # same raw query → same file (re-runnable), different queries → different files.
             query_hash = hashlib.md5(query.encode("utf-8")).hexdigest()[:8]
             lit_path = self.orch.base_dir / f"literature_search_{query_hash}.md"
             with open(lit_path, "w") as f:
-                f.write(f"# Literature Search Results\n\n**Query:** {query}\n\n{content}")
+                f.write(f"# Literature Search Results\n\n**Draft query:** {query}\n")
+                if refined_query != query:
+                    f.write(f"**Refined query:** {refined_query}\n")
+                f.write(f"\n{content}")
 
             print(f"  ✅ Literature search completed. Saved to {lit_path.name}")
 

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -15,6 +15,7 @@ LLM reasoning.  If extraction fails, the user is prompted and shown the
 sidecar contents to help them specify the variable manually.
 """
 
+import hashlib
 import json
 import logging
 import re
@@ -31,7 +32,7 @@ from .metadata_converter import (
     normalize_metadata_dict,
     normalize_metadata_dict_with_llm,
 )
-from ..lit_agents import OwlLiteratureAgent, NoveltyScorer
+from ..lit_agents import OwlLiteratureAgent, NoveltyScorer, FittingModelLiteratureAgent
 from .recommendation_agent import RecommendationAgent
 from ...skills.loader import list_skills, list_all_skills, load_skill
 # Note: DFTOrchestrator is imported lazily inside `run_dft_workflow` to avoid
@@ -1930,6 +1931,7 @@ class AnalysisOrchestratorTools:
             series_metadata: str = None,
             task_mode: str = None,
             prior_analysis_paths: List[str] = None,
+            literature_file: str = None,
         ) -> str:
             """
             Execute analysis with the selected or specified agent.
@@ -2405,6 +2407,8 @@ class AnalysisOrchestratorTools:
                     analyze_kwargs["prior_knowledge"] = self.orch.active_knowledge
                 if prior_analysis_paths:
                     analyze_kwargs["prior_analysis_paths"] = prior_analysis_paths
+                if literature_file:
+                    analyze_kwargs["literature_file"] = literature_file
                 result = agent.analyze(**analyze_kwargs)
                 
                 # === Store result ===
@@ -2598,11 +2602,23 @@ class AnalysisOrchestratorTools:
                         "extracted features, scientific claims, saved-arrays "
                         "catalog). Image-analysis agent only."
                     )
+                },
+                "literature_file": {
+                    "type": "string",
+                    "description": (
+                        "Path to a literature search markdown file produced by "
+                        "`search_literature`. When provided, its contents are "
+                        "injected into the planner so the proposed analysis plan "
+                        "is grounded in external literature. Skipped for the curve-"
+                        "fitting agent's `task_mode='identification'` to preserve "
+                        "the unbiased fit; in that case the literature still "
+                        "informs Stage-2 candidate enumeration."
+                    )
                 }
             },
             required=[]
         )
-        
+
         # =====================================================================
         # 6. LIST RESULTS
         # =====================================================================
@@ -2932,6 +2948,82 @@ class AnalysisOrchestratorTools:
                 }
             },
             required=[]
+        )
+
+        # =====================================================================
+        # 10b. SEARCH LITERATURE (preparatory — call BEFORE run_analysis)
+        # =====================================================================
+        def search_literature(query: str) -> str:
+            """
+            Search scientific literature for context to inform an upcoming
+            analysis. Returns a file path that should be passed as
+            `literature_file` to the next `run_analysis` call so the planner
+            can produce a literature-informed plan.
+            """
+            print(f"  ⚡ Tool: Searching literature for '{query[:80]}...'")
+
+            if not self.orch.futurehouse_api_key:
+                return json.dumps({
+                    "status": "error",
+                    "message": "No FutureHouse/Edison API Key provided in Orchestrator initialization."
+                })
+
+            try:
+                # 50-min ceiling matches plan mode's `LiteratureSearchAgent`
+                # default; Edison CROW jobs can take 20-30 min for harder queries.
+                lit_agent = FittingModelLiteratureAgent(
+                    api_key=self.orch.futurehouse_api_key, max_wait_time=3000
+                )
+            except Exception as e:
+                return json.dumps({"status": "error", "message": f"Failed to init Literature Agent: {e}"})
+
+            try:
+                result = lit_agent.query_for_models(query)
+            except Exception as e:
+                logging.error(f"Literature search error: {e}", exc_info=True)
+                return json.dumps({"status": "error", "message": str(e)})
+
+            if result.get("status") != "success":
+                return json.dumps({
+                    "status": result.get("status", "error"),
+                    "message": result.get("message", "Literature search did not succeed")
+                })
+
+            content = result.get("formatted_answer", "") or ""
+
+            # Hash the query for an idempotent, collision-free filename:
+            # same query → same file (re-runnable), different queries → different files.
+            query_hash = hashlib.md5(query.encode("utf-8")).hexdigest()[:8]
+            lit_path = self.orch.base_dir / f"literature_search_{query_hash}.md"
+            with open(lit_path, "w") as f:
+                f.write(f"# Literature Search Results\n\n**Query:** {query}\n\n{content}")
+
+            print(f"  ✅ Literature search completed. Saved to {lit_path.name}")
+
+            preview = content[:500] + "..." if len(content) > 500 else content
+            return json.dumps({
+                "status": "success",
+                "file_path": str(lit_path),
+                "content_preview": preview,
+                "hint": "Pass file_path as literature_file to the next run_analysis() call."
+            })
+
+        self._register_tool(
+            func=search_literature,
+            name="search_literature",
+            description=(
+                "Search scientific literature via the FutureHouse Edison API to gather "
+                "context that will inform an upcoming analysis. Call BEFORE run_analysis(); "
+                "pass the returned file_path as `literature_file` to run_analysis() so the "
+                "planner produces a literature-informed plan."
+            ),
+            parameters={
+                "query": {
+                    "type": "string",
+                    "description": "A focused research question (e.g., 'methods for detecting grain boundaries in HRTEM images of 2D materials')."
+                }
+            },
+            required=["query"]
         )
 
         # =====================================================================

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -449,7 +449,13 @@ class SeriesScoutController:
 
 
 class LiteratureSearchController:
-    """Search literature if enabled and query provided."""
+    """Search literature if enabled and query provided.
+
+    DEPRECATED: prefer the orchestrator-level `search_literature` tool, which
+    fetches lit context BEFORE planning so the planner can produce a
+    literature-informed plan. This in-pipeline controller is retained as a
+    fallback for direct-Python-API callers using `use_literature=True`.
+    """
 
     def __init__(
         self,
@@ -482,6 +488,10 @@ class LiteratureSearchController:
 
     def execute(self, state: dict) -> dict:
         if state.get("error_dict"):
+            return state
+
+        if state.get("literature_context"):
+            self.logger.info("\n📚 --- Skipping Literature (pre-fetched via search_literature tool) ---\n")
             return state
 
         if self.literature_agent is None:
@@ -958,6 +968,13 @@ class HumanFeedbackRefinementController:
         _append_skill_context(prompt, state, "planning")
         _append_prior_knowledge_context(prompt, state)
 
+        # Withhold lit context from the planner in identification mode — it
+        # would re-anchor the planner to specific known materials/phases and
+        # defeat the unbiased-fit purpose. Lit context still reaches Stage-2
+        # candidate enumeration via the synthesis prompt.
+        if state.get("literature_context") and state.get("task_mode") != "identification":
+            prompt.append("\n## Literature\n" + state["literature_context"])
+
         # Identification mode: require a generic, material-agnostic fit plan.
         if state.get("task_mode") == "identification":
             from ..instruct import ID_MODE_PLANNING_ADDENDUM
@@ -1188,6 +1205,9 @@ class HumanFeedbackRefinementController:
         _append_auxiliary_context(prompt, state)
         _append_skill_context(prompt, state, "planning")
         _append_prior_knowledge_context(prompt, state)
+
+        if state.get("literature_context") and state.get("task_mode") != "identification":
+            prompt.append("\n## Literature\n" + state["literature_context"])
 
         # Include current series plan and scout data in refinement context
         if state.get("series_analysis_plan"):

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -331,41 +331,18 @@ class SeriesScoutController:
     def _create_overlay_plot(
         scout_curves: list,
         system_info: dict,
-    ) -> bytes:
+    ) -> str:
         """Create a single overlay figure with all scout spectra.
 
-        Args:
-            scout_curves: list of {"label": str, "curve_data": np.ndarray}
-            system_info: metadata dict for axis labels
-        Returns:
-            PNG image bytes.
+        Returns base64-encoded PNG (preserved shape for the existing prompt
+        consumer at `state["scout_overlay_plot"]`). Rendering is delegated
+        to `scilink.utils.curve_preview.render_curve_overlay` so the lit-
+        search optimizer can reuse the same plotting logic.
         """
-        import matplotlib.pyplot as plt
-        import io
+        from ....utils.curve_preview import render_curve_overlay
 
-        fig, ax = plt.subplots(figsize=(10, 6))
-
-        cmap = plt.cm.viridis
-        n = len(scout_curves)
-        for i, entry in enumerate(scout_curves):
-            x, y = SeriesScoutController._extract_xy(entry["curve_data"])
-            color = cmap(i / max(n - 1, 1))
-            ax.plot(x, y, color=color, linewidth=1.2, label=entry["label"])
-
-        ax.set_xlabel(system_info.get("xlabel", "X"))
-        ax.set_ylabel(system_info.get("ylabel", "Y"))
-        ax.set_title(
-            system_info.get("title", "Data")
-            + " — Scout Overlay"
-        )
-        ax.legend(fontsize=8, loc="best")
-        fig.tight_layout()
-
-        buf = io.BytesIO()
-        fig.savefig(buf, format="png", dpi=120)
-        plt.close(fig)
-        buf.seek(0)
-        return base64.b64encode(buf.read()).decode("utf-8")
+        png_bytes = render_curve_overlay(scout_curves, system_info)
+        return base64.b64encode(png_bytes).decode("utf-8")
 
     def _load_spectrum(self, idx: int, state: dict) -> np.ndarray:
         spectrum_stack = state.get("spectrum_stack")

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -1119,6 +1119,9 @@ class ImagePlanningController:
         _append_prior_analysis_state(prompt, state)
         _append_subagent_context(prompt, state)
 
+        if state.get("literature_context"):
+            prompt.append("\n## Literature\n" + state["literature_context"])
+
         # Series context: use scout data if available, otherwise basic notice
         num_images = state.get("num_images", 1)
         scout_data = state.get("scout_data", [])
@@ -1423,6 +1426,9 @@ class ImagePlanningController:
         _append_prior_analysis_state(prompt, state)
         _append_subagent_context(prompt, state)
 
+        if state.get("literature_context"):
+            prompt.append("\n## Literature\n" + state["literature_context"])
+
         # Include current series plan and scout data in refinement context
         if state.get("series_analysis_plan"):
             prompt.append(
@@ -1668,7 +1674,13 @@ class ImagePlanningController:
 
 
 class LiteratureSearchController:
-    """Search literature if enabled and query provided."""
+    """Search literature if enabled and query provided.
+
+    DEPRECATED: prefer the orchestrator-level `search_literature` tool, which
+    fetches lit context BEFORE planning so the planner can produce a
+    literature-informed plan. This in-pipeline controller is retained as a
+    fallback for direct-Python-API callers using `use_literature=True`.
+    """
 
     def __init__(
         self,
@@ -1701,6 +1713,10 @@ class LiteratureSearchController:
 
     def execute(self, state: dict) -> dict:
         if state.get("error_dict"):
+            return state
+
+        if state.get("literature_context"):
+            self.logger.info("\n--- Skipping Literature (pre-fetched via search_literature tool) ---\n")
             return state
 
         if self.literature_agent is None:

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -269,6 +269,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         skill: Optional[str] = None,
         # Prior knowledge from reference analyses
         prior_knowledge: Optional[List[Dict[str, Any]]] = None,
+        literature_file: Optional[str] = None,
         # Quality control overrides (optional)
         r2_threshold: Optional[float] = None,
         max_model_retries: Optional[int] = None,
@@ -586,7 +587,20 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "result_json": {},
             "error_dict": None,
         }
-        
+
+        # Pre-populate literature context if a search file was supplied via
+        # the orchestrator's `search_literature` tool. Skips the in-pipeline
+        # `LiteratureSearchController`. In identification mode the planner
+        # ignores it (see _build_planning_prompt) to preserve the unbiased
+        # fit, but Stage-2 candidate enumeration still consumes it.
+        if literature_file:
+            lit_p = Path(literature_file)
+            if lit_p.is_file():
+                state["literature_context"] = lit_p.read_text()
+                self.logger.info(f"📚 Loaded literature context from {lit_p.name}")
+            else:
+                self.logger.warning(f"literature_file not found: {literature_file}")
+
         # Create unified pipeline with quality settings
         pipeline = create_unified_curve_fitting_pipeline(
             model=self.model,

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -229,6 +229,7 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         skill: Optional[str] = None,
         prior_knowledge: Optional[List[Dict[str, Any]]] = None,
         prior_analysis_paths: Optional[List[str]] = None,
+        literature_file: Optional[str] = None,
         # Quality control overrides
         outlier_sigma: Optional[float] = None,
         **kwargs,
@@ -436,6 +437,17 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "result_json": {},
             "error_dict": None,
         }
+
+        # Pre-populate literature context if a search file was supplied via
+        # the orchestrator's `search_literature` tool. Skips the in-pipeline
+        # `LiteratureSearchController` and lets the planner see lit context.
+        if literature_file:
+            lit_p = Path(literature_file)
+            if lit_p.is_file():
+                state["literature_context"] = lit_p.read_text()
+                self.logger.info(f"📚 Loaded literature context from {lit_p.name}")
+            else:
+                self.logger.warning(f"literature_file not found: {literature_file}")
 
         # Create unified pipeline
         pipeline = create_unified_image_analysis_pipeline(

--- a/scilink/agents/lit_agents/optimize_query_for_analysis.py
+++ b/scilink/agents/lit_agents/optimize_query_for_analysis.py
@@ -1,0 +1,238 @@
+"""Multimodal query optimizer for the analyze-mode `search_literature` tool.
+
+Refines a raw orchestrator-LLM query into a focused, experiment-grounded
+question by showing the optimizer LLM the same kind of preview the planner
+sees: a thumbnail/montage of the actual data plus normalized metadata.
+
+Always best-effort. On any failure (no data loaded, preview rendering error,
+LLM call error) the raw query is returned so Edison still gets *something* to
+search on. The refinement is expensive only relative to a single LLM call,
+which is cheap compared to the Edison job that follows.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# --- Tunables -----------------------------------------------------------------
+DEFAULT_SCOUT_N = 5
+DEFAULT_MAX_REFINED_CHARS = 600  # keep refined queries focused, not bloated
+
+# --- Prompt -------------------------------------------------------------------
+_OPTIMIZER_PROMPT = """\
+You refine literature-search queries for an experimental data analysis system.
+
+The orchestrator wrote a draft query. Your job is to rewrite it so it returns
+the most relevant prior art for THIS specific dataset — exploiting the visual
+preview, data shape, and experimental metadata you can see below.
+
+Rules:
+- Phrase the refined query as a single natural-language research question —
+  not a comma-separated bag of specifics or a long noun phrase.
+- Bake in concrete experimental specifics from the metadata (material,
+  technique, instrument, modality) when they sharpen retrieval.
+- Mention salient visual features (grain morphology, peak shape, defects,
+  texture) only if the preview clearly shows them.
+- Do NOT invent material identities or measurement parameters not present
+  in the metadata or clearly visible in the preview. Stay grounded.
+- Keep the query under {max_chars} characters.
+- Output JSON only: {{"refined_query": "..."}}
+"""
+
+
+def _summarize_metadata(metadata: Any) -> str:
+    if not metadata:
+        return "(no metadata loaded)"
+    try:
+        return json.dumps(metadata, indent=2, default=str)[:1500]
+    except Exception:
+        return str(metadata)[:1500]
+
+
+def _build_image_preview(data_path: str) -> tuple[bytes, str] | None:
+    """Single image → JPEG thumbnail bytes. Series (dir) → montage."""
+    from ...skills._shared.image_analysis_tools import (
+        create_image_montage,
+        image_to_thumbnail_bytes,
+    )
+
+    p = Path(data_path)
+
+    def _load(path: Path) -> np.ndarray:
+        if path.suffix.lower() == ".npy":
+            return np.load(path)
+        from PIL import Image
+        return np.asarray(Image.open(path))
+
+    if p.is_dir():
+        files = sorted(
+            f for f in p.iterdir()
+            if f.is_file()
+            and not f.name.startswith(".")
+            and f.suffix.lower() in (".npy", ".png", ".jpg", ".jpeg", ".tif", ".tiff")
+        )
+        if not files:
+            return None
+        if len(files) == 1:
+            return image_to_thumbnail_bytes(_load(files[0])), "image/jpeg"
+        n = min(DEFAULT_SCOUT_N, len(files))
+        # Uniform-stride sample (no LLM-driven adaptive selection — that's
+        # the in-pipeline scout's job; here we just need representative coverage)
+        idxs = np.linspace(0, len(files) - 1, n, dtype=int).tolist()
+        sampled = [files[i] for i in idxs]
+        images = [_load(f) for f in sampled]
+        labels = [f.name for f in sampled]
+        return create_image_montage(images, labels), "image/jpeg"
+
+    # Single file
+    arr = _load(p)
+    if arr.ndim == 3 and arr.shape[0] not in (3, 4) and arr.shape[-1] not in (3, 4):
+        # Image stack stored as a single .npy file (shape: N x H x W)
+        n = min(DEFAULT_SCOUT_N, arr.shape[0])
+        idxs = np.linspace(0, arr.shape[0] - 1, n, dtype=int).tolist()
+        images = [arr[i] for i in idxs]
+        labels = [f"frame {i}" for i in idxs]
+        return create_image_montage(images, labels), "image/jpeg"
+    return image_to_thumbnail_bytes(arr), "image/jpeg"
+
+
+def _build_curve_preview(data_path: str, metadata: Any) -> tuple[bytes, str] | None:
+    """Single curve → plot. Series (dir or 2D stack) → overlay plot."""
+    from ...utils.curve_preview import render_curve_overlay, render_curve_single
+
+    system_info = metadata if isinstance(metadata, dict) else {}
+    p = Path(data_path)
+
+    def _load(path: Path) -> np.ndarray:
+        if path.suffix.lower() == ".npy":
+            return np.load(path)
+        return np.loadtxt(path, delimiter=",")
+
+    if p.is_dir():
+        files = sorted(
+            f for f in p.iterdir()
+            if f.is_file()
+            and not f.name.startswith(".")
+            and f.suffix.lower() in (".npy", ".csv", ".txt", ".dat")
+        )
+        if not files:
+            return None
+        if len(files) == 1:
+            return render_curve_single(_load(files[0]), system_info), "image/png"
+        n = min(DEFAULT_SCOUT_N, len(files))
+        idxs = np.linspace(0, len(files) - 1, n, dtype=int).tolist()
+        scout = [
+            {"label": files[i].name, "curve_data": _load(files[i])}
+            for i in idxs
+        ]
+        return render_curve_overlay(scout, system_info), "image/png"
+
+    arr = _load(p)
+    # 2-D stack of N spectra: (N, M) where M >> N typically. Heuristic: if
+    # the smaller axis looks like spectra count and the larger like channels,
+    # treat as series.
+    if arr.ndim == 2 and arr.shape[0] != 2 and arr.shape[1] != 2:
+        n_spectra = arr.shape[0]
+        n = min(DEFAULT_SCOUT_N, n_spectra)
+        idxs = np.linspace(0, n_spectra - 1, n, dtype=int).tolist()
+        scout = [{"label": f"spectrum {i}", "curve_data": arr[i]} for i in idxs]
+        return render_curve_overlay(scout, system_info), "image/png"
+    return render_curve_single(arr, system_info), "image/png"
+
+
+def _build_preview(
+    data_type: str | None,
+    data_path: str | None,
+    metadata: Any,
+) -> tuple[bytes, str] | None:
+    """Dispatch by data_type. Return (bytes, mime_type) or None on failure."""
+    if not data_path:
+        return None
+    try:
+        if data_type == "image":
+            return _build_image_preview(data_path)
+        if data_type == "curve":
+            return _build_curve_preview(data_path, metadata)
+        # Hyperspectral / unknown: skip preview for v1
+        logger.info(
+            f"optimize_query_for_analysis: no preview builder for "
+            f"data_type={data_type!r}; refining with metadata only."
+        )
+        return None
+    except Exception as e:
+        logger.warning(f"optimize_query_for_analysis: preview failed: {e}")
+        return None
+
+
+def optimize_query_for_analysis(
+    raw_query: str,
+    data_type: str | None,
+    data_path: str | None,
+    metadata: Any,
+    model: Any,
+    max_chars: int = DEFAULT_MAX_REFINED_CHARS,
+) -> str:
+    """Refine `raw_query` using the loaded data preview + metadata.
+
+    Args:
+        raw_query: the orchestrator LLM's query string.
+        data_type: "image" | "curve" | "hyperspectral" | None — from
+            `examine_data` (`self.orch.current_data_type`).
+        data_path: path to the loaded data (file or directory).
+        metadata: normalized metadata dict (`self.orch.current_metadata`).
+        model: LLM client with `.generate_content(parts)` (the orchestrator's
+            existing wrapper instance).
+        max_chars: soft ceiling for the refined query length.
+
+    Returns:
+        Refined query string. On any failure, returns `raw_query` unchanged.
+    """
+    if not raw_query or not raw_query.strip():
+        return raw_query
+
+    preview = _build_preview(data_type, data_path, metadata)
+    if preview is None and not metadata:
+        # Nothing useful to add; don't burn a token on an LLM round-trip.
+        return raw_query
+
+    parts: list = [
+        _OPTIMIZER_PROMPT.format(max_chars=max_chars),
+        f"\n## Draft query\n{raw_query.strip()}",
+        f"\n## Data type\n{data_type or 'unknown'}",
+        f"\n## Metadata\n{_summarize_metadata(metadata)}",
+    ]
+    if preview is not None:
+        png_bytes, mime = preview
+        parts.append("\n## Data preview")
+        parts.append({"mime_type": mime, "data": png_bytes})
+
+    try:
+        response = model.generate_content(parts)
+        text = (response.text or "").strip()
+    except Exception as e:
+        logger.warning(f"optimize_query_for_analysis: LLM call failed: {e}")
+        return raw_query
+
+    # Parse JSON; tolerate raw-text fallback if the model omitted fences.
+    refined: str | None = None
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict):
+            refined = parsed.get("refined_query")
+    except Exception:
+        # Last-resort: take the response text as-is if it looks like a query
+        # (single line, sensible length). Otherwise give up and return raw.
+        if text and "\n" not in text and 10 < len(text) < max_chars * 2:
+            refined = text
+
+    if not refined or not isinstance(refined, str) or not refined.strip():
+        logger.info("optimize_query_for_analysis: no refined query parsed; using raw.")
+        return raw_query
+
+    return refined.strip()

--- a/scilink/utils/curve_preview.py
+++ b/scilink/utils/curve_preview.py
@@ -1,0 +1,84 @@
+"""Curve preview helpers for LLM-facing prompts.
+
+Pure rendering utilities — no controller / pipeline state involved. Shared
+between the in-pipeline `SeriesScoutController` and the lit-search query
+optimizer so both produce visually consistent previews.
+"""
+from __future__ import annotations
+
+import io
+
+import numpy as np
+
+
+def extract_xy(curve_data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Extract (x, y) arrays from common curve-data shapes."""
+    if curve_data.ndim == 1:
+        return np.arange(len(curve_data)), curve_data
+    if curve_data.shape[0] == 2:
+        return curve_data[0], curve_data[1]
+    if curve_data.shape[1] == 2:
+        return curve_data[:, 0], curve_data[:, 1]
+    raise ValueError(f"Unexpected curve_data shape: {curve_data.shape}")
+
+
+def render_curve_overlay(
+    scout_curves: list[dict],
+    system_info: dict | None = None,
+    title_suffix: str = " — Scout Overlay",
+) -> bytes:
+    """Render an overlay plot of multiple curves and return raw PNG bytes.
+
+    Args:
+        scout_curves: list of {"label": str, "curve_data": np.ndarray}.
+        system_info: optional metadata dict with xlabel/ylabel/title keys.
+        title_suffix: appended to the plot title.
+
+    Returns:
+        Raw PNG bytes, suitable for `{mime_type: image/png, data: <bytes>}`
+        prompt parts consumed by LLM wrappers.
+    """
+    import matplotlib.pyplot as plt
+
+    system_info = system_info or {}
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    cmap = plt.cm.viridis
+    n = len(scout_curves)
+    for i, entry in enumerate(scout_curves):
+        x, y = extract_xy(entry["curve_data"])
+        color = cmap(i / max(n - 1, 1))
+        ax.plot(x, y, color=color, linewidth=1.2, label=entry["label"])
+
+    ax.set_xlabel(system_info.get("xlabel", "X"))
+    ax.set_ylabel(system_info.get("ylabel", "Y"))
+    ax.set_title(system_info.get("title", "Data") + title_suffix)
+    ax.legend(fontsize=8, loc="best")
+    fig.tight_layout()
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=120)
+    plt.close(fig)
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def render_curve_single(curve_data: np.ndarray, system_info: dict | None = None) -> bytes:
+    """Render a single curve and return raw PNG bytes."""
+    import matplotlib.pyplot as plt
+
+    system_info = system_info or {}
+    x, y = extract_xy(curve_data)
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.plot(x, y, color="steelblue", linewidth=1.4)
+    ax.set_xlabel(system_info.get("xlabel", "X"))
+    ax.set_ylabel(system_info.get("ylabel", "Y"))
+    ax.set_title(system_info.get("title", "Data"))
+    fig.tight_layout()
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=120)
+    plt.close(fig)
+    buf.seek(0)
+    return buf.getvalue()

--- a/tests/test_lit_planner_injection.py
+++ b/tests/test_lit_planner_injection.py
@@ -1,0 +1,216 @@
+"""Offline tests for `literature_context` injection into planner prompts.
+
+Three contracts under test:
+
+1. `ImagePlanningController._build_planning_prompt` appends a `## Literature`
+   section when `state["literature_context"]` is set (no task_mode field on
+   the image agent — always inject if present).
+
+2. `HumanFeedbackRefinementController._plan_analysis` (curve fitting) appends
+   `## Literature` when `literature_context` is set AND
+   `task_mode != "identification"`.
+
+3. The same curve-fitting planner WITHHOLDS `## Literature` when
+   `task_mode == "identification"` — the load-bearing guard that protects the
+   unbiased-fit semantics of identification mode.
+
+4. `UnifiedCurveSynthesisController._build_interpretation_prompt` (Stage 2)
+   appends `## Literature` unconditionally — i.e., identification-mode
+   candidate enumeration still receives the lit context. (Smoke-tested by
+   grepping the source rather than constructing the full state; full
+   pipeline instantiation is too heavy for an offline test and the
+   conditional has no task_mode branch.)
+"""
+from __future__ import annotations
+
+import inspect
+import io
+import json
+import logging
+from types import SimpleNamespace
+
+import numpy as np
+
+
+# --- Image planner -----------------------------------------------------------
+
+def _make_image_planner():
+    """Construct an ImagePlanningController instance with stub dependencies."""
+    from scilink.agents.exp_agents.controllers.image_analysis_controllers import (
+        ImagePlanningController,
+    )
+
+    return ImagePlanningController(
+        model=SimpleNamespace(),  # not called by _build_planning_prompt
+        logger=logging.getLogger("test"),
+        generation_config=None,
+        safety_settings=None,
+        parse_fn=lambda r: (None, None),
+        instructions="STUB_INSTRUCTIONS",
+        output_dir="/tmp",
+    )
+
+
+def _minimal_image_state(literature_context: str | None = None) -> dict:
+    return {
+        "original_image_bytes": b"\xff\xd8\xff",  # JPEG-ish stub
+        "image_statistics": {"mean": 0.5, "std": 0.1},
+        "system_info": {"material": "stub"},
+        "is_single_image": True,
+        "num_images": 1,
+        "literature_context": literature_context,
+    }
+
+
+def _stringify_parts(parts: list) -> str:
+    """Flatten a multimodal prompt parts list to a single searchable string."""
+    out = []
+    for p in parts:
+        if isinstance(p, str):
+            out.append(p)
+        elif isinstance(p, dict):
+            out.append(f"<{p.get('mime_type', 'blob')}>")
+    return "\n".join(out)
+
+
+def test_image_planner_injects_literature_when_present():
+    planner = _make_image_planner()
+    state = _minimal_image_state(literature_context="DOMAIN_LIT_CONTENT")
+    parts = planner._build_planning_prompt(state)
+    flat = _stringify_parts(parts)
+    assert "## Literature" in flat
+    assert "DOMAIN_LIT_CONTENT" in flat
+
+
+def test_image_planner_omits_literature_when_absent():
+    planner = _make_image_planner()
+    state = _minimal_image_state(literature_context=None)
+    parts = planner._build_planning_prompt(state)
+    flat = _stringify_parts(parts)
+    assert "## Literature" not in flat
+
+
+# --- Curve planner — identification-mode guard -------------------------------
+
+def _make_curve_planner():
+    """Construct a HumanFeedbackRefinementController with stub deps + a model
+    that captures the prompt parts and returns a parseable JSON response."""
+    from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+        HumanFeedbackRefinementController,
+    )
+
+    captured: dict = {"parts": None}
+
+    class _CaptureModel:
+        def generate_content(self, parts, generation_config=None):
+            captured["parts"] = parts
+            payload = json.dumps({
+                "observations": "stub",
+                "analysis_approach": "stub approach",
+                "physical_model": "stub model",
+                "parameters_to_extract": [],
+                "fitting_strategy": "stub strategy",
+                "literature_query": None,
+            })
+            return SimpleNamespace(text=payload)
+
+    controller = HumanFeedbackRefinementController(
+        model=_CaptureModel(),
+        logger=logging.getLogger("test"),
+        generation_config=None,
+        safety_settings=None,
+        parse_fn=lambda r: (json.loads(r.text), None),
+        instructions="STUB_INSTRUCTIONS",
+        output_dir="/tmp",
+    )
+    return controller, captured
+
+
+def _minimal_curve_state(
+    literature_context: str | None,
+    task_mode: str | None,
+) -> dict:
+    # Render a tiny real PNG so the bytes field is plausibly valid.
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png")
+    plt.close(fig)
+
+    return {
+        "original_plot_bytes": buf.getvalue(),
+        "data_statistics": {"n_points": 200},
+        "system_info": {"xlabel": "E", "ylabel": "I"},
+        "is_single_spectrum": True,
+        "num_spectra": 1,
+        "literature_context": literature_context,
+        "task_mode": task_mode,
+    }
+
+
+def test_curve_planner_injects_literature_in_fitting_mode():
+    controller, captured = _make_curve_planner()
+    state = _minimal_curve_state(
+        literature_context="DOMAIN_LIT_CONTENT",
+        task_mode="fitting",
+    )
+    controller._plan_analysis(state)
+    flat = _stringify_parts(captured["parts"])
+    assert "## Literature" in flat
+    assert "DOMAIN_LIT_CONTENT" in flat
+
+
+def test_curve_planner_withholds_literature_in_identification_mode():
+    """Load-bearing guard: identification-mode planner must NOT see lit
+    context, even when `state["literature_context"]` is populated."""
+    controller, captured = _make_curve_planner()
+    state = _minimal_curve_state(
+        literature_context="DOMAIN_LIT_CONTENT_THAT_MUST_BE_HIDDEN",
+        task_mode="identification",
+    )
+    controller._plan_analysis(state)
+    flat = _stringify_parts(captured["parts"])
+    assert "## Literature" not in flat
+    assert "DOMAIN_LIT_CONTENT_THAT_MUST_BE_HIDDEN" not in flat
+
+
+def test_curve_planner_omits_literature_when_absent():
+    """No `literature_context` set → no section regardless of mode."""
+    for mode in ("fitting", "identification", None):
+        controller, captured = _make_curve_planner()
+        state = _minimal_curve_state(literature_context=None, task_mode=mode)
+        controller._plan_analysis(state)
+        flat = _stringify_parts(captured["parts"])
+        assert "## Literature" not in flat, f"unexpected lit injection in mode={mode!r}"
+
+
+# --- Curve synthesis — unconditional lit injection ---------------------------
+
+def test_curve_synthesis_injects_literature_unconditionally():
+    """`UnifiedCurveSynthesisController` Stage-2 prompt builder appends
+    `## Literature` whenever `state["literature_context"]` is set, with no
+    task_mode guard. This means identification-mode candidate enumeration
+    still receives the lit context for ranking candidates against literature
+    evidence.
+
+    Construct-then-call is prohibitively heavy for this controller (many
+    coupled state keys); a source-level check is the right granularity for
+    a regression guard on a one-line conditional.
+    """
+    from scilink.agents.exp_agents.controllers import curve_fitting_controllers
+    src = inspect.getsource(curve_fitting_controllers.UnifiedCurveSynthesisController)
+    # The Stage-2 prompt builder is the only consumer of literature_context
+    # inside this class. Confirm: (a) injection exists, (b) NO task_mode
+    # branch gates it.
+    assert 'state.get("literature_context")' in src
+    # Find every line that gates on literature_context; none may also test task_mode
+    lit_gates = [
+        line for line in src.splitlines()
+        if 'state.get("literature_context")' in line
+    ]
+    assert lit_gates, "expected at least one lit-context conditional in synthesis"
+    for line in lit_gates:
+        assert 'task_mode' not in line, (
+            f"unexpected task_mode guard on synthesis lit injection: {line!r}"
+        )

--- a/tests/test_lit_query_optimizer.py
+++ b/tests/test_lit_query_optimizer.py
@@ -1,0 +1,222 @@
+"""Offline tests for `optimize_query_for_analysis`.
+
+Mocks the LLM client; no API calls. Renders real previews (matplotlib +
+PIL) so the dispatch paths are exercised end-to-end.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from scilink.agents.lit_agents.optimize_query_for_analysis import (
+    DEFAULT_SCOUT_N,
+    _build_preview,
+    optimize_query_for_analysis,
+)
+
+
+class _FakeModel:
+    """Captures the last `generate_content` call and returns a canned response."""
+
+    def __init__(self, refined: str = "REFINED QUERY", raise_exc: Exception | None = None):
+        self.refined = refined
+        self.raise_exc = raise_exc
+        self.last_parts: list | None = None
+        self.call_count = 0
+
+    def generate_content(self, parts):
+        self.call_count += 1
+        self.last_parts = parts
+        if self.raise_exc:
+            raise self.raise_exc
+        return SimpleNamespace(text=json.dumps({"refined_query": self.refined}))
+
+
+def _has_image_part(parts: list) -> bool:
+    return any(isinstance(p, dict) and "mime_type" in p and "data" in p for p in parts)
+
+
+# --- Single image -------------------------------------------------------------
+
+def test_single_image_npy_builds_preview_and_calls_llm(tmp_path: Path):
+    arr = (np.random.rand(64, 64) * 255).astype(np.uint8)
+    path = tmp_path / "img.npy"
+    np.save(path, arr)
+
+    model = _FakeModel(refined="refined Q for single image")
+    out = optimize_query_for_analysis(
+        raw_query="generic grain query",
+        data_type="image",
+        data_path=str(path),
+        metadata={"material": "steel"},
+        model=model,
+    )
+
+    assert model.call_count == 1
+    assert _has_image_part(model.last_parts)
+    assert out == "refined Q for single image"
+
+
+# --- Image series via directory ----------------------------------------------
+
+def test_image_series_directory_builds_montage(tmp_path: Path):
+    for i in range(7):
+        arr = (np.random.rand(32, 32) * 255).astype(np.uint8)
+        np.save(tmp_path / f"frame_{i:02d}.npy", arr)
+
+    model = _FakeModel(refined="series-refined")
+    preview = _build_preview("image", str(tmp_path), {"technique": "AFM"})
+    assert preview is not None
+    assert preview[1] == "image/jpeg"
+    assert isinstance(preview[0], (bytes, bytearray)) and len(preview[0]) > 100
+
+    out = optimize_query_for_analysis(
+        raw_query="texture analysis",
+        data_type="image",
+        data_path=str(tmp_path),
+        metadata={"technique": "AFM"},
+        model=model,
+    )
+    assert model.call_count == 1
+    assert _has_image_part(model.last_parts)
+    assert out == "series-refined"
+
+
+# --- Image series stored as 3D .npy stack ------------------------------------
+
+def test_image_stack_npy_builds_montage(tmp_path: Path):
+    stack = (np.random.rand(8, 32, 32) * 255).astype(np.uint8)
+    path = tmp_path / "stack.npy"
+    np.save(path, stack)
+
+    preview = _build_preview("image", str(path), None)
+    assert preview is not None and preview[1] == "image/jpeg"
+    # Montage should be larger than a single-frame thumbnail
+    assert len(preview[0]) > 500
+
+
+# --- Single curve -------------------------------------------------------------
+
+def test_single_curve_npy_builds_plot(tmp_path: Path):
+    x = np.linspace(0, 10, 200)
+    y = np.exp(-((x - 5) ** 2) / 2)
+    path = tmp_path / "spec.npy"
+    np.save(path, np.stack([x, y]))  # shape (2, N)
+
+    preview = _build_preview("curve", str(path), {"xlabel": "x", "ylabel": "I"})
+    assert preview is not None and preview[1] == "image/png"
+
+
+# --- Curve series via 2D .npy stack ------------------------------------------
+
+def test_curve_stack_npy_builds_overlay(tmp_path: Path):
+    spectra = np.random.rand(6, 200)  # N=6 spectra of length 200
+    path = tmp_path / "spectra.npy"
+    np.save(path, spectra)
+
+    preview = _build_preview("curve", str(path), None)
+    assert preview is not None and preview[1] == "image/png"
+
+
+# --- Fallbacks ----------------------------------------------------------------
+
+def test_no_data_no_metadata_skips_llm():
+    """No data and no metadata: refinement is pointless — skip the LLM call."""
+    model = _FakeModel()
+    out = optimize_query_for_analysis(
+        raw_query="raw",
+        data_type=None,
+        data_path=None,
+        metadata=None,
+        model=model,
+    )
+    assert out == "raw"
+    assert model.call_count == 0  # no point calling LLM with nothing to add
+
+
+def test_metadata_only_still_refines():
+    """No data path, but metadata is present — still worth a refinement pass."""
+    model = _FakeModel(refined="metadata-grounded query")
+    out = optimize_query_for_analysis(
+        raw_query="raw",
+        data_type=None,
+        data_path=None,
+        metadata={"material": "MoS2", "technique": "Raman"},
+        model=model,
+    )
+    assert out == "metadata-grounded query"
+    assert model.call_count == 1
+    # no image part — metadata-only path
+    assert not _has_image_part(model.last_parts)
+
+
+def test_llm_error_returns_raw(tmp_path: Path):
+    arr = (np.random.rand(32, 32) * 255).astype(np.uint8)
+    path = tmp_path / "img.npy"
+    np.save(path, arr)
+
+    model = _FakeModel(raise_exc=RuntimeError("rate limited"))
+    out = optimize_query_for_analysis(
+        raw_query="raw fallback query",
+        data_type="image",
+        data_path=str(path),
+        metadata={"material": "steel"},
+        model=model,
+    )
+    assert out == "raw fallback query"
+
+
+def test_unparseable_llm_response_returns_raw(tmp_path: Path):
+    arr = (np.random.rand(32, 32) * 255).astype(np.uint8)
+    path = tmp_path / "img.npy"
+    np.save(path, arr)
+
+    class _NoiseModel:
+        def generate_content(self, parts):
+            return SimpleNamespace(text="not json\nmulti\nline gibberish")
+
+    out = optimize_query_for_analysis(
+        raw_query="raw",
+        data_type="image",
+        data_path=str(path),
+        metadata={"material": "steel"},
+        model=_NoiseModel(),
+    )
+    assert out == "raw"
+
+
+def test_unknown_data_type_metadata_only(tmp_path: Path):
+    """Unknown/unsupported data_type: fall through to metadata-only refinement."""
+    model = _FakeModel(refined="meta-only refined")
+    out = optimize_query_for_analysis(
+        raw_query="raw",
+        data_type="hyperspectral",  # no preview builder in v1
+        data_path=str(tmp_path),
+        metadata={"technique": "EELS"},
+        model=model,
+    )
+    assert out == "meta-only refined"
+    assert model.call_count == 1
+    assert not _has_image_part(model.last_parts)
+
+
+# --- Sampling stride ----------------------------------------------------------
+
+def test_image_series_samples_at_most_N(tmp_path: Path):
+    """Directory with >>N frames → exactly N images in the montage."""
+    for i in range(20):
+        np.save(tmp_path / f"f_{i:03d}.npy", (np.random.rand(16, 16) * 255).astype(np.uint8))
+
+    # We can't easily inspect the montage layout, but we can verify the
+    # sampling code path didn't crash and produced a non-trivial JPEG.
+    preview = _build_preview("image", str(tmp_path), None)
+    assert preview is not None
+    # Larger than any single-frame thumbnail
+    assert len(preview[0]) > 1000
+    # Sanity: DEFAULT_SCOUT_N is a small fixed number
+    assert DEFAULT_SCOUT_N == 5


### PR DESCRIPTION
## Summary

- Adds `search_literature(query)` as an orchestrator-level tool in analyze mode and a `literature_file` parameter on `run_analysis`. The agent reads the lit file into `state["literature_context"]` before pipeline execution and the planner prompt now includes a `## Literature` section, so the plan the user reviews is grounded in external literature — mirroring plan mode's `search_literature` → `generate_initial_plan` flow.
- Refines the raw query before sending it to Edison via a new multimodal `optimize_query_for_analysis`: the optimizer LLM sees a thumbnail (single image), montage (image series, N=5 uniform stride), plot (single curve), or overlay (curve series), plus normalized metadata, and emits a focused natural-language research question. Best-effort with raw-query fallback on any failure.
- In-pipeline `LiteratureSearchController` is retained as a fallback (`use_literature=True` direct-API path) and marked DEPRECATED; skips when `state["literature_context"]` is already pre-fetched. Curve-fitting `task_mode="identification"` withholds lit context from the planner to preserve the unbiased fit; Stage-2 candidate enumeration still consumes it via the existing synthesis path.

Refactor: lifts `_create_overlay_plot` rendering from `SeriesScoutController` to `scilink/utils/curve_preview.py` so the scout and optimizer share one definition.

## Test plan

- [x] 11 offline unit tests (`tests/test_lit_query_optimizer.py`) — mocked LLM; cover single-image / image-series / single-curve / curve-series preview dispatch, no-data fallback, metadata-only path, LLM-error fallback, unparseable-response fallback
- [x] 6 offline unit tests (`tests/test_lit_planner_injection.py`) — regression guards for planner lit injection: image planner injects unconditionally, curve planner injects in fitting mode, curve planner **withholds in identification mode** (the load-bearing guard), curve synthesis injects unconditionally (no task_mode branch)
- [x] 27 prior tests still passing (`test_skill_loader`, `test_knowledge_query`, `test_preprocessing_orchestrator`, `test_planning_campaigns`, `test_adaptive_annealing`) — no regressions
- [x] Live verification on `polycrystalline_grains_demo/image.npy`: `search_literature("grain analysis")` → optimizer LLM refines to a natural-language question grounded in metadata (steel 304, bright-field, 100 µm FOV) AND visual signal (equiaxed grains with distinct contrast levels) → Edison returns 20 KB markdown → `run_analysis(literature_file=...)` reads it into state → planner sees lit context → `LiteratureSearchController` logs `Skipping Literature (pre-fetched via search_literature tool)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)