### PR TITLE
Make tool-iteration cap configurable; surface exhaustion as run_task error

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -499,6 +499,7 @@ class AnalysisOrchestratorAgent:
         analysis_mode: AnalysisMode = AnalysisMode.CO_PILOT,
         futurehouse_api_key: Optional[str] = None,
         image_analysis_depth: str = "basic",
+        max_iterations: Optional[int] = None,
         # Deprecated
         google_api_key: Optional[str] = None,
         local_model: Optional[str] = None,
@@ -608,7 +609,17 @@ class AnalysisOrchestratorAgent:
         
         self.message_count = 0
         self.last_checkpoint_message_count = 0
-        
+
+        # Per-call tool-iteration cap (handlers read self.max_iterations) and
+        # a flag they set when they hit the cap. chat() returns the warning
+        # string as before; run_task reads the flag to flip status from
+        # success → error so programmatic callers can detect exhaustion.
+        self.max_iterations = (
+            max_iterations if max_iterations is not None
+            else self.MAX_TOOL_ITERATIONS
+        )
+        self._last_chat_hit_iter_cap = False
+
         # Restore from checkpoint if requested
         if restore_checkpoint and self.checkpoint_path.exists():
             self._restore_checkpoint()
@@ -1260,7 +1271,8 @@ class AnalysisOrchestratorAgent:
     def chat(self, user_input: str) -> str:
         """Main chat interface with robust function calling support."""
         self.message_count += 1
-        
+        self._last_chat_hit_iter_cap = False
+
         # AUTO-CHECKPOINT: Every N messages
         if self.message_count - self.last_checkpoint_message_count >= self.CHECKPOINT_INTERVAL:
             print(f"  💾 Auto-checkpoint triggered (every {self.CHECKPOINT_INTERVAL} messages)...")
