### PR TITLE
Move curve-fit preprocessing into the generated fit script (model-written, verified)

### DIFF
--- a/docs/preprocessing_in_fit_loop.md
+++ b/docs/preprocessing_in_fit_loop.md
@@ -1,0 +1,209 @@
+# Design note: move preprocessing into the verified fit loop
+
+**Status:** proposal (not implemented). Discussion captured from a live
+debugging session, 2026-05-28. No code changed.
+
+**Scope:** the `CurveFittingAgent` pipeline. The argument generalizes to any
+codegen-capable foundation agent that has a separate preprocessing step, but
+this note is written against curve fitting concretely.
+
+---
+
+## TL;DR
+
+Preprocessing currently runs **once, upstream of the fit loop**, its output is
+the only thing the verifier ever sees, and nothing downstream can detect or redo
+a bad preprocessing choice. Because preprocessing transforms (smoothing,
+baseline, cropping, clipping) **bias the very observables being fit**, a wrong
+choice silently corrupts the result while still scoring a clean R². The fix is
+to fold preprocessing into the `generate → execute → verify → anneal` loop and
+into planning, and — critically — to give the verifier the **raw** data so it
+can actually see preprocessing damage.
+
+---
+
+## Current architecture (with evidence)
+
+Pipeline factory: `scilink/agents/exp_agents/pipelines/curve_fitting_pipelines.py:136-261`.
+
+```
+1.  AnalyzeDataController            stats + initial plot
+1.5 SeriesScoutController            infer the series variable
+2.  HumanFeedbackRefinementController  LLM plans the MODEL; locks config for the series
+3.  LiteratureSearchController       optional
+4.  UnifiedSeriesProcessingController  fits all spectra
+        └─ preprocessor.run_preprocessing(...)   ← preprocessing happens HERE, once per spectrum
+        └─ _fit_single_spectrum(...)             ← contains the verify/anneal loop
+5.  AdaptiveRefitController          re-fit flagged spectra
+6.  ConditionalTrendAnalysisController
+7.  UnifiedCurveSynthesisController
+8.  StoreAnalysisResultsController
+9.  {Generate,Unified}CurveReportController
+```
+
+Three facts that define the problem:
+
+1. **Preprocessing is one-shot, upstream of the loop.**
+   `run_preprocessing` is only ever called at
+   `curve_fitting_controllers.py:3687`, `:3697`, `:4258` — all *outside*
+   `_fit_single_spectrum`. The verify/anneal loop is the `for attempt` loop
+   *inside* `_fit_single_spectrum` (`:2015`), which regenerates the fit script
+   and anneals model constraints but **never re-invokes the preprocessor**.
+   Flow: `preprocess once → [generate script → execute → verify → anneal]×N`.
+   The bracket iterates; preprocessing does not.
+
+2. **Planner and preprocessor are independent LLM calls.**
+   Preprocessing strategy is chosen by `_llm_select_preprocessing_strategy`
+   (`preprocess.py:183`) and locked for series consistency. The planner
+   (`HumanFeedbackRefinementController`, step 2) plans the *model*. They reason
+   separately; the planner does not own or see the preprocessing transform.
+
+3. **The verifier cannot see preprocessing damage.**
+   `_verify_fit_with_llm` (`:2281`) compares the fit to the *already-preprocessed*
+   `curve_data` and its plot. It never sees the raw signal, so a fit to
+   corrupted data scores a clean R² and is approved.
+
+## Failure mode (not hypothetical)
+
+Preprocessing transforms are **not neutral** — they bias the observables:
+
+- **EPR (observed):** preprocessing applied Savitzky-Golay smoothing
+  (window=5). For a sharp derivative feature, smoothing **broadens the line**,
+  biasing `lw_G` — the exact quantity being measured. The verifier sees a clean
+  fit to the smoothed data and approves; `lw_G` is silently wrong.
+- **TRPL:** over-smoothing or a wrong baseline/crop distorts a sub-µs decay
+  component before the fit ever runs.
+- **Crop dead-end (observed):** a `custom_processing_instruction` to "fit only
+  the decay, exclude dark counts" cannot satisfy the 1D preprocessing contract
+  that output length == input length (`preprocess.py:846-850`), so it fails and
+  silently falls back to original data. Region-of-interest is a *fit-domain*
+  concern misfiled as a preprocessing transform.
+
+Common thread: a preprocessing choice corrupts or constrains the result, it is
+made once, and **no downstream stage can detect or redo it.**
+
+## Why this violates the agent's own contract
+
+Foundation-agent element 5 (CLAUDE.md): *"Generated artifacts run in a sandbox,
+and the agent verifies the result before accepting it."* Preprocessing is a
+generated/parameterized transform that **escapes** verify-before-accept. It is
+the one stage that mutates the data and is never checked against an independent
+reference.
+
+## Target architecture
+
+1. **The fit script owns the full chain.** Generate one artifact that does
+   `load raw → preprocess → fit → output`. The verifier then sees the *entire*
+   transform and can reject preprocessing damage, not just model misfit.
+
+2. **Planning emits the preprocessing recipe jointly with the model.** One
+   locked plan covers both, so they are chosen coherently
+   (e.g. "do not smooth — it broadens the EPR line; fit the intrinsic
+   linewidth instead"; "fit domain is t ≥ t₀, not a crop").
+
+3. **The anneal loop can revise preprocessing** the same way it revises the
+   model. If distortion is detected, regenerate with gentler/no preprocessing.
+   "Preprocessing aggressiveness" becomes an annealing knob alongside the model
+   constraint schedule.
+
+## The one detail that makes or breaks it
+
+**The verifier must receive the raw data (and a raw-vs-processed overlay).**
+If preprocessing moves into the fit script but the verifier still only sees the
+*processed* curve, nothing is gained — it still cannot see the damage.
+Raw-vs-processed visibility is the actual safety mechanism; relocating
+preprocessing merely *enables* it. This is the required addition to
+`_verify_fit_with_llm`'s inputs.
+
+## Consequence: preprocessing becomes skill-specializable
+
+Today preprocessing is **skill-blind**: `_llm_select_preprocessing_strategy`
+(`preprocess.py:183`) receives only `stats` + `system_info` (metadata), never
+skill context. So domain knowledge that is *fundamentally about preprocessing*
+has nowhere to live in a skill — e.g.:
+
+- EPR: "do **not** smooth derivative spectra — it broadens the line and biases
+  `lw_G`."
+- TRPL: "identify t₀ at the intensity peak; fit from there; background is a
+  fit parameter, not a subtraction."
+- XPS: "Shirley background, not linear; do not clip."
+
+Because the smoothing/baseline/clip decision happens in a skill-agnostic step
+*before* the skill's context is consulted for fitting, the EPR skill cannot stop
+the smoothing that corrupts its own observable.
+
+Once preprocessing is part of planning + the generated fit script, it inherits
+the skill mechanism for free. The skill's existing fixed sections carry it:
+
+- `planning` → how to approach preprocessing for this technique;
+- `implementation` → the preprocessing recipe inside the generated script;
+- `validation` → "check the raw-vs-processed overlay did not distort the line."
+
+**Recommendation:** reuse the existing sections (`planning` + `implementation`)
+rather than adding a new `preprocessing` section. The six-section vocabulary is
+fixed and load-bearing; do not expand it speculatively. Only introduce a
+dedicated section if evidence shows preprocessing guidance is consistently
+mis-housed in `planning`/`implementation`. This keeps the change aligned with
+the "skills, not new agents / new vocabulary" thesis.
+
+## Disposition of `custom_processing_instruction`
+
+The metadata field does **not** disappear — it gets a better consumer.
+
+Today it routes into `_generate_and_execute_custom_script_1d` (a standalone
+preprocessing script bound by the length-preserving contract), which is where
+the crop dead-end happens. Under the new design the planner (step 2) consumes
+it directly and reconciles it into the locked plan, with two dispositions:
+
+1. **Fit-domain / model intent** (most cases): "fit only the decay, exclude
+   dark counts" → a fit *window* (t ≥ t₀) and a background *parameter*, decided
+   in planning and emitted in the fit script. No length-changing transform, so
+   the contract violation disappears entirely.
+2. **Genuine data-transform intent** (rare): "the first 50 points are an
+   instrument artifact, drop them"; "subtract this reference spectrum" → a real
+   preprocessing step, but now emitted **inside the verified fit script**, so
+   the verifier sees raw-vs-processed and can reject it if it distorts.
+
+So the field's *contract* changes from "an imperative for a length-preserving
+standalone script" to "free-text intent the planner routes to fit-domain, model
+parameter, or in-script transform as appropriate." This is migration step 1
+(reject-and-reroute) generalized: the planner, not a standalone preprocessing
+path, owns the field.
+
+## Tradeoffs and constraints
+
+- **Series consistency must be preserved.** Today preprocessing is locked once
+  and applied uniformly across a series — a real feature for cross-sample
+  comparability. The lock must now cover the combined preprocess+model recipe,
+  not just the model. Do not let per-spectrum preprocessing drift.
+- **Larger codegen surface to verify** — but the fit script already does
+  codegen + verify, so this is incremental, not new machinery.
+- **Keep a thin deterministic pre-step** for genuinely model-irrelevant,
+  non-distorting hygiene only: format/unit parsing, NaN handling, ascending-x
+  sorting. Anything that *can* bias an observable (smoothing, baseline, crop,
+  clip, normalization that rescales) goes inside the verified loop.
+
+## Migration (incremental, low-risk first)
+
+1. **Reject-and-reroute, not fail:** make the preprocessor refuse
+   length-changing `custom_processing_instruction`s and surface them to the
+   planner as a fit-domain hint. (Kills the live crop dead-end; smallest change.)
+2. **Give the verifier the raw data + raw-vs-processed overlay.** Safety
+   mechanism; valuable even before full relocation.
+3. **Move ROI/fit-domain and background into the model/plan** (background as a
+   fit parameter, not a subtraction; domain as a fit window, not a crop).
+4. **Fold the remaining length-preserving transforms into the generated fit
+   script**, locked jointly with the model, and add a preprocessing-aggressiveness
+   knob to the anneal schedule.
+
+Steps 1–2 are independently shippable and remove the worst silent-failure modes;
+3–4 complete the relocation.
+
+## Non-goals
+
+- Not proposing to delete the preprocessing helper code — its transforms remain,
+  they just move inside the verified loop and lose independent ROI/crop
+  authority.
+- Not a wholesale "one LLM call for everything" merge; the planner and fitter
+  stay distinct stages. Only the *responsibility boundaries* and *what the
+  verifier sees* change.

--- a/docs/preprocessing_in_fit_loop.md
+++ b/docs/preprocessing_in_fit_loop.md
@@ -92,19 +92,43 @@ reference.
 
 ## Target architecture
 
-1. **The fit script owns the full chain.** Generate one artifact that does
-   `load raw → preprocess → fit → output`. The verifier then sees the *entire*
+1. **The fit script owns the full chain, as free-form generated code.** Generate
+   one artifact that does `load raw → preprocess → fit → output`, where the
+   *preprocess* part is **code the model writes itself** — whatever is
+   appropriate for the data — not a call to a fixed menu of operations or any
+   prescribed preprocessing tool/helper. The verifier then sees the *entire*
    transform and can reject preprocessing damage, not just model misfit.
 
-2. **Planning emits the preprocessing recipe jointly with the model.** One
-   locked plan covers both, so they are chosen coherently
-   (e.g. "do not smooth — it broadens the EPR line; fit the intrinsic
-   linewidth instead"; "fit domain is t ≥ t₀, not a crop").
+   This is a deliberate move away from the current prescriptive approach: today
+   `_llm_select_1d_strategy` returns a fixed schema
+   (`{apply_clip, apply_smoothing, smoothing_window}`) and `_apply_1d_strategy`
+   applies exactly those two operations. That menu is **removed**. Preprocessing
+   becomes generated code on the same footing as the fit code the agent already
+   writes — consistent with CLAUDE.md (skill code blocks are LLM-facing
+   reference, not executable surfaces; runnable specialization is generated, not
+   prescribed).
 
-3. **The anneal loop can revise preprocessing** the same way it revises the
-   model. If distortion is detected, regenerate with gentler/no preprocessing.
-   "Preprocessing aggressiveness" becomes an annealing knob alongside the model
-   constraint schedule.
+   A direct consequence: the **length-preserving vs length-changing distinction
+   dissolves.** It only existed because preprocessing was a separate step handing
+   a same-length array to a downstream fitter (the `output length == input
+   length` contract). Once preprocessing is code inside the fit script, a crop, a
+   bin, a smooth, and a baseline are all just lines the model writes; there is no
+   hand-off and no length contract. (Steps 1 & 3 — rerouting crop/ROI to the
+   planner — are the *interim* fix while preprocessing is still a separate step;
+   once it is in-script, ROI is simply part of the generated preprocessing/fit
+   domain.)
+
+2. **Planning decides the preprocessing *approach* jointly with the model**, and
+   the skill supplies the *knowledge* (not tools): e.g. "for EPR derivative
+   spectra do not smooth — it broadens the line; fit the intrinsic linewidth";
+   "TRPL: estimate t₀ at the peak, fit from there, background as a parameter."
+   The model reads that guidance and writes appropriate preprocessing code. One
+   locked plan covers preprocessing + model so they are coherent.
+
+3. **The anneal loop can revise the preprocessing code** the same way it revises
+   the model. If the verifier flags distortion, regenerate with a different
+   preprocessing choice (gentler/none). "Preprocessing aggressiveness" becomes an
+   annealing knob alongside the model constraint schedule.
 
 ## The one detail that makes or breaks it
 
@@ -136,7 +160,8 @@ Once preprocessing is part of planning + the generated fit script, it inherits
 the skill mechanism for free. The skill's existing fixed sections carry it:
 
 - `planning` → how to approach preprocessing for this technique;
-- `implementation` → the preprocessing recipe inside the generated script;
+- `implementation` → guidance the model uses to *write its own* preprocessing
+  code in the generated fit script (not a prescribed recipe or tool to call);
 - `validation` → "check the raw-vs-processed overlay did not distort the line."
 
 **Recommendation:** reuse the existing sections (`planning` + `implementation`)
@@ -185,25 +210,35 @@ path, owns the field.
 
 ## Migration (incremental, low-risk first)
 
-1. **Reject-and-reroute, not fail:** make the preprocessor refuse
-   length-changing `custom_processing_instruction`s and surface them to the
-   planner as a fit-domain hint. (Kills the live crop dead-end; smallest change.)
-2. **Give the verifier the raw data + raw-vs-processed overlay.** Safety
-   mechanism; valuable even before full relocation.
-3. **Move ROI/fit-domain and background into the model/plan** (background as a
-   fit parameter, not a subtraction; domain as a fit window, not a crop).
-4. **Fold the remaining length-preserving transforms into the generated fit
-   script**, locked jointly with the model, and add a preprocessing-aggressiveness
-   knob to the anneal schedule.
+1. **[DONE — PR #215] Reject-and-reroute, not fail:** the preprocessor refuses
+   length-changing `custom_processing_instruction`s (`FitDomainInstruction`) and
+   defers them to the planner. (Killed the live crop dead-end.)
+2. **[DONE — PR #215] Give the verifier the raw data + raw-vs-processed overlay.**
+   The safety mechanism; valuable even before full relocation.
+3. **[DONE — PR #215] Surface ROI/background to the planner**
+   (`_append_fit_domain_guidance`): domain as a fit window, background as a fit
+   parameter — not preprocessing.
+4. **[Step 4 — pending] Make preprocessing free-form generated code in the fit
+   script.** Remove the prescriptive `_llm_select_1d_strategy` /
+   `_apply_1d_strategy` menu. The model writes whatever preprocessing is
+   appropriate (guided by the active skill's knowledge), inside the same
+   generated artifact as the fit; lock it jointly with the model for series
+   consistency; add a preprocessing-aggressiveness knob to the anneal schedule
+   so the loop can revise it. The length-preserving/changing distinction goes
+   away (no separate-step contract), so steps 1 & 3's reroute becomes a no-op
+   that can be retired once this lands.
 
-Steps 1–2 are independently shippable and remove the worst silent-failure modes;
-3–4 complete the relocation.
+Steps 1–3 (PR #215) are independently shippable and remove the worst
+silent-failure modes; Step 4 completes the relocation.
 
 ## Non-goals
 
-- Not proposing to delete the preprocessing helper code — its transforms remain,
-  they just move inside the verified loop and lose independent ROI/crop
-  authority.
 - Not a wholesale "one LLM call for everything" merge; the planner and fitter
-  stay distinct stages. Only the *responsibility boundaries* and *what the
-  verifier sees* change.
+  stay distinct stages. Only the *responsibility boundaries*, *what the verifier
+  sees*, and *who writes the preprocessing code* change.
+- Not prescribing preprocessing operations or tools. The point of Step 4 is the
+  opposite: the model writes its own preprocessing code from skill guidance. The
+  `_llm_select_1d_strategy` / `_apply_1d_strategy` fixed menu is removed, not
+  preserved. (A thin deterministic *loader*-level step may remain for genuinely
+  model-irrelevant, non-distorting hygiene — format/unit parsing, NaN handling,
+  ascending-x sorting — but that is data loading, not preprocessing choices.)

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -2278,6 +2278,27 @@ Remember: Rejecting a good fit (R² > {accept_threshold:.2f}) to chase marginal 
         "explain the deviation.\n\n",
     )
 
+    def _plot_raw_vs_processed(self, raw: np.ndarray, processed: np.ndarray, name: str = "") -> bytes:
+        """Overlay raw vs preprocessed curve as PNG bytes.
+
+        Given to the verifier so it can catch preprocessing-induced distortion
+        (e.g. over-smoothing broadening a peak / linewidth, a baseline removing
+        real signal) — the failure mode that is otherwise invisible because the
+        fit is plotted only against the already-processed data.
+        """
+        import io
+        import matplotlib.pyplot as plt
+        fig, ax = plt.subplots(figsize=(7, 4))
+        ax.plot(raw[:, 0], raw[:, 1], color="0.6", lw=0.8, label="raw")
+        ax.plot(processed[:, 0], processed[:, 1], color="#c0392b", lw=1.0, label="preprocessed")
+        ax.set_title(f"Raw vs preprocessed{(': ' + name) if name else ''}")
+        ax.set_xlabel("x"); ax.set_ylabel("y"); ax.legend(fontsize=8)
+        fig.tight_layout()
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", dpi=110)
+        plt.close(fig)
+        return buf.getvalue()
+
     def _verify_fit_with_llm(self, state: dict, fit_result: dict, history: List[dict] = None, verification_iter: int = 0, annealing_level: int | None = None, best_result: dict | None = None, best_verification: dict | None = None) -> Optional[dict]:
         """
         Use LLM to verify fit quality by examining the visualization.
@@ -2450,8 +2471,24 @@ Remember: Rejecting a good fit (R² > {accept_threshold:.2f}) to chase marginal 
             "data": fit_result["visualization_bytes"]
         })
         
+        # Raw-vs-preprocessed overlay (only present when preprocessing changed
+        # the data). Lets the verifier see — and flag — preprocessing-induced
+        # distortion, which is otherwise invisible because the fit is plotted
+        # against the already-processed curve.
+        if state.get("preprocess_overlay_bytes"):
+            prompt_parts.append(
+                "\n\n**RAW vs PREPROCESSED DATA:** Preprocessing was applied "
+                "before fitting. Verify it did not distort the feature being "
+                "measured (e.g. over-smoothing broadening a peak/linewidth, or a "
+                "baseline removing real signal). If it did, add an entry to "
+                "issues_found with location 'preprocessing' describing the "
+                "distortion, but set recommended_action to 'none' — the model fit "
+                "cannot compensate for preprocessing, so this is recorded for the "
+                "analysis caveats rather than triggering a refit."
+            )
+            prompt_parts.append({"mime_type": "image/png", "data": state["preprocess_overlay_bytes"]})
         # Also include original data if available for comparison
-        if state.get("original_plot_bytes"):
+        elif state.get("original_plot_bytes"):
             prompt_parts.append("\n\n**ORIGINAL DATA (for reference):**")
             prompt_parts.append({"mime_type": "image/png", "data": state["original_plot_bytes"]})
 
@@ -3665,6 +3702,10 @@ Return JSON with:
                 spectrum_name = Path(data_path).stem
                 curve_data = self._load_curve_data(data_path)
 
+            # Keep the raw curve so we can show the verifier a raw-vs-processed
+            # overlay (preprocessing distortion is otherwise invisible).
+            raw_curve_data = curve_data.copy() if isinstance(curve_data, np.ndarray) else None
+
             # Apply preprocessing with locking support for series consistency
             if self.preprocessor is not None:
                 try:
@@ -3702,6 +3743,25 @@ Return JSON with:
                     self.logger.info(f"Preprocessed: {spectrum_name}")
                 except Exception as e:
                     self.logger.warning(f"Preprocessing failed for {spectrum_name}: {e}, using raw data")
+
+            # Raw-vs-preprocessed overlay for the verifier — only when
+            # preprocessing actually changed the data (same length, different
+            # values). Cleared otherwise so a stale overlay never carries over.
+            state.pop("preprocess_overlay_bytes", None)
+            try:
+                if (raw_curve_data is not None
+                        and isinstance(curve_data, np.ndarray)
+                        and curve_data.shape == raw_curve_data.shape
+                        and not np.array_equal(curve_data, raw_curve_data)):
+                    state["preprocess_overlay_bytes"] = self._plot_raw_vs_processed(
+                        raw_curve_data, curve_data, spectrum_name
+                    )
+                    self.logger.info(
+                        "   🔬 Raw-vs-preprocessed overlay attached for verification "
+                        "(preprocessing changed the data)."
+                    )
+            except Exception as e:
+                self.logger.debug(f"raw-vs-processed overlay skipped: {e}")
 
             # Determine regime and set appropriate config
             regime_name = self._get_regime_for_spectrum(state, idx) or "default"

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -2493,25 +2493,23 @@ Remember: Rejecting a good fit (R² > {accept_threshold:.2f}) to chase marginal 
             "data": fit_result["visualization_bytes"]
         })
         
-        # Raw-vs-preprocessed overlay (only present when preprocessing changed
-        # the data). Lets the verifier see — and flag — preprocessing-induced
-        # distortion, which is otherwise invisible because the fit is plotted
-        # against the already-processed curve.
-        if state.get("preprocess_overlay_bytes"):
-            prompt_parts.append(
-                "\n\n**RAW vs PREPROCESSED DATA:** Preprocessing was applied "
-                "before fitting. Verify it did not distort the feature being "
-                "measured (e.g. over-smoothing broadening a peak/linewidth, or a "
-                "baseline removing real signal). If it did, add an entry to "
-                "issues_found with location 'preprocessing' describing the "
-                "distortion, but set recommended_action to 'none' — the model fit "
-                "cannot compensate for preprocessing, so this is recorded for the "
-                "analysis caveats rather than triggering a refit."
-            )
-            prompt_parts.append({"mime_type": "image/png", "data": state["preprocess_overlay_bytes"]})
-        # Also include original data if available for comparison
-        elif state.get("original_plot_bytes"):
-            prompt_parts.append("\n\n**ORIGINAL DATA (for reference):**")
+        # Preprocessing is now done INSIDE the fit script; when it preprocesses,
+        # its visualization shows the raw data faintly behind the fitted data.
+        # Always remind the verifier to check for preprocessing-induced
+        # distortion (otherwise invisible because the fit is plotted against the
+        # processed curve).
+        prompt_parts.append(
+            "\n\n**PREPROCESSING CHECK:** Any preprocessing is done inside the "
+            "fit script. If the visualization shows a faint raw trace behind the "
+            "fitted data, verify the preprocessing did not distort the fitted "
+            "features (e.g. over-smoothing broadening a peak/linewidth, or a "
+            "baseline removing real signal). If it did, add an issues_found entry "
+            "with location 'preprocessing' and set recommended_action to 'none' — "
+            "recorded as a caveat, not a refit trigger."
+        )
+        # Original (raw) data for reference.
+        if state.get("original_plot_bytes"):
+            prompt_parts.append("\n\n**ORIGINAL (RAW) DATA for reference:**")
             prompt_parts.append({"mime_type": "image/png", "data": state["original_plot_bytes"]})
 
         

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1714,7 +1714,6 @@ Your guidance: '''
         enable_human_feedback: bool = False,
         outlier_sigma: float = None,
         max_verification_iterations: int = None,
-        preprocessor: Any = None,
         conformance_instructions: str = "",
         parallel_workers: Optional[int] = None,
     ):
@@ -1738,7 +1737,6 @@ Your guidance: '''
         self.enable_human_feedback = enable_human_feedback
         self.outlier_sigma = outlier_sigma if outlier_sigma is not None else self.DEFAULT_OUTLIER_SIGMA
         self.max_verification_iterations = max_verification_iterations if max_verification_iterations is not None else self.DEFAULT_MAX_VERIFICATION_ITERATIONS
-        self.preprocessor = preprocessor
         # Non-anchor parallel fan-out. Defaults to 1 (serial, byte-identical
         # to pre-feature behavior). Anchor processing always runs serially.
         self.parallel_workers = _resolve_parallel_workers(parallel_workers)
@@ -2311,27 +2309,6 @@ Remember: Rejecting a good fit (R² > {accept_threshold:.2f}) to chase marginal 
         "Use as context. Override any rule if the data warrants it — "
         "explain the deviation.\n\n",
     )
-
-    def _plot_raw_vs_processed(self, raw: np.ndarray, processed: np.ndarray, name: str = "") -> bytes:
-        """Overlay raw vs preprocessed curve as PNG bytes.
-
-        Given to the verifier so it can catch preprocessing-induced distortion
-        (e.g. over-smoothing broadening a peak / linewidth, a baseline removing
-        real signal) — the failure mode that is otherwise invisible because the
-        fit is plotted only against the already-processed data.
-        """
-        import io
-        import matplotlib.pyplot as plt
-        fig, ax = plt.subplots(figsize=(7, 4))
-        ax.plot(raw[:, 0], raw[:, 1], color="0.6", lw=0.8, label="raw")
-        ax.plot(processed[:, 0], processed[:, 1], color="#c0392b", lw=1.0, label="preprocessed")
-        ax.set_title(f"Raw vs preprocessed{(': ' + name) if name else ''}")
-        ax.set_xlabel("x"); ax.set_ylabel("y"); ax.legend(fontsize=8)
-        fig.tight_layout()
-        buf = io.BytesIO()
-        fig.savefig(buf, format="png", dpi=110)
-        plt.close(fig)
-        return buf.getvalue()
 
     def _verify_fit_with_llm(self, state: dict, fit_result: dict, history: List[dict] = None, verification_iter: int = 0, annealing_level: int | None = None, best_result: dict | None = None, best_verification: dict | None = None) -> Optional[dict]:
         """
@@ -3734,66 +3711,9 @@ Return JSON with:
                 spectrum_name = Path(data_path).stem
                 curve_data = self._load_curve_data(data_path)
 
-            # Keep the raw curve so we can show the verifier a raw-vs-processed
-            # overlay (preprocessing distortion is otherwise invisible).
-            raw_curve_data = curve_data.copy() if isinstance(curve_data, np.ndarray) else None
-
-            # Apply preprocessing with locking support for series consistency
-            if self.preprocessor is not None:
-                try:
-                    if idx == 0 and state.get("first_spectrum_preprocessed"):
-                        # Reuse preprocessing from analyze() — avoid redundant LLM call
-                        curve_data = state.get("curve_data", curve_data)
-                        preprocess_quality = state.get(
-                            "first_spectrum_preprocess_quality", {}
-                        ) or {}
-                        locked_preprocessing_strategy = preprocess_quality.get("strategy")
-                        if locked_preprocessing_strategy:
-                            state["locked_preprocessing_strategy"] = locked_preprocessing_strategy
-                            self.logger.info(
-                                "📝 Preprocessing strategy locked (from planning stage): "
-                                f"{locked_preprocessing_strategy.get('reasoning', 'N/A')[:60]}"
-                            )
-                        else:
-                            self.logger.info("Preprocessed (reused from planning stage)")
-                    elif idx == 0:
-                        curve_data, preprocess_quality = self.preprocessor.run_preprocessing(
-                            curve_data, state.get("system_info", {})
-                        )
-                        locked_preprocessing_strategy = preprocess_quality.get("strategy")
-                        if locked_preprocessing_strategy:
-                            state["locked_preprocessing_strategy"] = locked_preprocessing_strategy
-                            self.logger.info(f"📝 Preprocessing strategy locked: {locked_preprocessing_strategy.get('reasoning', 'N/A')[:60]}")
-                        else:
-                            self.logger.info(f"Preprocessed (no lockable strategy returned)")
-                    else:
-                        curve_data, _ = self.preprocessor.run_preprocessing(
-                            curve_data,
-                            state.get("system_info", {}),
-                            locked_strategy=locked_preprocessing_strategy
-                        )
-                    self.logger.info(f"Preprocessed: {spectrum_name}")
-                except Exception as e:
-                    self.logger.warning(f"Preprocessing failed for {spectrum_name}: {e}, using raw data")
-
-            # Raw-vs-preprocessed overlay for the verifier — only when
-            # preprocessing actually changed the data (same length, different
-            # values). Cleared otherwise so a stale overlay never carries over.
-            state.pop("preprocess_overlay_bytes", None)
-            try:
-                if (raw_curve_data is not None
-                        and isinstance(curve_data, np.ndarray)
-                        and curve_data.shape == raw_curve_data.shape
-                        and not np.array_equal(curve_data, raw_curve_data)):
-                    state["preprocess_overlay_bytes"] = self._plot_raw_vs_processed(
-                        raw_curve_data, curve_data, spectrum_name
-                    )
-                    self.logger.info(
-                        "   🔬 Raw-vs-preprocessed overlay attached for verification "
-                        "(preprocessing changed the data)."
-                    )
-            except Exception as e:
-                self.logger.debug(f"raw-vs-processed overlay skipped: {e}")
+            # Raw data is fed straight to the fit script, which owns preprocessing
+            # (see docs/preprocessing_in_fit_loop.md). No separate preprocessing
+            # step here.
 
             # Determine regime and set appropriate config
             regime_name = self._get_regime_for_spectrum(state, idx) or "default"
@@ -4298,7 +4218,6 @@ class AdaptiveRefitController:
         r2_threshold: float = 0.95,
         max_model_retries: int = 1,
         max_verification_iterations: int = 7,
-        preprocessor: Any = None,
         enable_human_feedback: bool = False,
         conformance_instructions: str = "",
     ):
@@ -4325,7 +4244,6 @@ class AdaptiveRefitController:
             max_model_retries=max_model_retries,
             enable_human_feedback=False,
             max_verification_iterations=max_verification_iterations,
-            preprocessor=preprocessor,
             conformance_instructions=conformance_instructions,
         )
 
@@ -4340,20 +4258,6 @@ class AdaptiveRefitController:
                 self.logger.error(f"Failed to load {spectrum_paths[idx]}: {e}")
                 return None
         return None
-
-    def _preprocess_spectrum(self, curve_data, state):
-        """Apply locked preprocessing strategy if available."""
-        if self._fitting_helper.preprocessor is None:
-            return curve_data
-        locked_strategy = state.get("locked_preprocessing_strategy")
-        try:
-            curve_data, _ = self._fitting_helper.preprocessor.run_preprocessing(
-                curve_data, state.get("system_info", {}),
-                locked_strategy=locked_strategy,
-            )
-        except Exception as e:
-            self.logger.warning(f"Preprocessing failed during refit: {e}")
-        return curve_data
 
     def _build_refit_state(self, state, curve_data, idx, name):
         """Build a temporary state dict for independent re-analysis."""
@@ -4533,7 +4437,6 @@ class AdaptiveRefitController:
             curve_data = self._load_spectrum(idx, spectrum_paths, spectrum_stack)
             if curve_data is None:
                 continue
-            curve_data = self._preprocess_spectrum(curve_data, state)
 
             refit_state = self._build_refit_state(state, curve_data, idx, name)
             if peer_r2:
@@ -4652,7 +4555,6 @@ class AdaptiveRefitController:
                 self.logger.warning(f"  Could not load spectrum data for {name}, skipping")
                 continue
 
-            curve_data = self._preprocess_spectrum(curve_data, state)
 
             refit_state = self._build_refit_state(state, curve_data, idx, name)
             spectrum_paths_list = state.get("spectrum_paths", [])

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -247,6 +247,26 @@ def _append_auxiliary_context(prompt: list, state: dict) -> None:
     })
 
 
+def _append_fit_domain_guidance(prompt: list, state: dict) -> None:
+    """Surface a custom processing instruction to the planner as fit-domain
+    guidance.
+
+    A "fit only the decay / this range" or "ignore the background" request is a
+    fit-domain decision (a fit window + a background parameter), not data
+    preprocessing — preprocessing stays length-preserving so the raw data is
+    fit. The instruction is otherwise only buried in the metadata JSON dump.
+    """
+    instruction = (state.get("system_info") or {}).get("custom_processing_instruction")
+    if not instruction:
+        return
+    prompt.append(
+        "\n## Fit-domain & background guidance\n"
+        f"User processing note: {instruction}\n"
+        "Express any region-of-interest as the FIT DOMAIN and any "
+        "background/baseline as a FIT PARAMETER — not as preprocessing."
+    )
+
+
 def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
     """Append domain skill knowledge to an LLM prompt for the given stage.
 
@@ -1193,6 +1213,7 @@ class HumanFeedbackRefinementController:
         ]
 
         _append_objective_context(prompt, state)
+        _append_fit_domain_guidance(prompt, state)
 
         if state.get("analysis_hints"):
             prompt.append(f"\n## User Guidance\n{state['analysis_hints']}")
@@ -1448,6 +1469,7 @@ class HumanFeedbackRefinementController:
         ]
 
         _append_objective_context(prompt, state)
+        _append_fit_domain_guidance(prompt, state)
 
         if state.get("analysis_hints"):
             prompt.append(f"\n## Original Guidance\n{state['analysis_hints']}")

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -513,25 +513,18 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                     "output_directory": str(self.output_dir)
                 }
         
-        # Optional preprocessing of first spectrum
+        # No separate preprocessing: the fit script owns preprocessing (see
+        # docs/preprocessing_in_fit_loop.md). The planner sees the raw first
+        # spectrum, consistent with what the fit script receives.
         processed_first_spectrum = first_spectrum
         first_spectrum_preprocess_quality = None
-        if self.preprocessor is not None:
-            try:
-                processed_first_spectrum, first_spectrum_preprocess_quality = (
-                    self.preprocessor.run_preprocessing(
-                        first_spectrum, self._handle_system_info(system_info)
-                    )
-                )
-            except Exception as e:
-                self.logger.warning(f"Preprocessing failed: {e}, using raw data")
-        
+
         # Generate initial plot
         original_plot_bytes = plot_curve_to_bytes(
-            processed_first_spectrum, 
+            processed_first_spectrum,
             self._handle_system_info(system_info)
         )
-        
+
         # Compute statistics for first spectrum
         data_statistics = self._compute_statistics(processed_first_spectrum)
         
@@ -675,7 +668,6 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             plot_fn=plot_curve_to_bytes,
             executor=self.executor,
             output_dir=str(self.output_dir),
-            preprocessor=self.preprocessor,
             literature_agent=self.literature_agent,
             enable_human_feedback=self.enable_human_feedback,
             r2_threshold=effective_r2_threshold,

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -231,15 +231,13 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
 
         # Optional preprocessor
         self.run_preprocessing = run_preprocessing
+        # Preprocessing is now performed INSIDE the generated fit script — the
+        # model writes appropriate, length-preserving preprocessing as part of
+        # its own fitting code, verified in the same loop. The separate upstream
+        # 1D CurvePreprocessingAgent is retired, so self.preprocessor stays None
+        # and every site (analyze first-spectrum, series loop, adaptive refit)
+        # feeds RAW data to the fit script. See docs/preprocessing_in_fit_loop.md.
         self.preprocessor = None
-        if run_preprocessing:
-            self.preprocessor = CurvePreprocessingAgent(
-                api_key=self.api_key,
-                model_name=model_name,
-                base_url=self.base_url,
-                output_dir=os.path.join(self.output_dir, "preprocessing"),
-                executor_timeout=executor_timeout,
-            )
 
         # Optional literature agent
         self.literature_agent = None

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2204,6 +2204,13 @@ plan as specified and let the retry pipeline handle actual runtime failures.
      do NOT smooth (it broadens lines and biases linewidths).
    - **Background:** prefer fitting a background/baseline as a model parameter
      over subtracting it.
+   WHEN preprocessing IS appropriate:
+   - **Clipping:** setting negative values to zero is appropriate ONLY for
+     intensity-type spectra (Raman, PL, fluorescence) where negatives are noise;
+     NEVER for differential/derivative/absorption data, where negatives are real.
+   - **Denoising:** modest smoothing is acceptable ONLY when the data is genuinely
+     noisy (noise large relative to signal); prefer none for clean data, and never
+     on derivative spectra (see above).
    If you preprocess, keep both the raw and processed arrays so you can plot them.
 3. Implement your fitting approach (fit over the plan's fit domain).
 4. Compute R² and RMSE

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2191,10 +2191,26 @@ plan as specified and let the retry pipeline handle actual runtime failures.
 **Available Libraries:** numpy, pandas, scipy, lmfit, matplotlib, json
 
 **Requirements:**
-1. Load data (handle .npy, .csv, .txt)
-2. Implement your fitting approach
-3. Compute R² and RMSE
-4. Save `fit_visualization.png`: data + fit + residuals (show individual components if multiple peaks).
+1. Load data (handle .npy, .csv, .txt). The data you load is RAW — no preprocessing
+   has been applied upstream.
+2. Preprocess in-script as appropriate — YOU own this; there is no separate
+   preprocessing step. Apply only what is clearly warranted for this data (or
+   nothing). HARD CONSTRAINTS:
+   - **Length-preserving:** do NOT crop, trim, bin, or select a sub-range. The
+     region to analyze is your FIT DOMAIN (restrict the fit's x-range per the
+     plan); never delete points from the array.
+   - **Non-distorting:** do not blur peak positions/widths, decay rates, or — for
+     first-derivative spectra (e.g. CW-EPR) — line shapes. For derivative spectra
+     do NOT smooth (it broadens lines and biases linewidths).
+   - **Background:** prefer fitting a background/baseline as a model parameter
+     over subtracting it.
+   If you preprocess, keep both the raw and processed arrays so you can plot them.
+3. Implement your fitting approach (fit over the plan's fit domain).
+4. Compute R² and RMSE
+5. Save `fit_visualization.png`: data + fit + residuals (show individual components if multiple peaks).
+   If you applied any preprocessing, ALSO plot the raw data faintly (light grey,
+   low alpha) so the reviewer can confirm preprocessing did not distort the
+   fitted features.
    **Plot labels must be neutral** — this plot is passed to the interpretation stage, \
 so any text in it becomes part of that stage's input:
    - Title: use "Data and Fit" or "Fit" (NOT "Lorentzian fit at 1580 cm⁻¹", \
@@ -2204,7 +2220,7 @@ NOT any material/phase name, NOT any model name)
    - Annotations: parameter values are OK (e.g. "FWHM=12"); physical assignments are NOT \
 (e.g. "sp² carbon" — do not add)
    - Axis labels: use xlabel/ylabel from sample metadata if provided; else generic "X" / "Y"
-5. Print results as JSON:
+6. Print results as JSON:
 ```python
 results = {{
     "model_type": "description",

--- a/scilink/agents/exp_agents/pipelines/curve_fitting_pipelines.py
+++ b/scilink/agents/exp_agents/pipelines/curve_fitting_pipelines.py
@@ -55,7 +55,6 @@ def create_unified_curve_fitting_pipeline(
     plot_fn: Callable,
     executor: Any,
     output_dir: str,
-    preprocessor: Any | None = None,
     literature_agent: Any | None = None,
     enable_human_feedback: bool = False,
     r2_threshold: float = 0.95,
@@ -120,7 +119,6 @@ def create_unified_curve_fitting_pipeline(
         plot_fn: Function to plot curve data
         executor: Script executor instance
         output_dir: Output directory path
-        preprocessor: Optional preprocessor agent
         literature_agent: Optional literature search agent
         enable_human_feedback: Enable human-in-the-loop refinement
         r2_threshold: Minimum acceptable R² value (default: 0.95)
@@ -189,7 +187,6 @@ def create_unified_curve_fitting_pipeline(
             enable_human_feedback=enable_human_feedback,
             outlier_sigma=outlier_sigma,
             max_verification_iterations=max_verification_iterations,
-            preprocessor=preprocessor,
             conformance_instructions=PLAN_CONFORMANCE_CHECK_INSTRUCTIONS,
             parallel_workers=parallel_workers,
         )
@@ -212,7 +209,6 @@ def create_unified_curve_fitting_pipeline(
             r2_threshold=r2_threshold,
             max_model_retries=max_model_retries,
             max_verification_iterations=max_verification_iterations,
-            preprocessor=preprocessor,
             enable_human_feedback=enable_human_feedback,
             conformance_instructions=PLAN_CONFORMANCE_CHECK_INSTRUCTIONS,
         )
@@ -281,7 +277,6 @@ def create_curve_fitting_pipeline(
     plot_fn: Callable,
     executor: Any,
     output_dir: str,
-    preprocessor: Any | None = None,
     literature_agent: Any | None = None,
     enable_human_feedback: bool = False,
     settings: dict | None = None,  # Deprecated
@@ -315,7 +310,6 @@ def create_curve_fitting_pipeline(
         plot_fn=plot_fn,
         executor=executor,
         output_dir=output_dir,
-        preprocessor=preprocessor,
         literature_agent=literature_agent,
         enable_human_feedback=enable_human_feedback,
         r2_threshold=r2_threshold,

--- a/scilink/agents/exp_agents/preprocess.py
+++ b/scilink/agents/exp_agents/preprocess.py
@@ -27,6 +27,19 @@ from ...executors import ScriptExecutor, require_sandbox_approval
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 
+class FitDomainInstruction(Exception):
+    """Raised when a custom preprocessing instruction changes the point count
+    (e.g. "fit only the decay region", "exclude the dark counts").
+
+    Such an instruction is a *fit-domain* / region-of-interest decision, not a
+    length-preserving data transform — it belongs to the planner and the fit
+    script, not to the preprocessing step (whose output must align point-for-
+    point with the input). The 1D preprocessor raises this so ``run_preprocessing``
+    can defer the instruction to the fit stage instead of failing silently and
+    returning unprocessed data. See docs/preprocessing_in_fit_loop.md.
+    """
+
+
 class HyperspectralPreprocessingAgent(BaseUtilityAgent):
     """
     An agent that uses an LLM to determine the optimal pre-processing strategy
@@ -541,7 +554,13 @@ class CurvePreprocessingAgent(BaseUtilityAgent):
         # Check for a custom, overriding instruction
         custom_instruction = system_info.get("custom_processing_instruction")
         
-        # Check if we have a locked custom script strategy from a previous spectrum
+        # A custom instruction (or locked custom script) that changes the point
+        # count is a region-of-interest / fit-domain decision, not a length-
+        # preserving transform. The planner and fit script already receive the
+        # instruction via metadata, so we defer it there and apply standard
+        # preprocessing here instead of failing. See docs/preprocessing_in_fit_loop.md.
+
+        # Locked custom script from a previous spectrum (series consistency)
         if (locked_strategy is not None
                 and locked_strategy.get("type") == "custom_script"):
             self.logger.info("Replaying locked custom preprocessing script for series consistency.")
@@ -551,16 +570,19 @@ class CurvePreprocessingAgent(BaseUtilityAgent):
                 )
                 data_quality["strategy"] = locked_strategy
                 data_quality["reasoning"] = "Locked custom script replayed for series consistency."
+                return processed_data, data_quality
+            except FitDomainInstruction as e:
+                self.logger.info(f"   ↪ Locked custom script implies a fit-domain change; deferring to the fit stage. ({e})")
+                data_quality["deferred_to_fit_domain"] = True
+                # fall through to standard preprocessing
             except Exception as e:
                 self.logger.error(f"Locked custom script replay failed: {e}. Returning original data.")
-                processed_data = curve_data
                 data_quality["reasoning"] = f"LOCKED CUSTOM SCRIPT REPLAY FAILED: {e}"
-            return processed_data, data_quality
+                return curve_data, data_quality
 
-        if custom_instruction:  # Custom script path
-            self.logger.info(f"Detected custom 1D processing instruction. Diverting to script executor.")
+        elif custom_instruction:  # Custom script path
+            self.logger.info("Detected custom 1D processing instruction.")
             self.logger.info(f"Instruction: {custom_instruction}")
-
             try:
                 processed_data, script_path, script_content = (
                     self._run_custom_script_processing_1d(
@@ -577,32 +599,50 @@ class CurvePreprocessingAgent(BaseUtilityAgent):
                         "script_content": script_content,
                         "reasoning": f"Custom preprocessing: {custom_instruction[:100]}",
                     }
+                return processed_data, data_quality
+            except FitDomainInstruction as e:
+                self.logger.info(
+                    "   ↪ Custom instruction implies a region-of-interest / "
+                    "fit-domain change. The planner and fit script own this "
+                    "(the instruction is already passed to them via metadata); "
+                    "applying standard length-preserving preprocessing instead."
+                )
+                self.logger.info(f"      ({e})")
+                data_quality["deferred_to_fit_domain"] = True
+                # fall through to standard preprocessing
             except Exception as e:
                 self.logger.error(f"Custom 1D script processing failed: {e}. Returning original data.")
-                processed_data = curve_data
                 data_quality["reasoning"] = f"CUSTOM 1D SCRIPT FAILED: {e}"
+                return curve_data, data_quality
 
-        else:  # Standard LLM-guided path
-            self.logger.info("Running LLM-guided standard 1D processing.")
+        # Standard (length-preserving) path — also the deferral target above.
+        return self._run_standard_1d(curve_data, system_info, locked_strategy, data_quality)
 
-            # 1. Calculate stats (needed for the LLM if no locked strategy)
-            stats = self._calculate_statistics_1d(curve_data)
+    def _run_standard_1d(
+        self,
+        curve_data: np.ndarray,
+        system_info: dict,
+        locked_strategy: Dict[str, Any] | None,
+        data_quality: dict,
+    ) -> Tuple[np.ndarray, Dict[str, Any]]:
+        """Standard, length-preserving 1D preprocessing (clip/smooth).
 
-            # 2. Use locked strategy if provided, otherwise ask LLM
-            if locked_strategy is not None:
-                self.logger.info("Using locked preprocessing strategy for series consistency.")
-                strategy = locked_strategy
-            else:
-                self.logger.info("No locked strategy - asking LLM for preprocessing strategy.")
-                strategy = self._llm_select_1d_strategy(stats, system_info)
-
-            # 3. Apply the strategy
-            processed_data = self._apply_1d_strategy(curve_data, strategy)
-
-            # 4. Return strategy in data_quality so it can be locked for series
-            data_quality["reasoning"] = strategy.get('reasoning', 'LLM-guided standard processing applied.')
-            data_quality["strategy"] = strategy
-
+        Used both as the default path and as the deferral target when a custom
+        instruction turns out to be a fit-domain change. A locked *custom_script*
+        strategy is ignored here (it is not a standard strategy); only a standard
+        locked strategy is reused for series consistency.
+        """
+        self.logger.info("Running LLM-guided standard 1D processing.")
+        stats = self._calculate_statistics_1d(curve_data)
+        if locked_strategy is not None and locked_strategy.get("type") != "custom_script":
+            self.logger.info("Using locked preprocessing strategy for series consistency.")
+            strategy = locked_strategy
+        else:
+            self.logger.info("No locked strategy - asking LLM for preprocessing strategy.")
+            strategy = self._llm_select_1d_strategy(stats, system_info)
+        processed_data = self._apply_1d_strategy(curve_data, strategy)
+        data_quality["reasoning"] = strategy.get('reasoning', 'LLM-guided standard processing applied.')
+        data_quality["strategy"] = strategy
         return processed_data, data_quality
 
     def _llm_select_1d_strategy(self, stats: Dict[str, Any], system_info: dict) -> dict:
@@ -844,9 +884,12 @@ class CurvePreprocessingAgent(BaseUtilityAgent):
                     f"a valid (N, 2) curve"
                 )
             if processed_data.shape[0] != curve_data.shape[0]:
-                raise RuntimeError(
+                raise FitDomainInstruction(
                     f"Custom script output has {processed_data.shape[0]} points, "
-                    f"expected {curve_data.shape[0]} to match input"
+                    f"expected {curve_data.shape[0]} to match input — the "
+                    f"instruction implies a region-of-interest / fit-domain "
+                    f"change, which is handled by the planner and fit script, "
+                    f"not by length-preserving preprocessing."
                 )
 
             # 3. Validation step (LLM quality check)
@@ -944,9 +987,10 @@ class CurvePreprocessingAgent(BaseUtilityAgent):
                     f"a valid (N, 2) curve"
                 )
             if processed_data.shape[0] != curve_data.shape[0]:
-                raise RuntimeError(
+                raise FitDomainInstruction(
                     f"Locked script output has {processed_data.shape[0]} points, "
-                    f"expected {curve_data.shape[0]} to match input"
+                    f"expected {curve_data.shape[0]} to match input — region-of-"
+                    f"interest / fit-domain change, deferred to the fit stage."
                 )
 
             return processed_data


### PR DESCRIPTION
## Summary

Moves curve-fitting **preprocessing into the generated fit script** — the model
writes its own appropriate preprocessing as part of its fitting code — and
removes the separate, prescriptive preprocessing step. Along the way it fixes a
silent failure and gives the fit verifier the raw data so preprocessing that
distorts a result becomes visible.

**The problem.** Preprocessing was a separate upstream step (`CurvePreprocessingAgent`)
that (a) chose from a fixed clip/smooth menu — skill-blind, so an EPR skill could
not say "don't smooth, it broadens the line"; (b) ran once, before the
verify/anneal loop, so a bad choice could never be redone and the verifier — which
only saw the *processed* curve — couldn't even detect it; and (c) failed silently
on any region-of-interest instruction ("fit only the decay") because its output
must match the input length, so a crop fell back to the original data.

**The fix (4 increments).**
1. Region-of-interest instructions defer to the planner instead of failing.
2. The verifier is shown the raw data so preprocessing distortion is visible.
3. The planner reliably owns ROI (fit domain) and background (fit parameter).
4. **Preprocessing becomes model-generated code inside the fit script** — one
   artifact (load raw → preprocess → fit), revisable by the same verify/anneal
   loop, with no prescriptive menu and no separate preprocessor. The model
   decides what (if any) preprocessing is appropriate, guided by skill knowledge.

**Why this shape** (per `docs/preprocessing_in_fit_loop.md`): preprocessing
choices bias the very observables being fit, so they belong in the verified loop,
not a one-shot upstream step; and they are domain-specific, so a skill should
guide them (knowledge, not a fixed menu). The fit-script codegen already injects
the active skill's `analysis`/`implementation` section (`_generate_fitting_script`
+ the loader's synonym fold), so skill preprocessing guidance reaches the
generated code directly — e.g. the EPR fit script's baseline detrend +
`fit_axial_powder` call come straight from the `epr` skill. With preprocessing in
the fit script, the loop revises it for free, and the length-preserving/length-
changing problem dissolves (no separate-step contract).

**Validated live** (claude-opus-4-6) on three datasets, fit script owning
preprocessing each time:
| Dataset | Preprocessing the model wrote | Fit |
|---|---|---|
| TRPL + "fit only the decay" | ROI as fit domain (mask, not a crop); no smoothing | R²=0.9994 |
| Synthetic peaks on a sloping baseline | baseline as a fit parameter (not subtracted); no smoothing; no crop | R²=0.9746 |
| EPR (with the `epr` skill) | skill's wing baseline detrend; **no smoothing** of the derivative; calls `fit_axial_powder`; plots raw faintly | R²=0.9734 |

---

<!-- Technical details for AI reviewers -->
## Technical details

**Step 1 — `preprocess.py`** (still present; now exercised only if a preprocessor
is wired in): `FitDomainInstruction` raised on length mismatch; `run_preprocessing`
defers it (→ fit stage) instead of the old silent fallback. `_run_standard_1d`
extracted.

**Step 2 — `controllers/curve_fitting_controllers.py`**: verifier
(`_verify_fit_with_llm`) now always carries a **PREPROCESSING CHECK** note keyed
on the faint raw trace the fit script draws, and is shown the raw data for
reference. (`_plot_raw_vs_processed` + the controller-level overlay are now inert
since `preprocessor=None`; flagged for cleanup.)

**Step 3 — `controllers/curve_fitting_controllers.py`**: `_append_fit_domain_guidance`
surfaces a `custom_processing_instruction` to both planners as a one-line
principle (ROI = fit domain, background = fit parameter).

**Step 4 (the relocation):**
- `curve_fitting_agent.py`: the separate 1D `CurvePreprocessingAgent` is retired
  from the fitting flow; all sites (analyze first-spectrum, series loop, adaptive
  refit) feed RAW to the fit script. Planner sees raw too.
- `instruct.py FITTING_SCRIPT_INSTRUCTIONS`: the script owns preprocessing —
  model-written, length-preserving (no crop/trim/bin; ROI is the fit domain),
  non-distorting (no smoothing of derivative spectra), background preferably a fit
  parameter; plots raw faintly when it preprocesses. No fixed operation menu.

**Cleanup (final commit):** the now-inert separate-preprocessor plumbing is
removed entirely — `_plot_raw_vs_processed`, the execute()-loop preprocessing +
overlay block, `_preprocess_spectrum`, and the `preprocessor` param from the
controllers, both pipeline factories, and the agent. No behavior change (nothing
passed a real preprocessor); 29 offline tests pass + live re-confirmed.

**Merge:** `origin/main` merged in (clean) — brings the merged EPR skill (PR #214)
and series-robustness (#213); enabled the EPR-with-skill composition test above.

**Tests:** 29 pass offline (`test_epr_axial_powder`, `test_curve_fitting_orient_and_adapt`,
`test_skill_loader`). Each step additionally live-validated end-to-end.

**Known follow-ups (separate PRs):** (1) `_generate_fitting_script` injects the
skill's `analysis` section into codegen; via the loader's `analysis`↔`implementation`
synonym fold this carries the implementation content for single-section skills
(all current curve-fitting skills, incl. `epr`). But a skill authoring `analysis`
AND `implementation` as *distinct* sections would get `analysis` (input
characterization) injected, not `implementation` (the runnable recipe) — a latent
inconsistency; codegen should also inject `implementation` when both exist. No
current curve-fitting skill hits this. (2) let an experienced user override the R²
threshold from the UI/chat (agreed design recorded out-of-band).


