### PR TITLE
Add opt-in LLM call tracing (prompts, responses, token usage, latency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,33 @@ When using `SCILINK_API_KEY`, also provide a `--base-url` pointing to your OpenA
 
 ---
 
+## Tracing
+
+By default SciLink records nothing about individual LLM calls. Enable tracing to append one JSON
+record per call — model, prompt messages, response text, token usage, and latency — to a JSONL file.
+Useful for cost accounting, model comparison, and variability / reproducibility studies.
+
+```python
+import scilink
+scilink.enable_tracing("run/llm_trace.jsonl")   # or: export SCILINK_TRACE_FILE=run/llm_trace.jsonl
+# ... run agents / workflows ...
+scilink.disable_tracing()
+```
+
+Each line of the trace is a JSON object:
+
+```json
+{"timestamp": "...", "model": "...", "messages": [...], "response_text": "...",
+ "finish_reason": "stop",
+ "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+ "latency_s": 0.0}
+```
+
+Tracing is global and opt-in — nothing is recorded unless you enable it. Inline image payloads are
+collapsed to `<image>` so traces stay small.
+
+---
+
 ## Quick Start
 
 SciLink can be used via the **CLI**, **web UI**, **MCP server**, or **Python API**.

--- a/scilink/__init__.py
+++ b/scilink/__init__.py
@@ -1,4 +1,5 @@
 from .auth import set_api_key, show_api_status
+from .tracing import enable_tracing, disable_tracing, is_enabled as is_tracing_enabled
 import torch  # Load PyTorch's BLAS first to avoid conflicts with faiss
 
 def configure(service: str, api_key: str):
@@ -36,8 +37,11 @@ def show_config():
 
 
 __all__ = [
-    'configure', 
-    'configure_from_dict', 
+    'configure',
+    'configure_from_dict',
     'show_config',
+    'enable_tracing',
+    'disable_tracing',
+    'is_tracing_enabled',
     'torch'
 ]

--- a/scilink/tracing.py
+++ b/scilink/tracing.py
@@ -1,0 +1,129 @@
+"""
+Opt-in tracing of LLM calls.
+
+By default SciLink records nothing about individual LLM calls — no prompts, responses,
+or token usage. Enabling tracing appends one JSON record per call to a JSONL file,
+capturing the model, prompt messages, response text, token usage, and latency. This is
+useful for cost accounting, model comparisons, and variability / reproducibility studies.
+
+Enable in code::
+
+    import scilink
+    scilink.enable_tracing("run/llm_trace.jsonl")
+    ...
+    scilink.disable_tracing()
+
+or via the environment (auto-enabled on first call)::
+
+    export SCILINK_TRACE_FILE=run/llm_trace.jsonl
+
+Each line of the trace file is a JSON object::
+
+    {"timestamp", "model", "messages", "response_text", "finish_reason",
+     "usage": {"prompt_tokens", "completion_tokens", "total_tokens"}, "latency_s"}
+
+Tracing is global and opt-in: the LLM wrapper has no per-session output directory, so a
+single sink keeps it simple, and nothing is recorded unless tracing is enabled.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+_lock = threading.Lock()
+_trace_path: Optional[str] = None
+_env_checked = False
+
+
+def enable_tracing(path: str) -> None:
+    """Append a JSON record (one line) for every subsequent LLM call to ``path``."""
+    global _trace_path
+    parent = os.path.dirname(os.path.abspath(path))
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    _trace_path = path
+
+
+def disable_tracing() -> None:
+    """Turn off LLM-call tracing."""
+    global _trace_path
+    _trace_path = None
+
+
+def is_enabled() -> bool:
+    """Whether a trace destination is active (set via enable_tracing or $SCILINK_TRACE_FILE)."""
+    return _active_path() is not None
+
+
+def _active_path() -> Optional[str]:
+    """Resolve the active trace path, honoring $SCILINK_TRACE_FILE on first use."""
+    global _trace_path, _env_checked
+    if _trace_path is None and not _env_checked:
+        _env_checked = True
+        env = os.environ.get("SCILINK_TRACE_FILE")
+        if env:
+            enable_tracing(env)
+    return _trace_path
+
+
+def record(model: str,
+           messages: Any,
+           response_text: str,
+           finish_reason: Optional[str] = None,
+           usage: Optional[Dict[str, Any]] = None,
+           latency_s: Optional[float] = None,
+           extra: Optional[Dict[str, Any]] = None) -> None:
+    """Append one LLM-call record. No-op when tracing is disabled; never raises."""
+    path = _active_path()
+    if not path:
+        return
+    rec: Dict[str, Any] = {
+        "timestamp": datetime.now().isoformat(timespec="seconds"),
+        "model": model,
+        "messages": _sanitize_messages(messages),
+        "response_text": response_text,
+        "finish_reason": finish_reason,
+        "usage": usage,
+        "latency_s": latency_s,
+    }
+    if extra:
+        rec.update(extra)
+    try:
+        line = json.dumps(rec, default=str)
+        with _lock:
+            with open(path, "a") as fh:
+                fh.write(line + "\n")
+    except Exception:
+        # Tracing must never break a generation.
+        pass
+
+
+def _sanitize_messages(messages: Any) -> Any:
+    """Keep prompt text but replace inline image payloads with a marker, so traces stay small."""
+    if not isinstance(messages, list):
+        return messages
+    out: List[Dict[str, Any]] = []
+    for m in messages:
+        if not isinstance(m, dict):
+            out.append({"role": None, "content": str(m)})
+            continue
+        role, content = m.get("role"), m.get("content")
+        if isinstance(content, list):
+            parts = []
+            for p in content:
+                if isinstance(p, dict):
+                    if p.get("type") == "text":
+                        parts.append(p.get("text", ""))
+                    elif p.get("type") in ("image_url", "image"):
+                        parts.append("<image>")
+                    else:
+                        parts.append(f"<{p.get('type', 'part')}>")
+                else:
+                    parts.append(str(p))
+            content = " ".join(parts)
+        out.append({"role": role, "content": content})
+    return out

--- a/scilink/wrappers/litellm_wrapper.py
+++ b/scilink/wrappers/litellm_wrapper.py
@@ -31,6 +31,7 @@ import re
 import base64
 import json
 import logging
+import time
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Union
 
@@ -101,6 +102,33 @@ def _normalize_model_name(model: str) -> str:
     
     # Default: return as-is, let LiteLLM figure it out
     return model
+
+
+def _record_trace(model: str, messages, response, latency_s: float) -> None:
+    """Record one completed LLM call to the opt-in global tracer (no-op if disabled)."""
+    try:
+        from .. import tracing
+        if not tracing.is_enabled():
+            return
+        text, finish = "", None
+        choices = getattr(response, "choices", None) or []
+        if choices:
+            message = getattr(choices[0], "message", None)
+            text = (getattr(message, "content", None) or "") if message else ""
+            finish = getattr(choices[0], "finish_reason", None)
+        usage = None
+        u = getattr(response, "usage", None)
+        if u is not None:
+            usage = {
+                "prompt_tokens": getattr(u, "prompt_tokens", None),
+                "completion_tokens": getattr(u, "completion_tokens", None),
+                "total_tokens": getattr(u, "total_tokens", None),
+            }
+        tracing.record(model=model, messages=messages, response_text=text,
+                       finish_reason=finish, usage=usage, latency_s=latency_s)
+    except Exception:
+        pass  # tracing must never break a generation
+
 
 def _check_litellm():
     """Raise ImportError if LiteLLM is not available."""
@@ -233,6 +261,7 @@ class LiteLLMGenerativeModel:
         params = self._build_params(generation_config, tools or self.tools)
         
         try:
+            _t0 = time.perf_counter()
             response = litellm.completion(
                 model=self.model,
                 messages=messages,
@@ -246,8 +275,9 @@ class LiteLLMGenerativeModel:
             if stream:
                 return self._handle_stream(response)
             
+            _record_trace(self.model, messages, response, time.perf_counter() - _t0)
             return self._to_legacy_response(response)
-            
+
         except Exception as e:
             logging.error(f"LiteLLM generation error: {e}")
             raise
@@ -561,6 +591,7 @@ class LiteLLMChatSession:
         
         params = self._model._build_params(generation_config, self._model.tools)
         
+        _t0 = time.perf_counter()
         response = litellm.completion(
             model=self._model.model,
             messages=messages,
@@ -575,6 +606,7 @@ class LiteLLMChatSession:
         
         self._history.append({"role": "user", "content": user_content})
         
+        _record_trace(self._model.model, messages, response, time.perf_counter() - _t0)
         legacy_response = self._model._to_legacy_response(response)
         
         if legacy_response.text:


### PR DESCRIPTION
## Summary

SciLink currently records nothing about individual LLM calls (no prompts, responses, or token usage). This adds **opt-in** tracing: when enabled, every LLM call appends one JSON record to a JSONL file — model, prompt messages, response text, finish reason, token usage, and latency. Useful for cost accounting, model comparison, and variability / reproducibility studies.

**No behavior change unless tracing is enabled.**

## Usage

```python
import scilink
scilink.enable_tracing("run/llm_trace.jsonl")   # or: export SCILINK_TRACE_FILE=run/llm_trace.jsonl
# ... run agents / workflows ...
scilink.disable_tracing()
```

Each line of the trace:

```json
{"timestamp", "model", "messages", "response_text", "finish_reason",
 "usage": {"prompt_tokens", "completion_tokens", "total_tokens"}, "latency_s"}
```

## What's in the PR

- **`scilink/tracing.py`** (new): thread-safe, global, opt-in JSONL sink — `enable_tracing` / `disable_tracing` / `is_enabled`, plus `$SCILINK_TRACE_FILE`. Inline image payloads collapse to `<image>` so traces stay small.
- **`scilink/wrappers/litellm_wrapper.py`**: a shared `_record_trace` helper hooks both `litellm.completion` sites — `LiteLLMGenerativeModel.generate_content` and `LiteLLMChatSession.send_message` — pulling text / finish_reason / usage from the raw response plus latency.
- **`scilink/__init__.py`**: exports `enable_tracing` / `disable_tracing` / `is_tracing_enabled`.
- **README**: a short "Tracing" section.

## Design

Tracing is process-global because the LLM wrapper has no per-agent/session output directory; a single sink keeps the change minimal and free of behavior change unless explicitly enabled. Streaming responses are not traced in this first cut (token usage isn't reliably available on chunks).

## Testing

- Standalone unit check of the tracer (enable → record → JSONL → disable; image sanitization; usage/latency capture).
- Live smoke test against a real Anthropic response via litellm — both hooked paths (`generate_content` and `send_message`) recorded real token counts, finish reason, and latency.
- `py_compile` clean on all changed files.

## Future work (not in this PR)

- **Auto-enable per session:** have each orchestrator (analyze / plan / simulate) enable a trace into its own session/output directory, so every run is traced without an explicit `enable_tracing()` call. Requires threading the session dir into the wrapper and touching all three orchestrators.
- **Explicit agent/role tag:** today the calling agent is implicitly identifiable from the recorded `system` message; an explicit compact `agent` field would be easier to filter on, but needs a label passed through the agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
