### PR TITLE
orchestrator: expose parallel_workers + adaptive subprocess timeout

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -9,6 +9,7 @@ Coordinates multi-modal experimental analysis using specialized sub-agents:
 Follows the same design patterns as PlanningOrchestratorAgent for consistent UX.
 """
 
+import inspect
 import json
 import logging
 import os
@@ -391,6 +392,7 @@ class AnalysisOrchestratorAgent:
         analysis_mode: AnalysisMode = AnalysisMode.CO_PILOT,
         futurehouse_api_key: Optional[str] = None,
         image_analysis_depth: str = "basic",
+        curve_fit_parallel_workers: Optional[int] = None,
         # Deprecated
         google_api_key: Optional[str] = None,
         local_model: Optional[str] = None,
@@ -445,6 +447,12 @@ class AnalysisOrchestratorAgent:
         # in-agent escalation, so the image agent defaults to Tier-1-only.
         # Users can override via the constructor kwarg.
         self.image_analysis_depth = image_analysis_depth
+
+        # Non-anchor parallel fan-out for series curve fitting. None →
+        # the agent's own resolver picks up SCILINK_CURVE_FIT_WORKERS or
+        # falls back to 1 (serial). Forwarded only to agents whose
+        # __init__ declares the parameter — see create_agent_for_analysis.
+        self.curve_fit_parallel_workers = curve_fit_parallel_workers
 
         self.futurehouse_api_key = futurehouse_api_key
         if not self.futurehouse_api_key:
@@ -1018,6 +1026,18 @@ class AnalysisOrchestratorAgent:
             module = importlib.import_module(module_path)
             cls = getattr(module, class_name)
             entry["class"] = cls  # cache for subsequent calls
+
+        # Forward orchestrator-level optional kwargs only to agents whose
+        # __init__ declares them (or accepts **kwargs). Keeps backward
+        # compatibility with agents that haven't been updated.
+        sig_params = inspect.signature(cls.__init__).parameters
+        accepts_var_kw = any(
+            p.kind is inspect.Parameter.VAR_KEYWORD for p in sig_params.values()
+        )
+        if self.curve_fit_parallel_workers is not None and (
+            "parallel_workers" in sig_params or accepts_var_kw
+        ):
+            common_kwargs["parallel_workers"] = self.curve_fit_parallel_workers
 
         agent = cls(**common_kwargs)
         logging.info(f"   Created agent {agent_id}: {type(agent).__name__}")

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -1930,6 +1930,7 @@ class AnalysisOrchestratorTools:
             series_metadata: str = None,
             task_mode: str = None,
             prior_analysis_paths: List[str] = None,
+            parallel_workers: int = None,
         ) -> str:
             """
             Execute analysis with the selected or specified agent.
@@ -2401,6 +2402,11 @@ class AnalysisOrchestratorTools:
                     # accept **kwargs and silently ignore unknown parameters,
                     # matching the existing pattern for `hints`.
                     analyze_kwargs["task_mode"] = task_mode
+                if parallel_workers is not None:
+                    # Per-call override of non-anchor parallel fan-out for
+                    # series fitting. Consumed by CurveFittingAgent; other
+                    # agents accept **kwargs and silently ignore.
+                    analyze_kwargs["parallel_workers"] = parallel_workers
                 if self.orch.active_knowledge:
                     analyze_kwargs["prior_knowledge"] = self.orch.active_knowledge
                 if prior_analysis_paths:
@@ -2597,6 +2603,31 @@ class AnalysisOrchestratorTools:
                         "receives a state summary (pipeline, quality score, "
                         "extracted features, scientific claims, saved-arrays "
                         "catalog). Image-analysis agent only."
