### PR TITLE
meta + parsers: view_document tool for in-chat document & tabular preview

### DIFF
--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -505,7 +505,9 @@ class MetaOrchestratorTools:
         # model). NOT for registering a document into a planning KB — that's
         # what delegate_to_planning's `knowledge_paths` is for.
 
-        _DOCUMENT_EXTS = {".pdf", ".docx", ".md", ".txt"}
+        _DOCUMENT_EXTS = {".pdf", ".docx", ".md", ".txt",
+                          ".json", ".yaml", ".yml",
+                          ".csv", ".xlsx", ".xls"}
         _VIEW_DOC_MAX_CHARS = 200_000  # ~50k tokens; long docs are truncated
 
         def view_document(paths) -> str:
@@ -528,7 +530,7 @@ class MetaOrchestratorTools:
                 if pp.suffix.lower() not in _DOCUMENT_EXTS:
                     errors.append(
                         f"Not a supported document: {p} "
-                        f"(handles .pdf .docx .md .txt)"
+                        f"(handles {', '.join(sorted(_DOCUMENT_EXTS))})"
                     )
                     continue
                 try:
@@ -578,18 +580,23 @@ class MetaOrchestratorTools:
             func=view_document,
             name="view_document",
             description=(
-                "Open one or more documents (PDF, DOCX, Markdown, plain "
-                "text) and return their text content in this conversation. "
-                "Scanned / image-only PDFs are automatically OCR'd via the "
-                "vision model (the result reports n_ocr_pages plus a note "
-                "to verify any figures/numerics). Use this to inspect or "
-                "summarize a document's contents right here — e.g. to make "
-                "a routing decision, extract a reference excerpt to thread "
-                "into a delegate_to_* call's context, or answer a quick "
-                "question about a single file. NOT for ingesting a "
-                "document into a planning KnowledgeBase — for that, pass "
-                "the path as `knowledge_paths` in delegate_to_planning. "
-                "Accepts .pdf, .docx, .md, .txt."
+                "Open one or more documents and return their text content "
+                "in this conversation. Supports text-like files (.pdf, "
+                ".docx, .md, .txt, .json, .yaml/.yml) and tabular files "
+                "(.csv, .xlsx/.xls). Scanned / image-only PDFs are "
+                "automatically OCR'd via the vision model (the result "
+                "reports n_ocr_pages + a note to verify any "
+                "figures/numerics). Tabular files are previewed via the "
+                "adaptive parser — small files return the full table as "
+                "Markdown, large files a statistical summary; a sibling "
+                "JSON metadata file (e.g. data.json next to data.xlsx) "
+                "auto-enriches the preview. Use this to inspect / "
+                "summarize a file's contents right here — for a routing "
+                "decision, to extract context to thread into a "
+                "delegate_to_* call, or to answer a quick question about "
+                "a single file. NOT for ingesting into a planning "
+                "KnowledgeBase — for that, pass the path as "
+                "`knowledge_paths` in delegate_to_planning."
             ),
             parameters={
                 "paths": {

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -495,3 +495,110 @@ class MetaOrchestratorTools:
             },
             required=["paths"],
         )
