### PR TITLE
Extend HyperspectralAnalysisAgent: ICA, generic axes, skip-gate, skill→codegen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,9 @@
 # SciLink — Architecture Notes
 
 Forward-looking design decisions and conventions. Intended for AI assistants
-and contributors working on the orchestrator stack. Codebase tour and
-per-module docs are elsewhere; this file is about *direction*.
+and contributors working on the agentic stack — orchestrators, foundation
+agents, and the skill subsystem. Codebase tour and per-module docs are
+elsewhere; this file is about *direction*.
 
 ## The mode universe is fixed at three
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,21 @@ simulation it could be computational method (DFT, classical MD,
 machine-learning potentials). Each foundation agent picks its own axis;
 the definition is agnostic about *what counts as a modality*.
 
+A note on the `analysis` / `implementation` section pair: codegen-capable
+foundation agents inject the active skill's `implementation` section into
+per-task code-gen prompts. The skill loader treats `analysis` and
+`implementation` as synonyms when only one is authored — copying the
+content to the other — so skills written under either name flow into
+code-gen identically. When *both* are authored (e.g. `force_field/amber`,
+`molecular_dynamics/lammps`, `machine_learning_potentials/chgnet`), they
+are left distinct: the author's convention there is `analysis` for input
+characterization ("what kind of system is this?") and `implementation`
+for the runnable script recipe. This synonym fold is historical: the
+section was originally `fitting` in the curve-fitting-only era, renamed
+to `analysis` when image_analysis joined, and is now `implementation` in
+the most recent sim_agents and hyperspectral work. Going forward, prefer
+`implementation`.
+
 ## Plan-mode capability boundaries
 
 Two settled conventions on where capability lives in plan mode:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,13 @@ to `analysis` when image_analysis joined, and is now `implementation` in
 the most recent sim_agents and hyperspectral work. Going forward, prefer
 `implementation`.
 
+**Recommended structure for new analysis-agent skills:** `Overview →
+Planning → Implementation → Interpretation → Validation`. This five-
+section pattern follows the cognitive flow of an analysis run — what the
+technique is, how to plan a use of it, how to write the code, how to
+read the output, and how to verify it. New skills should use this
+ordering; legacy `analysis` is accepted by the loader for backcompat.
+
 ## Plan-mode capability boundaries
 
 Two settled conventions on where capability lives in plan mode:

--- a/scilink/agents/exp_agents/controllers/base_controllers.py
+++ b/scilink/agents/exp_agents/controllers/base_controllers.py
@@ -18,14 +18,14 @@ class RunFinalInterpretationController:
         self._parse_llm_response = parse_fn  # Pass in the agent's parser
 
     def execute(self, state: dict) -> dict:
-        self.logger.info("🧠 LLM Step: Generating final scientific interpretation...")
+        self.logger.info("🧠 LLM Step: Generating scientific interpretation...")
         prompt = state.get("final_prompt_parts")
-        
+
         if not prompt:
-            self.logger.error("Pipeline reached final step, but no 'final_prompt_parts' in state.")
-            state["error_dict"] = {"error": "Pipeline failed to build final prompt"}
+            self.logger.error("Interpretation step invoked with no 'final_prompt_parts' in state.")
+            state["error_dict"] = {"error": "Pipeline failed to build interpretation prompt"}
             return state
-        
+
         try:
             response = self.model.generate_content(
                 contents=prompt,
@@ -33,19 +33,19 @@ class RunFinalInterpretationController:
                 safety_settings=self.safety_settings,
             )
             result_json, error_dict = self._parse_llm_response(response)
-            
+
             state["result_json"] = result_json
             state["error_dict"] = error_dict
-            
+
             if not error_dict:
-                self.logger.info("✅ LLM Step Complete: Final analysis generated.")
+                self.logger.info("✅ LLM Step Complete: Interpretation generated.")
             else:
                 self.logger.error(f"❌ LLM Step Failed: {error_dict.get('details')}")
 
         except Exception as e:
             self.logger.exception(f"❌ LLM Step Failed: {e}")
             state["result_json"] = None
-            state["error_dict"] = {"error": "Final LLM analysis failed", "details": str(e)}
+            state["error_dict"] = {"error": "LLM interpretation step failed", "details": str(e)}
 
         return state
 

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -292,9 +292,9 @@ class RunPreprocessingController:
 class GetInitialComponentParamsController:
     """
     [🧠 LLM Step]
-    Asks LLM for initial n_components and decomposition method (NMF or PCA).
+    Asks LLM for initial n_components and decomposition method (NMF, PCA, or ICA).
     """
-    VALID_METHODS = ("nmf", "pca")
+    VALID_METHODS = ("nmf", "pca", "ica")
 
     def __init__(self, model, logger, generation_config, safety_settings, parse_fn: Callable):
         self.model = model
@@ -398,11 +398,25 @@ class RunComponentTestLoopController:
         if state.get("error_dict"): return state
         self.logger.info("\n\n🛠️ --- CALLING TOOL: COMPONENT TEST LOOP --- 🛠️\n")
 
+        method_name = state.get("settings", {}).get("method", "nmf").upper()
+
+        # ICA has no meaningful reconstruction-error trend in n_components, so
+        # the elbow loop is uninformative. Skip it and let the downstream
+        # selection controller fall back to the LLM's initial estimate.
+        if method_name == "ICA":
+            self.logger.info(
+                "ICA mode: skipping component test loop (no informative elbow). "
+                "Final n_components will use the LLM's initial estimate."
+            )
+            state["component_test_range"] = []
+            state["component_test_errors"] = []
+            state["component_test_visuals"] = []
+            return state
+
         tool_settings = self.settings.copy()
         for key in AGENT_METADATA_KEYS_TO_STRIP:
             tool_settings.pop(key, None)
 
-        method_name = state.get("settings", {}).get("method", "nmf").upper()
         initial_estimate = state.get("initial_n_components", 4)
         min_c = self.settings.get('min_auto_components', 2)
         max_c = self.settings.get('max_auto_components', min(initial_estimate + 4, 12))
@@ -655,10 +669,12 @@ class CreateAnalysisPlotsController:
         final_plots = []
         validated_bytes_list = []
 
-        if method_name == "PCA":
-            # --- PCA MODE: Summary-only (no per-component validation) ---
+        if method_name in ("PCA", "ICA"):
+            # --- PCA / ICA MODE: Summary-only (no per-component validation) ---
+            # Both produce signed components that don't map directly to physical
+            # phases, so we skip per-component reconstruction validation.
             self.logger.info(
-                f"PCA mode: Generating summary plot for {components.shape[0]} components..."
+                f"{method_name} mode: Generating summary plot for {components.shape[0]} components..."
             )
             summary_bytes = tools.create_nmf_summary_plot(
                 components, abundance_maps, components.shape[0],
@@ -821,6 +837,20 @@ Below is a PCA decomposition summary of the dataset.
 Top row: Principal Component spectra. Bottom row: Corresponding spatial loading maps.
 PCA components are exploratory — they capture variance directions, not necessarily physical phases.
 Identify spectral features of interest (peaks, edges, shifts) for custom code modeling.
+""")
+                # Append only the summary image (no per-component metrics)
+                for plot in state["component_pair_plots"]:
+                    prompt_parts.append(f"\n{plot['label']}:")
+                    prompt_parts.append({"mime_type": "image/jpeg", "data": plot['bytes']})
+            elif method_name == "ICA":
+                # ICA mode: summary-only, independent-source framing
+                prompt_parts.append(f"""
+Below is an ICA decomposition summary of the dataset.
+Top row: Independent Component spectra. Bottom row: Corresponding spatial loading maps.
+ICA components represent statistically independent sources rather than variance directions;
+they may overlap spectrally and can have signed loadings. Use them to identify candidate
+distinct contributions for custom code modeling, but do not treat them as physical phases
+without further validation.
 """)
                 # Append only the summary image (no per-component metrics)
                 for plot in state["component_pair_plots"]:
@@ -1290,10 +1320,10 @@ class GenerateHTMLReportController:
 
             # --- 2. Concept Triggers (The Safety Net) ---
 
-            # TRIGGER: Decomposition Summary (NMF or PCA)
+            # TRIGGER: Decomposition Summary (NMF, PCA, or ICA)
             # If the plot is a summary grid and the text mentions the method or "Components", show it.
             if "summary grid" in label_lower:
-                if "nmf" in lower_text or "pca" in lower_text or "component" in lower_text or "unmixing" in lower_text or "decomposition" in lower_text:
+                if "nmf" in lower_text or "pca" in lower_text or "ica" in lower_text or "component" in lower_text or "unmixing" in lower_text or "decomposition" in lower_text:
                     cited_images.append(img)
                     continue
 

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -29,40 +29,62 @@ from ....skills.hyperspectral.eels.eels import AGENT_METADATA_KEYS_TO_STRIP
 from ....executors import ExecutionTimeout
 
 
+def _render_skill_block(state: dict, stage: str) -> str:
+    """Render the active domain skill's block for ``stage`` as a single string.
+
+    Returns ``""`` when no skill is active or no content exists for the
+    requested stage. Use this from prompt builders that assemble a single
+    string (e.g. ``build_code_generation_prompt``); the list-mode wrapper
+    ``_append_skill_context`` below uses this internally.
+    """
+    sections = state.get("skill_sections")
+    if not sections:
+        return ""
+    content = sections.get(stage, "")
+    if not content:
+        return ""
+
+    skill_name = state.get("skill_name", "domain skill")
+    parts = [
+        f"\n## MANDATORY Domain Skill Rules: {skill_name} ({stage})",
+        (
+            "The following rules are MANDATORY. Your analysis plan and implementation "
+            "MUST conform to these domain-specific requirements. These rules encode "
+            "validated domain expertise and take precedence over general-purpose defaults. "
+            "Do NOT substitute your own preferences where these rules specify a method, "
+            "treatment, or constraint."
+        ),
+        content,
+    ]
+
+    # Include validation rules during planning, interpretation, and
+    # implementation so the LLM knows quality criteria upfront — at planning
+    # to shape the approach, at interpretation/implementation to shape the
+    # output and the generated code.
+    if stage in ("planning", "interpretation", "implementation"):
+        validation = sections.get("validation", "")
+        if validation:
+            parts.append(f"\n## MANDATORY Domain Validation Rules ({skill_name})")
+            parts.append(validation)
+
+    return "\n".join(parts)
+
+
 def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
-    """Append domain skill knowledge to an LLM prompt for the given stage.
+    """Append domain skill knowledge to an LLM prompt list for the given stage.
+
+    Thin list-mode wrapper around ``_render_skill_block`` for prompt
+    builders that assemble multi-part (text + image) prompts.
 
     Args:
         prompt: Mutable list of prompt parts to extend.
         state: Pipeline state dict containing ``skill_sections`` and ``skill_name``.
-        stage: One of ``"planning"``, ``"analysis"``, ``"interpretation"``, ``"validation"``.
+        stage: One of ``"planning"``, ``"analysis"``, ``"interpretation"``,
+               ``"validation"``, ``"implementation"``.
     """
-    sections = state.get("skill_sections")
-    if not sections:
-        return
-
-    skill_name = state.get("skill_name", "domain skill")
-    content = sections.get(stage, "")
-    if not content:
-        return
-
-    prompt.append(f"\n## MANDATORY Domain Skill Rules: {skill_name} ({stage})")
-    prompt.append(
-        "The following rules are MANDATORY. Your analysis plan and implementation "
-        "MUST conform to these domain-specific requirements. These rules encode "
-        "validated domain expertise and take precedence over general-purpose defaults. "
-        "Do NOT substitute your own preferences where these rules specify a method, "
-        "treatment, or constraint."
-    )
-    prompt.append(content)
-
-    # Include validation rules during planning and interpretation
-    # so the LLM knows quality criteria upfront
-    if stage in ("planning", "interpretation"):
-        validation = sections.get("validation", "")
-        if validation:
-            prompt.append(f"\n## MANDATORY Domain Validation Rules ({skill_name})")
-            prompt.append(validation)
+    block = _render_skill_block(state, stage)
+    if block:
+        prompt.append(block)
 
 
 def _append_prior_knowledge_context(prompt: list, state: dict) -> None:
@@ -144,7 +166,21 @@ def build_code_generation_prompt(
     hints: str | None = None,
     objective: str | None = None,
     required_outputs: list[str] | None = None,
+    skill_implementation: str | None = None,
 ) -> str:
+    skill_section = ""
+    if skill_implementation:
+        skill_section = f"""
+
+### 0. ACTIVE DOMAIN SKILL — IMPLEMENTATION GUIDANCE
+{skill_implementation}
+
+If the skill's guidance suggests map key names that differ from the
+REQUIRED OUTPUTS block (when present), the REQUIRED OUTPUTS keys are
+authoritative — produce maps under those exact names even if the skill
+recommends different naming.
+"""
+
     hints_section = ""
     if required_outputs:
         keys_str = ", ".join(f'"{n}"' for n in required_outputs)
@@ -182,12 +218,12 @@ The user has indicated interest in: {hints}
 Prioritize this guidance in your analysis, but also capture any other significant features present in the data.
 """
     return f"""
-You are a Python Data Scientist specialized in Spectroscopy. 
+You are a Python Data Scientist specialized in Spectroscopy.
 The standard NMF tool failed to model a spectral feature described as: "{target_desc}".
 
-Your task: Write a Python function to mathematically model this feature. 
+Your task: Write a Python function to mathematically model this feature.
 Since complex features often require multiple parameters (e.g., Peak Position AND Peak Width), your function must be able to return MULTIPLE maps.
-
+{skill_section}
 ### 1. DATA CONTEXT
 - Input Data `hspy_data`: Shape ({h}, {w}, {e}) (Numpy array)
 - X-Axis `axis`: Shape ({e},) (Numpy array). **Units: {axis_units}**
@@ -1584,6 +1620,11 @@ class RunDynamicAnalysisController:
                 hints=state.get("analysis_hints"),
                 objective=state.get("analysis_objective"),
                 required_outputs=required_outputs,
+                # Inject the active skill's `implementation` section so the
+                # code-gen LLM gets domain-specific recipe guidance (lineshape,
+                # baseline, library choice). Empty string when no skill is
+                # active or no implementation section is defined.
+                skill_implementation=_render_skill_block(state, "implementation"),
             )
 
             # Append a preprocessing-mask hint when one exists and identifies
@@ -1790,11 +1831,14 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
             state["dynamic_analysis_failed"] = True
             return state
 
-        # Stack maps from ALL scripts into one 3D array (H, W, N)
-        state["final_abundance_maps"] = np.stack(all_valid_maps, axis=-1)
+        # Commit per-feature metadata; downstream synthesis reads
+        # custom_analysis_metadata_list. We no longer overwrite the NMF/PCA/ICA
+        # state["final_abundance_maps"] key with the stacked custom maps —
+        # that write had no downstream reader after the Phase C cleanup and
+        # would have collided semantically with the decomposition's own
+        # abundance maps. method_used and new_tasks writes are likewise gone
+        # (no consumers).
         state["custom_analysis_metadata_list"] = all_valid_meta
