### PR TITLE
vision: OCR for scanned PDFs + a general view_image tool on meta (#182 Part B)

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -48,18 +48,20 @@ from ...skills.loader import list_skills, list_all_skills, load_skill
 _READ_DOC_MAX_CHARS = 200_000  # ~50k tokens; longer documents are truncated
 
 
-def _extract_document_text(path: Path) -> Dict[str, Any]:
+def _extract_document_text(path: Path, ocr_model: Any = None) -> Dict[str, Any]:
     """Extract plain text from a PDF / DOCX / Markdown / text file.
 
     Thin wrapper over the shared ``scilink.parsers.extract_text`` (which adds
     table-aware PDF extraction); it applies read_document's character cap.
-    Returns a dict with ``text`` plus metadata (page/paragraph count,
-    ``n_chars``, ``truncated``). Raises ValueError for an unsupported
-    extension; reader errors propagate to the caller.
+    When ``ocr_model`` is supplied, scanned/sparse PDF pages are transcribed
+    via the vision-OCR fallback. Returns a dict with ``text`` plus metadata
+    (page/paragraph count, ``n_chars``, ``truncated``, ``n_ocr_pages``).
+    Raises ValueError for an unsupported extension; reader errors propagate
+    to the caller.
     """
     from scilink.parsers import extract_text
 
-    info = extract_text(path)
+    info = extract_text(path, ocr_model=ocr_model)
     text = info.get("text", "")
     info["truncated"] = len(text) > _READ_DOC_MAX_CHARS
     if info["truncated"]:
@@ -4335,7 +4337,8 @@ class AnalysisOrchestratorTools:
                     errors.append(f"Not a file: {p}")
                     continue
                 try:
-                    docs.append((dp, _extract_document_text(dp)))
+                    docs.append((dp, _extract_document_text(
+                        dp, ocr_model=self.orch.model)))
                 except ValueError as e:
                     errors.append(str(e))
                 except Exception as e:
@@ -4364,10 +4367,16 @@ class AnalysisOrchestratorTools:
                 lit_path.write_text(combined)
             except Exception as e:
                 logging.error(f"read_document: could not save literature file: {e}")
+            n_ocr = sum(info.get("n_ocr_pages", 0) for _, info in docs)
             return json.dumps({
                 "status": "success",
                 "file_path": str(lit_path) if lit_path else None,
                 "n_documents": len(docs),
+                "n_ocr_pages": n_ocr,
+                "ocr_note": (
+                    f"{n_ocr} scanned page(s) had no text layer and were "
+                    "transcribed by vision-OCR — verify any figures/numerics."
+                ) if n_ocr else None,
                 "documents": [
                     {"name": dp.name,
                      **{k: v for k, v in info.items() if k != "text"}}

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -392,3 +392,106 @@ class MetaOrchestratorTools:
             },
             required=[],
         )
+
+        # ----- view_image -----------------------------------------------------
+        # Generic "view & describe an arbitrary image" — the meta itself has no
+        # multimodal input path, so this is how a notebook photo / diagram /
+        # screenshot / figure becomes content the meta can reason about. NOT
+        # for scientific images (route those to analysis for quantification).
+
+        _IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".tif", ".tiff",
+                       ".bmp", ".gif", ".webp"}
+        _VIEW_IMAGE_DEFAULT_PROMPT = (
+            "Describe the contents of this image in detail. If it contains "
+            "any readable text — printed or handwritten — transcribe it "
+            "faithfully, rendering tables as GitHub-flavored Markdown. "
+            "Return your description and any transcription as plain text, "
+            "with no extra commentary."
+        )
+
+        def view_image(paths, question: str = None) -> str:
+            """Open one or more images and have the vision model describe
+            (and transcribe text/tables in) them."""
+            if isinstance(paths, str):
+                paths = [paths]
+            if not paths:
+                return json.dumps({"status": "error",
+                                   "message": "No image path provided."})
+            print(f"  🖼️  Tool: Viewing {len(paths)} image(s)...")
+
+            import io
+            from PIL import Image as _PILImage
+            from scilink.parsers.ocr import describe_image
+
+            prompt = question.strip() if question else _VIEW_IMAGE_DEFAULT_PROMPT
+            results, errors = [], []
+            for p in paths:
+                pp = Path(p)
+                if not pp.is_file():
+                    errors.append(f"Not a file: {p}")
+                    continue
+                if pp.suffix.lower() not in _IMAGE_EXTS:
+                    errors.append(f"Not an image file: {p}")
+                    continue
+                try:
+                    img = _PILImage.open(pp)
+                    if img.mode not in ("RGB", "L"):
+                        img = img.convert("RGB")
+                    # Cap the longest side at 2048 px — keeps fine print legible
+                    # while keeping payload size reasonable.
+                    img.thumbnail((2048, 2048))
+                    buf = io.BytesIO()
+                    img.save(buf, format="JPEG", quality=90)
+                    description = describe_image(
+                        buf.getvalue(), self.orch.model, prompt
+                    )
+                    results.append({"name": pp.name,
+                                    "description": description})
+                except Exception as e:  # noqa: BLE001 - one bad image must not break the tool
+                    logging.error(f"view_image failed for {p}: {e}")
+                    errors.append(f"Could not view {pp.name}: {e}")
+            if not results:
+                return json.dumps({
+                    "status": "error",
+                    "message": "No images could be viewed.",
+                    "errors": errors,
+                })
+            return json.dumps({
+                "status": "success",
+                "n_images": len(results),
+                "images": results,
+                "errors": errors or None,
+            })
+
+        self._register_tool(
+            func=view_image,
+            name="view_image",
+            description=(
+                "Open one or more image files and have the vision model "
+                "describe them — including faithfully transcribing any "
+                "readable text or tables (printed or handwritten). Use this "
+                "for a photo of a notebook page, a diagram, a screenshot, a "
+                "figure, or any image that needs to be interpreted as "
+                "content. NOT for scientific images that need feature "
+                "extraction or quantification — route those to analysis. "
+                "Accepts .png, .jpg/.jpeg, .tif/.tiff, .bmp, .gif, .webp."
+            ),
+            parameters={
+                "paths": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Absolute path(s) to the image file(s) to view."
+                    ),
+                },
+                "question": {
+                    "type": "string",
+                    "description": (
+                        "Optional question or instruction (e.g. "
+                        "'transcribe the table' or 'what does the diagram "
+                        "show?'). Default is to describe + transcribe."
+                    ),
+                },
+            },
+            required=["paths"],
+        )

