### PR TITLE
curve-fitting: cap scientific_claims at 1 (single) / 2 (series)

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -5050,6 +5050,13 @@ instrumental drift) without explicit evidence.
     "caveats": "limitations and considerations, including model-vs-data divergence from Stage 2"
 }
 ```
+
+**Number of claims:** emit **at most 2** `scientific_claims` for a series — the \
+dominant trend across the spectra (1 claim) plus, only if independent, a \
+secondary finding (e.g. a flagged-spectrum anomaly that doesn't fit the \
+trend). One claim is the right answer when the series tells a single \
+coherent story. Never more than 2. Do not pad with restatements of the \
+same trend.
 '''
 
     def __init__(self, model, logger: logging.Logger, generation_config, safety_settings,

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2426,6 +2426,14 @@ Return a single JSON object with exactly these keys:
     "suggested_followup": "Next steps"
 }
 ```
+
+**Number of claims:** emit **exactly 1** `scientific_claims` entry for a \
+single spectrum — the single most important finding. Use 2 only when the \
+analysis genuinely surfaced two independent findings that cannot be \
+merged into one (e.g. a primary fitted quantity AND an unexpected \
+residual feature pointing to a different physical process). Never emit \
+more than 2. Do not pad the list with restatements of the same finding \
+in different words.
 """
 
 # Generic interpretation instruction used by feedback-refinement flows that do
@@ -2457,6 +2465,12 @@ If the residuals suggest the model is inadequate for part of the data, say so.
     "suggested_followup": "Next steps"
 }
 ```
+
+**Number of claims:** emit **exactly 1** `scientific_claims` entry — the \
+single most important finding from this spectrum. Use 2 only when the \
+analysis genuinely surfaced two independent findings that cannot be \
+merged. Never more than 2. Do not pad with restatements of the same \
+finding.
 """
 
 


### PR DESCRIPTION
## What this changes

CurveFittingAgent's synthesis reports sometimes pad the \`scientific_claims\` list with 4-6 entries that restate the same finding in slightly different words. The synthesis prompts allow any number of claims, so the model fills the schema.

Three prompts get a one-paragraph cap appended after their JSON output schema:

| Prompt | Used by | Cap |
|---|---|---|
| \`FITTING_INTERPRETATION_STAGE3\` | single-spectrum staged synthesis | exactly 1; 2 only when two independent findings can't be merged; never >2 |
| \`FITTING_INTERPRETATION_INSTRUCTIONS\` | legacy single-spectrum (human_feedback refinement and non-staged flows) | same |
| \`UnifiedCurveSynthesisController.SERIES_STAGE3\` | series synthesis | at most 2 — dominant trend (1) + at most one independent secondary finding (e.g. flagged-spectrum anomaly); 1 is the right answer when the series tells a single story |

The phrasing explicitly bars padding with restatements of the same finding.

## Why this matters

Reports with 5+ claims are noisier to read and downstream literature search burns API calls on near-duplicate queries. Single fitted spectra usually surface one headline finding; a series usually surfaces one trend plus, occasionally, one anomaly. Capping the count reflects that.

---

<details>
<summary><strong>Technical details (for AI reviewers)</strong></summary>

### Files modified

- \`scilink/agents/exp_agents/instruct.py\`:
  - \`FITTING_INTERPRETATION_STAGE3\` (around line 2407): appended count rule after the closing \`\`\`\`\`\` of the JSON schema.
  - \`FITTING_INTERPRETATION_INSTRUCTIONS\` (around line 2435): same.
- \`scilink/agents/exp_agents/controllers/curve_fitting_controllers.py\`:
  - \`UnifiedCurveSynthesisController.SERIES_STAGE3\` (around line 5015): same.

### Why phrasing rather than a hard validator

A post-validation step that truncates the claims list would silently drop content the model thought was worth emitting and would give the user no signal of the over-emission. Putting the rule in the prompt — "exactly 1; 2 only when two genuinely independent findings cannot be merged" — gives the model the chance to merge before emitting and surfaces the constraint in plain English.

### Memory-saved feedback this aligns with

\`feedback_prompt_specificity\` (state principles, not example phrases) — the cap is encoded as one short principled sentence per prompt rather than as a list of phrasings to avoid, matching the project's prompt-patch convention.

### Not changed

- Per-claim schema (\`claim\`, \`scientific_impact\`, \`has_anyone_question\`, \`keywords\`) untouched.
- Identification-mode addendum (\`ID_MODE_OUTPUT_ADDENDUM\`) and its "consistent with X, Y, or Z" phrasing rule for claims untouched.
- No agent class or controller logic changes — prompts only.

### Verification (forthcoming)

User asked for live-tests on both single and series. Will run a single-spectrum test (e.g. one of the existing xrd_profile sharp-Si runs) plus a new series test (Si patterns with varying FWHM simulating grain growth) against Claude Opus 4.6 and report \`len(scientific_claims)\` from the analysis_results JSON. Pre-cap runs from PR #202 emitted 3-5 claims on single Si patterns; post-cap should land 1.

</details>
