### PR TITLE
Auto-discover LLM credentials via litellm.validate_environment + SCILINK_API_KEY fallback

### DIFF
--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -40,6 +40,11 @@ from .preprocess import CurvePreprocessingAgent
 from .pipelines.curve_fitting_pipelines import create_unified_curve_fitting_pipeline
 from ...skills._shared.curve_fitting_tools import load_curve_data, plot_curve_to_bytes
 from ._deprecation import normalize_params
+import litellm
+from ...auth import (
+    get_internal_proxy_key,
+    APIKeyNotFoundError,
+)
 from ...skills.loader import load_skill
 
 from .instruct import (
@@ -200,6 +205,16 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         self.api_key, self.base_url = normalize_params(
             api_key, google_api_key, base_url, local_model, source="CurveFittingAgent"
         )
+
+        # Auto-discover API keys: delegate model→provider→env-var resolution to LiteLLM
+        # (validate_environment tells us which env vars LiteLLM expects for this model).
+        # If those aren't set, fall back to the internal-proxy key (SCILINK_API_KEY).
+        if self.api_key is None and self.base_url is None:
+            env = litellm.validate_environment(model_name)
+            if not env["keys_in_environment"]:
+                self.api_key = get_internal_proxy_key()
+                if not self.api_key:
+                    raise APIKeyNotFoundError(", ".join(env["missing_keys"]) or "unknown")
 
         super().__init__(
             api_key=self.api_key,

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -26,6 +26,11 @@ from ...executors import require_sandbox_approval
 from ...skills.loader import load_skill
 
 from ._deprecation import normalize_params
+import litellm
+from ...auth import (
+    get_internal_proxy_key,
+    APIKeyNotFoundError,
+)
 
 
 class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
@@ -88,6 +93,16 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             api_key, google_api_key, base_url, local_model,
             source="HyperspectralAnalysisAgent"
         )
+
+        # Auto-discover API keys: delegate model→provider→env-var resolution to LiteLLM
+        # (validate_environment tells us which env vars LiteLLM expects for this model).
+        # If those aren't set, fall back to the internal-proxy key (SCILINK_API_KEY).
+        if self.api_key is None and self.base_url is None:
+            env = litellm.validate_environment(model_name)
+            if not env["keys_in_environment"]:
+                self.api_key = get_internal_proxy_key()
+                if not self.api_key:
+                    raise APIKeyNotFoundError(", ".join(env["missing_keys"]) or "unknown")
         
         super().__init__(
             api_key=self.api_key,

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -44,6 +44,11 @@ from ...skills._shared.image_analysis_tools import (
     create_image_montage,
 )
 from ._deprecation import normalize_params
+import litellm
+from ...auth import (
+    get_internal_proxy_key,
+    APIKeyNotFoundError,
+)
 from ...skills.loader import load_skill
 
 from .instruct import (
@@ -172,6 +177,16 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         self.api_key, self.base_url = normalize_params(
             api_key, google_api_key, base_url, local_model, source="ImageAnalysisAgent"
         )
+
+        # Auto-discover API keys: delegate model→provider→env-var resolution to LiteLLM
+        # (validate_environment tells us which env vars LiteLLM expects for this model).
+        # If those aren't set, fall back to the internal-proxy key (SCILINK_API_KEY).
+        if self.api_key is None and self.base_url is None:
+            env = litellm.validate_environment(model_name)
+            if not env["keys_in_environment"]:
+                self.api_key = get_internal_proxy_key()
+                if not self.api_key:
+                    raise APIKeyNotFoundError(", ".join(env["missing_keys"]) or "unknown")
 
         super().__init__(
             api_key=self.api_key,

--- a/scilink/agents/planning_agents/bo_agent.py
+++ b/scilink/agents/planning_agents/bo_agent.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from typing import Dict, Any, List, Optional, Tuple
 import PIL.Image as PIL_Image
 
-from ...auth import get_internal_proxy_key
+import litellm
+from ...auth import (
+    get_internal_proxy_key,
+    APIKeyNotFoundError,
+)
 from scilink.knowledge import parse_json_from_response
 from .bo_tools import get_optimizer
 from .instruct import (
@@ -205,6 +209,16 @@ class BOAgent(BaseAgent):
             )
         else:
             # PUBLIC LITELLM
+            # Auto-discover API key: delegate model→provider→env-var resolution to LiteLLM
+            # (validate_environment tells us which env vars LiteLLM expects for this model).
+            # If those aren't set, fall back to the internal-proxy key (SCILINK_API_KEY).
+            if api_key is None:
+                env = litellm.validate_environment(model_name)
+                if not env["keys_in_environment"]:
+                    api_key = get_internal_proxy_key()
+                    if not api_key:
+                        raise APIKeyNotFoundError(", ".join(env["missing_keys"]) or "unknown")
+
             logging.info(f"🌐 BOAgent using LiteLLM: {model_name}")
             self.model = LiteLLMGenerativeModel(
                 model=model_name,

--- a/scilink/agents/sim_agents/structure_orchestrator.py
+++ b/scilink/agents/sim_agents/structure_orchestrator.py
@@ -7,10 +7,10 @@ from io import StringIO
 from typing import Optional, Dict, Any
 from pathlib import Path
 
+import litellm
 from ...auth import (
     get_api_key,
     get_internal_proxy_key,
-    infer_provider,
     APIKeyNotFoundError,
 )
 from .structure_agent import StructureGenerator
@@ -63,15 +63,15 @@ class StructureOrchestrator:
             max_refinement_cycles: Maximum validator-guided correction cycles.
             script_timeout: Timeout (seconds) for executing generated ASE scripts.
         """
-        # Auto-discover API keys: infer provider from the generator model
-        # (LiteLLM routes by model prefix, so the key must match the model's
-        # provider). Fall back to the internal-proxy key (SCILINK_API_KEY) when
-        # no provider-specific key is set.
+        # Auto-discover API keys: delegate model→provider→env-var resolution to LiteLLM
+        # (validate_environment tells us which env vars LiteLLM expects for this model).
+        # If those aren't set, fall back to the internal-proxy key (SCILINK_API_KEY).
         if api_key is None and base_url is None:
-            provider = infer_provider(generator_model) or 'google'
-            api_key = get_api_key(provider) or get_internal_proxy_key()
-            if not api_key:
-                raise APIKeyNotFoundError(provider)
+            env = litellm.validate_environment(generator_model)
+            if not env["keys_in_environment"]:
+                api_key = get_internal_proxy_key()
+                if not api_key:
+                    raise APIKeyNotFoundError(", ".join(env["missing_keys"]) or "unknown")
 
         if mp_api_key is None:
             mp_api_key = get_api_key('materials_project')


### PR DESCRIPTION
## Summary

Same gap as `DFTOrchestrator`'s commit `73059f74`, but for the experiment
agents (`ImageAnalysisAgent`, `CurveFittingAgent`, `HyperspectralAnalysisAgent`)
and `BOAgent`'s public-LiteLLM path. Also folds in the same simplification for
`StructureOrchestrator` (which now owns DFT's auto-discovery after the
structure-step refactor), so all of scilink's auth auto-discovery uses one
pattern.

This iteration takes your PR-review point about model-name heuristics
seriously: instead of `infer_provider`'s hardcoded `'claude'/'gpt-'/'gemini'`
substrings (which would have to be chased every time a provider renames a
model), **we delegate model→provider→env-var resolution to LiteLLM itself**
via `litellm.validate_environment(model_name)`. If LiteLLM reports the
expected env vars are missing, we fall back to `SCILINK_API_KEY`. As LiteLLM
grows support for new providers or Anthropic renames their models, scilink
automatically benefits — no change here required.

Tested in both directions:
- `ANTHROPIC_API_KEY` unset + `SCILINK_API_KEY` set → all 4 agents +
  `StructureOrchestrator` resolve to `SCILINK_API_KEY`.
- `ANTHROPIC_API_KEY` set → agents leave `api_key=None`, LiteLLM does its
  own lookup.
- Bedrock works correctly when `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
  are in env.

---

## Detail

### The gap (recap)

`DFTOrchestrator` / `StructureOrchestrator` got model-aware auto-discovery in
commit `73059f74`: infer provider from the model name → look up the matching
env var → fall back to `SCILINK_API_KEY`. The four other agents (Image,
Curve, Hyperspectral, `BOAgent`'s public-LiteLLM path) had **no auto-discovery
at all** on their public path, so any caller relying on `SCILINK_API_KEY`
alone failed.

### The fix

```python
import litellm

# in each agent's __init__, right after normalize_params and before super().__init__:
if api_key is None and base_url is None:
    env = litellm.validate_environment(model_name)
    if not env["keys_in_environment"]:
        api_key = get_internal_proxy_key()
        if not api_key:
            raise APIKeyNotFoundError(", ".join(env["missing_keys"]) or "unknown")
```

Applied to:

- `ImageAnalysisAgent.__init__`
- `CurveFittingAgent.__init__`
- `HyperspectralAnalysisAgent.__init__`
- `BOAgent.__init__` (inside the `else: # PUBLIC LITELLM` branch, using local `api_key` instead of `self.api_key`)
- `StructureOrchestrator.__init__` (was using `infer_provider(generator_model) or 'google'`; same `validate_environment` pattern, so all of scilink's auth auto-discovery is consistent)

### Why `litellm.validate_environment`

`litellm.validate_environment(model)` returns the env vars LiteLLM itself
expects for a given model, so we always match LiteLLM's own resolution.
Examples:

```
claude-opus-4-6                        -> {"keys_in_environment": false, "missing_keys": ["ANTHROPIC_API_KEY"]}
gpt-4o                                 -> {"keys_in_environment": false, "missing_keys": ["OPENAI_API_KEY"]}
gemini-2.0-flash                       -> {"keys_in_environment": false, "missing_keys": ["VERTEXAI_PROJECT","VERTEXAI_LOCATION"]}
mistral/mistral-large                  -> {"keys_in_environment": false, "missing_keys": ["MISTRAL_API_KEY"]}
bedrock/anthropic.claude-3-5-sonnet    -> {"keys_in_environment": false, "missing_keys": ["AWS_ACCESS_KEY_ID","AWS_SECRET_ACCESS_KEY"]}
```

For **Bedrock**: when AWS creds are set, `validate_environment` reports
`keys_in_environment: true` and we leave `api_key=None` so LiteLLM does its
own AWS SigV4 signing (works correctly). When AWS creds are missing, the
error names `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` instead of an
unrelated `'anthropic'`.

### Verification

```
SCILINK_API_KEY only (no ANTHROPIC_API_KEY):
  ImageAnalysisAgent          api_key = 'test-key-XYZ'   ✓
  CurveFittingAgent           api_key = 'test-key-XYZ'   ✓
  HyperspectralAnalysisAgent  api_key = 'test-key-XYZ'   ✓
  BOAgent (LiteLLM)           model.api_key = 'test-key-XYZ'   ✓
  StructureOrchestrator       api_key = 'test-key-XYZ'   ✓

ANTHROPIC_API_KEY set:
  agents leave api_key=None  -> LiteLLM handles env-var lookup itself
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