--- a/scilink/agents/planning_agents/planning_agent.py
+++ b/scilink/agents/planning_agents/planning_agent.py
@@ -353,7 +353,8 @@ class PlanningAgent(BaseAgent):
         doc_chunks = []
         if knowledge_paths:
             print(f"Processing {len(knowledge_paths)} Scientific Paths...")
-            doc_chunks.extend(ingest_files(knowledge_paths, is_code_mode=False))
+            doc_chunks.extend(ingest_files(knowledge_paths, is_code_mode=False,
+                                           ocr_model=self.model))
 
         if doc_chunks:
             print(f"  - Building Scientific KB with {len(doc_chunks)} chunks...")

--- a/scilink/parsers/extract.py
+++ b/scilink/parsers/extract.py
@@ -10,14 +10,18 @@ from pathlib import Path
 from typing import Any, Dict, Union
 
 from .pdf_parser import _extract_pdf_blocks, _assemble_flat_text
+from .ocr import DEFAULT_OCR_DPI, MAX_OCR_PAGES
 
 
-def extract_text(path: Union[str, Path], max_pages: int = None) -> Dict[str, Any]:
+def extract_text(path: Union[str, Path], max_pages: int = None,
+                 ocr_model: Any = None, ocr_dpi: int = DEFAULT_OCR_DPI,
+                 max_ocr_pages: int = MAX_OCR_PAGES) -> Dict[str, Any]:
     """Extract plain text (and markdown tables, for PDFs) from a document.
 
     Supports ``.pdf``, ``.docx``, ``.md`` and ``.txt``. Returns a dict with
     ``text``, ``n_chars`` and a format-specific count
-    (``n_pages`` for PDFs, ``n_paragraphs`` for DOCX).
+    (``n_pages`` for PDFs, ``n_paragraphs`` for DOCX). For a PDF it also
+    returns ``n_ocr_pages`` — pages transcribed via the vision-OCR fallback.
 
     No truncation is applied — any length cap is the caller's policy.
 
@@ -26,6 +30,11 @@ def extract_text(path: Union[str, Path], max_pages: int = None) -> Dict[str, Any
         max_pages: For PDFs only — stop after this many pages and skip table
             extraction. A lightweight mode for previews/probes; ``n_pages``
             still reports the true total.
+        ocr_model: Optional vision LLM (any object with ``generate_content``).
+            When given, scanned/sparse PDF pages are transcribed via OCR;
+            without it, such pages simply yield their (sparse) text.
+        ocr_dpi: Render resolution for OCR'd pages.
+        max_ocr_pages: Cap on the number of pages sent to vision-OCR.
 
     Raises:
         ValueError: For an unsupported extension.
@@ -36,11 +45,13 @@ def extract_text(path: Union[str, Path], max_pages: int = None) -> Dict[str, Any
     info: Dict[str, Any] = {}
 
     if ext == ".pdf":
-        page_texts, table_chunks, n_pages = _extract_pdf_blocks(
-            str(path), max_pages=max_pages
+        page_texts, table_chunks, n_pages, ocr_pages = _extract_pdf_blocks(
+            str(path), max_pages=max_pages, ocr_model=ocr_model,
+            ocr_dpi=ocr_dpi, max_ocr_pages=max_ocr_pages,
         )
-        text = _assemble_flat_text(page_texts, table_chunks)
+        text = _assemble_flat_text(page_texts, table_chunks, ocr_pages)
         info["n_pages"] = n_pages
+        info["n_ocr_pages"] = len(ocr_pages)
     elif ext == ".docx":
         try:
             import docx

--- a/scilink/parsers/ingestor.py
+++ b/scilink/parsers/ingestor.py
@@ -73,10 +73,14 @@ def extract_images(file_paths: List[str]) -> List[str]:
     return found_images
 
 
-def ingest_files(file_paths: List[str], is_code_mode: bool, code_chunk_size: int = 20000, repo_name: str = None) -> List[Dict[str, Any]]:
+def ingest_files(file_paths: List[str], is_code_mode: bool, code_chunk_size: int = 20000,
+                 repo_name: str = None, ocr_model: Any = None) -> List[Dict[str, Any]]:
     """