@@ -1291,7 +1303,8 @@ class AnalysisOrchestratorAgent:
             return f"❌ Error: {e}\n\n(Emergency checkpoint saved to {self.checkpoint_path})"
 
     def run_task(self, task: str, context: Optional[Dict[str, Any]] = None,
-                 autonomy: Optional[AnalysisMode] = None) -> Dict[str, Any]:
+                 autonomy: Optional[AnalysisMode] = None,
+                 max_iterations: Optional[int] = None) -> Dict[str, Any]:
         """Non-interactive entry point — used by the meta agent.
 
         Runs the task and returns a structured summary that's easy to
@@ -1343,12 +1356,24 @@ class AnalysisOrchestratorAgent:
         # human-feedback prompts to the user driving the session.
         run_mode = autonomy if autonomy is not None else AnalysisMode.AUTONOMOUS
         original_mode = self.analysis_mode
+        original_max_iter = self.max_iterations
         try:
             self.set_analysis_mode(run_mode)
+            if max_iterations is not None:
+                self.max_iterations = max_iterations
             try:
                 summary_text = self.chat(prompt)
-                status = "success"
-                error_msg: Optional[str] = None
+                # chat() handles the iteration-cap case internally and returns
+                # the warning string (preserving CLI/UI behavior); a flag on
+                # self tells us whether that happened so we can surface it as
+                # an error to programmatic callers instead of silently
+                # reporting success.
+                if self._last_chat_hit_iter_cap:
+                    status = "error"
+                    error_msg: Optional[str] = summary_text
+                else:
+                    status = "success"
+                    error_msg = None
             except Exception as e:
                 self.logger.exception(f"run_task failed: {e}")
                 summary_text = ""
@@ -1357,6 +1382,7 @@ class AnalysisOrchestratorAgent:
         finally:
             # Always restore the original mode, even if chat() raised.
             self.set_analysis_mode(original_mode)
+            self.max_iterations = original_max_iter
 
         # Derive the structured summary from the session-state delta.
         new_analyses = self.analysis_results[n_before:]
@@ -1476,7 +1502,7 @@ class AnalysisOrchestratorAgent:
         
         iteration = 0
         
-        while iteration < self.MAX_TOOL_ITERATIONS:
+        while iteration < self.max_iterations:
             iteration += 1
             
             print(f"  ⏳ Waiting for orchestrator response ...")
@@ -1544,6 +1570,7 @@ class AnalysisOrchestratorAgent:
                     "content": result
                 })
         
+        self._last_chat_hit_iter_cap = True
         return "⚠️ Maximum tool iterations reached. Please simplify your request."
 
     def _handle_litellm_chat(self, user_input: str) -> str:
@@ -1560,7 +1587,7 @@ class AnalysisOrchestratorAgent:
         
         iteration = 0
         
-        while iteration < self.MAX_TOOL_ITERATIONS:
+        while iteration < self.max_iterations:
             iteration += 1
             
             print(f"  ⏳ Waiting for orchestrator response ...")
@@ -1637,6 +1664,7 @@ class AnalysisOrchestratorAgent:
                     "content": result
                 })
         
+        self._last_chat_hit_iter_cap = True
         return "⚠️ Maximum tool iterations reached. Please simplify your request."
 
     def _load_history(self) -> List[Dict]:

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -310,6 +310,7 @@ class MetaOrchestratorAgent:
         futurehouse_api_key: Optional[str] = None,
         restore_checkpoint: bool = False,
         meta_mode: MetaMode = MetaMode.AUTOPILOT,
+        max_iterations: Optional[int] = None,
     ):
         self.logger = logging.getLogger(self.__class__.__name__)
 
@@ -379,6 +380,14 @@ class MetaOrchestratorAgent:
 
         self.message_count = 0
         self.last_checkpoint_message_count = 0
+
+        # Per-call tool-iteration cap. Mirrors the child orchestrators so a
+        # meta caller can raise it for long-running multi-delegation turns.
+        self.max_iterations = (
+            max_iterations if max_iterations is not None
+            else self.MAX_TOOL_ITERATIONS
+        )
+        self._last_chat_hit_iter_cap = False
 
         if restore_checkpoint and self.checkpoint_path.exists():
             self._restore_checkpoint()
@@ -1091,6 +1100,7 @@ class MetaOrchestratorAgent:
     def chat(self, user_input: str) -> str:
         """Main chat interface with robust function calling support."""
         self.message_count += 1
+        self._last_chat_hit_iter_cap = False
 
         # First-turn: fill the system prompt's specialist-capability inventory
         # from the children's live tool registries (idempotent thereafter).
@@ -1145,7 +1155,7 @@ class MetaOrchestratorAgent:
             self.messages = [system_msg] + recent_msgs
 
         iteration = 0
-        while iteration < self.MAX_TOOL_ITERATIONS:
+        while iteration < self.max_iterations:
             iteration += 1
             print(f"  ⏳ Waiting for meta-orchestrator response ...")
 
@@ -1213,6 +1223,7 @@ class MetaOrchestratorAgent:
                     "content": result,
                 })
 
+        self._last_chat_hit_iter_cap = True
         return "⚠️ Maximum tool iterations reached. Please simplify your request."
 
     def _handle_litellm_chat(self, user_input: str) -> str:
@@ -1228,7 +1239,7 @@ class MetaOrchestratorAgent:
             self.messages = [system_msg] + recent_msgs
 
         iteration = 0
-        while iteration < self.MAX_TOOL_ITERATIONS:
+        while iteration < self.max_iterations:
             iteration += 1
             print(f"  ⏳ Waiting for meta-orchestrator response ...")
 
@@ -1301,4 +1312,5 @@ class MetaOrchestratorAgent:
                     "content": result,
                 })
 
+        self._last_chat_hit_iter_cap = True
         return "⚠️ Maximum tool iterations reached. Please simplify your request."

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -576,6 +576,7 @@ class PlanningOrchestratorAgent:
         data_dir: Optional[str] = None,
         knowledge_dir: Optional[str] = None,
         code_dir: Optional[str] = None,
+        max_iterations: int = 20,
         # Deprecated
         google_api_key: Optional[str] = None,
         local_model: Optional[str] = None,
@@ -669,6 +670,13 @@ class PlanningOrchestratorAgent:
         # writes land in base_dir exactly as before.
         self._delegation_counter = 0
         self._active_output_subdir = None
+
+        # Per-call tool-iteration cap (handlers read self.max_iterations) and
+        # a flag the handlers raise when they hit the cap. chat() returns the
+        # warning string as before; run_task reads the flag to flip the
+        # delegation result's status from success → error.
+        self.max_iterations = max_iterations
+        self._last_chat_hit_iter_cap = False
 
         # Custom tools / MCP state
         self._tool_data_cache: Dict[tuple, Any] = {}
@@ -1191,6 +1199,7 @@ class PlanningOrchestratorAgent:
     def chat(self, user_input: str) -> str:
         """Main chat interface with robust function calling support."""
         self.message_count += 1
+        self._last_chat_hit_iter_cap = False
         
         # AUTO-CHECKPOINT: Every 10 messages
         if self.message_count - self.last_checkpoint_message_count >= 10:
@@ -1223,7 +1232,8 @@ class PlanningOrchestratorAgent:
             return f"❌ Error: {e}\n\n(Emergency checkpoint saved to {self.checkpoint_path})"
 
     def run_task(self, task: str, context: Optional[Dict[str, Any]] = None,
-                 autonomy: Optional[AutonomyLevel] = None) -> Dict[str, Any]:
+                 autonomy: Optional[AutonomyLevel] = None,
+                 max_iterations: Optional[int] = None) -> Dict[str, Any]:
         """Non-interactive entry point — used by the meta agent.
 
         Runs the task and returns a structured summary that's easy to