+                    )
+                },
+                "parallel_workers": {
+                    "type": "integer",
+                    "description": (
+                        "CurveFitting agent only. Worker count for the "
+                        "non-anchor parallel fan-out in series fitting. Each "
+                        "regime anchor is fit serially with full quality "
+                        "control; the remaining spectra in that regime are "
+                        "then fit concurrently using this many workers. "
+                        "Speedup scales roughly linearly up to min(N-1, "
+                        "cores) where N is series length. "
+                        "**Policy:** treat this as a user preference, not a "
+                        "scientific decision. Do NOT set this parameter "
+                        "without first asking the user — the LLM lacks "
+                        "context about their hardware (core count), latency "
+                        "tolerance, and CI/interactive setting. For series "
+                        "with ≥10 spectra, ask the user something like "
+                        "'This is a 30-spectrum series. Would you like to "
+                        "run non-anchor fits in parallel? A typical value "
+                        "is 4-8 workers.' For single spectra or short series "
+                        "(<5), omit this parameter — the parallel section is "
+                        "negligible. Leave unset to use the session default "
+                        "(operator-set at orchestrator construction or via "
+                        "SCILINK_CURVE_FIT_WORKERS env var)."
                     )
                 }
             },

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1712,6 +1712,47 @@ Your guidance: '''
             except ValueError:
                 return np.loadtxt(data_path, skiprows=1)
 
+    # Adaptive-timeout policy for per-spectrum subprocess execution.
+    # A subprocess that times out is rarely "broken code" — usually the
+    # fit just needs longer. Re-running the SAME script with 2× the
+    # timeout, up to a hard cap, avoids burning LLM tokens on
+    # _correct_script "fixing" code that wasn't actually wrong.
+    _TIMEOUT_ESCALATIONS = 2
+    _TIMEOUT_GROWTH = 2.0
+    _TIMEOUT_HARD_CAP_S = 1800
+
+    def _execute_with_adaptive_timeout(self, script: str) -> dict:
+        """Run a script via the executor; on timeout, retry the same script
+        with a longer timeout until it succeeds, the hard cap is hit, or the
+        escalation budget is exhausted. Non-timeout failures are returned
+        as-is so the caller's script-correction loop can handle them.
+        """
+        base = self.executor.timeout
+        current = base
+        result = None
+        for esc in range(self._TIMEOUT_ESCALATIONS + 1):
+            result = self.executor.execute_script(
+                script, working_dir=str(self.output_dir), timeout=current
+            )
+            if result.get("status") == "success":
+                return result
+            msg = (result.get("message") or "").lower()
+            if "timed out" not in msg:
+                return result  # genuine script error — escalate via _correct_script
+            next_timeout = min(int(current * self._TIMEOUT_GROWTH), self._TIMEOUT_HARD_CAP_S)
+            if next_timeout <= current or esc >= self._TIMEOUT_ESCALATIONS:
+                self.logger.warning(
+                    f"    ⏱  Timed out at {current}s; hit escalation cap "
+                    f"({self._TIMEOUT_HARD_CAP_S}s / {self._TIMEOUT_ESCALATIONS} retries) — giving up."
+                )
+                return result
+            self.logger.warning(
+                f"    ⏱  Script timed out at {current}s — retrying same script with {next_timeout}s "
+                f"(escalation {esc + 1}/{self._TIMEOUT_ESCALATIONS})"
+            )
+            current = next_timeout
+        return result
+
     def _fit_single_spectrum(
         self,
         state: dict,
@@ -1784,7 +1825,7 @@ Your guidance: '''
                     script, diagnosis = self._correct_script(state, script, last_error)
                     script_errors.append({"error": last_error, "diagnosis": diagnosis})
 
-                exec_result = self.executor.execute_script(script, working_dir=str(self.output_dir))
+                exec_result = self._execute_with_adaptive_timeout(script)
 
                 if exec_result.get("status") == "success":
                     # Check if the script actually produced the expected outputs

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -277,6 +277,10 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         r2_threshold: Optional[float] = None,
         max_model_retries: Optional[int] = None,
         outlier_sigma: Optional[float] = None,
+        # Per-call override of non-anchor parallel fan-out. None → falls back
+        # to the agent's construction-time `self.parallel_workers` (which in
+        # turn falls back to the SCILINK_CURVE_FIT_WORKERS env var or 1).
+        parallel_workers: Optional[int] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """
@@ -609,7 +613,9 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             max_model_retries=effective_max_retries,
             outlier_sigma=effective_outlier_sigma,
             max_verification_iterations=self.max_verification_iterations,
-            parallel_workers=self.parallel_workers,
+            parallel_workers=(
+                parallel_workers if parallel_workers is not None else self.parallel_workers
+            ),
         )
         
         # Execute pipeline

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -73,7 +73,8 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # Agent specific params
         spectral_unmixing_settings: dict | None = None,
         run_preprocessing: bool = True,
-        enable_human_feedback: bool = True
+        enable_human_feedback: bool = True,
+        **kwargs,
     ):
         
         if not require_sandbox_approval(

--- a/scilink/executors.py
+++ b/scilink/executors.py
@@ -285,14 +285,25 @@ class ScriptExecutor:
         
         logging.info(f"ScriptExecutor initialized (timeout: {self.timeout}s)")
 
-    def execute_script(self, script_content: str, working_dir: str = None) -> dict:
+    def execute_script(self, script_content: str, working_dir: str = None,
+                       timeout: int | None = None) -> dict:
         """Execute a Python script.
 
         Thread-safe: the subprocess's CWD is set via ``Popen(cwd=...)`` and the
         caller's process CWD is never mutated, so concurrent calls from
         different threads do not race on a shared global.
