### PR TITLE
sim_agents: tidy generated-script filenames

### DIFF
--- a/scilink/agents/sim_agents/structure_agent.py
+++ b/scilink/agents/sim_agents/structure_agent.py
@@ -591,10 +591,11 @@ class StructureGenerator:
 
                 current_script = script_content
 
-                # Save script
-                script_desc = f"{original_user_request[:30]}_cycle{attempt_number_overall}_attempt{attempt}"
+                # Save script (save_generated_script appends "_attempt{n}" itself,
+                # so script_desc carries only the request + cycle).
+                script_desc = f"{original_user_request[:30]}_cycle{attempt_number_overall}"
                 final_script_path = save_generated_script(
-                    current_script, script_desc, 1, output_dir=self.generated_script_dir
+                    current_script, script_desc, attempt, output_dir=self.generated_script_dir
                 )
                 
                 if not final_script_path:

--- a/scilink/agents/sim_agents/utils.py
+++ b/scilink/agents/sim_agents/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import logging
 from typing import Optional, List, Dict
 
@@ -370,8 +371,10 @@ def save_generated_script(script_content: str, description: str, attempt: int, o
         os.makedirs(output_dir, exist_ok=True)
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        # Sanitize description for use in filename
-        safe_desc = "".join(c if c.isalnum() else "_" for c in description[:30]).rstrip("_")
+        # Sanitize description for use in filename: collapse each run of
+        # non-alphanumeric chars into a single underscore (so "a, b" / "a. b"
+        # don't become "a__b"), strip edges, then cap the length.
+        safe_desc = re.sub(r"[^0-9A-Za-z]+", "_", description).strip("_")[:40]
         filename = f"script_{safe_desc}_attempt{attempt}_{timestamp}.py"
         saved_script_path = os.path.join(output_dir, filename)
 


### PR DESCRIPTION
## What

`save_generated_script` mapped every non-alphanumeric character to `_`, so a `.` or `,` in the structure description produced a doubled underscore — e.g. `script_BCC_Fe__Save_…`. It also applied `description[:30]` *before* sanitizing, while the only caller (`StructureGenerator.generate_script`) already baked `_cycle{n}_attempt{m}` into the description **and** passed a hardcoded `attempt=1`, yielding truncated, doubled names like `…_cycle1_attempt1_attempt1_<ts>.py`.

## Change

- `save_generated_script` collapses each run of non-alphanumeric chars into a single `_`, strips edges, and caps at 40 chars *after* cleaning.
- The caller passes only `request + cycle` in the description and forwards the real `attempt` number (instead of a hardcoded `1`), so the function's own `_attempt{n}` suffix isn't duplicated.

Filenames are now e.g. `script_BCC_Fe_bulk_cycle1_attempt1_<ts>.py`.

## Scope

Cosmetic-only (generated-script filenames). Single caller; no behavior change beyond the filename string. 2 files, +9/−5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)