-    Recursively finds files and routes them to the 
+    Recursively finds files and routes them to the
     correct parser (PDF, Excel, or Text) based on extension.
+
+    When ``ocr_model`` is supplied, scanned/sparse PDF pages are transcribed
+    via the vision-OCR fallback.
     """
     chunks = []
     expanded_paths = []
@@ -123,7 +127,7 @@ def ingest_files(file_paths: List[str], is_code_mode: bool, code_chunk_size: int
         
         # --- ROUTE A: PDF Documents ---
         if file_ext == '.pdf':
-            pdf_chunks = extract_pdf_two_pass(f_path)
+            pdf_chunks = extract_pdf_two_pass(f_path, ocr_model=ocr_model)
             if is_code_mode:
                 for c in pdf_chunks: c['metadata']['content_type'] = 'code'
             chunks.extend(pdf_chunks)

--- a/scilink/parsers/ocr.py
+++ b/scilink/parsers/ocr.py
@@ -1,7 +1,14 @@
-"""Vision-OCR fallback for scanned / image-only PDFs.
+"""Vision helpers for the parsers layer.
 
-When a PDF page carries no usable embedded text layer, the page is rendered
-to an image (PyMuPDF ``get_pixmap``) and transcribed with a vision LLM.
+Two responsibilities:
+
+- ``describe_image`` — a generic "send an image to a vision LLM with this
+  prompt" primitive, used by callers that want a description / transcription
+  of an arbitrary image (e.g. the meta ``view_image`` tool).
+- The PDF-OCR fallback — ``ocr_pdf_pages`` renders pages of a PDF whose
+  embedded text layer is empty/sparse via PyMuPDF ``get_pixmap`` and routes
+  each page image through ``transcribe_image`` (a specialization of
+  ``describe_image`` with an OCR-specific prompt).
 
 This module imports only ``fitz`` — the vision model is **injected** by the
 caller (any object with a ``generate_content`` method), so ``scilink/parsers/``
@@ -48,21 +55,30 @@ def render_pdf_page(page: Any, dpi: int = DEFAULT_OCR_DPI) -> bytes:
     return pix.tobytes("jpeg")
 
 
-def transcribe_image(image_bytes: bytes, model: Any) -> str:
-    """Transcribe a single page image with the injected vision model.
+def describe_image(image_bytes: bytes, model: Any, prompt: str,
+                   mime_type: str = "image/jpeg") -> str:
+    """Send an image to the injected vision model with the given prompt and
+    return the model's text response, or ``""`` on empty/error.
 
-    Returns the transcription, or an empty string on failure / empty output —
-    the caller is expected to fall back to whatever sparse text it already has.
+    Format-agnostic — accepts any image MIME type the model wrapper supports
+    (``image/jpeg``, ``image/png``, ...). Callers normalize as needed before
+    calling.
     """
     try:
         response = model.generate_content(
-            [OCR_PROMPT, {"mime_type": "image/jpeg", "data": image_bytes}]
+            [prompt, {"mime_type": mime_type, "data": image_bytes}]
         )
         text = getattr(response, "text", "") or ""
         return text.strip()
