### PR TITLE
Locked extraction-script reuse for incremental measurement series (#172)

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -295,6 +295,29 @@ examine_data returns data_type:
   `list_results()` already covers the new request's prerequisites (e.g. existing
   segmentation, fits, abundance maps). If so, pass its `output_directory` via
   `prior_analysis_paths` so the new run can build on it instead of recomputing.
+
+**INCREMENTAL MEASUREMENT SERIES (locked extraction-script reuse):**
+- When the new data is the NEXT MEASUREMENT of an existing measurement series —
+  the same kind of unit as a prior run, only the control parameters differ
+  (e.g. a new point added to a Bayesian-optimization / closed-loop campaign) —
+  pass that prior run's `output_directory` via `prior_analysis_paths`. The agent
+  reuses the prior run's locked extraction recipe (fitting script / image
+  pipeline) verbatim, so the new feature row has the SAME columns as the rest of
+  the campaign — which a downstream feature-table / BO append strictly requires.
+- Decide deliberately whether the new data IS a continuation. If it is a
+  different kind of measurement, do NOT pass `prior_analysis_paths` — a fresh
+  analysis is correct; forcing the prior recipe would extract the wrong things.
+- After such a run, READ the `reuse_validity` field in the `run_analysis`
+  result and act on its `verdict`:
+  - `good` — the reused recipe fits the new measurement well; proceed normally.
+  - `poor` — the row is still schema-consistent and safe to append, but the
+    reused recipe fits this measurement poorly. Surface the `reuse_warning` to
+    the user: the new measurement may not belong to this series, or conditions
+    shifted. If you judge it is genuinely a different measurement, re-run
+    `run_analysis` WITHOUT `prior_analysis_paths` for a correct fresh analysis.
+  - `script_failed` — the reused recipe could not run and the model/pipeline was
+    re-derived from scratch, so the feature columns may differ from the
+    campaign. Flag this clearly to the user — a campaign append may break.
 """
 
 

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2560,6 +2560,16 @@ class AnalysisOrchestratorTools:
                     feature_table = write_feature_table(analysis_output_dir)
                     if feature_table:
                         response["feature_table"] = feature_table
+                    # #172: surface the locked-script reuse verdict so the
+                    # orchestrator can act on a non-`good` outcome (a poorly
+                    # fitting reused recipe, or a re-derived schema).
+                    reuse_validity = result.get("reuse_validity")
+                    if reuse_validity:
+                        response["reuse_validity"] = reuse_validity
+                        if reuse_validity.get("verdict") != "good":
+                            response["reuse_warning"] = reuse_validity.get(
+                                "message", ""
+                            )
                     return json.dumps(response)
                 else:
                     return json.dumps({
@@ -2706,7 +2716,24 @@ class AnalysisOrchestratorTools:
                         "catalog). Consumed by the image-analysis agent and "
                         "the curve-fitting agent — for a prior curve-fit run "
                         "the saved fitting script and fit summary are surfaced "
-                        "to its planning and script-generation stages."
+                        "to its planning and script-generation stages.\n"
+                        "LOCKED EXTRACTION-SCRIPT REUSE: when the new data is "
+                        "the NEXT MEASUREMENT of the SAME measurement series as "
+                        "the prior run — the same kind of unit, only the "
+                        "control parameters differ (a new point in a "
+                        "Bayesian-optimization / closed-loop campaign) — the "
+                        "agent reuses the prior run's locked extraction script "
+                        "verbatim instead of re-deriving the model/pipeline. "
+                        "This guarantees the new feature row has the SAME "
+                        "columns as the campaign, which the planning-side "
+                        "feature-table append strictly requires. ONLY pass "
+                        "prior_analysis_paths when the new data genuinely "
+                        "continues that series; if it is a different kind of "
+                        "measurement, do NOT pass it (a fresh analysis is "
+                        "correct — forcing the prior recipe would be wrong). "
+                        "The run reports a `reuse_validity` verdict "
+                        "(`good` / `poor` / `script_failed`) — read it and act "
+                        "on a non-`good` verdict (see the system guidance)."
                     )
                 },
                 "literature_file": {

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -309,6 +309,25 @@ def _prior_curve_fit_block(state: dict) -> str:
     )
 
 
+def _first_prior_curve_fit_script(state: dict):
+    """Return the first reusable fitting script for locked-script reuse (#172).
+
+    Scans ``state['prior_analysis_paths']`` and returns
+    ``(script_text, source_label)`` for the first prior curve-fit run that
+    carries a saved fitting script, or ``(None, None)`` when no prior paths
+    are given or none have a script. The empty-case gate keeps a normal
+    (no-prior) run byte-identical.
+    """
+    paths = state.get("prior_analysis_paths") or []
+    for raw_path in paths:
+        anchor_dir, _summary, script_text, _label = (
+            _load_prior_curve_fit_state(raw_path)
+        )
+        if anchor_dir is not None and script_text:
+            return script_text, (anchor_dir.name or str(anchor_dir))
+    return None, None
+
+
 def _append_objective_context(prompt: list, state: dict) -> None:
     """Append high-level scientific objective to an LLM prompt.
 
@@ -2499,9 +2518,18 @@ Return JSON with:
             self.logger.error(f"Failed to refine model from feedback: {e}")
             return config
 
-    def _fit_with_quality_control(self, state: dict, curve_data: np.ndarray, data_path: str, spectrum_name: str, spectrum_idx: int, is_regime_anchor: bool = False) -> dict:
+    def _fit_with_quality_control(self, state: dict, curve_data: np.ndarray, data_path: str, spectrum_name: str, spectrum_idx: int, is_regime_anchor: bool = False, reuse_script: Optional[str] = None, reuse_source: Optional[str] = None) -> dict:
         """
         Fit a single spectrum with quality control, verification, and optional judge selection.
+
+        #172 locked-script reuse: when ``reuse_script`` is supplied (an anchor
+        fed a prior run's saved fitting script via ``prior_analysis_paths``),
+        the prior script is run verbatim on the new data first. If it executes,
+        its result is kept — regardless of R² — so the extracted-parameter
+        schema stays consistent across an incremental measurement campaign by
+        construction; R² is attached as a ``reuse_validity`` verdict the
+        orchestrator can act on, not a gate that re-derives the model. Full QC
+        re-derivation runs only when the prior script cannot execute at all.
 
         Flow:
         1. Initial fit attempt.
@@ -2528,6 +2556,77 @@ Return JSON with:
 
         # Anchor = first spectrum overall OR first in a regime; gets full QC
         _is_anchor = spectrum_idx == 0 or is_regime_anchor
+
+        # --- #172: locked-script reuse fast path ---
+        # A prior curve-fit run supplied via prior_analysis_paths means the new
+        # data is point N+1 of that series: reuse the prior run's locked fitting
+        # script verbatim instead of re-deriving the model. This keeps the
+        # extracted-parameter schema consistent across an incremental campaign
+        # by construction. R² is a validity *signal* (attached as reuse_validity
+        # for the orchestrator), never a gate that re-derives the model — a
+        # re-derived model could change the feature columns. The only fallback
+        # to full QC is a prior script that cannot execute at all.
+        if reuse_script and _is_anchor:
+            self.logger.info(
+                f"   ♻️  Reusing locked fitting script from prior run "
+                f"'{reuse_source or 'prior'}'..."
+            )
+            reuse_result = self._fit_single_spectrum(
+                state=state, curve_data=curve_data, data_path=data_path,
+                spectrum_name=spectrum_name, spectrum_idx=spectrum_idx,
+                base_script=reuse_script,
+            )
+            if reuse_result.get("success"):
+                reuse_r2 = (
+                    reuse_result.get("fit_quality", {}).get("r_squared", 0)
+                    or 0.0
+                )
+                verdict = "good" if reuse_r2 >= self.r2_threshold else "poor"
+                if verdict == "good":
+                    self.logger.info(
+                        f"   ✅ Reused script fits well (R² = {reuse_r2:.4f} ≥ "
+                        f"{self.r2_threshold:.3f}) — model re-derivation skipped"
+                    )
+                    message = (
+                        f"Reused the locked fitting script from prior run "
+                        f"'{reuse_source or 'prior'}'; R² = {reuse_r2:.4f} "
+                        f"meets the acceptance threshold "
+                        f"{self.r2_threshold:.3f}."
+                    )
+                else:
+                    self.logger.warning(
+                        f"   ⚠️  Reused script fits poorly (R² = "
+                        f"{reuse_r2:.4f} < {self.r2_threshold:.3f}). Keeping "
+                        f"the result to preserve feature-schema consistency; "
+                        f"flagging it as low-confidence."
+                    )
+                    message = (
+                        f"Reused the locked fitting script from prior run "
+                        f"'{reuse_source or 'prior'}', but R² = "
+                        f"{reuse_r2:.4f} is below the acceptance threshold "
+                        f"{self.r2_threshold:.3f}. The new measurement may "
+                        f"not belong to this series, or measurement "
+                        f"conditions shifted. Extracted parameters are "
+                        f"schema-consistent but should be treated as "
+                        f"low-confidence."
+                    )
+                reuse_result["reuse_validity"] = {
+                    "reused": True,
+                    "source": reuse_source,
+                    "r_squared": reuse_r2,
+                    "threshold": self.r2_threshold,
+                    "verdict": verdict,
+                    "message": message,
+                }
+                if verdict == "poor":
+                    reuse_result["quality_warning"] = message
+                return reuse_result
+            self.logger.warning(
+                f"   ⚠️  Prior fitting script could not execute on this data "
+                f"(even after correction). Falling back to full model "
+                f"re-derivation — the extracted-feature schema may differ "
+                f"from the prior run."
+            )
 
         # --- Initial fit (skills mandatory at T=0) ---
         state["_annealing_level"] = 0
@@ -3342,6 +3441,23 @@ Return JSON with:
         else:
             first_in_regime = {0}  # Only spectrum 0 needs full QC
 
+        # #172: locked-script reuse. When prior_analysis_paths supplies an
+        # earlier curve-fit run, the spectrum-0 anchor reuses that run's saved
+        # fitting script instead of re-deriving the model. Skipped for
+        # multi-regime runs (a single prior script has no regime mapping).
+        reuse_script, reuse_source = _first_prior_curve_fit_script(state)
+        if reuse_script and regime_configs:
+            self.logger.info(
+                "   ♻️  Prior curve-fit run supplied, but this run is "
+                "multi-regime — locked-script reuse skipped."
+            )
+            reuse_script, reuse_source = None, None
+        elif reuse_script:
+            self.logger.info(
+                f"   ♻️  Prior curve-fit run '{reuse_source}' supplied — the "
+                f"anchor will reuse its locked fitting script (#172)."
+            )
+
         results_by_idx: Dict[int, dict] = {}
         deferred_non_anchors: List[dict] = []
         base_scripts: Dict[str, str] = {}  # keyed by regime name
@@ -3448,6 +3564,8 @@ Return JSON with:
                     state=state, curve_data=curve_data, data_path=data_path,
                     spectrum_name=spectrum_name, spectrum_idx=idx,
                     is_regime_anchor=(idx != 0 and idx in first_in_regime),
+                    reuse_script=(reuse_script if idx == 0 else None),
+                    reuse_source=(reuse_source if idx == 0 else None),
                 )
 
                 # Restore original state
@@ -3455,6 +3573,25 @@ Return JSON with:
                     state["original_plot_bytes"] = _saved_original_plot
                 if _saved_data_statistics is not None:
                     state["data_statistics"] = _saved_data_statistics
+
+                # #172: reuse was attempted for the anchor but the result
+                # carries no reuse_validity verdict -> the prior script could
+                # not execute and full QC re-derived the model. Record the
+                # schema-drift caveat so the orchestrator can react.
+                if idx == 0 and reuse_script and not result.get("reuse_validity"):
+                    result["reuse_validity"] = {
+                        "reused": False,
+                        "source": reuse_source,
+                        "verdict": "script_failed",
+                        "message": (
+                            f"The locked fitting script from prior run "
+                            f"'{reuse_source or 'prior'}' could not execute "
+                            f"on this data; the model was re-derived from "
+                            f"scratch and the extracted-feature schema may "
+                            f"differ from the prior run."
+                        ),
+                    }
+                    result["quality_warning"] = result["reuse_validity"]["message"]
 
                 if result["success"] and result.get("script"):
                     base_scripts[regime_name] = result["script"]

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -463,6 +463,40 @@ def _load_prior_state(raw_path):
     return anchor_dir, data
 
 
+def _first_prior_image_script(state: dict):
+    """Return the first reusable analysis script for locked-script reuse (#172).
+
+    Mirrors the curve-fit helper: scans ``state['prior_analysis_paths']`` and
+    returns ``(script_text, source_label)`` for the first prior image-analysis
+    run that carries a saved analysis script under ``scripts/`` — a single-
+    image run writes ``scripts/analysis_script.py``; a series writes one
+    ``scripts/<image>.py`` per image (all share the locked pipeline, so the
+    first is a representative template). Returns ``(None, None)`` when no
+    prior paths are given or none carry a script, which keeps a normal
+    (no-prior) run byte-identical.
+    """
+    paths = state.get("prior_analysis_paths") or []
+    for raw_path in paths:
+        anchor_dir, _data = _load_prior_state(raw_path)
+        if anchor_dir is None:
+            continue
+        scripts_dir = anchor_dir / "scripts"
+        single = scripts_dir / "analysis_script.py"
+        candidate = None
+        if single.is_file():
+            candidate = single
+        elif scripts_dir.is_dir():
+            py_files = sorted(scripts_dir.glob("*.py"))
+            if py_files:
+                candidate = py_files[0]
+        if candidate is not None:
+            try:
+                return candidate.read_text(), (anchor_dir.name or str(anchor_dir))
+            except Exception:  # noqa: BLE001 - a malformed prior run is skipped
+                continue
+    return None, None
+
+
 def _append_prior_analysis_state(prompt: list, state: dict) -> None:
     """Surface a compact state summary from prior analyses to the planner.
 
@@ -2984,6 +3018,8 @@ Return JSON with:
         image_name: str,
         image_idx: int,
         is_regime_anchor: bool = False,
+        reuse_script: Optional[str] = None,
+        reuse_source: Optional[str] = None,
     ) -> dict:
         """Execute analysis with quality control, verification, and optional judge selection.
 
@@ -2995,6 +3031,16 @@ Return JSON with:
            - If still not approved: call judge to select best
         3. If still below quality threshold: try alternative pipelines
         4. If human feedback enabled: allow user to guide refinement
+
+        #172 locked-script reuse: when ``reuse_script`` is supplied (an anchor
+        fed a prior run's saved analysis script via ``prior_analysis_paths``),
+        the prior script is run verbatim on the new image first. If it
+        executes, its result is kept — regardless of the quality score — so
+        the extracted-feature schema stays consistent across an incremental
+        measurement campaign by construction. A single vision-verification
+        pass supplies a soft ``reuse_validity`` verdict the orchestrator can
+        act on; it never re-derives the pipeline. Full QC runs only when the
+        prior script cannot execute at all.
         """
         all_attempts = []
         verification_history = []
@@ -3006,6 +3052,90 @@ Return JSON with:
 
         # Anchor = first image overall OR first in a regime; gets full QC
         _is_anchor = image_idx == 0 or is_regime_anchor
+
+        # --- #172: locked-script reuse fast path ---
+        # A prior image-analysis run supplied via prior_analysis_paths means
+        # the new image is unit N+1 of that series: reuse the prior run's
+        # locked analysis script verbatim instead of re-deriving the pipeline.
+        # This keeps the extracted-feature schema consistent across an
+        # incremental campaign by construction. The vision verifier runs once
+        # as a soft validity *signal* (attached as reuse_validity for the
+        # orchestrator) — it never re-derives the pipeline, since a re-derived
+        # pipeline could change the feature columns. The only fallback to full
+        # QC is a prior script that cannot execute at all.
+        if reuse_script and _is_anchor:
+            self.logger.info(
+                f"   ♻️  Reusing locked analysis script from prior run "
+                f"'{reuse_source or 'prior'}'..."
+            )
+            reuse_result = self._process_single_image(
+                state=state, image_data=image_data, data_path=data_path,
+                image_name=image_name, image_idx=image_idx,
+                base_script=reuse_script,
+            )
+            if reuse_result.get("success"):
+                # Softer validity guard: a single vision-verification pass,
+                # no iterative re-derivation.
+                verification = self._verify_quality(
+                    state, reuse_result, history=[],
+                    verification_iter=0, annealing_level=0,
+                )
+                v_score = 0.0
+                if verification and isinstance(
+                    verification.get("quality_score"), (int, float)
+                ):
+                    v_score = verification["quality_score"]
+                verdict = "good" if v_score >= quality_threshold else "poor"
+                reuse_result["_quality_score"] = v_score
+                if verdict == "good":
+                    self.logger.info(
+                        f"   ✅ Reused script verified (score = {v_score:.2f} "
+                        f"≥ {quality_threshold}) — pipeline re-derivation "
+                        f"skipped"
+                    )
+                    message = (
+                        f"Reused the locked analysis script from prior run "
+                        f"'{reuse_source or 'prior'}'; vision verification "
+                        f"score {v_score:.2f} meets the threshold "
+                        f"{quality_threshold}."
+                    )
+                else:
+                    self.logger.warning(
+                        f"   ⚠️  Reused script verified low (score = "
+                        f"{v_score:.2f} < {quality_threshold}). Keeping the "
+                        f"result to preserve feature-schema consistency; "
+                        f"flagging it as low-confidence."
+                    )
+                    message = (
+                        f"Reused the locked analysis script from prior run "
+                        f"'{reuse_source or 'prior'}', but vision "
+                        f"verification scored {v_score:.2f}, below the "
+                        f"threshold {quality_threshold}. The new image may "
+                        f"not belong to this series, or imaging conditions "
+                        f"shifted. Extracted features are schema-consistent "
+                        f"but should be treated as low-confidence."
+                    )
+                reuse_result["reuse_validity"] = {
+                    "reused": True,
+                    "source": reuse_source,
+                    "quality_score": v_score,
+                    "threshold": quality_threshold,
+                    "verdict": verdict,
+                    "message": message,
+                }
+                reuse_result["quality_history"] = self._build_quality_history(
+                    v_score, quality_threshold, [],
+                    [verification] if verification else [], None,
+                )
+                if verdict == "poor":
+                    reuse_result["quality_warning"] = message
+                return reuse_result
+            self.logger.warning(
+                f"   ⚠️  Prior analysis script could not execute on this "
+                f"image (even after correction). Falling back to full "
+                f"pipeline re-derivation — the extracted-feature schema may "
+                f"differ from the prior run."
+            )
 
         # --- Initial analysis (skills at T=0 — guidance) ---
         state["_annealing_level"] = 0
@@ -4205,6 +4335,23 @@ Return JSON: {{"change_type": "cosmetic" | "analytical" | "rewrite", \
         else:
             first_in_regime = {0}
 
+        # #172: locked-script reuse. When prior_analysis_paths supplies an
+        # earlier image-analysis run, the image-0 anchor reuses that run's
+        # saved analysis script instead of re-deriving the pipeline. Skipped
+        # for multi-regime runs (a single prior script has no regime mapping).
+        reuse_script, reuse_source = _first_prior_image_script(state)
+        if reuse_script and regime_configs:
+            self.logger.info(
+                "   ♻️  Prior image-analysis run supplied, but this run is "
+                "multi-regime — locked-script reuse skipped."
+            )
+            reuse_script, reuse_source = None, None
+        elif reuse_script:
+            self.logger.info(
+                f"   ♻️  Prior image-analysis run '{reuse_source}' supplied "
+                f"— the anchor will reuse its locked analysis script (#172)."
+            )
+
         series_results = []
         base_scripts: Dict[str, str] = {}
         original_locked_config = state.get("locked_analysis_config", {})
@@ -4267,6 +4414,8 @@ Return JSON: {{"change_type": "cosmetic" | "analytical" | "rewrite", \
                     state=state, image_data=image_data, data_path=data_path,
                     image_name=image_name, image_idx=idx,
                     is_regime_anchor=(idx != 0 and idx in first_in_regime),
+                    reuse_script=(reuse_script if idx == 0 else None),
+                    reuse_source=(reuse_source if idx == 0 else None),
                 )
 
                 # Restore original state
@@ -4274,6 +4423,25 @@ Return JSON: {{"change_type": "cosmetic" | "analytical" | "rewrite", \
                     state["original_image_bytes"] = _saved_original_bytes
                 if _saved_image_statistics is not None:
                     state["image_statistics"] = _saved_image_statistics
+
+                # #172: reuse was attempted for the anchor but the result
+                # carries no reuse_validity verdict -> the prior script could
+                # not execute and full QC re-derived the pipeline. Record the
+                # schema-drift caveat so the orchestrator can react.
+                if idx == 0 and reuse_script and not result.get("reuse_validity"):
+                    result["reuse_validity"] = {
+                        "reused": False,
+                        "source": reuse_source,
+                        "verdict": "script_failed",
+                        "message": (
+                            f"The locked analysis script from prior run "
+                            f"'{reuse_source or 'prior'}' could not execute "
+                            f"on this image; the pipeline was re-derived from "
+                            f"scratch and the extracted-feature schema may "
+                            f"differ from the prior run."
+                        ),
+                    }
+                    result["quality_warning"] = result["reuse_validity"]["message"]
 
                 if result["success"] and result.get("script"):
                     base_scripts[regime_name] = result["script"]

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -933,6 +933,10 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             if series_results and series_results[0].get("quality_history"):
                 results["quality_history"] = series_results[0]["quality_history"]
 
+            # #172: surface the locked-script reuse verdict for the orchestrator
+            if series_results and series_results[0].get("reuse_validity"):
+                results["reuse_validity"] = series_results[0]["reuse_validity"]
+
         else:
             # Series: full structure with trends and flagged spectra
             successful = sum(1 for r in series_results if r.get("success", False))
@@ -971,9 +975,15 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                     "original_r2": r.get("original_r2"),
                     "locked_model_type": r.get("locked_model_type"),
                     "quality_history": r.get("quality_history"),
+                    "reuse_validity": r.get("reuse_validity"),
                 }
                 for r in series_results
             ]
+
+            # #172: surface the anchor's locked-script reuse verdict at the
+            # top level for the orchestrator.
+            if series_results and series_results[0].get("reuse_validity"):
+                results["reuse_validity"] = series_results[0]["reuse_validity"]
 
             results["flagged_spectra"] = flagged_spectra
             results["flagged_spectra_analysis"] = synthesis.get("flagged_spectra_analysis", {})

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -1081,6 +1081,10 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             if series_results and series_results[0].get("quality_history"):
                 results["quality_history"] = series_results[0]["quality_history"]
 
+            # #172: surface the locked-script reuse verdict for the orchestrator
+            if series_results and series_results[0].get("reuse_validity"):
+                results["reuse_validity"] = series_results[0]["reuse_validity"]
+
         else:
             # Series: full structure with trends and flagged images
             successful = sum(
@@ -1122,9 +1126,15 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                         r.get("quality_history", {}).get("final_score")
                         if r.get("quality_history") else None
                     ),
+                    "reuse_validity": r.get("reuse_validity"),
                 }
                 for r in series_results
             ]
+
+            # #172: surface the anchor's locked-script reuse verdict at the
+            # top level for the orchestrator.
+            if series_results and series_results[0].get("reuse_validity"):
+                results["reuse_validity"] = series_results[0]["reuse_validity"]
 
             results["flagged_images"] = flagged_images
             results["flagged_images_analysis"] = synthesis.get(


### PR DESCRIPTION
When a planning / Bayesian-optimization campaign consumes per-unit features from analysis, a new measurement is just point N+1 of the same series — the extraction recipe is constant, only the control parameters move. This makes the curve-fit and image agents reuse a prior run's locked extraction script instead of re-deriving the model/pipeline, so the new feature row keeps the same columns the campaign's append strictly requires.

Curve-fit:
- _first_prior_curve_fit_script() pulls a prior run's saved fitting script from prior_analysis_paths.
- UnifiedSeriesProcessingController._fit_with_quality_control gains a reuse_script fast path: the prior script runs verbatim on the new data and its result is kept regardless of R² (schema-consistent by construction). R² is attached as a reuse_validity verdict (good/poor), never a gate that re-derives the model. Full QC re-derivation runs only when the prior script cannot execute at all (verdict script_failed).

Image:
- Symmetric _first_prior_image_script() + _execute_and_verify reuse path; the vision verifier runs once as the softer validity guard.

Orchestrator:
- prior_analysis_paths tool description tightened: pass it only for genuine series continuations.
- System-prompt directive to read the reuse_validity verdict and act on a non-good outcome (surface warning / re-run fresh / flag schema drift).
- run_analysis surfaces reuse_validity in its response.

Every new path is gated on prior_analysis_paths — no-prior runs are byte-identical. Builds on #173.