### PR TITLE
One Agent to Rule Them All

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ meta agent delegates through.
 ## The meta agent
 
 The meta agent sits on top of the mode orchestrators so users don't switch
-manually — bare `scilink` (or `scilink meta`) launches it. It is **not a
+manually — bare `scilink` (or `scilink explore`) launches it. It is **not a
 fourth mode**; it's an orchestrator-of-orchestrators with a different role
 (router + context bridge). It lives in `scilink/agents/meta_agent/`
 (`MetaOrchestratorAgent` + `MetaOrchestratorTools`), copying the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ this is a settled architectural commitment, not a refactoring waypoint:
 |---|---|---|
 | `analyze` | `AnalysisOrchestratorAgent` | Experimental data analysis (microscopy, spectroscopy, …) |
 | `plan` | `PlanningOrchestratorAgent` | Experimental campaign design |
-| `simulate` | `SimulationOrchestratorAgent` *(not yet built — stub at `cli/simulate.py`)* | Computational simulations (DFT today, LAMMPS later) |
+| `simulate` | `SimulationOrchestratorAgent` | Computational simulations (DFT today, LAMMPS later) |
 
 Anything in scientific workflow falls under one of these three. There will
 **not** be a fourth mode. Future capability growth happens *inside* one of
@@ -128,46 +128,92 @@ simulate_session_YYYYMMDD_HHMMSS/
 Each orchestrator exposes both an interactive and a non-interactive entry
 point sharing the same state and tool registry:
 
-```python
-class SimulationOrchestratorAgent:
-    def run_chat(self, user_input: str) -> str:
-        """Interactive — CLI / UI."""
-    def run_task(self, task: str, context: dict) -> dict:
-        """Non-interactive — autonomous mode under the hood. Returns:
-            {summary, files_produced, key_findings, suggested_followups}
-        Used by the future meta agent to delegate sub-tasks.
-        """
-```
+- `chat(user_input: str) -> str` — interactive (CLI / UI).
+- `run_task(task, context=None, autonomy=None) -> dict` — programmatic
+  entry point. Runs one `chat` turn under the requested autonomy mode, then
+  derives a structured summary from the session-state delta. `autonomy=None`
+  defaults to AUTONOMOUS — the safe choice for a headless caller (never
+  pauses for a nonexistent user). A caller attached to a human passes a
+  co-pilot / supervised mode so the sub-agents' human-feedback prompts reach
+  that human.
 
-Plan and analyze will eventually need `run_task` too. Not a refactor —
-just a contract to honor when *adding* surfaces.
+`run_task` is implemented on **all three** orchestrators with that uniform
+signature. The return dict shares `status, task, summary, files_produced,
+key_findings, suggested_followups, warnings` (plus `error` on failure); the
+domain-specific field differs per mode — `analyses` (analyze),
+`campaign_state` (plan), `structures` (simulate). This is the contract the
+meta agent delegates through.
 
-## The meta agent (future)
+## The meta agent
 
-A meta agent will sit on top of the three modes so users don't switch
-manually. It is **not a fourth mode**; it's an orchestrator-of-orchestrators
-with a different role (router + context bridge).
+The meta agent sits on top of the mode orchestrators so users don't switch
+manually — bare `scilink` (or `scilink meta`) launches it. It is **not a
+fourth mode**; it's an orchestrator-of-orchestrators with a different role
+(router + context bridge). It lives in `scilink/agents/meta_agent/`
+(`MetaOrchestratorAgent` + `MetaOrchestratorTools`), copying the
+`AnalysisOrchestratorAgent` chat-loop shape.
+
+**v1 scope: analysis + planning.** Simulation delegation is deferred —
+`scilink.agents.sim_agents` hard-imports `ase` (an optional dependency), so
+the meta module must stay importable without it. `delegate_to_simulation`
+is a documented lazy seam: when added, its body does a guarded import
+*inside the function*, never at module scope.
 
 ### Pattern: agent-as-tool
 
 ```
 Meta tool registry
-  delegate_to_analysis(task, context)     → AnalysisOrchestratorAgent.run_task
-  delegate_to_planning(task, context)     → PlanningOrchestratorAgent.run_task
-  delegate_to_simulation(task, context)   → SimulationOrchestratorAgent.run_task
-  bridge_context(from_session, to_topic)  → extract findings/files between modes
-  summarize_session_state()               → cross-child status
+  delegate_to_analysis(task, context)   → AnalysisOrchestratorAgent.run_task
+  delegate_to_planning(task, context)   → PlanningOrchestratorAgent.run_task
+  summarize_session_state()             → cross-specialist status
+  get_delegation_history(limit)         → the delegation ledger
+  delegate_to_simulation(...)           → deferred lazy seam (not built)
 ```
 
-The meta agent presents a single conversational surface to the user;
-under the hood each delegation spins up a child sub-session with its
-own chat history, files, checkpoint — all nested under the meta-session
-directory.
+There is **no `bridge_context` tool**. `run_task` already accepts a
+`context` dict; the meta LLM bridges modes by reading a prior result via
+`get_delegation_history` and threading its `key_findings` / `files_produced`
+into the next delegation's `context`. The delegation ledger is the
+supporting structure.
 
-Because the meta consumes children through their `run_task` contract
-(not through inherited internals), no base class is required. The
-contract is duck-typed; what the children share is *interface shape*,
-not *implementation*.
+### Two autonomy levels, not three
+
+The individual modes have a three-level autonomy paradigm (co-pilot /
+supervised / autonomous); `MetaMode` has only **SUPERVISED** (default) and
+**AUTONOMOUS**. A delegation runs the child through its one-shot `run_task`
+— a single turn. Co-pilot's model is "pause after every step, wait for the
+user's next message," which needs many turns, so it cannot complete a
+delegated task. SUPERVISED and AUTONOMOUS each finish a task in one turn:
+SUPERVISED still pauses at the child's decision points (approve / edit plans
+and outputs) via `input()`-based human-feedback prompts — which compose with
+`run_task` because they block-and-resume *within* the turn — while AUTONOMOUS
+runs end to end. The three-level paradigm is untouched for the standalone
+`analyze` / `plan` / `simulate` modes.
+
+### Persistent children, nested sessions
+
+The meta keeps **one persistent child per mode** — lazily created on first
+delegation, reused across all delegations so context accumulates — in fixed
+sub-directories `<meta_session>/analysis/` and `<meta_session>/planning/`.
+After a meta restore a child is re-created with `restore_checkpoint=True`
+simply by probing for its `checkpoint.json`. **Each delegation runs the
+child under the meta's own autonomy mode** — passed as `run_task`'s
+`autonomy` arg (mapped by enum name); the child's resting mode is
+irrelevant. So a supervised delegation keeps the specialist's human-feedback
+prompts, which surface to the user driving the meta exactly as in a direct
+single-mode session. The planning child is built in CO_PILOT with
+`data_dir=None` — the one construction mode that does not require
+`data_dir`; `set_autonomy_level` does not re-validate it on the per-call
+switch. Per-delegation
+isolation: each `run_task` writes into its own sub-directory so a reused
+child does not overwrite earlier outputs (analysis already stamps result
+dirs; the planning orchestrator writes to a per-delegation
+`delegations/<NN>_<slug>/`).
+
+Because the meta consumes children through their `run_task` contract (not
+through inherited internals), no base class is required. The contract is
+duck-typed; what the children share is *interface shape*, not
+*implementation*.
 
 ## Sequencing — hard features first, UI later
 
@@ -190,7 +236,9 @@ Concretely, when the simulate orchestrator work starts, the order is:
 5. UI — sidebar mode, chat panel, possibly a wizard surface coexisting
    with the chat surface
 
-The meta agent comes after all three child orchestrators are stable.
+The meta agent (`scilink/agents/meta_agent/`) was built following this same
+backend → CLI → UI order, over the analysis and planning orchestrators;
+simulation delegation is wired into its lazy seam once that path is stable.
 
 ## Connection between modes today
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ point sharing the same state and tool registry:
   derives a structured summary from the session-state delta. `autonomy=None`
   defaults to AUTONOMOUS — the safe choice for a headless caller (never
   pauses for a nonexistent user). A caller attached to a human passes a
-  co-pilot / supervised mode so the sub-agents' human-feedback prompts reach
+  co-pilot / autopilot mode so the sub-agents' human-feedback prompts reach
   that human.
 
 `run_task` is implemented on **all three** orchestrators with that uniform
@@ -179,12 +179,12 @@ supporting structure.
 ### Two autonomy levels, not three
 
 The individual modes have a three-level autonomy paradigm (co-pilot /
-supervised / autonomous); `MetaMode` has only **SUPERVISED** (default) and
+autopilot / autonomous); `MetaMode` has only **AUTOPILOT** (default) and
 **AUTONOMOUS**. A delegation runs the child through its one-shot `run_task`
 — a single turn. Co-pilot's model is "pause after every step, wait for the
 user's next message," which needs many turns, so it cannot complete a
-delegated task. SUPERVISED and AUTONOMOUS each finish a task in one turn:
-SUPERVISED still pauses at the child's decision points (approve / edit plans
+delegated task. AUTOPILOT and AUTONOMOUS each finish a task in one turn:
+AUTOPILOT still pauses at the child's decision points (approve / edit plans
 and outputs) via `input()`-based human-feedback prompts — which compose with
 `run_task` because they block-and-resume *within* the turn — while AUTONOMOUS
 runs end to end. The three-level paradigm is untouched for the standalone
@@ -199,7 +199,7 @@ After a meta restore a child is re-created with `restore_checkpoint=True`
 simply by probing for its `checkpoint.json`. **Each delegation runs the
 child under the meta's own autonomy mode** — passed as `run_task`'s
 `autonomy` arg (mapped by enum name); the child's resting mode is
-irrelevant. So a supervised delegation keeps the specialist's human-feedback
+irrelevant. So an autopilot delegation keeps the specialist's human-feedback
 prompts, which surface to the user driving the meta exactly as in a direct
 single-mode session. The planning child is built in CO_PILOT with
 `data_dir=None` — the one construction mode that does not require

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SciLink provides three complementary agent systems that cover the full scientifi
 All systems support three autonomy levels:
 
 - **Co-Pilot** (default) — Human leads, AI assists. Reviews every step.
-- **Supervised** — AI leads, human reviews major decisions.
+- **Autopilot** — AI leads, human reviews major decisions.
 - **Autonomous** — Full autonomy, no human review.
 
 ---
@@ -75,7 +75,7 @@ SciLink can be used via the **CLI**, **web UI**, **MCP server**, or **Python API
 ```bash
 # Planning session
 scilink plan
-scilink plan --autonomy supervised --data-dir ./results --knowledge-dir ./papers
+scilink plan --autonomy autopilot --data-dir ./results --knowledge-dir ./papers
 
 # Analysis session
 scilink analyze
@@ -113,7 +113,7 @@ plan = planner.propose_experiments(
 )
 
 # Analyze image data
-analyzer = AnalysisOrchestratorAgent(analysis_mode=AnalysisMode.SUPERVISED)
+analyzer = AnalysisOrchestratorAgent(analysis_mode=AnalysisMode.AUTOPILOT)
 result = analyzer.chat("Analyze ./stem_image.tif and generate scientific claims")
 ```
 
@@ -232,7 +232,7 @@ PlanningOrchestratorAgent (main coordinator)
 
 ```bash
 scilink plan
-scilink plan --autonomy supervised --data-dir ./results --knowledge-dir ./papers
+scilink plan --autonomy autopilot --data-dir ./results --knowledge-dir ./papers
 scilink plan --model claude-opus-4-5
 ```
 
@@ -281,7 +281,7 @@ from scilink.agents.planning_agents import PlanningAgent, ScalarizerAgent, BOAge
 # Using the orchestrator
 orchestrator = PlanningOrchestratorAgent(
     objective="Optimize reaction yield",
-    autonomy_level=AutonomyLevel.SUPERVISED,
+    autonomy_level=AutonomyLevel.AUTOPILOT,
     data_dir="./experimental_results",
     knowledge_dir="./papers"
 )
@@ -382,7 +382,7 @@ from scilink.agents.exp_agents import (
 # Using the orchestrator
 orchestrator = AnalysisOrchestratorAgent(
     base_dir="./my_analysis",
-    analysis_mode=AnalysisMode.SUPERVISED
+    analysis_mode=AnalysisMode.AUTOPILOT
 )
 response = orchestrator.chat("Examine ./data/sample.tif")
 

--- a/docs/claude_code_integration.md
+++ b/docs/claude_code_integration.md
@@ -131,8 +131,8 @@ Available with `--mode plan` or `--mode both`:
 
 | Tool | Description |
 |------|-------------|
-| `scilink_set_autonomy` | Switch between autonomous/supervised/co-pilot modes at runtime |
-| `scilink_respond` | Approve or reject a pending action (co-pilot/supervised modes) |
+| `scilink_set_autonomy` | Switch between autonomous/autopilot/co-pilot modes at runtime |
+| `scilink_respond` | Approve or reject a pending action (co-pilot/autopilot modes) |
 | `scilink_job_status` | Check status of a background job |
 | `scilink_job_result` | Retrieve result of a completed background job |
 
@@ -199,7 +199,7 @@ scilink serve --help
 |------|---------|-------------|
 | `--model` | `gemini-3.1-pro-preview` | LLM model for analysis agents |
 | `--mode` | `both` | `analyze`, `plan`, or `both` |
-| `--autonomy` | `autonomous` | `autonomous`, `supervised`, or `co-pilot` |
+| `--autonomy` | `autonomous` | `autonomous`, `autopilot`, or `co-pilot` |
 | `--transport` | `stdio` | `stdio` or `sse` |
 | `--host` | `127.0.0.1` | Bind address (SSE only) |
 | `--port` | `8000` | Bind port (SSE only) |
@@ -214,17 +214,17 @@ Control how much approval SciLink requires:
 
 ```bash
 scilink serve --autonomy autonomous   # default — all tools run immediately
-scilink serve --autonomy supervised   # high-impact tools pause for approval
+scilink serve --autonomy autopilot   # high-impact tools pause for approval
 scilink serve --autonomy co-pilot     # most tools pause for approval
 ```
 
 You can also switch at runtime by asking the LLM to call `scilink_set_autonomy`.
 
-In **supervised** and **co-pilot** modes, high-impact tools return a `needs_input` response instead of executing. The MCP client calls `scilink_respond` with `"yes"` to approve or `"no"` to cancel.
+In **autopilot** and **co-pilot** modes, high-impact tools return a `needs_input` response instead of executing. The MCP client calls `scilink_respond` with `"yes"` to approve or `"no"` to cancel.
 
 Tools that require approval:
 - **Co-pilot**: `run_analysis`, `select_agent`, `assess_novelty`, `get_recommendations`, `run_optimization`, `generate_initial_plan`, `generate_implementation_code`, `run_economic_analysis`, `discard_plan`
-- **Supervised**: `run_analysis`, `run_optimization`, `discard_plan`
+- **Autopilot**: `run_analysis`, `run_optimization`, `discard_plan`
 
 ## Background execution
 

--- a/examples/planning_agent_demo/README.md
+++ b/examples/planning_agent_demo/README.md
@@ -27,7 +27,7 @@ scilink ui
 **CLI**:
 
 ```bash
-scilink plan --autonomy supervised \
+scilink plan --autonomy autopilot \
              --data-dir examples/planning_agent_demo/experimental_data \
              --knowledge-dir examples/planning_agent_demo/knowledge_folder
 ```

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -53,12 +53,19 @@ class AnalysisMode(Enum):
     Matches the autonomy levels in PlanningOrchestratorAgent for consistent UX.
     
     CO_PILOT: Human leads, AI assists (default). Human reviews every step.
-    SUPERVISED: AI leads, human supervises. AI proceeds with reasonable defaults.
+    AUTOPILOT: AI leads, human monitors. AI proceeds with reasonable defaults.
     AUTONOMOUS: Full autonomy. AI executes complete workflows without confirmation.
     """
     CO_PILOT = "co-pilot"        # Human leads, AI assists (default)
-    SUPERVISED = "supervised"    # AI leads, human supervises
+    AUTOPILOT = "autopilot"      # AI leads, human monitors
     AUTONOMOUS = "autonomous"    # Full autonomy
+
+    @classmethod
+    def _missing_(cls, value):
+        # Back-compat: the AUTOPILOT level was named "supervised" before.
+        if isinstance(value, str) and value.strip().lower() == "supervised":
+            return cls.AUTOPILOT
+        return None
 
 
 # Mode-specific directives (matching planning orchestrator patterns)
@@ -85,9 +92,9 @@ _CO_PILOT_DIRECTIVE = """
 - Instead say "Ready for your input." or "Let me know how to proceed."
 """
 
-_SUPERVISED_DIRECTIVE = """
-**CRITICAL OPERATING MODE: SUPERVISED (AI Leads, Human Supervises)**
-- You lead the analysis workflow. Human supervises and can intervene.
+_AUTOPILOT_DIRECTIVE = """
+**CRITICAL OPERATING MODE: AUTOPILOT (AI Leads, Human Monitors)**
+- You lead the analysis workflow. Human monitors and can intervene.
 - Suggest the most appropriate agent based on data type and metadata.
 - Proceed with reasonable defaults without asking for every detail.
 - Human will still review agent selection before execution.
@@ -293,7 +300,7 @@ def _build_agent_list_section(agent_registry: dict) -> str:
 #
 # This is a workflow GATE, not a tool description: the LLM otherwise chains
 # straight to run_analysis and never reaches literature search. The gate is
-# mode-aware — CO-PILOT pauses to ask the user; SUPERVISED/AUTONOMOUS decide
+# mode-aware — CO-PILOT pauses to ask the user; AUTOPILOT/AUTONOMOUS decide
 # on their own, since those modes have no interactive user to wait on (and
 # `run_task` pins the orchestrator into AUTONOMOUS).
 _LIT_TOOL_BLURB = (
@@ -320,7 +327,7 @@ answer — do NOT call `run_analysis` in the same turn as the question.
 {_LIT_TOOL_BLURB}
 """
 
-# SUPERVISED / AUTONOMOUS: no interactive user — decide without asking.
+# AUTOPILOT / AUTONOMOUS: no interactive user — decide without asking.
 _LITERATURE_SECTION_AUTONOMOUS = f"""
 **LITERATURE SEARCH — CONSIDER BEFORE ANALYSIS:**
 A FutureHouse API key is configured this session. Before the FIRST
@@ -364,7 +371,7 @@ def get_system_prompt(
     """
     directives = {
         AnalysisMode.CO_PILOT: _CO_PILOT_DIRECTIVE,
-        AnalysisMode.SUPERVISED: _SUPERVISED_DIRECTIVE,
+        AnalysisMode.AUTOPILOT: _AUTOPILOT_DIRECTIVE,
         AnalysisMode.AUTONOMOUS: _AUTONOMOUS_DIRECTIVE,
     }
     if agent_registry:
@@ -381,7 +388,7 @@ def get_system_prompt(
         # Interactive — pause and ask the user.
         lit_section = _LITERATURE_SECTION_COPILOT
     else:
-        # SUPERVISED / AUTONOMOUS — no user to wait on; decide autonomously.
+        # AUTOPILOT / AUTONOMOUS — no user to wait on; decide autonomously.
         lit_section = _LITERATURE_SECTION_AUTONOMOUS
     body = (
         _SYSTEM_PROMPT_BODY_PRE + agent_list
@@ -428,7 +435,7 @@ class AnalysisOrchestratorAgent:
         embedding_model: Embedding model name.
         embedding_api_key: API key for the embedding LLM provider.
         restore_checkpoint: Whether to restore from previous checkpoint.
-        analysis_mode: Level of autonomy (CO_PILOT, SUPERVISED, or AUTONOMOUS).
+        analysis_mode: Level of autonomy (CO_PILOT, AUTOPILOT, or AUTONOMOUS).
         image_analysis_depth: Default analysis depth passed to
             ImageAnalysisAgent ("basic", "auto", or "deep"). Defaults to
             "basic" so Tier 2 is handled at the orchestrator level via
@@ -1257,7 +1264,7 @@ class AnalysisOrchestratorAgent:
         ``autonomy`` selects the AnalysisMode for this call. Defaults to
         AUTONOMOUS — the safe choice for a headless/programmatic caller, so
         the agent never pauses for a nonexistent user. A caller attached to a
-        human (the meta agent, driven via CLI/UI) passes SUPERVISED so the
+        human (the meta agent, driven via CLI/UI) passes AUTOPILOT so the
         sub-agents' human-feedback prompts reach that human.
         The original mode is restored on exit, even if chat() raises.
         """
@@ -1281,7 +1288,7 @@ class AnalysisOrchestratorAgent:
 
         # Run under the requested autonomy mode — AUTONOMOUS by default (the
         # safe headless choice). The meta agent passes its own mode through,
-        # so a co-pilot / supervised delegation still raises the sub-agents'
+        # so a co-pilot / autopilot delegation still raises the sub-agents'
         # human-feedback prompts to the user driving the session.
         run_mode = autonomy if autonomy is not None else AnalysisMode.AUTONOMOUS
         original_mode = self.analysis_mode

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -9,6 +9,7 @@ Coordinates multi-modal experimental analysis using specialized sub-agents:
 Follows the same design patterns as PlanningOrchestratorAgent for consistent UX.
 """
 
+import inspect
 import json
 import logging
 import os
@@ -1087,8 +1088,9 @@ class AnalysisOrchestratorAgent:
             "base_url": self.base_url,
             "output_dir": output_dir,
             "enable_human_feedback": self._enable_human_feedback,
-            # Consumed only by ImageAnalysisAgent; other agents accept
-            # **kwargs and silently ignore.
+            # Consumed only by ImageAnalysisAgent. Filtered out below for any
+            # agent whose __init__ neither declares it nor accepts **kwargs
+            # (hyperspectral, FFT, SAM, atomistic) — passing it would raise.
             "analysis_depth": self.image_analysis_depth,
         }
 
@@ -1100,6 +1102,19 @@ class AnalysisOrchestratorAgent:
             module = importlib.import_module(module_path)
             cls = getattr(module, class_name)
             entry["class"] = cls  # cache for subsequent calls
+
+        # Keep only the kwargs this agent's __init__ actually accepts. An agent
+        # that declares **kwargs gets everything; one that does not gets only
+        # its explicitly-named parameters.
+        try:
+            params = inspect.signature(cls.__init__).parameters
+            if not any(p.kind is inspect.Parameter.VAR_KEYWORD
+                       for p in params.values()):
+                common_kwargs = {
+                    k: v for k, v in common_kwargs.items() if k in params
+                }
+        except (ValueError, TypeError):
+            pass  # unintrospectable __init__ — pass kwargs through unchanged
 
         agent = cls(**common_kwargs)
         logging.info(f"   Created agent {agent_id}: {type(agent).__name__}")

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1166,6 +1166,127 @@ class AnalysisOrchestratorAgent:
             
             return f"❌ Error: {e}\n\n(Emergency checkpoint saved to {self.checkpoint_path})"
 
+    def run_task(self, task: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Non-interactive entry point — used by the meta agent.
+
+        Runs the task in autonomous mode (regardless of the agent's current
+        configured mode) and returns a structured summary that's easy to
+        consume programmatically:
+
+            {
+                "status": "success" | "error",
+                "task": str,                       # echoed input
+                "summary": str,                    # the agent's final reply
+                "files_produced": List[str],       # absolute paths
+                "key_findings": List[str],         # extracted scientific claims
+                "suggested_followups": List[str],
+                "analyses": List[dict],            # session record snapshot
+                "warnings": List[str],
+            }
+
+        Mirrors SimulationOrchestratorAgent.run_task — see CLAUDE.md
+        "Two surfaces, one agent". The agent is pinned into AUTONOMOUS mode
+        for the duration of the call so it doesn't pause for a (nonexistent)
+        user; the original mode is restored on exit, even if chat() raises.
+        """
+        # Build a self-contained prompt that includes the optional context.
+        prompt = task
+        if context:
+            try:
+                ctx_str = json.dumps(context, indent=2, default=str)
+            except (TypeError, ValueError):
+                ctx_str = repr(context)
+            prompt = (
+                f"{task}\n\n"
+                f"Context provided by the caller (e.g., upstream agent's findings):\n"
+                f"```\n{ctx_str}\n```\n\n"
+                "Use this context together with your tools to complete the task."
+            )
+
+        # Snapshot prior state so we report "what was produced *during* this
+        # call" rather than "everything in the session."
+        n_before = len(self.analysis_results)
+
+        # Pin autonomy to AUTONOMOUS for the duration of this call so the
+        # agent doesn't pause to ask the (nonexistent) user for confirmation.
+        original_mode = self.analysis_mode
+        try:
+            self.set_analysis_mode(AnalysisMode.AUTONOMOUS)
+            try:
+                summary_text = self.chat(prompt)
+                status = "success"
+                error_msg: Optional[str] = None
+            except Exception as e:
+                self.logger.exception(f"run_task failed: {e}")
+                summary_text = ""
+                status = "error"
+                error_msg = str(e)
+        finally:
+            # Always restore the original mode, even if chat() raised.
+            self.set_analysis_mode(original_mode)
+
+        # Derive the structured summary from the session-state delta.
+        new_analyses = self.analysis_results[n_before:]
+
+        # files_produced: every file written under each new analysis's
+        # output directory (visualizations, reports, results JSON, ...).
+        files_produced: List[str] = []
+        for rec in new_analyses:
+            out_dir = rec.get("output_directory")
+            if out_dir and Path(out_dir).is_dir():
+                for p in sorted(Path(out_dir).rglob("*")):
+                    if p.is_file():
+                        files_produced.append(str(p.resolve()))
+
+        # key_findings: the scientific claims extracted by the sub-agents.
+        key_findings: List[str] = []
+        for rec in new_analyses:
+            full = rec.get("full_result") or {}
+            for claim in full.get("scientific_claims", []) or []:
+                text = claim.get("claim") if isinstance(claim, dict) else claim
+                if text:
+                    key_findings.append(f"[{rec.get('analysis_id')}] {text}")
+
+        # Heuristic: a successful analysis with no novelty assessment yet is
+        # a natural next step — claims can be checked against the literature.
+        suggested_followups: List[str] = []
+        for rec in new_analyses:
+            if rec.get("status") == "success" and not rec.get("novelty_assessment"):
+                suggested_followups.append(
+                    f"Assess novelty / get recommendations for analysis "
+                    f"{rec.get('analysis_id')}."
+                )
+
+        warnings: List[str] = []
+        for rec in new_analyses:
+            if rec.get("status") != "success":
+                warnings.append(
+                    f"Analysis {rec.get('analysis_id')} did not complete "
+                    f"successfully (status={rec.get('status')})."
+                )
+
+        result = {
+            "status": status,
+            "task": task,
+            "summary": summary_text,
+            "files_produced": files_produced,
+            "key_findings": key_findings,
+            "suggested_followups": suggested_followups,
+            "analyses": [
+                {
+                    "analysis_id": rec.get("analysis_id"),
+                    "agent_name": rec.get("agent_name"),
+                    "status": rec.get("status"),
+                    "data_path": rec.get("data_path"),
+                    "output_directory": rec.get("output_directory"),
+                } for rec in new_analyses
+            ],
+            "warnings": warnings,
+        }
+        if error_msg:
+            result["error"] = error_msg
+        return result
+
     def _auto_checkpoint(self):
         """Internal auto-checkpoint without LLM interaction."""
         try:

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1233,11 +1233,11 @@ class AnalysisOrchestratorAgent:
             
             return f"❌ Error: {e}\n\n(Emergency checkpoint saved to {self.checkpoint_path})"
 
-    def run_task(self, task: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def run_task(self, task: str, context: Optional[Dict[str, Any]] = None,
+                 autonomy: Optional[AnalysisMode] = None) -> Dict[str, Any]:
         """Non-interactive entry point — used by the meta agent.
 
-        Runs the task in autonomous mode (regardless of the agent's current
-        configured mode) and returns a structured summary that's easy to
+        Runs the task and returns a structured summary that's easy to
         consume programmatically:
 
             {
@@ -1252,9 +1252,14 @@ class AnalysisOrchestratorAgent:
             }
 
         Mirrors SimulationOrchestratorAgent.run_task — see CLAUDE.md
-        "Two surfaces, one agent". The agent is pinned into AUTONOMOUS mode
-        for the duration of the call so it doesn't pause for a (nonexistent)
-        user; the original mode is restored on exit, even if chat() raises.
+        "Two surfaces, one agent".
+
+        ``autonomy`` selects the AnalysisMode for this call. Defaults to
+        AUTONOMOUS — the safe choice for a headless/programmatic caller, so
+        the agent never pauses for a nonexistent user. A caller attached to a
+        human (the meta agent, driven via CLI/UI) passes SUPERVISED so the
+        sub-agents' human-feedback prompts reach that human.
+        The original mode is restored on exit, even if chat() raises.
         """
         # Build a self-contained prompt that includes the optional context.
         prompt = task
@@ -1274,11 +1279,14 @@ class AnalysisOrchestratorAgent:
         # call" rather than "everything in the session."
         n_before = len(self.analysis_results)
 
-        # Pin autonomy to AUTONOMOUS for the duration of this call so the
-        # agent doesn't pause to ask the (nonexistent) user for confirmation.
+        # Run under the requested autonomy mode — AUTONOMOUS by default (the
+        # safe headless choice). The meta agent passes its own mode through,
+        # so a co-pilot / supervised delegation still raises the sub-agents'
+        # human-feedback prompts to the user driving the session.
+        run_mode = autonomy if autonomy is not None else AnalysisMode.AUTONOMOUS
         original_mode = self.analysis_mode
         try:
-            self.set_analysis_mode(AnalysisMode.AUTONOMOUS)
+            self.set_analysis_mode(run_mode)
             try:
                 summary_text = self.chat(prompt)
                 status = "success"

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -292,8 +292,20 @@ def _build_agent_list_section(agent_registry: dict) -> str:
 # tool errors at call time, so the orchestrator is not told to offer it.
 #
 # This is a workflow GATE, not a tool description: the LLM otherwise chains
-# straight to run_analysis and never offers literature search.
-_LITERATURE_SECTION_AVAILABLE = """
+# straight to run_analysis and never reaches literature search. The gate is
+# mode-aware — CO-PILOT pauses to ask the user; SUPERVISED/AUTONOMOUS decide
+# on their own, since those modes have no interactive user to wait on (and
+# `run_task` pins the orchestrator into AUTONOMOUS).
+_LIT_TOOL_BLURB = (
+    "`search_literature` queries the FutureHouse Edison API and returns a\n"
+    "`file_path`. Supplied via `literature_file`, the literature informs the\n"
+    "analysis plan, the generated code, and the interpretation. (In curve-fitting\n"
+    "`task_mode=\"identification\"` the planner withholds lit context to keep the\n"
+    "fit unbiased; it still informs Stage-2 candidate enumeration.)"
+)
+
+# CO-PILOT: pause and ask the user, wait for their answer.
+_LITERATURE_SECTION_COPILOT = f"""
 **LITERATURE SEARCH — REQUIRED OFFER BEFORE ANALYSIS:**
 A FutureHouse API key is configured this session. Before the FIRST
 `run_analysis` on a dataset you MUST first ask the user whether the analysis
@@ -305,11 +317,21 @@ answer — do NOT call `run_analysis` in the same turn as the question.
 - Ask once per dataset; do not re-offer on follow-up `run_analysis` calls
   for the same data.
 
-`search_literature` queries the FutureHouse Edison API and returns a
-`file_path`. Supplied via `literature_file`, the literature informs the
-analysis plan, the generated code, and the interpretation. (In curve-fitting
-`task_mode="identification"` the planner withholds lit context to keep the fit
-unbiased; it still informs Stage-2 candidate enumeration.)
+{_LIT_TOOL_BLURB}
+"""
+
+# SUPERVISED / AUTONOMOUS: no interactive user — decide without asking.
+_LITERATURE_SECTION_AUTONOMOUS = f"""
+**LITERATURE SEARCH — CONSIDER BEFORE ANALYSIS:**
+A FutureHouse API key is configured this session. Before the FIRST
+`run_analysis` on a dataset, decide for yourself whether a literature search
+would materially shape the analysis (method choice, parameter ranges,
+interpretation). If so, call `search_literature(query=...)` and pass the
+returned `file_path` to `run_analysis` as `literature_file`; otherwise call
+`run_analysis` directly. Do NOT ask the user — decide from the data and
+objective. Decide once per dataset.
+
+{_LIT_TOOL_BLURB}
 """
 
 _LITERATURE_SECTION_UNAVAILABLE = ""
@@ -353,10 +375,14 @@ def get_system_prompt(
             "     * 1: ImageAnalysisAgent - Images: general-purpose analysis (microscopy, SEM, TEM, AFM, optical). Atomic resolution, grains, particles, textures, defects, morphology",
             "     * 2: HyperspectralAnalysisAgent - 3D datacubes: EELS-SI, EDS, Raman imaging",
         ])
-    lit_section = (
-        _LITERATURE_SECTION_AVAILABLE if literature_available
-        else _LITERATURE_SECTION_UNAVAILABLE
-    )
+    if not literature_available:
+        lit_section = _LITERATURE_SECTION_UNAVAILABLE
+    elif analysis_mode == AnalysisMode.CO_PILOT:
+        # Interactive — pause and ask the user.
+        lit_section = _LITERATURE_SECTION_COPILOT
+    else:
+        # SUPERVISED / AUTONOMOUS — no user to wait on; decide autonomously.
+        lit_section = _LITERATURE_SECTION_AUTONOMOUS
     body = (
         _SYSTEM_PROMPT_BODY_PRE + agent_list
         + _SYSTEM_PROMPT_BODY_POST.replace("___LITERATURE_SECTION___", lit_section)

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1252,6 +1252,7 @@ class AnalysisOrchestratorAgent:
                 "task": str,                       # echoed input
                 "summary": str,                    # the agent's final reply
                 "files_produced": List[str],       # absolute paths
+                "feature_tables": List[str],       # per-analysis feature CSVs
                 "key_findings": List[str],         # extracted scientific claims
                 "suggested_followups": List[str],
                 "analyses": List[dict],            # session record snapshot
@@ -1347,11 +1348,22 @@ class AnalysisOrchestratorAgent:
                     f"successfully (status={rec.get('status')})."
                 )
 
+        # feature_tables: per-analysis flat CSVs (conditions + extracted scalar
+        # features) for downstream planning / BO — see feature_table.py.
+        feature_tables: List[str] = []
+        for rec in new_analyses:
+            out_dir = rec.get("output_directory")
+            if out_dir:
+                ft = Path(out_dir) / "features.csv"
+                if ft.is_file():
+                    feature_tables.append(str(ft.resolve()))
+
         result = {
             "status": status,
             "task": task,
             "summary": summary_text,
             "files_produced": files_produced,
+            "feature_tables": feature_tables,
             "key_findings": key_findings,
             "suggested_followups": suggested_followups,
             "analyses": [

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -36,7 +36,7 @@ _BUILTIN_AGENTS = {
     1: {
         "class_path": "scilink.agents.exp_agents.image_analysis_agent.ImageAnalysisAgent",
         "name": "ImageAnalysisAgent",
-        "description": "Images: general-purpose analysis (microscopy, SEM, TEM, AFM, optical). Handles atomic resolution, grains, particles, textures, defects, morphology. Single images or series.",
+        "description": "Scientific microscopy images (SEM, TEM, AFM, optical micrographs): atomic resolution, grains, particles, textures, defects, morphology. Single images or series. NOT for charts, plots, diagrams, or figures lifted from documents.",
         "short_name": "ImageAnalysis",
     },
     2: {
@@ -279,6 +279,18 @@ examine_data returns data_type:
 - If disambiguation_needed=true in examine_data result, ASK the user before selecting agent
 - For directories, check if metadata_files was detected
 - If status="error", stop and report to user
+- If `run_analysis` fails because the data could not be loaded — "unsupported
+  file format", "failed to load spectrum / image", or similar — the file type
+  is not one the analysis agents handle. They take microscopy / spectroscopy
+  images, 1-D measurement curves, and hyperspectral datacubes — NOT generic
+  spreadsheets, results tables, or databases. Do NOT retry the same file with
+  a different agent and do NOT keep re-running. Report the failure once, and
+  note that this data may belong to a different mode (planning handles
+  tabular data and databases).
+- NEVER write an analysis report, summary, or findings from metadata alone.
+  A report requires successful `run_analysis` results. If no analysis
+  succeeded, say so plainly — do not fabricate quantitative findings from a
+  file's description or metadata.
 - Before launching a fresh `run_analysis`, consider whether a prior analysis from
   `list_results()` already covers the new request's prerequisites (e.g. existing
   segmentation, fits, abundance maps). If so, pass its `output_directory` via
@@ -380,7 +392,7 @@ def get_system_prompt(
     else:
         agent_list = "\n".join([
             "     * 0: CurveFittingAgent - 1D data: DSC, TGA, XRD, UV-Vis, Raman, PL, IV curves, kinetics",
-            "     * 1: ImageAnalysisAgent - Images: general-purpose analysis (microscopy, SEM, TEM, AFM, optical). Atomic resolution, grains, particles, textures, defects, morphology",
+            "     * 1: ImageAnalysisAgent - Scientific microscopy images (SEM, TEM, AFM, optical micrographs): grains, particles, defects, morphology. NOT charts/figures/diagrams",
             "     * 2: HyperspectralAnalysisAgent - 3D datacubes: EELS-SI, EDS, Raman imaging",
         ])
     if not literature_available:

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -156,15 +156,7 @@ You are the **Analysis Agent**. Your goal is to coordinate experimental data ana
 
 _SYSTEM_PROMPT_BODY_POST = """
 5. `preview_image`: Load image for visual inspection (for agent 0 vs 1 decision, or ambiguous 2D data).
-
-**LITERATURE CONTEXT (optional, before analysis):**
-5b. `search_literature`: Fetch external literature to inform an upcoming analysis.
-   - Input: `query` (a focused research question).
-   - Action: queries the FutureHouse Edison API; saves results to a markdown file.
-   - Output: `file_path`. Pass it as `literature_file` to the next `run_analysis` so the planner produces a literature-informed plan the user reviews.
-   - When to use: the user asks for literature support, or the analysis objective is one where domain context would meaningfully shape method/parameter choice. Skip for routine measurement-quality analyses.
-   - Note: in curve-fitting `task_mode="identification"` the planner withholds lit context (to keep the fit unbiased); the literature still informs Stage-2 candidate enumeration.
-
+___LITERATURE_SECTION___
 **ANALYSIS EXECUTION:**
 6. `run_analysis`: Execute analysis. Handles single files AND series automatically.
    - Each analysis run creates a unique output directory for traceability.
@@ -295,11 +287,40 @@ def _build_agent_list_section(agent_registry: dict) -> str:
     return "\n".join(lines)
 
 
+# Literature section — injected into the prompt body only when a FutureHouse
+# API key is configured this session. Without a key the `search_literature`
+# tool errors at call time, so the orchestrator is not told to offer it.
+#
+# This is a workflow GATE, not a tool description: the LLM otherwise chains
+# straight to run_analysis and never offers literature search.
+_LITERATURE_SECTION_AVAILABLE = """
+**LITERATURE SEARCH — REQUIRED OFFER BEFORE ANALYSIS:**
+A FutureHouse API key is configured this session. Before the FIRST
+`run_analysis` on a dataset you MUST first ask the user whether the analysis
+should be informed by a literature search of prior work, then wait for their
+answer — do NOT call `run_analysis` in the same turn as the question.
+- On yes: call `search_literature(query=...)`, then pass the returned
+  `file_path` to `run_analysis` as `literature_file`.
+- On no: call `run_analysis` normally.
+- Ask once per dataset; do not re-offer on follow-up `run_analysis` calls
+  for the same data.
+
+`search_literature` queries the FutureHouse Edison API and returns a
+`file_path`. Supplied via `literature_file`, the literature informs the
+analysis plan, the generated code, and the interpretation. (In curve-fitting
+`task_mode="identification"` the planner withholds lit context to keep the fit
+unbiased; it still informs Stage-2 candidate enumeration.)
+"""
+
+_LITERATURE_SECTION_UNAVAILABLE = ""
+
+
 def get_system_prompt(
     analysis_mode: AnalysisMode,
     agent_registry: dict = None,
     external_tools: list = None,
     custom_skills: dict = None,
+    literature_available: bool = False,
 ) -> str:
     """Returns the appropriate system prompt for the given analysis mode.
 
@@ -315,6 +336,9 @@ def get_system_prompt(
         custom_skills: ``{name: path}`` dict of custom skills registered via
             register_skill(). When provided, a "Custom skills" section is
             appended so the LLM knows to pass them to ``run_analysis``.
+        literature_available: True iff a FutureHouse API key is configured.
+            When True, the prompt instructs the orchestrator to offer a
+            literature search before the first analysis of a dataset.
     """
     directives = {
         AnalysisMode.CO_PILOT: _CO_PILOT_DIRECTIVE,
@@ -329,7 +353,14 @@ def get_system_prompt(
             "     * 1: ImageAnalysisAgent - Images: general-purpose analysis (microscopy, SEM, TEM, AFM, optical). Atomic resolution, grains, particles, textures, defects, morphology",
             "     * 2: HyperspectralAnalysisAgent - 3D datacubes: EELS-SI, EDS, Raman imaging",
         ])
-    body = _SYSTEM_PROMPT_BODY_PRE + agent_list + _SYSTEM_PROMPT_BODY_POST
+    lit_section = (
+        _LITERATURE_SECTION_AVAILABLE if literature_available
+        else _LITERATURE_SECTION_UNAVAILABLE
+    )
+    body = (
+        _SYSTEM_PROMPT_BODY_PRE + agent_list
+        + _SYSTEM_PROMPT_BODY_POST.replace("___LITERATURE_SECTION___", lit_section)
+    )
     if external_tools:
         lines = ["\n**CUSTOM TOOLS (registered externally, call directly by name):**"]
         for t in external_tools:
@@ -464,6 +495,9 @@ class AnalysisOrchestratorAgent:
         else:
              logging.warning("⚠️ Literature Analysis disabled (No FutureHouse API key)")
 
+        # Gates the literature-search offer in the system prompt.
+        self._literature_available = bool(self.futurehouse_api_key)
+
         logging.info(f"🎛️  Analysis Mode: {analysis_mode.value.upper()}")
         
         # Setup directories
@@ -521,6 +555,7 @@ class AnalysisOrchestratorAgent:
         system_prompt = get_system_prompt(
             self.analysis_mode, self._agent_registry,
             custom_skills=self._custom_skills or None,
+            literature_available=self._literature_available,
         )
         
         # Initialize LLM
@@ -575,6 +610,7 @@ class AnalysisOrchestratorAgent:
         new_system_prompt = get_system_prompt(
             mode, self._agent_registry, self._external_tools or None,
             self._custom_skills or None,
+            literature_available=self._literature_available,
         )
         self._system_prompt = new_system_prompt
 
@@ -669,6 +705,7 @@ class AnalysisOrchestratorAgent:
         self._system_prompt = get_system_prompt(
             self.analysis_mode, self._agent_registry,
             self._external_tools or None, self._custom_skills or None,
+            literature_available=self._literature_available,
         )
         if self.messages and self.messages[0]["role"] == "system":
             self.messages[0]["content"] = self._system_prompt
@@ -778,6 +815,7 @@ class AnalysisOrchestratorAgent:
         self._system_prompt = get_system_prompt(
             self.analysis_mode, self._agent_registry,
             self._external_tools, self._custom_skills or None,
+            literature_available=self._literature_available,
         )
         if self.messages and self.messages[0]["role"] == "system":
             self.messages[0]["content"] = self._system_prompt
@@ -817,6 +855,7 @@ class AnalysisOrchestratorAgent:
         self._system_prompt = get_system_prompt(
             self.analysis_mode, self._agent_registry,
             self._external_tools, self._custom_skills,
+            literature_available=self._literature_available,
         )
         if self.messages and self.messages[0]["role"] == "system":
             self.messages[0]["content"] = self._system_prompt
@@ -903,6 +942,7 @@ class AnalysisOrchestratorAgent:
         self._system_prompt = get_system_prompt(
             self.analysis_mode, self._agent_registry,
             self._external_tools, self._custom_skills or None,
+            literature_available=self._literature_available,
         )
         if self.messages and self.messages[0]["role"] == "system":
             self.messages[0]["content"] = self._system_prompt
@@ -944,6 +984,7 @@ class AnalysisOrchestratorAgent:
         self._system_prompt = get_system_prompt(
             self.analysis_mode, self._agent_registry,
             self._external_tools, self._custom_skills or None,
+            literature_available=self._literature_available,
         )
         if self.messages and self.messages[0]["role"] == "system":
             self.messages[0]["content"] = self._system_prompt

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -35,6 +35,7 @@ from .metadata_converter import (
 from ..lit_agents import OwlLiteratureAgent, NoveltyScorer, FittingModelLiteratureAgent
 from ..lit_agents.optimize_query_for_analysis import optimize_query_for_analysis
 from .recommendation_agent import RecommendationAgent
+from .feature_table import write_feature_table
 from ...skills.loader import list_skills, list_all_skills, load_skill
 # Note: DFTOrchestrator is imported lazily inside `run_dft_workflow` to avoid
 # pulling in the optional [sim] extras (ase, atomate2, pymatgen) on every
@@ -2506,6 +2507,12 @@ class AnalysisOrchestratorTools:
                         response["tier2_focus"] = t2.get(
                             "analysis_approach", "deeper analysis"
                         )
+                    # Emit a flat feature table (per-unit conditions + extracted
+                    # scalar features) so downstream planning / BO can ingest the
+                    # results as a file rather than re-typed prose.
+                    feature_table = write_feature_table(analysis_output_dir)
+                    if feature_table:
+                        response["feature_table"] = feature_table
                     return json.dumps(response)
                 else:
                     return json.dumps({

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -1891,33 +1891,65 @@ class AnalysisOrchestratorTools:
                     "message": f"File not found: {image_path}"
                 })
             
-            # Check if it's an image file
+            # Accept standard image formats, plus the array-container formats
+            # load_image can read (.npy/.h5/.hdf5). The latter are generic
+            # containers — a .npy may hold a spectrum or datacube, not an
+            # image — so the loaded array's shape is validated below.
             image_extensions = ['.tif', '.tiff', '.png', '.jpg', '.jpeg', '.bmp']
-            if path.suffix.lower() not in image_extensions:
+            array_extensions = ['.npy', '.h5', '.hdf5']
+            suffix = path.suffix.lower()
+            if suffix not in image_extensions and suffix not in array_extensions:
                 return json.dumps({
                     "status": "error",
-                    "message": f"Not an image file: {path.suffix}. Use this tool only for microscopy images."
+                    "message": (
+                        f"Unsupported file type: {path.suffix}. preview_image "
+                        "accepts .tif/.tiff/.png/.jpg/.jpeg/.bmp, or "
+                        ".npy/.h5/.hdf5 holding a 2-D or RGB image array."
+                    )
                 })
-            
+
             try:
                 from ...skills._shared.image_processor import load_image
                 import base64
                 from io import BytesIO
                 from PIL import Image
-                
-                # Load image
+
+                # load_image handles .npy/.h5 too, and normalizes them to uint8
                 img_array = load_image(str(path))
-                
+
+                # An array container may hold a non-image. Only a 2-D array,
+                # or 3-D with 3/4 colour channels, is a previewable image.
+                if img_array.ndim == 3 and img_array.shape[-1] == 1:
+                    img_array = img_array[:, :, 0]   # singleton channel -> 2-D
+                is_image = (
+                    img_array.ndim == 2
+                    or (img_array.ndim == 3 and img_array.shape[-1] in (3, 4))
+                )
+                if not is_image:
+                    if img_array.ndim == 1:
+                        guess = "a 1-D signal / spectrum"
+                    elif img_array.ndim == 3:
+                        guess = (f"a {img_array.shape[-1]}-channel datacube "
+                                 "(e.g. hyperspectral)")
+                    else:
+                        guess = f"a {img_array.ndim}-D array"
+                    return json.dumps({
+                        "status": "error",
+                        "message": (
+                            f"{path.name} holds an array of shape "
+                            f"{list(img_array.shape)} — not a previewable "
+                            f"image; it looks like {guess}. preview_image "
+                            "renders 2-D or RGB images only."
+                        )
+                    })
+
                 # Get basic stats
                 shape = img_array.shape
                 dtype = str(img_array.dtype)
-                
+
                 # Convert to PIL for resizing and encoding
-                if len(shape) == 2:
-                    pil_img = Image.fromarray(img_array)
-                else:
-                    pil_img = Image.fromarray(img_array)
-                
+                pil_img = Image.fromarray(img_array)
+
                 # Resize for preview (max 512px)
                 max_dim = 512
                 if max(pil_img.size) > max_dim:
@@ -1955,7 +1987,10 @@ class AnalysisOrchestratorTools:
             name="preview_image",
             description=(
                 "Load a microscopy image preview for visual inspection. "
-                "Returns the image as base64 for you to examine."
+                "Accepts .png/.tif/.jpg/.bmp and .npy/.h5 array files that "
+                "hold a 2-D or RGB image (a non-image array — spectrum, "
+                "datacube — is rejected with an explanation). Returns the "
+                "image as base64 for you to examine."
             ),
             parameters={
                 "image_path": {

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2655,13 +2655,15 @@ class AnalysisOrchestratorTools:
                 "literature_file": {
                     "type": "string",
                     "description": (
-                        "Path to a literature search markdown file produced by "
-                        "`search_literature`. When provided, its contents are "
-                        "injected into the planner so the proposed analysis plan "
-                        "is grounded in external literature. Skipped for the curve-"
-                        "fitting agent's `task_mode='identification'` to preserve "
-                        "the unbiased fit; in that case the literature still "
-                        "informs Stage-2 candidate enumeration."
+                        "Path to a markdown file of literature / document "
+                        "context — produced by `search_literature` (external "
+                        "search) or `read_document` (user-provided papers). "
+                        "When provided, its contents are injected into the "
+                        "planner so the proposed analysis plan is grounded in "
+                        "that literature. Skipped for the curve-fitting agent's "
+                        "`task_mode='identification'` to preserve the unbiased "
+                        "fit; in that case the literature still informs Stage-2 "
+                        "candidate enumeration."
                     )
                 }
             },
@@ -4251,58 +4253,99 @@ class AnalysisOrchestratorTools:
         # =====================================================================
         # READ DOCUMENT
         # =====================================================================
-        def read_document(path: str) -> str:
-            """Read a PDF/DOCX/MD/TXT document and return its full text."""
-            print(f"  📄 Tool: Reading document {path}...")
-            doc_path = Path(path)
-            if not doc_path.exists():
+        def read_document(paths) -> str:
+            """Read one or more PDF/DOCX/MD/TXT documents; return the combined
+            text and persist a literature_file for run_analysis."""
+            if isinstance(paths, str):
+                paths = [paths]
+            if not paths:
                 return json.dumps({
                     "status": "error",
-                    "message": f"File not found: {path}",
+                    "message": "No document path provided.",
                 })
-            if doc_path.is_dir():
+            print(f"  📄 Tool: Reading {len(paths)} document(s)...")
+            docs, errors = [], []
+            for p in paths:
+                dp = Path(p)
+                if not dp.is_file():
+                    errors.append(f"Not a file: {p}")
+                    continue
+                try:
+                    docs.append((dp, _extract_document_text(dp)))
+                except ValueError as e:
+                    errors.append(str(e))
+                except Exception as e:
+                    logging.error(f"read_document failed for {p}: {e}")
+                    errors.append(f"Could not read {dp.name}: {e}")
+            if not docs:
                 return json.dumps({
                     "status": "error",
-                    "message": f"Path is a directory, not a document: {path}",
+                    "message": "No documents could be read.",
+                    "errors": errors,
                 })
+            combined = "\n\n---\n\n".join(
+                f"## {dp.name}\n\n{info['text']}" for dp, info in docs
+            )
+            combined_truncated = len(combined) > _READ_DOC_MAX_CHARS
+            if combined_truncated:
+                combined = combined[:_READ_DOC_MAX_CHARS]
+            # Persist as a literature_file so run_analysis can ground its plan
+            # in these documents — the same channel search_literature uses.
+            lit_path = None
             try:
-                info = _extract_document_text(doc_path)
-            except ValueError as e:
-                return json.dumps({"status": "error", "message": str(e)})
+                lit_dir = self.orch.base_dir / "literature"
+                lit_dir.mkdir(parents=True, exist_ok=True)
+                ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+                lit_path = lit_dir / f"provided_documents_{ts}.md"
+                lit_path.write_text(combined)
             except Exception as e:
-                logging.error(f"read_document failed: {e}")
-                return json.dumps({
-                    "status": "error",
-                    "message": f"Could not read document: {e}",
-                })
+                logging.error(f"read_document: could not save literature file: {e}")
             return json.dumps({
                 "status": "success",
-                "path": str(doc_path.absolute()),
-                **info,
+                "file_path": str(lit_path) if lit_path else None,
+                "n_documents": len(docs),
+                "documents": [
+                    {"name": dp.name,
+                     **{k: v for k, v in info.items() if k != "text"}}
+                    for dp, info in docs
+                ],
+                "errors": errors or None,
+                "combined_truncated": combined_truncated,
+                "text": combined,
+                "hint": (
+                    "Pass file_path as `literature_file` to the next "
+                    "run_analysis() call so the planner produces a "
+                    "document-informed plan."
+                ),
             })
 
         self._register_tool(
             func=read_document,
             name="read_document",
             description=(
-                "Read a document — PDF, DOCX, Markdown, or text file — and "
-                "return its full extracted text to use as context for the "
-                "analysis (a methods paper, protocol, prior report, or notes "
-                "the user provided). For a few documents read straight into "
-                "context; it does NO literature search and builds no index — "
-                "use search_literature to query the wider literature. Pass an "
-                "absolute file path."
+                "Read one or more documents the user provided — PDF, DOCX, "
+                "Markdown, or text files (a methods paper, protocol, prior "
+                "report, notes). Returns the combined text AND saves a "
+                "literature file: pass the returned `file_path` as "
+                "`literature_file` to run_analysis() so the provided documents "
+                "drive the analysis plan, exactly as a search_literature "
+                "result does. For a handful of documents read straight into "
+                "context — it runs NO external literature search and builds no "
+                "index (use search_literature for the wider literature). Pass "
+                "absolute file paths."
             ),
             parameters={
-                "path": {
-                    "type": "string",
+                "paths": {
+                    "type": "array",
+                    "items": {"type": "string"},
                     "description": (
-                        "Absolute path to the document (.pdf, .docx, .md, "
-                        "or .txt)."
+                        "Absolute path(s) to the document(s) to read (.pdf, "
+                        ".docx, .md, or .txt). Multiple documents are combined "
+                        "into one literature file."
                     ),
                 },
             },
-            required=["path"]
+            required=["paths"]
         )
 
     def _register_tool(

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -197,64 +197,54 @@ def _detect_sidecar_jsons(
     return sidecar_map, global_jsons
 
 
-def _parse_single_key_response(raw: str, valid_keys: list[str]) -> str | None:
-    """Extract a candidate key name from a potentially noisy LLM response.
+def _parse_key_list_response(raw: str, valid_keys: list[str]) -> list[str]:
+    """Extract an ordered list of key names from a (possibly noisy) LLM
+    response. The LLM is asked for the control-variable field names
+    comma-separated, most primary first; ``NONE`` means none qualifies.
 
-    Handles common verbosity patterns:
-    - Bare key:         ``temperature``
-    - Quoted:           ``"temperature"`` or ``'temperature'``
-    - Backtick-wrapped: `` `temperature` `` or `` **temperature** ``
-    - Markdown fence:   ````` ```temperature``` `````
-    - Sentence:         ``The control variable is temperature.``
-    - With preamble:    ``Based on the context, temperature``
-
-    Returns the matched key, or ``None`` for NONE / UNCERTAIN / no match.
+    Returns the matched keys in response order (deduped), or ``[]``.
     """
     # Strip markdown fences
     text = raw.strip()
     if text.startswith("```"):
         text = text.split("```")[1].split("```")[0].strip()
 
-    # Quick exact match (ideal case)
-    clean = text.strip().strip("\"'`*. ")
-    if clean.upper() in ("NONE", "UNCERTAIN"):
-        return None
-    if clean in valid_keys:
-        return clean
+    if text.strip().strip("\"'`*. ").upper() == "NONE":
+        return []
 
-    # Try to find a candidate key anywhere in the response (case-sensitive,
-    # matching whole words to avoid partial matches like "temp" in
-    # "temperature").  If exactly one key appears, use it.
-    found = []
+    # Ideal case: comma / newline / semicolon separated tokens.
+    ordered: list[str] = []
+    for token in re.split(r"[,\n;]+", text):
+        tok = token.strip().strip("\"'`*. ")
+        if tok in valid_keys and tok not in ordered:
+            ordered.append(tok)
+    if ordered:
+        return ordered
+
+    # Fallback: scan for any valid key as a whole word, in order of appearance.
+    positions: list[tuple[int, str]] = []
     for key in valid_keys:
-        if re.search(rf"\b{re.escape(key)}\b", text):
-            found.append(key)
-
-    if len(found) == 1:
-        return found[0]
-
-    # Check for NONE / UNCERTAIN buried in the response
-    upper = text.upper()
-    if "NONE" in upper or "UNCERTAIN" in upper:
-        return None
-
-    # Truly ambiguous or unrecognisable
-    return None
+        m = re.search(rf"\b{re.escape(key)}\b", text)
+        if m:
+            positions.append((m.start(), key))
+    positions.sort()
+    return [k for _, k in positions]
 
 
-def _llm_pick_series_variable(
+def _llm_identify_control_variables(
     varying_keys: list[str],
     sidecar_data: dict[str, dict],
     model,
     logger: logging.Logger,
     experimental_context: dict | None = None,
-) -> str | None:
-    """Use the LLM to decide which varying sidecar field, if any, is the
-    true independent control variable.
+) -> list[str]:
+    """Use the LLM to identify which varying sidecar fields are genuine
+    independent control variables, ordered most-primary-first.
 
-    Works for both single- and multi-candidate scenarios. The LLM may
-    return ``NONE`` when no candidate is a genuine control variable
-    (e.g. a single varying field that is clearly an acquisition setting).
+    An experiment may deliberately vary several variables at once (a
+    factorial / grid design — e.g. temperature AND pH). The LLM returns the
+    full set, so the caller can record a primary axis plus secondary
+    variables rather than being forced into a single pick.
 
     Parameters
     ----------
@@ -272,9 +262,9 @@ def _llm_pick_series_variable(
 
     Returns
     -------
-    str | None
-        The chosen key name, or ``None`` if the LLM could not decide or
-        determined that none of the candidates is a control variable.
+    list[str]
+        Control-variable key names, primary first; ``[]`` when none of the
+        candidates is a genuine control variable.
     """
     # Build a summary of each candidate key and its per-file values
     candidates_summary = {}
@@ -308,31 +298,35 @@ def _llm_pick_series_variable(
         "You are a scientific data analysis assistant. A user has a series of "
         "data files, each accompanied by a JSON sidecar containing per-file "
         "metadata. The following numeric fields change across the files.\n\n"
-        "Your task is to decide whether any of these fields is the "
-        "**independent control variable** — the physical or experimental "
-        "quantity the experimenter intentionally varied across measurements "
-        "(e.g. temperature, concentration, voltage, pressure, dose, time). "
+        "Identify which of these fields are genuine **independent control "
+        "variables** — physical or experimental quantities the experimenter "
+        "intentionally varied across measurements (e.g. temperature, "
+        "concentration, voltage, pressure, dose, time).\n\n"
+        "An experiment may deliberately vary MORE THAN ONE at once — a "
+        "factorial / grid design (e.g. temperature AND pH together). Report "
+        "ALL genuine control variables; do NOT force a single choice and do "
+        "NOT answer 'uncertain' just because there are several.\n\n"
         "For in-situ, time-resolved, or kinetic experiments, elapsed time "
-        "or total time IS the control variable — do not dismiss it as mere "
+        "or total time IS a control variable — do not dismiss it as mere "
         "acquisition metadata. "
         "Instrument and acquisition parameters that happen to differ "
         "(e.g. laser_power, integration_time, slit_width, probe_current) "
-        "are NOT control variables. Note: 'integration_time' (detector "
-        "exposure per scan) is an acquisition setting, but 'total time' or "
-        "'elapsed time' (cumulative experiment duration) is typically a "
-        "real control variable.\n\n"
-        "If multiple candidates exist, prefer the one that represents the "
-        "primary experimental axis (e.g. 'Total time (s)' over redundant "
-        "derivatives like 'measurement_duration').\n\n"
+        "are NOT control variables — exclude them. Note: 'integration_time' "
+        "(detector exposure per scan) is an acquisition setting, but 'total "
+        "time' or 'elapsed time' (cumulative experiment duration) is a real "
+        "control variable.\n\n"
         "It is also possible that NONE of the listed fields is a true "
-        "control variable — for example the real control variable was set "
-        "manually and not recorded in the sidecar metadata.\n\n"
+        "control variable — for example the real one was set manually and "
+        "not recorded in the sidecar metadata.\n\n"
         f"Experimental context:\n{context_block}\n\n"
         f"Candidate fields and their per-file values:\n"
         f"{json.dumps(candidates_summary, indent=2)}\n\n"
-        "IMPORTANT: Your response must be a SINGLE word — no explanations, "
-        "no punctuation, no formatting. Respond with exactly one of:\n"
-        f"  {keys_list}, NONE, UNCERTAIN\n"
+        "RESPONSE FORMAT: a single line, comma-separated, listing the control "
+        "variable field names MOST PRIMARY FIRST (the dominant experimental "
+        "axis first, the rest after). No explanations, no other text. If "
+        "none of the fields is a genuine control variable, respond with "
+        "exactly NONE.\n"
+        f"Choose only from: {keys_list}\n"
     )
 
     try:
@@ -343,27 +337,27 @@ def _llm_pick_series_variable(
             else str(response)
         ).strip()
 
-        chosen = _parse_single_key_response(raw, varying_keys)
+        chosen = _parse_key_list_response(raw, varying_keys)
 
-        if chosen is None:
+        if not chosen:
             logger.info(
-                "LLM did not select a series variable "
+                "LLM identified no series control variable "
                 "(response: %r, candidates: %s)",
                 raw,
                 varying_keys,
             )
-            return None
+            return []
 
         logger.info(
-            "LLM selected '%s' as the series variable from candidates %s",
+            "LLM identified control variable(s) %s from candidates %s",
             chosen,
             varying_keys,
         )
         return chosen
 
     except Exception as exc:
-        logger.warning("LLM series-variable selection failed: %s", exc)
-        return None
+        logger.warning("LLM control-variable identification failed: %s", exc)
+        return []
 
 
 # Keys produced by the LLM metadata normalization schema.
@@ -443,8 +437,10 @@ def _extract_series_from_sidecars(
     Returns
     -------
     series_meta : dict | None
-        ``{"variable": ..., "values": {fname: val}, "unit": ...}``
-        or ``None`` when extraction is not possible.
+        ``{"variable": ..., "values": {fname: val}, "unit": ...}`` for the
+        primary control variable, plus an optional ``"secondary_variables"``
+        list of the same shape for any others that co-vary (grid designs).
+        ``None`` when extraction is not possible.
     per_file_meta : dict[str, dict]
         Full sidecar contents keyed by data filename (always returned,
         even when ``series_meta`` is ``None``).
@@ -497,21 +493,22 @@ def _extract_series_from_sidecars(
     if not varying_keys:
         return None, per_file_meta
 
-    # 5. Ask the LLM to evaluate candidates (even a single one could be
-    #    just an acquisition setting rather than a true control variable).
+    # 5. Ask the LLM which varying fields are genuine control variables
+    #    (even a single one could be just an acquisition setting; a grid
+    #    design may have several).
     if model is not None:
         print(
             f"    Varying fields in sidecars: {varying_keys}. "
-            f"Asking LLM to identify the control variable..."
+            f"Asking LLM to identify the control variable(s)..."
         )
-        variable = _llm_pick_series_variable(
+        control_vars = _llm_identify_control_variables(
             varying_keys, sidecar_data, model, logger,
             experimental_context=experimental_context,
         )
     else:
-        variable = None
+        control_vars = []
 
-    if variable is None:
+    if not control_vars:
         logger.info(
             "Could not identify a series control variable from "
             "sidecar candidates: %s",
@@ -519,18 +516,31 @@ def _extract_series_from_sidecars(
         )
         return None, per_file_meta
 
-    # 6. Build series metadata
-    values = {fname: sidecar_data[fname][variable] for fname in sidecar_data}
+    # 6. Build series metadata. The primary control variable becomes
+    #    variable/values/unit (the axis used for file ordering, scouting and
+    #    trend analysis); any others are recorded as secondary_variables so
+    #    the analysis is told the full set of conditions that co-vary.
+    def _meta_for(var: str) -> dict:
+        vals = {fname: sidecar_data[fname][var] for fname in sidecar_data}
+        unit = ""
+        sample_sidecar = next(iter(sidecar_data.values()))
+        for unit_key in (f"{var}_unit", f"{var}_units", "unit", "units"):
+            if unit_key in sample_sidecar:
+                unit = str(sample_sidecar[unit_key])
+                break
+        return {"variable": var, "values": vals, "unit": unit}
 
-    # Try to find a unit: {variable}_unit, {variable}_units, unit, units
-    unit = ""
-    sample_sidecar = next(iter(sidecar_data.values()))
-    for unit_key in [f"{variable}_unit", f"{variable}_units", "unit", "units"]:
-        if unit_key in sample_sidecar:
-            unit = str(sample_sidecar[unit_key])
-            break
+    series_meta = _meta_for(control_vars[0])
+    if len(control_vars) > 1:
+        series_meta["secondary_variables"] = [
+            _meta_for(v) for v in control_vars[1:]
+        ]
+        logger.info(
+            "Series control variables: primary=%s, secondary=%s",
+            control_vars[0], control_vars[1:],
+        )
 
-    return {"variable": variable, "values": values, "unit": unit}, per_file_meta
+    return series_meta, per_file_meta
 
 
 class AnalysisOrchestratorTools:

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2172,12 +2172,12 @@ class AnalysisOrchestratorTools:
                                 f"    Auto-extracted series variable "
                                 f"'{extracted_series['variable']}' from sidecar JSONs"
                             )
-                            # In co-pilot / supervised modes, let the user
+                            # In co-pilot / autopilot modes, let the user
                             # know which control variable was extracted and
                             # give them a chance to confirm or correct it
                             # before proceeding with the analysis.
                             mode = self.orch.analysis_mode.value
-                            if mode in ("co-pilot", "supervised"):
+                            if mode in ("co-pilot", "autopilot"):
                                 values = extracted_series.get("values", {})
                                 unit = extracted_series.get("unit", "")
                                 # Build a readable summary of the mapping

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -242,9 +242,9 @@ def _llm_identify_control_variables(
     independent control variables, ordered most-primary-first.
 
     An experiment may deliberately vary several variables at once (a
-    factorial / grid design — e.g. temperature AND pH). The LLM returns the
-    full set, so the caller can record a primary axis plus secondary
-    variables rather than being forced into a single pick.
+    factorial / grid design). The LLM returns the full set, so the caller
+    can record a primary axis plus secondary variables rather than being
+    forced into a single pick.
 
     Parameters
     ----------
@@ -303,9 +303,10 @@ def _llm_identify_control_variables(
         "intentionally varied across measurements (e.g. temperature, "
         "concentration, voltage, pressure, dose, time).\n\n"
         "An experiment may deliberately vary MORE THAN ONE at once — a "
-        "factorial / grid design (e.g. temperature AND pH together). Report "
-        "ALL genuine control variables; do NOT force a single choice and do "
-        "NOT answer 'uncertain' just because there are several.\n\n"
+        "factorial / grid design varies several parameters across the "
+        "measurements. Report ALL genuine control variables; do NOT force a "
+        "single choice and do NOT answer 'uncertain' just because there are "
+        "several.\n\n"
         "For in-situ, time-resolved, or kinetic experiments, elapsed time "
         "or total time IS a control variable — do not dismiss it as mere "
         "acquisition metadata. "

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -40,6 +40,54 @@ from ...skills.loader import list_skills, list_all_skills, load_skill
 # pulling in the optional [sim] extras (ase, atomate2, pymatgen) on every
 # AnalysisOrchestratorAgent instantiation.
 
+
+# Full-text extraction for the read_document tool — a few documents read
+# straight into the LLM context, with no embeddings / chunking / vector store
+# (that is the planning KB's job, for large corpora). The fitz / docx readers
+# are imported lazily so this module stays importable without them.
+_READ_DOC_MAX_CHARS = 200_000  # ~50k tokens; longer documents are truncated
+
+
+def _extract_document_text(path: Path) -> Dict[str, Any]:
+    """Extract plain text from a PDF / DOCX / Markdown / text file.
+
+    Returns a dict with ``text`` plus metadata (page/paragraph count,
+    ``n_chars``, ``truncated``). Raises ValueError for an unsupported
+    extension; reader errors propagate to the caller.
+    """
+    ext = path.suffix.lower()
+    info: Dict[str, Any] = {}
+    if ext == ".pdf":
+        import fitz
+        doc = fitz.open(path)
+        try:
+            info["n_pages"] = doc.page_count
+            text = "\n\n".join(
+                doc[i].get_text() or "" for i in range(doc.page_count)
+            )
+        finally:
+            doc.close()
+    elif ext == ".docx":
+        import docx
+        d = docx.Document(str(path))
+        info["n_paragraphs"] = len(d.paragraphs)
+        text = "\n".join(p.text for p in d.paragraphs)
+    elif ext in (".md", ".txt"):
+        text = path.read_text(errors="replace")
+    else:
+        raise ValueError(
+            f"Unsupported document type '{ext}' — read_document handles "
+            f".pdf, .docx, .md, and .txt."
+        )
+    text = text.strip()
+    info["truncated"] = len(text) > _READ_DOC_MAX_CHARS
+    if info["truncated"]:
+        text = text[:_READ_DOC_MAX_CHARS]
+    info["text"] = text
+    info["n_chars"] = len(text)
+    return info
+
+
 def _build_skill_description(agent_registry: dict = None,
                               custom_skills: dict = None) -> str:
     """Build the ``skill`` parameter description for ``run_analysis``.
@@ -4198,6 +4246,63 @@ class AnalysisOrchestratorTools:
                 },
             },
             required=["filename", "content"]
+        )
+
+        # =====================================================================
+        # READ DOCUMENT
+        # =====================================================================
+        def read_document(path: str) -> str:
+            """Read a PDF/DOCX/MD/TXT document and return its full text."""
+            print(f"  📄 Tool: Reading document {path}...")
+            doc_path = Path(path)
+            if not doc_path.exists():
+                return json.dumps({
+                    "status": "error",
+                    "message": f"File not found: {path}",
+                })
+            if doc_path.is_dir():
+                return json.dumps({
+                    "status": "error",
+                    "message": f"Path is a directory, not a document: {path}",
+                })
+            try:
+                info = _extract_document_text(doc_path)
+            except ValueError as e:
+                return json.dumps({"status": "error", "message": str(e)})
+            except Exception as e:
+                logging.error(f"read_document failed: {e}")
+                return json.dumps({
+                    "status": "error",
+                    "message": f"Could not read document: {e}",
+                })
+            return json.dumps({
+                "status": "success",
+                "path": str(doc_path.absolute()),
+                **info,
+            })
+
+        self._register_tool(
+            func=read_document,
+            name="read_document",
+            description=(
+                "Read a document — PDF, DOCX, Markdown, or text file — and "
+                "return its full extracted text to use as context for the "
+                "analysis (a methods paper, protocol, prior report, or notes "
+                "the user provided). For a few documents read straight into "
+                "context; it does NO literature search and builds no index — "
+                "use search_literature to query the wider literature. Pass an "
+                "absolute file path."
+            ),
+            parameters={
+                "path": {
+                    "type": "string",
+                    "description": (
+                        "Absolute path to the document (.pdf, .docx, .md, "
+                        "or .txt)."
+                    ),
+                },
+            },
+            required=["path"]
         )
 
     def _register_tool(

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -892,10 +892,7 @@ class HumanFeedbackRefinementController:
         # avoid mangling numbers in text (e.g. "cm-1.", "8.7").
         _strategy = _re.sub(r"\. (\d+)\. ", r".\n   \1. ", _strategy)
         print(f"\n⚙️  Fitting Strategy:\n   {_strategy}")
-        
-        if state.get("literature_query"):
-            print(f"\n📚 Literature Query:\n   {state['literature_query']}")
-        
+
         # Display regime plan if present
         series_plan = state.get("series_analysis_plan")
         if series_plan and series_plan.get("regimes") and not is_single:

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1097,6 +1097,20 @@ class HumanFeedbackRefinementController:
             )
             if values:
                 prompt.append(f"Range: {values[0]} to {values[-1]} {unit}")
+            secondary = series_metadata.get("secondary_variables") or []
+            if secondary:
+                names = "; ".join(
+                    f"{s.get('variable')}"
+                    + (f" ({s.get('unit')})" if s.get("unit") else "")
+                    for s in secondary
+                )
+                prompt.append(
+                    f"Additional control variable(s) co-varying across the "
+                    f"series: {names}. The series is ordered by "
+                    f"{series_metadata['variable']}, but these also change "
+                    f"between spectra — account for their effect when "
+                    f"interpreting how the data evolves."
+                )
 
         # Overlay comparison plot (all scouts on one figure)
         overlay = state.get("scout_overlay_plot")

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -1041,9 +1041,6 @@ class ImagePlanningController:
         if state.get("expected_outputs"):
             print(f"\n📄 Expected Outputs:\n   {', '.join(state.get('expected_outputs', []))}")
 
-        if state.get("literature_query"):
-            print(f"\n📚 Literature Query:\n   {state['literature_query']}")
-
         # Display regime plan if present
         series_plan = state.get("series_analysis_plan")
         if series_plan and series_plan.get("regimes") and not is_single:

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -1318,6 +1318,20 @@ class ImagePlanningController:
             )
             if values:
                 prompt.append(f"Range: {values[0]} to {values[-1]} {unit}")
+            secondary = series_metadata.get("secondary_variables") or []
+            if secondary:
+                names = "; ".join(
+                    f"{s.get('variable')}"
+                    + (f" ({s.get('unit')})" if s.get("unit") else "")
+                    for s in secondary
+                )
+                prompt.append(
+                    f"Additional control variable(s) co-varying across the "
+                    f"series: {names}. The series is ordered by "
+                    f"{series_metadata['variable']}, but these also change "
+                    f"between images — account for their effect when "
+                    f"interpreting how the data evolves."
+                )
 
         # Montage comparison (all scouts in one figure)
         montage = state.get("scout_montage_bytes")

--- a/scilink/agents/exp_agents/feature_table.py
+++ b/scilink/agents/exp_agents/feature_table.py
@@ -73,9 +73,32 @@ def _curve_fit_rows(output_dir: Path) -> List[Dict[str, Any]]:
     return rows
 
 
+def _image_series_rows(output_dir: Path) -> List[Dict[str, Any]]:
+    """One row per image from an image-analysis run's
+    series_analysis_results.json (the image-series analog of a curve-fitting
+    run's series_fit_results.json; a single image is a series of one)."""
+    sar = output_dir / "series_analysis_results.json"
+    if not sar.is_file():
+        return []
+    try:
+        data = json.loads(sar.read_text())
+    except Exception:  # noqa: BLE001
+        return []
+    rows: List[Dict[str, Any]] = []
+    for r in data.get("results", []):
+        if not isinstance(r, dict) or not r.get("success"):
+            continue
+        row: Dict[str, Any] = {"unit": r.get("name") or f"index_{r.get('index')}"}
+        row.update(_sidecar_conditions(r.get("data_path")))
+        row.update(_flatten_scalars(r.get("extracted_features")))
+        row.update(_flatten_scalars(r.get("quality_metrics"), "quality_"))
+        rows.append(row)
+    return rows
+
+
 def _extracted_feature_rows(output_dir: Path) -> List[Dict[str, Any]]:
-    """One row from an agent that records an ``extracted_features`` dict in
-    analysis_results.json (e.g. image analysis)."""
+    """Generic fallback: one row from an agent that records a top-level
+    ``extracted_features`` dict in analysis_results.json."""
     ar = output_dir / "analysis_results.json"
     if not ar.is_file():
         return []
@@ -101,9 +124,14 @@ def write_feature_table(output_dir) -> Optional[str]:
     """
     try:
         output_dir = Path(output_dir)
-        # Curve-fitting series first (richest, explicitly per-unit); fall back
-        # to the generic ``extracted_features`` dict (image analysis, etc.).
-        rows = _curve_fit_rows(output_dir) or _extracted_feature_rows(output_dir)
+        # Per-unit series adapters first (curve-fitting spectra, then image
+        # series — both one row per unit with conditions merged from sidecars);
+        # fall back to the generic top-level ``extracted_features`` dict.
+        rows = (
+            _curve_fit_rows(output_dir)
+            or _image_series_rows(output_dir)
+            or _extracted_feature_rows(output_dir)
+        )
         if not rows:
             return None
         columns: List[str] = []

--- a/scilink/agents/exp_agents/feature_table.py
+++ b/scilink/agents/exp_agents/feature_table.py
@@ -1,0 +1,123 @@
+"""Flatten a completed analysis run into a tabular feature file.
+
+One row per analyzed unit (a spectrum, an image, …); columns = the unit's
+experimental conditions (from its per-unit sidecar JSON) + extracted scalar
+features. The CSV feeds the planning Scalarizer / Bayesian optimization via
+the meta-agent — see ``analysis_bo_feature_table_plan.md``.
+
+The numeric path is LLM-free: this reads the structured result files the
+analysis pipeline already persisted and writes a deterministic flatten.
+"""
+
+import csv
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _flatten_scalars(obj: Any, prefix: str = "") -> Dict[str, Any]:
+    """Recursively collect scalar leaves of a nested dict as flat columns.
+
+    Lists / arrays / maps are skipped — only scalars belong in a feature row.
+    """
+    flat: Dict[str, Any] = {}
+    if not isinstance(obj, dict):
+        return flat
+    for key, value in obj.items():
+        name = f"{prefix}{key}"
+        if isinstance(value, dict):
+            flat.update(_flatten_scalars(value, name + "_"))
+        elif isinstance(value, (int, float, str)):  # bool is an int subclass
+            flat[name] = value
+    return flat
+
+
+def _sidecar_conditions(data_path: Optional[str]) -> Dict[str, Any]:
+    """Per-unit experimental conditions from the data file's sidecar JSON
+    (``spec_5K.csv`` -> ``spec_5K.json``). Empty dict if absent / unreadable."""
+    if not data_path:
+        return {}
+    sidecar = Path(data_path).with_suffix(".json")
+    if not sidecar.is_file():
+        return {}
+    try:
+        cond = json.loads(sidecar.read_text())
+    except Exception:  # noqa: BLE001 - a bad sidecar must not break the run
+        return {}
+    if not isinstance(cond, dict):
+        return {}
+    return {k: v for k, v in cond.items() if isinstance(v, (int, float, str))}
+
+
+def _curve_fit_rows(output_dir: Path) -> List[Dict[str, Any]]:
+    """One row per spectrum from a curve-fitting run's series_fit_results.json."""
+    sfr = output_dir / "series_fit_results.json"
+    if not sfr.is_file():
+        return []
+    try:
+        data = json.loads(sfr.read_text())
+    except Exception:  # noqa: BLE001
+        return []
+    rows: List[Dict[str, Any]] = []
+    for r in data.get("results", []):
+        if not isinstance(r, dict) or not r.get("success"):
+            continue
+        row: Dict[str, Any] = {"unit": r.get("name") or f"index_{r.get('index')}"}
+        row.update(_sidecar_conditions(r.get("data_path")))
+        row.update(_flatten_scalars(r.get("parameters")))
+        row.update(_flatten_scalars(r.get("fit_quality"), "fit_"))
+        rows.append(row)
+    return rows
+
+
+def _extracted_feature_rows(output_dir: Path) -> List[Dict[str, Any]]:
+    """One row from an agent that records an ``extracted_features`` dict in
+    analysis_results.json (e.g. image analysis)."""
+    ar = output_dir / "analysis_results.json"
+    if not ar.is_file():
+        return []
+    try:
+        data = json.loads(ar.read_text())
+    except Exception:  # noqa: BLE001
+        return []
+    feats = data.get("extracted_features")
+    if not isinstance(feats, dict) or not feats:
+        return []
+    row: Dict[str, Any] = {"unit": output_dir.name}
+    row.update(_flatten_scalars(feats))
+    return [row]
+
+
+def write_feature_table(output_dir) -> Optional[str]:
+    """Write ``<output_dir>/features.csv`` — a flat per-unit feature table
+    derived from the run's structured result files.
+
+    Returns the absolute path, or ``None`` if no adapter applies or the run
+    produced no scalar features. Never raises — a failure here must not break
+    the analysis.
+    """
+    try:
+        output_dir = Path(output_dir)
+        # Curve-fitting series first (richest, explicitly per-unit); fall back
+        # to the generic ``extracted_features`` dict (image analysis, etc.).
+        rows = _curve_fit_rows(output_dir) or _extracted_feature_rows(output_dir)
+        if not rows:
+            return None
+        columns: List[str] = []
+        for row in rows:
+            for key in row:
+                if key not in columns:
+                    columns.append(key)
+        dest = output_dir / "features.csv"
+        with open(dest, "w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=columns)
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(row)
+        return str(dest.resolve())
+    except Exception as e:  # noqa: BLE001 - never break the analysis on this
+        logger.warning(f"feature table emit failed: {e}")
+        return None

--- a/scilink/agents/meta_agent/__init__.py
+++ b/scilink/agents/meta_agent/__init__.py
@@ -1,0 +1,14 @@
+"""Meta-agent package — the orchestrator-of-orchestrators.
+
+Presents a single chat surface and delegates to the analysis and planning
+mode orchestrators through their ``run_task`` contract. See CLAUDE.md
+"The meta agent".
+
+This package must stay importable without optional dependencies (notably
+ASE): the simulation orchestrator is reached only through a guarded,
+in-function import in the deferred ``delegate_to_simulation`` seam.
+"""
+
+from .meta_orchestrator import MetaOrchestratorAgent, MetaMode
+
+__all__ = ["MetaOrchestratorAgent", "MetaMode"]

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -181,9 +181,18 @@ attempt to delegate simulation work.
   pauses at its decision points for the user to approve or edit plans and
   outputs (via its own human-feedback prompts) — that is expected and good;
   let it happen. In autonomous mode it runs the task end to end.
-- `task` must still be a complete, self-contained instruction (including
-  absolute paths to any data files) — the specialist cannot see this
-  conversation.
+- Each specialist is ONE persistent agent for the whole session: a second
+  `delegate_to_planning` reaches the SAME planning agent that handled the
+  first, and likewise for analysis. It remembers its own prior delegations —
+  the analyses it ran, the plan it produced, its campaign state. So a
+  follow-up or refinement delegation can simply reference that prior work
+  ("refine the plan you produced last step, but ...", "extend your previous
+  analysis to ...") instead of re-deriving it from scratch.
+- `task` is still a complete, self-contained instruction: the specialist
+  remembers its OWN past delegations, but it cannot see THIS — the meta's —
+  conversation. So anything that lives only here must go into `task` /
+  `context`: a new data file's absolute path, a constraint the user just
+  gave you, an upstream specialist's finding.
 - Pass upstream findings via the `context` dict, not by re-typing them into
   `task`.
 - Give each call a short `label` (required) — a 2-5 word noun phrase, NOT a

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -108,6 +108,17 @@ attempt to delegate simulation work.
 - `inspect_uploads` is for routing only — do not use its output to interpret
   or analyze the data yourself; hand that to the specialist.
 
+**EXPERIMENTAL METADATA:**
+- Experimental data needs metadata — measurement technique, instrument,
+  sample, and conditions — for a meaningful analysis, and planning data
+  needs the experimental conditions behind each measurement.
+- Before delegating an analysis or planning task, check whether the user
+  supplied it: in their message, an uploaded metadata JSON, or per-file
+  sidecar files (`inspect_uploads` shows JSON keys and sidecar pairings).
+- If it is missing, ask the user for it conversationally FIRST, then put it
+  into the delegation's `task` / `context`. Do not delegate a data task with
+  no metadata and let the specialist stop midway to ask for it.
+
 **THE DELEGATION CONTRACT:**
 - `delegate_to_analysis(task, context)` and `delegate_to_planning(task,
   context)` run the specialist and return a structured JSON result: status,

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1,0 +1,786 @@
+"""Meta-Agent Orchestrator — the orchestrator-of-orchestrators.
+
+Presents a single conversational surface and routes each piece of work to the
+right specialist mode orchestrator (analysis or planning), consuming them
+through their non-interactive ``run_task`` contract. See CLAUDE.md
+"The meta agent".
+
+It is **not a fourth mode** — it sits on top of the three modes with a
+different role (router + context bridge). v1 covers analysis + planning;
+simulation delegation is a deferred lazy seam (see meta_orchestrator_tools.py).
+
+The chat-loop / checkpoint / history shape is copied from
+AnalysisOrchestratorAgent. The duplication is intentional and acceptable at
+this development stage — see CLAUDE.md "Why no BaseChatOrchestrator refactor".
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import List, Dict, Any, Optional
+from datetime import datetime
+from enum import Enum
+
+from ...auth import get_internal_proxy_key
+from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
+from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
+from .meta_orchestrator_tools import MetaOrchestratorTools
+
+
+class MetaMode(Enum):
+    """Autonomy level for the meta orchestrator — **two levels, not three**.
+
+    The individual modes use a three-level paradigm (co-pilot / supervised /
+    autonomous). The meta agent cannot: a delegation runs the child through
+    its one-shot ``run_task``, which gives the child a single turn. Co-pilot's
+    model — pause after *every* step and wait for the user's next message —
+    needs many turns, so it cannot complete a delegated task. SUPERVISED and
+    AUTONOMOUS each finish a task within one turn.
+
+    Each delegated child runs under this same mode (mapped by enum name):
+    SUPERVISED keeps the child's human-feedback prompts — it pauses at
+    decision points for the user to approve / edit plans and outputs;
+    AUTONOMOUS runs end to end without pausing.
+    """
+    SUPERVISED = "supervised"    # Children pause for feedback at decision points
+    AUTONOMOUS = "autonomous"    # Children run end to end without pausing
+
+
+_SUPERVISED_DIRECTIVE = """**OPERATING MODE: SUPERVISED (default)**
+- Delegate on your own judgement; briefly announce each delegation before
+  making it, and ask a clarifying question when the goal or the right
+  specialist is genuinely ambiguous.
+- Each delegated specialist runs supervised — it pauses at its own decision
+  points for the user to approve or edit plans and outputs. Let that happen.
+- Chain delegations when the path is clear; pause to report if a child
+  returns an error or an ambiguous result.
+
+"""
+
+_AUTONOMOUS_DIRECTIVE = """**OPERATING MODE: AUTONOMOUS**
+- Fulfil the user's goal end to end. Chain `delegate_to_*` calls as needed.
+- Thread results forward: pass a child's relevant `key_findings` /
+  `files_produced` into the next delegation's `context`.
+- Only stop for an unrecoverable error. Summarize the whole effort at the end.
+
+"""
+
+_SYSTEM_PROMPT_BODY = """You are the **Meta-Agent** — a research orchestrator that coordinates
+SciLink's specialist mode orchestrators. You do not analyze data or design
+experiments yourself; you route each piece of work to the right specialist
+and weave their results into one coherent response for the user.
+
+**WHEN TO USE EACH SPECIALIST:**
+- `delegate_to_analysis` — experimental data already exists and needs to be
+  interpreted: microscopy / spectroscopy images, 1D curves, hyperspectral
+  datacubes, "analyze this file", data-quality assessment, feature
+  extraction, novelty checks against the literature.
+- `delegate_to_planning` — deciding what to do next: experimental campaign
+  design, multi-objective Bayesian optimization, "what should I measure or
+  run next", hypothesis generation, trade-off analysis.
+
+Computational simulation (DFT / MD) is NOT available in this build — do not
+attempt to delegate simulation work.
+
+**THE DELEGATION CONTRACT:**
+- `delegate_to_analysis(task, context)` and `delegate_to_planning(task,
+  context)` run the specialist and return a structured JSON result: status,
+  summary, key_findings, files_produced, suggested_followups, warnings,
+  delegation_index.
+- The specialist runs in the SAME autonomy mode as you. In supervised mode it
+  pauses at its decision points for the user to approve or edit plans and
+  outputs (via its own human-feedback prompts) — that is expected and good;
+  let it happen. In autonomous mode it runs the task end to end.
+- `task` must still be a complete, self-contained instruction (including
+  absolute paths to any data files) — the specialist cannot see this
+  conversation.
+- Pass upstream findings via the `context` dict, not by re-typing them into
+  `task`.
+
+**BRIDGING CONTEXT BETWEEN SPECIALISTS:**
+- Every delegation's result is kept in a delegation ledger. Call
+  `get_delegation_history` to retrieve an earlier result, then pass the
+  relevant `key_findings` / `files_produced` as the `context` argument of the
+  next `delegate_to_*` call. That is how analysis findings inform planning.
+- `summarize_session_state` reports what each specialist has done so far.
+
+**RESPONSE STYLE:**
+- Do not dump raw tool JSON back to the user — synthesize it into plain
+  language.
+- Make clear which specialist produced which result.
+- Surface the specialists' `suggested_followups` when proposing next steps.
+"""
+
+
+def get_system_prompt(meta_mode: MetaMode) -> str:
+    """Return the system prompt for the given meta autonomy mode."""
+    directives = {
+        MetaMode.SUPERVISED: _SUPERVISED_DIRECTIVE,
+        MetaMode.AUTONOMOUS: _AUTONOMOUS_DIRECTIVE,
+    }
+    return directives[meta_mode] + _SYSTEM_PROMPT_BODY
+
+
+class MetaOrchestratorAgent:
+    """Orchestrator-of-orchestrators.
+
+    Presents one chat surface; delegates analysis and planning sub-tasks to
+    persistent child orchestrators (one per mode, reused across delegations)
+    nested under the meta-session directory. Children are consumed only
+    through their public ``run_task`` contract — duck-typed, no base class.
+
+    Args:
+        base_dir: Base directory for the meta session.
+        api_key: API key for the LLM provider (forwarded to children).
+        model_name: Model name (forwarded to children).
+        base_url: Base URL for an internal proxy endpoint (forwarded).
+        embedding_model: Embedding model name (forwarded).
+        embedding_api_key: API key for the embedding provider (forwarded).
+        futurehouse_api_key: Optional FutureHouse API key (forwarded).
+        restore_checkpoint: Whether to restore from a previous checkpoint.
+        meta_mode: Autonomy level (SUPERVISED or AUTONOMOUS). The meta has
+            only these two — see MetaMode.
+    """
+
+    # Configuration constants (match the child orchestrators).
+    MAX_TOOL_ITERATIONS = 20
+    MAX_HISTORY_MESSAGES = 100
+    CHECKPOINT_INTERVAL = 10
+
+    def __init__(
+        self,
+        base_dir: str = "./meta_session",
+        api_key: Optional[str] = None,
+        model_name: str = "claude-opus-4-6",
+        base_url: Optional[str] = None,
+        embedding_model: str = "gemini-embedding-001",
+        embedding_api_key: Optional[str] = None,
+        futurehouse_api_key: Optional[str] = None,
+        restore_checkpoint: bool = False,
+        meta_mode: MetaMode = MetaMode.SUPERVISED,
+    ):
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+        if base_url:
+            if api_key is None:
+                api_key = get_internal_proxy_key()
+            if not api_key:
+                raise ValueError(
+                    "API key required for internal proxy.\n"
+                    "Set SCILINK_API_KEY environment variable or pass api_key parameter."
+                )
+            if embedding_api_key is not None:
+                logging.warning(
+                    "⚠️ embedding_api_key is ignored for internal proxy. "
+                    "Using api_key for all requests."
+                )
+            embedding_api_key = api_key
+        else:
+            if embedding_api_key is None:
+                embedding_api_key = api_key
+
+        # Store configuration — these are forwarded verbatim to child
+        # orchestrators when they are lazily created.
+        self.api_key = api_key
+        self.model_name = model_name
+        self.base_url = base_url
+        self.embedding_model = embedding_model
+        self.embedding_api_key = embedding_api_key
+        self.futurehouse_api_key = (
+            futurehouse_api_key or os.environ.get("FUTUREHOUSE_API_KEY")
+        )
+
+        self.meta_mode = meta_mode
+        self._enable_human_feedback = self._should_enable_human_feedback()
+        logging.info(f"🎛️  Meta Mode: {meta_mode.value.upper()}")
+
+        # Setup directories. Children live in fixed sub-directories so a
+        # persistent child can be re-created (with restore_checkpoint=True)
+        # after a meta restore simply by probing for its checkpoint.json.
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.history_path = self.base_dir / "chat_history.json"
+        self.checkpoint_path = self.base_dir / "checkpoint.json"
+        self.analysis_dir = self.base_dir / "analysis"
+        self.planning_dir = self.base_dir / "planning"
+
+        # Session state — kept shallow; children own their deep state.
+        self._children: Dict[str, Any] = {}          # "analysis"/"planning" -> agent
+        self._delegation_ledger: List[Dict[str, Any]] = []
+
+        self.message_count = 0
+        self.last_checkpoint_message_count = 0
+
+        if restore_checkpoint and self.checkpoint_path.exists():
+            self._restore_checkpoint()
+
+        # Tools registry.
+        self.tools = MetaOrchestratorTools(self)
+
+        system_prompt = get_system_prompt(self.meta_mode)
+
+        # Initialize LLM (dual path, copied from AnalysisOrchestratorAgent).
+        if base_url:
+            logging.info(f"🏛️ Meta orchestrator using internal proxy: {base_url}")
+            self.model = OpenAIAsGenerativeModel(
+                model=model_name, api_key=api_key, base_url=base_url
+            )
+            self.use_openai = True
+            self.tools_for_model = self.tools.openai_schemas
+        else:
+            logging.info(f"🌐 Meta orchestrator using LiteLLM: {model_name}")
+            self.model = LiteLLMGenerativeModel(
+                model=model_name,
+                api_key=api_key,
+                system_instruction=system_prompt,
+                tools=self._convert_tools_to_litellm_format(),
+            )
+            self.use_openai = False
+            self.tools_for_model = self._convert_tools_to_litellm_format()
+
+        self._system_prompt = system_prompt
+
+        # Initialize message history.
+        history = self._load_history()
+        self.messages = [{"role": "system", "content": system_prompt}]
+        if history:
+            self.messages.extend(
+                self._trim_history(history, max_messages=self.MAX_HISTORY_MESSAGES)
+            )
+
+        logging.info(f"✅ MetaOrchestratorAgent initialized. Session: {self.base_dir}")
+
+    # =========================================================================
+    # Mode / configuration
+    # =========================================================================
+
+    def _convert_tools_to_litellm_format(self) -> List[Dict]:
+        """Convert OpenAI tool schemas to LiteLLM format (passthrough)."""
+        return self.tools.openai_schemas
+
+    def _should_enable_human_feedback(self) -> bool:
+        """Human feedback is on unless the meta is fully autonomous."""
+        return self.meta_mode != MetaMode.AUTONOMOUS
+
+    def set_meta_mode(self, mode: MetaMode) -> None:
+        """Change the meta autonomy mode at runtime."""
+        old_mode = self.meta_mode
+        self.meta_mode = mode
+        self._enable_human_feedback = self._should_enable_human_feedback()
+
+        new_system_prompt = get_system_prompt(mode)
+        self._system_prompt = new_system_prompt
+        if self.messages and self.messages[0]["role"] == "system":
+            self.messages[0]["content"] = new_system_prompt
+
+        logging.info(f"🔄 Meta mode changed: {old_mode.value} → {mode.value}")
+
+    def get_human_feedback_setting(self) -> bool:
+        """Returns the current human feedback setting."""
+        return self._enable_human_feedback
+
+    # =========================================================================
+    # Child orchestrators (lazy, persistent, one per mode)
+    # =========================================================================
+
+    def _get_analysis_child(self):
+        """Lazily create (or restore) the persistent analysis child.
+
+        Imported lazily inside the method so importing the meta-agent module
+        does not pull the analysis stack until a delegation actually happens.
+        """
+        if "analysis" not in self._children:
+            from ..exp_agents.analysis_orchestrator import (
+                AnalysisOrchestratorAgent, AnalysisMode,
+            )
+            restore = (self.analysis_dir / "checkpoint.json").exists()
+            self.logger.info(
+                f"🧩 {'Restoring' if restore else 'Creating'} analysis child "
+                f"at {self.analysis_dir}"
+            )
+            # Resting mode CO_PILOT; each delegation's run_task sets the
+            # autonomy mode for that call to match the meta's.
+            self._children["analysis"] = AnalysisOrchestratorAgent(
+                base_dir=str(self.analysis_dir),
+                api_key=self.api_key,
+                model_name=self.model_name,
+                base_url=self.base_url,
+                embedding_model=self.embedding_model,
+                embedding_api_key=self.embedding_api_key,
+                futurehouse_api_key=self.futurehouse_api_key,
+                restore_checkpoint=restore,
+                analysis_mode=AnalysisMode.CO_PILOT,
+            )
+        return self._children["analysis"]
+
+    def _get_planning_child(self):
+        """Lazily create (or restore) the persistent planning child.
+
+        Built in CO_PILOT with data_dir=None: PlanningOrchestratorAgent only
+        requires data_dir under SUPERVISED/AUTONOMOUS at *construction* time.
+        Each delegation's run_task sets the autonomy level via
+        set_autonomy_level, which does not re-validate data_dir — so a
+        supervised/autonomous delegation is still safe. Per-task data files
+        arrive as absolute paths in the delegation `task`.
+        """
+        if "planning" not in self._children:
+            from ..planning_agents.planning_orchestrator import (
+                PlanningOrchestratorAgent, AutonomyLevel,
+            )
+            restore = (self.planning_dir / "checkpoint.json").exists()
+            self.logger.info(
+                f"🧩 {'Restoring' if restore else 'Creating'} planning child "
+                f"at {self.planning_dir}"
+            )
+            self._children["planning"] = PlanningOrchestratorAgent(
+                objective="Delegated by meta-agent",
+                base_dir=str(self.planning_dir),
+                api_key=self.api_key,
+                model_name=self.model_name,
+                base_url=self.base_url,
+                embedding_model=self.embedding_model,
+                embedding_api_key=self.embedding_api_key,
+                futurehouse_api_key=self.futurehouse_api_key,
+                restore_checkpoint=restore,
+                autonomy_level=AutonomyLevel.CO_PILOT,
+                data_dir=None,
+            )
+        return self._children["planning"]
+
+    # =========================================================================
+    # Delegation + ledger (used by MetaOrchestratorTools)
+    # =========================================================================
+
+    def _delegate(self, mode: str, task: str, context: Optional[dict] = None) -> str:
+        """Run a task on a child orchestrator, record it, return a JSON summary.
+
+        The child runs under the meta's own autonomy mode (mapped by enum
+        name), so a supervised delegation keeps the specialist's
+        human-feedback prompts — they reach the user driving the meta exactly
+        as in a direct single-mode session. Called by the delegate_to_* tools.
+        Never raises — child/setup failures are captured into an error result.
+        """
+        try:
+            if mode == "analysis":
+                from ..exp_agents.analysis_orchestrator import AnalysisMode
+                child = self._get_analysis_child()
+                child_autonomy = AnalysisMode[self.meta_mode.name]
+            elif mode == "planning":
+                from ..planning_agents.planning_orchestrator import AutonomyLevel
+                child = self._get_planning_child()
+                child_autonomy = AutonomyLevel[self.meta_mode.name]
+            else:
+                return json.dumps({
+                    "status": "error",
+                    "message": f"Unknown delegation target: {mode}",
+                })
+            result = child.run_task(task, context=context, autonomy=child_autonomy)
+        except Exception as e:
+            self.logger.exception(f"Delegation to {mode} failed: {e}")
+            result = {
+                "status": "error", "error": str(e), "summary": "",
+                "key_findings": [], "files_produced": [],
+                "suggested_followups": [], "warnings": [],
+            }
+
+        entry = self._record_delegation(mode, task, context, result)
+        return self._summarize_delegation_result(mode, result, entry["index"])
+
+    def _record_delegation(self, mode, task, context, result) -> Dict[str, Any]:
+        """Append a compact entry to the delegation ledger (not the full result)."""
+        entry = {
+            "index": len(self._delegation_ledger) + 1,
+            "timestamp": datetime.now().isoformat(),
+            "mode": mode,
+            "task": task,
+            "context_keys": sorted(context.keys()) if isinstance(context, dict) else [],
+            "status": result.get("status"),
+            "summary": result.get("summary", ""),
+            "key_findings": result.get("key_findings", []),
+            "files_produced": result.get("files_produced", []),
+            "suggested_followups": result.get("suggested_followups", []),
+            "warnings": result.get("warnings", []),
+            "error": result.get("error"),
+        }
+        self._delegation_ledger.append(entry)
+        return entry
+
+    def _summarize_delegation_result(self, mode, result, index) -> str:
+        """Build the JSON string a delegate_to_* tool returns to the meta LLM."""
+        summary = {
+            "delegation_index": index,
+            "mode": mode,
+            "status": result.get("status"),
+            "summary": result.get("summary", ""),
+            "key_findings": result.get("key_findings", []),
+            "files_produced": result.get("files_produced", []),
+            "suggested_followups": result.get("suggested_followups", []),
+            "warnings": result.get("warnings", []),
+        }
+        if result.get("error"):
+            summary["error"] = result["error"]
+        # Domain-specific field, passed through lightly.
+        if "analyses" in result:
+            summary["analyses"] = result["analyses"]
+        if "campaign_state" in result:
+            summary["campaign_state"] = result["campaign_state"]
+        return json.dumps(summary, indent=2, default=str)
+
+    def _session_state_summary(self) -> str:
+        """JSON snapshot of cross-specialist session state."""
+        children = {}
+        for name in ("analysis", "planning"):
+            child = self._children.get(name)
+            if child is None:
+                children[name] = {"instantiated": False}
+                continue
+            info = {
+                "instantiated": True,
+                "base_dir": str(getattr(child, "base_dir", "")),
+                "message_count": getattr(child, "message_count", 0),
+            }
+            if name == "analysis":
+                info["analyses_run"] = len(getattr(child, "analysis_results", []) or [])
+            else:
+                info["optimization_targets"] = (
+                    getattr(child, "expected_target_columns", []) or []
+                )
+                bo_path = getattr(child, "bo_data_path", None)
+                try:
+                    import pandas as pd
+                    info["bo_data_points"] = (
+                        len(pd.read_csv(bo_path))
+                        if bo_path and Path(bo_path).exists() else 0
+                    )
+                except Exception:
+                    info["bo_data_points"] = 0
+            children[name] = info
+
+        last = self._delegation_ledger[-1] if self._delegation_ledger else None
+        return json.dumps({
+            "meta_mode": self.meta_mode.value,
+            "session_dir": str(self.base_dir),
+            "delegations_total": len(self._delegation_ledger),
+            "last_delegation": (
+                f"{last['mode']} / {last['status']}" if last else None
+            ),
+            "children": children,
+        }, indent=2, default=str)
+
+    def _delegation_history(self, limit: Optional[int] = None) -> str:
+        """JSON dump of the delegation ledger (optionally the most recent N)."""
+        ledger = self._delegation_ledger
+        if limit is not None and limit > 0:
+            ledger = ledger[-limit:]
+        return json.dumps(ledger, indent=2, default=str)
+
+    # =========================================================================
+    # Checkpoint / history
+    # =========================================================================
+
+    def _restore_checkpoint(self):
+        """Restore shallow meta state from checkpoint. Children are re-created
+        lazily on the next delegation (their own checkpoint.json survives in
+        the fixed sub-directory)."""
+        print(f"  📂 Restoring checkpoint from: {self.checkpoint_path}")
+        try:
+            with open(self.checkpoint_path, 'r') as f:
+                state = json.load(f)
+
+            if "meta_mode" in state:
+                try:
+                    self.meta_mode = MetaMode(state["meta_mode"])
+                    self._enable_human_feedback = self._should_enable_human_feedback()
+                except ValueError:
+                    pass
+
+            self.message_count = state.get("message_count", 0)
+            self._delegation_ledger = state.get("delegation_ledger", [])
+
+            print(f"    ✅ Restored state:")
+            print(f"       - Meta mode: {self.meta_mode.value}")
+            print(f"       - Delegations: {len(self._delegation_ledger)}")
+
+        except Exception as e:
+            logging.warning(f"Failed to restore checkpoint: {e}")
+
+    def _auto_checkpoint(self):
+        """Internal auto-checkpoint without LLM interaction."""
+        try:
+            checkpoint_data = {
+                "timestamp": datetime.now().isoformat(),
+                "meta_mode": self.meta_mode.value,
+                "message_count": self.message_count,
+                "children_instantiated": sorted(self._children.keys()),
+                "delegation_ledger": self._delegation_ledger,
+            }
+            with open(self.checkpoint_path, 'w') as f:
+                json.dump(checkpoint_data, f, indent=2, default=str)
+            print(f"    ✅ Auto-checkpoint saved")
+        except Exception as e:
+            logging.warning(f"Auto-checkpoint failed: {e}")
+
+    def _trim_history(self, history: List[Dict], max_messages: int = None) -> List[Dict]:
+        """Keep only recent messages to avoid context window overflow."""
+        if max_messages is None:
+            max_messages = self.MAX_HISTORY_MESSAGES
+
+        if len(history) <= max_messages:
+            return history
+
+        print(f"  ⚠️  Trimming history: {len(history)} → {max_messages} messages")
+
+        context_window = 10
+        recent_window = max_messages - context_window
+
+        trimmed = history[:context_window] + history[-recent_window:]
+
+        summary_marker = {
+            "role": "system",
+            "content": f"[{len(history) - max_messages} messages omitted for context management]",
+        }
+        trimmed.insert(context_window, summary_marker)
+
+        return trimmed
+
+    def _load_history(self) -> List[Dict]:
+        """Load conversation history from disk."""
+        if not self.history_path.exists():
+            return []
+        print("  🧠 Memory: Loading previous conversation...")
+        try:
+            with open(self.history_path, 'r') as f:
+                return json.load(f)
+        except Exception as e:
+            logging.warning(f"Failed to load history: {e}")
+            return []
+
+    def _save_history(self):
+        """Save conversation history to disk."""
+        try:
+            history_data = [m for m in self.messages if m["role"] != "system"]
+            with open(self.history_path, 'w') as f:
+                json.dump(history_data, f, indent=2)
+        except Exception as e:
+            logging.warning(f"Failed to save history: {e}")
+
+    @classmethod
+    def restore_from_checkpoint(cls, base_dir: str, **kwargs):
+        """Factory method to create a MetaOrchestratorAgent from a checkpoint."""
+        return cls(base_dir=base_dir, restore_checkpoint=True, **kwargs)
+
+    # =========================================================================
+    # Chat
+    # =========================================================================
+
+    def chat(self, user_input: str) -> str:
+        """Main chat interface with robust function calling support."""
+        self.message_count += 1
+
+        # Auto-checkpoint every N messages.
+        if self.message_count - self.last_checkpoint_message_count >= self.CHECKPOINT_INTERVAL:
+            print(f"  💾 Auto-checkpoint triggered (every {self.CHECKPOINT_INTERVAL} messages)...")
+            self._auto_checkpoint()
+            self.last_checkpoint_message_count = self.message_count
+
+        try:
+            if self.use_openai:
+                response_text = self._handle_openai_chat(user_input)
+            else:
+                response_text = self._handle_litellm_chat(user_input)
+
+            # The response is returned to the caller (CLI / UI), which is
+            # responsible for displaying it — chat() does not print it.
+            self._save_history()
+
+            if self.message_count > 80:
+                response_text += (
+                    "\n\n⚠️ Note: Conversation is getting long. "
+                    "Consider starting a fresh meta session."
+                )
+
+            return response_text
+
+        except Exception as e:
+            logging.error(f"Chat Error: {e}", exc_info=True)
+            print("  💾 Error detected - saving emergency checkpoint...")
+            self._auto_checkpoint()
+            return f"❌ Error: {e}\n\n(Emergency checkpoint saved to {self.checkpoint_path})"
+
+    def _handle_openai_chat(self, user_input: str) -> str:
+        """Handle chat with OpenAI-compatible models — manual tool-calling loop."""
+        from openai import OpenAI
+
+        client = OpenAI(
+            api_key=self.model.api_key,
+            base_url=self.model.base_url,
+            timeout=120.0,
+        )
+
+        self.messages.append({"role": "user", "content": user_input})
+
+        if len(self.messages) > 120:
+            print("  ⚠️  Context window getting full - trimming history...")
+            system_msg = self.messages[0]
+            recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)
+            self.messages = [system_msg] + recent_msgs
+
+        iteration = 0
+        while iteration < self.MAX_TOOL_ITERATIONS:
+            iteration += 1
+            print(f"  ⏳ Waiting for meta-orchestrator response ...")
+
+            try:
+                response = client.chat.completions.create(
+                    model=self.model.model,
+                    messages=self.messages,
+                    tools=self.tools_for_model,
+                    tool_choice="auto",
+                )
+            except Exception as e:
+                if "timeout" in str(e).lower() or "timed out" in str(e).lower():
+                    print(f"  ⚠️ API timeout on iteration {iteration}. Retrying...")
+                    if iteration < 3:
+                        continue
+                raise
+
+            message = response.choices[0].message
+
+            if not message.tool_calls:
+                text = message.content
+                if not text and iteration > 0:
+                    self.messages.append({
+                        "role": "user",
+                        "content": "Please briefly summarize what you just did and suggest next steps.",
+                    })
+                    followup = client.chat.completions.create(
+                        model=self.model.model,
+                        messages=self.messages,
+                        tools=self.tools_for_model,
+                        tool_choice="none",
+                    )
+                    text = followup.choices[0].message.content or ""
+                self.messages.append({"role": "assistant", "content": text})
+                return text
+
+            self.messages.append({
+                "role": "assistant",
+                "content": message.content,
+                "tool_calls": [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments,
+                        },
+                    } for tc in message.tool_calls
+                ],
+            })
+
+            for tool_call in message.tool_calls:
+                func_name = tool_call.function.name
+                try:
+                    args = json.loads(tool_call.function.arguments)
+                except json.JSONDecodeError:
+                    args = {}
+
+                print(f"  🔧 Calling tool: {func_name}")
+                result = self.tools.execute_tool(func_name, **args)
+
+                self.messages.append({
+                    "role": "tool",
+                    "tool_call_id": tool_call.id,
+                    "content": result,
+                })
+
+        return "⚠️ Maximum tool iterations reached. Please simplify your request."
+
+    def _handle_litellm_chat(self, user_input: str) -> str:
+        """Handle chat with LiteLLM models — manual tool-calling loop."""
+        import litellm
+
+        self.messages.append({"role": "user", "content": user_input})
+
+        if len(self.messages) > 120:
+            print("  ⚠️  Context window getting full - trimming history...")
+            system_msg = self.messages[0]
+            recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)
+            self.messages = [system_msg] + recent_msgs
+
+        iteration = 0
+        while iteration < self.MAX_TOOL_ITERATIONS:
+            iteration += 1
+            print(f"  ⏳ Waiting for meta-orchestrator response ...")
+
+            try:
+                response = litellm.completion(
+                    model=self.model.model,
+                    messages=self.messages,
+                    tools=self.tools_for_model,
+                    tool_choice="auto",
+                    api_key=self.model.api_key,
+                    api_base=self.model.base_url,
+                    timeout=120,
+                    request_timeout=120,
+                )
+            except Exception as e:
+                if "timeout" in str(e).lower() or "timed out" in str(e).lower():
+                    print(f"  ⚠️ API timeout on iteration {iteration}. Retrying...")
+                    if iteration < 3:
+                        continue
+                raise
+
+            message = response.choices[0].message
+            tool_calls = getattr(message, "tool_calls", None)
+            content = getattr(message, "content", None)
+
+            if not tool_calls:
+                if not content and iteration > 0:
+                    self.messages.append({
+                        "role": "user",
+                        "content": "Please briefly summarize what you just did and suggest next steps.",
+                    })
+                    followup = litellm.completion(
+                        model=self.model.model,
+                        messages=self.messages,
+                        tools=self.tools_for_model,
+                        tool_choice="none",
+                    )
+                    content = getattr(followup.choices[0].message, "content", None) or ""
+                self.messages.append({"role": "assistant", "content": content or ""})
+                return content or ""
+
+            self.messages.append({
+                "role": "assistant",
+                "content": content,
+                "tool_calls": [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments,
+                        },
+                    } for tc in tool_calls
+                ],
+            })
+
+            for tool_call in tool_calls:
+                func_name = tool_call.function.name
+                try:
+                    args = json.loads(tool_call.function.arguments)
+                except json.JSONDecodeError:
+                    args = {}
+
+                print(f"  🔧 Calling tool: {func_name}")
+                result = self.tools.execute_tool(func_name, **args)
+
+                self.messages.append({
+                    "role": "tool",
+                    "tool_call_id": tool_call.id,
+                    "content": result,
+                })
+
+        return "⚠️ Maximum tool iterations reached. Please simplify your request."

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -132,6 +132,19 @@ attempt to delegate simulation work.
   into the delegation's `task` / `context`. Do not delegate a data task with
   no metadata and let the specialist stop midway to ask for it.
 
+**EXPERIMENT DESIGN — AVAILABLE EQUIPMENT:**
+- A task that asks for an experimental plan, protocol, or optimization
+  campaign must be designed against the equipment the user can actually run
+  it on — available instruments, equipment, automation, and any setup
+  constraints. A plan written for a setup the user does not have is not
+  actionable.
+- Before delegating an experiment-design task to planning, check whether the
+  user has stated their available equipment / experimental setup. If they
+  have not, ask for it conversationally FIRST — then put what they give you
+  into the delegation's `task` / `context`.
+- Do not delegate an experiment-design task with no equipment information
+  and let the specialist invent a setup or stop midway to ask for it.
+
 **COMPLEMENTARY MEASUREMENTS OF ONE SYSTEM:**
 - Uploads may be different modalities of the SAME physical system (e.g. a
   STEM image, an XPS survey, and a Raman spectrum of one sample) — not a

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -146,9 +146,10 @@ attempt to delegate simulation work.
   conversation.
 - Pass upstream findings via the `context` dict, not by re-typing them into
   `task`.
-- Give each call a short `label` — the data type for an analysis (e.g.
-  "1-D Raman spectra", "STEM image") or the focus for a planning task (e.g.
-  "follow-up BO campaign"). It is how the delegation is shown in the UI.
+- Give each call a short `label` (required) — a 2-5 word noun phrase, NOT a
+  sentence: the data type for an analysis ("1-D Raman spectra", "STEM
+  image"), or the focus for a planning task ("follow-up BO campaign"). It is
+  how the delegation is shown in the UI.
 
 **BRIDGING CONTEXT BETWEEN SPECIALISTS:**
 - Every delegation's result is kept in a delegation ledger. Call

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -79,16 +79,7 @@ SciLink's specialist mode orchestrators. You do not analyze data or design
 experiments yourself; you route each piece of work to the right specialist
 and weave their results into one coherent response for the user.
 
-**WHEN TO USE EACH SPECIALIST:**
-- `delegate_to_analysis` — experimental data already exists and needs to be
-  interpreted: microscopy / spectroscopy images, 1D curves, hyperspectral
-  datacubes, "analyze this file", data-quality assessment, feature
-  extraction, novelty checks against the literature. It can also read a few
-  user-provided papers or reports directly as reference context for the
-  analysis.
-- `delegate_to_planning` — deciding what to do next: experimental campaign
-  design, multi-objective Bayesian optimization, "what should I measure or
-  run next", hypothesis generation, trade-off analysis.
+__SPECIALIST_CAPABILITIES__
 
 Computational simulation (DFT / MD) is NOT available in this build — do not
 attempt to delegate simulation work.
@@ -98,9 +89,19 @@ attempt to delegate simulation work.
   `inspect_uploads` FIRST, before delegating. It returns a content probe of
   each file (array shape/dtype, table columns, document text, JSON keys) so
   you route from evidence rather than guessing from filenames.
-- Route data from the probe, not the name: images and measurement arrays,
-  and data tables with experimental columns → `delegate_to_analysis`; code
-  → `delegate_to_planning`.
+- Route data from the probe, not the name. Microscopy / spectroscopy
+  MEASUREMENTS — images, 1-D measurement curves (x vs y), hyperspectral
+  datacubes → `delegate_to_analysis`. TABULAR data — results tables,
+  composition tables, spreadsheets, multi-column databases → `delegate_to_
+  planning` (its `analyze_file` / `query_knowledge_data` tools read tables;
+  the analysis agents cannot). Code → `delegate_to_planning`.
+- A 1-D measurement *curve* (a spectrum, a scan) is analysis data; a
+  *results table* (rows = samples / runs, columns = properties) is planning
+  data. Do not conflate them.
+- Charts, plots, diagrams, figures lifted from documents, screenshots are
+  NOT scientific image data — never send them to `delegate_to_analysis`
+  (its image agent is for microscopy data only). Treat a chart/figure as
+  reference context: read it yourself, or route the document to planning.
 - Papers / reports / notes route by INTENT, not file type. A few documents
   that are reference context for interpreting the data — a methods paper, a
   prior analysis report — go WITH the data to `delegate_to_analysis`, which
@@ -195,12 +196,34 @@ attempt to delegate simulation work.
 
 
 def get_system_prompt(meta_mode: MetaMode) -> str:
-    """Return the system prompt for the given meta autonomy mode."""
+    """Return the system prompt for the given meta autonomy mode.
+
+    The prompt still contains the ``__SPECIALIST_CAPABILITIES__`` placeholder;
+    it is filled in on the meta's first chat turn by ``_inject_capabilities``
+    (the live tool inventory can only be read once the child orchestrators
+    exist).
+    """
     directives = {
         MetaMode.AUTOPILOT: _AUTOPILOT_DIRECTIVE,
         MetaMode.AUTONOMOUS: _AUTONOMOUS_DIRECTIVE,
     }
     return directives[meta_mode] + _SYSTEM_PROMPT_BODY
+
+
+def _tool_lines(schemas) -> str:
+    """Bulleted ``name``: first-line-description list from OpenAI tool
+    schemas (``[{"function": {"name", "description", ...}}, ...]``)."""
+    lines = []
+    for s in schemas or []:
+        fn = s.get("function") if isinstance(s, dict) else None
+        if not isinstance(fn, dict) or not fn.get("name"):
+            continue
+        desc = " ".join(str(fn.get("description") or "").split())
+        if len(desc) > 160:
+            desc = desc[:159] + "…"
+        lines.append(f"    - `{fn['name']}`: {desc}" if desc
+                     else f"    - `{fn['name']}`")
+    return "\n".join(lines)
 
 
 class MetaOrchestratorAgent:
@@ -289,6 +312,9 @@ class MetaOrchestratorAgent:
         # Session state — kept shallow; children own their deep state.
         self._children: Dict[str, Any] = {}          # "analysis"/"planning" -> agent
         self._delegation_ledger: List[Dict[str, Any]] = []
+        # Auto-generated specialist capability inventory — built once on the
+        # first chat turn (children must exist to read their tool registries).
+        self._capabilities_block: Optional[str] = None
 
         self.message_count = 0
         self.last_checkpoint_message_count = 0
@@ -428,6 +454,74 @@ class MetaOrchestratorAgent:
                 data_dir=None,
             )
         return self._children["planning"]
+
+    # =========================================================================
+    # Specialist capability inventory
+    # =========================================================================
+
+    def _build_capabilities_block(self) -> str:
+        """Build the routing inventory by reading each specialist's LIVE tool
+        registry — so a new tool / sub-agent in any mode appears here with no
+        meta-agent edit. Constructs the child orchestrators to read them."""
+        sections: List[str] = []
+
+        try:
+            analysis = self._get_analysis_child()
+            agents = getattr(analysis, "_agent_registry", {}) or {}
+            agent_lines = "\n".join(
+                f"    - {s.get('name')}: {s.get('description')}"
+                for s in agents.values() if isinstance(s, dict)
+            )
+            a_tools = _tool_lines(
+                getattr(getattr(analysis, "tools", None), "openai_schemas", []))
+            sections.append(
+                "`delegate_to_analysis` — interpret EXISTING experimental "
+                "measurements. Each `run_analysis` picks ONE of these "
+                "sub-agents by data type:\n"
+                f"{agent_lines}\n  Orchestrator tools:\n{a_tools}"
+            )
+        except Exception as e:  # noqa: BLE001 - probe must not break chat()
+            self.logger.warning(f"analysis capability probe failed: {e}")
+
+        try:
+            planning = self._get_planning_child()
+            p_tools = _tool_lines(
+                getattr(getattr(planning, "tools", None), "openai_schemas", []))
+            sections.append(
+                "`delegate_to_planning` — decide what to do next AND handle "
+                "all tabular / knowledge data. Tools:\n"
+                f"{p_tools}"
+            )
+        except Exception as e:  # noqa: BLE001
+            self.logger.warning(f"planning capability probe failed: {e}")
+
+        if not sections:
+            raise RuntimeError("no specialist capabilities could be read")
+        return (
+            "**SPECIALIST CAPABILITIES** — auto-generated from each "
+            "specialist's live tool registry; route against these:\n\n"
+            + "\n\n".join(sections)
+        )
+
+    def _inject_capabilities(self) -> None:
+        """Splice the capability inventory into the system prompt. Built once
+        and cached; re-applied if the prompt is later rebuilt. Never raises."""
+        if not self.messages or self.messages[0].get("role") != "system":
+            return
+        if "__SPECIALIST_CAPABILITIES__" not in self.messages[0]["content"]:
+            return  # placeholder already consumed
+        if self._capabilities_block is None:
+            try:
+                self._capabilities_block = self._build_capabilities_block()
+            except Exception as e:  # noqa: BLE001 - must never break chat()
+                self.logger.warning(f"capability inventory unavailable: {e}")
+                self._capabilities_block = (
+                    "**SPECIALIST CAPABILITIES**: (inventory unavailable — "
+                    "route by the principles below.)"
+                )
+        self.messages[0]["content"] = self.messages[0]["content"].replace(
+            "__SPECIALIST_CAPABILITIES__", self._capabilities_block
+        )
 
     # =========================================================================
     # Delegation + ledger (used by MetaOrchestratorTools)
@@ -702,6 +796,10 @@ class MetaOrchestratorAgent:
     def chat(self, user_input: str) -> str:
         """Main chat interface with robust function calling support."""
         self.message_count += 1
+
+        # First-turn: fill the system prompt's specialist-capability inventory
+        # from the children's live tool registries (idempotent thereafter).
+        self._inject_capabilities()
 
         # Auto-checkpoint every N messages.
         if self.message_count - self.last_checkpoint_message_count >= self.CHECKPOINT_INTERVAL:

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -175,6 +175,17 @@ attempt to delegate simulation work.
   this records the provenance of the threaded findings.
 - `summarize_session_state` reports what each specialist has done so far.
 
+**ANALYSIS RESULTS -> PLANNING / BO:**
+- An analysis delegation result may include `feature_tables` — CSV files of the
+  extracted per-unit features (one row per spectrum / image, columns =
+  experimental conditions + extracted scalar features). When a follow-up
+  planning or Bayesian-optimization task needs those quantitative results, pass
+  the feature-table file PATH to `delegate_to_planning` (in `context`, and name
+  it in `task`).
+- Do NOT re-summarize the numbers as prose for the planning specialist to
+  retype — that loses precision and risks transcription errors. The planning
+  specialist ingests the file directly with its `analyze_file` tool.
+
 **RESPONSE STYLE:**
 - Do not dump raw tool JSON back to the user — synthesize it into plain
   language.
@@ -497,6 +508,7 @@ class MetaOrchestratorAgent:
             "summary": "",
             "key_findings": [],
             "files_produced": [],
+            "feature_tables": [],
             "suggested_followups": [],
             "warnings": [],
             "error": None,
@@ -511,6 +523,7 @@ class MetaOrchestratorAgent:
             "summary": result.get("summary", ""),
             "key_findings": result.get("key_findings", []),
             "files_produced": result.get("files_produced", []),
+            "feature_tables": result.get("feature_tables", []),
             "suggested_followups": result.get("suggested_followups", []),
             "warnings": result.get("warnings", []),
             "error": result.get("error"),
@@ -526,6 +539,7 @@ class MetaOrchestratorAgent:
             "summary": result.get("summary", ""),
             "key_findings": result.get("key_findings", []),
             "files_produced": result.get("files_produced", []),
+            "feature_tables": result.get("feature_tables", []),
             "suggested_followups": result.get("suggested_followups", []),
             "warnings": result.get("warnings", []),
         }

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -341,6 +341,13 @@ class MetaOrchestratorAgent:
         # first chat turn (children must exist to read their tool registries).
         self._capabilities_block: Optional[str] = None
 
+        # Runtime-registered external tools (from MCP servers). These extend
+        # the meta itself — callable alongside the delegate_to_* tools. MCP
+        # connections are live subprocesses; they are not checkpointed and
+        # must be reconnected after a restore.
+        self._external_tools: List[Dict[str, str]] = []
+        self._mcp_connections: Dict[str, Any] = {}
+
         self.message_count = 0
         self.last_checkpoint_message_count = 0
 
@@ -479,6 +486,124 @@ class MetaOrchestratorAgent:
                 data_dir=None,
             )
         return self._children["planning"]
+
+    # =========================================================================
+    # MCP server integration
+    # =========================================================================
+
+    def connect_mcp_server(
+        self,
+        server_name: str,
+        *,
+        command: list = None,
+        url: str = None,
+        env: dict = None,
+    ) -> int:
+        """Connect to an MCP server and register its tools on the meta.
+
+        The registered tools become directly callable by the meta LLM,
+        alongside the ``delegate_to_*`` tools — so an MCP server (filesystem,
+        database, web, ...) extends the meta itself, not a child orchestrator.
+
+        Args:
+            server_name: Human-readable label for this server.
+            command: Command + args for stdio transport,
+                e.g. ``["npx", "-y", "@mcp/server-filesystem", "/tmp"]``.
+            url: URL for SSE transport.
+            env: Optional environment variables for the subprocess.
+
+        Returns:
+            Number of tools registered from this server.
+        """
+        from ...mcp_client import MCPConnection
+
+        if server_name in self._mcp_connections:
+            logging.warning(
+                f"MCP server '{server_name}' already connected — "
+                "disconnect first to reconnect."
+            )
+            return 0
+
+        conn = MCPConnection(server_name, command=command, url=url, env=env)
+        schemas = conn.connect()
+
+        existing_names = {t["name"] for t in self._external_tools}
+        registered = 0
+        for schema in schemas:
+            fn_info = schema.get("function", {})
+            tool_name = fn_info.get("name", "")
+            if not tool_name:
+                continue
+
+            # Prefix with the server name on a collision with an existing tool.
+            display_name = tool_name
+            if tool_name in self.tools.functions_map or tool_name in existing_names:
+                tool_name = f"{server_name}_{tool_name}"
+                logging.info(
+                    f"MCP tool renamed to '{tool_name}' to avoid collision"
+                )
+
+            description = fn_info.get("description", "")
+            params_spec = fn_info.get("parameters", {})
+            properties = params_spec.get("properties", {})
+            required = params_spec.get("required", [])
+
+            def _make_mcp_wrapper(_conn, _name):
+                def wrapper(**kwargs):
+                    return _conn.call_tool(_name, kwargs)
+                return wrapper
+
+            self.tools._register_tool(
+                func=_make_mcp_wrapper(conn, display_name),
+                name=tool_name,
+                description=f"[MCP:{server_name}] {description}",
+                parameters=properties,
+                required=required,
+            )
+            self._external_tools.append({
+                "name": tool_name,
+                "description": f"[MCP:{server_name}] {description}",
+            })
+            registered += 1
+
+        self._mcp_connections[server_name] = conn
+        logging.info(f"✅ MCP '{server_name}': registered {registered} tool(s)")
+        return registered
+
+    def disconnect_mcp_server(self, server_name: str) -> None:
+        """Disconnect from an MCP server and unregister its tools."""
+        conn = self._mcp_connections.pop(server_name, None)
+        if conn is None:
+            logging.warning(f"MCP server '{server_name}' not found.")
+            return
+
+        conn.disconnect()
+
+        prefix = f"[MCP:{server_name}]"
+        names_to_remove = {
+            s.get("function", {}).get("name")
+            for s in self.tools.openai_schemas
+            if s.get("function", {}).get("description", "").startswith(prefix)
+        }
+        self._external_tools = [
+            t for t in self._external_tools
+            if not t["description"].startswith(prefix)
+        ]
+        # Slice-assign so the list identity is preserved: tools_for_model
+        # aliases this list and is bound once at construction.
+        self.tools.openai_schemas[:] = [
+            s for s in self.tools.openai_schemas
+            if s.get("function", {}).get("name") not in names_to_remove
+        ]
+        for name in names_to_remove:
+            self.tools.functions_map.pop(name, None)
+
+        logging.info(f"🔌 MCP '{server_name}' disconnected.")
+
+    def disconnect_all_mcp_servers(self) -> None:
+        """Disconnect from all connected MCP servers."""
+        for name in list(self._mcp_connections):
+            self.disconnect_mcp_server(name)
 
     # =========================================================================
     # Specialist capability inventory

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -220,12 +220,25 @@ attempt to delegate simulation work.
 - Do NOT re-summarize the numbers as prose for the planning specialist to
   retype — that loses precision and risks transcription errors. The planning
   specialist ingests the file directly with its `analyze_file` tool.
+- When the user wants Bayesian optimization — "optimize X", "what should I
+  measure / do next", "recommend the next experiments" over an existing
+  dataset — delegate a concise run-it task: "Run Bayesian optimization on
+  `<feature-table path>`, inputs=[...], targets=[...], to recommend the next
+  measurement(s)." Do NOT phrase it as "design a campaign" and do NOT
+  pre-author a multi-phase experimental plan in the `task`. The optimizer's
+  recommended batch IS the deliverable; a hand-written plan alongside it
+  would contradict the optimizer's output.
 
 **RESPONSE STYLE:**
 - Do not dump raw tool JSON back to the user — synthesize it into plain
   language.
 - Make clear which specialist produced which result.
 - Surface the specialists' `suggested_followups` when proposing next steps.
+- Report produced files accurately: name each artifact and where it lives.
+  Do NOT claim one file contains another's content unless you actually
+  checked it (e.g. by reading the file) — e.g. do not state that a plan's
+  HTML report "includes" the optimizer's diagnostic plots when those are
+  separate image files in their own directory.
 """
 
 

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -89,19 +89,18 @@ attempt to delegate simulation work.
   `inspect_uploads` FIRST, before delegating. It returns a content probe of
   each file (array shape/dtype, table columns, document text, JSON keys) so
   you route from evidence rather than guessing from filenames.
-- Route data from the probe, not the name. Microscopy / spectroscopy
-  MEASUREMENTS — images, 1-D measurement curves (x vs y), hyperspectral
-  datacubes → `delegate_to_analysis`. TABULAR data — results tables,
-  composition tables, spreadsheets, multi-column databases → `delegate_to_
-  planning` (its `analyze_file` / `query_knowledge_data` tools read tables;
-  the analysis agents cannot). Code → `delegate_to_planning`.
-- A 1-D measurement *curve* (a spectrum, a scan) is analysis data; a
-  *results table* (rows = samples / runs, columns = properties) is planning
-  data. Do not conflate them.
-- Charts, plots, diagrams, figures lifted from documents, screenshots are
-  NOT scientific image data — never send them to `delegate_to_analysis`
-  (its image agent is for microscopy data only). Treat a chart/figure as
-  reference context: read it yourself, or route the document to planning.
+- Match each piece of work to the specialist whose capabilities — listed
+  under SPECIALIST CAPABILITIES above — cover it. That inventory, generated
+  from each mode's live tool registry, is the source of truth: reason from
+  the tool and sub-agent descriptions, not from fixed file-type rules.
+- Route from the probe (data type, shape, columns, document text), not the
+  filename. When a file does not clearly match one mode, weigh it against
+  the capability descriptions; if still unclear, ask the user.
+- Two distinctions the descriptions assume you already make: (1) a 1-D
+  measurement *curve* (a spectrum / scan — x vs y) is analysis data, but a
+  *results table* (rows = samples or runs, columns = properties) is planning
+  data, though both look "tabular"; (2) a chart, plot, or figure lifted from
+  a document is reference context to read — not scientific image data.
 - Papers / reports / notes route by INTENT, not file type. A few documents
   that are reference context for interpreting the data — a methods paper, a
   prior analysis report — go WITH the data to `delegate_to_analysis`, which

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -342,11 +342,15 @@ class MetaOrchestratorAgent:
         self._capabilities_block: Optional[str] = None
 
         # Runtime-registered external tools (from MCP servers). These extend
-        # the meta itself — callable alongside the delegate_to_* tools. MCP
-        # connections are live subprocesses; they are not checkpointed and
-        # must be reconnected after a restore.
+        # the meta itself — callable alongside the delegate_to_* tools — and
+        # are propagated to every specialist child. MCP connections are live
+        # subprocesses; they are not checkpointed and must be reconnected
+        # after a restore.
         self._external_tools: List[Dict[str, str]] = []
         self._mcp_connections: Dict[str, Any] = {}
+        # Server configs kept so MCP tools reach every child — including a
+        # child created lazily after the server was connected.
+        self._mcp_server_configs: Dict[str, Dict[str, Any]] = {}
 
         self.message_count = 0
         self.last_checkpoint_message_count = 0
@@ -451,6 +455,8 @@ class MetaOrchestratorAgent:
                 restore_checkpoint=restore,
                 analysis_mode=AnalysisMode.CO_PILOT,
             )
+            # Share any MCP servers already connected on the meta.
+            self._propagate_mcp_to_child(self._children["analysis"])
         return self._children["analysis"]
 
     def _get_planning_child(self):
@@ -485,6 +491,8 @@ class MetaOrchestratorAgent:
                 autonomy_level=AutonomyLevel.CO_PILOT,
                 data_dir=None,
             )
+            # Share any MCP servers already connected on the meta.
+            self._propagate_mcp_to_child(self._children["planning"])
         return self._children["planning"]
 
     # =========================================================================
@@ -499,11 +507,14 @@ class MetaOrchestratorAgent:
         url: str = None,
         env: dict = None,
     ) -> int:
-        """Connect to an MCP server and register its tools on the meta.
+        """Connect to an MCP server and register its tools on the meta and
+        every specialist child.
 
-        The registered tools become directly callable by the meta LLM,
-        alongside the ``delegate_to_*`` tools — so an MCP server (filesystem,
-        database, web, ...) extends the meta itself, not a child orchestrator.
+        The tools become callable by the meta LLM (alongside the
+        ``delegate_to_*`` tools) AND by each analysis / planning child during
+        a delegation. The server config is recorded so a child created later
+        picks it up too. Each agent holds its own connection — an MCP stdio
+        server is spawned once per agent (meta + each created child).
 
         Args:
             server_name: Human-readable label for this server.
@@ -513,7 +524,7 @@ class MetaOrchestratorAgent:
             env: Optional environment variables for the subprocess.
 
         Returns:
-            Number of tools registered from this server.
+            Number of tools registered on the meta from this server.
         """
         from ...mcp_client import MCPConnection
 
@@ -567,7 +578,15 @@ class MetaOrchestratorAgent:
             registered += 1
 
         self._mcp_connections[server_name] = conn
+        self._mcp_server_configs[server_name] = {
+            "command": command, "url": url, "env": env,
+        }
         logging.info(f"✅ MCP '{server_name}': registered {registered} tool(s)")
+
+        # Propagate to every already-created specialist child. Children
+        # created later replay _mcp_server_configs in _get_*_child.
+        for child in self._children.values():
+            self._connect_mcp_on_child(child, server_name)
         return registered
 
     def disconnect_mcp_server(self, server_name: str) -> None:
@@ -598,12 +617,51 @@ class MetaOrchestratorAgent:
         for name in names_to_remove:
             self.tools.functions_map.pop(name, None)
 
+        # Tear the server down on every specialist child too.
+        self._mcp_server_configs.pop(server_name, None)
+        for child in self._children.values():
+            try:
+                child.disconnect_mcp_server(server_name)
+            except Exception as e:  # noqa: BLE001
+                self.logger.warning(
+                    f"Could not disconnect MCP '{server_name}' on "
+                    f"{type(child).__name__}: {e}"
+                )
+
         logging.info(f"🔌 MCP '{server_name}' disconnected.")
 
     def disconnect_all_mcp_servers(self) -> None:
         """Disconnect from all connected MCP servers."""
         for name in list(self._mcp_connections):
             self.disconnect_mcp_server(name)
+
+    def _connect_mcp_on_child(self, child, server_name: str) -> None:
+        """Connect one recorded MCP server onto a child orchestrator.
+
+        Failures are logged, not raised — a child stays usable without an
+        MCP server, and one bad child must not break the meta's connection.
+        """
+        cfg = self._mcp_server_configs.get(server_name)
+        if cfg is None:
+            return
+        try:
+            child.connect_mcp_server(
+                server_name,
+                command=cfg.get("command"),
+                url=cfg.get("url"),
+                env=cfg.get("env"),
+            )
+        except Exception as e:  # noqa: BLE001
+            self.logger.warning(
+                f"Could not connect MCP '{server_name}' on "
+                f"{type(child).__name__}: {e}"
+            )
+
+    def _propagate_mcp_to_child(self, child) -> None:
+        """Replay every recorded MCP server onto a freshly created child, so
+        a child instantiated after the connection still shares the tools."""
+        for server_name in self._mcp_server_configs:
+            self._connect_mcp_on_child(child, server_name)
 
     # =========================================================================
     # Specialist capability inventory

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -103,11 +103,13 @@ attempt to delegate simulation work.
   → `delegate_to_planning`.
 - Papers / reports / notes route by INTENT, not file type. A few documents
   that are reference context for interpreting the data — a methods paper, a
-  prior report, a protocol — go WITH the data to `delegate_to_analysis`,
-  which can read documents directly. Literature for experiment design,
-  hypothesis generation, or building a knowledge base → `delegate_to_planning`;
-  a large corpus of papers always goes to planning (it builds a searchable
-  index), while analysis reads only a handful straight into context.
+  prior analysis report — go WITH the data to `delegate_to_analysis`, which
+  can read documents directly. Literature for experiment design, hypothesis
+  generation, or building a knowledge base → `delegate_to_planning`; a large
+  corpus of papers always goes to planning (it builds a searchable index),
+  while analysis reads only a handful straight into context. Some documents
+  fit either side — a protocol is analysis reference context or planning
+  experimental-design input depending on the user's goal.
 - Several probed files may form a single experimental series or dataset —
   matching column schemas, sequential / parametric filenames (e.g.
   `spec_5K`, `spec_10K`, ...), or a shared sidecar-JSON pattern. Recognize

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -146,6 +146,9 @@ attempt to delegate simulation work.
   conversation.
 - Pass upstream findings via the `context` dict, not by re-typing them into
   `task`.
+- Give each call a short `label` — the data type for an analysis (e.g.
+  "1-D Raman spectra", "STEM image") or the focus for a planning task (e.g.
+  "follow-up BO campaign"). It is how the delegation is shown in the UI.
 
 **BRIDGING CONTEXT BETWEEN SPECIALISTS:**
 - Every delegation's result is kept in a delegation ledger. Call
@@ -405,7 +408,8 @@ class MetaOrchestratorAgent:
     # =========================================================================
 
     def _delegate(self, mode: str, task: str, context: Optional[dict] = None,
-                  context_from: Optional[list] = None) -> str:
+                  context_from: Optional[list] = None,
+                  label: Optional[str] = None) -> str:
         """Run a task on a child orchestrator, record it, return a JSON summary.
 
         The child runs under the meta's own autonomy mode (mapped by enum
@@ -430,7 +434,7 @@ class MetaOrchestratorAgent:
                 "message": f"Unknown delegation target: {mode}",
             })
 
-        entry = self._open_delegation(mode, task, context, context_from)
+        entry = self._open_delegation(mode, task, context, context_from, label)
         try:
             child = get_child()
             result = child.run_task(
@@ -447,7 +451,8 @@ class MetaOrchestratorAgent:
         self._close_delegation(entry, result)
         return self._summarize_delegation_result(mode, result, entry["index"])
 
-    def _open_delegation(self, mode, task, context, context_from) -> Dict[str, Any]:
+    def _open_delegation(self, mode, task, context, context_from,
+                         label=None) -> Dict[str, Any]:
         """Append a provisional 'running' ledger entry before the child runs.
 
         Finalized later by ``_close_delegation``. Having the entry present up
@@ -470,6 +475,7 @@ class MetaOrchestratorAgent:
             "timestamp": datetime.now().isoformat(),
             "mode": mode,
             "task": task,
+            "label": (label or "").strip(),
             "context_keys": sorted(context.keys()) if isinstance(context, dict) else [],
             "context_from": sources,
             "status": "running",

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -413,22 +413,30 @@ class MetaOrchestratorAgent:
         human-feedback prompts — they reach the user driving the meta exactly
         as in a direct single-mode session. Called by the delegate_to_* tools.
         Never raises — child/setup failures are captured into an error result.
+
+        A provisional 'running' ledger entry is opened before the child runs,
+        so the UI delegation tree shows the delegation live; it is finalized
+        with the result on completion.
         """
+        if mode == "analysis":
+            from ..exp_agents.analysis_orchestrator import AnalysisMode
+            get_child, autonomy_enum = self._get_analysis_child, AnalysisMode
+        elif mode == "planning":
+            from ..planning_agents.planning_orchestrator import AutonomyLevel
+            get_child, autonomy_enum = self._get_planning_child, AutonomyLevel
+        else:
+            return json.dumps({
+                "status": "error",
+                "message": f"Unknown delegation target: {mode}",
+            })
+
+        entry = self._open_delegation(mode, task, context, context_from)
         try:
-            if mode == "analysis":
-                from ..exp_agents.analysis_orchestrator import AnalysisMode
-                child = self._get_analysis_child()
-                child_autonomy = AnalysisMode[self.meta_mode.name]
-            elif mode == "planning":
-                from ..planning_agents.planning_orchestrator import AutonomyLevel
-                child = self._get_planning_child()
-                child_autonomy = AutonomyLevel[self.meta_mode.name]
-            else:
-                return json.dumps({
-                    "status": "error",
-                    "message": f"Unknown delegation target: {mode}",
-                })
-            result = child.run_task(task, context=context, autonomy=child_autonomy)
+            child = get_child()
+            result = child.run_task(
+                task, context=context,
+                autonomy=autonomy_enum[self.meta_mode.name],
+            )
         except Exception as e:
             self.logger.exception(f"Delegation to {mode} failed: {e}")
             result = {
@@ -436,13 +444,15 @@ class MetaOrchestratorAgent:
                 "key_findings": [], "files_produced": [],
                 "suggested_followups": [], "warnings": [],
             }
-
-        entry = self._record_delegation(mode, task, context, result, context_from)
+        self._close_delegation(entry, result)
         return self._summarize_delegation_result(mode, result, entry["index"])
 
-    def _record_delegation(self, mode, task, context, result,
-                           context_from=None) -> Dict[str, Any]:
-        """Append a compact entry to the delegation ledger (not the full result)."""
+    def _open_delegation(self, mode, task, context, context_from) -> Dict[str, Any]:
+        """Append a provisional 'running' ledger entry before the child runs.
+
+        Finalized later by ``_close_delegation``. Having the entry present up
+        front lets the UI delegation tree show the delegation while it runs.
+        """
         index = len(self._delegation_ledger) + 1
         # Normalize context_from to valid prior delegation indices (the LLM may
         # pass ints, strings, or "#n" forms; drop anything out of range).
@@ -462,6 +472,20 @@ class MetaOrchestratorAgent:
             "task": task,
             "context_keys": sorted(context.keys()) if isinstance(context, dict) else [],
             "context_from": sources,
+            "status": "running",
+            "summary": "",
+            "key_findings": [],
+            "files_produced": [],
+            "suggested_followups": [],
+            "warnings": [],
+            "error": None,
+        }
+        self._delegation_ledger.append(entry)
+        return entry
+
+    def _close_delegation(self, entry: Dict[str, Any], result: dict) -> None:
+        """Finalize a provisional ledger entry with the child's result."""
+        entry.update({
             "status": result.get("status"),
             "summary": result.get("summary", ""),
             "key_findings": result.get("key_findings", []),
@@ -469,9 +493,8 @@ class MetaOrchestratorAgent:
             "suggested_followups": result.get("suggested_followups", []),
             "warnings": result.get("warnings", []),
             "error": result.get("error"),
-        }
-        self._delegation_ledger.append(entry)
-        return entry
+            "completed_at": datetime.now().isoformat(),
+        })
 
     def _summarize_delegation_result(self, mode, result, index) -> str:
         """Build the JSON string a delegate_to_* tool returns to the meta LLM."""

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -132,6 +132,20 @@ attempt to delegate simulation work.
   into the delegation's `task` / `context`. Do not delegate a data task with
   no metadata and let the specialist stop midway to ask for it.
 
+**COMPLEMENTARY MEASUREMENTS OF ONE SYSTEM:**
+- Uploads may be different modalities of the SAME physical system (e.g. a
+  STEM image, an XPS survey, and a Raman spectrum of one sample) — not a
+  series. Clues: a shared filename stem / prefix, a shared sample name in
+  metadata, or the user stating it.
+- You cannot be sure they share a system. In AUTOPILOT mode, when it is not
+  clear, ask the user before treating them as one. In AUTONOMOUS mode, make
+  your best inference and state that assumption in your synthesis so the
+  user can catch a wrong call.
+- For a confirmed shared system: analyze each modality with its proper
+  specialist agent, thread each result into the next delegation's `context`,
+  and end with ONE correlated interpretation across modalities — not N
+  separate reports.
+
 **THE DELEGATION CONTRACT:**
 - `delegate_to_analysis(task, context)` and `delegate_to_planning(task,
   context)` run the specialist and return a structured JSON result: status,

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -134,22 +134,29 @@ attempt to delegate simulation work.
 
 **EQUIPMENT & SETUP — A HARD PRE-DELEGATION GATE:**
 - This gate applies to any task whose output guides what the user does next
-  in the lab: an experimental plan, a protocol, an optimization campaign, OR
+  in the lab: an experimental plan, a protocol, an optimization campaign, or
   a recommendation / assessment of what to measure or which steps to take
   next. All of these are only actionable when grounded in what the user can
   actually run — their measurement instruments (and what those instruments
   can and cannot detect), their processing / fabrication equipment, any
-  automation, and any setup constraints. A recommendation to measure or do
-  something the user has no instrument or equipment for is not actionable.
-- BEFORE delegating any such task to planning, check whether the user has
-  already stated their available instruments, equipment, and experimental
-  setup — in their messages so far.
-- If they have NOT, STOP. Do not delegate. Ask for it conversationally
-  first. Once the user answers, put their equipment and constraints into the
-  delegation's `task` / `context`, then delegate.
+  automation, and any setup constraints. A plan or recommendation to measure
+  or do something the user has no instrument or equipment for is not
+  actionable.
+- The gate fires BEFORE the FIRST such delegation of the session. If the
+  user's goal will involve designing experiments at all, gather the
+  equipment up front — before any plan-generating delegation. Do NOT
+  delegate an initial / phase-1 plan and then ask for equipment when
+  designing a later phase: the first plan is itself an experiment-design
+  artifact and depends on the user's instruments just as much. A plan that
+  recommends additional or follow-up measurements needs to know what the
+  user's instruments can detect.
+- So, before that first delegation, check whether the user has already
+  stated their available instruments, equipment, and setup in their
+  messages so far. If they have NOT, STOP — do not delegate — and ask for it
+  conversationally first. Once the user answers, put their equipment and
+  constraints into the delegation's `task` / `context`, then delegate.
 - This gate is not optional and is not waived in autonomous mode — equipment
-  is input you cannot infer or invent. The only thing that satisfies it is
-  the user having actually told you their setup.
+  is input you cannot infer or invent.
 
 **COMPLEMENTARY MEASUREMENTS OF ONE SYSTEM:**
 - Uploads may be different modalities of the SAME physical system (e.g. a

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -99,6 +99,12 @@ attempt to delegate simulation work.
 - Route from the probe, not the name: images and measurement arrays, and
   data tables with experimental columns → `delegate_to_analysis`; papers,
   reports and code → `delegate_to_planning`.
+- Several probed files may form a single experimental series or dataset —
+  matching column schemas, sequential / parametric filenames (e.g.
+  `spec_5K`, `spec_10K`, ...), or a shared sidecar-JSON pattern. Recognize
+  this from the probes and the user's goal, and delegate the whole set as
+  ONE batched task (pass the file list or their shared directory) so the
+  specialist's batch tools engage — never one delegation per file.
 - `inspect_uploads` is for routing only — do not use its output to interpret
   or analyze the data yourself; hand that to the specialist.
 

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -91,6 +91,17 @@ and weave their results into one coherent response for the user.
 Computational simulation (DFT / MD) is NOT available in this build — do not
 attempt to delegate simulation work.
 
+**INSPECTING UPLOADED FILES:**
+- When the user refers to uploaded files — or points you at a folder — call
+  `inspect_uploads` FIRST, before delegating. It returns a content probe of
+  each file (array shape/dtype, table columns, document text, JSON keys) so
+  you route from evidence rather than guessing from filenames.
+- Route from the probe, not the name: images and measurement arrays, and
+  data tables with experimental columns → `delegate_to_analysis`; papers,
+  reports and code → `delegate_to_planning`.
+- `inspect_uploads` is for routing only — do not use its output to interpret
+  or analyze the data yourself; hand that to the specialist.
+
 **THE DELEGATION CONTRACT:**
 - `delegate_to_analysis(task, context)` and `delegate_to_planning(task,
   context)` run the specialist and return a structured JSON result: status,

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -132,18 +132,24 @@ attempt to delegate simulation work.
   into the delegation's `task` / `context`. Do not delegate a data task with
   no metadata and let the specialist stop midway to ask for it.
 
-**EXPERIMENT DESIGN — AVAILABLE EQUIPMENT:**
-- A task that asks for an experimental plan, protocol, or optimization
-  campaign must be designed against the equipment the user can actually run
-  it on — available instruments, equipment, automation, and any setup
-  constraints. A plan written for a setup the user does not have is not
-  actionable.
-- Before delegating an experiment-design task to planning, check whether the
-  user has stated their available equipment / experimental setup. If they
-  have not, ask for it conversationally FIRST — then put what they give you
-  into the delegation's `task` / `context`.
-- Do not delegate an experiment-design task with no equipment information
-  and let the specialist invent a setup or stop midway to ask for it.
+**EQUIPMENT & SETUP — A HARD PRE-DELEGATION GATE:**
+- This gate applies to any task whose output guides what the user does next
+  in the lab: an experimental plan, a protocol, an optimization campaign, OR
+  a recommendation / assessment of what to measure or which steps to take
+  next. All of these are only actionable when grounded in what the user can
+  actually run — their measurement instruments (and what those instruments
+  can and cannot detect), their processing / fabrication equipment, any
+  automation, and any setup constraints. A recommendation to measure or do
+  something the user has no instrument or equipment for is not actionable.
+- BEFORE delegating any such task to planning, check whether the user has
+  already stated their available instruments, equipment, and experimental
+  setup — in their messages so far.
+- If they have NOT, STOP. Do not delegate. Ask for it conversationally
+  first. Once the user answers, put their equipment and constraints into the
+  delegation's `task` / `context`, then delegate.
+- This gate is not optional and is not waived in autonomous mode — equipment
+  is input you cannot infer or invent. The only thing that satisfies it is
+  the user having actually told you their setup.
 
 **COMPLEMENTARY MEASUREMENTS OF ONE SYSTEM:**
 - Uploads may be different modalities of the SAME physical system (e.g. a

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -83,7 +83,9 @@ and weave their results into one coherent response for the user.
 - `delegate_to_analysis` — experimental data already exists and needs to be
   interpreted: microscopy / spectroscopy images, 1D curves, hyperspectral
   datacubes, "analyze this file", data-quality assessment, feature
-  extraction, novelty checks against the literature.
+  extraction, novelty checks against the literature. It can also read a few
+  user-provided papers or reports directly as reference context for the
+  analysis.
 - `delegate_to_planning` — deciding what to do next: experimental campaign
   design, multi-objective Bayesian optimization, "what should I measure or
   run next", hypothesis generation, trade-off analysis.
@@ -96,9 +98,16 @@ attempt to delegate simulation work.
   `inspect_uploads` FIRST, before delegating. It returns a content probe of
   each file (array shape/dtype, table columns, document text, JSON keys) so
   you route from evidence rather than guessing from filenames.
-- Route from the probe, not the name: images and measurement arrays, and
-  data tables with experimental columns → `delegate_to_analysis`; papers,
-  reports and code → `delegate_to_planning`.
+- Route data from the probe, not the name: images and measurement arrays,
+  and data tables with experimental columns → `delegate_to_analysis`; code
+  → `delegate_to_planning`.
+- Papers / reports / notes route by INTENT, not file type. A few documents
+  that are reference context for interpreting the data — a methods paper, a
+  prior report, a protocol — go WITH the data to `delegate_to_analysis`,
+  which can read documents directly. Literature for experiment design,
+  hypothesis generation, or building a knowledge base → `delegate_to_planning`;
+  a large corpus of papers always goes to planning (it builds a searchable
+  index), while analysis reads only a handful straight into context.
 - Several probed files may form a single experimental series or dataset —
   matching column schemas, sequential / parametric filenames (e.g.
   `spec_5K`, `spec_10K`, ...), or a shared sidecar-JSON pattern. Recognize

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -114,7 +114,9 @@ attempt to delegate simulation work.
   needs the experimental conditions behind each measurement.
 - Before delegating an analysis or planning task, check whether the user
   supplied it: in their message, an uploaded metadata JSON, or per-file
-  sidecar files (`inspect_uploads` shows JSON keys and sidecar pairings).
+  sidecar files. `inspect_uploads` shows each JSON's keys and filename — a
+  JSON whose name matches a data file's stem (`spec_5K.json` ↔
+  `spec_5K.csv`) is that file's sidecar metadata.
 - If it is missing, ask the user for it conversationally FIRST, then put it
   into the delegation's `task` / `context`. Do not delegate a data task with
   no metadata and let the specialist stop midway to ask for it.

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -341,16 +341,19 @@ class MetaOrchestratorAgent:
         # first chat turn (children must exist to read their tool registries).
         self._capabilities_block: Optional[str] = None
 
-        # Runtime-registered external tools (from MCP servers). These extend
-        # the meta itself — callable alongside the delegate_to_* tools — and
-        # are propagated to every specialist child. MCP connections are live
-        # subprocesses; they are not checkpointed and must be reconnected
-        # after a restore.
+        # External tools registered on the meta itself (MCP server tools) —
+        # callable alongside the delegate_to_* tools. MCP connections are
+        # live subprocesses; not checkpointed, reconnect after a restore.
         self._external_tools: List[Dict[str, str]] = []
         self._mcp_connections: Dict[str, Any] = {}
-        # Server configs kept so MCP tools reach every child — including a
-        # child created lazily after the server was connected.
-        self._mcp_server_configs: Dict[str, Dict[str, Any]] = {}
+        # Custom skills registered for the session (name → path) — kept for
+        # display; the meta has no skill-running tools of its own.
+        self._custom_skills: Dict[str, str] = {}
+        # Shared extensions — skills, custom tools, MCP servers — registered
+        # on the meta and propagated to every specialist child, including a
+        # child created lazily after registration. One mechanism for all
+        # three: see _register_shared_extension.
+        self._shared_extensions: List[Dict[str, Any]] = []
 
         self.message_count = 0
         self.last_checkpoint_message_count = 0
@@ -455,8 +458,8 @@ class MetaOrchestratorAgent:
                 restore_checkpoint=restore,
                 analysis_mode=AnalysisMode.CO_PILOT,
             )
-            # Share any MCP servers already connected on the meta.
-            self._propagate_mcp_to_child(self._children["analysis"])
+            # Share skills / custom tools / MCP servers registered on the meta.
+            self._propagate_extensions_to_child(self._children["analysis"])
         return self._children["analysis"]
 
     def _get_planning_child(self):
@@ -491,12 +494,12 @@ class MetaOrchestratorAgent:
                 autonomy_level=AutonomyLevel.CO_PILOT,
                 data_dir=None,
             )
-            # Share any MCP servers already connected on the meta.
-            self._propagate_mcp_to_child(self._children["planning"])
+            # Share skills / custom tools / MCP servers registered on the meta.
+            self._propagate_extensions_to_child(self._children["planning"])
         return self._children["planning"]
 
     # =========================================================================
-    # MCP server integration
+    # Shared extensions: skills, custom tools, MCP servers
     # =========================================================================
 
     def connect_mcp_server(
@@ -578,15 +581,13 @@ class MetaOrchestratorAgent:
             registered += 1
 
         self._mcp_connections[server_name] = conn
-        self._mcp_server_configs[server_name] = {
-            "command": command, "url": url, "env": env,
-        }
         logging.info(f"✅ MCP '{server_name}': registered {registered} tool(s)")
 
-        # Propagate to every already-created specialist child. Children
-        # created later replay _mcp_server_configs in _get_*_child.
-        for child in self._children.values():
-            self._connect_mcp_on_child(child, server_name)
+        # Share with every specialist child (now and lazily-created later).
+        self._register_shared_extension({
+            "kind": "mcp", "server_name": server_name,
+            "command": command, "url": url, "env": env,
+        })
         return registered
 
     def disconnect_mcp_server(self, server_name: str) -> None:
@@ -617,8 +618,12 @@ class MetaOrchestratorAgent:
         for name in names_to_remove:
             self.tools.functions_map.pop(name, None)
 
-        # Tear the server down on every specialist child too.
-        self._mcp_server_configs.pop(server_name, None)
+        # Drop the shared record and tear the server down on every child.
+        self._shared_extensions = [
+            e for e in self._shared_extensions
+            if not (e.get("kind") == "mcp"
+                    and e.get("server_name") == server_name)
+        ]
         for child in self._children.values():
             try:
                 child.disconnect_mcp_server(server_name)
@@ -635,33 +640,93 @@ class MetaOrchestratorAgent:
         for name in list(self._mcp_connections):
             self.disconnect_mcp_server(name)
 
-    def _connect_mcp_on_child(self, child, server_name: str) -> None:
-        """Connect one recorded MCP server onto a child orchestrator.
+    def register_skill(self, skill_path: str) -> str:
+        """Register a custom skill (.md) and share it with every specialist.
 
-        Failures are logged, not raised — a child stays usable without an
-        MCP server, and one bad child must not break the meta's connection.
+        The meta runs no analyses itself, so the skill is not registered on
+        the meta — it is propagated to the analysis and planning children,
+        where the skill-aware tools (run_analysis, planning) can select it.
+
+        Returns:
+            The skill name (the file stem) used to reference it.
         """
-        cfg = self._mcp_server_configs.get(server_name)
-        if cfg is None:
-            return
+        path = Path(skill_path).expanduser().resolve()
+        if not path.exists():
+            raise FileNotFoundError(f"Skill file not found: {path}")
+        if path.suffix.lower() != ".md":
+            raise ValueError(f"Skill file must be a .md file: {path}")
+        if path.stat().st_size == 0:
+            raise ValueError(f"Skill file is empty: {path}")
+
+        self._custom_skills[path.stem] = str(path)
+        self._register_shared_extension(
+            {"kind": "skill", "skill_path": str(path)}
+        )
+        logging.info(f"✅ Skill '{path.stem}' shared with specialists")
+        return path.stem
+
+    def register_tools(self, schemas: list, factory: callable) -> None:
+        """Register custom tool functions and share them with every specialist.
+
+        Custom tools bind to a loaded data file (the factory receives the
+        child's current data), which the meta — a router — has no concept
+        of, so they are registered on the children, not the meta itself.
+        """
+        self._register_shared_extension(
+            {"kind": "tools", "schemas": schemas, "factory": factory}
+        )
+        for schema in schemas:
+            if schema.get("type") != "function":
+                continue
+            fn = schema.get("function", {})
+            if fn.get("name"):
+                self._external_tools.append({
+                    "name": fn["name"],
+                    "description": fn.get("description", ""),
+                })
+        n = sum(1 for s in schemas if s.get("type") == "function")
+        logging.info(f"✅ {n} custom tool(s) shared with specialists")
+
+    # ── Shared-extension propagation ───────────────────────────────────
+
+    def _register_shared_extension(self, ext: Dict[str, Any]) -> None:
+        """Record a shared extension and apply it to every already-created
+        child. A child created later replays it in _get_*_child. This is the
+        one mechanism behind register_skill / register_tools / MCP sharing."""
+        self._shared_extensions.append(ext)
+        for child in self._children.values():
+            self._apply_extension_to_child(child, ext)
+
+    def _apply_extension_to_child(self, child, ext: Dict[str, Any]) -> None:
+        """Apply one shared extension (skill / tools / MCP) to a child.
+
+        Failures are logged, not raised — a child stays usable, and one bad
+        child must not break the meta-side registration.
+        """
+        kind = ext.get("kind")
         try:
-            child.connect_mcp_server(
-                server_name,
-                command=cfg.get("command"),
-                url=cfg.get("url"),
-                env=cfg.get("env"),
-            )
+            if kind == "skill":
+                child.register_skill(ext["skill_path"])
+            elif kind == "tools":
+                child.register_tools(ext["schemas"], ext["factory"])
+            elif kind == "mcp":
+                child.connect_mcp_server(
+                    ext["server_name"],
+                    command=ext.get("command"),
+                    url=ext.get("url"),
+                    env=ext.get("env"),
+                )
         except Exception as e:  # noqa: BLE001
             self.logger.warning(
-                f"Could not connect MCP '{server_name}' on "
+                f"Could not apply {kind} extension to "
                 f"{type(child).__name__}: {e}"
             )
 
-    def _propagate_mcp_to_child(self, child) -> None:
-        """Replay every recorded MCP server onto a freshly created child, so
-        a child instantiated after the connection still shares the tools."""
-        for server_name in self._mcp_server_configs:
-            self._connect_mcp_on_child(child, server_name)
+    def _propagate_extensions_to_child(self, child) -> None:
+        """Replay every shared extension onto a freshly created child, so a
+        child instantiated after registration still shares skills/tools."""
+        for ext in self._shared_extensions:
+            self._apply_extension_to_child(child, ext)
 
     # =========================================================================
     # Specialist capability inventory

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -31,28 +31,36 @@ from .meta_orchestrator_tools import MetaOrchestratorTools
 class MetaMode(Enum):
     """Autonomy level for the meta orchestrator — **two levels, not three**.
 
-    The individual modes use a three-level paradigm (co-pilot / supervised /
+    The individual modes use a three-level paradigm (co-pilot / autopilot /
     autonomous). The meta agent cannot: a delegation runs the child through
     its one-shot ``run_task``, which gives the child a single turn. Co-pilot's
     model — pause after *every* step and wait for the user's next message —
-    needs many turns, so it cannot complete a delegated task. SUPERVISED and
+    needs many turns, so it cannot complete a delegated task. AUTOPILOT and
     AUTONOMOUS each finish a task within one turn.
 
     Each delegated child runs under this same mode (mapped by enum name):
-    SUPERVISED keeps the child's human-feedback prompts — it pauses at
+    AUTOPILOT keeps the child's human-feedback prompts — it pauses at
     decision points for the user to approve / edit plans and outputs;
     AUTONOMOUS runs end to end without pausing.
     """
-    SUPERVISED = "supervised"    # Children pause for feedback at decision points
+    AUTOPILOT = "autopilot"      # Children pause for feedback at decision points
     AUTONOMOUS = "autonomous"    # Children run end to end without pausing
 
+    @classmethod
+    def _missing_(cls, value):
+        # Back-compat: the AUTOPILOT level was named "supervised" before.
+        if isinstance(value, str) and value.strip().lower() == "supervised":
+            return cls.AUTOPILOT
+        return None
 
-_SUPERVISED_DIRECTIVE = """**OPERATING MODE: SUPERVISED (default)**
+
+_AUTOPILOT_DIRECTIVE = """**OPERATING MODE: AUTOPILOT (default)**
 - Delegate on your own judgement; briefly announce each delegation before
   making it, and ask a clarifying question when the goal or the right
   specialist is genuinely ambiguous.
-- Each delegated specialist runs supervised — it pauses at its own decision
-  points for the user to approve or edit plans and outputs. Let that happen.
+- Each delegated specialist runs in autopilot mode — it pauses at its own
+  decision points for the user to approve or edit plans and outputs. Let
+  that happen.
 - Chain delegations when the path is clear; pause to report if a child
   returns an error or an ambiguous result.
 
@@ -88,7 +96,7 @@ attempt to delegate simulation work.
   context)` run the specialist and return a structured JSON result: status,
   summary, key_findings, files_produced, suggested_followups, warnings,
   delegation_index.
-- The specialist runs in the SAME autonomy mode as you. In supervised mode it
+- The specialist runs in the SAME autonomy mode as you. In autopilot mode it
   pauses at its decision points for the user to approve or edit plans and
   outputs (via its own human-feedback prompts) — that is expected and good;
   let it happen. In autonomous mode it runs the task end to end.
@@ -116,7 +124,7 @@ attempt to delegate simulation work.
 def get_system_prompt(meta_mode: MetaMode) -> str:
     """Return the system prompt for the given meta autonomy mode."""
     directives = {
-        MetaMode.SUPERVISED: _SUPERVISED_DIRECTIVE,
+        MetaMode.AUTOPILOT: _AUTOPILOT_DIRECTIVE,
         MetaMode.AUTONOMOUS: _AUTONOMOUS_DIRECTIVE,
     }
     return directives[meta_mode] + _SYSTEM_PROMPT_BODY
@@ -139,7 +147,7 @@ class MetaOrchestratorAgent:
         embedding_api_key: API key for the embedding provider (forwarded).
         futurehouse_api_key: Optional FutureHouse API key (forwarded).
         restore_checkpoint: Whether to restore from a previous checkpoint.
-        meta_mode: Autonomy level (SUPERVISED or AUTONOMOUS). The meta has
+        meta_mode: Autonomy level (AUTOPILOT or AUTONOMOUS). The meta has
             only these two — see MetaMode.
     """
 
@@ -158,7 +166,7 @@ class MetaOrchestratorAgent:
         embedding_api_key: Optional[str] = None,
         futurehouse_api_key: Optional[str] = None,
         restore_checkpoint: bool = False,
-        meta_mode: MetaMode = MetaMode.SUPERVISED,
+        meta_mode: MetaMode = MetaMode.AUTOPILOT,
     ):
         self.logger = logging.getLogger(self.__class__.__name__)
 
@@ -318,10 +326,10 @@ class MetaOrchestratorAgent:
         """Lazily create (or restore) the persistent planning child.
 
         Built in CO_PILOT with data_dir=None: PlanningOrchestratorAgent only
-        requires data_dir under SUPERVISED/AUTONOMOUS at *construction* time.
+        requires data_dir under AUTOPILOT/AUTONOMOUS at *construction* time.
         Each delegation's run_task sets the autonomy level via
         set_autonomy_level, which does not re-validate data_dir — so a
-        supervised/autonomous delegation is still safe. Per-task data files
+        autopilot/autonomous delegation is still safe. Per-task data files
         arrive as absolute paths in the delegation `task`.
         """
         if "planning" not in self._children:
@@ -356,7 +364,7 @@ class MetaOrchestratorAgent:
         """Run a task on a child orchestrator, record it, return a JSON summary.
 
         The child runs under the meta's own autonomy mode (mapped by enum
-        name), so a supervised delegation keeps the specialist's
+        name), so an autopilot delegation keeps the specialist's
         human-feedback prompts — they reach the user driving the meta exactly
         as in a direct single-mode session. Called by the delegate_to_* tools.
         Never raises — child/setup failures are captured into an error result.

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -152,6 +152,9 @@ attempt to delegate simulation work.
   `get_delegation_history` to retrieve an earlier result, then pass the
   relevant `key_findings` / `files_produced` as the `context` argument of the
   next `delegate_to_*` call. That is how analysis findings inform planning.
+- When the `context` you pass draws on earlier delegations, also list those
+  delegations' `delegation_index` numbers in the `context_from` argument —
+  this records the provenance of the threaded findings.
 - `summarize_session_state` reports what each specialist has done so far.
 
 **RESPONSE STYLE:**
@@ -401,7 +404,8 @@ class MetaOrchestratorAgent:
     # Delegation + ledger (used by MetaOrchestratorTools)
     # =========================================================================
 
-    def _delegate(self, mode: str, task: str, context: Optional[dict] = None) -> str:
+    def _delegate(self, mode: str, task: str, context: Optional[dict] = None,
+                  context_from: Optional[list] = None) -> str:
         """Run a task on a child orchestrator, record it, return a JSON summary.
 
         The child runs under the meta's own autonomy mode (mapped by enum
@@ -433,17 +437,31 @@ class MetaOrchestratorAgent:
                 "suggested_followups": [], "warnings": [],
             }
 
-        entry = self._record_delegation(mode, task, context, result)
+        entry = self._record_delegation(mode, task, context, result, context_from)
         return self._summarize_delegation_result(mode, result, entry["index"])
 
-    def _record_delegation(self, mode, task, context, result) -> Dict[str, Any]:
+    def _record_delegation(self, mode, task, context, result,
+                           context_from=None) -> Dict[str, Any]:
         """Append a compact entry to the delegation ledger (not the full result)."""
+        index = len(self._delegation_ledger) + 1
+        # Normalize context_from to valid prior delegation indices (the LLM may
+        # pass ints, strings, or "#n" forms; drop anything out of range).
+        raw = context_from
+        if isinstance(raw, (int, str)):
+            raw = [raw]
+        elif not isinstance(raw, (list, tuple)):
+            raw = []
+        sources = sorted({
+            int(s) for s in (str(v).strip().lstrip("#") for v in raw)
+            if s.isdigit() and 0 < int(s) < index
+        })
         entry = {
-            "index": len(self._delegation_ledger) + 1,
+            "index": index,
             "timestamp": datetime.now().isoformat(),
             "mode": mode,
             "task": task,
             "context_keys": sorted(context.keys()) if isinstance(context, dict) else [],
+            "context_from": sources,
             "status": result.get("status"),
             "summary": result.get("summary", ""),
             "key_findings": result.get("key_findings", []),

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -175,9 +175,10 @@ class MetaOrchestratorTools:
 
         # -- delegate_to_analysis -------------------------------------------
         def delegate_to_analysis(task: str, context: dict = None,
-                                 context_from: list = None) -> str:
+                                 context_from: list = None,
+                                 label: str = None) -> str:
             print(f"  🧪 Delegating to analysis specialist: {task[:80]}...")
-            return self.orch._delegate("analysis", task, context, context_from)
+            return self.orch._delegate("analysis", task, context, context_from, label)
 
         self._register_tool(
             func=delegate_to_analysis,
@@ -213,15 +214,24 @@ class MetaOrchestratorTools:
                         "findings you threaded into `context` — records provenance."
                     ),
                 },
+                "label": {
+                    "type": "string",
+                    "description": (
+                        "Short label shown in the UI delegation tree — the data "
+                        "type being analyzed (e.g. '1-D Raman spectra', "
+                        "'STEM image', 'hyperspectral datacube')."
+                    ),
+                },
             },
             required=["task"],
         )
 
         # -- delegate_to_planning -------------------------------------------
         def delegate_to_planning(task: str, context: dict = None,
-                                 context_from: list = None) -> str:
+                                 context_from: list = None,
+                                 label: str = None) -> str:
             print(f"  📋 Delegating to planning specialist: {task[:80]}...")
-            return self.orch._delegate("planning", task, context, context_from)
+            return self.orch._delegate("planning", task, context, context_from, label)
 
         self._register_tool(
             func=delegate_to_planning,
@@ -254,6 +264,14 @@ class MetaOrchestratorTools:
                     "description": (
                         "delegation_index numbers of earlier delegations whose "
                         "findings you threaded into `context` — records provenance."
+                    ),
+                },
+                "label": {
+                    "type": "string",
+                    "description": (
+                        "Short label shown in the UI delegation tree — the "
+                        "focus of the planning task (e.g. 'follow-up BO "
+                        "campaign', 'experiment design')."
                     ),
                 },
             },

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -13,7 +13,105 @@ refactor".
 
 import json
 import logging
+from pathlib import Path
 from typing import Any, Callable, Dict
+
+
+# ── Upload inspection ────────────────────────────────────────────────
+# Lightweight, content-based file probes so the meta-agent routes each
+# uploaded file from evidence (array shape, table columns, document text)
+# rather than guessing from the filename. Every heavy / optional import is
+# done lazily inside the relevant branch, so this module stays importable
+# without those packages and a missing reader degrades one file's probe
+# instead of breaking the whole tool.
+
+_PROBE_MAX_FILES = 60
+_PROBE_TEXT_HEAD = 400
+
+
+def _probe_file(path: Path) -> Dict[str, Any]:
+    """Content-probe a single file for routing. Never raises — any failure
+    is reported in the returned dict's ``note`` field."""
+    ext = path.suffix.lower()
+    info: Dict[str, Any] = {"file": str(path), "ext": ext}
+    try:
+        info["size_kb"] = round(path.stat().st_size / 1024, 1)
+    except OSError:
+        pass
+    try:
+        if ext == ".npy":
+            import numpy as np
+            arr = np.load(path, mmap_mode="r", allow_pickle=False)
+            info.update(kind="array", shape=list(arr.shape), dtype=str(arr.dtype))
+        elif ext in (".tif", ".tiff", ".png", ".jpg", ".jpeg"):
+            from PIL import Image
+            with Image.open(path) as im:
+                info.update(kind="image", height=im.height, width=im.width,
+                            mode=im.mode, n_frames=getattr(im, "n_frames", 1))
+        elif ext in (".csv", ".tsv"):
+            import pandas as pd
+            df = pd.read_csv(path, sep="\t" if ext == ".tsv" else ",", nrows=200)
+            info.update(kind="table", n_columns=int(df.shape[1]),
+                        sampled_rows=int(df.shape[0]),
+                        columns=[str(c) for c in df.columns[:40]],
+                        dtypes={str(c): str(t)
+                                for c, t in list(df.dtypes.items())[:40]})
+        elif ext == ".xlsx":
+            import pandas as pd
+            df = pd.read_excel(path, nrows=200)
+            info.update(kind="table", n_columns=int(df.shape[1]),
+                        sampled_rows=int(df.shape[0]),
+                        columns=[str(c) for c in df.columns[:40]])
+        elif ext == ".json":
+            with open(path, "r", errors="replace") as fh:
+                obj = json.load(fh)
+            if isinstance(obj, dict):
+                info.update(kind="json", json_type="object",
+                            top_level_keys=[str(k) for k in list(obj)[:40]])
+            elif isinstance(obj, list):
+                info.update(kind="json", json_type="array", length=len(obj))
+            else:
+                info.update(kind="json", json_type=type(obj).__name__)
+        elif ext == ".pdf":
+            info.update(kind="document", doc_type="pdf")
+            try:
+                import fitz
+                doc = fitz.open(path)
+                try:
+                    info["n_pages"] = doc.page_count
+                    info["text_head"] = (
+                        doc[0].get_text() or "")[:_PROBE_TEXT_HEAD].strip()
+                finally:
+                    doc.close()
+            except Exception as e:  # noqa: BLE001 - optional reader / bad PDF
+                info["note"] = f"page/text probe unavailable: {e}"
+        elif ext == ".docx":
+            info.update(kind="document", doc_type="docx")
+            try:
+                import docx
+                d = docx.Document(str(path))
+                info["n_paragraphs"] = len(d.paragraphs)
+                text = "\n".join(p.text for p in d.paragraphs if p.text.strip())
+                info["text_head"] = text[:_PROBE_TEXT_HEAD].strip()
+            except Exception as e:  # noqa: BLE001 - optional reader / bad docx
+                info["note"] = f"text probe unavailable: {e}"
+        elif ext in (".md", ".txt"):
+            text = path.read_text(errors="replace")
+            info.update(kind="text", n_chars=len(text),
+                        text_head=text[:_PROBE_TEXT_HEAD].strip())
+        elif ext == ".py":
+            text = path.read_text(errors="replace")
+            info.update(kind="code", n_lines=text.count("\n") + 1,
+                        text_head=text[:_PROBE_TEXT_HEAD].strip())
+        elif ext in (".yaml", ".yml"):
+            text = path.read_text(errors="replace")
+            info.update(kind="config", text_head=text[:_PROBE_TEXT_HEAD].strip())
+        else:
+            info["kind"] = "unknown"
+    except Exception as e:  # noqa: BLE001 - probe must never break the tool
+        info.setdefault("kind", "unreadable")
+        info["note"] = f"probe failed: {e}"
+    return info
 
 
 class MetaOrchestratorTools:
@@ -202,6 +300,59 @@ class MetaOrchestratorTools:
                 "limit": {
                     "type": "integer",
                     "description": "Return only the most recent N delegations.",
+                },
+            },
+            required=[],
+        )
+
+        # -- inspect_uploads ------------------------------------------------
+        def inspect_uploads(path: str = None) -> str:
+            base = Path(path) if path else (self.orch.base_dir / "uploads")
+            print(f"  🔍 Inspecting uploads at {base} ...")
+            if not base.exists():
+                return json.dumps({
+                    "status": "error",
+                    "message": f"Path not found: {base}",
+                })
+            if base.is_file():
+                files = [base]
+                directory = str(base.parent)
+            else:
+                files = sorted(
+                    f for f in base.iterdir()
+                    if f.is_file() and not f.name.startswith(".")
+                )
+                directory = str(base)
+            probes = [_probe_file(f) for f in files[:_PROBE_MAX_FILES]]
+            return json.dumps({
+                "status": "success",
+                "directory": directory,
+                "n_files": len(files),
+                "truncated": len(files) > _PROBE_MAX_FILES,
+                "files": probes,
+            }, default=str)
+
+        self._register_tool(
+            func=inspect_uploads,
+            name="inspect_uploads",
+            description=(
+                "Inspect uploaded files to decide how to route them. Returns a "
+                "lightweight CONTENT probe of each file — array shape/dtype, "
+                "table column names, document text snippets, JSON keys — so you "
+                "classify from evidence, not from filenames. Call this FIRST "
+                "whenever the user refers to uploaded files or points you at a "
+                "folder. With no argument it inspects the meta session's "
+                "uploads/ directory; pass `path` for a specific file or folder. "
+                "Read-only — use the result only to choose a specialist, never "
+                "to interpret the data yourself."
+            ),
+            parameters={
+                "path": {
+                    "type": "string",
+                    "description": (
+                        "Optional file or directory to inspect. Defaults to "
+                        "the meta session's uploads/ directory."
+                    ),
                 },
             },
             required=[],

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -217,13 +217,15 @@ class MetaOrchestratorTools:
                 "label": {
                     "type": "string",
                     "description": (
-                        "Short label shown in the UI delegation tree — the data "
-                        "type being analyzed (e.g. '1-D Raman spectra', "
-                        "'STEM image', 'hyperspectral datacube')."
+                        "REQUIRED short label for the UI delegation tree — a "
+                        "2-5 word noun phrase naming the data type being "
+                        "analyzed (e.g. '1-D Raman spectra', 'STEM image', "
+                        "'hyperspectral datacube'). NOT a sentence or a "
+                        "restatement of the task."
                     ),
                 },
             },
-            required=["task"],
+            required=["task", "label"],
         )
 
         # -- delegate_to_planning -------------------------------------------
@@ -269,13 +271,14 @@ class MetaOrchestratorTools:
                 "label": {
                     "type": "string",
                     "description": (
-                        "Short label shown in the UI delegation tree — the "
-                        "focus of the planning task (e.g. 'follow-up BO "
-                        "campaign', 'experiment design')."
+                        "REQUIRED short label for the UI delegation tree — a "
+                        "2-5 word noun phrase naming the focus of the planning "
+                        "task (e.g. 'follow-up BO campaign', 'experiment "
+                        "design'). NOT a sentence."
                     ),
                 },
             },
-            required=["task"],
+            required=["task", "label"],
         )
 
         # -- delegate_to_simulation: DEFERRED lazy seam, intentionally NOT built

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -174,9 +174,10 @@ class MetaOrchestratorTools:
         """Register the meta-agent's delegation and introspection tools."""
 
         # -- delegate_to_analysis -------------------------------------------
-        def delegate_to_analysis(task: str, context: dict = None) -> str:
+        def delegate_to_analysis(task: str, context: dict = None,
+                                 context_from: list = None) -> str:
             print(f"  🧪 Delegating to analysis specialist: {task[:80]}...")
-            return self.orch._delegate("analysis", task, context)
+            return self.orch._delegate("analysis", task, context, context_from)
 
         self._register_tool(
             func=delegate_to_analysis,
@@ -204,14 +205,23 @@ class MetaOrchestratorTools:
                         "earlier delegation) to inform the task."
                     ),
                 },
+                "context_from": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "description": (
+                        "delegation_index numbers of earlier delegations whose "
+                        "findings you threaded into `context` — records provenance."
+                    ),
+                },
             },
             required=["task"],
         )
 
         # -- delegate_to_planning -------------------------------------------
-        def delegate_to_planning(task: str, context: dict = None) -> str:
+        def delegate_to_planning(task: str, context: dict = None,
+                                 context_from: list = None) -> str:
             print(f"  📋 Delegating to planning specialist: {task[:80]}...")
-            return self.orch._delegate("planning", task, context)
+            return self.orch._delegate("planning", task, context, context_from)
 
         self._register_tool(
             func=delegate_to_planning,
@@ -236,6 +246,14 @@ class MetaOrchestratorTools:
                     "description": (
                         "Optional upstream findings / file paths (e.g. analysis "
                         "key_findings) to inform the task."
+                    ),
+                },
+                "context_from": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "description": (
+                        "delegation_index numbers of earlier delegations whose "
+                        "findings you threaded into `context` — records provenance."
                     ),
                 },
             },

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -1,0 +1,208 @@
+"""Tool registry for MetaOrchestratorAgent.
+
+Mirrors the AnalysisOrchestratorTools shape — a ``ToolsClass(orchestrator)``
+that builds ``functions_map`` + ``openai_schemas`` and exposes
+``execute_tool``. The meta-agent's tools delegate to child orchestrators via
+their ``run_task`` contract and introspect the delegation ledger. See
+CLAUDE.md "The meta agent".
+
+The duplication with AnalysisOrchestratorTools is intentional and acceptable
+at this development stage — see CLAUDE.md "Why no BaseChatOrchestrator
+refactor".
+"""
+
+import json
+import logging
+from typing import Any, Callable, Dict
+
+
+class MetaOrchestratorTools:
+    """Tool definitions, schemas, and execution for MetaOrchestratorAgent."""
+
+    def __init__(self, orchestrator_instance):
+        """
+        Args:
+            orchestrator_instance: the parent MetaOrchestratorAgent.
+        """
+        self.orch = orchestrator_instance
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+        self.functions_map: Dict[str, Callable] = {}
+        self.openai_schemas: list = []
+
+        self._register_all_tools()
+
+    def _register_tool(
+        self,
+        func: Callable,
+        name: str,
+        description: str,
+        parameters: Dict[str, Any],
+        required: list = None,
+    ):
+        """Register a tool in OpenAI function-calling format."""
+        self.functions_map[name] = func
+        self.openai_schemas.append({
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": description,
+                "parameters": {
+                    "type": "object",
+                    "properties": parameters,
+                    "required": required or [],
+                },
+            },
+        })
+
+    def execute_tool(self, tool_name: str, **kwargs) -> str:
+        """Execute a tool by name; always returns a JSON string."""
+        if tool_name not in self.functions_map:
+            return json.dumps({
+                "status": "error",
+                "message": f"Tool '{tool_name}' not found",
+            })
+        try:
+            return self.functions_map[tool_name](**kwargs)
+        except Exception as e:
+            logging.error(f"Tool execution error ({tool_name}): {e}", exc_info=True)
+            return json.dumps({
+                "status": "error",
+                "message": str(e),
+                "tool": tool_name,
+            })
+
+    def _register_all_tools(self):
+        """Register the meta-agent's delegation and introspection tools."""
+
+        # -- delegate_to_analysis -------------------------------------------
+        def delegate_to_analysis(task: str, context: dict = None) -> str:
+            print(f"  🧪 Delegating to analysis specialist: {task[:80]}...")
+            return self.orch._delegate("analysis", task, context)
+
+        self._register_tool(
+            func=delegate_to_analysis,
+            name="delegate_to_analysis",
+            description=(
+                "Delegate an experimental-data-analysis task to the analysis "
+                "specialist (microscopy, spectroscopy, curve fitting, "
+                "hyperspectral datacubes, quality assessment, feature "
+                "extraction, novelty checks). The specialist runs autonomously "
+                "with no interactive user and returns a structured JSON result "
+                "(status, summary, key_findings, files_produced, "
+                "suggested_followups, warnings, delegation_index). `task` must "
+                "be a complete, self-contained instruction including absolute "
+                "paths to any data files."
+            ),
+            parameters={
+                "task": {
+                    "type": "string",
+                    "description": "Complete, self-contained analysis instruction.",
+                },
+                "context": {
+                    "type": "object",
+                    "description": (
+                        "Optional upstream findings / file paths (e.g. from an "
+                        "earlier delegation) to inform the task."
+                    ),
+                },
+            },
+            required=["task"],
+        )
+
+        # -- delegate_to_planning -------------------------------------------
+        def delegate_to_planning(task: str, context: dict = None) -> str:
+            print(f"  📋 Delegating to planning specialist: {task[:80]}...")
+            return self.orch._delegate("planning", task, context)
+
+        self._register_tool(
+            func=delegate_to_planning,
+            name="delegate_to_planning",
+            description=(
+                "Delegate an experimental-campaign-planning task to the "
+                "planning specialist (experiment design, multi-objective "
+                "Bayesian optimization, hypothesis generation, deciding what "
+                "to measure or run next). The specialist runs autonomously "
+                "with no interactive user and returns a structured JSON result "
+                "(status, summary, key_findings, files_produced, "
+                "suggested_followups, warnings, delegation_index). `task` must "
+                "be a complete, self-contained instruction."
+            ),
+            parameters={
+                "task": {
+                    "type": "string",
+                    "description": "Complete, self-contained planning instruction.",
+                },
+                "context": {
+                    "type": "object",
+                    "description": (
+                        "Optional upstream findings / file paths (e.g. analysis "
+                        "key_findings) to inform the task."
+                    ),
+                },
+            },
+            required=["task"],
+        )
+
+        # -- delegate_to_simulation: DEFERRED lazy seam, intentionally NOT built
+        #
+        # v1 covers analysis + planning only. When simulation delegation is
+        # added, register a tool whose body does a GUARDED import INSIDE the
+        # function — never at module scope, because scilink.agents.sim_agents
+        # hard-imports `ase`, an optional dependency, and the meta-agent module
+        # must stay importable without ASE:
+        #
+        #   def delegate_to_simulation(task, context=None):
+        #       try:
+        #           from ..sim_agents.simulation_orchestrator import (
+        #               SimulationOrchestratorAgent, SimulationMode)
+        #       except ImportError as e:
+        #           return json.dumps({"status": "error",
+        #               "message": "Simulation support requires the optional "
+        #               "[sim] extra (pip install scilink[sim]).",
+        #               "detail": str(e)})
+        #       return self.orch._delegate("simulation", task, context)
+        #
+        # MetaOrchestratorAgent._delegate / _get_*_child would gain a
+        # "simulation" branch using a self.orch.simulation_dir sub-directory.
+
+        # -- summarize_session_state ----------------------------------------
+        def summarize_session_state() -> str:
+            return self.orch._session_state_summary()
+
+        self._register_tool(
+            func=summarize_session_state,
+            name="summarize_session_state",
+            description=(
+                "Report the cross-specialist session state: which specialists "
+                "have been instantiated, how many delegations have run, and "
+                "per-specialist counters (analyses run, optimization targets, "
+                "collected data points). Read-only."
+            ),
+            parameters={},
+            required=[],
+        )
+
+        # -- get_delegation_history -----------------------------------------
+        def get_delegation_history(limit: int = None) -> str:
+            return self.orch._delegation_history(limit)
+
+        self._register_tool(
+            func=get_delegation_history,
+            name="get_delegation_history",
+            description=(
+                "Retrieve the delegation ledger — the results of prior "
+                "delegations (status, summary, key_findings, files_produced, "
+                "suggested_followups). Use it to pull an earlier specialist's "
+                "result and thread the relevant pieces as the `context` "
+                "argument of the next delegate_to_* call. Optional `limit` "
+                "returns only the most recent N entries."
+            ),
+            parameters={
+                "limit": {
+                    "type": "integer",
+                    "description": "Return only the most recent N delegations.",
+                },
+            },
+            required=[],
+        )

--- a/scilink/agents/meta_agent/telemetry.py
+++ b/scilink/agents/meta_agent/telemetry.py
@@ -155,13 +155,34 @@ def _analysis_reports(base_dir: Path) -> List[Dict[str, Any]]:
     return reports
 
 
+def _maybe_json(value: Any) -> Any:
+    """Parse a JSON string into a dict/list; leave anything else as-is."""
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except Exception:  # noqa: BLE001
+            return value
+    return value
+
+
 def _extract_tool_calls(messages: list) -> List[Dict[str, Any]]:
-    """Ordered (tool, args) for every tool call in one chat history.
+    """Ordered tool calls in one chat history, each matched to its result.
 
     Handles the OpenAI-style ``tool_calls`` on assistant messages
     (``function.name`` / ``function.arguments`` JSON string), with a light
-    fallback for a flattened ``{name, args}`` shape.
+    fallback for a flattened ``{name, args}`` shape. Each entry carries the
+    parsed ``args``, the parsed tool ``result`` (matched by ``tool_call_id``),
+    and a ``status`` derived from that result — ``pending`` when the call has
+    no result yet (a tool still running, or a turn in flight).
     """
+    # First pass: tool_call_id -> result payload, from role:"tool" messages.
+    results: Dict[str, Any] = {}
+    for m in messages:
+        if isinstance(m, dict) and m.get("role") == "tool":
+            tcid = m.get("tool_call_id")
+            if tcid:
+                results[tcid] = _maybe_json(m.get("content"))
+
     seq: List[Dict[str, Any]] = []
     for m in messages:
         if not isinstance(m, dict):
@@ -173,15 +194,15 @@ def _extract_tool_calls(messages: list) -> List[Dict[str, Any]]:
             name = fn.get("name")
             if not name:
                 continue
-            raw = fn.get("arguments", fn.get("args"))
-            args: Any = raw
-            if isinstance(raw, str):
-                try:
-                    args = json.loads(raw)
-                except Exception:  # noqa: BLE001
-                    args = {"_raw": raw}
-            seq.append({"tool": name,
-                        "args": args if isinstance(args, dict) else {}})
+            args = _maybe_json(fn.get("arguments", fn.get("args")))
+            has_result = tc.get("id") in results
+            result = results.get(tc.get("id"))
+            seq.append({
+                "tool": name,
+                "args": args if isinstance(args, dict) else {"_value": args},
+                "result": result,
+                "status": _action_status(result) if has_result else "pending",
+            })
     return seq
 
 

--- a/scilink/agents/meta_agent/telemetry.py
+++ b/scilink/agents/meta_agent/telemetry.py
@@ -154,6 +154,57 @@ def _analysis_reports(base_dir: Path) -> List[Dict[str, Any]]:
     return reports
 
 
+def _extract_tool_calls(messages: list) -> List[Dict[str, Any]]:
+    """Ordered (tool, args) for every tool call in one chat history.
+
+    Handles the OpenAI-style ``tool_calls`` on assistant messages
+    (``function.name`` / ``function.arguments`` JSON string), with a light
+    fallback for a flattened ``{name, args}`` shape.
+    """
+    seq: List[Dict[str, Any]] = []
+    for m in messages:
+        if not isinstance(m, dict):
+            continue
+        for tc in m.get("tool_calls") or []:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function") if isinstance(tc.get("function"), dict) else tc
+            name = fn.get("name")
+            if not name:
+                continue
+            raw = fn.get("arguments", fn.get("args"))
+            args: Any = raw
+            if isinstance(raw, str):
+                try:
+                    args = json.loads(raw)
+                except Exception:  # noqa: BLE001
+                    args = {"_raw": raw}
+            seq.append({"tool": name,
+                        "args": args if isinstance(args, dict) else {}})
+    return seq
+
+
+def _tool_sequence(base_dir: Path) -> Dict[str, List[Dict[str, Any]]]:
+    """Per-agent ordered tool-call sequence, read from each ``chat_history.json``
+    (the meta's at the session root, each specialist's in its sub-dir)."""
+    out: Dict[str, List[Dict[str, Any]]] = {}
+    for layer, sub in (("meta", ""), ("analysis", "analysis"),
+                        ("planning", "planning")):
+        path = (base_dir / sub / "chat_history.json" if sub
+                else base_dir / "chat_history.json")
+        if not path.is_file():
+            continue
+        try:
+            messages = json.loads(path.read_text())
+        except Exception:  # noqa: BLE001
+            continue
+        if isinstance(messages, list):
+            calls = _extract_tool_calls(messages)
+            if calls:
+                out[layer] = calls
+    return out
+
+
 def _csv_row_count(path: Any) -> int:
     """Row count of a CSV, or 0 if absent / unreadable."""
     try:
@@ -221,6 +272,7 @@ def collect_session_telemetry(meta_agent: Any) -> Dict[str, Any]:
 
         agents: List[Dict[str, Any]] = []
         analysis_reports: List[Dict[str, Any]] = []
+        tool_sequence: Dict[str, List[Dict[str, Any]]] = {}
         if base_dir_raw and Path(base_dir_raw).is_dir():
             base = Path(base_dir_raw)
             for sp in sorted(base.rglob("*_state.json")):
@@ -228,6 +280,7 @@ def collect_session_telemetry(meta_agent: Any) -> Dict[str, Any]:
                 if row:
                     agents.append(row)
             analysis_reports = _analysis_reports(base)
+            tool_sequence = _tool_sequence(base)
 
         # Which sub-agents each specialist (mode) ended up using — for the
         # dependency graph's per-mode sub-agent annotation.
@@ -248,8 +301,9 @@ def collect_session_telemetry(meta_agent: Any) -> Dict[str, Any]:
             "agents": agents,
             "sub_agents": sub_agents,
             "analysis_reports": analysis_reports,
+            "tool_sequence": tool_sequence,
         }
     except Exception as e:  # noqa: BLE001 - telemetry must never break the UI
         logger.warning(f"telemetry collection failed: {e}")
-        return {"meta": {}, "specialists": {}, "agents": [],
-                "sub_agents": {}, "analysis_reports": [], "error": str(e)}
+        return {"meta": {}, "specialists": {}, "agents": [], "sub_agents": {},
+                "analysis_reports": [], "tool_sequence": {}, "error": str(e)}

--- a/scilink/agents/meta_agent/telemetry.py
+++ b/scilink/agents/meta_agent/telemetry.py
@@ -185,25 +185,47 @@ def _extract_tool_calls(messages: list) -> List[Dict[str, Any]]:
     return seq
 
 
-def _tool_sequence(base_dir: Path) -> Dict[str, Dict[str, Any]]:
-    """Per-agent ordered tool-call sequence, read from each ``chat_history.json``
-    (the meta's at the session root, each specialist's in its sub-dir). Each
-    layer's entry carries its ``calls`` and the ``source`` file path."""
+def _tool_sequence(base_dir: Path, meta_agent: Any) -> Dict[str, Dict[str, Any]]:
+    """Per-agent ordered tool-call sequence.
+
+    Prefers each agent's live in-memory ``messages`` — which grows per tool
+    iteration mid-turn, so the sequence updates in real time — and falls back
+    to the persisted ``chat_history.json`` (written only at end of turn) when
+    no live agent object is available (e.g. a child not yet re-created after a
+    resume). Pure read: a snapshot copy guards against the background chat
+    thread mutating ``messages`` concurrently.
+
+    Each layer's entry carries its ``calls`` and the ``source`` file path (the
+    meta's at the session root, each specialist's in its sub-dir).
+    """
+    children = getattr(meta_agent, "_children", {}) or {}
+    live = {"meta": meta_agent, "analysis": children.get("analysis"),
+            "planning": children.get("planning")}
     out: Dict[str, Dict[str, Any]] = {}
     for layer, sub in (("meta", ""), ("analysis", "analysis"),
                         ("planning", "planning")):
         path = (base_dir / sub / "chat_history.json" if sub
                 else base_dir / "chat_history.json")
-        if not path.is_file():
-            continue
-        try:
-            messages = json.loads(path.read_text())
-        except Exception:  # noqa: BLE001
-            continue
-        if isinstance(messages, list):
-            calls = _extract_tool_calls(messages)
-            if calls:
-                out[layer] = {"calls": calls, "source": str(path)}
+        calls: Optional[List[Dict[str, Any]]] = None
+
+        obj = live.get(layer)
+        msgs = getattr(obj, "messages", None) if obj is not None else None
+        if isinstance(msgs, list):
+            try:
+                calls = _extract_tool_calls(list(msgs))  # snapshot, then read
+            except Exception:  # noqa: BLE001 - concurrent mutation; next poll
+                calls = None
+
+        if calls is None and path.is_file():  # fall back to the persisted file
+            try:
+                messages = json.loads(path.read_text())
+                if isinstance(messages, list):
+                    calls = _extract_tool_calls(messages)
+            except Exception:  # noqa: BLE001
+                calls = None
+
+        if calls:
+            out[layer] = {"calls": calls, "source": str(path)}
     return out
 
 
@@ -282,7 +304,7 @@ def collect_session_telemetry(meta_agent: Any) -> Dict[str, Any]:
                 if row:
                     agents.append(row)
             analysis_reports = _analysis_reports(base)
-            tool_sequence = _tool_sequence(base)
+            tool_sequence = _tool_sequence(base, meta_agent)
 
         # Which sub-agents each specialist (mode) ended up using — for the
         # dependency graph's per-mode sub-agent annotation.

--- a/scilink/agents/meta_agent/telemetry.py
+++ b/scilink/agents/meta_agent/telemetry.py
@@ -1,12 +1,13 @@
 """Read-only telemetry snapshot of a meta (Explore) session.
 
 Aggregates state the agents already persist — the meta's delegation ledger,
-the specialist orchestrators' counters, and each worker agent's
-``action_history`` (the uniform ``_log_action`` audit trail) — into one plain
-dict for the Telemetry UI tab.
+the specialist orchestrators' counters, each worker agent's ``action_history``
+(the uniform ``_log_action`` audit trail, with full input / result / rationale
+per action), and the analysis sub-agents' ``analysis_results.json`` reasoning
+— into one plain dict for the Telemetry UI tab.
 
-The reader is LLM-free, stdlib-only, and never raises: a malformed state file
-degrades that one agent's row to nothing rather than breaking the tab.
+The reader is LLM-free, stdlib-only, and never raises: a malformed file
+degrades that one entry rather than breaking the tab.
 """
 
 import json
@@ -16,7 +17,7 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-_RATIONALE_MAX = 200
+_DETAILED_MAX = 2000  # cap on the analysis detailed_analysis reasoning text
 
 # Friendly names for the known worker state files; anything else falls back to
 # a title-cased form of the file stem (so a new agent still shows up sanely).
@@ -64,7 +65,11 @@ def _specialist_of(path: Path) -> str:
 
 def _worker_telemetry(state_path: Path) -> Optional[Dict[str, Any]]:
     """One agent row from a ``*_state.json`` file, or None if it has no
-    ``action_history`` (so non-agent ``*_state.json`` files are skipped)."""
+    ``action_history`` (so non-agent ``*_state.json`` files are skipped).
+
+    Each action carries the full ``input`` / ``result`` / ``rationale`` /
+    ``feedback`` so the UI can render a detailed per-action breakdown.
+    """
     try:
         data = json.loads(state_path.read_text())
     except Exception:  # noqa: BLE001 - a bad state file must not break the tab
@@ -90,14 +95,14 @@ def _worker_telemetry(state_path: Path) -> Optional[Dict[str, Any]]:
             outcomes["error"] += 1
         else:
             outcomes["other"] += 1
-        rationale = entry.get("rationale")
-        if isinstance(rationale, str) and len(rationale) > _RATIONALE_MAX:
-            rationale = rationale[:_RATIONALE_MAX - 1] + "…"
         actions.append({
             "timestamp": entry.get("timestamp"),
             "action": action,
             "status": status,
-            "rationale": rationale,
+            "rationale": entry.get("rationale"),
+            "input": entry.get("input"),
+            "result": entry.get("result"),
+            "feedback": entry.get("feedback"),
         })
 
     stamps = [a["timestamp"] for a in actions if a["timestamp"]]
@@ -113,6 +118,40 @@ def _worker_telemetry(state_path: Path) -> Optional[Dict[str, Any]]:
         "actions": actions,
         "source_file": str(state_path),
     }
+
+
+def _analysis_reports(base_dir: Path) -> List[Dict[str, Any]]:
+    """Per-analysis scientific reasoning from each ``analysis_results.json`` —
+    the detailed_analysis narrative and the extracted scientific claims."""
+    reports: List[Dict[str, Any]] = []
+    adir = base_dir / "analysis"
+    if not adir.is_dir():
+        return reports
+    for ar in sorted(adir.rglob("analysis_results.json")):
+        try:
+            data = json.loads(ar.read_text())
+        except Exception:  # noqa: BLE001
+            continue
+        if not isinstance(data, dict):
+            continue
+        claims: List[Dict[str, Any]] = []
+        for c in data.get("scientific_claims") or []:
+            if isinstance(c, dict):
+                claims.append({"claim": c.get("claim"),
+                               "impact": c.get("scientific_impact")})
+            elif c:
+                claims.append({"claim": str(c), "impact": None})
+        detailed = str(data.get("detailed_analysis") or "")
+        if len(detailed) > _DETAILED_MAX:
+            detailed = detailed[:_DETAILED_MAX] + "…"
+        reports.append({
+            "analysis_id": ar.parent.name,
+            "status": data.get("status"),
+            "detailed_analysis": detailed,
+            "claims": claims,
+            "output_dir": str(ar.parent),
+        })
+    return reports
 
 
 def _csv_row_count(path: Any) -> int:
@@ -181,11 +220,22 @@ def collect_session_telemetry(meta_agent: Any) -> Dict[str, Any]:
         } for e in ledger]
 
         agents: List[Dict[str, Any]] = []
+        analysis_reports: List[Dict[str, Any]] = []
         if base_dir_raw and Path(base_dir_raw).is_dir():
-            for sp in sorted(Path(base_dir_raw).rglob("*_state.json")):
+            base = Path(base_dir_raw)
+            for sp in sorted(base.rglob("*_state.json")):
                 row = _worker_telemetry(sp)
                 if row:
                     agents.append(row)
+            analysis_reports = _analysis_reports(base)
+
+        # Which sub-agents each specialist (mode) ended up using — for the
+        # dependency graph's per-mode sub-agent annotation.
+        sub_agents: Dict[str, List[str]] = {}
+        for a in agents:
+            names = sub_agents.setdefault(a["specialist"], [])
+            if a["name"] not in names:
+                names.append(a["name"])
 
         return {
             "meta": {
@@ -196,7 +246,10 @@ def collect_session_telemetry(meta_agent: Any) -> Dict[str, Any]:
             },
             "specialists": _specialists(meta_agent),
             "agents": agents,
+            "sub_agents": sub_agents,
+            "analysis_reports": analysis_reports,
         }
     except Exception as e:  # noqa: BLE001 - telemetry must never break the UI
         logger.warning(f"telemetry collection failed: {e}")
-        return {"meta": {}, "specialists": {}, "agents": [], "error": str(e)}
+        return {"meta": {}, "specialists": {}, "agents": [],
+                "sub_agents": {}, "analysis_reports": [], "error": str(e)}

--- a/scilink/agents/meta_agent/telemetry.py
+++ b/scilink/agents/meta_agent/telemetry.py
@@ -1,0 +1,202 @@
+"""Read-only telemetry snapshot of a meta (Explore) session.
+
+Aggregates state the agents already persist — the meta's delegation ledger,
+the specialist orchestrators' counters, and each worker agent's
+``action_history`` (the uniform ``_log_action`` audit trail) — into one plain
+dict for the Telemetry UI tab.
+
+The reader is LLM-free, stdlib-only, and never raises: a malformed state file
+degrades that one agent's row to nothing rather than breaking the tab.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_RATIONALE_MAX = 200
+
+# Friendly names for the known worker state files; anything else falls back to
+# a title-cased form of the file stem (so a new agent still shows up sanely).
+_AGENT_LABELS = {
+    "curve_fitting": "Curve Fitting",
+    "bo": "Bayesian Optimization",
+    "scalarizer": "Scalarizer",
+}
+
+
+def _agent_label(agent_type: Optional[str], stem: str) -> str:
+    """Human-readable agent name from ``agent_type`` or the state-file stem."""
+    if isinstance(agent_type, str) and agent_type.strip():
+        key = agent_type.strip().lower()
+        return _AGENT_LABELS.get(key, agent_type.strip())
+    base = stem[:-6] if stem.endswith("_state") else stem  # "bo_state" -> "bo"
+    return _AGENT_LABELS.get(base, base.replace("_", " ").title())
+
+
+def _action_status(result: Any) -> str:
+    """Best-effort outcome label for one action_history entry's ``result``.
+
+    BO / Scalarizer results carry an explicit ``status``; curve-fitting results
+    do not — for those a completed action is reported as ``ok``.
+    """
+    if isinstance(result, dict):
+        status = result.get("status")
+        if isinstance(status, str) and status:
+            return status
+        if result.get("error"):
+            return "error"
+        return "ok"
+    return "ok" if result else "-"
+
+
+def _specialist_of(path: Path) -> str:
+    """Which specialist subtree (``analysis`` / ``planning``) a file sits in."""
+    parts = set(path.parts)
+    if "analysis" in parts:
+        return "analysis"
+    if "planning" in parts:
+        return "planning"
+    return "other"
+
+
+def _worker_telemetry(state_path: Path) -> Optional[Dict[str, Any]]:
+    """One agent row from a ``*_state.json`` file, or None if it has no
+    ``action_history`` (so non-agent ``*_state.json`` files are skipped)."""
+    try:
+        data = json.loads(state_path.read_text())
+    except Exception:  # noqa: BLE001 - a bad state file must not break the tab
+        return None
+    if not isinstance(data, dict):
+        return None
+    history = data.get("action_history")
+    if not isinstance(history, list) or not history:
+        return None
+
+    actions: List[Dict[str, Any]] = []
+    by_type: Dict[str, int] = {}
+    outcomes = {"success": 0, "error": 0, "other": 0}
+    for entry in history:
+        if not isinstance(entry, dict):
+            continue
+        action = str(entry.get("action") or "?")
+        status = _action_status(entry.get("result"))
+        by_type[action] = by_type.get(action, 0) + 1
+        if status in ("success", "ok"):
+            outcomes["success"] += 1
+        elif status == "error":
+            outcomes["error"] += 1
+        else:
+            outcomes["other"] += 1
+        rationale = entry.get("rationale")
+        if isinstance(rationale, str) and len(rationale) > _RATIONALE_MAX:
+            rationale = rationale[:_RATIONALE_MAX - 1] + "…"
+        actions.append({
+            "timestamp": entry.get("timestamp"),
+            "action": action,
+            "status": status,
+            "rationale": rationale,
+        })
+
+    stamps = [a["timestamp"] for a in actions if a["timestamp"]]
+    return {
+        "specialist": _specialist_of(state_path),
+        "name": _agent_label(data.get("agent_type"), state_path.stem),
+        "status": data.get("status"),
+        "action_count": len(actions),
+        "actions_by_type": by_type,
+        "outcomes": outcomes,
+        "first_timestamp": min(stamps) if stamps else None,
+        "last_timestamp": max(stamps) if stamps else None,
+        "actions": actions,
+        "source_file": str(state_path),
+    }
+
+
+def _csv_row_count(path: Any) -> int:
+    """Row count of a CSV, or 0 if absent / unreadable."""
+    try:
+        import pandas as pd
+        if path and Path(path).exists():
+            return len(pd.read_csv(path))
+    except Exception:  # noqa: BLE001
+        pass
+    return 0
+
+
+def _specialists(meta_agent: Any) -> Dict[str, Any]:
+    """Per-specialist counters — the same fields the meta's
+    ``_session_state_summary`` reads, defensively via ``getattr``."""
+    children = getattr(meta_agent, "_children", {}) or {}
+    out: Dict[str, Any] = {}
+    for name in ("analysis", "planning"):
+        child = children.get(name)
+        if child is None:
+            out[name] = {"instantiated": False}
+            continue
+        info: Dict[str, Any] = {
+            "instantiated": True,
+            "message_count": getattr(child, "message_count", 0),
+        }
+        if name == "analysis":
+            info["analyses_run"] = len(
+                getattr(child, "analysis_results", []) or [])
+        else:
+            info["optimization_targets"] = list(
+                getattr(child, "expected_target_columns", []) or [])
+            info["bo_data_points"] = _csv_row_count(
+                getattr(child, "bo_data_path", None))
+        out[name] = info
+    return out
+
+
+def collect_session_telemetry(meta_agent: Any) -> Dict[str, Any]:
+    """Read-only telemetry snapshot of a meta session. Never raises.
+
+    Works for a live session (ledger in memory) and a resumed one (ledger
+    restored from the checkpoint; worker state files re-read from disk).
+    """
+    try:
+        meta_mode = getattr(meta_agent, "meta_mode", None)
+        meta_mode_str = getattr(meta_mode, "value", None) or str(meta_mode)
+        # No configured base_dir -> scan nothing (never fall back to cwd, which
+        # would rglob the whole tree).
+        base_dir_raw = getattr(meta_agent, "base_dir", None)
+        ledger = list(getattr(meta_agent, "_delegation_ledger", []) or [])
+
+        delegations = [{
+            "index": e.get("index"),
+            "mode": e.get("mode"),
+            "label": (e.get("label") or "").strip()
+            or " ".join(str(e.get("task") or "").split())[:60],
+            "status": e.get("status"),
+            "context_from": e.get("context_from") or [],
+            "timestamp": e.get("timestamp"),
+            "completed_at": e.get("completed_at"),
+            "files": len(e.get("files_produced") or []),
+            "feature_tables": len(e.get("feature_tables") or []),
+            "warnings": len(e.get("warnings") or []),
+        } for e in ledger]
+
+        agents: List[Dict[str, Any]] = []
+        if base_dir_raw and Path(base_dir_raw).is_dir():
+            for sp in sorted(Path(base_dir_raw).rglob("*_state.json")):
+                row = _worker_telemetry(sp)
+                if row:
+                    agents.append(row)
+
+        return {
+            "meta": {
+                "meta_mode": meta_mode_str,
+                "session_dir": str(base_dir_raw or ""),
+                "delegations_total": len(ledger),
+                "delegations": delegations,
+            },
+            "specialists": _specialists(meta_agent),
+            "agents": agents,
+        }
+    except Exception as e:  # noqa: BLE001 - telemetry must never break the UI
+        logger.warning(f"telemetry collection failed: {e}")
+        return {"meta": {}, "specialists": {}, "agents": [], "error": str(e)}

--- a/scilink/agents/meta_agent/telemetry.py
+++ b/scilink/agents/meta_agent/telemetry.py
@@ -150,6 +150,7 @@ def _analysis_reports(base_dir: Path) -> List[Dict[str, Any]]:
             "detailed_analysis": detailed,
             "claims": claims,
             "output_dir": str(ar.parent),
+            "report_file": str(ar),
         })
     return reports
 
@@ -184,10 +185,11 @@ def _extract_tool_calls(messages: list) -> List[Dict[str, Any]]:
     return seq
 
 
-def _tool_sequence(base_dir: Path) -> Dict[str, List[Dict[str, Any]]]:
+def _tool_sequence(base_dir: Path) -> Dict[str, Dict[str, Any]]:
     """Per-agent ordered tool-call sequence, read from each ``chat_history.json``
-    (the meta's at the session root, each specialist's in its sub-dir)."""
-    out: Dict[str, List[Dict[str, Any]]] = {}
+    (the meta's at the session root, each specialist's in its sub-dir). Each
+    layer's entry carries its ``calls`` and the ``source`` file path."""
+    out: Dict[str, Dict[str, Any]] = {}
     for layer, sub in (("meta", ""), ("analysis", "analysis"),
                         ("planning", "planning")):
         path = (base_dir / sub / "chat_history.json" if sub
@@ -201,7 +203,7 @@ def _tool_sequence(base_dir: Path) -> Dict[str, List[Dict[str, Any]]]:
         if isinstance(messages, list):
             calls = _extract_tool_calls(messages)
             if calls:
-                out[layer] = calls
+                out[layer] = {"calls": calls, "source": str(path)}
     return out
 
 

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -412,6 +412,16 @@ class OrchestratorTools:
             "hint": "Check filename spelling or use /files command to see available files"
         })
     
+    def _output_dir(self):
+        """Directory for plan artifacts (plan.json, tea_analysis, output_scripts,
+        literature_search*, molecule_design, ...).
+
+        During a meta-agent delegation this is a per-delegation sub-directory
+        so a reused planning child does not overwrite an earlier delegation's
+        artifacts; for direct `scilink plan` use it is the campaign root
+        (``_active_output_subdir`` is None, so behaviour is unchanged)."""
+        return self.orch._active_output_subdir or self.orch.base_dir
+
     def _register_all_tools(self):
         """Register all tools with both OpenAI and Gemini formats."""
         
@@ -492,7 +502,7 @@ class OrchestratorTools:
                     })
 
                 # Save to file (distinct per search_type to avoid overwrites)
-                lit_path = self.orch.base_dir / f"literature_search_{search_type}.md"
+                lit_path = self._output_dir() / f"literature_search_{search_type}.md"
                 with open(lit_path, 'w') as f:
                     f.write(f"# Literature Search Results ({search_type})\n\n")
                     f.write(lit_res['content'])
@@ -562,7 +572,7 @@ class OrchestratorTools:
                     })
 
                 # Save to file
-                mol_path = self.orch.base_dir / "molecule_design.md"
+                mol_path = self._output_dir() / "molecule_design.md"
                 with open(mol_path, 'w') as f:
                     f.write("# Molecular Design & Synthesis Planning Results\n\n")
                     f.write(mol_res['content'])
@@ -742,13 +752,13 @@ class OrchestratorTools:
                     })
 
                 # Save
-                output_path = self.orch.base_dir / "plan.json"
+                output_path = self._output_dir() / "plan.json"
                 with open(output_path, 'w') as f:
                     json.dump(plan, f, indent=2)
 
                 # If literature came from the deprecated internal path, save it
                 if not literature_context and plan.get("literature_search"):
-                    lit_path = self.orch.base_dir / "literature_search.md"
+                    lit_path = self._output_dir() / "literature_search.md"
                     with open(lit_path, 'w') as f:
                         f.write("# Literature Search Results\n\n")
                         f.write(plan["literature_search"])
@@ -756,7 +766,7 @@ class OrchestratorTools:
 
                 # Generate HTML
                 from .html_generator import HTMLReportGenerator
-                html_path = self.orch.base_dir / "plan.html"
+                html_path = self._output_dir() / "plan.html"
                 generator = HTMLReportGenerator(self.orch.planner.state)
                 generator.generate(str(html_path))
 
@@ -905,13 +915,13 @@ class OrchestratorTools:
                     })
                 
                 # Save
-                output_path = self.orch.base_dir / "plan.json"
+                output_path = self._output_dir() / "plan.json"
                 with open(output_path, 'w') as f:
                     json.dump(updated_plan, f, indent=2)
                 
                 # Regenerate HTML
                 from .html_generator import HTMLReportGenerator
-                html_path = self.orch.base_dir / "plan.html"
+                html_path = self._output_dir() / "plan.html"
                 generator = HTMLReportGenerator(self.orch.planner.state)
                 generator.generate(str(html_path))
                 
@@ -932,7 +942,7 @@ class OrchestratorTools:
                     })
 
                 # Save scripts to output folder
-                final_out = str(self.orch.base_dir / "output_scripts")
+                final_out = str(self._output_dir() / "output_scripts")
                 print(f"\n--- Saving Scripts to: {final_out} ---")
                 write_experiments_to_disk(updated_plan, final_out)
 
@@ -1052,7 +1062,7 @@ class OrchestratorTools:
                     objective=obj,
                     knowledge_paths=knowledge_list,
                     primary_data_set=primary_dataset,
-                    output_json_path=str(self.orch.base_dir / "tea_analysis.json"),
+                    output_json_path=str(self._output_dir() / "tea_analysis.json"),
                     external_context=ext_ctx
                 )
                 
@@ -1075,8 +1085,8 @@ class OrchestratorTools:
                 return json.dumps({
                     "status": "success",
                     "summary": summary,
-                    "output_path": str(self.orch.base_dir / "tea_analysis.json"),
-                    "html_report": str(self.orch.base_dir / "tea_analysis.html"),
+                    "output_path": str(self._output_dir() / "tea_analysis.json"),
+                    "html_report": str(self._output_dir() / "tea_analysis.html"),
                     "hint": "These results will automatically inform future generate_initial_plan calls"
                 })
                 
@@ -1162,7 +1172,7 @@ class OrchestratorTools:
                 print(f"    📚 Literature context provided")
             else:
                 # Auto-load hypothesis context from session if available
-                lit_path = self.orch.base_dir / "literature_search_hypothesis_context.md"
+                lit_path = self._output_dir() / "literature_search_hypothesis_context.md"
                 if lit_path.is_file():
                     ext_parts.append(lit_path.read_text())
                     print(f"    📚 Auto-loaded literature hypothesis context from session")
@@ -1191,13 +1201,13 @@ class OrchestratorTools:
                     })
                 
                 # Save
-                output_path = self.orch.base_dir / "plan.json"
+                output_path = self._output_dir() / "plan.json"
                 with open(output_path, 'w') as f:
                     json.dump(plan, f, indent=2)
 
                 # Generate HTML
                 from .html_generator import HTMLReportGenerator
-                html_path = self.orch.base_dir / "plan.html"
+                html_path = self._output_dir() / "plan.html"
                 generator = HTMLReportGenerator(self.orch.planner.state)
                 generator.generate(str(html_path))
 
@@ -1273,13 +1283,13 @@ class OrchestratorTools:
                     })
 
                 # Save
-                output_path = self.orch.base_dir / "plan.json"
+                output_path = self._output_dir() / "plan.json"
                 with open(output_path, 'w') as f:
                     json.dump(plan, f, indent=2)
 
                 # Generate HTML
                 from .html_generator import HTMLReportGenerator
-                html_path = self.orch.base_dir / "plan.html"
+                html_path = self._output_dir() / "plan.html"
                 generator = HTMLReportGenerator(self.orch.planner.state)
                 generator.generate(str(html_path))
 
@@ -1354,18 +1364,18 @@ class OrchestratorTools:
                     })
                 
                 # Save
-                output_path = self.orch.base_dir / "plan_refined.json"
+                output_path = self._output_dir() / "plan_refined.json"
                 with open(output_path, 'w') as f:
                     json.dump(updated_plan, f, indent=2)
                 
                 # Regenerate HTML
                 from .html_generator import HTMLReportGenerator
-                html_path = self.orch.base_dir / "plan_refined.html"
+                html_path = self._output_dir() / "plan_refined.html"
                 generator = HTMLReportGenerator(self.orch.planner.state)
                 generator.generate(str(html_path))
                 
                 # Save scripts
-                final_out = str(self.orch.base_dir / "output_scripts")
+                final_out = str(self._output_dir() / "output_scripts")
                 print(f"\n--- Saving Scripts to: {final_out} ---")
                 write_experiments_to_disk(updated_plan, final_out)
                 

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -3641,13 +3641,28 @@ class OrchestratorTools:
             return sorted(found.values(), key=lambda x: x["name"])
 
         def _resolve_knowledge_data_file(file_name: str):
-            """Resolve a file name to a path in the knowledge directory.
+            """Resolve a file name to a queryable target.
+
+            An absolute / relative path to an existing file or directory is
+            used directly — so a meta-delegated task, whose data lives outside
+            the knowledge directory, works (mirroring read_file / analyze_file).
+            Otherwise the name is matched within the knowledge directory.
 
             Returns (target, error) where target is either:
             - a file path string (for single files)
             - a dict with "type": "directory" (for directory databases)
             """
             from difflib import get_close_matches
+
+            # Direct path: an existing file/directory given by path is used
+            # as-is, without requiring knowledge-directory discovery.
+            p = Path(file_name).expanduser()
+            if p.is_file() and p.suffix.lower() in QUERYABLE_EXTENSIONS:
+                return str(p.resolve()), None
+            if p.is_dir():
+                return {"name": p.name, "path": str(p.resolve()),
+                        "type": "directory"}, None
+
             candidates = _discover_queryable_files()
             if not candidates:
                 return None, json.dumps({
@@ -3898,29 +3913,31 @@ class OrchestratorTools:
 
             print(f"  ⚡ Tool: Querying knowledge data: '{query[:80]}...'")
 
-            # 1. Discover queryable files and directory databases
+            # 1. Discover queryable files / directory databases. Informational
+            #    only — an explicit `file_name` path is resolved directly below,
+            #    so discovery being empty is not an error when a path is given.
             queryable = _discover_queryable_files()
-            if not queryable:
-                return json.dumps({
-                    "status": "error",
-                    "message": "No queryable data files or directories found in knowledge directory."
-                })
 
             # 2. Resolve target
-            if file_name is None:
-                if len(queryable) == 1:
-                    target = queryable[0]
-                    print(f"    - Auto-selected: {target['name']}")
-                else:
-                    return json.dumps({
-                        "status": "file_selection_needed",
-                        "message": "Multiple queryable sources found. Specify file_name.",
-                        "available_files": [f["name"] for f in queryable]
-                    })
-            else:
+            if file_name is not None:
                 target, error = _resolve_knowledge_data_file(file_name)
                 if error:
                     return error
+            elif not queryable:
+                return json.dumps({
+                    "status": "error",
+                    "message": "No queryable data files or directories found by "
+                               "discovery. Pass the file's absolute path as `file_name`."
+                })
+            elif len(queryable) == 1:
+                target = queryable[0]
+                print(f"    - Auto-selected: {target['name']}")
+            else:
+                return json.dumps({
+                    "status": "file_selection_needed",
+                    "message": "Multiple queryable sources found. Specify file_name.",
+                    "available_files": [f["name"] for f in queryable]
+                })
 
             # 2b. Branch: directory database vs single file
             if isinstance(target, dict) and target.get("type") == "directory":
@@ -4039,10 +4056,12 @@ class OrchestratorTools:
             func=query_knowledge_data,
             name="query_knowledge_data",
             description=(
-                "Query knowledge data with natural language. Works with single "
+                "Query tabular data with natural language. Works with single "
                 "data files (CSV, XLSX) and directory databases (folders of "
                 "uniformly-structured files like JSON records). Generates and "
-                "executes a Python script to answer questions about the data."
+                "executes a Python script to answer questions about the data. "
+                "Accepts a file by an absolute path (preferred when the data "
+                "lives outside the knowledge directory) or by name."
             ),
             parameters={
                 "query": {
@@ -4051,7 +4070,12 @@ class OrchestratorTools:
                 },
                 "file_name": {
                     "type": "string",
-                    "description": "Name of knowledge file to query (e.g., 'PWSdatabase.xlsx'). If omitted, lists available files."
+                    "description": (
+                        "The data file to query, given as an absolute path to "
+                        "an existing file or directory, or as a bare file name "
+                        "to look up in the knowledge directory. If omitted, "
+                        "lists available files."
+                    )
                 }
             },
             required=["query"]

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -1825,7 +1825,7 @@ class OrchestratorTools:
                                     "available_columns": all_cols
                                 })
                             else:
-                                # SUPERVISED/AUTONOMOUS: accept directly
+                                # AUTOPILOT/AUTONOMOUS: accept directly
                                 self.orch.expected_input_columns = proposed_inputs
                                 self.orch.expected_target_columns = proposed_targets
                                 if opt_dir:

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -745,10 +745,14 @@ class OrchestratorTools:
                 if effective_skill:
                     self.orch._active_skill = effective_skill
 
-                if plan.get("error"):
+                # generate_plan signals failure as either `error` (RAG / parse
+                # failure) or `status="failed"` + `last_error` (a returned state
+                # dict) — check both so a failed plan never reports as success.
+                if plan.get("error") or plan.get("status") == "failed":
                     return json.dumps({
                         "status": "error",
-                        "message": plan.get("error")
+                        "message": (plan.get("error") or plan.get("last_error")
+                                    or "Plan generation failed")
                     })
 
                 # Save

--- a/scilink/agents/planning_agents/planning_agent.py
+++ b/scilink/agents/planning_agents/planning_agent.py
@@ -488,17 +488,17 @@ class PlanningAgent(BaseAgent):
         self.state["iteration_index"] = existing_iter + 1
         current_iter = self.state["iteration_index"]
 
-        # Build KB (docs only)
+        # Build KB (docs only). A missing / unbuilt knowledge base is NOT fatal:
+        # perform_science_rag below falls back to the LLM's general scientific
+        # knowledge when no documents are retrievable (its "Insufficient context"
+        # path swaps in HYPOTHESIS_GENERATION_INSTRUCTIONS_FALLBACK). Aborting
+        # here instead would break every planning task delegated without
+        # literature documents (e.g. from the meta-agent).
         if not self._ensure_kb_is_ready(knowledge_paths, code_paths=None):
-            self.state["status"] = "failed"
-            self.state["last_error"] = "KB Init Failed"
-            self._log_action(
-                action="generate_plan",
-                input_ctx={"objective": objective},
-                result={"status": "failed", "error": "KB Init Failed"},
-                rationale=None
+            logging.warning(
+                "Knowledge base unavailable — generating the plan from general "
+                "scientific knowledge without document retrieval."
             )
-            return self.state
         
         # Build context string
         ctx_string = ""

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -243,6 +243,14 @@ Do NOT run TEA for purely scientific exploration (e.g., "study phase transitions
 "characterize this sample", "explore structure-property relationships").
 
 1. `generate_initial_plan`: Use this when starting a NEW campaign or defining a new objective.
+   - Do NOT use for a Bayesian-optimization campaign over an existing dataset —
+     i.e. the objective is "recommend / design the next experiments (batch)" and
+     experimental data is available. That is the Math Loop: go `analyze_file` /
+     `analyze_batch` → `run_optimization`. `run_optimization`'s batch IS the
+     recommendation; a plan would hand-enumerate a different, non-optimal batch
+     that contradicts BO's acquisition output. Skip the planning step entirely
+     and report the BO batch (save it with `save_file` if a shareable file is
+     wanted).
    - Extract knowledge_paths when user mentions papers/PDFs/documents
    - Extract primary_data_set when user mentions experimental data or results folders or files
    - additional_context: Lab constraints, equipment, reagents, budget
@@ -451,6 +459,11 @@ Assume user runs agent from project directory. For example, when user says "file
 - You are optimizing a well-defined property for the current experimental setup.
 - The experiments are running successfully (no failures), and you just need to tune parameters.
 - **At least 3 data files have been successfully analyzed** (check by calling list_workspace_files).
+- **The objective itself is a Bayesian-optimization / "recommend the next
+  experiments" campaign.** Then `run_optimization` IS the deliverable — do NOT
+  also call `generate_initial_plan`. BO is a built-in capability: run it
+  directly. A separately generated plan would hand-design a batch that
+  contradicts (and is inferior to) BO's acquisition-function output.
 
 **Use `iterate_with_results` (The Cognitive Loop) IF:**
 - You need to propose a NEW strategy or experimental setup (e.g., "Change catalyst").

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -810,9 +810,10 @@ class PlanningOrchestratorAgent:
     
     def _should_enable_human_feedback(self) -> bool:
         """Determines if human feedback should be enabled based on autonomy level."""
-        # Only CO_PILOT pauses for human review
-        # AUTOPILOT and AUTONOMOUS proceed without asking
-        return self.autonomy_level == AutonomyLevel.CO_PILOT
+        # CO_PILOT and AUTOPILOT surface generated plans/code for human
+        # review (accept or request changes) — the AUTOPILOT directive
+        # promises this review interface. Only AUTONOMOUS runs without it.
+        return self.autonomy_level != AutonomyLevel.AUTONOMOUS
 
     def set_autonomy_level(self, level: AutonomyLevel) -> None:
         """

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -1189,6 +1189,137 @@ class PlanningOrchestratorAgent:
             
             return f"❌ Error: {e}\n\n(Emergency checkpoint saved to {self.checkpoint_path})"
 
+    def run_task(self, task: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Non-interactive entry point — used by the meta agent.
+
+        Runs the task in autonomous mode (regardless of the agent's current
+        configured autonomy level) and returns a structured summary that's
+        easy to consume programmatically:
+
+            {
+                "status": "success" | "error",
+                "task": str,                       # echoed input
+                "summary": str,                    # the agent's final reply
+                "files_produced": List[str],       # absolute paths
+                "key_findings": List[str],         # campaign configuration
+                "suggested_followups": List[str],
+                "campaign_state": dict,            # objective / targets / data
+                "warnings": List[str],
+            }
+
+        Mirrors SimulationOrchestratorAgent.run_task — see CLAUDE.md
+        "Two surfaces, one agent". The agent is pinned into AUTONOMOUS mode
+        for the duration of the call so it doesn't pause for a (nonexistent)
+        user; the original autonomy level is restored on exit, even if
+        chat() raises.
+
+        Planning has no analysis-style record list, so files_produced is a
+        before/after diff of the campaign directory (session-churn files
+        like chat_history.json are excluded).
+        """
+        # Build a self-contained prompt that includes the optional context.
+        prompt = task
+        if context:
+            try:
+                ctx_str = json.dumps(context, indent=2, default=str)
+            except (TypeError, ValueError):
+                ctx_str = repr(context)
+            prompt = (
+                f"{task}\n\n"
+                f"Context provided by the caller (e.g., upstream agent's findings):\n"
+                f"```\n{ctx_str}\n```\n\n"
+                "Use this context together with your tools to complete the task."
+            )
+
+        def _snapshot_files() -> set:
+            """Resolved paths of campaign artifacts, minus session churn."""
+            skip_names = {
+                "chat_history.json", "checkpoint.json",
+                "analyzed_files.json", "session_log.txt",
+            }
+            snap = set()
+            if self.base_dir.is_dir():
+                for p in self.base_dir.rglob("*"):
+                    if (p.is_file() and p.name not in skip_names
+                            and p.suffix not in (".log", ".pyc")):
+                        snap.add(str(p.resolve()))
+            return snap
+
+        # Snapshot prior state so we report "what was produced *during* this
+        # call" rather than "everything in the session."
+        files_before = _snapshot_files()
+
+        # Pin autonomy to AUTONOMOUS for the duration of this call so the
+        # agent doesn't pause to ask the (nonexistent) user for confirmation.
+        original_level = self.autonomy_level
+        try:
+            self.set_autonomy_level(AutonomyLevel.AUTONOMOUS)
+            try:
+                summary_text = self.chat(prompt)
+                status = "success"
+                error_msg: Optional[str] = None
+            except Exception as e:
+                logging.exception(f"run_task failed: {e}")
+                summary_text = ""
+                status = "error"
+                error_msg = str(e)
+        finally:
+            # Always restore the original level, even if chat() raised.
+            self.set_autonomy_level(original_level)
+
+        files_produced = sorted(_snapshot_files() - files_before)
+
+        # data_points_collected: rows in the BO optimization table, if any.
+        data_points = 0
+        try:
+            if self.bo_data_path.exists():
+                data_points = len(pd.read_csv(self.bo_data_path))
+        except Exception:
+            data_points = 0
+
+        # key_findings: the campaign configuration the orchestrator settled
+        # on. Planning's substantive output is the plan text itself, which
+        # the caller reads from `summary`.
+        key_findings: List[str] = []
+        for col in self.expected_target_columns or []:
+            direction = self.target_directions.get(col, "optimize")
+            key_findings.append(f"Optimization target: {col} ({direction}).")
+        if self.latest_tea_results:
+            key_findings.append("Techno-economic analysis results are available.")
+
+        # Heuristic: collected BO data with no further direction is a natural
+        # cue to propose the next experiment batch.
+        suggested_followups: List[str] = []
+        if data_points > 0:
+            suggested_followups.append(
+                f"Run the next BO iteration ({data_points} data point(s) "
+                f"collected so far)."
+            )
+
+        warnings: List[str] = []
+        if status == "success" and not files_produced:
+            warnings.append("Task completed but produced no campaign artifacts.")
+
+        result = {
+            "status": status,
+            "task": task,
+            "summary": summary_text,
+            "files_produced": files_produced,
+            "key_findings": key_findings,
+            "suggested_followups": suggested_followups,
+            "campaign_state": {
+                "objective": self.objective,
+                "expected_input_columns": self.expected_input_columns,
+                "expected_target_columns": self.expected_target_columns,
+                "target_directions": self.target_directions,
+                "data_points_collected": data_points,
+            },
+            "warnings": warnings,
+        }
+        if error_msg:
+            result["error"] = error_msg
+        return result
+
     def _compress_large_tool_results(self):
         """Compress large tool results in chat history to prevent context overflow.
 

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -23,12 +23,19 @@ class AutonomyLevel(Enum):
     Defines the level of autonomy for the orchestrator.
     
     CO_PILOT: AI assists human (default). Human reviews all plans/code.
-    SUPERVISED: Human assists AI. AI proceeds unless human intervenes.
+    AUTOPILOT: Human assists AI. AI proceeds unless human intervenes.
     AUTONOMOUS: Full autonomy. No human feedback requested.
     """
     CO_PILOT = "co_pilot"       # Human leads, AI assists (current default)
-    SUPERVISED = "supervised"   # AI leads, human can intervene
+    AUTOPILOT = "autopilot"     # AI leads, human can intervene
     AUTONOMOUS = "autonomous"   # Full autonomy, no human feedback
+
+    @classmethod
+    def _missing_(cls, value):
+        # Back-compat: the AUTOPILOT level was named "supervised" before.
+        if isinstance(value, str) and value.strip().lower() == "supervised":
+            return cls.AUTOPILOT
+        return None
 
 
 # Mode-specific directives (inserted at the top)
@@ -85,9 +92,9 @@ Only call `generate_implementation_code` when BOTH conditions are true:
 - Instead say "Ready for results." or "Let me know how to proceed."
 """
 
-_SUPERVISED_DIRECTIVE = """
-**CRITICAL OPERATING MODE: SUPERVISED (AI Leads, Human Supervises)**
-- You lead the research workflow. Human supervises and can intervene.
+_AUTOPILOT_DIRECTIVE = """
+**CRITICAL OPERATING MODE: AUTOPILOT (AI Leads, Human Monitors)**
+- You lead the research workflow. Human monitors and can intervene.
 - Proceed with reasonable next steps without asking for permission.
 - Human will still review generated plans and code through the standard review interface.
 - Do NOT ask clarifying questions unless truly ambiguous - make reasonable assumptions.
@@ -286,7 +293,7 @@ Do NOT run TEA for purely scientific exploration (e.g., "study phase transitions
 7. `adjust_plan_for_constraints`: Adjusts the plan for implementation constraints.
    - In CO_PILOT mode: ONLY call when the user explicitly provides constraints.
      Do NOT call proactively after plan approval.
-   - In SUPERVISED/AUTONOMOUS mode: May be called proactively when you identify
+   - In AUTOPILOT/AUTONOMOUS mode: May be called proactively when you identify
      clear implementation incompatibilities.
 
 **DATA TOOLS:**
@@ -500,7 +507,7 @@ def get_system_prompt(
     """
     directives = {
         AutonomyLevel.CO_PILOT: _CO_PILOT_DIRECTIVE,
-        AutonomyLevel.SUPERVISED: _SUPERVISED_DIRECTIVE,
+        AutonomyLevel.AUTOPILOT: _AUTOPILOT_DIRECTIVE,
         AutonomyLevel.AUTONOMOUS: _AUTONOMOUS_DIRECTIVE,
     }
     prompt = directives[autonomy_level] + _SYSTEM_PROMPT_BODY
@@ -536,7 +543,7 @@ class PlanningOrchestratorAgent:
         embedding_api_key: API key for the embedding LLM provider.
         futurehouse_api_key: Optional FutureHouse API key for literature search.
         restore_checkpoint: Whether to restore from previous checkpoint.
-        autonomy_level: Level of autonomy (CO_PILOT, SUPERVISED, or AUTONOMOUS).
+        autonomy_level: Level of autonomy (CO_PILOT, AUTOPILOT, or AUTONOMOUS).
         
         google_api_key: DEPRECATED. Use 'api_key' instead.
         local_model: DEPRECATED. Use 'base_url' instead.
@@ -597,7 +604,7 @@ class PlanningOrchestratorAgent:
         logging.info(f"🎛️  Autonomy Level: {autonomy_level.value.upper()}")
 
         # Validate and store workspace directories
-        if autonomy_level in (AutonomyLevel.SUPERVISED, AutonomyLevel.AUTONOMOUS):
+        if autonomy_level in (AutonomyLevel.AUTOPILOT, AutonomyLevel.AUTONOMOUS):
             if data_dir is None:
                 raise ValueError(
                     f"data_dir is required for {autonomy_level.value} mode.\n"
@@ -791,7 +798,7 @@ class PlanningOrchestratorAgent:
     def _should_enable_human_feedback(self) -> bool:
         """Determines if human feedback should be enabled based on autonomy level."""
         # Only CO_PILOT pauses for human review
-        # SUPERVISED and AUTONOMOUS proceed without asking
+        # AUTOPILOT and AUTONOMOUS proceed without asking
         return self.autonomy_level == AutonomyLevel.CO_PILOT
 
     def set_autonomy_level(self, level: AutonomyLevel) -> None:
@@ -1225,7 +1232,7 @@ class PlanningOrchestratorAgent:
         ``autonomy`` selects the AutonomyLevel for this call. Defaults to
         AUTONOMOUS — the safe choice for a headless/programmatic caller, so
         the agent never pauses for a nonexistent user. A caller attached to a
-        human (the meta agent, driven via CLI/UI) passes SUPERVISED so the
+        human (the meta agent, driven via CLI/UI) passes AUTOPILOT so the
         sub-agents' human-feedback prompts reach that human.
         The original autonomy level is restored on exit, even if chat()
         raises.
@@ -1279,7 +1286,7 @@ class PlanningOrchestratorAgent:
 
         # Run under the requested autonomy level — AUTONOMOUS by default (the
         # safe headless choice). The meta agent passes its own mode through,
-        # so a co-pilot / supervised delegation still raises the sub-agents'
+        # so a co-pilot / autopilot delegation still raises the sub-agents'
         # human-feedback prompts to the user driving the session.
         run_level = autonomy if autonomy is not None else AutonomyLevel.AUTONOMOUS
         original_level = self.autonomy_level

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 import pandas as pd
 from pathlib import Path
 from typing import List, Dict, Any, Optional
@@ -639,6 +640,16 @@ class PlanningOrchestratorAgent:
         self.expected_input_levels = None  # {col: [level0, level1, ...]} for categorical inputs
         self.latest_tea_results = None
 
+        # Per-delegation output isolation. Used only by run_task: the meta
+        # agent reuses one planning child across delegations, and the plan
+        # tools write fixed filenames (plan.json, tea_analysis.json, ...).
+        # Without a per-delegation sub-directory, each delegation would
+        # overwrite the previous one's artifacts. Direct `scilink plan` use
+        # never calls run_task, so _active_output_subdir stays None and
+        # writes land in base_dir exactly as before.
+        self._delegation_counter = 0
+        self._active_output_subdir = None
+
         # Custom tools / MCP state
         self._tool_data_cache: Dict[tuple, Any] = {}
         self._external_tools: List[Dict[str, str]] = []
@@ -1102,7 +1113,8 @@ class PlanningOrchestratorAgent:
             self.expected_input_types = state.get("expected_input_types")
             self.expected_input_levels = state.get("expected_input_levels")
             self.latest_tea_results = state.get("latest_tea_results")
-            
+            self._delegation_counter = state.get("delegation_counter", 0)
+
             # Restore autonomy level if saved
             if "autonomy_level" in state:
                 try:
@@ -1189,12 +1201,12 @@ class PlanningOrchestratorAgent:
             
             return f"❌ Error: {e}\n\n(Emergency checkpoint saved to {self.checkpoint_path})"
 
-    def run_task(self, task: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def run_task(self, task: str, context: Optional[Dict[str, Any]] = None,
+                 autonomy: Optional[AutonomyLevel] = None) -> Dict[str, Any]:
         """Non-interactive entry point — used by the meta agent.
 
-        Runs the task in autonomous mode (regardless of the agent's current
-        configured autonomy level) and returns a structured summary that's
-        easy to consume programmatically:
+        Runs the task and returns a structured summary that's easy to
+        consume programmatically:
 
             {
                 "status": "success" | "error",
@@ -1208,10 +1220,15 @@ class PlanningOrchestratorAgent:
             }
 
         Mirrors SimulationOrchestratorAgent.run_task — see CLAUDE.md
-        "Two surfaces, one agent". The agent is pinned into AUTONOMOUS mode
-        for the duration of the call so it doesn't pause for a (nonexistent)
-        user; the original autonomy level is restored on exit, even if
-        chat() raises.
+        "Two surfaces, one agent".
+
+        ``autonomy`` selects the AutonomyLevel for this call. Defaults to
+        AUTONOMOUS — the safe choice for a headless/programmatic caller, so
+        the agent never pauses for a nonexistent user. A caller attached to a
+        human (the meta agent, driven via CLI/UI) passes SUPERVISED so the
+        sub-agents' human-feedback prompts reach that human.
+        The original autonomy level is restored on exit, even if chat()
+        raises.
 
         Planning has no analysis-style record list, so files_produced is a
         before/after diff of the campaign directory (session-churn files
@@ -1249,11 +1266,25 @@ class PlanningOrchestratorAgent:
         # call" rather than "everything in the session."
         files_before = _snapshot_files()
 
-        # Pin autonomy to AUTONOMOUS for the duration of this call so the
-        # agent doesn't pause to ask the (nonexistent) user for confirmation.
+        # Isolate this delegation's plan artifacts in their own sub-directory
+        # so a persistent planning child (reused by the meta agent) does not
+        # overwrite an earlier delegation's plan.json / tea_analysis /
+        # output_scripts. The plan tools read self._active_output_subdir.
+        self._delegation_counter += 1
+        slug = re.sub(r"[^a-z0-9]+", "_", task.lower()).strip("_")[:40] or "task"
+        self._active_output_subdir = (
+            self.base_dir / "delegations" / f"{self._delegation_counter:02d}_{slug}"
+        )
+        self._active_output_subdir.mkdir(parents=True, exist_ok=True)
+
+        # Run under the requested autonomy level — AUTONOMOUS by default (the
+        # safe headless choice). The meta agent passes its own mode through,
+        # so a co-pilot / supervised delegation still raises the sub-agents'
+        # human-feedback prompts to the user driving the session.
+        run_level = autonomy if autonomy is not None else AutonomyLevel.AUTONOMOUS
         original_level = self.autonomy_level
         try:
-            self.set_autonomy_level(AutonomyLevel.AUTONOMOUS)
+            self.set_autonomy_level(run_level)
             try:
                 summary_text = self.chat(prompt)
                 status = "success"
@@ -1266,6 +1297,9 @@ class PlanningOrchestratorAgent:
         finally:
             # Always restore the original level, even if chat() raised.
             self.set_autonomy_level(original_level)
+            # _active_output_subdir is scoped to this call; clear it so a
+            # later direct chat() on the same instance writes to base_dir.
+            self._active_output_subdir = None
 
         files_produced = sorted(_snapshot_files() - files_before)
 
@@ -1362,6 +1396,7 @@ class PlanningOrchestratorAgent:
                 "planner_state": self.planner.state,
                 "message_count": self.message_count,
                 "latest_tea_results": self.latest_tea_results,
+                "delegation_counter": self._delegation_counter,
                 "autonomy_level": self.autonomy_level.value,
                 "data_dir": str(self.data_dir) if self.data_dir else None,
                 "knowledge_dir": str(self.knowledge_dir) if self.knowledge_dir else None,

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -403,11 +403,11 @@ class SimulationOrchestratorAgent:
         self._save_history()
         return response
 
-    def run_task(self, task: str, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-        """Non-interactive entry point — used by the future meta agent.
+    def run_task(self, task: str, context: Optional[Dict[str, Any]] = None,
+                 autonomy: Optional[SimulationMode] = None) -> Dict[str, Any]:
+        """Non-interactive entry point — used by the meta agent.
 
-        Runs the task in autonomous mode (regardless of the agent's current
-        configured mode) and returns a structured summary that's easy to
+        Runs the task and returns a structured summary that's easy to
         consume programmatically:
 
             {
@@ -421,11 +421,13 @@ class SimulationOrchestratorAgent:
                 "task": str,                       # echoed input
             }
 
-        The implementation pins the agent into AUTONOMOUS mode for the
-        duration of the call, runs the chat loop once with the task as
-        user input, then derives the structured summary from the
-        post-call session state. The original autonomy mode is restored
-        on exit so an interactive session is unaffected.
+        ``autonomy`` selects the SimulationMode for this call. Defaults to
+        AUTONOMOUS — the safe choice for a headless/programmatic caller, so
+        the agent never pauses for a nonexistent user. A caller attached to a
+        human (the meta agent, driven via CLI/UI) passes SUPERVISED so the
+        sub-agents' human-feedback prompts reach that human.
+        The structured summary is derived from the post-call session-state
+        delta; the original mode is restored on exit, even if chat() raises.
         """
         # Build a self-contained prompt that includes the optional context.
         prompt = task
@@ -446,11 +448,14 @@ class SimulationOrchestratorAgent:
         structures_before = list(self.generated_structures or [])
         n_before = len(structures_before)
 
-        # Pin autonomy to AUTONOMOUS for the duration of this call so the
-        # agent doesn't pause to ask the (nonexistent) user for confirmation.
+        # Run under the requested autonomy mode — AUTONOMOUS by default (the
+        # safe headless choice). The meta agent passes its own mode through,
+        # so a co-pilot / supervised delegation still raises the sub-agents'
+        # human-feedback prompts to the user driving the session.
+        run_mode = autonomy if autonomy is not None else SimulationMode.AUTONOMOUS
         original_mode = self.simulation_mode
         try:
-            self.set_simulation_mode(SimulationMode.AUTONOMOUS)
+            self.set_simulation_mode(run_mode)
             try:
                 summary_text = self.chat(prompt)
                 status = "success"

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -36,8 +36,15 @@ class SimulationMode(Enum):
     """Autonomy level for the simulation orchestrator. Mirrors AnalysisMode
     for consistent UX across modes."""
     CO_PILOT = "co-pilot"        # Human leads, AI assists (default)
-    SUPERVISED = "supervised"    # AI leads, human supervises
+    AUTOPILOT = "autopilot"      # AI leads, human monitors
     AUTONOMOUS = "autonomous"    # Full autonomy
+
+    @classmethod
+    def _missing_(cls, value):
+        # Back-compat: the AUTOPILOT level was named "supervised" before.
+        if isinstance(value, str) and value.strip().lower() == "supervised":
+            return cls.AUTOPILOT
+        return None
 
 
 _CO_PILOT_DIRECTIVE = """**AUTONOMY: CO-PILOT (default)** — The human is leading the work; you are
@@ -49,7 +56,7 @@ user a chance to redirect after each significant step.
 
 """
 
-_SUPERVISED_DIRECTIVE = """**AUTONOMY: SUPERVISED** — You are leading the work with reasonable defaults.
+_AUTOPILOT_DIRECTIVE = """**AUTONOMY: AUTOPILOT** — You are leading the work with reasonable defaults.
 Proceed with sensible choices for routine decisions, but surface significant
 decisions (polymorph selection when not specified, supercell size choices
 that drive cost, expensive operations) for a one-line confirmation before
@@ -172,7 +179,7 @@ def get_system_prompt(
     """
     directives = {
         SimulationMode.CO_PILOT: _CO_PILOT_DIRECTIVE,
-        SimulationMode.SUPERVISED: _SUPERVISED_DIRECTIVE,
+        SimulationMode.AUTOPILOT: _AUTOPILOT_DIRECTIVE,
         SimulationMode.AUTONOMOUS: _AUTONOMOUS_DIRECTIVE,
     }
     # Tools section is filled dynamically by the orchestrator after tool
@@ -424,7 +431,7 @@ class SimulationOrchestratorAgent:
         ``autonomy`` selects the SimulationMode for this call. Defaults to
         AUTONOMOUS — the safe choice for a headless/programmatic caller, so
         the agent never pauses for a nonexistent user. A caller attached to a
-        human (the meta agent, driven via CLI/UI) passes SUPERVISED so the
+        human (the meta agent, driven via CLI/UI) passes AUTOPILOT so the
         sub-agents' human-feedback prompts reach that human.
         The structured summary is derived from the post-call session-state
         delta; the original mode is restored on exit, even if chat() raises.
@@ -450,7 +457,7 @@ class SimulationOrchestratorAgent:
 
         # Run under the requested autonomy mode — AUTONOMOUS by default (the
         # safe headless choice). The meta agent passes its own mode through,
-        # so a co-pilot / supervised delegation still raises the sub-agents'
+        # so a co-pilot / autopilot delegation still raises the sub-agents'
         # human-feedback prompts to the user driving the session.
         run_mode = autonomy if autonomy is not None else SimulationMode.AUTONOMOUS
         original_mode = self.simulation_mode

--- a/scilink/cli/analyze.py
+++ b/scilink/cli/analyze.py
@@ -26,8 +26,8 @@ Examples:
   # Start with data file
   scilink analyze --data ./sample.tif --metadata ./metadata.json
   
-  # Use supervised mode (AI leads, human approves)
-  scilink analyze --mode supervised --data ./data/
+  # Use autopilot mode (AI leads, human approves)
+  scilink analyze --mode autopilot --data ./data/
   
   # Full autonomous mode (runs entire pipeline automatically)
   scilink analyze --mode autonomous --data ./sample.npy --metadata ./description.txt
@@ -43,7 +43,7 @@ Examples:
 
 Analysis Modes (matching 'scilink plan' for consistent UX):
   co-pilot (default)   Human leads, AI assists. Reviews all agent selections.
-  supervised           AI leads, human approves. AI proceeds with reasonable defaults.
+  autopilot           AI leads, human approves. AI proceeds with reasonable defaults.
   autonomous           Full autonomy. AI selects agents and runs without confirmation.
 
 Environment Variables:
@@ -101,7 +101,7 @@ Metadata Options:
     parser.add_argument(
         '--mode',
         type=str,
-        choices=['co-pilot', 'supervised', 'autonomous'],
+        choices=['co-pilot', 'autopilot', 'autonomous'],
         default='co-pilot',
         help='Analysis mode (default: co-pilot)'
     )
@@ -383,7 +383,7 @@ class AnalysisPlayground:
         # Convert mode string to enum
         mode_map = {
             'co-pilot': AnalysisMode.CO_PILOT,
-            'supervised': AnalysisMode.SUPERVISED,
+            'autopilot': AnalysisMode.AUTOPILOT,
             'autonomous': AnalysisMode.AUTONOMOUS,
         }
         analysis_mode = mode_map.get(analysis_mode_str, AnalysisMode.CO_PILOT)
@@ -764,11 +764,11 @@ Supported data types:
             if len(parts) == 1:
                 print(f"\n🎛️  Current Analysis Mode: {self.agent.analysis_mode.value}")
                 print(f"   Human Feedback: {'Enabled' if self.agent._enable_human_feedback else 'Disabled'}")
-                print("\n   To change: /mode <co-pilot|supervised|autonomous>")
+                print("\n   To change: /mode <co-pilot|autopilot|autonomous>")
             else:
                 mode_map = {
                     'co-pilot': AnalysisMode.CO_PILOT,
-                    'supervised': AnalysisMode.SUPERVISED,
+                    'autopilot': AnalysisMode.AUTOPILOT,
                     'autonomous': AnalysisMode.AUTONOMOUS,
                 }
                 new_mode = mode_map.get(parts[1].lower())
@@ -779,7 +779,7 @@ Supported data types:
                     print(f"   Human Feedback: {'Enabled' if self.agent._enable_human_feedback else 'Disabled'}")
                 else:
                     print(f"\n   ❌ Unknown mode: {parts[1]}")
-                    print("   Valid options: co-pilot, supervised, autonomous")
+                    print("   Valid options: co-pilot, autopilot, autonomous")
             return True
         
         elif cmd == "/checkpoint":
@@ -810,7 +810,7 @@ Supported data types:
         Process initial --data and --metadata inputs.
         Handles different modes appropriately:
         - co-pilot: Examine data, load metadata, then wait for user
-        - supervised: Examine, load metadata, suggest agent, wait for approval
+        - autopilot: Examine, load metadata, suggest agent, wait for approval
         - autonomous: Run the entire pipeline automatically
         """
         has_data = self._initial_data_path is not None
@@ -866,7 +866,7 @@ Supported data types:
                 print("   Falling back to loading metadata only...\n")
                 # Fall through to load metadata
         
-        # === CO-PILOT / SUPERVISED / Fallback: Step-by-step ===
+        # === CO-PILOT / AUTOPILOT / Fallback: Step-by-step ===
         
         # Step 1: Examine data (if provided)
         if has_data:
@@ -888,9 +888,9 @@ Supported data types:
                 self.agent.chat(f"Convert the text description to metadata from {meta_path}")
             print()
         
-        # Step 3: In supervised mode with both inputs, suggest next step
-        if mode == 'supervised' and has_data and has_metadata:
-            print("🔄 SUPERVISED MODE: Suggesting agent selection...")
+        # Step 3: In autopilot mode with both inputs, suggest next step
+        if mode == 'autopilot' and has_data and has_metadata:
+            print("🔄 AUTOPILOT MODE: Suggesting agent selection...")
             self.agent.chat(
                 "Based on the data type and metadata, recommend the appropriate "
                 "analysis agent and explain your reasoning."

--- a/scilink/cli/main.py
+++ b/scilink/cli/main.py
@@ -123,10 +123,13 @@ def main():
     print_gradient_logo()
 
     if len(sys.argv) < 2:
-        print()  # Spacing after logo
-        print_usage()
-        return 1
-    
+        # Bare `scilink` launches the meta-agent — the default entry point,
+        # which auto-routes work between the analyze and plan specialists.
+        # Explicit per-mode commands and `scilink help` still work below.
+        from scilink.cli.meta import main as meta_main
+        sys.argv = [sys.argv[0] + ' meta']
+        return meta_main()
+
     command = sys.argv[1]
     
     # Route to appropriate handler
@@ -149,6 +152,11 @@ def main():
         from scilink.cli.analyze import main as analyze_main
         sys.argv = [sys.argv[0] + ' analyze'] + sys.argv[2:]
         return analyze_main()
+
+    elif command == 'meta':
+        from scilink.cli.meta import main as meta_main
+        sys.argv = [sys.argv[0] + ' meta'] + sys.argv[2:]
+        return meta_main()
 
     elif command == 'ui':
         from scilink.cli.ui import main as ui_main
@@ -180,21 +188,27 @@ def print_usage():
 ║              AI-Powered Scientific Research Automation                   ║
 ╚══════════════════════════════════════════════════════════════════════════╝
 
-Usage: scilink <command> [options]
+Usage: scilink [command] [options]
+
+Run `scilink` with no command to launch the meta-agent — a single
+conversational agent that auto-routes your request to the right specialist.
 
 Available Commands:
-  plan          Interactive planning orchestrator for experimental design
-                and Bayesian optimization workflows
-                
-  simulate      Simulation agents for MD, DFT, LAMMPS, VASP workflows
-                (Coming soon)
+  (none)        Launch the meta-agent orchestrator — coordinates the
+                analyze and plan specialists from one chat surface
 
-  prepare-ff    Force field agent for generating LAMMPS force field and 
-                data files with AMBER
+  meta          The meta-agent, explicit form (same as bare `scilink`)
 
   analyze       Analysis agents for microscopy, spectroscopy, and
                 experimental data processing
-                (Coming soon)
+
+  plan          Interactive planning orchestrator for experimental design
+                and Bayesian optimization workflows
+
+  simulate      Simulation agents for MD, DFT, LAMMPS, VASP workflows
+
+  prepare-ff    Force field agent for generating LAMMPS force field and
+                data files with AMBER
 
   ui            Launch the Streamlit web interface for interactive
                 analysis (requires: pip install scilink[ui])
@@ -203,11 +217,11 @@ Available Commands:
                 (Claude Desktop, Cursor) can use SciLink's tools
 
 Examples:
-  scilink plan                              # Start planning orchestrator
-  scilink plan --model gemini-2.0-flash-exp # Use different model
-  scilink simulate --help                   # See simulation options
+  scilink                                   # Launch the meta-agent
+  scilink meta --mode supervised            # Meta-agent, supervised autonomy
   scilink analyze --help                    # See analysis options
-  scilink prepare-ff --help                 # See force field options
+  scilink plan --model gemini-2.0-flash-exp # Use a different model
+  scilink simulate --help                   # See simulation options
 
 Get Help:
   scilink <command> --help                  # Command-specific help

--- a/scilink/cli/main.py
+++ b/scilink/cli/main.py
@@ -127,7 +127,7 @@ def main():
         # which auto-routes work between the analyze and plan specialists.
         # Explicit per-mode commands and `scilink help` still work below.
         from scilink.cli.meta import main as meta_main
-        sys.argv = [sys.argv[0] + ' meta']
+        sys.argv = [sys.argv[0] + ' explore']
         return meta_main()
 
     command = sys.argv[1]
@@ -153,9 +153,9 @@ def main():
         sys.argv = [sys.argv[0] + ' analyze'] + sys.argv[2:]
         return analyze_main()
 
-    elif command == 'meta':
+    elif command in ('explore', 'meta'):  # 'meta' kept as a back-compat alias
         from scilink.cli.meta import main as meta_main
-        sys.argv = [sys.argv[0] + ' meta'] + sys.argv[2:]
+        sys.argv = [f"{sys.argv[0]} {command}"] + sys.argv[2:]
         return meta_main()
 
     elif command == 'ui':
@@ -197,7 +197,8 @@ Available Commands:
   (none)        Launch the meta-agent orchestrator — coordinates the
                 analyze and plan specialists from one chat surface
 
-  meta          The meta-agent, explicit form (same as bare `scilink`)
+  explore       The meta-agent, explicit form (same as bare `scilink`).
+                Alias: `meta`
 
   analyze       Analysis agents for microscopy, spectroscopy, and
                 experimental data processing
@@ -218,7 +219,7 @@ Available Commands:
 
 Examples:
   scilink                                   # Launch the meta-agent
-  scilink meta --mode autopilot            # Meta-agent, autopilot autonomy
+  scilink explore --mode autopilot         # Meta-agent, autopilot autonomy
   scilink analyze --help                    # See analysis options
   scilink plan --model gemini-2.0-flash-exp # Use a different model
   scilink simulate --help                   # See simulation options

--- a/scilink/cli/main.py
+++ b/scilink/cli/main.py
@@ -218,7 +218,7 @@ Available Commands:
 
 Examples:
   scilink                                   # Launch the meta-agent
-  scilink meta --mode supervised            # Meta-agent, supervised autonomy
+  scilink meta --mode autopilot            # Meta-agent, autopilot autonomy
   scilink analyze --help                    # See analysis options
   scilink plan --model gemini-2.0-flash-exp # Use a different model
   scilink simulate --help                   # See simulation options

--- a/scilink/cli/meta.py
+++ b/scilink/cli/meta.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""
+scilink meta - Interactive Meta-Agent Orchestrator
+
+The meta-agent is SciLink's default entry point (bare `scilink`): a single
+conversational agent that auto-routes each request to the right specialist —
+the analysis orchestrator (experimental data) or the planning orchestrator
+(campaign design / Bayesian optimization) — and bridges findings between them.
+
+Each delegation runs as a nested child sub-session under the meta session
+directory. Simulation delegation is not available in this build.
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+# ==============================================================================
+# CLI entry point
+# ==============================================================================
+
+def main():
+    """Main entry point for the 'scilink meta' command (and bare 'scilink')."""
+
+    parser = argparse.ArgumentParser(
+        prog='scilink meta',
+        description='SciLink Meta-Agent - one chat surface that auto-routes '
+                    'to the analyze and plan specialists',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Launch the meta-agent (identical to running bare `scilink`)
+  scilink meta
+
+  # Seed the first turn with your research goal
+  scilink meta --message "Analyze grains.tif then plan a follow-up campaign"
+
+  # Supervised mode (meta delegates on its own judgement; reports as it goes)
+  scilink meta --mode supervised
+
+  # Use a different model / an internal proxy
+  scilink meta --model gemini-2.0-flash
+  scilink meta --base-url https://my-proxy.example.com/v1 --model my-model
+
+Modes — the meta has two levels (a delegation runs a specialist through its
+one-shot run_task, so the specialists' step-by-step co-pilot mode does not
+apply here):
+  supervised (default)  Specialists pause at decision points for you to
+                        approve / edit plans and outputs.
+  autonomous            Specialists run end to end without pausing.
+
+Environment Variables:
+  SCILINK_API_KEY          API key for internal proxy
+  GEMINI_API_KEY           Google Gemini API key
+  GOOGLE_API_KEY           Google API key (alias for GEMINI_API_KEY)
+  OPENAI_API_KEY           OpenAI API key
+  ANTHROPIC_API_KEY        Anthropic API key
+  CLAUDE_API_KEY           Anthropic API key (alias)
+  FUTUREHOUSE_API_KEY      FutureHouse API key (enables literature search)
+        """
+    )
+
+    # Model / API
+    parser.add_argument('--model', type=str, default='claude-opus-4-6',
+                        help='Model name (default: claude-opus-4-6)')
+    parser.add_argument('--base-url', type=str, dest='base_url',
+                        help='Base URL for OpenAI-compatible endpoint')
+    parser.add_argument('--api-key', type=str, dest='api_key',
+                        help='API key for LLM provider (overrides environment variables)')
+    parser.add_argument('--embedding-model', type=str, dest='embedding_model',
+                        default='gemini-embedding-001',
+                        help='Embedding model for the child orchestrators '
+                             '(default: gemini-embedding-001)')
+    parser.add_argument('--embedding-api-key', type=str, dest='embedding_api_key',
+                        help='API key for the embedding provider')
+    parser.add_argument('--futurehouse-api-key', type=str, dest='futurehouse_api_key',
+                        help='FutureHouse API key (or set FUTUREHOUSE_API_KEY env var). '
+                             'Enables literature search in delegated analysis.')
+
+    # Mode
+    parser.add_argument('--mode', type=str, dest='mode',
+                        choices=['supervised', 'autonomous'],
+                        default='supervised',
+                        help='Autonomy mode (default: supervised). The meta '
+                             'has two levels, not the modes’ three.')
+
+    # Initial message — seeds the first chat turn
+    parser.add_argument('--message', type=str, dest='initial_message',
+                        help='Optional initial message to seed the session. '
+                             'If omitted, starts at an empty chat prompt.')
+
+    # Session
+    parser.add_argument('--session-dir', type=str, dest='session_dir',
+                        help='Session directory for outputs (default: auto-generated)')
+    parser.add_argument('--restore', action='store_true',
+                        help='Restore from previous checkpoint in session directory')
+
+    args = parser.parse_args()
+
+    config = {
+        'model_name': args.model,
+        'base_url': args.base_url,
+        'api_key': args.api_key,
+        'embedding_model': args.embedding_model,
+        'embedding_api_key': args.embedding_api_key,
+        'futurehouse_api_key': args.futurehouse_api_key,
+        'meta_mode': args.mode,
+        'initial_message': args.initial_message,
+        'session_dir': args.session_dir,
+        'restore': args.restore,
+    }
+
+    try:
+        playground = MetaPlayground(config)
+        playground.run()
+        return 0
+    except KeyboardInterrupt:
+        print("\n\n👋 Session interrupted. Goodbye!")
+        return 0
+    except Exception as e:
+        print(f"\n❌ Error: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+# ==============================================================================
+# Interactive Orchestrator
+# ==============================================================================
+
+class MetaPlayground:
+    """Interactive session manager for the Meta-Agent Orchestrator."""
+
+    def __init__(self, config: dict = None):
+        self.agent = None
+        self.session_dir = None
+        self.config = config or {}
+
+    def _infer_provider(self, model_name: str) -> tuple:
+        """Infer provider info from model name."""
+        m = model_name.lower()
+        if 'claude' in m:
+            return ("Anthropic", "ANTHROPIC_API_KEY or CLAUDE_API_KEY",
+                    ["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"])
+        if m.startswith(('gpt-', 'o1-', 'o3-', 'text-embedding')):
+            return ("OpenAI", "OPENAI_API_KEY", ["OPENAI_API_KEY"])
+        return ("Google Gemini", "GEMINI_API_KEY or GOOGLE_API_KEY",
+                ["GEMINI_API_KEY", "GOOGLE_API_KEY"])
+
+    def _api_key_from_env(self, env_vars: list) -> str:
+        for var in env_vars:
+            v = os.getenv(var)
+            if v:
+                return v
+        return None
+
+    def setup(self):
+        """Resolve config and build the meta-agent."""
+        from scilink.agents.meta_agent.meta_orchestrator import (
+            MetaOrchestratorAgent, MetaMode,
+        )
+
+        model_name = self.config.get('model_name', 'claude-opus-4-6')
+        base_url = self.config.get('base_url')
+        api_key = self.config.get('api_key')
+        embedding_model = self.config.get('embedding_model', 'gemini-embedding-001')
+        embedding_api_key = self.config.get('embedding_api_key')
+        futurehouse_api_key = self.config.get('futurehouse_api_key')
+        mode_str = self.config.get('meta_mode', 'supervised')
+        session_dir = self.config.get('session_dir')
+        restore = self.config.get('restore', False)
+
+        self._initial_message = self.config.get('initial_message')
+
+        mode_map = {
+            'supervised': MetaMode.SUPERVISED,
+            'autonomous': MetaMode.AUTONOMOUS,
+        }
+        meta_mode = mode_map.get(mode_str, MetaMode.SUPERVISED)
+
+        print("\n" + "=" * 60)
+        print("🧭  SCILINK META-AGENT")
+        print("=" * 60)
+        print("""
+One chat surface that coordinates SciLink's specialists for you:
+  • Analysis  — interpret experimental data (microscopy, spectroscopy, ...)
+  • Planning  — design experimental campaigns / Bayesian optimization
+
+Describe your research goal and the meta-agent routes the work to the
+right specialist, bridging findings between them. Each delegation runs as
+a nested child sub-session under this meta session.
+""")
+        print("=" * 60)
+
+        # ── API key resolution ───────────────────────────────────────
+        if not api_key:
+            if base_url:
+                api_key = os.getenv("SCILINK_API_KEY")
+                if not api_key:
+                    print("\n⚠️  No SCILINK_API_KEY found in environment.")
+                    api_key = input("Enter your proxy API key (SCILINK_API_KEY): ").strip()
+                    if not api_key:
+                        print("❌ Cannot proceed without API key for internal proxy.")
+                        sys.exit(1)
+            else:
+                provider_name, env_var_hint, env_vars = self._infer_provider(model_name)
+                api_key = self._api_key_from_env(env_vars)
+                if not api_key:
+                    print(f"\n⚠️  No {env_var_hint} found in environment.")
+                    user_key = input(f"Enter your {provider_name} API key (or Enter to skip): ").strip()
+                    if user_key:
+                        api_key = user_key
+
+        if not futurehouse_api_key:
+            futurehouse_api_key = os.getenv("FUTUREHOUSE_API_KEY")
+
+        # ── Session directory ────────────────────────────────────────
+        if session_dir:
+            self.session_dir = Path(session_dir)
+        elif restore:
+            import glob
+            sessions = sorted(glob.glob("./meta_session_*"), reverse=True)
+            if sessions:
+                self.session_dir = Path(sessions[0])
+                print(f"\n📂 Found session to restore: {self.session_dir}")
+            else:
+                print("\n⚠️  No existing meta sessions found. Creating new session.")
+                self.session_dir = Path(f"./meta_session_{datetime.now().strftime('%Y%m%d_%H%M%S')}")
+        else:
+            default_dir = f"./meta_session_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+            print(f"\n📁 Where should I save session data?")
+            session_input = input(f"   Path (default: {default_dir}): ").strip()
+            self.session_dir = Path(session_input) if session_input else Path(default_dir)
+
+        self.session_dir.mkdir(parents=True, exist_ok=True)
+
+        # ── Initialize agent ────────────────────────────────────────
+        print("\n🔧 Initializing meta-agent...")
+        try:
+            self.agent = MetaOrchestratorAgent(
+                base_dir=str(self.session_dir),
+                api_key=api_key,
+                model_name=model_name,
+                base_url=base_url,
+                embedding_model=embedding_model,
+                embedding_api_key=embedding_api_key,
+                futurehouse_api_key=futurehouse_api_key,
+                restore_checkpoint=restore,
+                meta_mode=meta_mode,
+            )
+            print("✅ Meta-agent ready!")
+        except Exception as e:
+            print(f"❌ Failed to initialize meta-agent: {e}")
+            import traceback
+            traceback.print_exc()
+            sys.exit(1)
+
+        # ── Session info ────────────────────────────────────────────
+        print("\n" + "=" * 60)
+        print("SESSION INFO")
+        print("=" * 60)
+        print(f"Session Directory: {self.session_dir}")
+        print(f"Meta Mode: {meta_mode.value}")
+        print(f"Human Feedback: {'Enabled' if self.agent.get_human_feedback_setting() else 'Disabled'}")
+        print(f"Literature search (in delegated analysis): "
+              f"{'Enabled' if futurehouse_api_key else 'Disabled'}")
+
+        provider_name, _, _ = self._infer_provider(model_name)
+        if base_url:
+            print(f"Model: {model_name}")
+            print(f"Endpoint: {base_url}")
+        else:
+            print(f"Model: {model_name} ({provider_name})")
+
+        print(f"\nDelegation Tools: {', '.join(self.agent.tools.functions_map.keys())}")
+
+    def print_help(self):
+        print("\n" + "=" * 60)
+        print("AVAILABLE COMMANDS")
+        print("=" * 60)
+        print("  /help              Show this help message")
+        print("  /tools             List the meta-agent's delegation tools")
+        print("  /children          List delegations made this session")
+        print("  /status            Show current session state")
+        print("  /mode [level]      Show or change meta autonomy mode")
+        print("  /clear             Clear screen")
+        print("  /quit or /exit     Exit")
+        print("\nOr just describe your research goal and let the meta-agent route it!")
+        print("=" * 60)
+
+    def handle_command(self, user_input: str):
+        """Returns True if handled, 'QUIT' to exit, False otherwise."""
+        cmd = user_input.lower().strip()
+
+        if cmd == "/help":
+            self.print_help()
+            return True
+
+        if cmd == "/tools":
+            print("\n📦 Delegation Tools:")
+            for i, tool_name in enumerate(self.agent.tools.functions_map.keys(), 1):
+                print(f"  {i}. {tool_name}")
+            return True
+
+        if cmd == "/children":
+            ledger = self.agent._delegation_ledger or []
+            print(f"\n🧩 Delegations this session: {len(ledger)}")
+            for entry in ledger:
+                task = (entry.get('task') or '')[:70]
+                summary = (entry.get('summary') or '')[:70]
+                print(f"  [{entry.get('index')}] {entry.get('mode')} "
+                      f"— status: {entry.get('status')}")
+                print(f"      task:    {task}")
+                if summary:
+                    print(f"      result:  {summary}")
+            return True
+
+        if cmd == "/status":
+            children = self.agent._children or {}
+            print("\n🔍 Session State:")
+            print(f"  Session Directory: {self.session_dir}")
+            print(f"  Meta Mode: {self.agent.meta_mode.value}")
+            print(f"  Human Feedback: {'Enabled' if self.agent.get_human_feedback_setting() else 'Disabled'}")
+            print(f"  Message Count: {self.agent.message_count}")
+            print(f"  Specialists active: {', '.join(sorted(children.keys())) or 'none'}")
+            print(f"  Delegations: {len(self.agent._delegation_ledger or [])}")
+            return True
+
+        if cmd.startswith("/mode"):
+            from scilink.agents.meta_agent.meta_orchestrator import MetaMode
+            parts = cmd.split()
+            if len(parts) == 1:
+                print(f"\n🎛️  Current Meta Mode: {self.agent.meta_mode.value}")
+                print("\n   To change: /mode <supervised|autonomous>")
+            else:
+                mode_map = {
+                    'supervised': MetaMode.SUPERVISED,
+                    'autonomous': MetaMode.AUTONOMOUS,
+                }
+                new_mode = mode_map.get(parts[1].lower())
+                if new_mode:
+                    self.agent.set_meta_mode(new_mode)
+                    print(f"\n   ✅ Meta mode changed to: {new_mode.value}")
+                else:
+                    print(f"\n   ❌ Unknown mode: {parts[1]}")
+                    print("   Valid options: supervised, autonomous")
+            return True
+
+        if cmd == "/clear":
+            os.system('cls' if os.name == 'nt' else 'clear')
+            print("🧭  Meta-Agent - Session Resumed\n")
+            return True
+
+        if cmd in ("/quit", "/exit", "/q", "quit", "exit"):
+            return "QUIT"
+
+        return False
+
+    def run(self):
+        """Main interactive loop."""
+        self.setup()
+        self.print_help()
+
+        print("\n" + "=" * 60)
+        print("💬 CHAT SESSION STARTED")
+        print("=" * 60)
+        print("Type /help for commands, or just describe your research goal!\n")
+
+        # Process initial message if provided
+        if self._initial_message:
+            print(f"📝 Initial message: {self._initial_message}\n")
+            try:
+                response = self.agent.chat(self._initial_message)
+                print(f"\n🤖 Meta-Agent: {response}\n")
+            except Exception as e:
+                print(f"❌ Error processing initial message: {e}")
+
+        # Main chat loop
+        while True:
+            try:
+                user_input = input("You: ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print("\n\n👋 Goodbye!")
+                break
+
+            if not user_input:
+                continue
+
+            handled = self.handle_command(user_input)
+            if handled == "QUIT":
+                print("\n👋 Goodbye!")
+                break
+            if handled is True:
+                continue
+
+            try:
+                response = self.agent.chat(user_input)
+                print(f"\n🤖 Meta-Agent: {response}\n")
+            except Exception as e:
+                print(f"\n❌ Error: {e}")
+                import traceback
+                traceback.print_exc()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scilink/cli/meta.py
+++ b/scilink/cli/meta.py
@@ -38,8 +38,8 @@ Examples:
   # Seed the first turn with your research goal
   scilink meta --message "Analyze grains.tif then plan a follow-up campaign"
 
-  # Supervised mode (meta delegates on its own judgement; reports as it goes)
-  scilink meta --mode supervised
+  # Autopilot mode (meta delegates on its own judgement; reports as it goes)
+  scilink meta --mode autopilot
 
   # Use a different model / an internal proxy
   scilink meta --model gemini-2.0-flash
@@ -48,7 +48,7 @@ Examples:
 Modes — the meta has two levels (a delegation runs a specialist through its
 one-shot run_task, so the specialists' step-by-step co-pilot mode does not
 apply here):
-  supervised (default)  Specialists pause at decision points for you to
+  autopilot (default)  Specialists pause at decision points for you to
                         approve / edit plans and outputs.
   autonomous            Specialists run end to end without pausing.
 
@@ -82,9 +82,9 @@ Environment Variables:
 
     # Mode
     parser.add_argument('--mode', type=str, dest='mode',
-                        choices=['supervised', 'autonomous'],
-                        default='supervised',
-                        help='Autonomy mode (default: supervised). The meta '
+                        choices=['autopilot', 'autonomous'],
+                        default='autopilot',
+                        help='Autonomy mode (default: autopilot). The meta '
                              'has two levels, not the modes’ three.')
 
     # Initial message — seeds the first chat turn
@@ -169,17 +169,17 @@ class MetaPlayground:
         embedding_model = self.config.get('embedding_model', 'gemini-embedding-001')
         embedding_api_key = self.config.get('embedding_api_key')
         futurehouse_api_key = self.config.get('futurehouse_api_key')
-        mode_str = self.config.get('meta_mode', 'supervised')
+        mode_str = self.config.get('meta_mode', 'autopilot')
         session_dir = self.config.get('session_dir')
         restore = self.config.get('restore', False)
 
         self._initial_message = self.config.get('initial_message')
 
         mode_map = {
-            'supervised': MetaMode.SUPERVISED,
+            'autopilot': MetaMode.AUTOPILOT,
             'autonomous': MetaMode.AUTONOMOUS,
         }
-        meta_mode = mode_map.get(mode_str, MetaMode.SUPERVISED)
+        meta_mode = mode_map.get(mode_str, MetaMode.AUTOPILOT)
 
         print("\n" + "=" * 60)
         print("🧭  SCILINK META-AGENT")
@@ -334,10 +334,10 @@ a nested child sub-session under this meta session.
             parts = cmd.split()
             if len(parts) == 1:
                 print(f"\n🎛️  Current Meta Mode: {self.agent.meta_mode.value}")
-                print("\n   To change: /mode <supervised|autonomous>")
+                print("\n   To change: /mode <autopilot|autonomous>")
             else:
                 mode_map = {
-                    'supervised': MetaMode.SUPERVISED,
+                    'autopilot': MetaMode.AUTOPILOT,
                     'autonomous': MetaMode.AUTONOMOUS,
                 }
                 new_mode = mode_map.get(parts[1].lower())
@@ -346,7 +346,7 @@ a nested child sub-session under this meta session.
                     print(f"\n   ✅ Meta mode changed to: {new_mode.value}")
                 else:
                     print(f"\n   ❌ Unknown mode: {parts[1]}")
-                    print("   Valid options: supervised, autonomous")
+                    print("   Valid options: autopilot, autonomous")
             return True
 
         if cmd == "/clear":

--- a/scilink/cli/meta.py
+++ b/scilink/cli/meta.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-scilink meta - Interactive Meta-Agent Orchestrator
+scilink explore - Interactive Meta-Agent Orchestrator
 
 The meta-agent is SciLink's default entry point (bare `scilink`): a single
 conversational agent that auto-routes each request to the right specialist —
@@ -23,27 +23,27 @@ from pathlib import Path
 # ==============================================================================
 
 def main():
-    """Main entry point for the 'scilink meta' command (and bare 'scilink')."""
+    """Main entry point for the 'scilink explore' command (and bare 'scilink')."""
 
     parser = argparse.ArgumentParser(
-        prog='scilink meta',
+        prog='scilink explore',
         description='SciLink Meta-Agent - one chat surface that auto-routes '
                     'to the analyze and plan specialists',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
   # Launch the meta-agent (identical to running bare `scilink`)
-  scilink meta
+  scilink explore
 
   # Seed the first turn with your research goal
-  scilink meta --message "Analyze grains.tif then plan a follow-up campaign"
+  scilink explore --message "Analyze grains.tif then plan a follow-up campaign"
 
   # Autopilot mode (meta delegates on its own judgement; reports as it goes)
-  scilink meta --mode autopilot
+  scilink explore --mode autopilot
 
   # Use a different model / an internal proxy
-  scilink meta --model gemini-2.0-flash
-  scilink meta --base-url https://my-proxy.example.com/v1 --model my-model
+  scilink explore --model gemini-2.0-flash
+  scilink explore --base-url https://my-proxy.example.com/v1 --model my-model
 
 Modes — the meta has two levels (a delegation runs a specialist through its
 one-shot run_task, so the specialists' step-by-step co-pilot mode does not

--- a/scilink/cli/plan.py
+++ b/scilink/cli/plan.py
@@ -23,8 +23,8 @@ Examples:
   # Start with default settings (co-pilot mode)
   scilink plan
   
-  # Use supervised mode (AI leads, human reviews plans/code)
-  scilink plan --autonomy supervised --data-dir ./experimental_results
+  # Use autopilot mode (AI leads, human reviews plans/code)
+  scilink plan --autonomy autopilot --data-dir ./experimental_results
   
   # Full autonomous mode (no human review)
   scilink plan --autonomy autonomous --data-dir ./data --knowledge-dir ./papers --code-dir ./code
@@ -43,10 +43,10 @@ Examples:
 
 Autonomy Levels:
   co-pilot (default)  Human leads, AI assists. Reviews every step.
-  supervised          AI leads, human supervises. Human reviews plans/code only.
+  autopilot           AI leads, human monitors. Human reviews plans/code only.
   autonomous          Full autonomy. No human review, AI chains all tools.
 
-  Note: supervised and autonomous modes require --data-dir to be specified.
+  Note: autopilot and autonomous modes require --data-dir to be specified.
 
 Environment Variables:
   SCILINK_API_KEY          API key for internal proxy
@@ -98,7 +98,7 @@ Supported Models:
     parser.add_argument(
         '--autonomy',
         type=str,
-        choices=['co-pilot', 'supervised', 'autonomous'],
+        choices=['co-pilot', 'autopilot', 'autonomous'],
         default='co-pilot',
         help='Autonomy level (default: co-pilot). Higher levels require --data-dir.'
     )
@@ -107,7 +107,7 @@ Supported Models:
         '--data-dir',
         type=str,
         dest='data_dir',
-        help='Path to experimental data directory (required for supervised/autonomous)'
+        help='Path to experimental data directory (required for autopilot/autonomous)'
     )
     
     parser.add_argument(
@@ -201,7 +201,7 @@ Supported Models:
             api_key = args.google_api_key
 
     # Validate: higher autonomy requires data-dir
-    if args.autonomy in ('supervised', 'autonomous') and not args.data_dir:
+    if args.autonomy in ('autopilot', 'autonomous') and not args.data_dir:
         parser.error(
             f"--data-dir is required for {args.autonomy} mode.\n"
             f"Example: scilink plan --autonomy {args.autonomy} --data-dir ./experimental_results"
@@ -321,7 +321,7 @@ class OrchestratorPlayground:
         # Convert autonomy level string to enum
         autonomy_map = {
             'co-pilot': AutonomyLevel.CO_PILOT,
-            'supervised': AutonomyLevel.SUPERVISED,
+            'autopilot': AutonomyLevel.AUTOPILOT,
             'autonomous': AutonomyLevel.AUTONOMOUS,
         }
         autonomy_level = autonomy_map.get(autonomy_level_str, AutonomyLevel.CO_PILOT)
@@ -445,7 +445,7 @@ class OrchestratorPlayground:
             print("   1. Check that planning_agents package is installed")
             print("   2. Verify all dependencies are installed")
             print("   3. Check your API key is valid")
-            print("   4. For supervised/autonomous: ensure directories exist")
+            print("   4. For autopilot/autonomous: ensure directories exist")
             sys.exit(1)
 
         # === LOAD CUSTOM TOOL FILES ===
@@ -477,7 +477,7 @@ class OrchestratorPlayground:
         print(f"Literature Search: {'Enabled' if futurehouse_key else 'Disabled'}")
         
         # Directory info for higher autonomy
-        if autonomy_level in (AutonomyLevel.SUPERVISED, AutonomyLevel.AUTONOMOUS):
+        if autonomy_level in (AutonomyLevel.AUTOPILOT, AutonomyLevel.AUTONOMOUS):
             print(f"\nWorkspace Directories:")
             print(f"  Data: {self.data_dir}")
             print(f"  Knowledge: {self.knowledge_dir or 'not configured'}")
@@ -694,21 +694,21 @@ class OrchestratorPlayground:
                 # Show current level
                 print(f"\n🎛️  Current Autonomy Level: {self.agent.autonomy_level.value}")
                 print(f"   Human Feedback: {'Enabled' if self.agent._enable_human_feedback else 'Disabled'}")
-                print("\n   To change: /autonomy <co-pilot|supervised|autonomous>")
+                print("\n   To change: /autonomy <co-pilot|autopilot|autonomous>")
                 print("   Note: Higher autonomy works best when started with --data-dir")
             else:
                 # Change level
                 level_map = {
                     'co-pilot': AutonomyLevel.CO_PILOT,
                     'copilot': AutonomyLevel.CO_PILOT,
-                    'supervised': AutonomyLevel.SUPERVISED,
+                    'autopilot': AutonomyLevel.AUTOPILOT,
                     'autonomous': AutonomyLevel.AUTONOMOUS,
                 }
                 new_level = level_map.get(parts[1].lower())
                 
                 if new_level:
                     # Warn if switching to higher autonomy without directories
-                    if new_level in (AutonomyLevel.SUPERVISED, AutonomyLevel.AUTONOMOUS):
+                    if new_level in (AutonomyLevel.AUTOPILOT, AutonomyLevel.AUTONOMOUS):
                         if not self.data_dir:
                             print(f"\n   ⚠️  Warning: No data directory configured.")
                             print(f"   For best results, restart with: scilink plan --autonomy {new_level.value} --data-dir ./your_data")
@@ -719,7 +719,7 @@ class OrchestratorPlayground:
                     print(f"   Human Feedback: {'Enabled' if self.agent._enable_human_feedback else 'Disabled'}")
                 else:
                     print(f"\n   ❌ Unknown level: {parts[1]}")
-                    print("   Valid options: co-pilot, supervised, autonomous")
+                    print("   Valid options: co-pilot, autopilot, autonomous")
             return True
         
         elif cmd == "/checkpoint":
@@ -744,7 +744,7 @@ class OrchestratorPlayground:
         
         Behavior by mode:
         - co-pilot: Do nothing (human leads, full backward compatibility)
-        - supervised: Survey workspace, analyze available data, suggest next steps
+        - autopilot: Survey workspace, analyze available data, suggest next steps
         - autonomous: Execute full pipeline (survey → TEA → plan → checkpoint)
         """
         from scilink.agents.planning_agents.planning_orchestrator import AutonomyLevel
@@ -761,7 +761,7 @@ class OrchestratorPlayground:
         has_code = self.code_dir is not None
         
         # Nothing to process if no directories configured
-        # (This shouldn't happen for supervised/autonomous due to CLI validation,
+        # (This shouldn't happen for autopilot/autonomous due to CLI validation,
         # but we handle it gracefully anyway)
         if not has_data and not has_knowledge:
             return
@@ -837,9 +837,9 @@ class OrchestratorPlayground:
             print("-"*60)
             return
         
-        # === SUPERVISED MODE: Survey and recommend ===
-        if autonomy == AutonomyLevel.SUPERVISED:
-            print("🔄 SUPERVISED MODE: Surveying workspace and preparing recommendations...")
+        # === AUTOPILOT MODE: Survey and recommend ===
+        if autonomy == AutonomyLevel.AUTOPILOT:
+            print("🔄 AUTOPILOT MODE: Surveying workspace and preparing recommendations...")
             print(f"   Objective: {self.agent.objective}")
             print(f"   Data: {self.data_dir}")
             print(f"   Knowledge: {self.knowledge_dir or 'not provided'}")

--- a/scilink/cli/serve.py
+++ b/scilink/cli/serve.py
@@ -48,7 +48,7 @@ def main():
     parser.add_argument(
         "--autonomy",
         type=str,
-        choices=["autonomous", "supervised", "co-pilot"],
+        choices=["autonomous", "autopilot", "co-pilot"],
         default="autonomous",
         help="Autonomy level (default: autonomous)",
     )

--- a/scilink/cli/simulate.py
+++ b/scilink/cli/simulate.py
@@ -34,8 +34,8 @@ Examples:
   # Seed the session with an initial structure request
   scilink simulate --request "Build a rutile TiO2 supercell with one O vacancy"
 
-  # Supervised mode (AI proceeds with reasonable defaults; surfaces big decisions)
-  scilink simulate --mode supervised
+  # Autopilot mode (AI proceeds with reasonable defaults; surfaces big decisions)
+  scilink simulate --mode autopilot
 
   # Use a different model
   scilink simulate --model gemini-2.0-flash
@@ -45,7 +45,7 @@ Examples:
 
 Modes (matching `scilink analyze` / `scilink plan` for consistent UX):
   co-pilot (default)   Human leads, AI assists. Confirms before each tool call.
-  supervised           AI leads with defaults; surfaces significant decisions.
+  autopilot           AI leads with defaults; surfaces significant decisions.
   autonomous           Full autonomy. AI executes without confirmation.
 
 Environment Variables:
@@ -80,7 +80,7 @@ Scope (for now):
 
     # Mode
     parser.add_argument('--mode', type=str, dest='mode',
-                        choices=['co-pilot', 'supervised', 'autonomous'],
+                        choices=['co-pilot', 'autopilot', 'autonomous'],
                         default='co-pilot',
                         help='Autonomy mode (default: co-pilot)')
 
@@ -191,7 +191,7 @@ class SimulatePlayground:
 
         mode_map = {
             'co-pilot': SimulationMode.CO_PILOT,
-            'supervised': SimulationMode.SUPERVISED,
+            'autopilot': SimulationMode.AUTOPILOT,
             'autonomous': SimulationMode.AUTONOMOUS,
         }
         simulation_mode = mode_map.get(mode_str, SimulationMode.CO_PILOT)
@@ -422,11 +422,11 @@ planned follow-up work; see CLAUDE.md.
             parts = cmd.split()
             if len(parts) == 1:
                 print(f"\n🎛️  Current Simulation Mode: {self.agent.simulation_mode.value}")
-                print("\n   To change: /mode <co-pilot|supervised|autonomous>")
+                print("\n   To change: /mode <co-pilot|autopilot|autonomous>")
             else:
                 mode_map = {
                     'co-pilot': SimulationMode.CO_PILOT,
-                    'supervised': SimulationMode.SUPERVISED,
+                    'autopilot': SimulationMode.AUTOPILOT,
                     'autonomous': SimulationMode.AUTONOMOUS,
                 }
                 new_mode = mode_map.get(parts[1].lower())
@@ -435,7 +435,7 @@ planned follow-up work; see CLAUDE.md.
                     print(f"\n   ✅ Simulation mode changed to: {new_mode.value}")
                 else:
                     print(f"\n   ❌ Unknown mode: {parts[1]}")
-                    print("   Valid options: co-pilot, supervised, autonomous")
+                    print("   Valid options: co-pilot, autopilot, autonomous")
             return True
 
         if cmd == "/clear":

--- a/scilink/mcp_server.py
+++ b/scilink/mcp_server.py
@@ -7,7 +7,7 @@ tool provider.  Start with::
 
 Supports three autonomy modes:
 - **autonomous** (default) — tools execute without human approval.
-- **supervised** — tools run but return key decisions for review.
+- **autopilot** — tools run but return key decisions for review.
 - **co-pilot** — tools that need approval return a ``needs_input``
   response; the MCP client must call ``scilink_respond`` to continue.
 
@@ -41,8 +41,8 @@ def _require_mcp():
         )
 
 
-# Tools that require user approval in co-pilot / supervised modes.
-# In co-pilot mode ALL of these pause; in supervised mode only the
+# Tools that require user approval in co-pilot / autopilot modes.
+# In co-pilot mode ALL of these pause; in autopilot mode only the
 # high-impact subset (run_analysis, run_optimization) pauses.
 _COPILOT_APPROVAL_TOOLS = {
     "run_analysis", "select_agent", "assess_novelty",
@@ -50,7 +50,7 @@ _COPILOT_APPROVAL_TOOLS = {
     "generate_implementation_code", "run_economic_analysis",
     "discard_plan",
 }
-_SUPERVISED_APPROVAL_TOOLS = {
+_AUTOPILOT_APPROVAL_TOOLS = {
     "run_analysis", "run_optimization", "discard_plan",
 }
 
@@ -120,7 +120,7 @@ def _execute_tool_captured(tools, tool_name: str, kwargs: dict) -> str:
     return result
 
 
-# ── Pending action support (co-pilot / supervised) ──────────────────────
+# ── Pending action support (co-pilot / autopilot) ──────────────────────
 
 class PendingAction:
     """Holds a pending tool call that needs user approval before execution."""
@@ -138,8 +138,8 @@ def _needs_approval(tool_name: str, mode: str) -> bool:
         return False
     if mode in ("co-pilot", "co_pilot", "copilot"):
         return tool_name in _COPILOT_APPROVAL_TOOLS
-    if mode == "supervised":
-        return tool_name in _SUPERVISED_APPROVAL_TOOLS
+    if mode == "autopilot":
+        return tool_name in _AUTOPILOT_APPROVAL_TOOLS
     return False
 
 
@@ -176,7 +176,7 @@ def create_server(
         base_url: Optional OpenAI-compatible endpoint.
         mode: ``"analyze"``, ``"plan"``, or ``"both"``.
         session_dir: Directory for session outputs.
-        analysis_mode: ``"autonomous"``, ``"supervised"``, or ``"co-pilot"``.
+        analysis_mode: ``"autonomous"``, ``"autopilot"``, or ``"co-pilot"``.
         futurehouse_api_key: Optional FutureHouse/Edison API key.
 
     Returns:
@@ -272,13 +272,13 @@ def create_server(
                 tools.append(_openai_to_mcp_tool(schema, prefix=prefix))
 
         # Always include scilink_respond so it's available if the user
-        # switches to co-pilot/supervised mode mid-session via
+        # switches to co-pilot/autopilot mode mid-session via
         # scilink_set_autonomy (MCP clients only call tools/list once).
         tools.append(types.Tool(
             name="scilink_respond",
             description=(
                 "Send a response to a pending SciLink action that requires "
-                "human approval. Only needed in co-pilot or supervised mode. "
+                "human approval. Only needed in co-pilot or autopilot mode. "
                 "Call this after receiving a 'needs_input' status from another tool."
             ),
             inputSchema={
@@ -337,7 +337,7 @@ def create_server(
             name="scilink_set_autonomy",
             description=(
                 "Change the autonomy mode at runtime. In 'autonomous' mode "
-                "all tools execute immediately. In 'supervised' mode high-impact "
+                "all tools execute immediately. In 'autopilot' mode high-impact "
                 "tools (run_analysis, run_optimization) pause for approval. "
                 "In 'co-pilot' mode most action tools pause for approval. "
                 "Returns the new mode and whether scilink_respond is now needed."
@@ -347,7 +347,7 @@ def create_server(
                 "properties": {
                     "mode": {
                         "type": "string",
-                        "enum": ["autonomous", "supervised", "co-pilot"],
+                        "enum": ["autonomous", "autopilot", "co-pilot"],
                         "description": "The autonomy mode to switch to.",
                     },
                 },
@@ -480,7 +480,7 @@ def create_server(
         orch = state[orch_key]
         autonomy = state["config"]["analysis_mode"]
 
-        # Co-pilot / supervised: intercept tools that need approval
+        # Co-pilot / autopilot: intercept tools that need approval
         if _needs_approval(original_name, autonomy):
             prompt = _build_approval_prompt(original_name, arguments)
             state["pending_action"] = PendingAction(
@@ -678,7 +678,7 @@ def _init_orchestrators(state: dict, config: dict) -> None:
             "co-pilot": AnalysisMode.CO_PILOT,
             "co_pilot": AnalysisMode.CO_PILOT,
             "copilot": AnalysisMode.CO_PILOT,
-            "supervised": AnalysisMode.SUPERVISED,
+            "autopilot": AnalysisMode.AUTOPILOT,
             "autonomous": AnalysisMode.AUTONOMOUS,
         }
         analysis_mode = mode_map.get(
@@ -702,7 +702,7 @@ def _init_orchestrators(state: dict, config: dict) -> None:
                 "co-pilot": AutonomyLevel.CO_PILOT,
                 "co_pilot": AutonomyLevel.CO_PILOT,
                 "copilot": AutonomyLevel.CO_PILOT,
-                "supervised": AutonomyLevel.SUPERVISED,
+                "autopilot": AutonomyLevel.AUTOPILOT,
                 "autonomous": AutonomyLevel.AUTONOMOUS,
             }
             autonomy_level = autonomy_map.get(
@@ -900,7 +900,7 @@ def _handle_set_autonomy(
 ) -> List["types.TextContent"]:
     """Switch autonomy mode at runtime."""
     new_mode = arguments.get("mode", "").strip().lower()
-    valid = {"autonomous", "supervised", "co-pilot"}
+    valid = {"autonomous", "autopilot", "co-pilot"}
     if new_mode not in valid:
         return [types.TextContent(
             type="text",
@@ -924,7 +924,7 @@ def _handle_set_autonomy(
             "current_mode": new_mode,
             "approval_required_for": sorted(
                 _COPILOT_APPROVAL_TOOLS if new_mode == "co-pilot"
-                else _SUPERVISED_APPROVAL_TOOLS if new_mode == "supervised"
+                else _AUTOPILOT_APPROVAL_TOOLS if new_mode == "autopilot"
                 else set()
             ),
             "scilink_respond_needed": new_mode != "autonomous",
@@ -932,7 +932,7 @@ def _handle_set_autonomy(
     )]
 
 
-# ── Respond handler (co-pilot / supervised) ──────────────────────────────
+# ── Respond handler (co-pilot / autopilot) ──────────────────────────────
 
 async def _handle_respond(
     state: dict, arguments: dict

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -469,16 +469,22 @@ if st.session_state.app_mode == "simulate" and simulate_enabled():
             "the full agent framework alongside HPC simulations."
         )
 else:
-    # ── Analyze / Plan modes: full agent UI ──────────────────
+    # ── Analyze / Plan / Explore modes: full agent UI ────────
+    # Tabs are built dynamically: Telemetry is appended only in Explore
+    # (meta) mode, Simulations only when the simulate extra is enabled.
+    _is_meta = st.session_state.app_mode == "meta"
+    _tab_labels = ["Chat", "File Explorer", "Tools", "Skills"]
+    if _is_meta:
+        _tab_labels.append("Telemetry")
     if simulate_enabled():
-        chat_tab, files_tab, tools_tab, skills_tab, sim_tab = st.tabs(
-            ["Chat", "File Explorer", "Tools", "Skills", "Simulations"]
-        )
-    else:
-        chat_tab, files_tab, tools_tab, skills_tab = st.tabs(
-            ["Chat", "File Explorer", "Tools", "Skills"]
-        )
-        sim_tab = None
+        _tab_labels.append("Simulations")
+    _tabs = st.tabs(_tab_labels)
+    chat_tab, files_tab, tools_tab, skills_tab = _tabs[:4]
+    _next = 4
+    telemetry_tab = None
+    if _is_meta:
+        telemetry_tab, _next = _tabs[_next], _next + 1
+    sim_tab = _tabs[_next] if simulate_enabled() else None
 
     # ── Chat tab ─────────────────────────────────────────────────────
     with chat_tab:
@@ -1003,6 +1009,12 @@ else:
     with skills_tab:
         render_skills_tab()
     
+    # ── Telemetry tab (Explore mode only) ────────────────────────────
+    if telemetry_tab is not None:
+        from scilink.ui.components.telemetry import render_telemetry_tab
+        with telemetry_tab:
+            render_telemetry_tab()
+
     # ── Simulations tab ──────────────────────────────────────────────
     if sim_tab is not None:
         from scilink.ui.components.simulations import render_simulations_tab

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -369,12 +369,14 @@ if not st.session_state.agent_initialized:
             with _col:
                 _btype = ("primary" if st.session_state.app_mode == _m["key"]
                           else "secondary")
-                _label = _m["label"] + (" (beta)" if _m.get("beta") else "")
-                if st.button(_label, type=_btype, use_container_width=True,
+                if st.button(_m["label"], type=_btype, use_container_width=True,
                              key=f"mode_{_m['key']}"):
                     st.session_state.app_mode = _m["key"]
                     st.rerun()
-        _cur_desc = _mode_map[st.session_state.app_mode]["description"]
+        _cur_mode = _mode_map[st.session_state.app_mode]
+        _cur_desc = _cur_mode["description"]
+        if _cur_mode.get("beta"):
+            _cur_desc = f"BETA · {_cur_desc}"
         st.markdown(
             f'<p style="text-align:center;color:#6B7A8C;font-size:0.85em;'
             f'margin-top:-4px;margin-bottom:12px">'

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -97,7 +97,7 @@ def _find_new_images(summary_only: bool = False) -> list[str]:
             st.session_state.known_images.add(s)
 
         # In co-pilot mode, show sample fits inline (first, middle, last)
-        # In supervised/autonomous, skip — user can find them in File Explorer
+        # In autopilot/autonomous, skip — user can find them in File Explorer
         agent = st.session_state.get("agent")
         is_copilot = (
             agent is not None

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -851,7 +851,11 @@ else:
     _chat_disabled = task.is_running or (
         not _has_conversation and st.session_state.app_mode not in _free_start_modes
     )
-    user_text = st.chat_input(_chat_placeholder, disabled=_chat_disabled)
+    # Render the chat input inside the Chat tab container. A top-level
+    # st.chat_input is pinned to the bottom of the whole app and shows on
+    # every tab; scoping it to chat_tab keeps it on the Chat tab only.
+    with chat_tab:
+        user_text = st.chat_input(_chat_placeholder, disabled=_chat_disabled)
     _upload_preamble = st.session_state.pop("_upload_preamble", None)
 
     if _upload_preamble and user_text:

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -360,27 +360,18 @@ if not st.session_state.agent_initialized:
         if st.session_state.app_mode == "simulate" and not simulate_enabled():
             st.session_state.app_mode = "analyze"
         _mode_map = {m["key"]: m for m in APP_MODES}
+        # One button per mode; simulate is dropped when [sim] isn't installed.
+        _modes = [m for m in APP_MODES
+                  if m["key"] != "simulate" or simulate_enabled()]
         st.markdown('<div class="mode-selector-anchor"></div>', unsafe_allow_html=True)
-        if simulate_enabled():
-            _, _mc1, _mc2, _mc3, _ = st.columns([1.5, 1, 1, 1, 1.5])
-        else:
-            _, _mc1, _mc2, _ = st.columns([1.5, 1.5, 1.5, 1.5])
-            _mc3 = None
-        with _mc1:
-            _atype = "primary" if st.session_state.app_mode == "analyze" else "secondary"
-            if st.button("Analyze", type=_atype, use_container_width=True, key="mode_analyze"):
-                st.session_state.app_mode = "analyze"
-                st.rerun()
-        with _mc2:
-            _ptype = "primary" if st.session_state.app_mode == "plan" else "secondary"
-            if st.button("Plan", type=_ptype, use_container_width=True, key="mode_plan"):
-                st.session_state.app_mode = "plan"
-                st.rerun()
-        if _mc3 is not None:
-            with _mc3:
-                _stype = "primary" if st.session_state.app_mode == "simulate" else "secondary"
-                if st.button("Simulate", type=_stype, use_container_width=True, key="mode_simulate"):
-                    st.session_state.app_mode = "simulate"
+        _cols = st.columns([1.5] + [1.0] * len(_modes) + [1.5])
+        for _m, _col in zip(_modes, _cols[1:-1]):
+            with _col:
+                _btype = ("primary" if st.session_state.app_mode == _m["key"]
+                          else "secondary")
+                if st.button(_m["label"], type=_btype, use_container_width=True,
+                             key=f"mode_{_m['key']}"):
+                    st.session_state.app_mode = _m["key"]
                     st.rerun()
         _cur_desc = _mode_map[st.session_state.app_mode]["description"]
         st.markdown(
@@ -837,7 +828,11 @@ else:
             )
 
     _has_conversation = bool(st.session_state.chat_messages)
-    if st.session_state.app_mode == "plan":
+    # plan and meta accept a free-text goal with no prior upload.
+    _free_start_modes = ("plan", "meta")
+    if st.session_state.app_mode == "meta":
+        _chat_placeholder = "Describe your research goal..."
+    elif st.session_state.app_mode == "plan":
         _chat_placeholder = "Message the planning agent..."
     elif _has_conversation:
         _chat_placeholder = "Message the analysis agent..."
@@ -845,7 +840,7 @@ else:
         _chat_placeholder = "Upload data and click Analyze to start"
 
     _chat_disabled = task.is_running or (
-        not _has_conversation and st.session_state.app_mode != "plan"
+        not _has_conversation and st.session_state.app_mode not in _free_start_modes
     )
     user_text = st.chat_input(_chat_placeholder, disabled=_chat_disabled)
     _upload_preamble = st.session_state.pop("_upload_preamble", None)

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -369,7 +369,8 @@ if not st.session_state.agent_initialized:
             with _col:
                 _btype = ("primary" if st.session_state.app_mode == _m["key"]
                           else "secondary")
-                if st.button(_m["label"], type=_btype, use_container_width=True,
+                _label = _m["label"] + (" (beta)" if _m.get("beta") else "")
+                if st.button(_label, type=_btype, use_container_width=True,
                              key=f"mode_{_m['key']}"):
                     st.session_state.app_mode = _m["key"]
                     st.rerun()

--- a/scilink/ui/components/chat_uploads.py
+++ b/scilink/ui/components/chat_uploads.py
@@ -290,10 +290,13 @@ def _render_planning_uploads(start_task_fn) -> None:
 def _render_meta_uploads(start_task_fn) -> None:
     st.markdown(
         '<div class="upload-hero-box">'
-        '<p class="upload-hero-title">What would you like to do?</p>'
+        '<p class="upload-hero-title">What would you like to do? '
+        '<span style="font-size:0.45em;vertical-align:middle;'
+        'background:#8893a5;color:#fff;padding:2px 8px;border-radius:9px;'
+        'letter-spacing:1px;font-weight:600;">BETA</span></p>'
         '<p class="upload-hero-subtitle">'
-        "Describe your research goal — the meta-agent routes it to the "
-        "analysis and planning specialists</p>"
+        "Describe your research goal — Explore routes it to the analysis "
+        "and planning specialists</p>"
         "</div>",
         unsafe_allow_html=True,
     )
@@ -394,7 +397,7 @@ def save_planning_uploads(files, category: str) -> None:
 
 
 def save_meta_uploads(files) -> None:
-    """Save Auto-mode uploads into the meta session's ``uploads/`` directory.
+    """Save Explore-mode uploads into the meta session's ``uploads/`` directory.
 
     Everything lands in one place; the meta-agent decides which child
     specialist each file belongs to when it builds its delegations.

--- a/scilink/ui/components/chat_uploads.py
+++ b/scilink/ui/components/chat_uploads.py
@@ -26,6 +26,8 @@ def render_pre_chat_uploads(start_task_fn) -> None:
         _render_analyze_uploads(start_task_fn)
     elif mode == "plan":
         _render_planning_uploads(start_task_fn)
+    elif mode == "meta":
+        _render_meta_uploads(start_task_fn)
 
 
 # ── Analyze mode uploads ─────────────────────────────────────────
@@ -280,6 +282,48 @@ def _render_planning_uploads(start_task_fn) -> None:
 
     if not can_start:
         st.caption("Enter a research objective or upload files to begin.")
+
+
+# ── Meta mode (free-text goal; no file uploaders in v1) ──────────
+
+def _render_meta_uploads(start_task_fn) -> None:
+    st.markdown(
+        '<div class="upload-hero-box">'
+        '<p class="upload-hero-title">What would you like to do?</p>'
+        '<p class="upload-hero-subtitle">'
+        "Describe your research goal — the meta-agent routes it to the "
+        "analysis and planning specialists</p>"
+        "</div>",
+        unsafe_allow_html=True,
+    )
+
+    goal = st.text_area(
+        "Research goal",
+        key="meta_objective",
+        placeholder=(
+            "e.g., Analyze the STEM image at /data/grains.tif, then plan a "
+            "follow-up experiment campaign based on what you find"
+        ),
+        height=110,
+        label_visibility="collapsed",
+    )
+
+    can_start = bool((goal or "").strip())
+    if st.button(
+        "Start",
+        type="primary",
+        use_container_width=True,
+        disabled=not can_start,
+    ):
+        prompt = goal.strip()
+        st.session_state.chat_messages.append({"role": "user", "content": prompt})
+        start_task_fn(prompt)
+
+    if not can_start:
+        st.caption(
+            "Describe a research goal to begin. Include absolute file paths "
+            "for any data you want analyzed."
+        )
 
 
 def save_planning_uploads(files, category: str) -> None:

--- a/scilink/ui/components/chat_uploads.py
+++ b/scilink/ui/components/chat_uploads.py
@@ -8,6 +8,7 @@ from ..config import (
     SUPPORTED_CODE_EXTENSIONS,
     SUPPORTED_DATA_EXTENSIONS,
     SUPPORTED_KNOWLEDGE_EXTENSIONS,
+    SUPPORTED_META_EXTENSIONS,
     SUPPORTED_METADATA_EXTENSIONS,
     SUPPORTED_PLANNING_DATA_EXTENSIONS,
     extra_data_extensions_for,
@@ -284,7 +285,7 @@ def _render_planning_uploads(start_task_fn) -> None:
         st.caption("Enter a research objective or upload files to begin.")
 
 
-# ── Meta mode (free-text goal; no file uploaders in v1) ──────────
+# ── Meta mode (free-text goal + one combined uploader) ───────────
 
 def _render_meta_uploads(start_task_fn) -> None:
     st.markdown(
@@ -301,29 +302,72 @@ def _render_meta_uploads(start_task_fn) -> None:
         "Research goal",
         key="meta_objective",
         placeholder=(
-            "e.g., Analyze the STEM image at /data/grains.tif, then plan a "
+            "e.g., Analyze the STEM image I uploaded, then plan a "
             "follow-up experiment campaign based on what you find"
         ),
         height=110,
         label_visibility="collapsed",
     )
 
-    can_start = bool((goal or "").strip())
+    with st.expander("Add files (optional) — papers, code, data, metadata",
+                     expanded=True):
+        extra_exts = extra_data_extensions_for(st.session_state.get("agent"))
+        meta_exts = tuple(SUPPORTED_META_EXTENSIONS) + tuple(extra_exts)
+        files = st.file_uploader(
+            "Upload files",
+            type=[e.lstrip(".") for e in meta_exts],
+            key="main_uploader_auto",
+            accept_multiple_files=True,
+            label_visibility="collapsed",
+        )
+        if files:
+            save_meta_uploads(files)
+        folder = st.text_input(
+            "or paste a folder path",
+            key="meta_folder_path",
+            placeholder="/path/to/papers/ or /path/to/data/",
+            label_visibility="collapsed",
+        )
+        st.caption(
+            "One drop zone for everything — the meta-agent sorts each file "
+            "to the analysis or planning specialist."
+        )
+
+    folder = (folder or "").strip()
+    folder_ok = bool(folder) and Path(folder).is_dir()
+    if folder and not folder_ok:
+        st.warning(f"Folder not found: {folder}")
+
+    uploads = st.session_state.uploaded_meta_paths
+    goal = (goal or "").strip()
+    can_start = bool(goal) or bool(uploads) or folder_ok
     if st.button(
         "Start",
         type="primary",
         use_container_width=True,
         disabled=not can_start,
     ):
-        prompt = goal.strip()
+        parts = []
+        if goal:
+            parts.append(goal)
+        if uploads:
+            listed = "\n".join(f"  - `{p}`" for p in uploads)
+            parts.append(
+                f"I uploaded {len(uploads)} file(s):\n{listed}\n\n"
+                "Inspect them to determine what each file is, then route them "
+                "to the right specialist."
+            )
+        if folder_ok:
+            parts.append(
+                f"Additional resources are in the folder `{folder}` — "
+                "inspect it as well."
+            )
+        prompt = "\n\n".join(parts) if parts else "Please help with my research."
         st.session_state.chat_messages.append({"role": "user", "content": prompt})
         start_task_fn(prompt)
 
     if not can_start:
-        st.caption(
-            "Describe a research goal to begin. Include absolute file paths "
-            "for any data you want analyzed."
-        )
+        st.caption("Describe a research goal or add files to begin.")
 
 
 def save_planning_uploads(files, category: str) -> None:
@@ -347,3 +391,24 @@ def save_planning_uploads(files, category: str) -> None:
         st.session_state._processed_uploads.add(upload_key)
         st.session_state[state_key].append(str(dest))
         st.sidebar.success(f"Uploaded {category}: {f.name}")
+
+
+def save_meta_uploads(files) -> None:
+    """Save Auto-mode uploads into the meta session's ``uploads/`` directory.
+
+    Everything lands in one place; the meta-agent decides which child
+    specialist each file belongs to when it builds its delegations.
+    """
+    session_dir = Path(st.session_state.session_dir)
+    target_dir = session_dir / "uploads"
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    for f in files:
+        dest = target_dir / f.name
+        upload_key = ("meta", str(dest))
+        if upload_key in st.session_state._processed_uploads:
+            continue
+        dest.write_bytes(f.getvalue())
+        st.session_state._processed_uploads.add(upload_key)
+        st.session_state.uploaded_meta_paths.append(str(dest))
+        st.sidebar.success(f"Uploaded: {f.name}")

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -564,19 +564,51 @@ def _render_planning_status() -> None:
     st.metric("Autonomy", mode.replace("-", " ").title())
 
 
-def _render_meta_status() -> None:
-    """Show meta-agent status metrics."""
-    agent = st.session_state.agent
-    children = getattr(agent, "_children", {}) or {}
-    ledger = getattr(agent, "_delegation_ledger", []) or []
-    mode = st.session_state.agent_config.get("mode", "co-pilot")
+def _meta_delegation_tree(ledger: list, specialist: str) -> str:
+    """Monospace meta → specialist → delegations tree for the sidebar."""
+    rows = [e for e in ledger if e.get("mode") == specialist]
+    lines = ["🧭 Explore", f"└─ {specialist.title()}  ({len(rows)})"]
+    glyphs = {"success": "✓", "error": "✗"}
+    for i, e in enumerate(rows):
+        branch = "   └─" if i == len(rows) - 1 else "   ├─"
+        task = " ".join(str(e.get("task") or "").split())
+        if len(task) > 30:
+            task = task[:29] + "…"
+        glyph = glyphs.get(e.get("status"), "⋯")
+        cf = e.get("context_from") or []
+        cf_str = "  ←" + ",".join(f"#{n}" for n in cf) if cf else ""
+        lines.append(f"{branch} #{e.get('index', '?')} {task} {glyph}{cf_str}")
+    return "\n".join(lines)
 
-    row_c1, row_c2 = st.columns(2)
-    with row_c1:
-        st.metric("Delegations", len(ledger))
-    with row_c2:
-        st.metric("Autonomy", mode.replace("-", " ").title())
-    st.metric("Specialists Active", ", ".join(sorted(children)) or "None")
+
+def _render_meta_status() -> None:
+    """Show the Explore meta-agent's delegation tree, by specialist."""
+    agent = st.session_state.agent
+    ledger = getattr(agent, "_delegation_ledger", []) or []
+    mode = st.session_state.agent_config.get("mode", "autopilot")
+
+    if not ledger:
+        st.caption(f"Autonomy: {mode.replace('-', ' ').title()}")
+        st.info("No delegations yet — describe a goal and the meta routes it.")
+        return
+
+    by_mode: dict = {}
+    for e in ledger:
+        m = e.get("mode", "?")
+        by_mode[m] = by_mode.get(m, 0) + 1
+    specialists = sorted(by_mode)
+
+    st.caption(f"{len(ledger)} delegation(s) · {mode.replace('-', ' ').title()}")
+    if st.session_state.get("meta_status_specialist") not in specialists:
+        st.session_state["meta_status_specialist"] = specialists[0]
+    selected = st.selectbox(
+        "Specialist",
+        specialists,
+        format_func=lambda s: f"{s.title()} ({by_mode[s]})",
+        key="meta_status_specialist",
+    )
+    st.text(_meta_delegation_tree(ledger, selected))
+    st.caption("✓ done · ✗ error · ⋯ running · ←#n context source")
 
 
 # ── helpers ──────────────────────────────────────────────────────

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -565,19 +565,22 @@ def _render_planning_status() -> None:
 
 
 def _meta_delegation_tree(ledger: list, specialist: str) -> str:
-    """Monospace meta → specialist → delegations tree for the sidebar."""
+    """Monospace mission-control → specialist → delegations tree."""
     rows = [e for e in ledger if e.get("mode") == specialist]
-    lines = ["🧭 Explore", f"└─ {specialist.title()}  ({len(rows)})"]
+    lines = ["🛰️ Mission control", f"└─ {specialist.title()}  ({len(rows)})"]
     glyphs = {"success": "✓", "error": "✗"}
     for i, e in enumerate(rows):
         branch = "   └─" if i == len(rows) - 1 else "   ├─"
-        task = " ".join(str(e.get("task") or "").split())
-        if len(task) > 30:
-            task = task[:29] + "…"
+        # Prefer the meta-supplied short label (e.g. the data type); fall
+        # back to the task text for older entries.
+        label = (e.get("label") or "").strip() or " ".join(
+            str(e.get("task") or "").split())
+        if len(label) > 32:
+            label = label[:31] + "…"
         glyph = glyphs.get(e.get("status"), "⋯")
         cf = e.get("context_from") or []
         cf_str = "  ←" + ",".join(f"#{n}" for n in cf) if cf else ""
-        lines.append(f"{branch} #{e.get('index', '?')} {task} {glyph}{cf_str}")
+        lines.append(f"{branch} #{e.get('index', '?')} {label} {glyph}{cf_str}")
     return "\n".join(lines)
 
 
@@ -618,7 +621,6 @@ def _render_meta_status() -> None:
             key="meta_status_specialist",
         )
         st.text(_meta_delegation_tree(ledger, selected))
-        st.caption("✓ done · ✗ error · ⋯ running · ←#n context source")
 
     _delegation_tree_panel()
 

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -640,7 +640,10 @@ def _render_meta_status() -> None:
         if not ledger:
             st.info("No delegations yet — describe a goal and the meta routes it.")
             return
-        st.markdown(_meta_delegation_tree(ledger), unsafe_allow_html=True)
+        # st.html (not st.markdown) — renders raw HTML with no Markdown
+        # processing, so the <pre> newlines survive and the tree stays
+        # top-down rather than collapsing into a wrapped inline run.
+        st.html(_meta_delegation_tree(ledger))
 
     _delegation_tree_panel()
 

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -228,8 +228,9 @@ def render_sidebar() -> None:
         if simulate_enabled():
             _render_hpc_connection()
 
-        # Planning mode: embedding model
-        if st.session_state.app_mode == "plan":
+        # Planning + meta modes: embedding model (the meta delegates to a
+        # planning child that uses embeddings for literature / KB retrieval).
+        if st.session_state.app_mode in ("plan", "meta"):
             st.selectbox(
                 "Embedding model",
                 EMBEDDING_MODEL_OPTIONS + ["Custom"],

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -582,33 +582,45 @@ def _meta_delegation_tree(ledger: list, specialist: str) -> str:
 
 
 def _render_meta_status() -> None:
-    """Show the Explore meta-agent's delegation tree, by specialist."""
-    agent = st.session_state.agent
-    ledger = getattr(agent, "_delegation_ledger", []) or []
-    mode = st.session_state.agent_config.get("mode", "autopilot")
+    """Show the Explore meta-agent's delegation tree, by specialist.
 
-    if not ledger:
-        st.caption(f"Autonomy: {mode.replace('-', ' ').title()}")
-        st.info("No delegations yet — describe a goal and the meta routes it.")
-        return
+    The tree is wrapped in an ``st.fragment`` that polls the live delegation
+    ledger every 2s while a chat is running, so delegations appear (and flip
+    from ⋯ running to ✓/✗) without waiting for the whole turn to finish.
+    """
+    task = st.session_state.get("chat_task")
+    _interval = "2s" if (task is not None and getattr(task, "is_running", False)) else None
 
-    by_mode: dict = {}
-    for e in ledger:
-        m = e.get("mode", "?")
-        by_mode[m] = by_mode.get(m, 0) + 1
-    specialists = sorted(by_mode)
+    @st.fragment(run_every=_interval)
+    def _delegation_tree_panel() -> None:
+        agent = st.session_state.get("agent")
+        ledger = getattr(agent, "_delegation_ledger", []) or []
+        mode = st.session_state.agent_config.get("mode", "autopilot")
 
-    st.caption(f"{len(ledger)} delegation(s) · {mode.replace('-', ' ').title()}")
-    if st.session_state.get("meta_status_specialist") not in specialists:
-        st.session_state["meta_status_specialist"] = specialists[0]
-    selected = st.selectbox(
-        "Specialist",
-        specialists,
-        format_func=lambda s: f"{s.title()} ({by_mode[s]})",
-        key="meta_status_specialist",
-    )
-    st.text(_meta_delegation_tree(ledger, selected))
-    st.caption("✓ done · ✗ error · ⋯ running · ←#n context source")
+        if not ledger:
+            st.caption(f"Autonomy: {mode.replace('-', ' ').title()}")
+            st.info("No delegations yet — describe a goal and the meta routes it.")
+            return
+
+        by_mode: dict = {}
+        for e in ledger:
+            m = e.get("mode", "?")
+            by_mode[m] = by_mode.get(m, 0) + 1
+        specialists = sorted(by_mode)
+
+        st.caption(f"{len(ledger)} delegation(s) · {mode.replace('-', ' ').title()}")
+        if st.session_state.get("meta_status_specialist") not in specialists:
+            st.session_state["meta_status_specialist"] = specialists[0]
+        selected = st.selectbox(
+            "Specialist",
+            specialists,
+            format_func=lambda s: f"{s.title()} ({by_mode[s]})",
+            key="meta_status_specialist",
+        )
+        st.text(_meta_delegation_tree(ledger, selected))
+        st.caption("✓ done · ✗ error · ⋯ running · ←#n context source")
+
+    _delegation_tree_panel()
 
 
 # ── helpers ──────────────────────────────────────────────────────

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -14,6 +14,7 @@ from ..config import (
     SUPPORTED_CODE_EXTENSIONS,
     SUPPORTED_DATA_EXTENSIONS,
     SUPPORTED_KNOWLEDGE_EXTENSIONS,
+    SUPPORTED_META_EXTENSIONS,
     SUPPORTED_METADATA_EXTENSIONS,
     SUPPORTED_PLANNING_DATA_EXTENSIONS,
     extra_data_extensions_for,
@@ -374,6 +375,8 @@ def render_sidebar() -> None:
                 _render_analyze_sidebar_uploads()
             elif app_mode == "plan":
                 _render_planning_sidebar_uploads()
+            elif app_mode == "meta":
+                _render_meta_sidebar_uploads()
 
             # ── Agent status (mode-specific) ─────────────────────
             st.divider()
@@ -497,6 +500,31 @@ def _render_planning_sidebar_uploads() -> None:
     if data_files:
         from .chat_uploads import save_planning_uploads
         save_planning_uploads(data_files, "data")
+
+
+def _render_meta_sidebar_uploads() -> None:
+    """Compact sidebar upload widget for Explore (meta) mode.
+
+    One combined uploader — files land in the session's uploads/ directory;
+    the meta-agent's inspect_uploads tool classifies and routes them.
+    """
+    st.subheader("Upload Files")
+
+    extra_exts = extra_data_extensions_for(st.session_state.get("agent"))
+    meta_exts = tuple(SUPPORTED_META_EXTENSIONS) + tuple(extra_exts)
+    files = st.file_uploader(
+        "Files (papers, code, data, metadata)",
+        type=[e.lstrip(".") for e in meta_exts],
+        key="sidebar_uploader_meta",
+        accept_multiple_files=True,
+    )
+    if files:
+        from .chat_uploads import save_meta_uploads
+        save_meta_uploads(files)
+    st.caption(
+        "Saved to the session's uploads/ folder — ask the meta-agent to "
+        "inspect them and it routes each file to the right specialist."
+    )
 
 
 def _render_analyze_status() -> None:

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -564,32 +564,46 @@ def _render_planning_status() -> None:
     st.metric("Autonomy", mode.replace("-", " ").title())
 
 
-def _meta_delegation_tree(ledger: list, specialist: str) -> str:
-    """Monospace mission-control → specialist → delegations tree."""
-    rows = [e for e in ledger if e.get("mode") == specialist]
-    lines = ["🛰️ Mission control", f"└─ {specialist.title()}  ({len(rows)})"]
+def _meta_delegation_tree(ledger: list) -> str:
+    """Monospace mission-control → specialists → delegations tree.
+
+    Shows every specialist branch at once — no selector.
+    """
+    by_mode: dict = {}
+    for e in ledger:
+        by_mode.setdefault(e.get("mode", "?"), []).append(e)
     glyphs = {"success": "✓", "error": "✗"}
-    for i, e in enumerate(rows):
-        branch = "   └─" if i == len(rows) - 1 else "   ├─"
-        # Prefer the meta-supplied short label (e.g. the data type); fall
-        # back to the task text for older entries.
-        label = (e.get("label") or "").strip() or " ".join(
-            str(e.get("task") or "").split())
-        if len(label) > 32:
-            label = label[:31] + "…"
-        glyph = glyphs.get(e.get("status"), "⋯")
-        cf = e.get("context_from") or []
-        cf_str = "  ←" + ",".join(f"#{n}" for n in cf) if cf else ""
-        lines.append(f"{branch} #{e.get('index', '?')} {label} {glyph}{cf_str}")
+    icons = {"analysis": "🧪", "planning": "📋"}
+    lines = ["🛰️ Mission control"]
+    modes = sorted(by_mode)
+    for mi, mode in enumerate(modes):
+        rows = by_mode[mode]
+        last_mode = mi == len(modes) - 1
+        lines.append(f"{'└─' if last_mode else '├─'} {icons.get(mode, '•')} "
+                     f"{mode.title()}  ({len(rows)})")
+        cont = "   " if last_mode else "│  "
+        for ri, e in enumerate(rows):
+            rbranch = "└─" if ri == len(rows) - 1 else "├─"
+            # Prefer the meta-supplied short label (the data type); fall back
+            # to the task text for older, unlabelled entries.
+            label = (e.get("label") or "").strip() or " ".join(
+                str(e.get("task") or "").split())
+            if len(label) > 30:
+                label = label[:29] + "…"
+            glyph = glyphs.get(e.get("status"), "⋯")
+            cf = e.get("context_from") or []
+            cf_str = " ←" + ",".join(f"#{n}" for n in cf) if cf else ""
+            lines.append(f"{cont}{rbranch} #{e.get('index', '?')} "
+                         f"{label} {glyph}{cf_str}")
     return "\n".join(lines)
 
 
 def _render_meta_status() -> None:
-    """Show the Explore meta-agent's delegation tree, by specialist.
+    """Show the Explore meta-agent's delegation tree.
 
-    The tree is wrapped in an ``st.fragment`` that polls the live delegation
-    ledger every 2s while a chat is running, so delegations appear (and flip
-    from ⋯ running to ✓/✗) without waiting for the whole turn to finish.
+    Wrapped in an ``st.fragment`` that polls the live delegation ledger every
+    2s while a chat is running, so delegations appear (and flip from ⋯ running
+    to ✓/✗) without waiting for the whole turn to finish.
     """
     task = st.session_state.get("chat_task")
     _interval = "2s" if (task is not None and getattr(task, "is_running", False)) else None
@@ -600,27 +614,11 @@ def _render_meta_status() -> None:
         ledger = getattr(agent, "_delegation_ledger", []) or []
         mode = st.session_state.agent_config.get("mode", "autopilot")
 
+        st.caption(f"{len(ledger)} delegation(s) · {mode.replace('-', ' ').title()}")
         if not ledger:
-            st.caption(f"Autonomy: {mode.replace('-', ' ').title()}")
             st.info("No delegations yet — describe a goal and the meta routes it.")
             return
-
-        by_mode: dict = {}
-        for e in ledger:
-            m = e.get("mode", "?")
-            by_mode[m] = by_mode.get(m, 0) + 1
-        specialists = sorted(by_mode)
-
-        st.caption(f"{len(ledger)} delegation(s) · {mode.replace('-', ' ').title()}")
-        if st.session_state.get("meta_status_specialist") not in specialists:
-            st.session_state["meta_status_specialist"] = specialists[0]
-        selected = st.selectbox(
-            "Specialist",
-            specialists,
-            format_func=lambda s: f"{s.title()} ({by_mode[s]})",
-            key="meta_status_specialist",
-        )
-        st.text(_meta_delegation_tree(ledger, selected))
+        st.text(_meta_delegation_tree(ledger))
 
     _delegation_tree_panel()
 

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -574,7 +574,7 @@ def _meta_delegation_tree(ledger: list) -> str:
         by_mode.setdefault(e.get("mode", "?"), []).append(e)
     glyphs = {"success": "✓", "error": "✗"}
     icons = {"analysis": "🧪", "planning": "📋"}
-    lines = ["🛰️ Mission control"]
+    lines = ["🎛️ Mission control"]
     modes = sorted(by_mode)
     for mi, mode in enumerate(modes):
         rows = by_mode[mode]

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -565,22 +565,39 @@ def _render_planning_status() -> None:
 
 
 def _meta_delegation_tree(ledger: list) -> str:
-    """Monospace mission-control → specialists → delegations tree.
+    """HTML monospace mission-control → specialists → delegations tree.
 
-    Shows every specialist branch at once — no selector.
+    Every specialist branch is shown at once; delegation rows are colored by
+    status. Returned as an HTML ``<pre>`` (so the box-drawing stays aligned)
+    inside a fixed-height scroll box, so a long session does not stretch the
+    sidebar.
     """
+    import html
+
+    GREY = "#8893a5"  # root / specialist headers — no status
+    status_colors = {
+        "success": "#3fb950",   # green
+        "error": "#f85149",     # red
+        "running": "#d29922",   # amber
+    }
+
     by_mode: dict = {}
     for e in ledger:
         by_mode.setdefault(e.get("mode", "?"), []).append(e)
     glyphs = {"success": "✓", "error": "✗"}
     icons = {"analysis": "🧪", "planning": "📋"}
-    lines = ["🎛️ Mission control"]
+
+    def _line(text: str, color: str) -> str:
+        return f'<span style="color:{color}">{html.escape(text)}</span>'
+
+    out = [_line("🎛️ Mission control", GREY)]
     modes = sorted(by_mode)
     for mi, mode in enumerate(modes):
         rows = by_mode[mode]
         last_mode = mi == len(modes) - 1
-        lines.append(f"{'└─' if last_mode else '├─'} {icons.get(mode, '•')} "
-                     f"{mode.title()}  ({len(rows)})")
+        out.append(_line(
+            f"{'└─' if last_mode else '├─'} {icons.get(mode, '•')} "
+            f"{mode.title()}  ({len(rows)})", GREY))
         cont = "   " if last_mode else "│  "
         for ri, e in enumerate(rows):
             rbranch = "└─" if ri == len(rows) - 1 else "├─"
@@ -590,12 +607,17 @@ def _meta_delegation_tree(ledger: list) -> str:
                 str(e.get("task") or "").split())
             if len(label) > 30:
                 label = label[:29] + "…"
-            glyph = glyphs.get(e.get("status"), "⋯")
+            status = e.get("status")
+            glyph = glyphs.get(status, "⋯")
             cf = e.get("context_from") or []
             cf_str = " ←" + ",".join(f"#{n}" for n in cf) if cf else ""
-            lines.append(f"{cont}{rbranch} #{e.get('index', '?')} "
-                         f"{label} {glyph}{cf_str}")
-    return "\n".join(lines)
+            out.append(_line(
+                f"{cont}{rbranch} #{e.get('index', '?')} "
+                f"{label} {glyph}{cf_str}",
+                status_colors.get(status, status_colors["running"])))
+    body = "\n".join(out)
+    return (f'<pre style="margin:0;font-size:0.8rem;line-height:1.45;'
+            f'white-space:pre;max-height:340px;overflow:auto">{body}</pre>')
 
 
 def _render_meta_status() -> None:
@@ -618,7 +640,7 @@ def _render_meta_status() -> None:
         if not ledger:
             st.info("No delegations yet — describe a goal and the meta routes it.")
             return
-        st.text(_meta_delegation_tree(ledger))
+        st.markdown(_meta_delegation_tree(ledger), unsafe_allow_html=True)
 
     _delegation_tree_panel()
 

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -250,8 +250,8 @@ def render_sidebar() -> None:
         # one-shot run_task, so the modes' step-by-step co-pilot does not
         # apply). Other modes keep the full three-level paradigm.
         _is_meta = st.session_state.app_mode == "meta"
-        _mode_opts = (["supervised", "autonomous"] if _is_meta
-                      else ["co-pilot", "supervised", "autonomous"])
+        _mode_opts = (["autopilot", "autonomous"] if _is_meta
+                      else ["co-pilot", "autopilot", "autonomous"])
         if st.session_state.get("cfg_mode") not in _mode_opts:
             st.session_state.cfg_mode = _mode_opts[0]
         mode = st.selectbox(
@@ -527,7 +527,7 @@ def _render_planning_status() -> None:
     """Show planning-specific agent status metrics."""
     objective = st.session_state.get("planning_objective", "")
     n_messages = len(st.session_state.chat_messages)
-    mode = st.session_state.agent_config.get("mode", "supervised")
+    mode = st.session_state.agent_config.get("mode", "autopilot")
 
     if objective:
         st.metric("Objective", objective[:40] + ("..." if len(objective) > 40 else ""))
@@ -628,7 +628,7 @@ def _init_analysis_agent(session_dir, api_key, model, base_url, mode, fh_api_key
 
     mode_map = {
         "co-pilot": AnalysisMode.CO_PILOT,
-        "supervised": AnalysisMode.SUPERVISED,
+        "autopilot": AnalysisMode.AUTOPILOT,
         "autonomous": AnalysisMode.AUTONOMOUS,
     }
     return AnalysisOrchestratorAgent(
@@ -651,7 +651,7 @@ def _init_planning_agent(session_dir, api_key, model, base_url, mode, fh_api_key
 
     mode_map = {
         "co-pilot": AutonomyLevel.CO_PILOT,
-        "supervised": AutonomyLevel.SUPERVISED,
+        "autopilot": AutonomyLevel.AUTOPILOT,
         "autonomous": AutonomyLevel.AUTONOMOUS,
     }
     objective = st.session_state.get("planning_objective", "").strip() or "Undefined Research Goal"
@@ -699,7 +699,7 @@ def _init_meta_agent(session_dir, api_key, model, base_url, mode, fh_api_key,
     )
 
     mode_map = {
-        "supervised": MetaMode.SUPERVISED,
+        "autopilot": MetaMode.AUTOPILOT,
         "autonomous": MetaMode.AUTONOMOUS,
     }
     kwargs = {}
@@ -830,7 +830,7 @@ def resume_session(
                 MetaOrchestratorAgent,
             )
             meta_mode_map = {
-                "supervised": MetaMode.SUPERVISED,
+                "autopilot": MetaMode.AUTOPILOT,
                 "autonomous": MetaMode.AUTONOMOUS,
             }
             kwargs = {}
@@ -854,7 +854,7 @@ def resume_session(
             )
             plan_mode_map = {
                 "co-pilot": AutonomyLevel.CO_PILOT,
-                "supervised": AutonomyLevel.SUPERVISED,
+                "autopilot": AutonomyLevel.AUTOPILOT,
                 "autonomous": AutonomyLevel.AUTONOMOUS,
             }
             kwargs = {}
@@ -878,7 +878,7 @@ def resume_session(
             )
             analysis_mode_map = {
                 "co-pilot": AnalysisMode.CO_PILOT,
-                "supervised": AnalysisMode.SUPERVISED,
+                "autopilot": AnalysisMode.AUTOPILOT,
                 "autonomous": AnalysisMode.AUTONOMOUS,
             }
             agent = AnalysisOrchestratorAgent.restore_from_checkpoint(

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -246,9 +246,17 @@ def render_sidebar() -> None:
             )
             st.caption("\u2139\ufe0f Leave blank to use the main API key")
 
+        # The meta-agent has only two autonomy levels (a delegation is a
+        # one-shot run_task, so the modes' step-by-step co-pilot does not
+        # apply). Other modes keep the full three-level paradigm.
+        _is_meta = st.session_state.app_mode == "meta"
+        _mode_opts = (["supervised", "autonomous"] if _is_meta
+                      else ["co-pilot", "supervised", "autonomous"])
+        if st.session_state.get("cfg_mode") not in _mode_opts:
+            st.session_state.cfg_mode = _mode_opts[0]
         mode = st.selectbox(
             "Autonomy mode",
-            ["co-pilot", "supervised", "autonomous"],
+            _mode_opts,
             key="cfg_mode",
             disabled=_locked,
         )
@@ -373,6 +381,8 @@ def render_sidebar() -> None:
                 _render_analyze_status()
             elif app_mode == "plan":
                 _render_planning_status()
+            elif app_mode == "meta":
+                _render_meta_status()
 
         # ── Vibes ──────────────────────────────────────────
         st.divider()
@@ -525,6 +535,21 @@ def _render_planning_status() -> None:
     st.metric("Autonomy", mode.replace("-", " ").title())
 
 
+def _render_meta_status() -> None:
+    """Show meta-agent status metrics."""
+    agent = st.session_state.agent
+    children = getattr(agent, "_children", {}) or {}
+    ledger = getattr(agent, "_delegation_ledger", []) or []
+    mode = st.session_state.agent_config.get("mode", "co-pilot")
+
+    row_c1, row_c2 = st.columns(2)
+    with row_c1:
+        st.metric("Delegations", len(ledger))
+    with row_c2:
+        st.metric("Autonomy", mode.replace("-", " ").title())
+    st.metric("Specialists Active", ", ".join(sorted(children)) or "None")
+
+
 # ── helpers ──────────────────────────────────────────────────────
 
 def start_session(model: str, api_key: str, base_url: str, mode: str, fh_api_key: str = "", mp_api_key: str = "", embedding_model: str = None, embedding_api_key: str = None) -> None:
@@ -562,7 +587,13 @@ def start_session(model: str, api_key: str, base_url: str, mode: str, fh_api_key
     executors._GLOBAL_SANDBOX_APPROVED = True
 
     try:
-        if app_mode == "plan":
+        if app_mode == "meta":
+            agent = _init_meta_agent(
+                session_dir, resolved_key, model, base_url, mode, fh_api_key,
+                embedding_model=embedding_model,
+                embedding_api_key=embedding_api_key,
+            )
+        elif app_mode == "plan":
             agent = _init_planning_agent(
                 session_dir, resolved_key, model, base_url, mode, fh_api_key,
                 embedding_model=embedding_model,
@@ -651,6 +682,39 @@ def _init_planning_agent(session_dir, api_key, model, base_url, mode, fh_api_key
         knowledge_dir=str(knowledge_dir),
         code_dir=str(code_dir),
         data_dir=str(data_dir),
+        **kwargs,
+    )
+
+
+def _init_meta_agent(session_dir, api_key, model, base_url, mode, fh_api_key,
+                     embedding_model=None, embedding_api_key=None):
+    """Create a MetaOrchestratorAgent.
+
+    Child orchestrators are created lazily by the meta-agent on first
+    delegation, in fixed sub-directories of the meta session.
+    """
+    from scilink.agents.meta_agent.meta_orchestrator import (
+        MetaMode,
+        MetaOrchestratorAgent,
+    )
+
+    mode_map = {
+        "supervised": MetaMode.SUPERVISED,
+        "autonomous": MetaMode.AUTONOMOUS,
+    }
+    kwargs = {}
+    if embedding_model:
+        kwargs["embedding_model"] = embedding_model
+    if embedding_api_key:
+        kwargs["embedding_api_key"] = embedding_api_key
+
+    return MetaOrchestratorAgent(
+        base_dir=str(session_dir),
+        api_key=api_key,
+        model_name=model,
+        base_url=base_url or None,
+        meta_mode=mode_map[mode],
+        futurehouse_api_key=fh_api_key or None,
         **kwargs,
     )
 
@@ -760,7 +824,30 @@ def resume_session(
     app_mode = st.session_state.app_mode or "analyze"
 
     try:
-        if app_mode == "plan":
+        if app_mode == "meta":
+            from scilink.agents.meta_agent.meta_orchestrator import (
+                MetaMode,
+                MetaOrchestratorAgent,
+            )
+            meta_mode_map = {
+                "supervised": MetaMode.SUPERVISED,
+                "autonomous": MetaMode.AUTONOMOUS,
+            }
+            kwargs = {}
+            if embedding_model:
+                kwargs["embedding_model"] = embedding_model
+            if embedding_api_key:
+                kwargs["embedding_api_key"] = embedding_api_key
+            agent = MetaOrchestratorAgent.restore_from_checkpoint(
+                base_dir=str(session_path),
+                api_key=resolved_key,
+                model_name=model,
+                base_url=base_url or None,
+                meta_mode=meta_mode_map[mode],
+                futurehouse_api_key=fh_api_key or None,
+                **kwargs,
+            )
+        elif app_mode == "plan":
             from scilink.agents.planning_agents.planning_orchestrator import (
                 AutonomyLevel,
                 PlanningOrchestratorAgent,

--- a/scilink/ui/components/telemetry.py
+++ b/scilink/ui/components/telemetry.py
@@ -7,6 +7,8 @@ ledger and a per-agent tool-call sequence back it underneath. Refreshes on the
 sidebar delegation tree's cadence (2s while a chat task runs).
 """
 
+from pathlib import Path
+
 import streamlit as st
 
 from scilink.agents.meta_agent.telemetry import collect_session_telemetry
@@ -215,9 +217,19 @@ def _tool_sequence_section(sequence: dict) -> None:
         st.dataframe(pd.DataFrame(rows), use_container_width=True,
                      hide_index=True)
         src = entry.get("source")
-        if src:
-            st.caption("Chat-history file")
-            st.code(src, language=None, wrap_lines=True)
+        if src and Path(src).is_file():
+            try:
+                history = Path(src).read_text()
+            except Exception:  # noqa: BLE001
+                history = None
+            if history:
+                st.download_button(
+                    "Download full history",
+                    data=history,
+                    file_name=f"{key}_chat_history.json",
+                    mime="application/json",
+                    key=f"telemetry_dl_{key}",
+                )
     if not shown:
         st.caption("No tool calls recorded yet.")
 

--- a/scilink/ui/components/telemetry.py
+++ b/scilink/ui/components/telemetry.py
@@ -60,13 +60,7 @@ def render_telemetry_tab() -> None:
         st.caption("Grey edge = meta dispatched the delegation.  "
                    "Blue edge = a delegation's result fed the next as context.")
 
-        # ── Summary tables ───────────────────────────────────────────
-        st.subheader("Specialists")
-        _specialists_table(tel.get("specialists", {}))
-
-        st.subheader("Worker agents")
-        _workers_table(agents)
-
+        # ── Delegation ledger ────────────────────────────────────────
         st.subheader("Delegation ledger")
         _ledger_table(delegations)
 
@@ -134,7 +128,7 @@ def _delegation_graph_dot(meta: dict, sub_agents: dict) -> str:
     return "\n".join(out)
 
 
-# ── summary tables ───────────────────────────────────────────────────
+# ── tables ───────────────────────────────────────────────────────────
 
 def _short_time(ts) -> str:
     """ISO timestamp -> HH:MM:SS (keeps the table narrow)."""
@@ -142,45 +136,6 @@ def _short_time(ts) -> str:
         return ""
     s = str(ts)
     return s.split("T", 1)[1][:8] if "T" in s else s
-
-
-def _specialists_table(specs: dict) -> None:
-    import pandas as pd
-
-    rows = []
-    for name in ("analysis", "planning"):
-        info = specs.get(name, {})
-        if not info.get("instantiated"):
-            rows.append({"specialist": name, "messages": "—",
-                         "work": "not engaged"})
-            continue
-        if name == "analysis":
-            work = f"{info.get('analyses_run', 0)} analysis run(s)"
-        else:
-            targets = info.get("optimization_targets", [])
-            work = (f"{info.get('bo_data_points', 0)} BO data points"
-                    + (f" · targets: {', '.join(targets)}" if targets else ""))
-        rows.append({"specialist": name,
-                     "messages": info.get("message_count", 0), "work": work})
-    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
-
-
-def _workers_table(agents: list) -> None:
-    import pandas as pd
-
-    if not agents:
-        st.caption("No worker agents have run yet.")
-        return
-    rows = [{
-        "agent": a.get("name"),
-        "specialist": a.get("specialist"),
-        "actions": a.get("action_count", 0),
-        "✓": a.get("outcomes", {}).get("success", 0),
-        "✗": a.get("outcomes", {}).get("error", 0),
-        "first": _short_time(a.get("first_timestamp")),
-        "last": _short_time(a.get("last_timestamp")),
-    } for a in agents]
-    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
 
 
 def _ledger_table(delegations: list) -> None:

--- a/scilink/ui/components/telemetry.py
+++ b/scilink/ui/components/telemetry.py
@@ -8,8 +8,6 @@ ledger, a per-agent tool-call sequence, and a detailed per-action breakdown
 delegation tree's cadence (2s while a chat task runs).
 """
 
-import json
-
 import streamlit as st
 
 from scilink.agents.meta_agent.telemetry import collect_session_telemetry
@@ -175,19 +173,45 @@ _LAYER_LABELS = [
 ]
 
 
-def _compact_args(args, limit: int = 120) -> str:
-    """One-line, truncated rendering of a tool call's arguments."""
-    if not args:
-        return ""
-    try:
-        s = json.dumps(args, default=str, ensure_ascii=False)
-    except Exception:  # noqa: BLE001
-        s = str(args)
+def _type_name(v) -> str:
+    """Short type label for one value — no content, just the type."""
+    if v is None:
+        return "null"
+    if isinstance(v, bool):
+        return "bool"
+    if isinstance(v, int):
+        return "int"
+    if isinstance(v, float):
+        return "float"
+    if isinstance(v, str):
+        return "str"
+    if isinstance(v, list):
+        return f"list[{len(v)}]"
+    if isinstance(v, dict):
+        return f"dict[{len(v)}]"
+    return type(v).__name__
+
+
+def _type_summary(obj, limit: int = 220) -> str:
+    """Type signature of a value — for a dict, its keys mapped to value types;
+    otherwise the bare type. Shows the shape without the actual content."""
+    if obj is None:
+        return "—"
+    if isinstance(obj, dict):
+        if not obj:
+            return "{}"
+        s = "{" + ", ".join(f"{k}: {_type_name(v)}"
+                             for k, v in obj.items()) + "}"
+    elif isinstance(obj, list):
+        s = f"list[{len(obj)}]"
+    else:
+        s = _type_name(obj)
     return s if len(s) <= limit else s[:limit - 1] + "…"
 
 
 def _tool_sequence_section(sequence: dict) -> None:
-    """Per-agent ordered tool-call list — the full sequence of tools run."""
+    """Per-agent ordered tool calls — input/output types and whether each tool
+    worked, derived from its result."""
     import pandas as pd
 
     shown = False
@@ -198,9 +222,13 @@ def _tool_sequence_section(sequence: dict) -> None:
             continue
         shown = True
         st.markdown(f"**{label}** — {len(calls)} tool call(s)")
-        rows = [{"#": i, "tool": c.get("tool"),
-                 "arguments": _compact_args(c.get("args"))}
-                for i, c in enumerate(calls, 1)]
+        rows = [{
+            "#": i,
+            "tool": c.get("tool"),
+            "input": _type_summary(c.get("args")),
+            "output": _type_summary(c.get("result")),
+            "status": c.get("status", "—"),
+        } for i, c in enumerate(calls, 1)]
         st.dataframe(pd.DataFrame(rows), use_container_width=True,
                      hide_index=True)
         src = entry.get("source")
@@ -235,21 +263,12 @@ def _worker_breakdown(ag: dict) -> None:
             if rationale:
                 st.caption("Reasoning")
                 st.write(rationale)
-            _input = ac.get("input")
-            _result = ac.get("result")
-            ci, co = st.columns(2)
-            with ci:
-                st.caption("Input")
-                if _input:
-                    st.json(_input, expanded=True)
-                else:
-                    st.caption("— none recorded —")
-            with co:
-                st.caption("Output")
-                if _result:
-                    st.json(_result, expanded=True)
-                else:
-                    st.caption("— none recorded —")
+            st.caption("Input types")
+            st.code(_type_summary(ac.get("input"), limit=600),
+                    language=None, wrap_lines=True)
+            st.caption("Output types")
+            st.code(_type_summary(ac.get("result"), limit=600),
+                    language=None, wrap_lines=True)
             feedback = ac.get("feedback")
             if feedback:
                 st.caption("Feedback")

--- a/scilink/ui/components/telemetry.py
+++ b/scilink/ui/components/telemetry.py
@@ -71,12 +71,12 @@ def render_telemetry_tab() -> None:
         st.caption("Every tool call each agent's LLM made, in order.")
         _tool_sequence_section(tel.get("tool_sequence", {}))
 
-        # ── Detailed breakdown ───────────────────────────────────────
-        st.subheader("Detailed breakdown")
-        st.caption("Per worker agent: every logged action with its inputs, "
-                   "outputs and reasoning.")
+        # ── Sub-agent activity ───────────────────────────────────────
+        st.subheader("Sub-agent activity")
+        st.caption("Each worker sub-agent's logged operations — inputs, "
+                   "outputs, reasoning — with a link to its full state file.")
         if not agents:
-            st.caption("No worker actions recorded yet.")
+            st.caption("No sub-agent operations recorded yet.")
         for ag in agents:
             _worker_breakdown(ag)
 
@@ -192,7 +192,8 @@ def _tool_sequence_section(sequence: dict) -> None:
 
     shown = False
     for key, label in _LAYER_LABELS:
-        calls = sequence.get(key) or []
+        entry = sequence.get(key) or {}
+        calls = entry.get("calls") or []
         if not calls:
             continue
         shown = True
@@ -202,6 +203,10 @@ def _tool_sequence_section(sequence: dict) -> None:
                 for i, c in enumerate(calls, 1)]
         st.dataframe(pd.DataFrame(rows), use_container_width=True,
                      hide_index=True)
+        src = entry.get("source")
+        if src:
+            st.caption("Chat-history file")
+            st.code(src, language=None, wrap_lines=True)
     if not shown:
         st.caption("No tool calls recorded yet.")
 
@@ -215,6 +220,10 @@ def _worker_breakdown(ag: dict) -> None:
              f"{ag.get('action_count', 0)} action(s)  "
              f"({oc.get('success', 0)}✓ / {oc.get('error', 0)}✗)")
     with st.expander(title):
+        src = ag.get("source_file")
+        if src:
+            st.caption("State file")
+            st.code(src, language=None, wrap_lines=True)
         actions = ag.get("actions", [])
         for i, ac in enumerate(actions, 1):
             st.markdown(
@@ -255,6 +264,10 @@ def _analysis_report(rep: dict) -> None:
     title = (f"{rep.get('analysis_id', 'analysis')}  ·  "
              f"{len(claims)} claim(s)  ·  {rep.get('status', '—')}")
     with st.expander(title):
+        src = rep.get("report_file")
+        if src:
+            st.caption("Results file")
+            st.code(src, language=None, wrap_lines=True)
         detailed = rep.get("detailed_analysis")
         if detailed:
             st.markdown(detailed)

--- a/scilink/ui/components/telemetry.py
+++ b/scilink/ui/components/telemetry.py
@@ -2,11 +2,13 @@
 
 Explore (meta) mode only. A compact, status-colored dependency graph of the
 delegation ledger (meta -> delegations, annotated with the sub-agent each mode
-selected, plus the `context_from` provenance edges) sits on top; dense summary
-tables and a detailed per-action breakdown (inputs, outputs, reasoning) back it
-underneath. Refreshes on the sidebar delegation tree's cadence (2s while a chat
-task runs).
+selected, plus the `context_from` provenance edges) sits on top; the delegation
+ledger, a per-agent tool-call sequence, and a detailed per-action breakdown
+(inputs, outputs, reasoning) back it underneath. Refreshes on the sidebar
+delegation tree's cadence (2s while a chat task runs).
 """
+
+import json
 
 import streamlit as st
 
@@ -63,6 +65,11 @@ def render_telemetry_tab() -> None:
         # ── Delegation ledger ────────────────────────────────────────
         st.subheader("Delegation ledger")
         _ledger_table(delegations)
+
+        # ── Tool sequence ────────────────────────────────────────────
+        st.subheader("Tool sequence")
+        st.caption("Every tool call each agent's LLM made, in order.")
+        _tool_sequence_section(tel.get("tool_sequence", {}))
 
         # ── Detailed breakdown ───────────────────────────────────────
         st.subheader("Detailed breakdown")
@@ -157,6 +164,46 @@ def _ledger_table(delegations: list) -> None:
             "completed": _short_time(d.get("completed_at")),
         })
     st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+
+
+# ── tool sequence ────────────────────────────────────────────────────
+
+_LAYER_LABELS = [
+    ("meta", "Meta-agent"),
+    ("analysis", "Analysis specialist"),
+    ("planning", "Planning specialist"),
+]
+
+
+def _compact_args(args, limit: int = 120) -> str:
+    """One-line, truncated rendering of a tool call's arguments."""
+    if not args:
+        return ""
+    try:
+        s = json.dumps(args, default=str, ensure_ascii=False)
+    except Exception:  # noqa: BLE001
+        s = str(args)
+    return s if len(s) <= limit else s[:limit - 1] + "…"
+
+
+def _tool_sequence_section(sequence: dict) -> None:
+    """Per-agent ordered tool-call list — the full sequence of tools run."""
+    import pandas as pd
+
+    shown = False
+    for key, label in _LAYER_LABELS:
+        calls = sequence.get(key) or []
+        if not calls:
+            continue
+        shown = True
+        st.markdown(f"**{label}** — {len(calls)} tool call(s)")
+        rows = [{"#": i, "tool": c.get("tool"),
+                 "arguments": _compact_args(c.get("args"))}
+                for i, c in enumerate(calls, 1)]
+        st.dataframe(pd.DataFrame(rows), use_container_width=True,
+                     hide_index=True)
+    if not shown:
+        st.caption("No tool calls recorded yet.")
 
 
 # ── detailed breakdown ───────────────────────────────────────────────

--- a/scilink/ui/components/telemetry.py
+++ b/scilink/ui/components/telemetry.py
@@ -224,13 +224,21 @@ def _worker_breakdown(ag: dict) -> None:
             if rationale:
                 st.caption("Reasoning")
                 st.write(rationale)
+            _input = ac.get("input")
+            _result = ac.get("result")
             ci, co = st.columns(2)
             with ci:
                 st.caption("Input")
-                st.json(ac.get("input") or {}, expanded=False)
+                if _input:
+                    st.json(_input, expanded=True)
+                else:
+                    st.caption("— none recorded —")
             with co:
                 st.caption("Output")
-                st.json(ac.get("result") or {}, expanded=False)
+                if _result:
+                    st.json(_result, expanded=True)
+                else:
+                    st.caption("— none recorded —")
             feedback = ac.get("feedback")
             if feedback:
                 st.caption("Feedback")

--- a/scilink/ui/components/telemetry.py
+++ b/scilink/ui/components/telemetry.py
@@ -1,0 +1,123 @@
+"""Telemetry tab — live snapshot of meta + specialist + worker-agent state.
+
+Explore (meta) mode only. Reads ``collect_session_telemetry`` and renders it
+with native Streamlit widgets, refreshing on the same cadence as the sidebar
+delegation tree (2s while a chat task runs).
+"""
+
+import streamlit as st
+
+from scilink.agents.meta_agent.telemetry import collect_session_telemetry
+
+_SPECIALIST_TITLES = {"analysis": "🧪 Analysis", "planning": "📋 Planning"}
+
+
+def render_telemetry_tab() -> None:
+    """Render the Explore-mode Telemetry tab."""
+    task = st.session_state.get("chat_task")
+    _interval = "2s" if (task is not None
+                         and getattr(task, "is_running", False)) else None
+
+    @st.fragment(run_every=_interval)
+    def _panel() -> None:
+        agent = st.session_state.get("agent")
+        if agent is None or not hasattr(agent, "_delegation_ledger"):
+            st.info("Telemetry is available once an Explore session is running.")
+            return
+
+        tel = collect_session_telemetry(agent)
+        meta = tel.get("meta", {})
+
+        # ── Meta header ──────────────────────────────────────────────
+        c1, c2, c3 = st.columns(3)
+        c1.metric("Mode", str(meta.get("meta_mode", "—")).title())
+        c2.metric("Delegations", meta.get("delegations_total", 0))
+        c3.metric("Worker agents", len(tel.get("agents", [])))
+        st.caption(f"Session: {meta.get('session_dir', '—')}")
+
+        if not meta.get("delegations"):
+            st.info("No delegations yet — describe a goal and the meta "
+                    "routes it to a specialist.")
+            return
+
+        # ── Specialist cards ─────────────────────────────────────────
+        st.subheader("Specialists")
+        specs = tel.get("specialists", {})
+        for col, name in zip(st.columns(2), ("analysis", "planning")):
+            with col:
+                _specialist_card(name, specs.get(name, {}))
+
+        # ── Worker action histories ──────────────────────────────────
+        st.subheader("Worker activity")
+        agents = tel.get("agents", [])
+        if not agents:
+            st.caption("No worker actions recorded yet.")
+        for ag in agents:
+            _worker_expander(ag)
+
+        # ── Delegation ledger ────────────────────────────────────────
+        st.subheader("Delegation ledger")
+        _ledger_table(meta.get("delegations", []))
+
+    _panel()
+
+
+def _specialist_card(name: str, info: dict) -> None:
+    """One bordered card summarizing a specialist orchestrator."""
+    title = _SPECIALIST_TITLES.get(name, name.title())
+    with st.container(border=True):
+        st.markdown(f"**{title}**")
+        if not info.get("instantiated"):
+            st.caption("Not yet engaged.")
+            return
+        st.caption(f"{info.get('message_count', 0)} messages")
+        if name == "analysis":
+            st.metric("Analyses run", info.get("analyses_run", 0))
+        else:
+            st.metric("BO data points", info.get("bo_data_points", 0))
+            targets = info.get("optimization_targets", [])
+            if targets:
+                st.caption("Targets: " + ", ".join(str(t) for t in targets))
+
+
+def _worker_expander(ag: dict) -> None:
+    """One expander with a worker agent's action_history table."""
+    import pandas as pd
+
+    oc = ag.get("outcomes", {})
+    title = (f"{ag.get('name', '?')} — {ag.get('action_count', 0)} actions  "
+             f"({oc.get('success', 0)}✓ / {oc.get('error', 0)}✗)")
+    with st.expander(title):
+        by_type = ag.get("actions_by_type", {})
+        st.caption(
+            f"Specialist: {ag.get('specialist', '—')}"
+            + ("  ·  " + ", ".join(f"{k}×{v}" for k, v in by_type.items())
+               if by_type else "")
+        )
+        rows = ag.get("actions", [])
+        if rows:
+            df = pd.DataFrame(rows, columns=["timestamp", "action",
+                                             "status", "rationale"])
+            st.dataframe(df, use_container_width=True, hide_index=True)
+
+
+def _ledger_table(delegations: list) -> None:
+    """The delegation ledger as a flat table (richer than the sidebar tree)."""
+    import pandas as pd
+
+    rows = []
+    for d in delegations:
+        cf = d.get("context_from") or []
+        rows.append({
+            "#": d.get("index"),
+            "specialist": d.get("mode"),
+            "task": d.get("label"),
+            "status": d.get("status"),
+            "context from": ", ".join(f"#{n}" for n in cf) if cf else "",
+            "files": d.get("files", 0),
+            "feature tables": d.get("feature_tables", 0),
+            "warnings": d.get("warnings", 0),
+            "started": d.get("timestamp"),
+            "completed": d.get("completed_at"),
+        })
+    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)

--- a/scilink/ui/components/telemetry.py
+++ b/scilink/ui/components/telemetry.py
@@ -3,9 +3,8 @@
 Explore (meta) mode only. A compact, status-colored dependency graph of the
 delegation ledger (meta -> delegations, annotated with the sub-agent each mode
 selected, plus the `context_from` provenance edges) sits on top; the delegation
-ledger, a per-agent tool-call sequence, and a detailed per-action breakdown
-(inputs, outputs, reasoning) back it underneath. Refreshes on the sidebar
-delegation tree's cadence (2s while a chat task runs).
+ledger and a per-agent tool-call sequence back it underneath. Refreshes on the
+sidebar delegation tree's cadence (2s while a chat task runs).
 """
 
 import streamlit as st
@@ -39,11 +38,10 @@ def render_telemetry_tab() -> None:
         agents = tel.get("agents", [])
         delegations = meta.get("delegations", [])
 
-        total_actions = sum(a.get("action_count", 0) for a in agents)
         st.markdown(
             f"**{str(meta.get('meta_mode', '—')).title()}**  ·  "
             f"{meta.get('delegations_total', 0)} delegations  ·  "
-            f"{len(agents)} worker agents  ·  {total_actions} actions logged"
+            f"{len(agents)} worker agents"
         )
         st.caption(f"Session: {meta.get('session_dir', '—')}")
 
@@ -68,21 +66,6 @@ def render_telemetry_tab() -> None:
         st.subheader("Tool sequence")
         st.caption("Every tool call each agent's LLM made, in order.")
         _tool_sequence_section(tel.get("tool_sequence", {}))
-
-        # ── Sub-agent activity ───────────────────────────────────────
-        st.subheader("Sub-agent activity")
-        st.caption("Each worker sub-agent's logged operations — inputs, "
-                   "outputs, reasoning — with a link to its full state file.")
-        if not agents:
-            st.caption("No sub-agent operations recorded yet.")
-        for ag in agents:
-            _worker_breakdown(ag)
-
-        reports = tel.get("analysis_reports", [])
-        if reports:
-            st.markdown("**Analysis reasoning**")
-            for rep in reports:
-                _analysis_report(rep)
 
     _panel()
 
@@ -239,60 +222,3 @@ def _tool_sequence_section(sequence: dict) -> None:
         st.caption("No tool calls recorded yet.")
 
 
-# ── detailed breakdown ───────────────────────────────────────────────
-
-def _worker_breakdown(ag: dict) -> None:
-    """One expander per worker agent: every action with input/output/reason."""
-    oc = ag.get("outcomes", {})
-    title = (f"{ag.get('name', '?')}  ·  {ag.get('specialist', '—')}  ·  "
-             f"{ag.get('action_count', 0)} action(s)  "
-             f"({oc.get('success', 0)}✓ / {oc.get('error', 0)}✗)")
-    with st.expander(title):
-        src = ag.get("source_file")
-        if src:
-            st.caption("State file")
-            st.code(src, language=None, wrap_lines=True)
-        actions = ag.get("actions", [])
-        for i, ac in enumerate(actions, 1):
-            st.markdown(
-                f"**{i}. `{ac.get('action', '?')}`**  ·  "
-                f"`{ac.get('status', '—')}`  ·  "
-                f"{_short_time(ac.get('timestamp'))}"
-            )
-            rationale = ac.get("rationale")
-            if rationale:
-                st.caption("Reasoning")
-                st.write(rationale)
-            st.caption("Input types")
-            st.code(_type_summary(ac.get("input"), limit=600),
-                    language=None, wrap_lines=True)
-            st.caption("Output types")
-            st.code(_type_summary(ac.get("result"), limit=600),
-                    language=None, wrap_lines=True)
-            feedback = ac.get("feedback")
-            if feedback:
-                st.caption("Feedback")
-                st.write(feedback)
-            if i < len(actions):
-                st.divider()
-
-
-def _analysis_report(rep: dict) -> None:
-    """One expander per analysis run: its detailed reasoning + claims."""
-    claims = rep.get("claims", [])
-    title = (f"{rep.get('analysis_id', 'analysis')}  ·  "
-             f"{len(claims)} claim(s)  ·  {rep.get('status', '—')}")
-    with st.expander(title):
-        src = rep.get("report_file")
-        if src:
-            st.caption("Results file")
-            st.code(src, language=None, wrap_lines=True)
-        detailed = rep.get("detailed_analysis")
-        if detailed:
-            st.markdown(detailed)
-        if claims:
-            st.caption("Scientific claims")
-            for c in claims:
-                st.markdown(f"- **{c.get('claim', '')}**")
-                if c.get("impact"):
-                    st.caption(c["impact"])

--- a/scilink/ui/components/telemetry.py
+++ b/scilink/ui/components/telemetry.py
@@ -1,9 +1,11 @@
 """Telemetry tab — live snapshot of meta + specialist + worker-agent state.
 
-Explore (meta) mode only. A status-colored dependency graph of the delegation
-ledger (meta -> delegations, with the `context_from` provenance edges) sits on
-top; dense detail tables back it underneath. Refreshes on the same cadence as
-the sidebar delegation tree (2s while a chat task runs).
+Explore (meta) mode only. A compact, status-colored dependency graph of the
+delegation ledger (meta -> delegations, annotated with the sub-agent each mode
+selected, plus the `context_from` provenance edges) sits on top; dense summary
+tables and a detailed per-action breakdown (inputs, outputs, reasoning) back it
+underneath. Refreshes on the sidebar delegation tree's cadence (2s while a chat
+task runs).
 """
 
 import streamlit as st
@@ -51,25 +53,37 @@ def render_telemetry_tab() -> None:
             return
 
         # ── Dependency graph ─────────────────────────────────────────
-        st.graphviz_chart(_delegation_graph_dot(meta), use_container_width=True)
+        st.graphviz_chart(
+            _delegation_graph_dot(meta, tel.get("sub_agents", {})),
+            width="content",
+        )
         st.caption("Grey edge = meta dispatched the delegation.  "
                    "Blue edge = a delegation's result fed the next as context.")
 
-        # ── Specialists ──────────────────────────────────────────────
+        # ── Summary tables ───────────────────────────────────────────
         st.subheader("Specialists")
         _specialists_table(tel.get("specialists", {}))
 
-        # ── Worker agents ────────────────────────────────────────────
         st.subheader("Worker agents")
         _workers_table(agents)
 
-        # ── Every logged action ──────────────────────────────────────
-        st.subheader("Worker activity")
-        _actions_table(agents)
-
-        # ── Delegation ledger ────────────────────────────────────────
         st.subheader("Delegation ledger")
         _ledger_table(delegations)
+
+        # ── Detailed breakdown ───────────────────────────────────────
+        st.subheader("Detailed breakdown")
+        st.caption("Per worker agent: every logged action with its inputs, "
+                   "outputs and reasoning.")
+        if not agents:
+            st.caption("No worker actions recorded yet.")
+        for ag in agents:
+            _worker_breakdown(ag)
+
+        reports = tel.get("analysis_reports", [])
+        if reports:
+            st.markdown("**Analysis reasoning**")
+            for rep in reports:
+                _analysis_report(rep)
 
     _panel()
 
@@ -80,24 +94,35 @@ def _dot_escape(text) -> str:
     return str(text).replace("\\", "\\\\").replace('"', '\\"')
 
 
-def _delegation_graph_dot(meta: dict) -> str:
-    """DOT string: meta-agent root -> delegation nodes (colored by status),
-    with dispatch edges and `context_from` provenance edges."""
+def _truncate(text, limit: int) -> str:
+    text = str(text or "")
+    return text if len(text) <= limit else text[:limit - 1] + "…"
+
+
+def _delegation_graph_dot(meta: dict, sub_agents: dict) -> str:
+    """DOT string: meta-agent root -> delegation nodes (colored by status,
+    annotated with the sub-agent(s) the mode used), with dispatch edges and
+    `context_from` provenance edges. Kept compact via tight spacing + a size
+    cap so it does not dominate the tab."""
     dels = meta.get("delegations", [])
     out = [
         "digraph telemetry {",
-        '  rankdir=TB; bgcolor="transparent"; pad=0.2;',
+        '  rankdir=TB; bgcolor="transparent"; pad=0.15;',
+        '  size="7,4.5"; ratio=compress; ranksep=0.32; nodesep=0.22;',
         '  node [shape=box, style="filled,rounded", fontname="Helvetica", '
-        'fontsize=10, color="#30363d", fontcolor="white"];',
-        '  edge [fontname="Helvetica", fontsize=8];',
-        f'  meta [label="Meta-agent\\n({_dot_escape(str(meta.get("meta_mode", "")).title())})", '
+        'fontsize=9, margin="0.11,0.05", color="#30363d", fontcolor="white"];',
+        '  edge [fontname="Helvetica", fontsize=8, arrowsize=0.7];',
+        f'  meta [label="Meta-agent ({_dot_escape(str(meta.get("meta_mode", "")).title())})", '
         'fillcolor="#30363d"];',
     ]
     for d in dels:
         idx = d.get("index")
         fill = _STATUS_FILL.get(d.get("status"), _DEFAULT_FILL)
+        subs = sub_agents.get(d.get("mode"), [])
+        sub_line = ("\\n↳ " + _dot_escape(_truncate(", ".join(subs), 32))
+                    if subs else "")
         label = (f'#{idx} · {_dot_escape(d.get("mode", "?"))}\\n'
-                 f'{_dot_escape(d.get("label", ""))}')
+                 f'{_dot_escape(_truncate(d.get("label", ""), 24))}{sub_line}')
         out.append(f'  d{idx} [label="{label}", fillcolor="{fill}"];')
     for d in dels:                                   # dispatch edges
         out.append(f'  meta -> d{d.get("index")} [color="#8893a5"];')
@@ -109,7 +134,7 @@ def _delegation_graph_dot(meta: dict) -> str:
     return "\n".join(out)
 
 
-# ── tables ───────────────────────────────────────────────────────────
+# ── summary tables ───────────────────────────────────────────────────
 
 def _short_time(ts) -> str:
     """ISO timestamp -> HH:MM:SS (keeps the table narrow)."""
@@ -158,30 +183,6 @@ def _workers_table(agents: list) -> None:
     st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
 
 
-def _actions_table(agents: list) -> None:
-    """Every logged action across all workers, newest first."""
-    import pandas as pd
-
-    rows = []
-    for a in agents:
-        for ac in a.get("actions", []):
-            rows.append({
-                "time": _short_time(ac.get("timestamp")),
-                "specialist": a.get("specialist"),
-                "agent": a.get("name"),
-                "action": ac.get("action"),
-                "status": ac.get("status"),
-                "rationale": ac.get("rationale"),
-                "_sort": ac.get("timestamp") or "",
-            })
-    if not rows:
-        st.caption("No worker actions recorded yet.")
-        return
-    rows.sort(key=lambda r: r["_sort"], reverse=True)
-    df = pd.DataFrame(rows).drop(columns=["_sort"])
-    st.dataframe(df, use_container_width=True, hide_index=True)
-
-
 def _ledger_table(delegations: list) -> None:
     import pandas as pd
 
@@ -201,3 +202,55 @@ def _ledger_table(delegations: list) -> None:
             "completed": _short_time(d.get("completed_at")),
         })
     st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+
+
+# ── detailed breakdown ───────────────────────────────────────────────
+
+def _worker_breakdown(ag: dict) -> None:
+    """One expander per worker agent: every action with input/output/reason."""
+    oc = ag.get("outcomes", {})
+    title = (f"{ag.get('name', '?')}  ·  {ag.get('specialist', '—')}  ·  "
+             f"{ag.get('action_count', 0)} action(s)  "
+             f"({oc.get('success', 0)}✓ / {oc.get('error', 0)}✗)")
+    with st.expander(title):
+        actions = ag.get("actions", [])
+        for i, ac in enumerate(actions, 1):
+            st.markdown(
+                f"**{i}. `{ac.get('action', '?')}`**  ·  "
+                f"`{ac.get('status', '—')}`  ·  "
+                f"{_short_time(ac.get('timestamp'))}"
+            )
+            rationale = ac.get("rationale")
+            if rationale:
+                st.caption("Reasoning")
+                st.write(rationale)
+            ci, co = st.columns(2)
+            with ci:
+                st.caption("Input")
+                st.json(ac.get("input") or {}, expanded=False)
+            with co:
+                st.caption("Output")
+                st.json(ac.get("result") or {}, expanded=False)
+            feedback = ac.get("feedback")
+            if feedback:
+                st.caption("Feedback")
+                st.write(feedback)
+            if i < len(actions):
+                st.divider()
+
+
+def _analysis_report(rep: dict) -> None:
+    """One expander per analysis run: its detailed reasoning + claims."""
+    claims = rep.get("claims", [])
+    title = (f"{rep.get('analysis_id', 'analysis')}  ·  "
+             f"{len(claims)} claim(s)  ·  {rep.get('status', '—')}")
+    with st.expander(title):
+        detailed = rep.get("detailed_analysis")
+        if detailed:
+            st.markdown(detailed)
+        if claims:
+            st.caption("Scientific claims")
+            for c in claims:
+                st.markdown(f"- **{c.get('claim', '')}**")
+                if c.get("impact"):
+                    st.caption(c["impact"])

--- a/scilink/ui/components/telemetry.py
+++ b/scilink/ui/components/telemetry.py
@@ -1,15 +1,22 @@
 """Telemetry tab — live snapshot of meta + specialist + worker-agent state.
 
-Explore (meta) mode only. Reads ``collect_session_telemetry`` and renders it
-with native Streamlit widgets, refreshing on the same cadence as the sidebar
-delegation tree (2s while a chat task runs).
+Explore (meta) mode only. A status-colored dependency graph of the delegation
+ledger (meta -> delegations, with the `context_from` provenance edges) sits on
+top; dense detail tables back it underneath. Refreshes on the same cadence as
+the sidebar delegation tree (2s while a chat task runs).
 """
 
 import streamlit as st
 
 from scilink.agents.meta_agent.telemetry import collect_session_telemetry
 
-_SPECIALIST_TITLES = {"analysis": "🧪 Analysis", "planning": "📋 Planning"}
+# Same palette as the sidebar delegation tree, for consistency.
+_STATUS_FILL = {
+    "success": "#3fb950",   # green
+    "error": "#f85149",     # red
+    "running": "#d29922",   # amber
+}
+_DEFAULT_FILL = "#8893a5"   # grey — unknown / not-yet-finished
 
 
 def render_telemetry_tab() -> None:
@@ -27,82 +34,155 @@ def render_telemetry_tab() -> None:
 
         tel = collect_session_telemetry(agent)
         meta = tel.get("meta", {})
+        agents = tel.get("agents", [])
+        delegations = meta.get("delegations", [])
 
-        # ── Meta header ──────────────────────────────────────────────
-        c1, c2, c3 = st.columns(3)
-        c1.metric("Mode", str(meta.get("meta_mode", "—")).title())
-        c2.metric("Delegations", meta.get("delegations_total", 0))
-        c3.metric("Worker agents", len(tel.get("agents", [])))
+        total_actions = sum(a.get("action_count", 0) for a in agents)
+        st.markdown(
+            f"**{str(meta.get('meta_mode', '—')).title()}**  ·  "
+            f"{meta.get('delegations_total', 0)} delegations  ·  "
+            f"{len(agents)} worker agents  ·  {total_actions} actions logged"
+        )
         st.caption(f"Session: {meta.get('session_dir', '—')}")
 
-        if not meta.get("delegations"):
+        if not delegations:
             st.info("No delegations yet — describe a goal and the meta "
                     "routes it to a specialist.")
             return
 
-        # ── Specialist cards ─────────────────────────────────────────
-        st.subheader("Specialists")
-        specs = tel.get("specialists", {})
-        for col, name in zip(st.columns(2), ("analysis", "planning")):
-            with col:
-                _specialist_card(name, specs.get(name, {}))
+        # ── Dependency graph ─────────────────────────────────────────
+        st.graphviz_chart(_delegation_graph_dot(meta), use_container_width=True)
+        st.caption("Grey edge = meta dispatched the delegation.  "
+                   "Blue edge = a delegation's result fed the next as context.")
 
-        # ── Worker action histories ──────────────────────────────────
+        # ── Specialists ──────────────────────────────────────────────
+        st.subheader("Specialists")
+        _specialists_table(tel.get("specialists", {}))
+
+        # ── Worker agents ────────────────────────────────────────────
+        st.subheader("Worker agents")
+        _workers_table(agents)
+
+        # ── Every logged action ──────────────────────────────────────
         st.subheader("Worker activity")
-        agents = tel.get("agents", [])
-        if not agents:
-            st.caption("No worker actions recorded yet.")
-        for ag in agents:
-            _worker_expander(ag)
+        _actions_table(agents)
 
         # ── Delegation ledger ────────────────────────────────────────
         st.subheader("Delegation ledger")
-        _ledger_table(meta.get("delegations", []))
+        _ledger_table(delegations)
 
     _panel()
 
 
-def _specialist_card(name: str, info: dict) -> None:
-    """One bordered card summarizing a specialist orchestrator."""
-    title = _SPECIALIST_TITLES.get(name, name.title())
-    with st.container(border=True):
-        st.markdown(f"**{title}**")
-        if not info.get("instantiated"):
-            st.caption("Not yet engaged.")
-            return
-        st.caption(f"{info.get('message_count', 0)} messages")
-        if name == "analysis":
-            st.metric("Analyses run", info.get("analyses_run", 0))
-        else:
-            st.metric("BO data points", info.get("bo_data_points", 0))
-            targets = info.get("optimization_targets", [])
-            if targets:
-                st.caption("Targets: " + ", ".join(str(t) for t in targets))
+# ── dependency graph ─────────────────────────────────────────────────
+
+def _dot_escape(text) -> str:
+    return str(text).replace("\\", "\\\\").replace('"', '\\"')
 
 
-def _worker_expander(ag: dict) -> None:
-    """One expander with a worker agent's action_history table."""
+def _delegation_graph_dot(meta: dict) -> str:
+    """DOT string: meta-agent root -> delegation nodes (colored by status),
+    with dispatch edges and `context_from` provenance edges."""
+    dels = meta.get("delegations", [])
+    out = [
+        "digraph telemetry {",
+        '  rankdir=TB; bgcolor="transparent"; pad=0.2;',
+        '  node [shape=box, style="filled,rounded", fontname="Helvetica", '
+        'fontsize=10, color="#30363d", fontcolor="white"];',
+        '  edge [fontname="Helvetica", fontsize=8];',
+        f'  meta [label="Meta-agent\\n({_dot_escape(str(meta.get("meta_mode", "")).title())})", '
+        'fillcolor="#30363d"];',
+    ]
+    for d in dels:
+        idx = d.get("index")
+        fill = _STATUS_FILL.get(d.get("status"), _DEFAULT_FILL)
+        label = (f'#{idx} · {_dot_escape(d.get("mode", "?"))}\\n'
+                 f'{_dot_escape(d.get("label", ""))}')
+        out.append(f'  d{idx} [label="{label}", fillcolor="{fill}"];')
+    for d in dels:                                   # dispatch edges
+        out.append(f'  meta -> d{d.get("index")} [color="#8893a5"];')
+    for d in dels:                                   # context-provenance edges
+        for src in d.get("context_from", []):
+            out.append(f'  d{src} -> d{d.get("index")} '
+                       f'[color="#58a6ff", penwidth=2.0, label="ctx"];')
+    out.append("}")
+    return "\n".join(out)
+
+
+# ── tables ───────────────────────────────────────────────────────────
+
+def _short_time(ts) -> str:
+    """ISO timestamp -> HH:MM:SS (keeps the table narrow)."""
+    if not ts:
+        return ""
+    s = str(ts)
+    return s.split("T", 1)[1][:8] if "T" in s else s
+
+
+def _specialists_table(specs: dict) -> None:
     import pandas as pd
 
-    oc = ag.get("outcomes", {})
-    title = (f"{ag.get('name', '?')} — {ag.get('action_count', 0)} actions  "
-             f"({oc.get('success', 0)}✓ / {oc.get('error', 0)}✗)")
-    with st.expander(title):
-        by_type = ag.get("actions_by_type", {})
-        st.caption(
-            f"Specialist: {ag.get('specialist', '—')}"
-            + ("  ·  " + ", ".join(f"{k}×{v}" for k, v in by_type.items())
-               if by_type else "")
-        )
-        rows = ag.get("actions", [])
-        if rows:
-            df = pd.DataFrame(rows, columns=["timestamp", "action",
-                                             "status", "rationale"])
-            st.dataframe(df, use_container_width=True, hide_index=True)
+    rows = []
+    for name in ("analysis", "planning"):
+        info = specs.get(name, {})
+        if not info.get("instantiated"):
+            rows.append({"specialist": name, "messages": "—",
+                         "work": "not engaged"})
+            continue
+        if name == "analysis":
+            work = f"{info.get('analyses_run', 0)} analysis run(s)"
+        else:
+            targets = info.get("optimization_targets", [])
+            work = (f"{info.get('bo_data_points', 0)} BO data points"
+                    + (f" · targets: {', '.join(targets)}" if targets else ""))
+        rows.append({"specialist": name,
+                     "messages": info.get("message_count", 0), "work": work})
+    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+
+
+def _workers_table(agents: list) -> None:
+    import pandas as pd
+
+    if not agents:
+        st.caption("No worker agents have run yet.")
+        return
+    rows = [{
+        "agent": a.get("name"),
+        "specialist": a.get("specialist"),
+        "actions": a.get("action_count", 0),
+        "✓": a.get("outcomes", {}).get("success", 0),
+        "✗": a.get("outcomes", {}).get("error", 0),
+        "first": _short_time(a.get("first_timestamp")),
+        "last": _short_time(a.get("last_timestamp")),
+    } for a in agents]
+    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+
+
+def _actions_table(agents: list) -> None:
+    """Every logged action across all workers, newest first."""
+    import pandas as pd
+
+    rows = []
+    for a in agents:
+        for ac in a.get("actions", []):
+            rows.append({
+                "time": _short_time(ac.get("timestamp")),
+                "specialist": a.get("specialist"),
+                "agent": a.get("name"),
+                "action": ac.get("action"),
+                "status": ac.get("status"),
+                "rationale": ac.get("rationale"),
+                "_sort": ac.get("timestamp") or "",
+            })
+    if not rows:
+        st.caption("No worker actions recorded yet.")
+        return
+    rows.sort(key=lambda r: r["_sort"], reverse=True)
+    df = pd.DataFrame(rows).drop(columns=["_sort"])
+    st.dataframe(df, use_container_width=True, hide_index=True)
 
 
 def _ledger_table(delegations: list) -> None:
-    """The delegation ledger as a flat table (richer than the sidebar tree)."""
     import pandas as pd
 
     rows = []
@@ -117,7 +197,7 @@ def _ledger_table(delegations: list) -> None:
             "files": d.get("files", 0),
             "feature tables": d.get("feature_tables", 0),
             "warnings": d.get("warnings", 0),
-            "started": d.get("timestamp"),
-            "completed": d.get("completed_at"),
+            "started": _short_time(d.get("timestamp")),
+            "completed": _short_time(d.get("completed_at")),
         })
     st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)

--- a/scilink/ui/config.py
+++ b/scilink/ui/config.py
@@ -16,12 +16,14 @@ EMBEDDING_MODEL_OPTIONS = [
 
 # ── Mode registry ────────────────────────────────────────────────
 APP_MODES = [
+    {"key": "meta",    "label": "Auto",    "description": "Meta-agent — auto-routes to analyze & plan"},
     {"key": "analyze", "label": "Analyze", "description": "Multi-modal data analysis"},
     {"key": "plan",    "label": "Plan",    "description": "Experimental design & optimization"},
     {"key": "simulate", "label": "Simulate", "description": "Submit and monitor DFT/MD simulations"},
 ]
 
 SESSION_DIR_PREFIXES = {
+    "meta": "meta_session",
     "analyze": "analysis_session",
     "plan": "planning_session",
     "simulate": "simulation_session",

--- a/scilink/ui/config.py
+++ b/scilink/ui/config.py
@@ -16,7 +16,7 @@ EMBEDDING_MODEL_OPTIONS = [
 
 # ── Mode registry ────────────────────────────────────────────────
 APP_MODES = [
-    {"key": "meta",    "label": "Auto",    "description": "Meta-agent — auto-routes to analyze & plan"},
+    {"key": "meta",    "label": "Explore",  "beta": True, "description": "Routes your research goal to the Analyze & Plan specialists"},
     {"key": "analyze", "label": "Analyze", "description": "Multi-modal data analysis"},
     {"key": "plan",    "label": "Plan",    "description": "Experimental design & optimization"},
     {"key": "simulate", "label": "Simulate", "description": "Submit and monitor DFT/MD simulations"},
@@ -71,7 +71,7 @@ SUPPORTED_KNOWLEDGE_EXTENSIONS = (".pdf", ".txt", ".md", ".docx", ".png", ".jpg"
 SUPPORTED_CODE_EXTENSIONS = (".py", ".txt", ".md", ".json", ".yaml", ".yml")
 SUPPORTED_PLANNING_DATA_EXTENSIONS = (".csv", ".xlsx", ".tsv", ".txt", ".npy", ".json")
 
-# Auto (meta) mode accepts everything the specialist modes accept — one
+# Explore (meta) mode accepts everything the specialist modes accept — one
 # combined uploader; the meta-agent routes each file to the right child.
 SUPPORTED_META_EXTENSIONS = tuple(sorted(set(
     SUPPORTED_DATA_EXTENSIONS

--- a/scilink/ui/config.py
+++ b/scilink/ui/config.py
@@ -71,5 +71,14 @@ SUPPORTED_KNOWLEDGE_EXTENSIONS = (".pdf", ".txt", ".md", ".docx", ".png", ".jpg"
 SUPPORTED_CODE_EXTENSIONS = (".py", ".txt", ".md", ".json", ".yaml", ".yml")
 SUPPORTED_PLANNING_DATA_EXTENSIONS = (".csv", ".xlsx", ".tsv", ".txt", ".npy", ".json")
 
+# Auto (meta) mode accepts everything the specialist modes accept — one
+# combined uploader; the meta-agent routes each file to the right child.
+SUPPORTED_META_EXTENSIONS = tuple(sorted(set(
+    SUPPORTED_DATA_EXTENSIONS
+    + SUPPORTED_METADATA_EXTENSIONS
+    + SUPPORTED_KNOWLEDGE_EXTENSIONS
+    + SUPPORTED_CODE_EXTENSIONS
+)))
+
 AVATAR_USER = str(Path(__file__).resolve().parent / "assets" / "avatar_user.svg")
 AVATAR_AGENT = str(Path(__file__).resolve().parent / "assets" / "avatar_agent.svg")

--- a/scilink/ui/state.py
+++ b/scilink/ui/state.py
@@ -53,6 +53,7 @@ def init_session_state() -> None:
         "planning_objective": "",
         # Meta mode state
         "meta_objective": "",
+        "uploaded_meta_paths": [],
         "uploaded_knowledge_paths": [],
         "uploaded_code_paths": [],
         "uploaded_planning_data_paths": [],

--- a/scilink/ui/state.py
+++ b/scilink/ui/state.py
@@ -51,6 +51,8 @@ def init_session_state() -> None:
         "app_mode": None,
         # Planning mode state
         "planning_objective": "",
+        # Meta mode state
+        "meta_objective": "",
         "uploaded_knowledge_paths": [],
         "uploaded_code_paths": [],
         "uploaded_planning_data_paths": [],

--- a/tests/test_simulation_orchestrator.py
+++ b/tests/test_simulation_orchestrator.py
@@ -70,7 +70,7 @@ def _make_orch(model_name: str, base_dir: str, autonomy: str = "co-pilot"):
     )
     mode_map = {
         "co-pilot": SimulationMode.CO_PILOT,
-        "supervised": SimulationMode.SUPERVISED,
+        "autopilot": SimulationMode.AUTOPILOT,
         "autonomous": SimulationMode.AUTONOMOUS,
     }
     return SimulationOrchestratorAgent(
@@ -231,9 +231,9 @@ def test_4_mode_switching(model_name: str):
         # System prompt was rebuilt with the new directive
         assert "AUTONOMY: AUTONOMOUS" in orch._system_prompt
 
-        orch.set_simulation_mode(SimulationMode.SUPERVISED)
-        assert orch.get_human_feedback_setting() is True  # supervised still wants feedback
-        assert "AUTONOMY: SUPERVISED" in orch._system_prompt
+        orch.set_simulation_mode(SimulationMode.AUTOPILOT)
+        assert orch.get_human_feedback_setting() is True  # autopilot still wants feedback
+        assert "AUTONOMY: AUTOPILOT" in orch._system_prompt
 
     print("   ✅ Mode switching updates feedback flag + system prompt")
 


### PR DESCRIPTION
## Summary

Adds the **meta-agent** — an orchestrator-of-orchestrators that presents a
single conversational surface and routes each piece of research work to the
right specialist mode automatically, so the user no longer has to pick
`analyze` / `plan` / `simulate` up front.

Bare `scilink` (no subcommand) and the new `scilink meta` launch it; in the UI
it appears as the **Explore** mode. v1 covers analysis + planning; simulation
delegation is deferred behind a guarded lazy seam (the simulation package
hard-imports an optional dependency).

`scilink analyze` / `plan` / `simulate` and their orchestrators, playgrounds,
and UI modes are unchanged — the meta-agent reuses the existing orchestrators
only through their public methods.

## What the meta-agent does

- **Routes automatically.** Given a goal or uploaded files, it probes each
  file's content (array shape, table columns, document text, JSON keys) and
  delegates analysis vs planning work to the matching specialist — routing
  from evidence, not filenames.
- **Persistent specialists.** One analysis child and one planning child live
  for the whole session and are reused across delegations, so context
  accumulates — a follow-up or refinement delegation builds on the prior one
  rather than starting cold.
- **Threads context.** A delegation ledger records every delegation; the
  relevant findings of one specialist are passed as structured `context` into
  the next, with provenance.
- **Self-describing routing.** On its first turn the meta builds a capability
  inventory by reading each specialist's *live* tool registry and sub-agent
  list, so a new tool in any mode appears in the meta's routing knowledge with
  no meta-agent edit.

## Architecture

- New package `scilink/agents/meta_agent/` — `MetaOrchestratorAgent`,
  `MetaMode`, `MetaOrchestratorTools`, plus a telemetry collector.
- Specialists are consumed only through a uniform
  **`run_task(task, context) -> dict`** contract — added to the analysis and
  planning orchestrators alongside the existing `chat`. No base class;
  duck-typed.
- Children are created lazily, persist in fixed sub-directories under the
  meta-session directory, and restore from their own checkpoints, so context
  survives a meta restore.
- Each delegation runs the child under the meta's autonomy mode; in autopilot
  the specialist's human-feedback prompts (plan / code review) reach the user
  driving the session.
- Tool surface: `delegate_to_analysis`, `delegate_to_planning`,
  `inspect_uploads`, `get_delegation_history`, `summarize_session_state`.
  `delegate_to_simulation` is left as a documented, unbuilt lazy seam.

Meta session layout:

```
meta_session_YYYYMMDD_HHMMSS/
├── analysis/   results/<id>/              # persistent analysis child
├── planning/   delegations/<NN>_<slug>/   # persistent planning child
├── uploads/
├── chat_history.json
└── checkpoint.json
```

## Routing behavior

The meta gathers what a specialist genuinely needs *before* delegating:

- **Experimental metadata** — technique, instrument, conditions — is requested
  from the user up front if missing, rather than letting a specialist stall
  mid-task.
- **Equipment & setup** — for any task that produces an experimental plan,
  protocol, optimization campaign, or a recommendation of what to measure
  next, the meta asks for the user's available instruments and equipment
  before the *first* such delegation — a plan for equipment the user does not
  have is not actionable.
- A multi-file experimental series is delegated as one batched task; documents
  route by intent (analysis reference vs experiment-design input);
  charts / figures lifted from documents are treated as reference context,
  not scientofic imaging data.

## Shared extensions: skills, custom tools, MCP

One mechanism shares extensions from the meta to every specialist child:
`register_skill`, `register_tools`, and `connect_mcp_server` each record the
extension and apply it to every child — including children created lazily
afterwards. Connect an MCP server once on the meta and the analysis and
planning specialists can call its tools during a delegation.

## Telemetry

The Explore UI gains a **Telemetry** tab: a delegation dependency graph, a
per-agent tool-call sequence that updates in real time, input/output types
with tool worked/failed status, and download links to the underlying session
JSON.

## Analysis ↔ planning bridge

- Analysis runs emit a flat **feature table** (one row per spectrum / image,
  columns = conditions + extracted scalar features); a follow-up planning or
  Bayesian-optimization task ingests that file directly instead of re-typing
  numbers as prose.
- The analysis agent gains a `read_document` tool for direct PDF / DOCX
  ingestion, so a methods paper can ground an analysis plan.

## Supporting changes to existing modes

- `run_task` non-interactive entry point on the analysis and planning
  orchestrators (the delegation contract; standalone `chat` use unchanged).
- Planning per-delegation output isolation — a reused planning child writes
  each delegation's `plan.json` etc. into its own `delegations/<NN>/`
  sub-directory instead of overwriting the previous one.
- Middle autonomy level renamed `supervised` → `autopilot` (back-compatible).
- Image-series feature-table adapter; series analysis supports multiple
  control variables (primary + secondary).

## Fixes folded into this branch

- `query_knowledge_data` accepts an absolute file path, so a meta-delegated
  task whose data lives outside the knowledge directory can be queried.
- Planning no longer reports a false failure when no knowledge base is
  loaded — the LLM-knowledge fallback is used and real failures still surface.
- Planning AUTOPILOT now surfaces generated plans/code for human review, as
  its directive promises (the gate had been CO-PILOT-only).
- For a Bayesian-optimization campaign, planning runs BO directly instead of
  hand-designing a contradictory batch.
- Fixed a `TypeError` launching the hyperspectral / FFT / SAM / atomistic
  analysis agents.
- `preview_image` accepts `.npy` / `.h5` image arrays.

## Surfaces

- **CLI** — bare `scilink` and `scilink meta` launch the meta-agent;
  `scilink --help` / `-h` / `help` still print usage; `scilink meta` has its
  own argparse help. New `scilink/cli/meta.py` playground (`/children`,
  `/status`, `/mode`, …).
- **UI** — new **Explore** mode reusing the chat surface, a free-text "what do
  you want to do" upload zone with content-based file routing, a sidebar
  delegation tree with live "running" rows and status coloring, and the
  Telemetry tab. The chat input is now scoped to the Chat tab.

## Backward compatibility

- `scilink analyze` / `plan` / `simulate` behave exactly as before — dispatch
  branches, orchestrators, and playgrounds untouched.
- Bare `scilink` previously printed usage and now launches the meta-agent
  (the intended change); every `scilink <subcommand>` invocation is unchanged.
- The planning per-delegation output path is gated on a field set only inside
  `run_task`; a standalone `scilink plan` session writes to exactly today's
  locations. New checkpoint fields are read with defaults, so old checkpoints
  still load.
- No top-level import of the simulation package — installs without the
  optional simulation dependency are unaffected.

## Verification

Verified locally with ad-hoc live sessions (not committed, per project
convention):

- Importable without the optional simulation dependency; the meta exposes
  `delegate_to_analysis` / `delegate_to_planning` and no
  `delegate_to_simulation`.
- Two delegations to each specialist confirm the persistent child is reused
  and the second delegation sees the first.
- A follow-up analysis delegation answers from a prior analysis's fit results
  without re-running; a follow-up planning delegation drives
  `generate_initial_plan` → `refine_plan_with_results` to refine a plan from
  new results, with each delegation's plan isolated in its own sub-directory.
- CLI: bare `scilink`, `scilink meta --help`, `scilink --help`, and every
  `scilink <subcommand>` behave as expected.

## Next up: simulation

**Simulation will be added as the third delegation target.** The design
already accommodates it: `delegate_to_simulation` is in place as a guarded
lazy seam (the import lives inside the function body, so installs without the
optional simulation dependency stay unaffected), the capability inventory
picks up any orchestrator added to the child set automatically, and the meta
routes against live tool registries — so wiring in the simulation
orchestrator is additive and needs no change to the routing core. It is held
back here only until the simulation orchestrator stabilizes.

## Also deferred (intentionally not in this PR)

- Loading prior-analysis artifacts (`run_analysis(prior_analysis_paths=…)`)
  for the curve-fitting and hyperspectral agents — currently image-agent only.
- UI child-session navigator; possible `BasePlayground` extraction across the
  now-four mode CLIs.