+
+        # ----- view_document -------------------------------------------------
+        # Open & inspect a document's text content directly in the meta's
+        # chat — the symmetric counterpart of view_image, for routing /
+        # summarization decisions without having to delegate to a specialist
+        # just to extract text. Scanned PDFs are OCR'd automatically via the
+        # parsers vision-OCR fallback (the orchestrator's model is the OCR
+        # model). NOT for registering a document into a planning KB — that's
+        # what delegate_to_planning's `knowledge_paths` is for.
+
+        _DOCUMENT_EXTS = {".pdf", ".docx", ".md", ".txt"}
+        _VIEW_DOC_MAX_CHARS = 200_000  # ~50k tokens; long docs are truncated
+
+        def view_document(paths) -> str:
+            """Read one or more documents and return their text content."""
+            if isinstance(paths, str):
+                paths = [paths]
+            if not paths:
+                return json.dumps({"status": "error",
+                                   "message": "No document path provided."})
+            print(f"  📄 Tool: Reading {len(paths)} document(s)...")
+
+            from scilink.parsers import extract_text
+
+            docs, errors = [], []
+            for p in paths:
+                pp = Path(p)
+                if not pp.is_file():
+                    errors.append(f"Not a file: {p}")
+                    continue
+                if pp.suffix.lower() not in _DOCUMENT_EXTS:
+                    errors.append(
+                        f"Not a supported document: {p} "
+                        f"(handles .pdf .docx .md .txt)"
+                    )
+                    continue
+                try:
+                    info = extract_text(pp, ocr_model=self.orch.model)
+                    text = info.get("text", "")
+                    truncated = len(text) > _VIEW_DOC_MAX_CHARS
+                    if truncated:
+                        text = text[:_VIEW_DOC_MAX_CHARS]
+                    doc_info = {
+                        "name": pp.name,
+                        "text": text,
+                        "n_chars": len(text),
+                        "truncated": truncated,
+                    }
+                    # Format-specific metadata flows through transparently
+                    # (n_pages for PDFs, n_paragraphs for DOCX, plus the
+                    # OCR page count when the vision fallback fired).
+                    for k in ("n_pages", "n_paragraphs", "n_ocr_pages"):
+                        if k in info:
+                            doc_info[k] = info[k]
+                    docs.append(doc_info)
+                except ValueError as e:
+                    # extract_text raises ValueError for genuinely unsupported
+                    # extensions — surface it but don't crash the tool.
+                    errors.append(str(e))
+                except Exception as e:  # noqa: BLE001 - one bad doc must not break the tool
+                    logging.error(f"view_document failed for {p}: {e}")
+                    errors.append(f"Could not read {pp.name}: {e}")
+            if not docs:
+                return json.dumps({"status": "error",
+                                   "message": "No documents could be read.",
+                                   "errors": errors})
+            n_ocr = sum(d.get("n_ocr_pages", 0) for d in docs)
+            return json.dumps({
+                "status": "success",
+                "n_documents": len(docs),
+                "n_ocr_pages": n_ocr,
+                "ocr_note": (
+                    f"{n_ocr} scanned page(s) had no text layer and were "
+                    "transcribed by vision-OCR — verify any figures/numerics."
+                ) if n_ocr else None,
+                "documents": docs,
+                "errors": errors or None,
+            })
+
+        self._register_tool(
+            func=view_document,
+            name="view_document",
+            description=(
+                "Open one or more documents (PDF, DOCX, Markdown, plain "
+                "text) and return their text content in this conversation. "
+                "Scanned / image-only PDFs are automatically OCR'd via the "
+                "vision model (the result reports n_ocr_pages plus a note "
+                "to verify any figures/numerics). Use this to inspect or "
+                "summarize a document's contents right here — e.g. to make "
+                "a routing decision, extract a reference excerpt to thread "
+                "into a delegate_to_* call's context, or answer a quick "
+                "question about a single file. NOT for ingesting a "
+                "document into a planning KnowledgeBase — for that, pass "
+                "the path as `knowledge_paths` in delegate_to_planning. "
+                "Accepts .pdf, .docx, .md, .txt."
+            ),
+            parameters={
+                "paths": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Absolute path(s) to the document file(s) to read."
+                    ),
+                },
+            },
+            required=["paths"],
+        )