-    except Exception as e:  # noqa: BLE001 - one bad page must not abort the doc
-        logging.warning(f"Vision-OCR transcription failed: {e}")
+    except Exception as e:  # noqa: BLE001 - one bad image must not abort the caller
+        logging.warning(f"Vision describe_image failed: {e}")
         return ""
+
+
+def transcribe_image(image_bytes: bytes, model: Any) -> str:
+    """Transcribe a single page image with the OCR prompt — a specialization
+    of :func:`describe_image`."""
+    return describe_image(image_bytes, model, OCR_PROMPT)
 
 
 def ocr_pdf_pages(pdf_path: str,

--- a/scilink/parsers/ocr.py
+++ b/scilink/parsers/ocr.py
@@ -1,0 +1,117 @@
+"""Vision-OCR fallback for scanned / image-only PDFs.
+
+When a PDF page carries no usable embedded text layer, the page is rendered
+to an image (PyMuPDF ``get_pixmap``) and transcribed with a vision LLM.
+
+This module imports only ``fitz`` — the vision model is **injected** by the
+caller (any object with a ``generate_content`` method), so ``scilink/parsers/``
+stays free of dependencies on the rest of ``scilink``. When no model is
+supplied, callers simply skip OCR and keep whatever sparse text the page had.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# A page whose embedded text layer yields fewer than this many characters is
+# treated as scanned/sparse and becomes a candidate for vision-OCR.
+SPARSE_PAGE_CHAR_THRESHOLD = 50
+
+# Render resolution for OCR. 200 DPI is a reasonable balance of fine-print
+# fidelity against image size / token cost.
+DEFAULT_OCR_DPI = 200
+
+# Cost guard: OCR at most this many pages per document by default.
+MAX_OCR_PAGES = 50
+
+# Provenance marker prefixed to vision-OCR'd pages in flat text output — a
+# vision model can transcribe plausibly-but-wrong, so OCR'd content is flagged
+# rather than silently merged with exact text-layer extraction.
+OCR_MARKER = "[OCR — transcribed from a scanned page image; verify figures/numerics]"
+
+OCR_PROMPT = (
+    "This is an image of a single page from a scanned document. "
+    "Transcribe ALL of its text content verbatim and in reading order. "
+    "Render any tables as GitHub-flavored Markdown tables. "
+    "Do not summarize, explain, translate, or add commentary — output only "
+    "the transcribed page content. If the page has no readable text, output "
+    "nothing."
+)
+
+
+def render_pdf_page(page: Any, dpi: int = DEFAULT_OCR_DPI) -> bytes:
+    """Render a PyMuPDF page to JPEG image bytes at the given DPI."""
+    import fitz
+
+    zoom = dpi / 72.0
+    pix = page.get_pixmap(matrix=fitz.Matrix(zoom, zoom), alpha=False)
+    return pix.tobytes("jpeg")
+
+
+def transcribe_image(image_bytes: bytes, model: Any) -> str:
+    """Transcribe a single page image with the injected vision model.
+
+    Returns the transcription, or an empty string on failure / empty output —
+    the caller is expected to fall back to whatever sparse text it already has.
+    """
+    try:
+        response = model.generate_content(
+            [OCR_PROMPT, {"mime_type": "image/jpeg", "data": image_bytes}]
+        )
+        text = getattr(response, "text", "") or ""
+        return text.strip()
+    except Exception as e:  # noqa: BLE001 - one bad page must not abort the doc
+        logging.warning(f"Vision-OCR transcription failed: {e}")
+        return ""
+
+
+def ocr_pdf_pages(pdf_path: str,
+                  page_numbers: List[int],
+                  model: Any,
+                  dpi: int = DEFAULT_OCR_DPI,
+                  max_ocr_pages: int = MAX_OCR_PAGES
+                  ) -> Tuple[Dict[int, str], List[int]]:
+    """Render and transcribe the requested (1-indexed) pages of a PDF.
+
+    At most ``max_ocr_pages`` pages are transcribed; any beyond the cap are
+    returned as skipped. Per-page failures are isolated — a page that fails to
+    render or transcribe is simply absent from the result dict.
+
+    Returns ``(transcriptions, skipped)`` where ``transcriptions`` maps
+    1-indexed page number -> transcribed text, and ``skipped`` is the list of
+    1-indexed page numbers not attempted because of the cap.
+    """
+    import fitz
+
+    ordered = sorted(page_numbers)
+    to_ocr = ordered[:max_ocr_pages]
+    skipped = ordered[max_ocr_pages:]
+
+    if skipped:
+        print(f"  - ⚠️  Vision-OCR cap reached ({max_ocr_pages} pages); "
+              f"{len(skipped)} scanned page(s) left un-transcribed.")
+
+    transcriptions: Dict[int, str] = {}
+    if not to_ocr:
+        return transcriptions, skipped
+
+    print(f"  - 👁️  Vision-OCR: transcribing {len(to_ocr)} scanned page(s) "
+          f"at {dpi} DPI...")
+    doc = fitz.open(pdf_path)
+    try:
+        for page_num in to_ocr:
+            try:
+                image_bytes = render_pdf_page(doc[page_num - 1], dpi=dpi)
+            except Exception as e:  # noqa: BLE001 - isolate per-page render errors
+                logging.warning(f"Vision-OCR: could not render page {page_num}: {e}")
+                continue
+            text = transcribe_image(image_bytes, model)
+            if text:
+                transcriptions[page_num] = text
+            else:
+                print(f"    - ⚠️  Page {page_num}: no text transcribed.")
+    finally:
+        doc.close()
+
+    print(f"  - ✓ Vision-OCR transcribed {len(transcriptions)}/{len(to_ocr)} page(s).")
+    return transcriptions, skipped

--- a/scilink/parsers/pdf_parser.py
+++ b/scilink/parsers/pdf_parser.py
@@ -1,7 +1,15 @@
 import threading
-from typing import List, Dict, Tuple, Optional
+from typing import List, Dict, Tuple, Optional, Any
 from dataclasses import dataclass
 from pathlib import Path
+
+from .ocr import (
+    SPARSE_PAGE_CHAR_THRESHOLD,
+    DEFAULT_OCR_DPI,
+    MAX_OCR_PAGES,
+    OCR_MARKER,
+    ocr_pdf_pages,
+)
 
 # `fitz` (PyMuPDF) and `pdfplumber` are imported lazily inside the functions
 # that need them, so importing this module stays cheap for callers that only
@@ -75,24 +83,33 @@ def chunk_text(text: str, page_num: int, chunk_size: int, overlap: int) -> List[
 
 
 def _extract_pdf_blocks(pdf_path: str, table_timeout: int = 15,
-                        max_pages: Optional[int] = None
-                        ) -> Tuple[List[Tuple[int, str]], List[Dict[str, any]], int]:
-    """Shared two-pass PDF extraction.
+                        max_pages: Optional[int] = None,
+                        ocr_model: Any = None,
+                        ocr_dpi: int = DEFAULT_OCR_DPI,
+                        max_ocr_pages: int = MAX_OCR_PAGES
+                        ) -> Tuple[List[Tuple[int, str]], List[Dict[str, any]], int, set]:
+    """Shared two-pass PDF extraction, with an optional vision-OCR fallback.
 
     Pass 1 (PyMuPDF): fast per-page text + detection of pages with tables.
     Pass 2 (pdfplumber): high-accuracy table extraction on flagged pages only.
+    OCR fallback: pages whose embedded text layer is empty/sparse are rendered
+    and transcribed with ``ocr_model`` — when one is supplied.
 
-    Returns ``(page_texts, table_chunks, n_pages)`` where ``page_texts`` is an
-    ordered list of ``(page_number, text)``, ``table_chunks`` are
-    ``{'text', 'metadata'}`` dicts, and ``n_pages`` is the true page count.
-    When ``max_pages`` is set, Pass 1 stops after that many pages and Pass 2 is
-    skipped — a lightweight mode for previews/probes.
+    Returns ``(page_texts, table_chunks, n_pages, ocr_pages)`` where
+    ``page_texts`` is an ordered list of ``(page_number, text)``,
+    ``table_chunks`` are ``{'text', 'metadata'}`` dicts, ``n_pages`` is the
+    true page count, and ``ocr_pages`` is the set of 1-indexed pages whose
+    text came from vision-OCR. When ``max_pages`` is set, Pass 1 stops after
+    that many pages and both Pass 2 and OCR are skipped — a lightweight mode
+    for previews/probes.
     """
     import fitz  # PyMuPDF
 
     page_texts: List[Tuple[int, str]] = []
     table_chunks: List[Dict[str, any]] = []
     table_page_nums = set()