@@ -1304,12 +1314,24 @@ class PlanningOrchestratorAgent:
         # human-feedback prompts to the user driving the session.
         run_level = autonomy if autonomy is not None else AutonomyLevel.AUTONOMOUS
         original_level = self.autonomy_level
+        original_max_iter = self.max_iterations
         try:
             self.set_autonomy_level(run_level)
+            if max_iterations is not None:
+                self.max_iterations = max_iterations
             try:
                 summary_text = self.chat(prompt)
-                status = "success"
-                error_msg: Optional[str] = None
+                # chat() handles the iteration-cap case internally and returns
+                # the warning string (preserving CLI/UI behavior); a flag on
+                # self tells us whether that happened so we can surface it as
+                # an error to programmatic callers instead of silently
+                # reporting success.
+                if self._last_chat_hit_iter_cap:
+                    status = "error"
+                    error_msg: Optional[str] = summary_text
+                else:
+                    status = "success"
+                    error_msg = None
             except Exception as e:
                 logging.exception(f"run_task failed: {e}")
                 summary_text = ""
@@ -1318,6 +1340,7 @@ class PlanningOrchestratorAgent:
         finally:
             # Always restore the original level, even if chat() raised.
             self.set_autonomy_level(original_level)
+            self.max_iterations = original_max_iter
             # _active_output_subdir is scoped to this call; clear it so a
             # later direct chat() on the same instance writes to base_dir.
             self._active_output_subdir = None
@@ -1454,7 +1477,7 @@ class PlanningOrchestratorAgent:
 
         self._compress_large_tool_results()
 
-        max_iterations = 20
+        max_iterations = self.max_iterations
         iteration = 0
 
         while iteration < max_iterations:
@@ -1472,16 +1495,16 @@ class PlanningOrchestratorAgent:
                 tools=self.tools_for_model,
                 tool_choice="auto"
             )
-            
+
             message = response.choices[0].message
-            
+
             if not message.tool_calls:
                 self.messages.append({
                     "role": "assistant",
                     "content": message.content
                 })
                 return message.content
-            
+
             self.messages.append({
                 "role": "assistant",
                 "content": message.content,
@@ -1496,21 +1519,22 @@ class PlanningOrchestratorAgent:
                     } for tc in message.tool_calls
                 ]
             })