--- a/scilink/parsers/extract.py
+++ b/scilink/parsers/extract.py
@@ -18,10 +18,16 @@ def extract_text(path: Union[str, Path], max_pages: int = None,
                  max_ocr_pages: int = MAX_OCR_PAGES) -> Dict[str, Any]:
     """Extract plain text (and markdown tables, for PDFs) from a document.
 
-    Supports ``.pdf``, ``.docx``, ``.md`` and ``.txt``. Returns a dict with
-    ``text``, ``n_chars`` and a format-specific count
-    (``n_pages`` for PDFs, ``n_paragraphs`` for DOCX). For a PDF it also
-    returns ``n_ocr_pages`` — pages transcribed via the vision-OCR fallback.
+    Supports text-like (``.pdf``, ``.docx``, ``.md``, ``.txt``, ``.json``,
+    ``.yaml``/``.yml``) and tabular (``.csv``, ``.xlsx``/``.xls``) documents.
+    Returns a dict with ``text``, ``n_chars`` and a format-specific count
+    (``n_pages`` for PDFs, ``n_paragraphs`` for DOCX). PDFs also report
+    ``n_ocr_pages`` — pages transcribed via the vision-OCR fallback.
+    Tabular files are previewed via the adaptive Excel parser — small files
+    yield the full table as Markdown, large files a statistical summary; an
+    auto-detected sibling JSON metadata file (e.g. ``data.json`` next to
+    ``data.xlsx``) enriches the preview with title / objective / column
+    definitions.
 
     No truncation is applied — any length cap is the caller's policy.
 
@@ -63,12 +69,32 @@ def extract_text(path: Union[str, Path], max_pages: int = None,
         d = docx.Document(str(path))
         info["n_paragraphs"] = len(d.paragraphs)
         text = "\n".join(p.text for p in d.paragraphs)
-    elif ext in (".md", ".txt"):
+    elif ext in (".md", ".txt", ".json", ".yaml", ".yml"):
         text = path.read_text(errors="replace")
+    elif ext in (".csv", ".xlsx", ".xls"):
+        from .excel_parser import parse_adaptive_excel
+        # Auto-discover a sibling JSON metadata file (e.g. data.xlsx +
+        # data.json with title / objective / column_definitions) — the same
+        # convention parse_adaptive_excel uses elsewhere in the codebase.
+        sidecar = path.with_suffix(".json")
+        chunks = parse_adaptive_excel(
+            str(path),
+            context_path=str(sidecar) if sidecar.exists() else None,
+        )
+        if chunks:
+            summary = next(
+                (c for c in chunks if c["metadata"].get("content_type")
+                 in ("dataset_summary", "dataset_package")),
+                chunks[0],
+            )
+            text = summary["text"]
+        else:
+            text = ""
     else:
         raise ValueError(
             f"Unsupported document type '{ext}' — extract_text handles "
-            f".pdf, .docx, .md, and .txt."
+            f".pdf, .docx, .md, .txt, .json, .yaml/.yml, "
+            f".csv and .xlsx/.xls."
         )
 
     text = text.strip()


### PR DESCRIPTION
## Summary

Symmetric counterpart of `view_image` on the meta orchestrator. The meta
previously had no first-class path to read a document's content:
`inspect_uploads` returns only metadata + a ~400-char text head, and reading
a full PDF / docx / spreadsheet / JSON sidecar forced a delegation to the
analysis child — heavyweight for what is essentially "extract text and let
me reason over it." For scanned PDFs the gap was worse (probe text_head is
empty); for tabular files and JSON sidecars there was no in-chat read path
at all.

`view_document(paths)` is a thin wrapper over `scilink.parsers.extract_text`
(the layer from #182 Part A) called with `ocr_model=self.orch.model`, and
this PR also extends `extract_text` so the same call covers every document
class the meta is likely to encounter:

- **born-digital PDF / DOCX / MD / TXT** — fast text-layer extraction,
  including Part A's table-aware PDF path;
- **scanned PDFs** — Part B's vision-OCR fallback fires automatically; the
  result reports `n_ocr_pages` plus a verify-numerics note;
- **JSON / YAML / YML** — read as text (the common
  metadata-sidecar-alongside-data convention used throughout the codebase);
- **CSV / XLSX / XLS** — previewed via `parse_adaptive_excel` (small files
  return the full table as Markdown, large files a statistical summary); an
  auto-detected sibling JSON sidecar (e.g. `data.json` next to `data.xlsx`)
  enriches the preview with title / objective / column definitions.

A 200k-char cap matches the analysis `read_document` cap; per-file failures
are isolated and surface in the `errors` list. Returns text in the chat —
**no persistence**.

The meta now has a clean "open & interpret" surface:

- **detect** — `inspect_uploads`
- **interpret image** — `view_image`
- **interpret document** — `view_document` (this PR)

## Naming — why `view_document` and not `read_document`

Tool registries are per-orchestrator, so there's no runtime collision with
the analysis orchestrator's existing `read_document`. The verb difference
keeps a real semantic distinction crisp:

- `read_document` (analysis): read **for use** downstream — persists to
  `<session>/literature/provided_documents_*.md` and hints the planner to
  consume it as `literature_file` in `run_analysis`.
- `view_document` (meta, this PR): view **for inspection** — returns text in
  chat so the meta can reason, summarize, route, or extract a reference
  excerpt to thread into a `delegate_to_*` `context` dict.

Same naming pattern (`view_*`) as the meta's `view_image`, so the meta's
content-inspection surface stays internally consistent.

## What changed

Two files, two commits on this branch:

**1. `scilink/agents/meta_agent/meta_orchestrator_tools.py`** — the tool.
- New nested `view_document(paths) -> str` inside `_register_all_tools`,
  registered next to `view_image`.
- Calls `extract_text(pp, ocr_model=self.orch.model)` — vision-OCR engages
  automatically for scanned pages; tabular preview happens transparently
  via the shared layer.
- Returns JSON: `{status, n_documents, n_ocr_pages, ocr_note, documents,
  errors}`. Each document carries `name`, `text`, `n_chars`, `truncated`,
  and the format-specific count (`n_pages` / `n_paragraphs` /
  `n_ocr_pages`).
- The supported-formats whitelist + the per-file error message are derived
  from a single `_DOCUMENT_EXTS` set, so widening it in future is one edit.

**2. `scilink/parsers/extract.py`** — broaden the shared Tier-1 reader.
- Adds `.json / .yaml / .yml` branches (plain text read).
- Adds `.csv / .xlsx / .xls` branch routed through
  `parse_adaptive_excel`. Auto-discovers a sibling JSON metadata file
  (the existing parse_adaptive_excel convention) and uses it as
  `context_path` so the preview includes title / objective / column
  definitions.
- `analysis_orchestrator_tools.read_document` benefits transitively — no
  change needed there.

## Testing

Verified live (claude-opus-4-6):

PDF / OCR path (commit 1):
- **Born-digital PDF** — `meta.chat` triggers `view_document`; the reply
  correctly summarizes the paper.
- **Scanned PDF** (rasterized fixture, image-only) — `meta.chat` triggers
  `view_document`; the vision-OCR fallback fires through the parsers
  layer, and the reply surfaces the transcribed content *and* acknowledges
  OCR.

JSON / YAML / tabular path (commit 2):
- `extract_text` on a JSON sidecar returns the full file content.
- `extract_text` on a paired `.xlsx` auto-merges the sibling JSON sidecar
  into the preview (title / objective / column definitions present).
- `meta.chat` end-to-end — the exact failed-session scenario reproduced
  (JSON sidecar + paired XLSX in one `view_document` call): the meta now
  reads both, and its reply surfaces both the dataset description (from
  the XLSX preview) and the objective (from the auto-merged JSON sidecar).

Plus compile + import checks on the two modified modules.

## Out of scope (follow-ups)

- Adding a similar in-chat reader on the analysis orchestrator — analysis
  already has `read_document` with persistence semantics that are
  appropriate there; no parallel tool needed.
- Persisting `view_document` output to disk (deliberately not done — the
  meta uses the returned text in-chat; if a downstream consumer needs the
  file, the meta routes via delegation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
