### PR TITLE
Fix series-fit failure: column orientation + glob.glob fallback

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1905,6 +1905,18 @@ Your guidance: '''
         adapted = re.sub(r'(["\'"]).*?temp_spectrum_\d+\.npy\1', f'"{data_path}"', adapted)
         adapted = re.sub(r'DATA_PATH\s*=\s*["\'"].*?["\'"]', f'DATA_PATH = "{data_path}"', adapted)
         adapted = re.sub(r'data_path\s*=\s*["\'"].*?["\'"]', f'data_path = "{data_path}"', adapted)
+        # Neutralize LLM-introduced `glob.glob('*.npy')` fallbacks: in parallel
+        # fan-out, multiple spectra's temp files coexist briefly, and a glob
+        # for `*.npy` can find a sibling spectrum's file instead of the
+        # adapted one. Constrain each glob to the pinned data_path. The
+        # `[^()]` class refuses to span nested parens so calls like
+        # `glob.glob(os.path.join(d, '*.npy'))` are left intact rather than
+        # being chopped mid-expression.
+        adapted = re.sub(
+            r'glob\.glob\s*\([^()]*\.npy[^()]*\)',
+            f'["{data_path}"]',
+            adapted,
+        )
         return adapted
 
     def _compute_statistics(self, curve_data: np.ndarray) -> dict:

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -2233,6 +2233,18 @@ Your guidance: '''
         adapted = re.sub(r'(["\'"]).*?temp_image_\d+\.npy\1', f'"{data_path}"', adapted)
         adapted = re.sub(r'DATA_PATH\s*=\s*["\'"].*?["\'"]', f'DATA_PATH = "{data_path}"', adapted)
         adapted = re.sub(r'data_path\s*=\s*["\'"].*?["\'"]', f'data_path = "{data_path}"', adapted)
+        # Neutralize LLM-introduced `glob.glob('*.npy')` fallbacks: in parallel
+        # fan-out, multiple images' temp files coexist briefly, and a glob
+        # for `*.npy` can find a sibling image's file instead of the
+        # adapted one. Constrain each glob to the pinned data_path. The
+        # `[^()]` class refuses to span nested parens so calls like
+        # `glob.glob(os.path.join(d, '*.npy'))` are left intact rather than
+        # being chopped mid-expression.
+        adapted = re.sub(
+            r'glob\.glob\s*\([^()]*\.npy[^()]*\)',
+            f'["{data_path}"]',
+            adapted,
+        )
         return adapted
 
     @staticmethod

--- a/scilink/skills/_shared/curve_fitting_tools.py
+++ b/scilink/skills/_shared/curve_fitting_tools.py
@@ -7,18 +7,56 @@ import os
 logger = logging.getLogger(__name__)
 
 
-def load_curve_data(data_path: str) -> np.ndarray:
+def _try_orient_xy(data: np.ndarray) -> np.ndarray:
+    """Return a 2-column curve array with the monotonic (X-like) column first.
+
+    Monotonicity is the strongest portable cue that a column is the
+    independent variable (time, wavelength, energy). When exactly one
+    column is monotonic we use it to disambiguate; when both or neither
+    are, the heuristic is ambiguous and we leave the input untouched so
+    well-formed data is not perturbed. Non-2D inputs and shapes other
+    than (N, 2) pass through unchanged.
+    """
+    if data.ndim != 2 or data.shape[1] != 2:
+        return data
+    col0, col1 = data[:, 0], data[:, 1]
+    if not (np.isfinite(col0).all() and np.isfinite(col1).all()):
+        return data
+
+    def _mono(a: np.ndarray) -> bool:
+        if a.size < 2:
+            return False
+        diffs = np.diff(a)
+        return bool(np.all(diffs > 0) or np.all(diffs < 0))
+
+    if _mono(col1) and not _mono(col0):
+        logger.info(
+            "load_curve_data: swapped columns — col 1 is monotonic but col 0 is not, "
+            "so col 1 is treated as X."
+        )
+        return np.ascontiguousarray(data[:, ::-1])
+    return data
+
+
+def load_curve_data(data_path: str, auto_orient: bool = True) -> np.ndarray:
     """
     Robustly loads curve data (X, Y) from various file formats.
     Handles .npy, .h5/.hdf5/.nxs (NeXus), CSV, TSV, and whitespace separation
     automatically.
+
+    When ``auto_orient`` is True (default), a 2-column result whose first
+    column is non-monotonic but second column is monotonic is reoriented so
+    X comes first — fixing inputs where intensity precedes the independent
+    variable (e.g. CSVs whose header is ``intensity, time``). Pass
+    ``auto_orient=False`` for legacy raw-layout behavior.
     """
     if not os.path.exists(data_path):
         raise FileNotFoundError(f"File not found: {data_path}")
 
     # Native numpy format
     if data_path.endswith('.npy'):