-        state["method_used"] = "Dynamic Code Generation"
-        state["new_tasks"] = [] 
 
         self.logger.info(f"✅ Dynamic Analysis Complete. Total unique maps generated: {len(all_valid_maps)}")
         return state

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -874,16 +874,18 @@ class CreateAnalysisPlotsController:
 class BuildHyperspectralPromptController:
     """
     [📝 Prep Step]
-    Assembles all results into the final prompt for interpretation.
-    THIS IS FOR A SINGLE ITERATION, NOT THE FINAL SYNTHESIS.
+    Assembles per-iteration decomposition results into the interpretation
+    prompt for this iteration. Distinct from
+    BuildHolisticSynthesisPromptController, which assembles the synthesis
+    prompt run after dynamic analysis completes.
     """
     def __init__(self, logger: logging.Logger):
         self.logger = logger
 
     def execute(self, state: dict) -> dict:
-        if state.get("error_dict"): 
+        if state.get("error_dict"):
             return state
-        self.logger.info("\n\n📝 --- PREP STEP: BUILDING FINAL PROMPT --- 📝\n")
+        self.logger.info("\n\n📝 --- PREP STEP: BUILDING ITERATION INTERPRETATION PROMPT --- 📝\n")
         
         # 1. Base Instruction & Context
         prompt_parts = [state["instruction_prompt"]]
@@ -1011,7 +1013,7 @@ Overlays showing where components are concentrated on the structural image.
         prompt_parts.append("\n\nProvide your analysis in the requested JSON format.")
 
         state["final_prompt_parts"] = prompt_parts
-        self.logger.info("✅ Prep Step Complete: Final prompt is ready.")
+        self.logger.info("✅ Prep Step Complete: Iteration interpretation prompt is ready.")
         return state
 
 

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -13,6 +13,7 @@ import traceback
 from ....skills.hyperspectral.eels import eels as tools
 from ....skills._shared.image_processor import load_image
 from ..preprocess import HyperspectralPreprocessingAgent
+from ..metadata_converter import resolve_axis_spec, describe_axes_for_prompt
 from ..instruct import (
     COMPONENT_INITIAL_ESTIMATION_INSTRUCTIONS,
     COMPONENT_SELECTION_WITH_ELBOW_INSTRUCTIONS,
@@ -20,8 +21,8 @@ from ..instruct import (
     SPECTROSCOPY_HOLISTIC_SYNTHESIS_INSTRUCTIONS,
     SPECTROSCOPY_REFLECTION_INSTRUCTIONS,
     SPECTROSCOPY_REFLECTION_UPDATE_INSTRUCTIONS,
-    SPECTROSCOPY_VALIDATION_INTERPRETATION_INSTRUCTIONS,  
-    SPECTROSCOPY_VISUAL_QC_INSTRUCTIONS,                  
+    SPECTROSCOPY_VALIDATION_INTERPRETATION_INSTRUCTIONS,
+    SPECTROSCOPY_VISUAL_QC_INSTRUCTIONS,
 )
 
 from ....skills.hyperspectral.eels.eels import AGENT_METADATA_KEYS_TO_STRIP
@@ -310,10 +311,11 @@ class GetInitialComponentParamsController:
 
         h, w, e = state["hspy_data"].shape
         data_quality = state.get("data_quality", {})
+        axis_spec = resolve_axis_spec(state.get("system_info"))
 
         prompt_parts = [self.instructions]
         prompt_parts.append(f"\n\n--- Hyperspectral Data Information ---")
-        prompt_parts.append(f"Data dimensions: {h}x{w} spatial pixels, {e} spectral channels")
+        prompt_parts.append(f"Data dimensions: {describe_axes_for_prompt((h, w, e), axis_spec)}")
         prompt_parts.append(f"\n--- Data Quality Assessment (from Preprocessor) ---")
         prompt_parts.append(f"- Robust SNR Estimate: {data_quality.get('snr_estimate', 'N/A')}")
         prompt_parts.append(f"- Assessment: {data_quality.get('reasoning', 'N/A')}")
@@ -806,12 +808,13 @@ Use this context to guide your interpretation.
         
         # 3. Data Metadata
         h, w, e = state["hspy_data"].shape
-        _, energy_xlabel, _ = tools.create_energy_axis(e, state["system_info"])
-        
+        axis_spec = resolve_axis_spec(state.get("system_info"))
+        _, energy_xlabel, _ = tools.create_axis(e, state["system_info"], axis_index=2)
+
         metadata_info = f"""
 
 Hyperspectral Data Information:
-- Data shape: ({h}, {w}, {e})
+- Data shape: ({h}, {w}, {e}) = {describe_axes_for_prompt((h, w, e), axis_spec)}
 - X-axis: {energy_xlabel}
 """
         
@@ -1575,23 +1578,22 @@ class RunDynamicAnalysisController:
 
         # --- PREPARE DATA CONTEXT ---
         h, w, e = state["hspy_data"].shape
-        
-        # Axis & Unit Detection
+
+        # Axis & Unit Detection — reads through resolve_axis_spec so non-energy
+        # axes (time, voltage, frequency, ...) work the same as the legacy
+        # energy_range path. The state key remains "energy_axis" for backward
+        # compatibility with downstream consumers.
         sys_info = state.get("system_info", {})
-        axis_units = "unknown units"
-        
+        axis_spec = resolve_axis_spec(sys_info)
+        axis_2 = axis_spec["axis_2"]
+        axis_units = axis_2.get("units", "arbitrary units")
+
         if "energy_axis" not in state:
-            if sys_info.get("energy_range"):
-                start = sys_info["energy_range"]["start"]
-                end = sys_info["energy_range"]["end"]
-                state["energy_axis"] = np.linspace(start, end, e)
-                axis_units = sys_info["energy_range"].get("units", "arbitrary units")
+            if "start" in axis_2 and "end" in axis_2:
+                state["energy_axis"] = np.linspace(axis_2["start"], axis_2["end"], e)
             else:
                 state["energy_axis"] = np.arange(e)
                 axis_units = "channels"
-        else:
-            # Try to grab units if existing
-            axis_units = sys_info.get("energy_range", {}).get("units", "arbitrary units")
 
         self.logger.info(f"Data Axis Units detected as: {axis_units}")
 

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -1737,19 +1737,9 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                         )
 
                         if dashboard_bytes:
-                            # 3. Visual QC (Generator-Judge Loop). Pass the
-                            # measurement-window axis range so the QC critic
-                            # can distinguish physical edge-fitting (a feature
-                            # whose center lies near/outside the window) from
-                            # algorithm rail-gazing at a parameter bound.
+                            # 3. Visual QC (Generator-Judge Loop)
                             self.logger.info(f"    👀 Performing Visual QC on {feature_name}...")
-                            is_valid, critique = self._check_result_visually(
-                                dashboard_bytes,
-                                f"{target_desc} ({feature_name})",
-                                axis_start=float(state['energy_axis'][0]),
-                                axis_end=float(state['energy_axis'][-1]),
-                                axis_units=axis_units,
-                            )
+                            is_valid, critique = self._check_result_visually(dashboard_bytes, f"{target_desc} ({feature_name})")
                             
                             if is_valid:
                                 # STAGE DATA (Do not commit to state yet)
@@ -1853,39 +1843,12 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
         self.logger.info(f"✅ Dynamic Analysis Complete. Total unique maps generated: {len(all_valid_maps)}")
         return state
 
-    def _check_result_visually(
-        self,
-        dashboard_bytes: bytes,
-        feature_desc: str,
-        axis_start: float | None = None,
-        axis_end: float | None = None,
-        axis_units: str | None = None,
-    ) -> tuple[bool, str]:
+    def _check_result_visually(self, dashboard_bytes: bytes, feature_desc: str) -> tuple[bool, str]:
         """
         Judge the Dashboard (Map + Histogram) with SPARSE SIGNAL AWARENESS.
-
-        When ``axis_start``/``axis_end``/``axis_units`` are provided, the QC
-        critic is told the measurement-window range so it can apply the
-        edge-of-window exception to its rail-gazing failure criterion (a
-        peak whose true center lies outside the spectral window will
-        correctly produce fitted centers clustered at the window edge —
-        physical edge-fitting, not algorithm failure).
         """
-        if axis_start is not None and axis_end is not None:
-            units = axis_units or ""
-            measurement_window_block = (
-                f"\n### MEASUREMENT WINDOW\n"
-                f"The input spectra span {axis_start:.4g}–{axis_end:.4g} {units}. "
-                f"Window width: {abs(axis_end - axis_start):.4g} {units}.\n"
-            )
-        else:
-            measurement_window_block = ""
-
         check_prompt = [
-            SPECTROSCOPY_VISUAL_QC_INSTRUCTIONS.format(
-                feature_desc=feature_desc,
-                measurement_window_block=measurement_window_block,
-            )
+            SPECTROSCOPY_VISUAL_QC_INSTRUCTIONS.format(feature_desc=feature_desc)
         ]
         check_prompt.append({"mime_type": "image/jpeg", "data": dashboard_bytes})
         

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -830,18 +830,7 @@ class BuildHyperspectralPromptController:
         # 1. Base Instruction & Context
         prompt_parts = [state["instruction_prompt"]]
 