-            
+
             for tool_call in message.tool_calls:
                 func_name = tool_call.function.name
                 args = json.loads(tool_call.function.arguments)
-                
+
                 print(f"  🔧 Calling tool: {func_name}")
-                
+
                 result = self.tools.execute_tool(func_name, **args)
-                
+
                 self.messages.append({
                     "role": "tool",
                     "tool_call_id": tool_call.id,
                     "content": result
                 })
-        
+
+        self._last_chat_hit_iter_cap = True
         return "⚠️ Maximum tool iterations reached. Please simplify your request."
 
     def _handle_litellm_chat(self, user_input: str) -> str:
@@ -1527,7 +1551,7 @@ class PlanningOrchestratorAgent:
 
         self._compress_large_tool_results()
 
-        max_iterations = 20
+        max_iterations = self.max_iterations
         iteration = 0
 
         while iteration < max_iterations:
@@ -1594,7 +1618,8 @@ class PlanningOrchestratorAgent:
                     "tool_call_id": tool_call.id,
                     "content": result
                 })
-        
+
+        self._last_chat_hit_iter_cap = True
         return "⚠️ Maximum tool iterations reached. Please simplify your request."
 
     def _extract_response_text(self, response) -> str:

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -262,6 +262,7 @@ class SimulationOrchestratorAgent:
         futurehouse_api_key: Optional[str] = None,
         hpc_connection=None,
         hpc_scheduler=None,
+        max_iterations: Optional[int] = None,
         # Deprecated
         google_api_key: Optional[str] = None,
         local_model: Optional[str] = None,
@@ -342,6 +343,16 @@ class SimulationOrchestratorAgent:
         self.message_count = 0
         self.last_checkpoint_message_count = 0
 
+        # Per-call tool-iteration cap (handlers read self.max_iterations) and
+        # a flag they set when they hit the cap. chat() returns the warning
+        # string as before; run_task reads the flag to flip status from
+        # success → error so programmatic callers can detect exhaustion.
+        self.max_iterations = (
+            max_iterations if max_iterations is not None
+            else self.MAX_TOOL_ITERATIONS
+        )
+        self._last_chat_hit_iter_cap = False
+
         # Restore from checkpoint if requested
         if restore_checkpoint and self.checkpoint_path.exists():
             self._restore_checkpoint()
@@ -401,6 +412,7 @@ class SimulationOrchestratorAgent:
 
     def chat(self, user_input: str) -> str:
         """Interactive chat — used by the CLI and UI."""
+        self._last_chat_hit_iter_cap = False
         if self.use_openai:
             response = self._handle_openai_chat(user_input)
         else:
