### PR TITLE
sim orchestrator: escape literal curly braces + update EXPECTED_TOOLS

### DIFF
--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -86,7 +86,7 @@ are loaded AND what the user has installed locally.
 **Routing first:**
 On any new simulation request, call `route_simulation` BEFORE
 generating structures or inputs. The router returns
-{scale, engine, reasoning, candidates_considered} based on the user's
+{{scale, engine, reasoning, candidates_considered}} based on the user's
 goal, the system, and what's actually available. Once a routing
 decision exists in the session, plan subsequent tool calls around
 that engine (don't re-route on every turn unless the user pivots).

--- a/tests/test_simulation_orchestrator.py
+++ b/tests/test_simulation_orchestrator.py
@@ -99,6 +99,7 @@ EXPECTED_TOOLS = {
     "list_generated_structures",
     "analyze_vasp_output",
     "suggest_incar_fixes",
+    "route_simulation",
     # HPC tools
     "submit_vasp_job",
     "get_job_status",


### PR DESCRIPTION
## Summary

Two small fixes from my own commit `6f49a4764` (\"Wire SimulationRouter into SimulationOrchestratorAgent as a tool\"):

1. `_SYSTEM_PROMPT_BODY` documents the router's return shape as `{scale, engine, reasoning, candidates_considered}` with literal curly braces. `.format(tools_section=...)` was treating those as placeholder names and raising `KeyError: 'scale, engine, reasoning, candidates_considered'` at every `SimulationOrchestratorAgent.__init__`. Escaped with `{{...}}` to keep the doc-string literal.

2. `EXPECTED_TOOLS` in `tests/test_simulation_orchestrator.py` wasn't updated when `route_simulation` was added to the tool registry, so even past the KeyError the \"Orchestrator constructs\" test would still fail with an assertion mismatch.

`python tests/test_simulation_orchestrator.py` now passes **8 / 8** (was failing 7 / 8 silently since 2026-05-12 — the test wasn't in CI).

## Test plan

- [x] `python tests/test_simulation_orchestrator.py` — all 8 tests pass locally
- [x] `python -c \"from scilink.agents.sim_agents import SimulationOrchestratorAgent, SimulationMode; SimulationOrchestratorAgent(api_key='test', base_dir='/tmp/x', simulation_mode=SimulationMode.CO_PILOT)\"` — no longer raises

🤖 Generated with [Claude Code](https://claude.com/claude-code)