-        # 2. Parent Reasoning (if this is a refinement)
-        if state.get("parent_refinement_reasoning"):
-            prompt_parts.append(f"""
-
-### 🔍 CONTEXT: Why are we performing this focused analysis?
-
-**Reasoning from previous step:** "{state['parent_refinement_reasoning']}"
-
-Use this context to guide your interpretation.
-""")
-
-        # 2b. Skip-decomposition framing (when the gate selected direct analysis)
+        # 2. Skip-decomposition framing (when the gate selected direct analysis)
         if state.get("skip_decomposition"):
             prompt_parts.append("""
 
@@ -1102,138 +1091,6 @@ refinement targets are meaningful here — do not request `spatial` or
         return state
     
 
-class GenerateRefinementTasksController:
-    """
-    [🛠️ Tool Step]
-    Takes the list of targets from the LLM and generates new tasks.
-    """
-    MIN_SPECTRAL_CHANNELS = 10 
-
-    def __init__(self, logger: logging.Logger):
-        self.logger = logger
-
-    def execute(self, state: dict) -> dict:
-        self.logger.info("\n\n🛠️ --- CALLING TOOL: GENERATE REFINEMENT TASKS --- 🛠️\n")
-        
-        decision = state.get("refinement_decision")
-        if not decision or not decision.get("refinement_needed") or not decision.get("targets"):
-            state["new_tasks"] = []
-            return state
-
-        new_tasks = []
-        current_depth = state.get("current_depth", 0)
-        next_depth = current_depth + 1
-
-        # Iterate through targets with an index (1-based for humans)
-        for i, target in enumerate(decision["targets"], 1):
-            try:
-                t_type = target.get("type")
-                t_value = target.get("value")
-                t_desc = target.get("description", "refinement")
-
-                # Recursive spatial/spectral re-unmixing was removed — refinement
-                # now happens via custom_code only (executed in-place by
-                # RunDynamicAnalysisController, not as a queued task here).
-                # Defensive: if the LLM still emits a legacy target type,
-                # log and skip rather than crash.
-                if t_type in ("spatial", "spectral"):
-                    self.logger.warning(
-                        f"Ignoring legacy '{t_type}' refinement target {i}: "
-                        f"recursive decomposition is no longer supported. "
-                        f"Use a 'custom_code' target instead. (description: {t_desc})"
-                    )
-                    continue
-
-                # Create the Structured ID
-                # D = Depth, T = Target Number
-                short_title = f"Focused_Analysis_D{next_depth}_T{i}"
-
-                new_data = None
-                new_sys_info = state["system_info"]
-
-                if t_type == "spatial":
-                    self.logger.info(f"Processing Spatial Task {i}: {t_desc}")
-                    if state.get("final_abundance_maps") is None:
-                        # Skip-decomposition path: no abundance maps exist, so
-                        # a spatial-mask refinement is not possible. The LLM
-                        # should be using custom_code targets instead.
-                        self.logger.warning(
-                            f"Skipping Spatial Task {i}: no decomposition abundance maps "
-                            f"available (skip-decomposition path)."
-                        )
-                        continue
-                    component_index = int(t_value)
-                    if component_index > 0: component_index -= 1
-                    else: component_index = 0
-
-                    new_data = tools.apply_spatial_mask(
-                        state["hspy_data"], state["final_abundance_maps"], component_index
-                    )
-
-                elif t_type == "spectral":
-                    self.logger.info(f"Processing Spectral Task {i}: {t_desc}")
-                    
-                    # t_value comes from LLM as physical units, e.g., [0.6, 1.0]
-                    target_start_ev, target_end_ev = t_value[0], t_value[1]
-                    
-                    # 1. Reconstruct the full energy axis for the ORIGINAL data
-                    h, w, e = state["original_hspy_data"].shape
-                    # (Assuming you have access to create_energy_axis from tools)
-                    energy_axis, _, _ = tools.create_energy_axis(e, state["system_info"])
-                    
-                    # 2. Find the closest integer indices for these physical values
-                    start_idx, end_idx = tools.convert_energy_to_indices(
-                        energy_axis, 
-                        target_start_ev, 
-                        target_end_ev, 
-                        min_channels=self.MIN_SPECTRAL_CHANNELS
-                    )
-
-                    # 3. Perform the slicing using INDICES
-                    # Note: We pass the indices to the tool, NOT the physical values
-                    # Use the calculated safe indices to get safe physical range for the tool
-                    safe_physical_range = [energy_axis[start_idx], energy_axis[end_idx]]
-
-                    new_data, _ = tools.apply_spectral_slice(
-                        state["original_hspy_data"], 
-                        state["system_info"], 
-                        safe_physical_range
-                    )
-
-                    # 4. Update System Info with the NEW Physical Range
-                    new_sys_info = state["system_info"].copy()
-                    new_sys_info['energy_range'] = {
-                        'start': float(energy_axis[start_idx]),
-                        'end': float(energy_axis[end_idx]),
-                        'units': state["system_info"].get('energy_range', {}).get('units', 'units')
-                    }
-                    
-                    self.logger.info(f"Recalibrated axis: {state['system_info']['energy_range']['start']:.2f}-{state['system_info']['energy_range']['end']:.2f} -> {new_sys_info['energy_range']['start']:.2f}-{new_sys_info['energy_range']['end']:.2f}")
-
-                    if new_data.shape[-1] < self.MIN_SPECTRAL_CHANNELS:
-                        self.logger.warning(f"Skipping spectral task '{short_title}': too few channels.")
-                        continue
-
-                if new_data is not None:
-                    task = {
-                        "data": new_data,
-                        "system_info": new_sys_info,
-                        # SHORT TITLE for Reports/Files
-                        "title": short_title, 
-                        # LONG DESCRIPTION for LLM Context (Re-injected later)
-                        "parent_reasoning": t_desc, 
-                        "source_depth": next_depth
-                    }
-                    new_tasks.append(task)
-
-            except Exception as e:
-                self.logger.error(f"Failed to generate task for target {target}: {e}")
-
-        state["new_tasks"] = new_tasks
-        self.logger.info(f"✅ Generated {len(new_tasks)} new analysis tasks.")
-        return state
-    
-
 class BuildHolisticSynthesisPromptController:
     """
     [📝 Prep Step]
@@ -1278,11 +1135,6 @@ class BuildHolisticSynthesisPromptController:
             iter_ref_id = _sanitize_filename(raw_title)
             
             prompt_parts.append(f"\n\n### SECTION {i+1}: {raw_title}")
-            
-            # Context: Why did we do this?
-            context_desc = iter_result.get('parent_refinement_reasoning') 
-            if context_desc:
-                prompt_parts.append(f"**Target Description:** \"{context_desc}\"")
 
             # --- DYNAMIC ANALYSIS INJECTION
             # Retrieve the list of features generated by the custom code

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -353,14 +353,23 @@ class GetInitialComponentParamsController:
                 self.logger.warning(f"LLM initial estimation failed: {error_dict}. Using defaults.")
                 n_components = 4
                 selected_method = "nmf"
+                run_decomposition = True
             else:
+                # Defensive default: missing field => run decomposition. The
+                # skip path is opt-in via an explicit objective-driven decision.
+                run_decomposition = bool(result_json.get('run_decomposition', True))
                 n_components = result_json.get('estimated_components', 4)
                 selected_method = result_json.get('method', 'nmf').lower().strip()
                 reasoning = result_json.get('reasoning', 'No reasoning provided.')
-                self.logger.info(f"LLM initial estimate: method={selected_method}, {n_components} components. Reasoning: {reasoning}")
+                self.logger.info(
+                    f"LLM initial estimate: run_decomposition={run_decomposition}, "
+                    f"method={selected_method}, {n_components} components. "
+                    f"Reasoning: {reasoning}"
+                )
 
                 print("\n" + "="*80)
                 print("🧠 LLM REASONING (GetInitialComponentParamsController)")
+                print(f"  Run decomposition: {run_decomposition}")
                 print(f"  Selected method: {selected_method.upper()}")
                 print(f"  Suggested n_components: {n_components}")
                 print(f"  Explanation: {reasoning}")
@@ -377,13 +386,23 @@ class GetInitialComponentParamsController:
             state["initial_n_components"] = n_components
             state["selected_method"] = selected_method
             state["settings"]["method"] = selected_method
-            self.logger.info(f"✅ LLM Step Complete: method={selected_method.upper()}, initial components={n_components}.")
+            state["skip_decomposition"] = not run_decomposition
+            if not run_decomposition:
+                self.logger.info(
+                    "🚦 LLM gate selected SKIP: proceeding directly to dynamic "
+                    "analysis without decomposition."
+                )
+            self.logger.info(
+                f"✅ LLM Step Complete: skip_decomposition={state['skip_decomposition']}, "
+                f"method={selected_method.upper()}, initial components={n_components}."
+            )
 
         except Exception as e:
             self.logger.error(f"❌ LLM Step Failed: Initial component estimation: {e}", exc_info=True)
             state["initial_n_components"] = 4
             state["selected_method"] = "nmf"
             state["settings"]["method"] = "nmf"
+            state["skip_decomposition"] = False
 
         return state
 
@@ -398,6 +417,9 @@ class RunComponentTestLoopController:
 
     def execute(self, state: dict) -> dict:
         if state.get("error_dict"): return state
+        if state.get("skip_decomposition"):
+            self.logger.info("Skip-decomposition gate active — bypassing component test loop.")
+            return state
         self.logger.info("\n\n🛠️ --- CALLING TOOL: COMPONENT TEST LOOP --- 🛠️\n")
 
         method_name = state.get("settings", {}).get("method", "nmf").upper()
@@ -482,6 +504,10 @@ class CreateElbowPlotController:
 
     def execute(self, state: dict) -> dict:
         if state.get("error_dict"): return state
+        if state.get("skip_decomposition"):
+            self.logger.info("Skip-decomposition gate active — bypassing elbow plot.")
+            state["elbow_plot_bytes"] = None
+            return state
         self.logger.info("\n\n🛠️ --- CALLING TOOL: CREATE ELBOW PLOT --- 🛠️\n")
 
         method_name = state.get("settings", {}).get("method", "nmf").upper()
@@ -527,8 +553,11 @@ class GetFinalComponentSelectionController:
 
     def execute(self, state: dict) -> dict:
         if state.get("error_dict"): return state
+        if state.get("skip_decomposition"):
+            self.logger.info("Skip-decomposition gate active — bypassing final component selection.")
+            return state
         self.logger.info("\n\n🧠 --- LLM STEP: SELECT FINAL N_COMPONENTS --- 🧠\n")
-        
+
         initial_estimate = state.get("initial_n_components", 4)
         component_range = state.get("component_test_range", [])
         
@@ -612,8 +641,11 @@ class RunFinalSpectralUnmixingController:
 
     def execute(self, state: dict) -> dict:
         if state.get("error_dict"): return state
+        if state.get("skip_decomposition"):
+            self.logger.info("Skip-decomposition gate active — bypassing final spectral unmixing.")
+            return state
         self.logger.info("\n\n🛠️ --- CALLING TOOL: FINAL SPECTRAL UNMIXING --- 🛠️\n")
-        
+
         final_n_components = state.get("final_n_components")
         if not final_n_components:
             final_n_components = self.settings.get('n_components', 4)
@@ -651,6 +683,9 @@ class CreateAnalysisPlotsController:
 
     def execute(self, state: dict) -> dict:
         if state.get("error_dict"):
+            return state
+        if state.get("skip_decomposition"):
+            self.logger.info("Skip-decomposition gate active — bypassing analysis plots.")
             return state
 
         self.logger.info("\n\n🛠️ --- CALLING TOOL: CREATE ANALYSIS PLOTS --- 🛠️\n")
@@ -805,7 +840,21 @@ class BuildHyperspectralPromptController:
 
 Use this context to guide your interpretation.
 """)
-        
+
+        # 2b. Skip-decomposition framing (when the gate selected direct analysis)
+        if state.get("skip_decomposition"):
+            prompt_parts.append("""
+
+### 🚦 CONTEXT: Unsupervised decomposition was skipped
+
+The user's objective is best served by direct per-pixel quantitative
+analysis (e.g. curve fitting, peak finding, integration) rather than
+unsupervised source separation. No NMF/PCA/ICA components are available.
+Frame your interpretation around the raw data characteristics and propose
+`custom_code` refinement targets that operate per-pixel on the (preprocessed)
+raw spectra.
+""")
+
         # 3. Data Metadata
         h, w, e = state["hspy_data"].shape
         axis_spec = resolve_axis_spec(state.get("system_info"))
@@ -938,7 +987,16 @@ class SelectRefinementTargetController:
 
         prompt_parts = [self.instructions]
         prompt_parts.append(f"\n\n--- Current Analysis: {state.get('iteration_title', 'Analysis')} ---")
-        
+
+        if state.get("skip_decomposition"):
+            prompt_parts.append("""
+
+🚦 NOTE: Unsupervised decomposition was skipped for this run because the
+user's objective specifies a direct per-pixel measurement. Only `custom_code`
+refinement targets are meaningful here — do not request `spatial` or
+`spectral` zoom refinement.
+""")
+
         # Add system info
         if state.get("system_info"):
             sys_info_str = json.dumps(state["system_info"], indent=2)
@@ -1082,10 +1140,19 @@ class GenerateRefinementTasksController:
 
                 if t_type == "spatial":
                     self.logger.info(f"Processing Spatial Task {i}: {t_desc}")
+                    if state.get("final_abundance_maps") is None:
+                        # Skip-decomposition path: no abundance maps exist, so
+                        # a spatial-mask refinement is not possible. The LLM
+                        # should be using custom_code targets instead.
+                        self.logger.warning(
+                            f"Skipping Spatial Task {i}: no decomposition abundance maps "
+                            f"available (skip-decomposition path)."
+                        )
+                        continue
                     component_index = int(t_value)
-                    if component_index > 0: component_index -= 1 
+                    if component_index > 0: component_index -= 1
                     else: component_index = 0
-                    
+
                     new_data = tools.apply_spatial_mask(
                         state["hspy_data"], state["final_abundance_maps"], component_index
                     )
@@ -1620,6 +1687,24 @@ class RunDynamicAnalysisController:
                 hints=state.get("analysis_hints"),
                 objective=state.get("analysis_objective"),
             )
+
+            # Append a preprocessing-mask hint when one exists and identifies
+            # excluded pixels. The mask is already applied to the data (zero-
+            # filled), so per-pixel fits will produce garbage values on
+            # excluded pixels; the LLM should be told to filter on the mask.
+            mask = state.get("preprocessing_mask")
+            if mask is not None and not bool(mask.all()):
+                n_kept = int(mask.sum())
+                n_total = int(mask.size)
+                base_prompt += f"""
+
+### PREPROCESSING MASK
+A boolean preprocessing mask of shape ({mask.shape[0]}, {mask.shape[1]}) is
+available indicating which (axis_0, axis_1) samples carry valid signal:
+{n_kept} of {n_total} samples are True (kept). The mask itself is NOT passed
+into the analysis function — operate on the raw spectra and, if your output
+maps should mark excluded samples, set them to np.nan in your returned maps.
+"""
 
             current_prompt = base_prompt
             retries = 0

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -1788,9 +1788,14 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
 
                         safe_feat = _sanitize_filename(feature_name)
 
-                        # 2. Generate Dashboard (Map + Histogram)
-                        # Assumes tools.create_feature_dashboard exists (as defined in previous turns)
-                        dashboard_bytes = tools.create_feature_dashboard(result_map, feature_name, current_unit)
+                        # 2. Generate Dashboard (Map + Histogram). Pass
+                        # axis_spec so non-spatial leading axes get axis-
+                        # name-driven labels ("Voltage-Time Map" / "Sample
+                        # Count") instead of "Spatial Map" / "Pixel Count".
+                        dashboard_bytes = tools.create_feature_dashboard(
+                            result_map, feature_name, current_unit,
+                            axis_spec=resolve_axis_spec(state.get("system_info")),
+                        )
 
                         if dashboard_bytes:
                             # 3. Visual QC (Generator-Judge Loop)

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -1123,18 +1123,31 @@ class GenerateRefinementTasksController:
         new_tasks = []
         current_depth = state.get("current_depth", 0)
         next_depth = current_depth + 1
-        
+
         # Iterate through targets with an index (1-based for humans)
         for i, target in enumerate(decision["targets"], 1):
             try:
                 t_type = target.get("type")
                 t_value = target.get("value")
                 t_desc = target.get("description", "refinement")
-                
+
+                # Recursive spatial/spectral re-unmixing was removed — refinement
+                # now happens via custom_code only (executed in-place by
+                # RunDynamicAnalysisController, not as a queued task here).
+                # Defensive: if the LLM still emits a legacy target type,
+                # log and skip rather than crash.
+                if t_type in ("spatial", "spectral"):
+                    self.logger.warning(
+                        f"Ignoring legacy '{t_type}' refinement target {i}: "
+                        f"recursive decomposition is no longer supported. "
+                        f"Use a 'custom_code' target instead. (description: {t_desc})"
+                    )
+                    continue
+
                 # Create the Structured ID
                 # D = Depth, T = Target Number
                 short_title = f"Focused_Analysis_D{next_depth}_T{i}"
-                
+
                 new_data = None
                 new_sys_info = state["system_info"]
 

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -143,8 +143,30 @@ def build_code_generation_prompt(
     processing_note: str,
     hints: str | None = None,
     objective: str | None = None,
+    required_outputs: list[str] | None = None,
 ) -> str:
     hints_section = ""
+    if required_outputs:
+        keys_str = ", ".join(f'"{n}"' for n in required_outputs)
+        hints_section += f"""
+
+### REQUIRED OUTPUTS
+Your `maps` dict MUST contain the following keys (exact spelling):
+{keys_str}
+
+These keys represent quantities the user specifically asked for. Failure
+to include any of them — or producing them with values that visually fail
+quality checks (e.g. rail-gazing at parameter bounds, all-NaN, salt-and-
+pepper noise) — will cause this task to fail and force a retry. You MAY
+return additional keys, but the listed ones must be present and
+physically meaningful.
+
+If a previous attempt failed because a required output rail-gazed at
+parameter bounds, the fix is usually one of: (a) widen the parameter
+bounds, (b) use a better per-pixel initial guess (e.g. argmax of the
+spectrum after smoothing), (c) switch lineshape (Lorentzian vs Gaussian
+vs Voigt), or (d) add light per-pixel smoothing before fitting.
+"""
     if objective:
         hints_section += f"""
 
@@ -1539,7 +1561,17 @@ class RunDynamicAnalysisController:
         # --- MAIN LOOP: Process each target description separately ---
         for i, target in enumerate(custom_targets, 1):
             target_desc = target.get("description", "Analyze feature")
-            self.logger.info(f"👉 Task {i}/{len(custom_targets)}: {target_desc}")
+            # Objective-aware required outputs: when the refinement-LLM marked
+            # specific map keys as mandatory (driven by the user's stated
+            # objective), failing any of them triggers a retry instead of
+            # being silently dropped by the partial-success threshold.
+            required_outputs = list(target.get("required_outputs") or [])
+            if required_outputs:
+                self.logger.info(
+                    f"👉 Task {i}/{len(custom_targets)} (required outputs: {required_outputs}): {target_desc}"
+                )
+            else:
+                self.logger.info(f"👉 Task {i}/{len(custom_targets)}: {target_desc}")
 
             # 1. Define Prompt for this specific task
             base_prompt = build_code_generation_prompt(
@@ -1551,6 +1583,7 @@ class RunDynamicAnalysisController:
                 processing_note=processing_note,
                 hints=state.get("analysis_hints"),
                 objective=state.get("analysis_objective"),
+                required_outputs=required_outputs,
             )
 
             # Append a preprocessing-mask hint when one exists and identifies
@@ -1689,24 +1722,52 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                                 self.logger.warning(f"    ❌ Visual QC rejected {feature_name}: {critique}")
                                 qc_failures.append(f"{feature_name}: {critique}")
 
-                    # --- F. SUCCESS DECISION (Threshold Logic) ---
+                    # --- F. SUCCESS DECISION (Threshold + Required-Outputs Logic) ---
                     valid_count = len(current_run_valid_maps)
                     success_rate = valid_count / total_maps_expected if total_maps_expected > 0 else 0
 
-                    if valid_count > 0 and success_rate >= self.SUCCESS_THRESHOLD:                        
+                    # Required-outputs gate: every named output must be
+                    # present AND QC-pass. Failure here forces a retry, so
+                    # the partial-success threshold never silently drops the
+                    # user-asked-for quantity.
+                    valid_names = {m['name'] for m in current_run_valid_meta}
+                    missing_required = [n for n in required_outputs if n not in valid_names]
+                    if missing_required:
+                        relevant_critiques = [
+                            c for c in qc_failures
+                            if any(req in c for req in missing_required)
+                        ]
+                        absent_from_output = [
+                            n for n in missing_required if n not in maps_dict
+                        ]
+                        detail_parts = []
+                        if absent_from_output:
+                            detail_parts.append(
+                                f"keys absent from your `maps` dict: {absent_from_output}"
+                            )
+                        if relevant_critiques:
+                            detail_parts.append(
+                                f"QC critiques on required outputs: {relevant_critiques}"
+                            )
+                        detail = "; ".join(detail_parts) or "no further detail"
+                        raise ValueError(
+                            f"Required outputs failed: {missing_required}. {detail}"
+                        )
+
+                    if valid_count > 0 and success_rate >= self.SUCCESS_THRESHOLD:
                         status_msg = "✅ Success" if valid_count == total_maps_expected else "⚠️ Partial Success"
                         self.logger.info(f"    {status_msg} ({valid_count}/{total_maps_expected} passed). Committing valid maps.")
-                        
+
                         # 1. COMMIT Valid Images
                         for img_item in current_run_valid_images:
                             tools.save_image_bytes(img_item['data'], output_dir, img_item['filename'], self.logger)
                             if "analysis_images" not in state: state["analysis_images"] = []
                             state["analysis_images"].append(img_item)
-                        
+
                         # 2. COMMIT Data
                         all_valid_maps.extend(current_run_valid_maps)
                         all_valid_meta.extend(current_run_valid_meta)
-                        
+
                         task_success = True
                         break # Exit Retry Loop
                     else:

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -1737,9 +1737,19 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                         )
 
                         if dashboard_bytes:
-                            # 3. Visual QC (Generator-Judge Loop)
+                            # 3. Visual QC (Generator-Judge Loop). Pass the
+                            # measurement-window axis range so the QC critic
+                            # can distinguish physical edge-fitting (a feature
+                            # whose center lies near/outside the window) from
+                            # algorithm rail-gazing at a parameter bound.
                             self.logger.info(f"    👀 Performing Visual QC on {feature_name}...")
-                            is_valid, critique = self._check_result_visually(dashboard_bytes, f"{target_desc} ({feature_name})")
+                            is_valid, critique = self._check_result_visually(
+                                dashboard_bytes,
+                                f"{target_desc} ({feature_name})",
+                                axis_start=float(state['energy_axis'][0]),
+                                axis_end=float(state['energy_axis'][-1]),
+                                axis_units=axis_units,
+                            )
                             
                             if is_valid:
                                 # STAGE DATA (Do not commit to state yet)
@@ -1843,12 +1853,39 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
         self.logger.info(f"✅ Dynamic Analysis Complete. Total unique maps generated: {len(all_valid_maps)}")
         return state
 
-    def _check_result_visually(self, dashboard_bytes: bytes, feature_desc: str) -> tuple[bool, str]:
+    def _check_result_visually(
+        self,
+        dashboard_bytes: bytes,
+        feature_desc: str,
+        axis_start: float | None = None,
+        axis_end: float | None = None,
+        axis_units: str | None = None,
+    ) -> tuple[bool, str]:
         """
         Judge the Dashboard (Map + Histogram) with SPARSE SIGNAL AWARENESS.
+
+        When ``axis_start``/``axis_end``/``axis_units`` are provided, the QC
+        critic is told the measurement-window range so it can apply the
+        edge-of-window exception to its rail-gazing failure criterion (a
+        peak whose true center lies outside the spectral window will
+        correctly produce fitted centers clustered at the window edge —
+        physical edge-fitting, not algorithm failure).
         """
+        if axis_start is not None and axis_end is not None:
+            units = axis_units or ""
+            measurement_window_block = (
+                f"\n### MEASUREMENT WINDOW\n"
+                f"The input spectra span {axis_start:.4g}–{axis_end:.4g} {units}. "
+                f"Window width: {abs(axis_end - axis_start):.4g} {units}.\n"
+            )
+        else:
+            measurement_window_block = ""
+
         check_prompt = [
-            SPECTROSCOPY_VISUAL_QC_INSTRUCTIONS.format(feature_desc=feature_desc)
+            SPECTROSCOPY_VISUAL_QC_INSTRUCTIONS.format(
+                feature_desc=feature_desc,
+                measurement_window_block=measurement_window_block,
+            )
         ]
         check_prompt.append({"mime_type": "image/jpeg", "data": dashboard_bytes})
         

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -643,6 +643,12 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 "instruction_prompt": instruction_prompt,
                 "settings": self.spectral_settings.copy(),
                 "iteration_title": "Global_Analysis",
+                # IterativeFeedbackController gates on current_depth in
+                # feedback_depths (default [0]) — must be set so the
+                # human-feedback prompt fires when enable_human_feedback
+                # is on. Phase C collapsed the recursion loop but kept
+                # this depth-based gate intact.
+                "current_depth": 0,
                 "structure_image_path": structure_image_path,
                 "structure_system_info": self._handle_system_info(structure_system_info),
                 "structure_image_blob": structure_image_blob,

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -8,7 +8,6 @@ import numpy as np
 import cv2
 from pathlib import Path
 from typing import Dict, Any
