### PR TITLE
Fix curve-fit crash when planning falls back to a null config

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1571,7 +1571,15 @@ class HumanFeedbackRefinementController:
             state["parameters_to_extract"] = []
             state["fitting_strategy"] = "Standard curve fitting"
             state["literature_query"] = None
-            state["locked_fitting_config"] = None
+            # Mirror the success-path config shape (not None) so downstream
+            # consumers that do `locked_fitting_config.copy()` /
+            # `.get("physical_model")` don't crash on the fallback path.
+            state["locked_fitting_config"] = {
+                "analysis_approach": state.get("analysis_approach"),
+                "physical_model": state.get("physical_model"),
+                "parameters_to_extract": state.get("parameters_to_extract", []),
+                "fitting_strategy": state.get("fitting_strategy"),
+            }
             state["series_analysis_plan"] = None
             state["regime_configs"] = None
 
@@ -2468,7 +2476,7 @@ Remember: Rejecting a good fit (R² > {accept_threshold:.2f}) to chase marginal 
         Apply LLM verification feedback to refine the fitting configuration.
         Returns updated config.
         """
-        config = state.get("locked_fitting_config", {}).copy()
+        config = (state.get("locked_fitting_config") or {}).copy()
 
         recommended_action = verification.get("recommended_action", "")
         if not recommended_action or recommended_action.lower() == "none":
@@ -2720,7 +2728,7 @@ Return JSON with:
         verification_history = []
         best_result = None
         best_r2 = -1.0
-        best_config = state.get("locked_fitting_config", {}).copy()
+        best_config = (state.get("locked_fitting_config") or {}).copy()
         # Option B gate: set to True if the verifier ever rejects best_result
         # without later approving it.  Drives the threshold short-circuit
         # at the post-loop checkpoint.
@@ -2814,13 +2822,13 @@ Return JSON with:
             r2 = result.get("fit_quality", {}).get("r_squared") or 0
             all_attempts.append({
                 "model": initial_model, "r2": r2, "result": result,
-                "config": state.get("locked_fitting_config", {}).copy(),
+                "config": (state.get("locked_fitting_config") or {}).copy(),
             })
 
             if r2 > best_r2:
                 best_r2 = r2
                 best_result = result
-                best_config = state.get("locked_fitting_config", {}).copy()
+                best_config = (state.get("locked_fitting_config") or {}).copy()
 
             # --- Verification loop (for anchor spectra: first overall or first in regime) ---
             fit_was_approved = False
@@ -2900,7 +2908,7 @@ Return JSON with:
                             note = (verification.get("comparison_note") or "physics improvement")[:90]
                             best_r2 = current_r2
                             best_result = current_result
-                            best_config = state.get("locked_fitting_config", {}).copy()
+                            best_config = (state.get("locked_fitting_config") or {}).copy()
                             state["locked_fitting_config"] = best_config
                             self.logger.info(
                                 f"   Retroactively promoted current (R² = {current_r2:.4f}) on physics — {note}"
@@ -2934,7 +2942,7 @@ Return JSON with:
                             # grounds (e.g. better peak shape).  Promote.
                             best_r2 = current_r2
                             best_result = current_result
-                            best_config = state.get("locked_fitting_config", {}).copy()
+                            best_config = (state.get("locked_fitting_config") or {}).copy()
                             best_verification = verification
                             best_ever_rejected = False
                             state["locked_fitting_config"] = best_config
@@ -3023,7 +3031,7 @@ Return JSON with:
                                 "model": f"Verification-{verification_iter + 1}",
                                 "r2": verified_r2,
                                 "result": verified_result,
-                                "config": state.get("locked_fitting_config", {}).copy(),
+                                "config": (state.get("locked_fitting_config") or {}).copy(),
                                 "verification": verification,
                             })
 
@@ -3044,7 +3052,7 @@ Return JSON with:
                             if verified_r2 > best_r2:
                                 best_r2 = verified_r2
                                 best_result = verified_result
-                                best_config = state.get("locked_fitting_config", {}).copy()
+                                best_config = (state.get("locked_fitting_config") or {}).copy()
                                 state["locked_fitting_config"] = best_config
                                 best_ever_rejected = False
                                 best_verification = None
@@ -3152,7 +3160,7 @@ Return JSON with:
                                 note = (final_verification.get("comparison_note") or "physics improvement")[:90]
                                 best_r2 = current_r2
                                 best_result = current_result
-                                best_config = state.get("locked_fitting_config", {}).copy()
+                                best_config = (state.get("locked_fitting_config") or {}).copy()
                                 self.logger.info(
                                     f"   Post-loop promoted current (R² = {current_r2:.4f}) on physics — {note}"
                                 )


### PR DESCRIPTION
## Summary

Curve fitting (the Group B / `CurveFittingAgent` path) currently crashes for anyone running
it in a notebook or a non-interactive script: `analyze()` dies partway through with
`'NoneType' object has no attribute 'copy'`, even on clean data. It's been broken since
v0.0.21.

The cause is small and unrelated to the fitting math: when the interactive "review the
plan?" prompt has no stdin to read, the planner treats that as a failure and stores a *null*
config, and the fitter then trips over the null. This PR makes that fallback store a valid
(empty) config instead of null, and hardens the spots that read it, so the pipeline runs
cleanly.

Verified on a real MoS₂ photoluminescence spectrum: it now fits to **R² = 0.9988** (3 peaks
+ baseline) instead of crashing. Full technical detail below.

---

## Problem

`CurveFittingAgent.analyze()` crashes at the fitting step with
`'NoneType' object has no attribute 'copy'` whenever the planning stage falls back.

### Root cause

`_fit_with_quality_control` opens with:

```python
best_config = state.get("locked_fitting_config", {}).copy()
```

`dict.get(key, default)` only uses `default` when the key is **missing**. The planning
fallback (`curve_fitting_controllers.py:1574`) sets the key explicitly to `None`:

```python
state["locked_fitting_config"] = None
```

so `.get(..., {})` returns `None`, and `None.copy()` raises.

### When the fallback fires

Any time planning raises. Notably, the human-feedback step calls `input()`
("Your feedback (or Enter to accept)"). In a **non-interactive** shell (notebook / script
without stdin) that throws `EOFError`, which is caught as "Planning failed -> fallback". So
curve fitting crashes in notebooks and on any genuine planning failure (e.g. a transient
LLM/network error). The plan is actually generated, then discarded by the fallback -- which
is why it can look like "planning succeeded yet it crashed".

### Regression

The crash path shipped in **v0.0.21** (commit `50785065`, *"Adaptive score-based constraint
annealing for curve fitting verification"*), which put the `.copy()` at the top of
`_fit_with_quality_control`. The `None` fallback and the unguarded `.get(key, {}).copy()`
pattern both date to v0.0.10.

## Fix

- The planning fallback now builds the success-shape config dict (from the fallback values)
  instead of `None`.
- Hardened all 9 read sites to `(state.get("locked_fitting_config") or {}).copy()` as
  defense-in-depth, so a `None` can never crash here again.

## Verification

The `mos2_pl` PL spectrum fits end-to-end after the fix (it crashed before):

```
✅ Verifier approved fit (R² = 0.9988)
✅ 3 Voigt profiles + linear baseline
✅ ANALYSIS COMPLETE
```

The verifier correctly escalated from 2 to 3 peaks (B/A exciton + defect emission) on a
linear baseline.

## Optional follow-up (not in this PR)

The human-feedback `input()` could catch `EOFError` and treat it as "accept", so the
generated plan is kept in non-interactive runs instead of being dropped into the fallback.
Left out to keep this change minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
