### PR TITLE
meta CLI: skills/tools/MCP flags + landing-page polish

### DIFF
--- a/scilink/cli/meta.py
+++ b/scilink/cli/meta.py
@@ -45,8 +45,10 @@ Examples:
   scilink explore --model gemini-2.0-flash
   scilink explore --base-url https://my-proxy.example.com/v1 --model my-model
 
-  # Share custom domain skills with every specialist
+  # Share custom skills / tools / MCP servers with every specialist
   scilink explore --skills ./raman_skill.md ./xrd_skill.md
+  scilink explore --tools ./image_tools.py
+  scilink explore --mcp stdio:fs:npx,-y,@modelcontextprotocol/server-filesystem,/tmp
 
 Modes — the meta has two levels (a delegation runs a specialist through its
 one-shot run_task, so the specialists' step-by-step co-pilot mode does not
@@ -116,6 +118,40 @@ Environment Variables:
         )
     )
 
+    # Custom tool files — shared with every specialist the meta delegates to
+    parser.add_argument(
+        '--tools',
+        type=str,
+        nargs='+',
+        dest='tool_files',
+        metavar='TOOL_FILE',
+        help=(
+            'Path(s) to Python files of domain-specific tool functions. Each '
+            'file must define a list of OpenAI-format tool schemas '
+            '(\'tool_schemas\' / \'openai_schemas\') and a factory function '
+            '(\'create_tool_functions\'). Each file is registered on the '
+            'meta-agent and shared with every specialist. Example: '
+            'scilink explore --tools ./image_tools.py'
+        )
+    )
+
+    # MCP servers — shared with every specialist
+    parser.add_argument(
+        '--mcp',
+        type=str,
+        nargs='+',
+        dest='mcp_servers',
+        metavar='MCP_CONFIG',
+        help=(
+            'MCP server configurations. Each entry can be:\n'
+            '  - A JSON config file ({"name":"...", "command":["..."], "env":{}})\n'
+            '  - stdio shorthand:  stdio:name:command,arg1,arg2\n'
+            '  - SSE shorthand:    sse:name:http://host:port/sse\n'
+            'Each server is shared with every specialist. Example: '
+            'scilink explore --mcp stdio:fs:npx,-y,@modelcontextprotocol/server-filesystem,/tmp'
+        )
+    )
+
     args = parser.parse_args()
 
     # Validate custom skill files if provided
@@ -125,6 +161,14 @@ Environment Variables:
                 parser.error(f"--skills path does not exist: {sf}")
             if not sf.endswith('.md'):
                 parser.error(f"--skills file must be a .md file: {sf}")
+
+    # Validate custom tool files if provided
+    if args.tool_files:
+        for tf in args.tool_files:
+            if not Path(tf).exists():
+                parser.error(f"--tools path does not exist: {tf}")
+            if not tf.endswith('.py'):
+                parser.error(f"--tools file must be a .py file: {tf}")
 
     config = {
         'model_name': args.model,
@@ -138,6 +182,8 @@ Environment Variables:
         'session_dir': args.session_dir,
         'restore': args.restore,
         'skill_files': args.skill_files or [],
+        'tool_files': args.tool_files or [],
+        'mcp_servers': args.mcp_servers or [],
     }
 
     try:
@@ -202,6 +248,8 @@ class MetaPlayground:
 
         self._initial_message = self.config.get('initial_message')
         self._skill_files = self.config.get('skill_files', [])