+
+        Args:
+            script_content: Python source to execute.
+            working_dir: Directory to use as the subprocess's CWD (and where
+                the temp script file is written). Defaults to current CWD.
+            timeout: Per-call timeout in seconds. When ``None`` (the default),
+                uses ``self.timeout`` from construction. Callers that need an
+                adaptive-timeout escalation pattern pass the override here
+                without mutating shared executor state.
         """
-        logging.info("   Executing Python script...")
+        effective_timeout = self.timeout if timeout is None else timeout
+        logging.info(f"   Executing Python script (timeout: {effective_timeout}s)...")
 
         if working_dir:
             os.makedirs(working_dir, exist_ok=True)
@@ -318,11 +329,11 @@ class ScriptExecutor:
             # Register so OutputCapture.kill_subprocesses() can terminate it.
             _register_subprocess(proc)
             try:
-                stdout, stderr = proc.communicate(timeout=self.timeout)
+                stdout, stderr = proc.communicate(timeout=effective_timeout)
             except subprocess.TimeoutExpired:
                 proc.kill()
                 proc.wait()
-                return {"status": "error", "message": f"Script execution timed out after {self.timeout} seconds."}
+                return {"status": "error", "message": f"Script execution timed out after {effective_timeout} seconds."}
             finally:
                 _unregister_subprocess(proc)
 


### PR DESCRIPTION
**Stacked on #163.** Set the base of this PR to `feat/curve-fit-parallel-spectra` so the diff stays focused on the orchestrator-level work. Once #163 merges, this branch rebases cleanly onto `main`.

## Summary

Three changes that make the parallel fan-out from #163 actually reachable from the analyze-mode chat, plus a related cleanup:

1. **`AnalysisOrchestratorAgent` gains `curve_fit_parallel_workers`** — session-level operator knob. Forwarded to agents whose `__init__` accepts `parallel_workers` (or `**kwargs`). Default `None` → behavior byte-identical to before.

2. **`run_analysis` tool gains a `parallel_workers` parameter** — per-call override that supersedes the session default. The tool description is policy-loaded: the LLM is told to treat this as a user preference (not a scientific decision), to ask the user before setting it, and to omit it for single spectra or short series.

3. **Adaptive timeout escalation in `_fit_single_spectrum`** — when a subprocess hits `TimeoutExpired`, retry the **same script** with 2× timeout (up to 2 escalations, capped at 1800 s) instead of routing through `_correct_script` and asking the LLM to "fix" code that wasn't broken. Saves tokens and avoids spurious "failed" results when fits are just slow.

4. **`HyperspectralAnalysisAgent` gains `**kwargs`** — pre-existing latent bug surfaced by live-testing the orchestrator chain. `create_agent_for_analysis` already forwards `analysis_depth` unconditionally on the assumption that agents silently ignore unknown kwargs; hyperspectral was the lone agent that didn't, so any analyze-mode session that picked `agent_id=2` would crash with `TypeError: unexpected keyword argument 'analysis_depth'`. Three-line fix.

## Plumbing chain

```
AnalysisOrchestratorAgent(curve_fit_parallel_workers=N)        ← session policy
    └─ create_agent_for_analysis(agent_id, ...)
        └─ inspect.signature(cls.__init__).parameters
            ├─ accepts `parallel_workers` or **kwargs → forward
            └─ otherwise → omit  (hyperspectral path, until #2 above)

run_analysis(parallel_workers=N, ...)                          ← per-call override
    └─ analyze_kwargs["parallel_workers"] = N
        └─ CurveFittingAgent.analyze(parallel_workers=N, ...)
            └─ effective = override or self.parallel_workers
                └─ create_unified_curve_fitting_pipeline(parallel_workers=effective)
                    └─ UnifiedSeriesProcessingController(parallel_workers=effective)
                        └─ execute() emits "Parallel non-anchor fan-out: up to N workers"

executor.execute_script(..., timeout=T)                        ← per-call override
    └─ self.timeout when T is None  (existing callers unaffected)

_execute_with_adaptive_timeout(script)                         ← new helper
    └─ run with base timeout
        if TimeoutExpired: retry SAME script at 2× (≤ 2 escalations, ≤ 1800 s)
        if non-timeout error: return as-is (caller's correction loop handles it)
```

## Live test results

| Test | Result |
|---|---|
| Adaptive timeout: 3 s sleep against 1 s base, no LLM | PASS — escalation ladder 1→2→4 s, succeeds at 4 s, **zero `_correct_script` invocations** |
| Orchestrator session default `curve_fit_parallel_workers=3`, autonomous chat | PASS — banner "up to 3 workers", controller drain phase fires |
| Orchestrator session default `None`, LLM passes `parallel_workers=3` per call via `run_analysis` tool | PASS — banner "up to 3 workers" (the per-call override took precedence over the None session default) |

All 18 existing `test_adaptive_annealing.py` tests pass unchanged.

## Backward compatibility

- `AnalysisOrchestratorAgent(curve_fit_parallel_workers=None)` (default) → no kwarg added to `common_kwargs` → all agents constructed exactly as before.
- `run_analysis()` without `parallel_workers` → no kwarg passed to `analyze` → agent's construction-time `self.parallel_workers` wins.
- `ScriptExecutor.execute_script(...)` without `timeout=` kwarg → uses `self.timeout` exactly as before.
- `_execute_with_adaptive_timeout` is internal; its escalation triggers only on actual `TimeoutExpired`. Successful runs return on the first call.