-        return np.load(data_path)
+        data = np.load(data_path)
+        return _try_orient_xy(data) if auto_orient else data
 
     # NeXus / HDF5 — pull the signal and (when present) its axis so we
     # can return (X, Y) pairs for callers that expect a 2D layout.
@@ -27,7 +65,7 @@ def load_curve_data(data_path: str) -> np.ndarray:
         signal, axes = load_hdf5_signal(data_path, return_axes=True)
         if signal.ndim == 1 and axes and axes[0] is not None and axes[0].size == signal.size:
             return np.column_stack([axes[0], signal])
-        return signal
+        return _try_orient_xy(signal) if auto_orient else signal
 
     attempts = [
         dict(),                                # whitespace-delimited, no header
@@ -40,7 +78,7 @@ def load_curve_data(data_path: str) -> np.ndarray:
         try:
             data = np.loadtxt(data_path, **kw)
             if data.size > 0:
-                return data
+                return _try_orient_xy(data) if auto_orient else data
         except Exception:
             pass
 

--- a/tests/test_curve_fitting_orient_and_adapt.py
+++ b/tests/test_curve_fitting_orient_and_adapt.py
@@ -1,0 +1,151 @@
+"""Tests for the curve-fitting series robustness fixes.
+
+Covers two narrow surfaces both motivated by a real failing run:
+
+  * ``_try_orient_xy`` — column-orientation heuristic for CSV-loaded curves.
+    The bug: a TRPL CSV had columns in ``(intensity, time)`` order and the
+    generated fit script used positional ``col 0 = x`` and got R² = 0.
+
+  * ``_adapt_script_for_spectrum`` — per-spectrum script adapter. The bug:
+    LLM-evolved scripts use ``glob.glob('*.npy')`` as a fallback loader,
+    which in parallel fan-out can find a sibling spectrum's temp file.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import numpy as np
+import pytest
+
+
+# Load the shared curve-fitting helpers without going through the package
+# ``__init__`` (which imports torch et al — overkill for a unit test).
+_spec = importlib.util.spec_from_file_location(
+    "_curve_fitting_tools_under_test",
+    "scilink/skills/_shared/curve_fitting_tools.py",
+)
+_cft = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_cft)
+_try_orient_xy = _cft._try_orient_xy
+
+
+class TestTryOrientXY:
+    def test_swaps_when_only_col1_is_monotonic(self):
+        # (intensity, time) — col 0 non-mono, col 1 mono. Should swap.
+        intensity = np.array([0.1, 0.5, 0.3, 0.2, 0.4])
+        time = np.linspace(0.0, 1.0, 5)
+        data = np.column_stack([intensity, time])
+
+        out = _try_orient_xy(data)
+        assert np.allclose(out[:, 0], time)
+        assert np.allclose(out[:, 1], intensity)
+
+    def test_passthrough_when_already_oriented(self):
+        # (time, intensity) — col 0 mono, col 1 non-mono. Must not swap.
+        time = np.linspace(0.0, 1.0, 5)
+        intensity = np.array([0.1, 0.5, 0.3, 0.2, 0.4])
+        data = np.column_stack([time, intensity])
+
+        out = _try_orient_xy(data)
+        assert np.array_equal(out, data)
+
+    def test_passthrough_when_both_monotonic(self):
+        # Ambiguous (both mono increasing) — leave as-is.
+        data = np.column_stack([np.arange(5.0), np.arange(5.0) * 2])
+        out = _try_orient_xy(data)
+        assert np.array_equal(out, data)
+
+    def test_passthrough_when_neither_monotonic(self):
+        # Ambiguous (neither mono) — leave as-is.
+        data = np.column_stack(
+            [np.array([1.0, 0.5, 0.3]), np.array([0.2, 0.4, 0.1])]
+        )
+        out = _try_orient_xy(data)
+        assert np.array_equal(out, data)
+
+    def test_recognizes_decreasing_monotonic_as_x(self):
+        # Time axes can be reversed (e.g. delay scans). Still an X-column.
+        y = np.array([0.1, 0.5, 0.3])
+        x = np.array([1.0, 0.5, 0.0])
+        data = np.column_stack([y, x])
+        out = _try_orient_xy(data)
+        assert np.allclose(out[:, 0], x)
+
+    def test_passthrough_for_1d_input(self):
+        data = np.arange(10.0)
+        assert _try_orient_xy(data) is data
+
+    def test_passthrough_when_data_has_nan(self):
+        # NaN/inf disables the heuristic — diff() would be misleading.
+        intensity = np.array([0.1, 0.5, 0.3, 0.2, 0.4])
+        time = np.linspace(0.0, 1.0, 5)
+        data = np.column_stack([intensity, time])
+        data[0, 1] = np.nan
+        assert _try_orient_xy(data) is data
+
+    def test_passthrough_for_two_row_shape(self):
+        # Only (N, 2) handled — (2, N) goes through untouched.
+        data = np.array([[0.1, 0.5, 0.3], [1.0, 2.0, 3.0]])
+        assert _try_orient_xy(data) is data
+
+
+class TestAdaptScriptForSpectrum:
+    @pytest.fixture
+    def adapter(self):
+        # Import lazily so importing this test module never triggers the
+        # heavy controller import chain unless these tests are selected.
+        from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+            UnifiedSeriesProcessingController,
+        )
+        # _adapt_script_for_spectrum is a pure method — no controller state
+        # needed. Bind it via a throwaway instance built from __new__ so we
+        # don't run __init__.
+        helper = UnifiedSeriesProcessingController.__new__(
+            UnifiedSeriesProcessingController
+        )
+        return helper._adapt_script_for_spectrum
+
+    def test_rewrites_bare_glob_fallback(self, adapter):
+        script = (
+            "import glob\n"
+            "npy_files = glob.glob('*.npy') + glob.glob('**/*.npy', recursive=True)\n"
+        )
+        out = adapter(script, "/session/results/temp_spectrum_1.npy", "spectrum_0001")
+        assert "glob.glob('*.npy')" not in out
+        assert "glob.glob('**/*.npy'" not in out
+        assert '["/session/results/temp_spectrum_1.npy"]' in out
+
+    def test_leaves_nested_paren_glob_intact(self, adapter):
+        # `glob.glob(os.path.join(d, '*.npy'))` would be sliced mid-expression
+        # if the regex spanned parens — must be left alone to keep the script
+        # syntactically valid.
+        script = "files = glob.glob(os.path.join(d, '*.npy'))\n"
+        out = adapter(script, "/session/results/temp_spectrum_1.npy", "spectrum_0001")
+        assert out == script
+
+    def test_does_not_touch_png_glob(self, adapter):
+        script = "images = glob.glob('*.png')\n"
+        out = adapter(script, "/session/results/temp_spectrum_1.npy", "spectrum_0001")
+        assert out == script
+
+    def test_rewrites_possible_paths_list_literal(self, adapter):
+        # The list-literal pattern observed in the real failing run.
+        script = (
+            "possible_paths = [\n"
+            "    '/session/results/temp_spectrum_0.npy',\n"
+            "    '/session/results/temp_spectrum_0.npy',\n"
+            "    'spectrum_0.npy',\n"
+            "]\n"
+        )
+        out = adapter(script, "/session/results/temp_spectrum_1.npy", "spectrum_0001")
+        assert "temp_spectrum_0.npy" not in out
+        assert out.count("temp_spectrum_1.npy") == 2
+
+    def test_windows_data_path_does_not_crash_regex(self, adapter):
+        # `\U` in a Windows path becomes `re.error: bad escape \U` if the
+        # path is interpolated into a replacement string without normalizing
+        # backslashes.
+        script = "data = np.load('/session/results/temp_spectrum_0.npy')\n"
+        out = adapter(script, r"C:\Users\me\session\temp_spectrum_1.npy", "spectrum_0001")
+        assert "C:/Users/me/session/temp_spectrum_1.npy" in out


### PR DESCRIPTION
## Summary

A real TRPL series run on three CSVs returned three "successful" fits that were all R² = 0.0 with identical-to-initial-guess parameters and infinite covariance. The root cause was two independent bugs in the curve-fitting series path; this PR fixes both with full backward compatibility for currently-working flows.

**Bug 1 — column orientation.** The user's CSVs had columns in `(intensity, time)` order (header `'<sample>_norm', time_s`), but every generated fit script trusted the positional convention `col 0 = x, col 1 = y`. The fit thus tried to model `time(intensity)`, which is degenerate: `argmax(y)` lands at the last sample of the time axis and `curve_fit` returns the seed values without raising.

**Bug 2 — `glob.glob('*.npy')` fallback.** The LLM evolved its base fit script to defend against missing temp files with a `glob.glob('*.npy')` fallback. In parallel fan-out, multiple spectra's `temp_spectrum_<N>.npy` files coexist briefly, so the glob could pick up a sibling spectrum's file. The existing path-rewrite regex (`_adapt_script_for_spectrum`) didn't touch glob calls.

Bug 1 was the dominant cause of R² = 0 in the observed run; bug 2 is a defense-in-depth fix for a race window we'd otherwise hit eventually.

---

## Technical details

### Fix 1: `_try_orient_xy` in `scilink/skills/_shared/curve_fitting_tools.py`

```python
def _try_orient_xy(data: np.ndarray) -> np.ndarray:
    if data.ndim != 2 or data.shape[1] != 2:
        return data
    col0, col1 = data[:, 0], data[:, 1]
    if not (np.isfinite(col0).all() and np.isfinite(col1).all()):
        return data
    def _mono(a):
        if a.size < 2: return False
        d = np.diff(a)
        return bool(np.all(d > 0) or np.all(d < 0))
    if _mono(col1) and not _mono(col0):
        return np.ascontiguousarray(data[:, ::-1])
    return data
```

Monotonicity is the strongest portable cue that a column is the independent variable (time, wavelength, energy). The helper acts **only** when exactly one column is monotonic — the case that is unambiguously broken today. Both-mono and neither-mono are left alone, so well-formed data is never perturbed. `auto_orient` is threaded through `load_curve_data` as an opt-out kwarg (default True) for callers who want the legacy raw-layout behavior.

**Backward compatibility analysis.** All current callers (`curve_fitting_agent.py:509,856`, `hyperspectral_analysis_agent.py:549`, `image_analysis_agent.py:651`, `curve_fitting_controllers.py:597,1935`) load 1D curves where the convention is `col 0 = x`. For data that already follows that convention, col 0 is monotonic (x always is) and col 1 isn't (signal isn't), so `_try_orient_xy` is a no-op. The only behavioral change is for data that was previously broken — exactly the desired outcome.

### Fix 2: glob-fallback rewrite in `_adapt_script_for_spectrum` / `_adapt_script_for_image`

`scilink/agents/exp_agents/controllers/curve_fitting_controllers.py:1908-1919` and `image_analysis_controllers.py:2236-2247` add:

```python
adapted = re.sub(
    r'glob\.glob\s*\([^()]*\.npy[^()]*\)',
    f'["{data_path}"]',
    adapted,
)
```

The `[^()]` class refuses to span nested parens, so `glob.glob(os.path.join(d, '*.npy'))` is left intact rather than sliced mid-expression. Calls that match — `glob.glob('*.npy')`, `glob.glob('**/*.npy', recursive=True)`, `glob.glob(f'{d}/*.npy')` — are pinned to the data_path the rest of the adapter is already pointing at.

Builds on the Windows-path backslash normalization from PR #212; without that fix, this new `re.sub` would crash on Windows paths too.

### Tests

New `tests/test_curve_fitting_orient_and_adapt.py` — 13 cases, all passing:
- `_try_orient_xy`: swap case, no-swap case (already oriented), both-mono ambiguous, neither-mono ambiguous, decreasing-monotonic-as-X, 1D passthrough, NaN passthrough, (2, N) passthrough.
- `_adapt_script_for_spectrum`: bare-glob rewrite, nested-paren glob preserved (syntax-safety), non-`.npy` glob untouched, possible-paths list-literal rewrite (the exact pattern from the real failing run), and a Windows-path regression guard cross-checking PR #212.

Existing curve-fitting tests (`test_curve_fitting_stdout_parser`, `test_extract_peaks`, `test_quality_gate`) still pass — 38/38.

### Not addressed

The verifier-loop diagnoses for the failing run were misleading ("script saves to wrong filename" — actually `visualization_path` was correctly set). That's a separate diagnose-prompt drift not in scope here.

## Test plan

- [ ] `pytest tests/test_curve_fitting_orient_and_adapt.py -v` — all 13 should pass.
- [ ] `pytest tests/test_curve_fitting_stdout_parser.py tests/test_extract_peaks.py tests/test_quality_gate.py` — confirm no regression in adjacent suites.
- [ ] Re-run the failing TRPL series from `meta_session_20260528_123430/` (or any series of CSVs with `(intensity, time)` column order) and confirm R² > 0.95 instead of R² = 0.0.
- [ ] Run an image-series fit to confirm `_adapt_script_for_image` still works as before (no glob rewrite path used).