### PR TITLE
ScalarizerAgent: defer sandbox check from __init__ to scalarize() + _execute_script

### DIFF
--- a/scilink/agents/planning_agents/scalarizer_agent.py
+++ b/scilink/agents/planning_agents/scalarizer_agent.py
@@ -61,13 +61,14 @@ class ScalarizerAgent(BaseAgent):
         google_api_key: Optional[str] = None,
         local_model: Optional[str] = None,
     ):
-        if not require_sandbox_approval(
-            context="ScalarizerAgent (scalarization of experimental data)"
-        ):
-            raise RuntimeError(
-                "ScalarizerAgent requires code execution but user declined. "
-                "Run in Docker, VM, or Colab for safe execution."
-            )
+        # Construction is always allowed.  The sandbox check is deferred to
+        # ``scalarize()`` (early gate, avoids LLM-call waste on decline) and
+        # to ``_execute_script`` (the actual subprocess boundary, defense-in-
+        # depth for any future caller that bypasses ``scalarize()``).  This
+        # lets the agent be instantiated in non-TTY contexts — Streamlit UI,
+        # scripts, CI, and meta-agent sessions that never actually scalarize.
+        # The first executed gate prompts the user once; the global cache in
+        # ``require_sandbox_approval`` short-circuits subsequent checks.
         super().__init__(output_dir)
         self.agent_type = "scalarizer"
 
@@ -144,7 +145,23 @@ class ScalarizerAgent(BaseAgent):
 
     def _execute_script(self, script_path: Path, args: List[str] = None) -> Dict[str, Any]:
         """Runs the generated python script in a subprocess."""
-       
+
+        # Defense-in-depth: ``scalarize()`` already gates on sandbox approval
+        # before any code is generated, but this method is the actual
+        # subprocess boundary — any future caller that bypasses
+        # ``scalarize()`` is still protected by the cache-cheap second check.
+        if not require_sandbox_approval(
+            context="ScalarizerAgent (scalarization of experimental data)"
+        ):
+            return {
+                "status": "failure",
+                "error": (
+                    "Sandbox approval declined — script not executed. "
+                    "Set UNSAFE_EXECUTION_OK=true or run inside Docker / "
+                    "VM / Colab to enable code execution."
+                ),
+            }
+
         # Construct command with arguments (if any)
         cmd = ["python", str(script_path)]
         if args:
@@ -270,8 +287,32 @@ class ScalarizerAgent(BaseAgent):
             - 'metrics': Dict of extracted scalars
             - 'source_script': Path to the generated Python script
         """
+        # Sandbox gate — fires here (the actual entry point that will run
+        # generated code) instead of in __init__, so the agent can be
+        # constructed in non-TTY contexts (Streamlit, scripts, CI, meta-agent
+        # sessions that may never scalarize anything).  The global cache in
+        # ``require_sandbox_approval`` short-circuits subsequent calls in the
+        # same session.  On decline we return a structured failure dict —
+        # callers in orchestrator_tools.py already check ``status != 'success'``,
+        # so the failure propagates correctly all the way up without
+        # triggering the in-loop "fix the code" retries.
+        if not require_sandbox_approval(
+            context="ScalarizerAgent (scalarization of experimental data)"
+        ):
+            return {
+                "status": "failure",
+                "metrics": {},
+                "source_script": None,
+                "column_roles": {},
+                "error": (
+                    "Sandbox approval declined — scalarization not executed. "
+                    "Set UNSAFE_EXECUTION_OK=true or run inside Docker / VM / "
+                    "Colab to enable code execution."
+                ),
+            }
+
         path_obj = Path(data_path)
-        
+
         # Initialize state
         self._init_state(current_data_path=data_path, current_objective=objective_query)
 

--- a/tests/test_scalarizer_sandbox.py
+++ b/tests/test_scalarizer_sandbox.py
@@ -1,0 +1,255 @@
+"""
+Tests for the ScalarizerAgent sandbox gate.
+
+The check was previously in ``__init__``, which made the agent
+unconstructable in any non-TTY context without ``UNSAFE_EXECUTION_OK=true``
+— blocking the meta-agent's planning child in Streamlit, scripts, and CI.
+
+These tests pin down the new behavior:
+  * Construction succeeds unconditionally (no sandbox check at __init__).
+  * ``scalarize()`` gates on sandbox approval — declined → structured
+    failure dict with all expected keys, approved → falls through to the
+    real workflow (here mocked to exercise just the gate, not the LLM).
+  * The downstream caller contract (``status != "success"`` ⇒ failure)
+    is preserved on the decline path.
+
+Run:
+    python tests/test_scalarizer_sandbox.py
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _no_sandbox_env() -> dict:
+    """Env that guarantees ``require_sandbox_approval`` will decline in
+    a non-TTY test runner (no env-var bypass, no Docker indicators)."""
+    env = os.environ.copy()
+    env.pop("UNSAFE_EXECUTION_OK", None)
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_construction_without_sandbox() -> None:
+    """ScalarizerAgent constructs cleanly in a non-TTY context without
+    UNSAFE_EXECUTION_OK — this is the regression we're fixing."""
+    from scilink.agents.planning_agents.scalarizer_agent import ScalarizerAgent
+    # Reset the global cache so this test runs in a known state regardless
+    # of test ordering.
+    import scilink.executors as _exec
+    _exec._GLOBAL_SANDBOX_APPROVED = False
+
+    os.environ.pop("UNSAFE_EXECUTION_OK", None)
+    with tempfile.TemporaryDirectory() as td:
+        agent = ScalarizerAgent(
+            api_key="test-dummy-not-used",
+            output_dir=td,
+        )
+        assert agent is not None
+        assert agent.agent_type == "scalarizer"
+
+
+def test_planning_orchestrator_constructs_planning_child() -> None:
+    """The meta-agent's planning-child construction path — the original
+    failure mode reported during PR #171 review."""
+    from scilink.agents.meta_agent.meta_orchestrator import (
+        MetaOrchestratorAgent, MetaMode,
+    )
+    import scilink.executors as _exec
+    _exec._GLOBAL_SANDBOX_APPROVED = False
+    os.environ.pop("UNSAFE_EXECUTION_OK", None)
+
+    with tempfile.TemporaryDirectory() as td:
+        meta = MetaOrchestratorAgent(
+            base_dir=td,
+            api_key="test-dummy-not-used",
+            meta_mode=MetaMode.AUTOPILOT,
+        )
+        # This call used to raise RuntimeError from inside
+        # PlanningOrchestratorAgent.__init__ → ScalarizerAgent.__init__.
+        planning_child = meta._get_planning_child()
+        assert planning_child is not None
+
+
+def test_scalarize_returns_failure_dict_on_declined_sandbox() -> None:
+    """When the sandbox is declined at scalarize() time, the return value
+    is a structured failure dict with the contract keys orchestrator_tools
+    relies on."""
+    from scilink.agents.planning_agents.scalarizer_agent import ScalarizerAgent
+    import scilink.executors as _exec
+    _exec._GLOBAL_SANDBOX_APPROVED = False
+
+    with tempfile.TemporaryDirectory() as td:
+        agent = ScalarizerAgent(api_key="test-dummy-not-used", output_dir=td)
+
+        # Pretend the sandbox check denies approval (e.g. non-TTY, no
+        # env-var, no Docker).  Patching at the call site in the module.
+        with patch(
+            "scilink.agents.planning_agents.scalarizer_agent.require_sandbox_approval",
+            return_value=False,
+        ):
+            result = agent.scalarize(
+                data_path="/path/does/not/matter.csv",
+                objective_query="Calculate yield",
+            )
+
+    # Contract: callers in orchestrator_tools.py do `res["status"] != "success"`
+    # and read `res.get("error", "Scalarizer failed")`.
+    assert isinstance(result, dict), f"got {type(result).__name__}, expected dict"
+    assert result["status"] == "failure", (
+        f"expected status='failure', got {result.get('status')!r}"
+    )
+    assert "error" in result and result["error"], (
+        f"expected non-empty error message; got {result.get('error')!r}"
+    )
+    assert "Sandbox" in result["error"], (
+        f"error message should explain the sandbox decline; got {result['error']!r}"
+    )
+    # All other keys the callers may read, even if defaulted:
+    for key in ("metrics", "source_script", "column_roles"):
+        assert key in result, f"missing contract key: {key!r}"
+
+
+def test_execute_script_is_sandbox_gated_too() -> None:
+    """Defense in depth — _execute_script gates on sandbox approval as
+    well, so any future caller that bypasses ``scalarize()`` (e.g. a new
+    public method, a test helper, an external integration) is still
+    protected at the actual subprocess boundary.
+
+    The duplicate check is essentially free at runtime — the global cache
+    in ``require_sandbox_approval`` short-circuits the second call once
+    ``scalarize()`` has approved (or once UNSAFE_EXECUTION_OK is set)."""
+    from scilink.agents.planning_agents.scalarizer_agent import ScalarizerAgent
+    import scilink.executors as _exec
+    _exec._GLOBAL_SANDBOX_APPROVED = False
+
+    with tempfile.TemporaryDirectory() as td:
+        agent = ScalarizerAgent(api_key="test-dummy-not-used", output_dir=td)
+
+        # Direct call to _execute_script without going through scalarize().
+        # No UNSAFE_EXECUTION_OK, cache cleared above → the gate must fire.
+        os.environ.pop("UNSAFE_EXECUTION_OK", None)
+        script = Path(td) / "trivial.py"
+        script.write_text(
+            "import json\n"
+            "print(json.dumps({'metrics': {'value': 1.0}, 'plot_path': ''}))\n"
+        )
+
+        with patch(
+            "scilink.agents.planning_agents.scalarizer_agent.require_sandbox_approval",
+            return_value=False,
+        ):
+            exec_res = agent._execute_script(script)
+
+        assert exec_res["status"] == "failure", (
+            f"_execute_script should be sandbox-gated; got {exec_res!r}"
+        )
+        assert "Sandbox" in (exec_res.get("error") or ""), (
+            f"_execute_script's sandbox-decline error should mention "
+            f"'Sandbox'; got {exec_res.get('error')!r}"
+        )
+
+        # And confirm the happy path still works when approval is granted —
+        # the gate's existence shouldn't break normal execution.
+        os.environ["UNSAFE_EXECUTION_OK"] = "true"
+        _exec._GLOBAL_SANDBOX_APPROVED = False
+        try:
+            exec_res = agent._execute_script(script)
+        finally:
+            os.environ.pop("UNSAFE_EXECUTION_OK", None)
+            _exec._GLOBAL_SANDBOX_APPROVED = False
+
+        assert exec_res["status"] == "success", (
+            f"_execute_script should succeed when sandbox is approved; "
+            f"got {exec_res!r}"
+        )
+        assert exec_res["metrics"]["value"] == 1.0
+
+
+def test_unsafe_execution_ok_env_var_short_circuits() -> None:
+    """If UNSAFE_EXECUTION_OK=true is set, scalarize() proceeds past the
+    sandbox gate.  We don't need the actual scalarize workflow to run
+    (mocking the LLM is heavyweight); we just need to confirm the gate
+    isn't returning the "declined" failure dict."""
+    from scilink.agents.planning_agents.scalarizer_agent import ScalarizerAgent
+    import scilink.executors as _exec
+    _exec._GLOBAL_SANDBOX_APPROVED = False
+
+    os.environ["UNSAFE_EXECUTION_OK"] = "true"
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            agent = ScalarizerAgent(api_key="test-dummy-not-used", output_dir=td)
+
+            # scalarize() will fail later (no LLM, no real data) but the
+            # failure must NOT be the sandbox-decline failure.
+            result = agent.scalarize(
+                data_path="/path/does/not/exist.csv",
+                objective_query="trivial",
+            )
+
+        # The sandbox-declined sentinel is what we're checking *isn't* there.
+        if result.get("status") == "failure":
+            err = result.get("error") or ""
+            assert "Sandbox approval declined" not in err, (
+                "UNSAFE_EXECUTION_OK should bypass the sandbox decline, "
+                f"but got: {err}"
+            )
+    finally:
+        os.environ.pop("UNSAFE_EXECUTION_OK", None)
+        _exec._GLOBAL_SANDBOX_APPROVED = False
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def _run(name: str, fn) -> bool:
+    try:
+        fn()
+    except AssertionError as e:
+        print(f"  ❌ {name}\n     {e}")
+        return False
+    except Exception as e:  # noqa: BLE001
+        import traceback
+        print(f"  💥 {name}\n     {type(e).__name__}: {e}")
+        traceback.print_exc()
+        return False
+    print(f"  ✅ {name}")
+    return True
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.WARNING)
+
+    print("=== ScalarizerAgent sandbox-gate tests ===\n")
+    passed = failed = 0
+    for name, fn in (
+        ("construction without sandbox",                test_construction_without_sandbox),
+        ("planning child construction (meta-agent)",    test_planning_orchestrator_constructs_planning_child),
+        ("scalarize returns failure dict on decline",   test_scalarize_returns_failure_dict_on_declined_sandbox),
+        ("_execute_script is sandbox-gated too",        test_execute_script_is_sandbox_gated_too),
+        ("UNSAFE_EXECUTION_OK env-var bypass",          test_unsafe_execution_ok_env_var_short_circuits),
+    ):
+        if _run(name, fn):
+            passed += 1
+        else:
+            failed += 1
+
+    print(f"\n  passed: {passed}    failed: {failed}")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