+    ocr_pages: set = set()
+    sparse_pages: List[int] = []
 
     # === PASS 1: Fast text extraction + table-page location (PyMuPDF) ===
     doc = fitz.open(pdf_path)
@@ -110,7 +127,11 @@ def _extract_pdf_blocks(pdf_path: str, table_timeout: int = 15,
             if full_page_text:
                 page_texts.append((page_num_one_indexed, full_page_text))
 
-            if page.find_tables():
+            # A near-empty text layer marks a scanned/sparse page — a candidate
+            # for the OCR fallback, and not worth handing to pdfplumber.
+            if len(full_page_text) < SPARSE_PAGE_CHAR_THRESHOLD:
+                sparse_pages.append(page_num_one_indexed)
+            elif page.find_tables():
                 table_page_nums.add(page_num_zero_indexed)
     finally:
         doc.close()
@@ -140,13 +161,29 @@ def _extract_pdf_blocks(pdf_path: str, table_timeout: int = 15,
         except Exception as e:
             print(f"❌ Error during table extraction (pdfplumber): {e}")
 
-    return page_texts, table_chunks, n_pages
+    # === OCR FALLBACK: transcribe scanned/sparse pages with a vision model ===
+    if ocr_model is not None and sparse_pages and max_pages is None:
+        transcriptions, _ = ocr_pdf_pages(
+            pdf_path, sparse_pages, ocr_model,
+            dpi=ocr_dpi, max_ocr_pages=max_ocr_pages,
+        )
+        if transcriptions:
+            ocr_pages = set(transcriptions)
+            # Replace any sparse text already captured for these pages with
+            # the OCR transcription, then keep page_texts in page order.
+            page_texts = [(p, t) for (p, t) in page_texts if p not in ocr_pages]
+            page_texts.extend(transcriptions.items())
+            page_texts.sort(key=lambda pt: pt[0])
+
+    return page_texts, table_chunks, n_pages, ocr_pages
 
 
 def _assemble_flat_text(page_texts: List[Tuple[int, str]],
-                        table_chunks: List[Dict[str, any]]) -> str:
+                        table_chunks: List[Dict[str, any]],
+                        ocr_pages: frozenset = frozenset()) -> str:
     """Join per-page text and per-page table markdown into one flat string,
-    in page order — tables placed after the text of their page."""
+    in page order — tables placed after the text of their page. Pages whose
+    text came from vision-OCR are prefixed with a provenance marker."""
     tables_by_page: Dict[int, List[str]] = {}
     for tc in table_chunks:
         tables_by_page.setdefault(tc['metadata']['page'], []).append(tc['text'])
@@ -154,7 +191,7 @@ def _assemble_flat_text(page_texts: List[Tuple[int, str]],
     parts: List[str] = []
     seen_pages = set()
     for page_num, text in page_texts:
-        parts.append(text)
+        parts.append(f"{OCR_MARKER}\n{text}" if page_num in ocr_pages else text)
         seen_pages.add(page_num)
         parts.extend(tables_by_page.get(page_num, []))
     # Tables on pages with no extracted text
@@ -165,34 +202,49 @@ def _assemble_flat_text(page_texts: List[Tuple[int, str]],
 
 
 def extract_pdf_text(pdf_path: str, table_timeout: int = 15,
-                     max_pages: Optional[int] = None) -> str:
+                     max_pages: Optional[int] = None,
+                     ocr_model: Any = None, ocr_dpi: int = DEFAULT_OCR_DPI,
+                     max_ocr_pages: int = MAX_OCR_PAGES) -> str:
     """Flat two-pass text extraction (PyMuPDF text + pdfplumber tables as
-    markdown), no chunking. For lightweight document reads."""
-    page_texts, table_chunks, _ = _extract_pdf_blocks(pdf_path, table_timeout, max_pages)
-    return _assemble_flat_text(page_texts, table_chunks)
+    markdown), no chunking. For lightweight document reads. When ``ocr_model``
+    is supplied, scanned/sparse pages are transcribed via vision-OCR."""
+    page_texts, table_chunks, _, ocr_pages = _extract_pdf_blocks(
+        pdf_path, table_timeout, max_pages, ocr_model, ocr_dpi, max_ocr_pages)
+    return _assemble_flat_text(page_texts, table_chunks, ocr_pages)
 
 
 def extract_pdf_two_pass(pdf_path: str, chunk_size: int = 500, overlap: int = 50,
-                         table_timeout: int = 15) -> List[Dict[str, any]]:
+                         table_timeout: int = 15, ocr_model: Any = None,
+                         ocr_dpi: int = DEFAULT_OCR_DPI,
+                         max_ocr_pages: int = MAX_OCR_PAGES) -> List[Dict[str, any]]:
     """
     A robust two-pass hybrid extraction pipeline for RAG.
     Pass 1 (PyMuPDF): Fast extraction of all text and identification of pages containing tables.
     Pass 2 (pdfplumber): High-accuracy extraction of tables from only the identified pages.
+    When ``ocr_model`` is supplied, scanned/sparse pages are transcribed via
+    vision-OCR; chunks from those pages are tagged ``metadata['ocr'] = True``.
     """
     print(f"Starting robust two-pass processing for: {pdf_path}")
 
     try:
-        page_texts, table_chunks, _ = _extract_pdf_blocks(pdf_path, table_timeout)
+        page_texts, table_chunks, _, ocr_pages = _extract_pdf_blocks(
+            pdf_path, table_timeout, ocr_model=ocr_model,
+            ocr_dpi=ocr_dpi, max_ocr_pages=max_ocr_pages)
     except Exception as e:
         print(f"❌ Error during PDF extraction: {e}")
         return []
 
     text_chunks: List[Dict[str, any]] = []
     for page_num, full_page_text in page_texts:
-        text_chunks.extend(chunk_text(full_page_text, page_num, chunk_size, overlap))
+        page_chunks = chunk_text(full_page_text, page_num, chunk_size, overlap)
+        if page_num in ocr_pages:
+            for c in page_chunks:
+                c['metadata']['ocr'] = True
+        text_chunks.extend(page_chunks)
 
     print(f"  - Extracted {len(text_chunks)} text chunks; "
-          f"found {len(table_chunks)} tables.")
+          f"found {len(table_chunks)} tables"
+          f"{f'; {len(ocr_pages)} page(s) via OCR' if ocr_pages else ''}.")
 
     # === Final Merge and Post-processing ===
     all_content = text_chunks + table_chunks


### PR DESCRIPTION
## Summary