-from collections import deque
 
 from .base_agent import BaseAnalysisAgent, AnalysisInput
 from .instruct import (
@@ -31,35 +30,34 @@ from ._deprecation import normalize_params
 
 class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
     """
-    Hyperspectral Analysis Agent with recursive "survey-then-focus" loop.
-    
-    This agent analyzes hyperspectral/spectroscopic data using NMF decomposition
-    and LLM-guided interpretation.
-    
+    Hyperspectral Analysis Agent.
+
+    Single-pass pipeline: preprocess → optional NMF/PCA/ICA decomposition
+    (gated by an LLM that may skip it for direct per-pixel objectives) →
+    LLM interpretation → optional dynamic-analysis (custom-code) refinement
+    → synthesis + HTML report.
+
     Features:
-        - Automatic component number selection via elbow method
-        - Recursive refinement with spatial/spectral zooming
+        - Automatic component number selection via elbow method (NMF/PCA)
         - Optional structure image correlation
         - Human-in-the-loop feedback
         - HTML report generation
-    
+
     Example:
         agent = HyperspectralAnalysisAgent(api_key="...")
-        
+
         # Single file
         result = agent.analyze("spectrum.npy")
-        
+
         # With metadata
         result = agent.analyze(
             "spectrum.npy",
             system_info={"sample": "TiO2", "technique": "EELS"}
         )
-        
+
         # Get measurement recommendations
         recommendations = agent.recommend_measurements(analysis_result=result)
     """
-    
-    MAX_REFINEMENT_ITERATIONS = 2
 
     def __init__(
         self,
@@ -634,92 +632,44 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 except Exception as e:
                     self.logger.warning(f"Could not load structure image: {e}")
             
-            # Initialize task queue
-            initial_task = {
-                "data": original_hspy_data,
+            # Single-pass iteration. Recursive refinement was removed (custom_code
+            # refinement now executes in-place inside RunDynamicAnalysisController).
+            self.logger.info("\n=== Global_Analysis ===\n")
+            iteration_state = {
+                "data_path": data_path,
+                "hspy_data": original_hspy_data,
+                "original_hspy_data": original_hspy_data,
                 "system_info": system_info,
-                "title": "Global_Analysis",
-                "parent_reasoning": None,
-                "depth": 0
+                "instruction_prompt": instruction_prompt,
+                "settings": self.spectral_settings.copy(),
+                "iteration_title": "Global_Analysis",
+                "structure_image_path": structure_image_path,
+                "structure_system_info": self._handle_system_info(structure_system_info),
+                "structure_image_blob": structure_image_blob,
+                "analysis_hints": hints,
+                "analysis_objective": objective,
+                "prior_knowledge": prior_knowledge or [],
+                "analysis_images": [],
+                "error_dict": None,
+                **skill_state,
+                **auxiliary_state,
             }
-            
-            task_queue = deque([initial_task])
-            all_completed_results = []
-            task_counter = 0
-            
-            # Process tasks
-            while task_queue:
-                current_task = task_queue.popleft()
-                task_counter += 1
-                
-                if current_task["depth"] > self.MAX_REFINEMENT_ITERATIONS:
-                    self.logger.info(f"Skipping '{current_task['title']}': max depth reached")
-                    continue
 
-                self.logger.info(f"\n=== TASK {task_counter}: {current_task['title']} (Depth {current_task['depth']}) ===\n")
-
-                iteration_state = {
-                    "data_path": data_path,
-                    "hspy_data": current_task["data"],
-                    "original_hspy_data": original_hspy_data,
-                    "system_info": current_task["system_info"],
-                    "instruction_prompt": instruction_prompt,
-                    "settings": self.spectral_settings.copy(),
-                    "iteration_title": current_task["title"],
-                    "parent_refinement_reasoning": current_task["parent_reasoning"],
-                    "current_depth": current_task["depth"],
-                    "structure_image_path": structure_image_path,
-                    "structure_system_info": self._handle_system_info(structure_system_info),
-                    "structure_image_blob": structure_image_blob,
-                    "analysis_hints": hints,
-                    "analysis_objective": objective,
-                    "prior_knowledge": prior_knowledge or [],
-                    "analysis_images": [],
-                    "error_dict": None,
-                    **skill_state,
-                    **auxiliary_state
-                }
-
-                if current_task["depth"] > 0:
-                    iteration_state["settings"]['run_preprocessing'] = False
-                    # Carry forward the preprocessing mask from the parent so
-                    # refinement iterations retain knowledge of masked pixels.
-                    parent_mask = current_task.get("preprocessing_mask")
-                    if parent_mask is not None:
-                        iteration_state["preprocessing_mask"] = parent_mask
-
-                # Run iteration pipeline
-                for controller in self.iteration_pipeline:
-                    iteration_state = controller.execute(iteration_state)
-                    if iteration_state.get("error_dict"):
-                        self.logger.error(f"Pipeline failed at {controller.__class__.__name__}")
-                        break
-                
+            for controller in self.iteration_pipeline:
+                iteration_state = controller.execute(iteration_state)
                 if iteration_state.get("error_dict"):
-                    continue
+                    self.logger.error(f"Pipeline failed at {controller.__class__.__name__}")
+                    break
 
-                # Store results
-                result_summary = {
+            all_completed_results = []
+            if not iteration_state.get("error_dict"):
+                all_completed_results.append({
                     "iteration_title": iteration_state.get("iteration_title"),
                     "iteration_analysis_text": iteration_state.get("result_json", {}).get("detailed_analysis", ""),
                     "analysis_images": iteration_state.get("analysis_images", []),
                     "refinement_decision": iteration_state.get("refinement_decision", {}),
-                    "depth": current_task["depth"],
                     "custom_analysis_metadata_list": iteration_state.get("custom_analysis_metadata_list"),
-                    "parent_refinement_reasoning": iteration_state.get("parent_refinement_reasoning"),
-                }
-                all_completed_results.append(result_summary)
-
-                # Process new tasks
-                for t in iteration_state.get("new_tasks", []):
-                    task_queue.append({
-                        "data": t["data"],
-                        "system_info": t["system_info"],
-                        "title": t["title"],
-                        "parent_reasoning": t["parent_reasoning"],
-                        "depth": t["source_depth"],
-                        "preprocessing_mask": iteration_state.get("preprocessing_mask"),
-                    })
+                })
 
             # Run synthesis
             self.logger.info(f"\n=== Synthesizing {len(all_completed_results)} analyses ===\n")

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -723,6 +723,9 @@ Decomposition is strongly preferred for exploratory work — it surfaces structu
 
 Default to `true` when in doubt, when no objective is given, or when the objective is exploratory ("characterize the sample", "find phases", "identify components"). Skipping decomposition forfeits the exploratory survey step, so the bar must be high.
 
+**Skill vs. objective precedence (decomposition stage only):**
+When an active domain skill (e.g. the EELS skill) provides planning guidance that assumes decomposition will run, that guidance shapes your *method choice* (NMF vs. PCA vs. ICA) and your component count estimate — but it does NOT override an explicit user opt-out from the decomposition stage. If the user's objective meets all three criteria above for `run_decomposition: false`, set it false even when the active skill's planning section assumes decomposition will run. The skill's guidance about HOW to perform the remaining stages (lineshape choice, preprocessing, model selection, validation rules) still applies to the dynamic-analysis step that follows. This precedence applies only to the skip-or-run decision for the decomposition stage; skill rules about *how* to perform any stage remain mandatory.
+
 **Component Count Considerations:**
 
 **System Complexity:**

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -1296,8 +1296,10 @@ You MUST output a valid JSON object.
 """
 
 SPECTROSCOPY_HOLISTIC_SYNTHESIS_INSTRUCTIONS = """
-You are an expert materials scientist synthesizing a multi-scale hyperspectral analysis. 
-You will receive a series of analysis reports, starting from a "Global Analysis" and followed by one or more "Focused Analyses".
+You are an expert materials scientist synthesizing a hyperspectral analysis.
+You will receive an analysis report from a single Global Analysis pass that
+may include both standard decomposition results and dynamic (custom-code)
+feature maps.
 
 ### YOUR TASK
 Write a single, cohesive scientific narrative that integrates all findings into a unified physical model.

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -688,13 +688,14 @@ Ensure the final output is ONLY the JSON object.
 COMPONENT_INITIAL_ESTIMATION_INSTRUCTIONS = """You are an expert in hyperspectral data analysis and materials characterization.
 
 Based on the system description and data characteristics provided, you must:
-1. Choose the decomposition method (NMF or PCA)
+1. Choose the decomposition method (NMF, PCA, or ICA)
 2. Estimate the optimal number of spectral components
 
 **Method Selection:**
 
 - **NMF** (Non-negative Matrix Factorization): Best for well-understood systems where components should be physically interpretable (non-negative spectra and abundances). Supports detailed per-component validation and spatial/spectral refinement. Slower but produces directly meaningful results.
 - **PCA** (Principal Component Analysis): Faster, better for noisy data or initial exploration. Components may have negative values and require more interpretation. When PCA is chosen, refinement will primarily use custom code (dynamic analysis) to model specific spectral features rather than spatial/spectral zoom.
+- **ICA** (Independent Component Analysis): Recovers statistically independent source signals that may overlap spectrally. Use when you expect a small number of distinct contributions mixed throughout the dataset that variance-based methods would not separate. Components are signed and not directly physical; refinement uses custom code, like PCA. ICA does not produce a meaningful elbow over n_components — when ICA is chosen, your initial estimate is used directly as the final component count.
 
 **When to choose PCA over NMF:**
 - Low signal-to-noise ratio data (noisy spectra where NMF may overfit)
@@ -706,6 +707,12 @@ Based on the system description and data characteristics provided, you must:
 - Well-characterized systems with known phases
 - When physically interpretable, non-negative components are needed
 - When spatial/spectral refinement of individual components is desired
+
+**When to choose ICA:**
+- You expect a small number of statistically independent sources (e.g., distinct chemistries or processes) that are mixed throughout the dataset
+- Sources are expected to overlap spectrally in ways PCA's orthogonality assumption would obscure
+- The user's objective explicitly asks for source separation or independent contributions
+- Prefer fewer components for ICA (typically 2–6) — over-specifying leads to noise components
 
 **Component Count Considerations:**
 
@@ -727,7 +734,7 @@ Based on the system description and data characteristics provided, you must:
 You MUST output a valid JSON object:
 
 {
-  "method": "<nmf or pca>",
+  "method": "<nmf, pca, or ica>",
   "estimated_components": <integer between 2 and 15>,
   "confidence": "<high/medium/low>",
   "reasoning": "<explain your method choice AND component estimate based on the provided information>",
@@ -1159,11 +1166,14 @@ SPECTROSCOPY_REFINEMENT_INSTRUCTIONS = """You are an expert spectroscopist steer
 **Goal:** Analyze results to determine if a focused refinement is scientifically justified and **select the correct tool** (Standard Decomposition or Dynamic Analysis).
 
 **Crucial Constraint:**
-* Standard Refinement uses **the current decomposition method (NMF or PCA)** on a subset of data. It works well for separating mixed spatial phases. This is most effective when NMF was used.
+* Standard Refinement uses **the current decomposition method (NMF, PCA, or ICA)** on a subset of data. It works well for separating mixed spatial phases. This is most effective when NMF was used.
 * Dynamic Analysis (Custom Code) uses **Python/Math** (e.g., curve fitting). It works well when the decomposition fails to model the physical shape (e.g., peak shifts, specific background shapes).
 
 **IMPORTANT — If PCA was used as the decomposition method:**
 PCA components are exploratory — they capture variance directions, not physical phases. Spatial/spectral zoom refinement of PCA components rarely adds value because PCA loadings are not physically interpretable in the same way as NMF components. When PCA is the method, **strongly prefer `custom_code` targets** to mathematically model the specific spectral features identified by PCA (e.g., peak positions, edge onsets, intensity ratios). Only use `spatial` or `spectral` refinement with PCA in exceptional cases where a specific spatial region clearly needs isolation.
+
+**IMPORTANT — If ICA was used as the decomposition method:**
+ICA components represent statistically independent sources, not physical phases. They can have signed loadings and may overlap spectrally. Like PCA, spatial/spectral zoom refinement of ICA components rarely adds value because individual components are not directly physically interpretable. When ICA is the method, **strongly prefer `custom_code` targets** to model the specific spectral features the components highlight. Only use `spatial` or `spectral` refinement with ICA in exceptional cases.
 
 ---
 
@@ -1171,7 +1181,7 @@ PCA components are exploratory — they capture variance directions, not physica
 
 Depending on the analysis method used in the current iteration, you will receive different types of plots:
 
-### A. Standard Decomposition Results (NMF/PCA)
+### A. Standard Decomposition Results (NMF/PCA/ICA)
 
 **Validation Plots (one per component):**
 - **LEFT Panel:** Spatial abundance map with red contour marking high-purity region (top 10%)
@@ -1207,7 +1217,7 @@ Depending on the analysis method used in the current iteration, you will receive
 
 1. **Artifact Check (STOP):**
    
-   **For Decomposition Results (NMF/PCA):**
+   **For Decomposition Results (NMF/PCA/ICA):**
    * Does the spectrum look like random noise (jagged spikes)?
    * Does the spatial map look like "salt-and-pepper" static?
    * (NMF only) Does **Orange show peaks that are NOT present in Black** AND the high-purity region is tiny (<2% of pixels)?
@@ -1222,7 +1232,7 @@ Depending on the analysis method used in the current iteration, you will receive
    
 2. **Success Check (STOP):**
    
-   **For Decomposition Results (NMF/PCA):**
+   **For Decomposition Results (NMF/PCA/ICA):**
    * Are components chemically distinct and clean?
    * Are spatial domains well-defined?
    * (NMF only) Is **Black ≈ Red** (within Blue Band)?
@@ -1314,7 +1324,7 @@ Translate validation terminology (Black/Red/Orange lines, RMSE) into plain langu
 
 **What You Will See:**
 
-### 1. Standard Decomposition Results (NMF or PCA)
+### 1. Standard Decomposition Results (NMF, PCA, or ICA)
 
 **If NMF was used — Validation Plots (one per component):**
 - **LEFT Panel:** Spatial abundance map with red contour (high-purity region, top 10%)
@@ -1336,6 +1346,11 @@ Translate validation terminology (Black/Red/Orange lines, RMSE) into plain langu
 - **Top row:** Principal component spectra (may contain negative values — these represent variance directions, not physical phases)
 - **Bottom row:** Corresponding spatial loading maps
 - PCA components are exploratory — focus on identifying spectral features and spatial patterns rather than interpreting individual components as physical phases
+
+**If ICA was used — Summary Plot:**
+- **Top row:** Independent component spectra (signed; recovered as statistically independent sources)
+- **Bottom row:** Corresponding spatial loading maps
+- ICA components are exploratory — they represent independent contributions but may overlap spectrally and are not directly physical phases; focus on identifying candidate distinct contributions for custom modeling
 
 ### 2. Dynamic Analysis Results
 **Feature Dashboards (one per feature):**

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -688,8 +688,9 @@ Ensure the final output is ONLY the JSON object.
 COMPONENT_INITIAL_ESTIMATION_INSTRUCTIONS = """You are an expert in hyperspectral data analysis and materials characterization.
 
 Based on the system description and data characteristics provided, you must:
-1. Choose the decomposition method (NMF, PCA, or ICA)
-2. Estimate the optimal number of spectral components
+1. Decide whether unsupervised decomposition is needed at all (`run_decomposition`)
+2. Choose the decomposition method (NMF, PCA, or ICA)
+3. Estimate the optimal number of spectral components
 
 **Method Selection:**
 
@@ -714,6 +715,14 @@ Based on the system description and data characteristics provided, you must:
 - The user's objective explicitly asks for source separation or independent contributions
 - Prefer fewer components for ICA (typically 2–6) — over-specifying leads to noise components
 
+**When to skip decomposition entirely (`run_decomposition: false`):**
+Decomposition is strongly preferred for exploratory work — it surfaces structure you would not anticipate. Set `run_decomposition: false` ONLY when ALL of the following hold:
+- The user has provided an explicit objective AND that objective specifies a per-pixel quantitative measurement that does not require source separation (e.g. "fit the Si 2p binding energy at each pixel", "integrate the peak between 530–540 eV at each pixel", "extract the FWHM of the dominant feature across the map").
+- The measurement can be expressed directly as a function of the raw spectrum at each pixel (curve fit, integration, peak finding) and does not depend on knowing which mixture of contributions is present.
+- The dataset is not described as a survey, exploration, or characterization task.
+
+Default to `true` when in doubt, when no objective is given, or when the objective is exploratory ("characterize the sample", "find phases", "identify components"). Skipping decomposition forfeits the exploratory survey step, so the bar must be high.
+
 **Component Count Considerations:**
 
 **System Complexity:**
@@ -734,12 +743,15 @@ Based on the system description and data characteristics provided, you must:
 You MUST output a valid JSON object:
 
 {
+  "run_decomposition": <true or false>,
   "method": "<nmf, pca, or ica>",
   "estimated_components": <integer between 2 and 15>,
   "confidence": "<high/medium/low>",
-  "reasoning": "<explain your method choice AND component estimate based on the provided information>",
+  "reasoning": "<explain your run_decomposition decision, method choice, AND component estimate based on the provided information>",
   "expected_components": "<briefly describe what the components might represent>"
 }
+
+When `run_decomposition` is `false`, the `method` and `estimated_components` fields are ignored downstream — you may still fill them with reasonable defaults but they will not be used.
 
 Focus on providing a reasonable estimate based on the available information about the material system and data characteristics.
 """

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -1523,7 +1523,7 @@ The Orange line (Basis Component) is a reference to help understand what mixing 
 SPECTROSCOPY_VISUAL_QC_INSTRUCTIONS = """
 You are a Quality Assurance Scientist. You wrote code to model the feature: '{feature_desc}'.
 Below is the resulting 'Feature Dashboard'. Left=Map, Right=Histogram.
-
+{measurement_window_block}
 ### YOUR TASK
 Determine if this result captures a REAL physical signal, even if that signal is rare or sparse.
 
@@ -1534,7 +1534,7 @@ If the Histogram shows a large pile-up at zero/bounds (background) BUT there is 
 ### FAILURE CRITERIA (Reject ONLY if these are true):
 1. **Total Noise:** The map is pure 'static' (salt-and-pepper) with ZERO recognizable structure.
 2. **Total Algorithm Failure:** The histogram is a **SINGLE** sharp spike (Dirac delta) containing 100% of the data.
-3. **Complete Rail-Gazing:** The data is piled up at the min/max edges with **NO secondary distribution** visible.
+3. **Complete Rail-Gazing:** The data is piled up at the min/max edges with **NO secondary distribution** visible. **EXCEPTION — edge-of-window clustering:** when the feature is a peak position / center / onset energy / edge-energy quantity AND the histogram concentrates near the measurement-window boundary (within ~5% of the window width of either edge), this MAY be *physical edge-fitting* rather than algorithm failure. If the spectrum captures only the rising-edge or tail of a feature whose center lies near or outside the measurement window, the fit will correctly place the center at the window edge — that is success, not railing. When window-edge clustering and rail-gazing are visually indistinguishable from the dashboard alone, **err toward ACCEPT** and note the caveat that the feature may lie near/outside the measurement window. Reject as rail-gazing only when clustering occurs at an *interior* value clearly inside the window.
 
 ### SUCCESS CRITERIA (Accept if present):
 - **Structure:** Does the map show ANY structured domains, even if they are small?

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -1523,7 +1523,7 @@ The Orange line (Basis Component) is a reference to help understand what mixing 
 SPECTROSCOPY_VISUAL_QC_INSTRUCTIONS = """
 You are a Quality Assurance Scientist. You wrote code to model the feature: '{feature_desc}'.
 Below is the resulting 'Feature Dashboard'. Left=Map, Right=Histogram.
-{measurement_window_block}
+
 ### YOUR TASK
 Determine if this result captures a REAL physical signal, even if that signal is rare or sparse.
 
@@ -1534,7 +1534,7 @@ If the Histogram shows a large pile-up at zero/bounds (background) BUT there is 
 ### FAILURE CRITERIA (Reject ONLY if these are true):
 1. **Total Noise:** The map is pure 'static' (salt-and-pepper) with ZERO recognizable structure.
 2. **Total Algorithm Failure:** The histogram is a **SINGLE** sharp spike (Dirac delta) containing 100% of the data.
-3. **Complete Rail-Gazing:** The data is piled up at the min/max edges with **NO secondary distribution** visible. **EXCEPTION — edge-of-window clustering:** when the feature is a peak position / center / onset energy / edge-energy quantity AND the histogram concentrates near the measurement-window boundary (within ~5% of the window width of either edge), this MAY be *physical edge-fitting* rather than algorithm failure. If the spectrum captures only the rising-edge or tail of a feature whose center lies near or outside the measurement window, the fit will correctly place the center at the window edge — that is success, not railing. When window-edge clustering and rail-gazing are visually indistinguishable from the dashboard alone, **err toward ACCEPT** and note the caveat that the feature may lie near/outside the measurement window. Reject as rail-gazing only when clustering occurs at an *interior* value clearly inside the window.
+3. **Complete Rail-Gazing:** The data is piled up at the min/max edges with **NO secondary distribution** visible.
 
 ### SUCCESS CRITERIA (Accept if present):
 - **Structure:** Does the map show ANY structured domains, even if they are small?

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -1269,6 +1269,11 @@ You MUST output a valid JSON object.
 * For `custom_code` targets: `value = null` (the description field is what matters).
 * Targets of other types (e.g. legacy `"spatial"` or `"spectral"`) are NOT supported and will be ignored by the downstream pipeline. Do not emit them.
 
+**Required outputs (objective-aware QC enforcement):**
+When the user's objective explicitly names one or more scalar quantities that should be extracted per pixel (e.g. "peak position", "FWHM", "integrated area", "binding energy", "edge onset"), list the EXACT Snake_Case map keys you intend the generated code to produce for those quantities in the optional `required_outputs` field on the target. The downstream code-generation prompt will be told those keys are mandatory, and the dynamic-analysis run will retry (and ultimately fail the task) if any named output is missing from the returned `maps` dict OR fails its visual quality check. Leave `required_outputs` as an empty list when the user's objective is exploratory or when you are selecting features at your own initiative.
+
+Example: if the objective says *"extract the peak position (in eV) of the dominant feature at every pixel"*, the target should set `"required_outputs": ["Peak_Position"]`. The generated code's `maps` dict must then include a key named exactly `Peak_Position`.
+
 **Example 1: STOP (Decomposition Artifact)**
 {
   "refinement_needed": false,
@@ -1289,7 +1294,8 @@ You MUST output a valid JSON object.
       {
         "type": "custom_code",
         "description": "Map peak center position around 0.5 eV using Gaussian fitting or cross-correlation to quantify the spatial variation in peak energy across the sample.",
-        "value": null
+        "value": null,
+        "required_outputs": ["Peak_Center"]
       }
   ]
 }

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -1175,17 +1175,7 @@ Output ONLY the JSON object.
 
 SPECTROSCOPY_REFINEMENT_INSTRUCTIONS = """You are an expert spectroscopist steering an automated analysis pipeline.
 
-**Goal:** Analyze results to determine if a focused refinement is scientifically justified and **select the correct tool** (Standard Decomposition or Dynamic Analysis).
-
-**Crucial Constraint:**
-* Standard Refinement uses **the current decomposition method (NMF, PCA, or ICA)** on a subset of data. It works well for separating mixed spatial phases. This is most effective when NMF was used.
-* Dynamic Analysis (Custom Code) uses **Python/Math** (e.g., curve fitting). It works well when the decomposition fails to model the physical shape (e.g., peak shifts, specific background shapes).
-
-**IMPORTANT — If PCA was used as the decomposition method:**
-PCA components are exploratory — they capture variance directions, not physical phases. Spatial/spectral zoom refinement of PCA components rarely adds value because PCA loadings are not physically interpretable in the same way as NMF components. When PCA is the method, **strongly prefer `custom_code` targets** to mathematically model the specific spectral features identified by PCA (e.g., peak positions, edge onsets, intensity ratios). Only use `spatial` or `spectral` refinement with PCA in exceptional cases where a specific spatial region clearly needs isolation.
-
-**IMPORTANT — If ICA was used as the decomposition method:**
-ICA components represent statistically independent sources, not physical phases. They can have signed loadings and may overlap spectrally. Like PCA, spatial/spectral zoom refinement of ICA components rarely adds value because individual components are not directly physically interpretable. When ICA is the method, **strongly prefer `custom_code` targets** to model the specific spectral features the components highlight. Only use `spatial` or `spectral` refinement with ICA in exceptional cases.
+**Goal:** Analyze results to determine if a focused refinement is scientifically justified. Refinement uses **Dynamic Analysis (Custom Code)** — Python/Math (e.g., curve fitting) that operates per-pixel on the raw spectra. Decomposition is run once globally and is not re-run on subsets; if the global decomposition (or skip-decomposition mode) leaves an open scientific question that is best answered by mathematical modelling of a specific spectral feature, propose a `custom_code` refinement target.
 
 ---
 
@@ -1257,25 +1247,16 @@ Depending on the analysis method used in the current iteration, you will receive
    
    *If YES, analysis is complete.*
    
-3. **Ambiguity Check & Tool Selection (REFINE):**
-   
-   If the signal is **real but complex**, identify the specific *type* of complexity to choose the tool:
+3. **Refinement via Custom Code (REFINE):**
 
-   **Scenario A: Spatial/Spectral Mixing (Use Standard Decomposition — best with NMF)**
-   * *Observation:* In decomposition results, Black ≈ Red (good reconstruction), but Orange differs from Black/Red (mixing present). The component is valid but represents a mixed phase.
-   * *Observation:* The spectrum looks real but "blended" (e.g., two phases mixed in one component).
-   * *Action:* Target a standard `spatial` or `spectral` zoom. **Note:** If PCA was used, prefer `custom_code` instead — PCA spatial refinement is rarely effective.
-
-   **IMPORTANT: When NOT to use spatial refinement:**
-   If multiple components show the SAME spectral feature (e.g., same peak) at slightly different energy positions, spatial zoom will NOT help — it will just reduce the visible shift range within the subregion. This pattern indicates a continuous physical variation (peak shift, edge shift) that requires `custom_code` (dynamic analysis) to quantify. Similarly, if residual autocorrelation is high (>0.3) across multiple components sharing similar spectral features, this is strong evidence of a continuous shift that the decomposition cannot model regardless of spatial subsetting.
-
-
-   **Scenario B: Missed Physics / Model Failure (Use Custom Code)**
-   * *Observation:* In decomposition results, **Black and Red diverge** (poor reconstruction).
-   * *Observation:* The Residual Plot shows a **Structured Shape** (e.g., a "Hill", a "Sine Wave", or a "Step") indicating the decomposition missed a specific feature.
+   If the signal is **real but complex** in a way the current results have not yet resolved, propose one or more `custom_code` targets that mathematically model the specific feature(s):
+   * *Observation:* In decomposition results, **Black and Red diverge** (poor reconstruction), or the Residual Plot shows a **Structured Shape** (e.g., a "Hill", a "Sine Wave", or a "Step") indicating the decomposition missed a specific feature.
    * *Observation:* Evidence of a **Peak Shift** (Derivative shape in residual) or **Specific Shape** (e.g., Edge onset, Power-law tail).
-   * *Observation (PCA-specific):* PCA components show interesting variance patterns that need mathematical modeling to extract physical quantities.
-   * *Action:* Define a target with `type: "custom_code"`. You must describe the *math* needed (e.g., "Fit a Gaussian to model the peak shift around 0.6eV").
+   * *Observation:* Multiple components share the SAME spectral feature at slightly different positions — a continuous physical variation (peak shift, edge shift) that decomposition cannot model regardless of subsetting.
+   * *Observation:* High residual autocorrelation (>0.3) across components sharing similar spectral features.
+   * *Observation (PCA / ICA):* Components show interesting patterns that need mathematical modelling to extract physical quantities.
+   * *Observation (skip-decomposition mode):* The user's objective specifies a per-pixel quantitative measurement.
+   * *Action:* Define a target with `type: "custom_code"`. Describe the *math* needed (e.g., "Fit a Gaussian to model the peak shift around 0.6 eV").
    * *Tip:* The custom code sandbox provides `lmfit` in addition to `numpy`/`scipy`/`sklearn`. Use `lmfit` for multi-peak or complex fitting scenarios — it offers built-in models (GaussianModel, LorentzianModel, VoigtModel), parameter constraints, and composite models via the `+` operator. For simple single-peak fits on large datasets, raw `curve_fit` is faster due to lower per-pixel overhead.
 
 ---
@@ -1284,9 +1265,9 @@ Depending on the analysis method used in the current iteration, you will receive
 You MUST output a valid JSON object.
 
 **STRICT TYPE RULES:**
-* For "spatial" targets: 'value' = Integer (1-based component index).
-* For "spectral" targets: 'value' = List of two Numbers [start, end].
-* For "custom_code" targets: 'value' = null (The description field is what matters).
+* All refinement targets have `"type": "custom_code"`.
+* For `custom_code` targets: `value = null` (the description field is what matters).
+* Targets of other types (e.g. legacy `"spatial"` or `"spectral"`) are NOT supported and will be ignored by the downstream pipeline. Do not emit them.
 
 **Example 1: STOP (Decomposition Artifact)**
 {
@@ -1300,16 +1281,7 @@ You MUST output a valid JSON object.
   "reasoning": "Dynamic Analysis successfully mapped the peak center positions. The spatial map shows clear grain-boundary localization, and the histogram shows a bimodal distribution consistent with two distinct chemical environments. Analysis complete."
 }
 
-**Example 3: REFINE (Standard NMF - Mixing)**
-{
-  "refinement_needed": true,
-  "reasoning": "Component 2 shows valid signal. Black and Red lines match well (RMSE=0.01), confirming accurate reconstruction. However, Orange differs from Black/Red, indicating ~10% mixing with adjacent phases. A spatial zoom could isolate the pure interface.",
-  "targets": [
-      { "type": "spatial", "description": "Isolate pure interface region to separate mixed phases", "value": 2 }
-  ]
-}
-
-**Example 4: REFINE (Dynamic Analysis - Peak Shift)**
+**Example 3: REFINE (Dynamic Analysis - Peak Shift)**
 {
   "refinement_needed": true,
   "reasoning": "Component 3 is valid (Black line shows clear peaks), but Black and Red diverge at 0.5 eV. The Residual plot shows a distinct derivative pattern indicating a physical peak shift that NMF's linear model cannot capture. Need mathematical modeling to quantify this shift spatially.",

--- a/scilink/agents/exp_agents/metadata_converter.py
+++ b/scilink/agents/exp_agents/metadata_converter.py
@@ -81,6 +81,38 @@ METADATA_SCHEMA_DICT = {
                 "units": {"type": ["string", "null"], "description": "Units like 'nm', 'eV', 'cm^-1'."}
             },
         },
+        # --- Generic Axis Spec (Optional, for non-energy 3D hyperspectral) ---
+        # Used when the dataset is 3D but the axes are not the standard
+        # (x_spatial, y_spatial, energy) layout — e.g. (force, distance, frequency),
+        # (x, y, voltage), (x, y, time). When absent, downstream code synthesizes
+        # axis_spec from legacy spatial_info + energy_range for backward compatibility.
+        "axis_spec": {
+            "type": ["object", "null"],
+            "description": (
+                "Optional per-axis description for 3D hyperspectral data. Keys "
+                "are 'axis_0', 'axis_1', 'axis_2'. Each value is an object with "
+                "'name' (e.g. 'x', 'time', 'voltage'), 'units' (e.g. 'nm', 's', "
+                "'V'), 'kind' (one of 'spatial', 'parameter', 'signal', 'time'), "
+                "and for the signal-like axis also 'start' and 'end' (physical "
+                "range endpoints). When absent, the system uses legacy "
+                "spatial_info + energy_range as if the layout were "
+                "(x_spatial, y_spatial, energy)."
+            ),
+            "properties": {
+                "axis_0": {"type": ["object", "null"]},
+                "axis_1": {"type": ["object", "null"]},
+                "axis_2": {"type": ["object", "null"]},
+                "signal_is_nonnegative": {
+                    "type": ["boolean", "null"],
+                    "description": (
+                        "Whether the signal-like axis is physically non-negative "
+                        "(e.g. photon counts). Defaults to true. Set to false for "
+                        "signed signals like derivative or difference spectra so "
+                        "preprocessing does not clip negative values."
+                    ),
+                },
+            },
+        },
         # --- 1D Curve Specific (Conditional) ---
         "title": {
             "type": ["string", "null"], # Optional
@@ -144,7 +176,7 @@ Fill Conditional Fields based on Type:
 
 If Microscopy: Focus on extracting spatial_info (field of view and units). Omit or use null for spectroscopy/curve fields if not relevant.
 
-If Spectroscopy/Hyperspectral: Focus on extracting energy_range (start, end, units). Omit or use null for microscopy/curve fields if not relevant.
+If Spectroscopy/Hyperspectral: Focus on extracting energy_range (start, end, units). Omit or use null for microscopy/curve fields if not relevant. If the third (channel) axis of a 3D hyperspectral dataset is NOT energy/wavelength (e.g. it is time, voltage, force, frequency, or another parameter), populate the optional axis_spec object (with axis_0, axis_1, axis_2 entries — each having name, units, kind, and for the signal axis also start/end) instead of energy_range. Use axis_spec.signal_is_nonnegative=false when the signal can be signed (e.g. derivative spectra, difference spectra).
 
 If 1D Curve Data (PL, XRD, etc.): Focus on extracting title, data_columns (determining X and Y column names/units), xlabel, and ylabel. energy_range might also apply if the x-axis represents energy. Omit or use null for microscopy fields.
 
@@ -360,6 +392,106 @@ def normalize_metadata_dict(metadata: dict) -> tuple[dict, bool]:
         modified = True
 
     return (d, True) if modified else (metadata, False)
+
+
+# =====================================================================
+# Axis spec resolution (used by hyperspectral pipeline)
+# =====================================================================
+# The hyperspectral analysis agent traditionally assumed a (x, y, energy)
+# layout. axis_spec generalizes that to 3D datasets where the axes can be
+# anything (e.g. (force, distance, frequency)). resolve_axis_spec is the
+# single point of truth: every downstream consumer reads through it so
+# legacy energy-style metadata and new generic metadata coexist.
+
+_AXIS_SPATIAL_DEFAULTS = [
+    {"name": "x", "units": "pixel", "kind": "spatial"},
+    {"name": "y", "units": "pixel", "kind": "spatial"},
+]
+_AXIS_SIGNAL_DEFAULT = {"name": "energy", "units": "eV", "kind": "signal"}
+
+
+def resolve_axis_spec(system_info: dict | None) -> dict:
+    """Return a fully-populated axis_spec for a 3D hyperspectral dataset.
+
+    If ``system_info['axis_spec']`` is present, missing per-axis fields are
+    filled with defaults. Otherwise the spec is synthesized from legacy
+    ``spatial_info`` and ``energy_range`` so that an existing (x, y, energy)
+    call site sees identical behavior.
+
+    The returned dict always has keys ``axis_0``, ``axis_1``, ``axis_2``
+    (each an object with at least ``name``, ``units``, ``kind``) plus
+    ``signal_is_nonnegative`` (bool). The signal-like axis additionally
+    carries ``start`` and ``end`` when known; downstream callers raise if
+    they need those values and they are absent — same behavior as today.
+    """
+    system_info = system_info or {}
+    provided = system_info.get("axis_spec") or {}
+
+    spec: dict = {}
+
+    # axis_0, axis_1 — default to spatial; legacy spatial_info supplies units
+    spatial_info = system_info.get("spatial_info") or {}
+    spatial_units = spatial_info.get("field_of_view_units") or _AXIS_SPATIAL_DEFAULTS[0]["units"]
+    for idx in (0, 1):
+        key = f"axis_{idx}"
+        user_axis = provided.get(key) or {}
+        default = dict(_AXIS_SPATIAL_DEFAULTS[idx])
+        if spatial_units:
+            default["units"] = spatial_units
+        spec[key] = {
+            "name": user_axis.get("name", default["name"]),
+            "units": user_axis.get("units", default["units"]),
+            "kind": user_axis.get("kind", default["kind"]),
+        }
+
+    # axis_2 — default to signal (energy). Legacy energy_range supplies
+    # start/end/units when axis_spec.axis_2 doesn't.
+    user_axis_2 = provided.get("axis_2") or {}
+    energy_range = system_info.get("energy_range") or {}
+    axis_2 = {
+        "name": user_axis_2.get("name", _AXIS_SIGNAL_DEFAULT["name"]),
+        "units": user_axis_2.get("units", energy_range.get("units") or _AXIS_SIGNAL_DEFAULT["units"]),
+        "kind": user_axis_2.get("kind", _AXIS_SIGNAL_DEFAULT["kind"]),
+    }
+    start = user_axis_2.get("start", energy_range.get("start"))
+    end = user_axis_2.get("end", energy_range.get("end"))
+    if start is not None:
+        axis_2["start"] = start
+    if end is not None:
+        axis_2["end"] = end
+    spec["axis_2"] = axis_2
+
+    # Signal sign assumption — default True (counts-like) for backward compat
+    nonneg = provided.get("signal_is_nonnegative")
+    if nonneg is None:
+        nonneg = True
+    spec["signal_is_nonnegative"] = bool(nonneg)
+
+    return spec
+
+
+def describe_axes_for_prompt(shape, axis_spec: dict) -> str:
+    """Render a short human-friendly axes description for LLM prompts.
+
+    For the legacy (x_spatial, y_spatial, energy) layout this returns the
+    historical wording ("{h}x{w} spatial pixels, {e} spectral channels") so
+    existing prompts are unchanged. For generic layouts it switches to an
+    axis-name-driven phrasing.
+    """
+    n0, n1, n2 = shape
+    a0, a1, a2 = axis_spec["axis_0"], axis_spec["axis_1"], axis_spec["axis_2"]
+    legacy_layout = (
+        a0.get("kind") == "spatial"
+        and a1.get("kind") == "spatial"
+        and a2.get("kind") == "signal"
+        and a2.get("name") == "energy"
+    )
+    if legacy_layout:
+        return f"{n0}x{n1} spatial pixels, {n2} spectral channels"
+    return (
+        f"{n0}x{n1} samples along ({a0['name']}, {a1['name']}), "
+        f"{n2} channels along {a2['name']}"
+    )
 
 
 def _run_metadata_llm(text: str, model) -> dict | None:

--- a/scilink/agents/exp_agents/pipelines/hyperspectral_pipelines.py
+++ b/scilink/agents/exp_agents/pipelines/hyperspectral_pipelines.py
@@ -11,11 +11,10 @@ from ..controllers.hyperspectral_controllers import (
     BuildHyperspectralPromptController,
     RunDynamicAnalysisController,
     SelectRefinementTargetController,
-    GenerateRefinementTasksController,
     BuildHolisticSynthesisPromptController,
     GenerateHTMLReportController,
-    RunSelfReflectionController,      
-    ApplyReflectionUpdatesController   
+    RunSelfReflectionController,
+    ApplyReflectionUpdatesController
 )
 from ..controllers.base_controllers import (
     RunFinalInterpretationController,
@@ -95,11 +94,8 @@ def create_hyperspectral_iteration_pipeline(
     pipeline.append(RunDynamicAnalysisController(
         model, logger, generation_config, safety_settings, parse_fn
     ))
-    
-    # 3f. [🛠️ Tool] Prepare data for next loop (Standard NMF tasks)
-    pipeline.append(GenerateRefinementTasksController(logger))
 
-    logger.info(f"Hyperspectral *iteration* pipeline created with {len(pipeline)} steps.")
+    logger.info(f"Hyperspectral iteration pipeline created with {len(pipeline)} steps.")
     return pipeline
 
 def create_hyperspectral_synthesis_pipeline(

--- a/scilink/agents/exp_agents/preprocess.py
+++ b/scilink/agents/exp_agents/preprocess.py
@@ -10,12 +10,13 @@ import matplotlib.pyplot as plt
 from io import BytesIO
 
 from .base_agent import BaseUtilityAgent
+from .metadata_converter import resolve_axis_spec
 
 from .instruct import (
     PRE_PROCESSING_STRATEGY_INSTRUCTIONS,
     CUSTOM_PREPROCESSING_SCRIPT_INSTRUCTIONS,
     CUSTOM_SCRIPT_CORRECTION_INSTRUCTIONS,
-    CUSTOM_PREPROCESSING_SCRIPT_1D_INSTRUCTIONS, 
+    CUSTOM_PREPROCESSING_SCRIPT_1D_INSTRUCTIONS,
     CUSTOM_SCRIPT_CORRECTION_1D_INSTRUCTIONS,
     CURVE_PREPROCESSING_STRATEGY_INSTRUCTIONS,
     PREPROCESSING_QUALITY_ASSESSMENT_INSTRUCTIONS
@@ -166,12 +167,15 @@ class HyperspectralPreprocessingAgent(BaseUtilityAgent):
 
         else:
             self.logger.info("No custom instruction. Running standard LLM strategy selection.")
-            
+
             # 4. Get cleaning strategy from LLM
             strategy = self._llm_select_preprocessing_strategy(stats, system_info)
-            
-            # 5. Apply the LLM's cleaning strategy
-            processed_data, mask_2d = self._apply_preprocessing(hspy_data, strategy)
+
+            # 5. Apply the LLM's cleaning strategy. axis_spec gates the
+            # legacy "clip negatives" and "(k, k, 1) despike kernel" choices
+            # so non-(spatial, spatial, signal-counts) layouts work correctly.
+            axis_spec = resolve_axis_spec(system_info)
+            processed_data, mask_2d = self._apply_preprocessing(hspy_data, strategy, axis_spec)
 
         # 6. Return all results
         return processed_data, mask_2d, data_quality
@@ -230,25 +234,57 @@ class HyperspectralPreprocessingAgent(BaseUtilityAgent):
               "reasoning": "Fallback: Default clipping and masking strategy."
             }
 
-    def _apply_preprocessing(self, hspy_data: np.ndarray, strategy: dict) -> tuple[np.ndarray, np.ndarray]:
+    def _apply_preprocessing(
+        self,
+        hspy_data: np.ndarray,
+        strategy: dict,
+        axis_spec: dict | None = None,
+    ) -> tuple[np.ndarray, np.ndarray]:
         """
         Applies a robust pre-processing pipeline.
-        
+
+        ``axis_spec`` (from ``resolve_axis_spec``) controls layout-dependent
+        steps:
+        * the despike kernel uses a 2D (k, k, 1) shape when both leading
+          axes are spatial (default) and a 1D (1, 1, k) shape otherwise, so
+          unrelated parameter samples are not medianed together;
+        * the "clip negatives" step runs only when the signal axis is
+          declared non-negative (default true — preserves legacy behavior).
+        ``axis_spec=None`` is equivalent to the legacy defaults.
         """
         #self.logger.info("\n\n🤖 --- DATA AGENT STEP: APPLYING PRE-PROCESSING --- 🤖")
         data_to_process = hspy_data.copy()
         mask_2d = None
 
+        leading_axes_are_spatial = True
+        signal_is_nonnegative = True
+        if axis_spec is not None:
+            leading_axes_are_spatial = (
+                axis_spec.get("axis_0", {}).get("kind") == "spatial"
+                and axis_spec.get("axis_1", {}).get("kind") == "spatial"
+            )
+            signal_is_nonnegative = bool(axis_spec.get("signal_is_nonnegative", True))
+
         # 1. Apply Despiking
         if strategy.get('apply_despike', False):
             kernel_size = int(strategy.get('despike_kernel_size', 3))
-            kernel_tuple = (kernel_size, kernel_size, 1)
+            if leading_axes_are_spatial:
+                kernel_tuple = (kernel_size, kernel_size, 1)
+            else:
+                # Non-spatial leading axes have no neighborhood structure, so
+                # median over the signal axis only.
+                kernel_tuple = (1, 1, kernel_size)
             self.logger.info(f"Applying 3D Median Filter (despike) with kernel {kernel_tuple}...")
             data_to_process = median_filter(data_to_process, size=kernel_tuple)
-        
-        # 2. Clip all negative values to zero
-        self.logger.info("Clipping all negative data points to 0.0...")
-        np.clip(data_to_process, 0, None, out=data_to_process)
+
+        # 2. Clip negatives — only when signal is physically non-negative.
+        if signal_is_nonnegative:
+            self.logger.info("Clipping all negative data points to 0.0...")
+            np.clip(data_to_process, 0, None, out=data_to_process)
+        else:
+            self.logger.info(
+                "axis_spec.signal_is_nonnegative is False — preserving signed values."
+            )
 
         # 3. Calculate Masking strategy
         if strategy.get('apply_masking', False):

--- a/scilink/skills/hyperspectral/eels/eels.md
+++ b/scilink/skills/hyperspectral/eels/eels.md
@@ -85,8 +85,9 @@ Initialization and bounds:
 **Reference edge energies (core-loss onset values).** The entries below
 are illustrative examples covering commonly encountered edges; the same
 chemical-shift / fine-structure principles apply to any core-loss edge.
-Consult tabulated EELS atlases (Gatan EELS Atlas, EELS.info) for
-elements and edges not listed.
+For elements / edges not listed, infer the initial edge energy from the
+data itself (the spectrum's rising-step or peak position) and keep fit
+bounds generous around that initial guess.
 
 Titanium Ti L2,3:
 - Ti L3 onset: ~456 eV (metal), ~458 eV (TiO2)

--- a/scilink/skills/hyperspectral/eels/eels.md
+++ b/scilink/skills/hyperspectral/eels/eels.md
@@ -52,7 +52,7 @@ mapping, phase identification, and chemical-state analysis.
 - Negative values from background subtraction or deconvolution violate
   NMF constraints. Either clip to zero or switch to PCA.
 
-## analysis
+## implementation
 
 **Per-pixel fitting recipes for EELS features.**
 

--- a/scilink/skills/hyperspectral/eels/eels.md
+++ b/scilink/skills/hyperspectral/eels/eels.md
@@ -27,11 +27,15 @@ mapping, phase identification, and chemical-state analysis.
 **Component count estimation:**
 - Start with the number of distinct core-loss edges present in the energy
   range, plus one for the background/plural-scattering component.
-- For a dataset spanning Ti L2,3 and O K edges in a TiO2/SrTiO3 system:
-  expect ~3-5 components (Ti4+ phase, Ti3+ or reduced phase, O-K
-  environment, background, possible interface component).
-- Datasets with a single edge region: 2-4 components typically suffice.
-- If the energy range includes both low-loss and core-loss: add 1-2
+- Add one component per distinct chemical environment / oxidation state
+  you expect for each element (e.g. mixed-valence phases, interface
+  states). *Example:* a dataset spanning two adjacent edges in a
+  mixed-valence transition-metal oxide (such as Ti L2,3 + O K in a
+  TiO2/SrTiO3 system) typically calls for ~3–5 components — one per
+  oxidation state, one per ligand environment, plus a background. Other
+  systems scale by the same logic.
+- Datasets with a single edge region: 2–4 components typically suffice.
+- If the energy range includes both low-loss and core-loss: add 1–2
   components for plasmon/zero-loss tail contributions.
 
 **Energy range considerations:**
@@ -78,7 +82,11 @@ Initialization and bounds:
 
 ## interpretation
 
-**Reference edge energies (core-loss onset values):**
+**Reference edge energies (core-loss onset values).** The entries below
+are illustrative examples covering commonly encountered edges; the same
+chemical-shift / fine-structure principles apply to any core-loss edge.
+Consult tabulated EELS atlases (Gatan EELS Atlas, EELS.info) for
+elements and edges not listed.
 
 Titanium Ti L2,3:
 - Ti L3 onset: ~456 eV (metal), ~458 eV (TiO2)
@@ -155,5 +163,6 @@ Nitrogen N K:
   within the energy resolution of the instrument (typically 0.5-1.5 eV
   for standard EELS, <0.1 eV for monochromated systems).
 - Spatial distributions should correlate with known sample morphology
-  (e.g., a Ti component should be concentrated in Ti-containing regions).
+  (e.g., a component associated with a given element should be
+  concentrated in regions of the sample that contain that element).
 - If HAADF-STEM or EDS data is available, verify spatial consistency.

--- a/scilink/skills/hyperspectral/eels/eels.md
+++ b/scilink/skills/hyperspectral/eels/eels.md
@@ -54,33 +54,27 @@ mapping, phase identification, and chemical-state analysis.
 
 ## analysis
 
-**NMF component interpretation for EELS:**
-- Each NMF component spectrum should resemble a physically plausible EELS
-  signal: non-negative, with recognizable edge shapes or smooth background.
-- The background component typically shows a monotonically decreasing
-  power-law shape (A * E^-r) without sharp edge onsets.
-- Physical components show characteristic edge shapes: delayed maxima for
-  L2,3 edges (white lines), sawtooth onset for K edges, sharp threshold
-  for M4,5 edges.
-- Artifact components may show: oscillatory negative-positive patterns,
-  noise-like random fluctuations, or derivative-like shapes. These
-  indicate over-decomposition.
+**Per-pixel fitting recipes for EELS features.**
 
-**Identifying edge features in components:**
-- White lines (sharp peaks at edge onset) indicate transitions to
-  unfilled d or f states. Their intensity ratio encodes oxidation state
-  (e.g., Ti L3/L2 ratio increases with Ti valence).
-- Near-edge fine structure (ELNES) in the first 30-50 eV above the edge
-  onset reflects local coordination and bonding environment.
-- Extended fine structure (EXELFS) beyond 50 eV provides interatomic
-  distance information but is rarely resolved in NMF components.
+Core-loss edges: subtract a power-law background (`A * E^-r`, r typically
+2.5–5) fit to a pre-edge window, then fit the edge step plus any ELNES
+peaks with `lmfit.models.StepModel` + `GaussianModel` / `LorentzianModel`.
 
-**Spatial abundance map quality:**
-- Maps should show spatially coherent regions (grains, layers, interfaces)
-  rather than random pixel-level noise patterns.
-- Sharp boundaries in maps typically indicate real phase boundaries;
-  gradual transitions suggest intermixing, beam damage, or specimen
-  thickness variations.
+Low-loss plasmons: a Drude-Lorentz oscillator in loss space is the most
+physically faithful model. A Lorentzian-on-linear-background is an
+acceptable approximation when the peak sits well inside the measurement
+window. When the peak appears to lie outside the window, leave the
+center parameter unbounded above the window — the lineshape constrains
+it from the tail curvature.
+
+Initialization and bounds:
+- Initialize peak center at the argmax of a lightly smoothed (Savitzky-
+  Golay, window 5–9, polyorder 2) spectrum, not a fixed value.
+- Keep parameter bounds wider than the prior expectation — tight bounds
+  cause rail-gazing failures that the visual QC step will flag.
+- Mark per-pixel fits with R² < ~0.5 or parameters railed at a bound
+  as NaN so the dashboard histogram reveals real distributions, not
+  boundary spikes.
 
 ## interpretation
 

--- a/scilink/skills/hyperspectral/eels/eels.md
+++ b/scilink/skills/hyperspectral/eels/eels.md
@@ -67,18 +67,26 @@ peaks with `lmfit.models.StepModel` + `GaussianModel` / `LorentzianModel`.
 Low-loss plasmons: a Drude-Lorentz oscillator in loss space is the most
 physically faithful model. A Lorentzian-on-linear-background is an
 acceptable approximation when the peak sits well inside the measurement
-window. When the peak appears to lie outside the window, leave the
-center parameter unbounded above the window — the lineshape constrains
-it from the tail curvature.
+window.
+
+A peak whose center lies outside the measurement window cannot be
+honestly measured from a tail-only fit — mathematically the lineshape
+admits a center value, but the uncertainty is large and the result is
+extrapolation, not measurement. The correct strategy is to **bound the
+center to the measurement window** and **NaN out pixels whose fit
+converges at the bound** (those pixels' peak is outside the window;
+the result is "no measurement available", not "peak at the bound").
+Do not widen bounds beyond the window to chase those pixels.
 
 Initialization and bounds:
 - Initialize peak center at the argmax of a lightly smoothed (Savitzky-
   Golay, window 5–9, polyorder 2) spectrum, not a fixed value.
-- Keep parameter bounds wider than the prior expectation — tight bounds
-  cause rail-gazing failures that the visual QC step will flag.
+- Bound the peak center to the measurement window (`[axis_start,
+  axis_end]`).
 - Mark per-pixel fits with R² < ~0.5 or parameters railed at a bound
-  as NaN so the dashboard histogram reveals real distributions, not
-  boundary spikes.
+  as NaN. The dashboard histogram will then show the real interior
+  distribution; boundary pile-ups indicate fit failures or features
+  outside the measurement window — both honestly reported as NaN.
 
 ## interpretation
 

--- a/scilink/skills/hyperspectral/eels/eels.py
+++ b/scilink/skills/hyperspectral/eels/eels.py
@@ -937,44 +937,69 @@ def create_annotated_heatmap(data_map: np.ndarray, title: str, units: str) -> by
     return resize_image_bytes(buf.getvalue())
 
 
-def create_feature_dashboard(data_map: np.ndarray, feature_name: str, units: str) -> bytes:
+def create_feature_dashboard(
+    data_map: np.ndarray,
+    feature_name: str,
+    units: str,
+    axis_spec: dict | None = None,
+) -> bytes:
     """
-    Creates a combined dashboard: Spatial Heatmap (Left) + Statistical Histogram (Right).
+    Creates a combined dashboard: 2D Heatmap (Left) + Statistical Histogram (Right).
+
+    ``axis_spec`` (from ``resolve_axis_spec``) controls the heatmap-panel
+    title and histogram count label: legacy spatial layouts keep the
+    "Spatial Map" / "Pixel Count" wording, generic layouts switch to
+    axis-name-driven wording. ``axis_spec=None`` preserves legacy text.
     """
+
+    # Decide labels from axis_spec. Default to the legacy spatial wording.
+    map_title_prefix = "Spatial Map"
+    count_label = "Pixel Count"
+    if axis_spec is not None:
+        a0 = axis_spec.get("axis_0", {})
+        a1 = axis_spec.get("axis_1", {})
+        leading_axes_are_spatial = (
+            a0.get("kind") == "spatial" and a1.get("kind") == "spatial"
+        )
+        if not leading_axes_are_spatial:
+            n0 = a0.get("name", "axis 0")
+            n1 = a1.get("name", "axis 1")
+            map_title_prefix = f"{n0.capitalize()}-{n1.capitalize()} Map"
+            count_label = "Sample Count"
 
     # 1. Clean Data for Histogram
     flat_data = data_map.ravel()
     valid_data = flat_data[~np.isnan(flat_data)]
-    
+
     if len(valid_data) == 0:
         return None
 
     # 2. Setup Figure (2 Columns)
     fig = plt.figure(figsize=(12, 5))
     gs = gridspec.GridSpec(1, 2, width_ratios=[1.5, 1]) # Map is slightly wider
-    
-    # --- LEFT PANEL: Spatial Heatmap ---
+
+    # --- LEFT PANEL: 2D Heatmap ---
     ax_map = fig.add_subplot(gs[0])
-    
+
     # Robust scaling (2nd-98th percentile) to ignore hot pixels
     vmin = np.nanpercentile(data_map, 2)
     vmax = np.nanpercentile(data_map, 98)
-    
+
     im = ax_map.imshow(data_map, cmap='plasma', vmin=vmin, vmax=vmax, origin='upper')
-    ax_map.set_title(f"Spatial Map: {feature_name}", fontsize=12, fontweight='bold')
+    ax_map.set_title(f"{map_title_prefix}: {feature_name}", fontsize=12, fontweight='bold')
     ax_map.axis('off') # Clean look
-    
+
     # Colorbar attached to map
     cbar = fig.colorbar(im, ax=ax_map, fraction=0.046, pad=0.04)
     cbar.set_label(units, rotation=270, labelpad=15)
 
     # --- RIGHT PANEL: Histogram ---
     ax_hist = fig.add_subplot(gs[1])
-    
+
     # Dynamic binning
     n_bins = min(50, max(15, int(len(valid_data)**0.4)))
     ax_hist.hist(valid_data, bins=n_bins, color='#2c3e50', alpha=0.75, edgecolor='white', linewidth=0.5)
-    
+
     # Statistics Box
     mu = np.mean(valid_data)
     sigma = np.std(valid_data)
@@ -982,9 +1007,9 @@ def create_feature_dashboard(data_map: np.ndarray, feature_name: str, units: str
     props = dict(boxstyle='round', facecolor='wheat', alpha=0.3)
     ax_hist.text(0.95, 0.95, stats_text, transform=ax_hist.transAxes, fontsize=10,
                  verticalalignment='top', horizontalalignment='right', bbox=props)
-    
+
     ax_hist.set_xlabel(f"{feature_name} ({units})")
-    ax_hist.set_ylabel("Pixel Count")
+    ax_hist.set_ylabel(count_label)
     ax_hist.set_title("Population Statistics")
     ax_hist.grid(True, linestyle=':', alpha=0.6)
     ax_hist.spines['top'].set_visible(False)

--- a/scilink/skills/hyperspectral/eels/eels.py
+++ b/scilink/skills/hyperspectral/eels/eels.py
@@ -127,6 +127,11 @@ def run_spectral_unmixing(
         elif method == 'pca':
             # Unexplained variance: 1 - cumulative explained variance ratio
             error = 1.0 - sum(unmixer.model.explained_variance_ratio_)
+        elif method == 'ica':
+            # FastICA has no built-in reconstruction error and no monotonic
+            # elbow trend in n_components — downstream controllers skip the
+            # elbow loop for ICA, so this is a placeholder.
+            error = 0.0
         else:
             error = 0.0
 

--- a/scilink/skills/hyperspectral/eels/eels.py
+++ b/scilink/skills/hyperspectral/eels/eels.py
@@ -146,43 +146,70 @@ def run_spectral_unmixing(
 # ENERGY AXIS UTILITIES
 # =============================================================================
 
+def create_axis(
+    n_channels: int,
+    system_info: dict = None,
+    axis_index: int = 2,
+) -> tuple[np.ndarray, str, bool]:
+    """
+    Create a physical axis for a hyperspectral dataset axis.
+
+    Defaults to ``axis_index=2`` (the third / "signal" axis), which preserves
+    the historical (x, y, energy) layout. Reads through
+    ``metadata_converter.resolve_axis_spec`` so that callers see the same
+    behavior whether the metadata uses legacy ``energy_range`` or a generic
+    ``axis_spec``.
+
+    Returns ``(axis_values, xlabel, has_axis_info)``. Raises ``ValueError``
+    when the requested axis has no physical range (``start`` / ``end``)
+    available — same contract as the legacy ``create_energy_axis``.
+    """
+    # Local import to avoid an agents -> skills -> agents cycle at module load.
+    from ....agents.exp_agents.metadata_converter import resolve_axis_spec
+
+    spec = resolve_axis_spec(system_info)
+    key = f"axis_{axis_index}"
+    if key not in spec:
+        raise ValueError(f"axis_index {axis_index} is out of range for a 3D dataset.")
+
+    axis_info = spec[key]
+    name = axis_info.get("name", "axis")
+    units = axis_info.get("units", "a.u.")
+
+    if "start" not in axis_info or "end" not in axis_info:
+        # Preserve the legacy error message for the common energy case so that
+        # existing call sites and user-facing messaging are unchanged.
+        if name == "energy" and not (system_info and "axis_spec" in system_info):
+            raise ValueError(
+                "Energy axis information is required for hyperspectral analysis. "
+                "Metadata must include 'energy_range' with 'start' and 'end' values "
+                "(and optionally 'units')."
+            )
+        raise ValueError(
+            f"Axis {axis_index} ('{name}') is missing physical range. "
+            f"axis_spec.{key} must include 'start' and 'end' "
+            f"(or legacy energy_range for axis_2)."
+        )
+
+    start = axis_info["start"]
+    end = axis_info["end"]
+    axis_values = np.linspace(start, end, n_channels)
+    # Title-case the axis name for the label so "energy" -> "Energy (eV)"
+    # and "time" -> "Time (s)" without callers having to remember.
+    label_name = name[:1].upper() + name[1:] if name else "Axis"
+    xlabel = f"{label_name} ({units})"
+    return axis_values, xlabel, True
+
+
 def create_energy_axis(n_channels: int, system_info: dict = None) -> tuple[np.ndarray, str, bool]:
     """
-    Create energy axis from system_info.
+    Backwards-compatible shim for the legacy energy-axis API.
 
-    Raises ValueError when energy_range is missing, None, or incomplete
-    because a physical energy axis is required for meaningful hyperspectral
-    analysis.
+    Delegates to ``create_axis(n_channels, system_info, axis_index=2)`` so
+    existing call sites continue to work unchanged. New callers should use
+    ``create_axis`` directly when they need a non-default axis_index.
     """
-    if not system_info or "energy_range" not in system_info:
-        raise ValueError(
-            "Energy axis information is required for hyperspectral analysis. "
-            "Metadata must include 'energy_range' with 'start' and 'end' values "
-            "(and optionally 'units')."
-        )
-
-    energy_info = system_info["energy_range"]
-
-    if not energy_info or not isinstance(energy_info, dict):
-        raise ValueError(
-            "energy_range in metadata is empty or invalid. "
-            "It must be a dict with 'start' and 'end' keys "
-            "(e.g. {\"start\": 0, \"end\": 50, \"units\": \"eV\"})."
-        )
-
-    if "start" not in energy_info or "end" not in energy_info:
-        raise ValueError(
-            f"energy_range is incomplete: {energy_info}. "
-            "Both 'start' and 'end' are required."
-        )
-
-    start = energy_info["start"]
-    end = energy_info["end"]
-    units = energy_info.get("units", "eV")
-
-    energy_axis = np.linspace(start, end, n_channels)
-    xlabel = f"Energy ({units})"
-    return energy_axis, xlabel, True
+    return create_axis(n_channels, system_info, axis_index=2)
 
 
 def convert_energy_to_indices(
@@ -1100,14 +1127,31 @@ def apply_spectral_slice(
         
     sliced_data = original_hspy_data[..., slice_indices]
     
-    # We must also update the system_info to reflect this slice
+    # We must also update the system_info to reflect this slice. Update
+    # both legacy energy_range (when present) and the generic axis_spec
+    # (when present) so downstream callers using either form see the slice.
+    new_start = float(energy_axis[slice_indices[0]])
+    new_end = float(energy_axis[slice_indices[-1]])
+
     new_system_info = system_info.copy()
+    legacy_units = system_info.get("energy_range", {}).get("units", "unknown")
     new_system_info["energy_range"] = {
-        "start": float(energy_axis[slice_indices[0]]),
-        "end": float(energy_axis[slice_indices[-1]]),
-        "units": system_info.get("energy_range", {}).get("units", "unknown")
+        "start": new_start,
+        "end": new_end,
+        "units": legacy_units,
     }
-    
+    if "axis_spec" in system_info and system_info["axis_spec"]:
+        # Deep-copy the axis_spec so we don't mutate the caller's dict.
+        new_axis_spec = {k: dict(v) if isinstance(v, dict) else v
+                         for k, v in system_info["axis_spec"].items()}
+        axis_2 = new_axis_spec.get("axis_2") or {}
+        if not isinstance(axis_2, dict):
+            axis_2 = {}
+        axis_2["start"] = new_start
+        axis_2["end"] = new_end
+        new_axis_spec["axis_2"] = axis_2
+        new_system_info["axis_spec"] = new_axis_spec
+
     return sliced_data, new_system_info
 
 

--- a/scilink/skills/loader.py
+++ b/scilink/skills/loader.py
@@ -159,6 +159,29 @@ def load_skill(skill: str, domain: str = "curve_fitting") -> Dict:
     meta, body = _split_frontmatter(text, source=str(path))
     sections, extras = _parse_sections(body, source=str(path))
 
+    # Synonym fold: `analysis` and `implementation` are treated as synonyms
+    # for the codegen-recipe role across foundation agents (history: this
+    # section was originally `fitting` in the curve-fitting-only era,
+    # renamed to `analysis` when image_analysis joined, and is now
+    # `implementation` in the latest sim_agents and hyperspectral work).
+    # If exactly one of the pair carries content, copy it to the other so
+    # downstream consumers reading either name see the same recipe. If
+    # both are present, respect the author's intent and leave them
+    # distinct (e.g. amber, chgnet, lammps deliberately use `analysis` for
+    # input characterization and `implementation` for the script recipe).
+    impl = sections.get("implementation", "").strip()
+    ana = sections.get("analysis", "").strip()
+    if impl and not ana:
+        sections["analysis"] = sections["implementation"]
+        _logger.debug(
+            "Skill %s: copied `implementation` to `analysis` (synonym fold).", str(path)
+        )
+    elif ana and not impl:
+        sections["implementation"] = sections["analysis"]
+        _logger.debug(
+            "Skill %s: copied `analysis` to `implementation` (synonym fold).", str(path)
+        )
+
     sections["name"] = path.stem
     sections["meta"] = meta
     sections["extras"] = extras


### PR DESCRIPTION
## Summary

Three user-requested extensions to `HyperspectralAnalysisAgent`, plus a few cascading cleanups that fell out of doing them properly:

- **ICA decomposition method** alongside NMF and PCA. Mirrors PCA's summary-only treatment (signed components, no per-component validation); elbow loop is skipped (FastICA has no informative elbow). LLM picks NMF / PCA / ICA via the existing initial-params controller.
- **Generic third axis** for 3D datasets (full backward compatibility). The agent no longer assumes (x_spatial, y_spatial, energy). An optional `axis_spec` in `system_info` lets users describe any 3D layout — (force, distance, frequency), (x, y, time), (x, y, voltage), etc. New `resolve_axis_spec` helper in `metadata_converter.py` synthesizes from legacy `energy_range` + `spatial_info` when `axis_spec` is absent, so existing call sites are byte-identical. Preprocessor gains a `signal_is_nonnegative` gate (default true) so signed signals (derivative spectra, χ", etc.) aren't silently clipped, and despike kernel switches between 2D-spatial and 1D-signal based on axis kinds.
- **Optional decomposition** via an LLM-driven skip-gate. When the user's objective specifies a direct per-pixel measurement (e.g. "fit Si 2p binding energy at every pixel"), the gate sets `run_decomposition: false` and bypasses the NMF/PCA/ICA stage entirely, going straight to dynamic-analysis (custom code). Default is biased toward running decomposition; skip requires an explicit objective with three positive criteria.

### Cascading work

- **Phase B + Phase C — recursive decomposition refinement removed.** PCA/ICA/skip modes all steer to `custom_code` targets; recursive NMF re-unmixing on subsets was paying complexity for limited benefit. Phase B disabled the prompt-level offer; Phase C deleted the now-unreachable queue loop, `MAX_REFINEMENT_ITERATIONS`, `parent_refinement_reasoning` plumbing, and `GenerateRefinementTasksController` (~250 LOC net delete).
- **Objective-aware QC + retry.** Refinement targets carry a `required_outputs` field declaring the named scalar quantities the codegen LLM must produce. Missing/QC-rejected required outputs force a retry instead of being silently dropped by the partial-success threshold. Closes the "objective drift" pattern (asked for peak position, got amplitude + FWHM only) observed in earlier live runs.
- **Skill vs. objective precedence.** When an active skill recommends running decomposition but the user's objective opts out, the objective wins for the skip/run decision — but the skill's *how-to* guidance (lineshape, preprocessing, validation) still applies to the dynamic-analysis step that follows.
- **Skill `implementation` section injected into code-gen.** Previously the codegen LLM saw skill knowledge only indirectly through the refinement-LLM's per-target description (lossy). Now `build_code_generation_prompt` accepts a `skill_implementation` block rendered as Section 0 above DATA CONTEXT, with an explicit precedence line: if skill suggests names that differ from `REQUIRED OUTPUTS`, the required-outputs keys are authoritative.
- **Loader-level `analysis` ↔ `implementation` synonym fold.** The codegen-recipe section has gone through three names — `fitting` (curve-fitting-only era) → `analysis` (when image_analysis joined) → `implementation` (most recent sim_agents and hyperspectral work). The loader folds the two as synonyms when exactly one is authored; dual-section skills (force_field/amber, molecular_dynamics/lammps, machine_learning_potentials/chgnet) are left distinct (author intent — `analysis` is input characterization, `implementation` is the script recipe).
- **CLAUDE.md updates.** Documents the synonym fold + history; names `Overview → Planning → Implementation → Interpretation → Validation` as the recommended structure for new analysis-agent skills; broadens preamble scope from "orchestrator stack" to "agentic stack — orchestrators, foundation agents, and the skill subsystem".
- **eels.md refresh.** `## analysis` renamed to `## implementation`; replaced placeholder NMF-interpretation content with light per-pixel fitting recipes (bound-and-NaN strategy, no extrapolation); Ti/O references reframed as explicit examples rather than implicit defaults; useless atlas-lookup advice removed.
- **Visualizations.** `create_feature_dashboard` accepts optional `axis_spec` so non-spatial leading axes get axis-name-driven labels (e.g. "Voltage-Time Map" / "Sample Count") instead of hard-coded "Spatial Map" / "Pixel Count".
- **Misleading "FINAL" log labels** corrected for prompts/interpretations that aren't actually final.
- **Feedback-prompt regression fix.** Phase C inadvertently removed `current_depth` from iteration state, which silently disabled the `IterativeFeedbackController` human-feedback prompt under co-pilot and autopilot modes. Restored.

19 commits total. Branched off `main`.

## Test plan

- [x] Structural verification across all four scenarios (NMF backcompat, ICA, generic-axis, skip-gate) — passes
- [x] Live verification with `claude-opus-4-6` across five scenarios (the four above + skill-precedence with `skill="eels"`) — all pass; gates fire correctly, no recursion artifacts, no spurious `Ignoring legacy` warnings
- [x] Loader fold matrix verified across all 17 existing skills (5 `analysis`-only fold to both, 8 `implementation`-only fold to both, 3 dual-section preserved, 1 empty)
- [x] Backcompat: legacy `(x, y, energy)` cubes with no `axis_spec` produce byte-identical describe text + plot labels
- [x] Manual UI test of the human-feedback prompt under co-pilot mode after the regression fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)