### PR TITLE
lit search: make consulted-literature provenance visible

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2516,6 +2516,7 @@ class AnalysisOrchestratorTools:
                     "agent_name": self.AGENT_NAMES.get(agent_id),
                     "status": result.get("status"),
                     "output_directory": str(analysis_output_dir),
+                    "literature_file": literature_file,
                     "full_result": result,
                     "novelty_assessment": None
                 }

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -589,7 +589,8 @@ class GenerateCurveFittingReportController:
                 or []
             )
         candidates_html = self._format_candidate_identifications(
-            candidate_identifications
+            candidate_identifications,
+            literature_used=bool(state.get("literature_context")),
         )
 
         html_content = self._build_html_report(
@@ -742,13 +743,17 @@ class GenerateCurveFittingReportController:
             <tbody>{rows}</tbody>
         </table>"""
 
-    def _format_candidate_identifications(self, candidates) -> str:
+    def _format_candidate_identifications(self, candidates, literature_used: bool = False) -> str:
         """Render the id-mode ranked candidate list as an HTML section.
 
         Returns an empty string when `candidates` is empty or missing —
         so the rest of the report is unchanged for fitting-mode runs.
         Missing per-candidate fields fall back to "—" rather than
         raising; malformed entries are skipped.
+
+        `literature_used` controls the provenance caveat: when a literature
+        search was consulted, the disclaimer must not claim the candidates
+        rest on model knowledge alone.
         """
         if not candidates:
             return ""
@@ -790,10 +795,21 @@ class GenerateCurveFittingReportController:
         if not rows:
             return ""
 
+        if literature_used:
+            provenance = (
+                "Candidates enumerated by the model from the spectral evidence "
+                "and a consulted literature search; ranks and consistency grades "
+                "remain qualitative model judgments (not database-verified)."
+            )
+        else:
+            provenance = (
+                "LLM-enumerated candidates from the spectral evidence; ranks and "
+                "consistency grades are qualitative LLM judgments (not database-verified)."
+            )
+
         return f"""
         <h2>Candidate Identifications (id-mode)</h2>
-        <p><em>LLM-enumerated candidates from the spectral evidence; ranks and
-        consistency grades are qualitative LLM judgments (not database-verified).
+        <p><em>{provenance}
         Use <strong>Distinguishing evidence</strong> to plan a follow-up measurement
         that would separate the top candidates.</em></p>
         <table class="params-table">

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -601,6 +601,10 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             lit_p = Path(literature_file)
             if lit_p.is_file():
                 state["literature_context"] = lit_p.read_text()
+                # Record provenance so the result reflects that literature
+                # was consulted — the in-pipeline LiteratureSearchController
+                # is skipped on this path and never populates literature_files.
+                state["literature_files"] = {"provided_file": str(lit_p)}
                 self.logger.info(f"📚 Loaded literature context from {lit_p.name}")
             else:
                 self.logger.warning(f"literature_file not found: {literature_file}")

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -445,6 +445,10 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             lit_p = Path(literature_file)
             if lit_p.is_file():
                 state["literature_context"] = lit_p.read_text()
+                # Record provenance so the result reflects that literature
+                # was consulted — the in-pipeline LiteratureSearchController
+                # is skipped on this path and never populates literature_files.
+                state["literature_files"] = {"provided_file": str(lit_p)}
                 self.logger.info(f"📚 Loaded literature context from {lit_p.name}")
             else:
                 self.logger.warning(f"literature_file not found: {literature_file}")


### PR DESCRIPTION
When a literature file is supplied via run_analysis(literature_file=...), the in-pipeline LiteratureSearchController is skipped, so it never populated state["literature_files"] — the agent result reported literature_files: null even though literature WAS consulted. And the identification-mode HTML report's candidate-list disclaimer flatly stated the candidates were "LLM-enumerated ... qualitative LLM judgments", with no acknowledgement that a literature search informed Stage-2 enumeration.

Two fixes:
- CurveFittingAgent / ImageAnalysisAgent record the provided file as state["literature_files"] = {"provided_file": <path>} when they read it, so the result surfaces the provenance. run_analysis also stores the literature_file on its analysis record.
- The id-mode candidate-identifications disclaimer is now literature- aware: when a search was consulted it says candidates were enumerated from the spectral evidence AND a consulted literature search; the "not database-verified" caveat still holds in both wordings.