Part B of #182 — two related vision-LLM capabilities, built on Part A's
`scilink/parsers/` layer:

1. A **vision-OCR fallback** so SciLink can read scanned / image-only PDFs.
2. A general **`view_image` tool on the meta orchestrator** so a notebook
   photo, diagram, screenshot or figure that lands at the meta can actually
   be opened and interpreted (previously the meta only saw image *metadata*
   from its probe).

## Motivation

Part A's `parsers/` layer relies entirely on a PDF's **embedded text layer**
(PyMuPDF + pdfplumber). A scanned / image-only PDF has no text layer, so
`extract_text()` and `extract_pdf_two_pass()` return essentially empty text —
silently. There is no OCR anywhere in the pipeline.

## What changed

### New `scilink/parsers/ocr.py`
- `render_pdf_page` — render a page to JPEG bytes via PyMuPDF `get_pixmap`.
- `transcribe_image` — one vision-LLM call to transcribe a page image.
- `ocr_pdf_pages` — render + transcribe a set of pages, honor the page cap,
  isolate per-page failures.
- Imports only `fitz`; the vision model is **injected as a parameter**, so
  `scilink/parsers/` still imports nothing else in `scilink` (the same shape
  as `knowledge.run_rag`). With no model supplied, a sparse PDF degrades
  gracefully to prior behavior — OCR never becomes mandatory.

