### PR TITLE
Fix Windows crash: bad escape \U in script adapter regex

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1890,6 +1890,9 @@ Your guidance: '''
             return None
 
     def _adapt_script_for_spectrum(self, base_script: str, data_path: str, output_prefix: str) -> str:
+        # Forward slashes so Windows paths like 'C:\Users\...' don't trigger
+        # re.sub's backslash-escape interpretation in the replacement string.
+        data_path = data_path.replace('\\', '/')
         adapted = base_script
         adapted = adapted.replace('fit_visualization.png', f'{output_prefix}_fit.png')
         adapted = re.sub(r'spectrum_\d{4}_fit\.png', f'{output_prefix}_fit.png', adapted)

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -2217,6 +2217,9 @@ Your guidance: '''
 
     def _adapt_script_for_image(self, base_script: str, data_path: str, output_prefix: str) -> str:
         """Adapt a base analysis script for a different image in the series."""
+        # Forward slashes so Windows paths like 'C:\Users\...' don't trigger
+        # re.sub's backslash-escape interpretation in the replacement string.
+        data_path = data_path.replace('\\', '/')
         adapted = base_script
         # Replace visualization output filenames
         adapted = adapted.replace('analysis_visualization.png', f'{output_prefix}_analysis.png')


### PR DESCRIPTION
## Summary

On Windows, the curve-fitting and image-analysis agents crashed during their per-item script adaptation step with:

```
re.error: bad escape \U at position 11
```

The cause is that the user's data path (e.g. `C:\Users\maxim\...`) was being spliced directly into the *replacement* string of `re.sub`. Python's regex engine treats backslash sequences in the replacement as escapes, and `\U` (from `C:\U...`) is invalid.

The fix is one line per affected adapter: normalize `data_path` to forward slashes before any `re.sub` runs. Python on Windows accepts forward-slash paths, so the scripts that the agent then writes out remain runnable on Windows unchanged.

This restores per-spectrum and per-image script adaptation on Windows. Without the fix, the affected refinement / multi-item paths surface a `re.error` and the LLM was producing a misleading diagnosis ("the failed script is 'None'") that obscured the real cause.

---

## Technical details

**Affected sites:**

- `scilink/agents/exp_agents/controllers/curve_fitting_controllers.py:1892` — `_adapt_script_for_spectrum`, four `re.sub` calls at lines 1897–1904 use `f'...{data_path}...'` as replacement.
- `scilink/agents/exp_agents/controllers/image_analysis_controllers.py:2218` — `_adapt_script_for_image`, four `re.sub` calls at lines 2225–2232 with the same shape.

**Failure mode:** When `data_path` contains any byte sequence that `re.sub` recognizes as a replacement escape — `\U`, `\a`, `\b`, `\f`, `\n`, `\r`, `\t`, `\v`, `\x..`, `\0..`, `\g<...>`, `\<digit>` — `re.sub` raises `re.error`. On POSIX the path uses `/` so no escapes appear; the bug is Windows-only and was not caught by tests since CI runs on Linux.

**Fix shape (mirror-image in both files):**

```python
def _adapt_script_for_spectrum(self, base_script, data_path, output_prefix):
    # Forward slashes so Windows paths like 'C:\Users\...' don't trigger
    # re.sub's backslash-escape interpretation in the replacement string.
    data_path = data_path.replace('\\', '/')
    adapted = base_script
    ...
```

**Why not `re.escape`:** `re.escape` is for patterns, not replacements. The equivalent for replacements would be `data_path.replace('\\', '\\\\')`, which works but leaves doubled backslashes in the generated script. Normalizing to forward slashes is cleaner and keeps the emitted script portable.

**Why not a callable replacement:** Wrapping each replacement in a `lambda m: f'...'` also avoids the escape interpretation, but four lambdas per adapter is heavier than one normalization at the top, and doesn't help downstream consumers that read the generated script.

**Scope:** Only these two adapter functions interpolate `data_path` into a `re.sub` replacement. A grep for `re\.sub.*data_path` across `scilink/` confirms no other sites.

**Not covered by tests yet:** A regression test would need to construct a Windows-style path string and run `_adapt_script_for_spectrum` / `_adapt_script_for_image` against a base script containing a `temp_*` placeholder. Happy to add one if reviewers want it; left out of this PR to keep the diff at the load-bearing minimum.

## Test plan

- [ ] On Windows, run a curve-fitting / image-analysis flow that triggers the per-item script adapter (multi-spectrum or multi-image input) and confirm no `re.error: bad escape` is raised.
- [ ] Inspect a generated script to confirm `data_path` appears with forward slashes and is loadable by `np.load(...)` on Windows.
- [ ] On Linux/macOS, run the existing curve-fitting and image-analysis tests to confirm no regression for POSIX paths.