### PR TITLE
Auto-discover planning skills in generate_initial_plan param

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,32 @@ across all three modes. For example, adding an XRD or Raman skill for
 existing CurveFittingAgent is strongly preferred over creating two new agents
 for Ramand and XRD.
 
+## Plan-mode capability boundaries
+
+Two settled conventions on where capability lives in plan mode:
+
+**Plan-mode skills are knowledge-only.** Skill bundles under
+`scilink/skills/planning/<name>/` are markdown — no per-skill
+`.py` / `TOOL_SPEC` tools. Plan mode reasons and synthesizes; it does
+not execute domain numerics. `PlanningAgent` produces plan text, heavy
+compute is `BOAgent`'s, and executable artifacts flow through
+`generate_implementation_code` — codegen *guided by* the skill's
+`implementation` section, so the skill shapes the code rather than
+shipping it. Planning subagents deliberately do not consume the
+`_shared/_registry` tool inventory. A planning skill that seems to need
+a vetted tool is mis-scoped.
+
+**The scalarizer is the lightweight analysis tier.** `ScalarizerAgent`
+does simple LLM-generated extraction (pandas / numpy / scipy) over
+tabular or otherwise simple data, reduced to scalars plus the BO
+input/target schema. It gets no vetted `.py` tools — needing one is the
+tripwire that the task is not lightweight and belongs in analyze mode.
+Heavy "data → number" extraction is reused, not rebuilt: `run_analysis`
+does the hard work with its skill tools, then the scalarizer reduces the
+result (`run_analysis → scalarize`). That cross-mode chain is gated on
+the future `run_task` contract; until it exists, run the analysis
+standalone and feed the resulting scalar in as a data file.
+
 ## Why no `BaseChatOrchestrator` refactor
 
 The three orchestrators share a near-identical chat-loop / message-history /

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -24,6 +24,47 @@ from .instruct import (
     KNOWLEDGE_QUERY_DIRECTORY_CODEGEN_PROMPT,
 )
 from ..lit_agents.optimize_query import optimize_search_query, is_molecule_design_objective
+from ...skills.loader import list_skills, load_skill
+
+
+def _build_planning_skill_description(custom_skills: dict = None) -> str:
+    """Build the ``skill`` parameter description for ``generate_initial_plan``.
+
+    Auto-discovers built-in planning skill bundles (and any custom or
+    graduated skills) so the orchestrator LLM can see which skills are
+    available by name instead of having to be told. Mirrors the analyze-mode
+    ``_build_skill_description`` helper, scoped to ``domain="planning"``.
+    """
+    parts = [
+        "Optional domain skill: a built-in planning skill name or a path to "
+        "a custom .md skill file. When set, the skill's validated domain "
+        "rules are injected as mandatory constraints on the generated plan."
+    ]
+
+    try:
+        names = list_skills(domain="planning")
+    except Exception:
+        names = []
+
+    skill_descs = []
+    for name in names:
+        try:
+            parsed = load_skill(name, domain="planning")
+            desc = (parsed.get("meta") or {}).get("description")
+            if not desc:
+                desc = parsed.get("overview", "").split("\n")[0].strip()
+            # Trim trailing punctuation so the join below stays clean.
+            desc = desc.rstrip(".;,") if desc else desc
+            skill_descs.append(f"'{name}' — {desc}" if desc else f"'{name}'")
+        except Exception:
+            skill_descs.append(f"'{name}'")
+    if skill_descs:
+        parts.append(f"Built-in planning skills: {'; '.join(skill_descs)}.")
+
+    if custom_skills:
+        parts.append(f"Custom skills: {sorted(custom_skills.keys())}.")
+
+    return " ".join(parts)
 
 
 class OrchestratorTools:
@@ -757,7 +798,12 @@ class OrchestratorTools:
                 "knowledge_paths": {"type": "string", "description": "Comma-separated paths to papers/reports/docs folders"},
                 "primary_data_set": {"type": "string", "description": "Path to experimental data file or folder"},
                 "additional_context": {"type": "string", "description": "Lab constraints, equipment, reagents, budget, etc."},
