### PR TITLE
Series trend analysis: handle ≥2 control variables

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -4259,11 +4259,23 @@ class ConditionalTrendAnalysisController:
 **VISUALIZATION SCOPE - TRENDS:**
 Create a SINGLE dashboard figure showing how fitted PARAMETERS evolve across the series.
 DO NOT recreate individual spectrum fits - those already exist separately.
-The dashboard should show:
-- Parameter values (y-axis) vs series variable like temperature/time/index (x-axis)
-- Error bars if uncertainties are available
-- Fit quality (R²) evolution
-- Mark flagged spectra with distinct markers
+
+The series may vary ONE control variable or SEVERAL at once (a factorial /
+grid design). Inspect `series_metadata` for a `secondary_variables` entry and
+choose the representation to match:
+- ONE control variable: parameter values (y-axis) vs that variable (x-axis),
+  with error bars where available - the standard trend dashboard.
+- TWO control variables: represent BOTH. If their values define a regular
+  lattice (grid sampling), use a heatmap or filled contour of each key
+  parameter over the 2-D space. If the sampling is scattered, use a scatter
+  plot positioned by the two variables and colored by the parameter value.
+  Detect grid vs scattered from the data itself.
+- THREE OR MORE: there is no single canonical N-D trend plot - produce a
+  best-effort view: plot each parameter against the primary variable and
+  facet or color by the remaining variable(s), or use pairwise panels.
+- In every case also show fit quality (R²) evolution and mark flagged
+  spectra with distinct markers.
+State the representation you chose (and why) in `analysis_approach`.
 
 **FIGURE REQUIREMENTS:**
 - Create ONE summary dashboard figure (parameter_trends.png)
@@ -4278,6 +4290,7 @@ The dashboard should show:
 **DATA EXTRACTION PATTERN:**
 ```python
 import json
+import os
 import numpy as np
 import matplotlib
 matplotlib.use('Agg')  # Non-interactive backend - REQUIRED
@@ -4289,7 +4302,15 @@ with open('series_fit_results.json', 'r') as f:
 
 results = data['results']
 series_metadata = data.get('series_metadata', {{}})
-# series_metadata has: variable, values (one per spectrum), unit
+# PRIMARY control variable:
+#   series_metadata['variable'] (name), series_metadata['unit'],
+#   series_metadata['values'] -> a list aligned to results by index:
+#   results[i] primary value = series_metadata['values'][results[i]['index']].
+# ADDITIONAL control variables (present only for a grid / factorial design):
+#   series_metadata.get('secondary_variables', []) -> a list of entries
+#   {{'variable': name, 'unit': unit, 'values': {{filename: value}}}}.
+#   Each secondary 'values' is a dict keyed by file name; align it to a
+#   result via key = os.path.basename(results[i]['data_path']).
 
 # Extract series variable and parameters...
 # Create figure with subplots...

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -5201,11 +5201,23 @@ class ConditionalImageTrendController:
 **VISUALIZATION SCOPE - TRENDS:**
 Create a SINGLE dashboard figure showing how extracted FEATURES evolve across the series.
 DO NOT recreate individual image analyses - those already exist separately.
-The dashboard should show:
-- Feature values (y-axis) vs series variable like temperature/time/index (x-axis)
-- Error bars if uncertainties are available
-- Quality metrics evolution
-- Mark flagged images with distinct markers
+
+The series may vary ONE control variable or SEVERAL at once (a factorial /
+grid design). Inspect `series_metadata` for a `secondary_variables` entry and
+choose the representation to match:
+- ONE control variable: feature values (y-axis) vs that variable (x-axis),
+  with error bars where available - the standard trend dashboard.
+- TWO control variables: represent BOTH. If their values define a regular
+  lattice (grid sampling), use a heatmap or filled contour of each key
+  feature over the 2-D space. If the sampling is scattered, use a scatter
+  plot positioned by the two variables and colored by the feature value.
+  Detect grid vs scattered from the data itself.
+- THREE OR MORE: there is no single canonical N-D trend plot - produce a
+  best-effort view: plot each feature against the primary variable and
+  facet or color by the remaining variable(s), or use pairwise panels.
+- In every case also show quality-metric evolution and mark flagged images
+  with distinct markers.
+State the representation you chose (and why) in `analysis_approach`.
 
 **FIGURE REQUIREMENTS:**
 - Create ONE summary dashboard figure (feature_trends.png)
@@ -5220,6 +5232,7 @@ The dashboard should show:
 **DATA EXTRACTION PATTERN:**
 ```python
 import json
+import os
 import numpy as np
 import matplotlib
 matplotlib.use('Agg')  # Non-interactive backend - REQUIRED
@@ -5231,7 +5244,15 @@ with open('series_analysis_results.json', 'r') as f:
 
 results = data['results']
 series_metadata = data.get('series_metadata', {{}})
-# series_metadata has: variable, values (one per image), unit
+# PRIMARY control variable:
+#   series_metadata['variable'] (name), series_metadata['unit'],
+#   series_metadata['values'] -> a list aligned to results by index:
+#   results[i] primary value = series_metadata['values'][results[i]['index']].
+# ADDITIONAL control variables (present only for a grid / factorial design):
+#   series_metadata.get('secondary_variables', []) -> a list of entries
+#   {{'variable': name, 'unit': unit, 'values': {{filename: value}}}}.
+#   Each secondary 'values' is a dict keyed by file name; align it to a
+#   result via key = os.path.basename(results[i]['data_path']).
 
 # Extract series variable and features...
 # Create figure with subplots...


### PR DESCRIPTION
The trend-analysis prompt in both the curve-fitting and image controllers described only a single x-axis, so a series varying two or more control variables (a factorial / grid design) plotted only the primary axis — secondary control variables, already carried in
series_metadata.secondary_variables, were ignored.

Rewrote the VISUALIZATION SCOPE and DATA EXTRACTION PATTERN sections of both TREND_ANALYSIS_INSTRUCTIONS to branch on the control-variable count: 1 → the current single-axis dashboard; 2 → a 2-D heatmap/contour for grid sampling or a colored scatter for scattered sampling; ≥3 → best-effort faceting/coloring. The data-extraction comment now states the exact structure — the primary `values` is a list aligned to results by index; each secondary's `values` is a {filename: value} dict aligned via os.path.basename(result['data_path']).

Prompt-only change — the data is already produced: verified that _llm_identify_control_variables returns all control variables and the recorder writes secondary_variables for a multi-variable series.

Implements #170.