@@ -411,7 +423,8 @@ class SimulationOrchestratorAgent:
         return response
 
     def run_task(self, task: str, context: Optional[Dict[str, Any]] = None,
-                 autonomy: Optional[SimulationMode] = None) -> Dict[str, Any]:
+                 autonomy: Optional[SimulationMode] = None,
+                 max_iterations: Optional[int] = None) -> Dict[str, Any]:
         """Non-interactive entry point — used by the meta agent.
 
         Runs the task and returns a structured summary that's easy to
@@ -461,12 +474,24 @@ class SimulationOrchestratorAgent:
         # human-feedback prompts to the user driving the session.
         run_mode = autonomy if autonomy is not None else SimulationMode.AUTONOMOUS
         original_mode = self.simulation_mode
+        original_max_iter = self.max_iterations
         try:
             self.set_simulation_mode(run_mode)
+            if max_iterations is not None:
+                self.max_iterations = max_iterations
             try:
                 summary_text = self.chat(prompt)
-                status = "success"
-                error_msg: Optional[str] = None
+                # chat() handles the iteration-cap case internally and returns
+                # the warning string (preserving CLI/UI behavior); a flag on
+                # self tells us whether that happened so we can surface it as
+                # an error to programmatic callers instead of silently
+                # reporting success.
+                if self._last_chat_hit_iter_cap:
+                    status = "error"
+                    error_msg: Optional[str] = summary_text
+                else:
+                    status = "success"
+                    error_msg = None
             except Exception as e:
                 self.logger.exception(f"run_task failed: {e}")
                 summary_text = ""
@@ -475,6 +500,7 @@ class SimulationOrchestratorAgent:
         finally:
             # Always restore the original mode, even if chat() raised.
             self.set_simulation_mode(original_mode)
+            self.max_iterations = original_max_iter
 
         # Derive the structured summary from session state.
         new_structures = (self.generated_structures or [])[n_before:]
@@ -718,7 +744,7 @@ class SimulationOrchestratorAgent:
             self.messages = [system_msg] + recent_msgs
 
         iteration = 0
-        while iteration < self.MAX_TOOL_ITERATIONS:
+        while iteration < self.max_iterations:
             iteration += 1
             print(f"  ⏳ Waiting for orchestrator response ...")
 
@@ -781,6 +807,7 @@ class SimulationOrchestratorAgent:
                     "content": result,
                 })
 
+        self._last_chat_hit_iter_cap = True
         return "⚠️ Maximum tool iterations reached. Please simplify your request."
 
     def _handle_litellm_chat(self, user_input: str) -> str:
@@ -796,7 +823,7 @@ class SimulationOrchestratorAgent:
             self.messages = [system_msg] + recent_msgs
 
         iteration = 0
-        while iteration < self.MAX_TOOL_ITERATIONS:
+        while iteration < self.max_iterations:
             iteration += 1
             print(f"  ⏳ Waiting for orchestrator response ...")
 
@@ -867,6 +894,7 @@ class SimulationOrchestratorAgent:
                     "content": result,
                 })
 
+        self._last_chat_hit_iter_cap = True
         return "⚠️ Maximum tool iterations reached. Please simplify your request."
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Every SciLink orchestrator (analyze, plan, simulate, meta) caps its
chat-tool loop at 20 iterations. Two real consequences for programmatic
use:

1. **The cap was hardcoded** — no way to raise it for long-running
   campaigns when calling `run_task` from Python or the meta agent.
2. **Exhaustion silently looked like success.** When the cap was hit,
   the chat loop returned the warning string `⚠️ Maximum tool
   iterations reached. Please simplify your request.`, but `run_task`
   only flipped `status` to `"error"` if `chat()` *raised* — so the
   warning rode along inside `result["summary"]` while `result["status"]`
   stayed `"success"`. The meta agent's delegation ledger then recorded
   the run as successful and could chain further work off output that
   was never produced.

CLI/UI sessions don't see this because each interactive turn gets its
own fresh 20-iteration budget and the user naturally breaks a campaign
across many turns. `run_task` packs the whole goal into one turn under
AUTONOMOUS autonomy with no approval pauses, so it actually hits the
cap on non-trivial work (e.g. the produced-water tutorial: four KB
query rounds + plan generation in one shot).

This PR makes the cap configurable per-instance and per-call, and makes
exhaustion an explicit error in the programmatic surface — without
changing what CLI/UI users see.

### What changed for users

- New `max_iterations` kwarg on all four orchestrator constructors
  (default = previous 20, so existing code is untouched).
- New `max_iterations` kwarg on `run_task` (`PlanningOrchestratorAgent`,
  `AnalysisOrchestratorAgent`, `SimulationOrchestratorAgent`) — overrides
  the instance cap for a single call, then restores it.
- `run_task` now returns `status="error"` with the warning in `error`
  when the cap is hit (instead of `status="success"`).
- `chat()` returns the same warning string as before; no exception is
  raised. CLI / UI behavior is byte-identical.

### What this means for the meta agent

`MetaOrchestrator._close_delegation` already has an `error` field and
already routes the child's `status` straight through to the meta LLM.
Today an exhausted delegation gets reported as `success`; after this
change it correctly surfaces as `error`. No code change in meta beyond
its own constructor + handlers gaining the same `max_iterations`
kwarg.

### Verified live

`claude-opus-4-6` against `SimulationOrchestratorAgent`:

- Default `self.max_iterations == 20` (no API call).
- `max_iterations=1` + a tool-requiring task → `run_task` returns
  `status="error"`, warning string in `error`, `_last_chat_hit_iter_cap`
  flag set.
- Per-call `run_task(max_iterations=15)` on the same low-cap instance
  → `status="success"`; instance cap (1) restored after the call.
- `chat()` on an exhausted cap returns the warning string as a normal
  `str` (no exception), preserving CLI/UI contract.

Existing `tests/test_simulation_orchestrator.py::test_5_run_task_without_llm`
still passes. The one preexisting failure in `test_1_orchestrator_constructs`
reproduces on `main` unchanged (EXPECTED_TOOLS set drift — unrelated).

## Technical details

### Files changed

- `scilink/agents/planning_agents/planning_orchestrator.py`
  - Constructor: added `max_iterations: int = 20` kwarg.
  - Init body (after `_active_output_subdir`): `self.max_iterations = max_iterations`; `self._last_chat_hit_iter_cap = False`.
  - `chat()`: resets the flag at top of each turn.
  - `_handle_openai_chat` (line ~1457) and `_handle_litellm_chat` (line ~1530): `max_iterations = self.max_iterations`; on exhaustion set `self._last_chat_hit_iter_cap = True` *before* returning the warning string.
  - `run_task`: added `max_iterations: Optional[int] = None` kwarg, snapshots `original_max_iter` alongside `original_level`, applies override under the same try/finally, reads `_last_chat_hit_iter_cap` after `chat()` to flip status, restores cap in `finally`.

- `scilink/agents/exp_agents/analysis_orchestrator.py`
  - Same pattern as planning, but constructor default is `Optional[int] = None` falling back to the existing class constant `MAX_TOOL_ITERATIONS = 20` (kept for documentation).
  - Both handlers used `self.MAX_TOOL_ITERATIONS` → now `self.max_iterations`.
  - `run_task` mirrors planning's edits.

- `scilink/agents/sim_agents/simulation_orchestrator.py`
  - Same as analysis (class-constant fallback).

- `scilink/agents/meta_agent/meta_orchestrator.py`
  - Same as analysis (class-constant fallback).
  - No `run_task` method on meta — only constructor + handlers + `chat()` flag reset.

### Design choice: flag vs. exception

A `MaxIterationsReached` exception raised by the handlers (caught by
`chat()` and re-raised through `run_task`) would also work and is
arguably more idiomatic. Rejected because (a) `chat()`'s public contract
returns a string for every termination including the cap, so adding
*any* new raise from inside the loop is a CLI/UI surface change we'd
have to defend; (b) a per-instance flag is local to the orchestrator,
doesn't require defining/duplicating an exception class across four
files (CLAUDE.md "no base class" rule), and is read once at exactly
one site (`run_task` after `chat()` returns).

### Backward compatibility

- All four constructor `max_iterations` defaults preserve the previous
  cap of 20 — existing instantiations get identical behavior.
- `chat()` signature and return type are unchanged. CLI files
  (`cli/plan.py`, `cli/analyze.py`, `cli/simulate.py`, `cli/meta.py`)
  and `ui/app.py` call `agent.chat(...)` only.
- `ui/components/vasp_workflow.py:487` is the one UI surface that calls
  `run_task`; it ignores `result["status"]` and checks
  `agent.generated_structures` side-effects, so the status flip is
  invisible to it.
- Class constants `MAX_TOOL_ITERATIONS` kept in analyze/sim/meta as the
  documented default the constructor falls back to.

### Meta integration

`meta_orchestrator.py:903` already initializes `"error": None` in the
delegation ledger entry; `:911, :918` already write `result["status"]`
and `result["error"]` verbatim; `:935-936` already conditionally
surfaces `error` to the driving LLM. The status-flip lands in code
that's been waiting for it — no additional meta-side change required.