`ScalarizerAgent.__init__` called `require_sandbox_approval()` synchronously.  In any non-TTY context without `UNSAFE_EXECUTION_OK=true`, this raised `RuntimeError` the moment the agent was instantiated — even if no scalarization was ever attempted.

Since bare `scilink` now launches the meta-agent (#171), and the meta lazily creates its planning child on first delegation (which constructs a `ScalarizerAgent` along the way), **every first-run user who ran `scilink ui` or invoked `scilink` programmatically hit this crash before issuing any planning task**.

## What changed

Belt-and-suspenders gate placement, both essentially free at runtime thanks to `require_sandbox_approval`'s global cache:

- **`scalarize()`** — fires once at the public entry point, before any code generation happens.  On decline, returns a structured failure dict, so the in-loop \"fix the code\" retry pathway in `_execute_script` never spins on something the LLM can't fix (zero wasted LLM calls).
- **`_execute_script`** — the actual subprocess boundary.  Any future caller that bypasses `scalarize()` (a new public method, a test helper, an external integration) is still protected.

Either gate, on decline, returns a structured failure dict.  Existing callers in `orchestrator_tools.py` (lines 1498, 1545, 2150) already check `status != \"success\"` and surface `error`, so the decline propagates correctly all the way up.

## Verification

Before (on `upstream/main`):

```python
>>> from scilink.agents.meta_agent.meta_orchestrator import MetaOrchestratorAgent, MetaMode
>>> m = MetaOrchestratorAgent(base_dir=\"/tmp/x\", api_key=\"dummy\", meta_mode=MetaMode.AUTOPILOT)
>>> m._get_planning_child()
RuntimeError: ScalarizerAgent requires code execution but user declined. ...
```

After:

```python
>>> m._get_planning_child()    # succeeds; gates fire only when scalarization is actually requested
```

New tests (`tests/test_scalarizer_sandbox.py`, 5/5 pass):
1. construction succeeds in non-TTY without env-var bypass
2. meta-agent planning-child construction succeeds (the original regression)
3. declined sandbox at `scalarize()` returns the contract failure dict with all keys `orchestrator_tools.py` reads
4. `_execute_script` is sandbox-gated too (defense-in-depth + happy-path confirmation)
5. `UNSAFE_EXECUTION_OK` env-var bypass still works

Existing tests still green: `test_simulation_orchestrator.py` 8/8, `test_adaptive_annealing.py` 18/18, `test_md_agent_smoke.py`, `test_mlip_agent_smoke.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)