-                "skill": {"type": "string", "description": "Domain skill name or path to custom .md skill file"},
+                "skill": {
+                    "type": "string",
+                    "description": _build_planning_skill_description(
+                        getattr(self.orch, "_custom_skills", None)
+                    ),
+                },
                 "literature_context": {"type": "string", "description": "File path or text from search_literature() tool. Provides external scientific literature context."},
                 "molecule_context": {"type": "string", "description": "File path or text from query_molecules() tool. Provides molecular design / synthesis context."}
             },
@@ -4528,7 +4574,25 @@ class OrchestratorTools:
             }
         }
         self.openai_schemas.append(openai_schema)
-    
+
+    def _update_skill_description(self, custom_skills: dict = None) -> None:
+        """Refresh the ``skill`` parameter description in ``generate_initial_plan``.
+
+        Called after a skill is registered at runtime (e.g. ``graduate_to_skill``)
+        so newly available skills become visible to the orchestrator LLM. The
+        schema dict is mutated in place, so the change propagates to
+        ``tools_for_model`` (which is the same ``openai_schemas`` list object).
+        """
+        new_desc = _build_planning_skill_description(custom_skills)
+        for schema in self.openai_schemas:
+            fn = schema.get("function", {})
+            if fn.get("name") != "generate_initial_plan":
+                continue
+            skill_prop = fn.get("parameters", {}).get("properties", {}).get("skill")
+            if skill_prop is not None:
+                skill_prop["description"] = new_desc
+            break
+
     def execute_tool(self, tool_name: str, **kwargs) -> str:
         """
         Execute a tool by name with given arguments.

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -832,6 +832,9 @@ class PlanningOrchestratorAgent:
         # Make it the active skill for subsequent generate_initial_plan calls
         self._active_skill = str(path)
 
+        # Surface the new skill to the orchestrator LLM's generate_initial_plan tool
+        self.tools._update_skill_description(self._custom_skills)
+
         logging.info(f"📖 Registered planning skill: {name} → {path}")
         return name
 


### PR DESCRIPTION
## Summary

Plan mode's skill plumbing (`load_skill`, `_build_skill_context`,
`graduate_to_skill`) was already wired into `PlanningAgent`, but the
`skill` parameter of the `generate_initial_plan` tool carried a static
description — so the orchestrator LLM had no way to know which planning
skills exist, and graduated skills were never advertised back to it.

This mirrors the analyze-mode `_build_skill_description` pattern, scoped
to `domain="planning"`:

- New `_build_planning_skill_description()` discovers built-in bundles via
  `list_skills(domain="planning")`, pulls each bundle's frontmatter
  `description`, and folds in custom / graduated skills.
- `generate_initial_plan`'s `skill` param now uses it instead of a fixed
  string.
- New `OrchestratorTools._update_skill_description()` refreshes that
  description in place; `register_skill()` calls it so `graduate_to_skill`
  output becomes visible mid-session.

Scope is intentionally limited to discovery wiring. `skill` stays a
single `str` (multi-skill loading would be a separate change). No agent
signatures, state, or plan-generation behavior are touched — only a
tool-parameter description string. `tools_for_model` aliases the same
`openai_schemas` list object, so the in-place mutation propagates with
no re-conversion; checkpoint restore runs before tool registration, so
resumed sessions pick up custom skills without extra handling.

With no bundles under `scilink/skills/planning/` yet, the description
shows the base text plus any graduated skills — it activates
automatically once a bundle lands at `scilink/skills/planning/<name>/<name>.md`.

## Test plan

- [x] `py_compile` + import of both modified modules
- [x] `_build_planning_skill_description()` — empty, with custom skills, and with a real bundle dropped via `SCILINK_SKILLS_PATH` (frontmatter `description` flows through)
- [x] Live `claude-opus-4-6` call with the real `generate_initial_plan` schema — model enumerated the discovered skill from the `skill`-param description
- [x] Full `PlanningOrchestratorAgent` construction + live chat turn (`claude-opus-4-6`) — discovered skill present in the live tool schema, and the orchestrator correctly named it in a real chat response

🤖 Generated with [Claude Code](https://claude.com/claude-code)