+        self._tool_files = self.config.get('tool_files', [])
+        self._mcp_servers = self.config.get('mcp_servers', [])
 
         mode_map = {
             'autopilot': MetaMode.AUTOPILOT,
@@ -286,9 +334,13 @@ a nested child sub-session under this meta session.
             traceback.print_exc()
             sys.exit(1)
 
-        # ── Register custom skills ──────────────────────────────────
+        # ── Register custom skills / tools / MCP servers ────────────
         if self._skill_files:
             self._register_custom_skills(self._skill_files)
+        if self._tool_files:
+            self._load_custom_tools(self._tool_files)
+        if self._mcp_servers:
+            self._connect_mcp_servers(self._mcp_servers)
 
         # ── Session info ────────────────────────────────────────────
         print("\n" + "=" * 60)
@@ -320,6 +372,141 @@ a nested child sub-session under this meta session.
             except Exception as e:
                 print(f"   ❌ Failed to register {path.name}: {e}")
 
+    def _load_custom_tools(self, tool_files: list) -> None:
+        """Load external tool functions from user-supplied .py files and register them.
+
+        Each file must expose:
+          1. A list of OpenAI-format tool schemas — discovered by looking for a
+             module-level variable named ``tool_schemas`` or ``openai_schemas``
+             first, then falling back to any top-level list whose first element is
+             a dict with ``type == "function"``.
+          2. A factory function that accepts data and returns a dict mapping tool
+             names to callables.  The factory is discovered by looking for
+             ``create_tool_functions`` first, then any module-level function whose
+             name ends with ``_tool_functions``.
+
+        Each registered tool set is shared with every specialist the meta-agent
+        delegates to.
+        """
+        import importlib.util
+        import inspect
+        import sys
+
+        for file_path in tool_files:
+            path = Path(file_path).resolve()
+            print(f"\n🔧 Loading custom tools from: {path}")
+            try:
+                spec = importlib.util.spec_from_file_location(path.stem, path)
+                module = importlib.util.module_from_spec(spec)
+                _prev = sys.dont_write_bytecode
+                sys.dont_write_bytecode = True
+                try:
+                    spec.loader.exec_module(module)
+                finally:
+                    sys.dont_write_bytecode = _prev
+            except Exception as e:
+                print(f"   ❌ Failed to load {path.name}: {e}")
+                continue
+
+            # ── Discover schemas ──────────────────────────────────────────────
+            schemas = (
+                getattr(module, 'tool_schemas', None)
+                or getattr(module, 'openai_schemas', None)
+            )
+            if schemas is None:
+                # Auto-detect: any top-level list of OpenAI function dicts
+                for attr_name in dir(module):
+                    obj = getattr(module, attr_name, None)
+                    if (
+                        isinstance(obj, list)
+                        and obj
+                        and isinstance(obj[0], dict)
+                        and obj[0].get('type') == 'function'
+                    ):
+                        schemas = obj
+                        print(f"   📋 Auto-detected schemas in '{attr_name}'")
+                        break
+
+            if not schemas:
+                print(
+                    f"   ⚠️  No tool schemas found in {path.name}.\n"
+                    "       Define 'tool_schemas' as a list of OpenAI-format tool dicts."
+                )
+                continue
+
+            # ── Discover factory ──────────────────────────────────────────────
+            factory = getattr(module, 'create_tool_functions', None)
+            if factory is None:
+                for name, fn in inspect.getmembers(module, inspect.isfunction):
+                    if (
+                        name.endswith('_tool_functions')
+                        and fn.__module__ == module.__name__
+                    ):
+                        factory = fn
+                        print(f"   🏭 Auto-detected factory '{name}'")
+                        break
+
+            if factory is None:
+                print(
+                    f"   ⚠️  No factory function found in {path.name}.\n"
+                    "       Define 'create_tool_functions(data)' returning "
+                    "a dict mapping tool names to callables."
+                )
+                continue
+
+            self.agent.register_tools(schemas, factory)
+            count = sum(1 for s in schemas if s.get('type') == 'function')
+            print(f"   ✅ Registered {count} tool(s) from {path.name} "
+                  f"— shared with all specialists")
+
+    def _connect_mcp_servers(self, mcp_configs: list) -> None:
+        """Parse MCP server configs and connect to each.
+
+        Each connected server is shared with every specialist the meta-agent
+        delegates to.
+        """
+        import json as _json
+
+        for entry in mcp_configs:
+            try:
+                if entry.startswith("stdio:"):
+                    # stdio:name:cmd,arg1,arg2
+                    parts = entry[len("stdio:"):].split(":", 1)
+                    name = parts[0]
+                    command = parts[1].split(",") if len(parts) > 1 else []
+                    print(f"\n🔌 Connecting to MCP server '{name}' (stdio)...")
+                    count = self.agent.connect_mcp_server(
+                        name, command=command
+                    )
+                    print(f"   ✅ Registered {count} tool(s) from '{name}'")
+
+                elif entry.startswith("sse:"):
+                    # sse:name:http://host:port/path
+                    parts = entry[len("sse:"):].split(":", 1)
+                    name = parts[0]
+                    url = parts[1] if len(parts) > 1 else ""
+                    print(f"\n🔌 Connecting to MCP server '{name}' (SSE)...")
+                    count = self.agent.connect_mcp_server(name, url=url)
+                    print(f"   ✅ Registered {count} tool(s) from '{name}'")
+
+                else:
+                    # JSON config file
+                    path = Path(entry).resolve()
+                    with open(path) as f:
+                        cfg = _json.load(f)
+                    name = cfg.get("name", path.stem)
+                    print(f"\n🔌 Connecting to MCP server '{name}'...")
+                    count = self.agent.connect_mcp_server(
+                        name,
+                        command=cfg.get("command"),
+                        url=cfg.get("url"),
+                        env=cfg.get("env"),
+                    )
+                    print(f"   ✅ Registered {count} tool(s) from '{name}'")
+
+            except Exception as e:
+                print(f"   ❌ Failed to connect MCP server '{entry}': {e}")
+
     def print_help(self):
         print("\n" + "=" * 60)
         print("AVAILABLE COMMANDS")
@@ -330,6 +517,8 @@ a nested child sub-session under this meta session.
         print("  /status            Show current session state")
         print("  /mode [level]      Show or change meta autonomy mode")
         print("  /skill <path>      Register a custom skill (.md), shared with specialists")
+        print("  /tool <path>       Register a custom tool file (.py), shared with specialists")
+        print("  /mcp <config>      Connect an MCP server, shared with specialists")
         print("  /clear             Clear screen")
         print("  /quit or /exit     Exit")
         print("\nOr just describe your research goal and let the meta-agent route it!")
@@ -402,6 +591,25 @@ a nested child sub-session under this meta session.
                 print("   Registers a custom skill and shares it with every specialist.")
             else:
                 self._register_custom_skills([parts[1].strip()])
+            return True
+
+        if cmd == "/tool" or cmd.startswith("/tool "):
+            parts = user_input.strip().split(maxsplit=1)
+            if len(parts) < 2 or not parts[1].strip():
+                print("\n   Usage: /tool <path-to-tools.py>")
+                print("   Loads a custom tool file and shares it with every specialist.")
+            else:
+                self._load_custom_tools([parts[1].strip()])
+            return True
+
+        if cmd == "/mcp" or cmd.startswith("/mcp "):
+            parts = user_input.strip().split(maxsplit=1)
+            if len(parts) < 2 or not parts[1].strip():
+                print("\n   Usage: /mcp <config>")
+                print("   Config: a JSON file, stdio:name:cmd,arg..., or sse:name:url")
+                print("   Connects an MCP server and shares it with every specialist.")
+            else:
+                self._connect_mcp_servers([parts[1].strip()])
             return True
 
         if cmd == "/clear":

--- a/scilink/cli/meta.py
+++ b/scilink/cli/meta.py
@@ -45,6 +45,9 @@ Examples:
   scilink explore --model gemini-2.0-flash
   scilink explore --base-url https://my-proxy.example.com/v1 --model my-model
 
+  # Share custom domain skills with every specialist
+  scilink explore --skills ./raman_skill.md ./xrd_skill.md
+
 Modes — the meta has two levels (a delegation runs a specialist through its
 one-shot run_task, so the specialists' step-by-step co-pilot mode does not
 apply here):
@@ -98,7 +101,30 @@ Environment Variables:
     parser.add_argument('--restore', action='store_true',
                         help='Restore from previous checkpoint in session directory')
 
+    # Custom skills — shared with every specialist the meta delegates to
+    parser.add_argument(
+        '--skills',
+        type=str,
+        nargs='+',
+        dest='skill_files',
+        metavar='SKILL_FILE',
+        help=(
+            'Path(s) to custom skill .md files. Each skill is registered on '
+            'the meta-agent and shared with every specialist it delegates to '
+            '(analysis + planning). Example: '
+            'scilink explore --skills ./raman_skill.md ./ftir_skill.md'
+        )
+    )
+
     args = parser.parse_args()
+
+    # Validate custom skill files if provided
+    if args.skill_files:
+        for sf in args.skill_files:
+            if not Path(sf).exists():
+                parser.error(f"--skills path does not exist: {sf}")
+            if not sf.endswith('.md'):
+                parser.error(f"--skills file must be a .md file: {sf}")
 
     config = {
         'model_name': args.model,
@@ -111,6 +137,7 @@ Environment Variables:
         'initial_message': args.initial_message,
         'session_dir': args.session_dir,
         'restore': args.restore,
+        'skill_files': args.skill_files or [],
     }
 
     try:
@@ -174,6 +201,7 @@ class MetaPlayground:
         restore = self.config.get('restore', False)
 
         self._initial_message = self.config.get('initial_message')
+        self._skill_files = self.config.get('skill_files', [])
 
         mode_map = {
             'autopilot': MetaMode.AUTOPILOT,
@@ -258,6 +286,10 @@ a nested child sub-session under this meta session.
             traceback.print_exc()
             sys.exit(1)
 
+        # ── Register custom skills ──────────────────────────────────
+        if self._skill_files:
+            self._register_custom_skills(self._skill_files)
+
         # ── Session info ────────────────────────────────────────────
         print("\n" + "=" * 60)
         print("SESSION INFO")
@@ -277,6 +309,17 @@ a nested child sub-session under this meta session.
 
         print(f"\nDelegation Tools: {', '.join(self.agent.tools.functions_map.keys())}")
 
+    def _register_custom_skills(self, skill_files: list) -> None:
+        """Register custom skill .md files; each is shared with every specialist."""
+        for file_path in skill_files:
+            path = Path(file_path).expanduser().resolve()
+            print(f"\n📖 Registering custom skill: {path}")
+            try:
+                name = self.agent.register_skill(str(path))
+                print(f"   ✅ Skill '{name}' registered — shared with all specialists")
+            except Exception as e:
+                print(f"   ❌ Failed to register {path.name}: {e}")
+
     def print_help(self):
         print("\n" + "=" * 60)
         print("AVAILABLE COMMANDS")
@@ -286,6 +329,7 @@ a nested child sub-session under this meta session.
         print("  /children          List delegations made this session")
         print("  /status            Show current session state")
         print("  /mode [level]      Show or change meta autonomy mode")
+        print("  /skill <path>      Register a custom skill (.md), shared with specialists")
         print("  /clear             Clear screen")
         print("  /quit or /exit     Exit")
         print("\nOr just describe your research goal and let the meta-agent route it!")
@@ -347,6 +391,17 @@ a nested child sub-session under this meta session.
                 else:
                     print(f"\n   ❌ Unknown mode: {parts[1]}")
                     print("   Valid options: autopilot, autonomous")
+            return True
+
+        if cmd.startswith("/skill"):
+            # Parse the path from the original input — cmd is lower-cased and
+            # would corrupt a case-sensitive file path.
+            parts = user_input.strip().split(maxsplit=1)
+            if len(parts) < 2 or not parts[1].strip():
+                print("\n   Usage: /skill <path-to-skill.md>")
+                print("   Registers a custom skill and shares it with every specialist.")
+            else:
+                self._register_custom_skills([parts[1].strip()])
             return True
 
         if cmd == "/clear":

--- a/scilink/ui/components/chat_uploads.py
+++ b/scilink/ui/components/chat_uploads.py
@@ -295,8 +295,8 @@ def _render_meta_uploads(start_task_fn) -> None:
         'background:#8893a5;color:#fff;padding:2px 8px;border-radius:9px;'
         'letter-spacing:1px;font-weight:600;">BETA</span></p>'
         '<p class="upload-hero-subtitle">'
-        "Describe your research goal — Explore routes it to the analysis "
-        "and planning specialists</p>"
+        "Describe your research goal — mission control agent will route "
+        "it to the specialist agents</p>"
         "</div>",
         unsafe_allow_html=True,
     )

--- a/scilink/ui/config.py
+++ b/scilink/ui/config.py
@@ -16,7 +16,7 @@ EMBEDDING_MODEL_OPTIONS = [
 
 # ── Mode registry ────────────────────────────────────────────────
 APP_MODES = [
-    {"key": "meta",    "label": "Explore",  "beta": True, "description": "Routes your research goal to the Analyze & Plan specialists"},
+    {"key": "meta",    "label": "🧪 📋 ⚛️",  "beta": True, "description": "Routes your research goal to the Analyze & Plan specialists"},
     {"key": "analyze", "label": "Analyze", "description": "Multi-modal data analysis"},
     {"key": "plan",    "label": "Plan",    "description": "Experimental design & optimization"},
     {"key": "simulate", "label": "Simulate", "description": "Submit and monitor DFT/MD simulations"},


### PR DESCRIPTION
## Summary

Brings the meta-agent CLI (`scilink explore` / bare `scilink`) to parity
with `scilink analyze` for custom extensions, and applies two small
landing-page tweaks.

## CLI — custom extensions

The meta CLI previously had no way to register custom skills, tools, or
MCP servers, even though `MetaOrchestratorAgent` already exposes
`register_skill()` / `register_tools()` / `connect_mcp_server()` (the UI
Skills and Tools tabs already use them). Added, mirroring `cli/analyze.py`:

| | flag (all `nargs='+'`) | slash command |
|---|---|---|
| Skills | `--skills A.md B.md` | `/skill <path>` |
| Tools  | `--tools A.py B.py`  | `/tool <path>`  |
| MCP    | `--mcp stdio:… sse:…` | `/mcp <config>` |

Each registration is shared with every specialist the meta delegates to
(analysis + planning) via the existing shared-extension mechanism.
Tool-file loading and MCP-config parsing mirror `cli/analyze.py` verbatim
(`_load_custom_tools` / `_connect_mcp_servers`). Slash-command paths are
parsed from the raw input, so case-sensitive paths survive.

## UI — landing-page polish

- Mode button: the `Explore` text label becomes the three specialist
  emojis it routes to — 🧪 (analysis) and 📋 (planning), matching the meta
  delegation-tree sidebar icons, plus ⚛️ (simulation).
- Explore upload hero subtitle: "Describe your research goal — mission
  control agent will route it to the specialist agents".

## Verification

`scilink/cli/meta.py`, `ui/config.py`, `ui/components/chat_uploads.py`
syntax-check and import cleanly; `scilink explore --help` lists
`--skills` / `--tools` / `--mcp`; invalid `--tools`/`--skills` paths are
rejected with clear errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)