### Wired into the pipeline
- OCR is integrated at the shared `_extract_pdf_blocks` helper, so **both**
  the flat `extract_text` path and the `extract_pdf_two_pass` / KB-ingest path
  inherit it from one place.
- The decision is **per page**: a page whose text layer is empty/sparse is
  OCR-eligible. Born-digital pages keep the fast, exact, free text-layer path;
  mixed PDFs (some scanned pages) are handled correctly.
- `extract_text` and `ingest_files` thread an `ocr_model`; `extract_text`
  returns `n_ocr_pages`.

### Consumers (OCR)
- The analysis `read_document` tool passes the orchestrator's model and
  surfaces `n_ocr_pages` + an `ocr_note` in its result.
- Planning `_build_and_save_kb` passes its model to `ingest_files`, so a
  scanned PDF can be ingested into a KnowledgeBase.
- The meta `inspect_uploads` probe is left text-layer-only — kept cheap; an
  empty probe is itself a useful "scanned document" routing signal.

### Meta `view_image` tool
- Generic `view_image(paths, question=None)` registered alongside
  `inspect_uploads`. Opens one or more image files, PIL-normalizes to JPEG
  (so `.png` / `.jpg` / `.tif` / `.bmp` / `.gif` / `.webp` all work; large
  photos are capped at 2048 px on the longest side), and sends them to the
  orchestrator's existing vision model.
- Default prompt asks for a description **and** faithful transcription of
  any readable text or tables (printed or handwritten — covers the
  notebook-photo case in one shot); callers can override via `question` for
  a specific ask.
- Description is returned in the chat result; no persistence to a file.
- Backed by a new generic primitive in `parsers/ocr.py`:
  `describe_image(image_bytes, model, prompt, mime_type)`. `transcribe_image`
  (OCR) is now a thin specialization of it.

## Notes / decisions

- **Automatic, per-page fallback** — the vision path triggers only when a
  page's text layer is empty/sparse, never for born-digital pages.
- **Cost guard** — one vision call per page, capped by a configurable
  `max_ocr_pages` (default 50); v1 transcribes pages sequentially.
- **Provenance** — a vision model can transcribe plausibly-but-wrong, so
  OCR-derived content is flagged rather than silently merged: a marker line in
  flat text and `metadata['ocr'] = True` on chunks. OCR'd figures/numerics
  warrant a verification pass.
- `pyproject.toml` is unchanged — `fitz` (PyMuPDF) already provides
  `get_pixmap`; no new dependency.


## Out of scope (follow-ups)

- Parallelizing per-page OCR calls (v1 is sequential).
- Saving rendered page images to disk for spot-checking.
- Per-token / per-numeric confidence scoring — coarse per-page marking only.
- OCR in the meta `inspect_uploads` probe (kept deliberately cheap).
- Exposing `view_image` on the analysis orchestrator — analysis already
  passes images to its model via `run_analysis`; the meta was the actual
  gap. Adding it there is a one-liner if it turns out to be useful.
