### PR TITLE
Codegen prefers skill `implementation` section over `analysis` (curve-fit + image)

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1736,12 +1736,17 @@ Your guidance: '''
         if state.get("literature_context"):
             context_parts.append(state["literature_context"])
         skill_sections = state.get("skill_sections")
-        if skill_sections and skill_sections.get("analysis"):
+        # Prefer the `implementation` section for codegen. CLAUDE.md: implementation
+        # is the going-forward name; the loader's analysis<->implementation synonym
+        # fold makes single-section skills populate both, while dual-section skills
+        # keep `implementation` as the runnable recipe (not `analysis`).
+        codegen_recipe = (skill_sections or {}).get("implementation") or (skill_sections or {}).get("analysis")
+        if codegen_recipe:
             level = state.get("_annealing_level", 0)
             preamble = self._SKILL_STRICTNESS_SCHEDULE[
                 min(level, len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
             ].format(name=state.get("skill_name", "skill"))
-            context_parts.append(preamble + skill_sections["analysis"])
+            context_parts.append(preamble + codegen_recipe)
         prior_runs = _prior_curve_fit_block(state)
         if prior_runs:
             context_parts.append(prior_runs)
@@ -1816,12 +1821,14 @@ Your guidance: '''
             tool_inventory=_tool_inventory_text(state),
         )
         skill_sections = state.get("skill_sections")
-        if skill_sections and skill_sections.get("analysis"):
+        # Prefer `implementation` for codegen (see _generate_fitting_script).
+        codegen_recipe = (skill_sections or {}).get("implementation") or (skill_sections or {}).get("analysis")
+        if codegen_recipe:
             level = state.get("_annealing_level", 0)
             preamble = self._SKILL_STRICTNESS_SCHEDULE[
                 min(level, len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
             ].format(name=state.get("skill_name", "skill"))
-            prompt += "\n\n" + preamble + skill_sections["analysis"]
+            prompt += "\n\n" + preamble + codegen_recipe
 
         response = self.model.generate_content(prompt)
         result, error = self._parse(response)

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -2004,12 +2004,17 @@ Your guidance: '''
         if state.get("literature_context"):
             context_parts.append(state["literature_context"])
         skill_sections = state.get("skill_sections")
-        if skill_sections and skill_sections.get("analysis"):
+        # Prefer the `implementation` section for codegen. CLAUDE.md: implementation
+        # is the going-forward name; the loader's analysis<->implementation synonym
+        # fold makes single-section skills populate both, while dual-section skills
+        # keep `implementation` as the runnable recipe (not `analysis`).
+        codegen_recipe = (skill_sections or {}).get("implementation") or (skill_sections or {}).get("analysis")
+        if codegen_recipe:
             level = state.get("_annealing_level", 0)
             preamble = self._SKILL_STRICTNESS_SCHEDULE[
                 min(level, len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
             ].format(name=state.get("skill_name", "skill"))
-            context_parts.append(preamble + skill_sections["analysis"])
+            context_parts.append(preamble + codegen_recipe)
 
         # Add sub-agent preprocessing array paths
         for key in ("fft_preprocessing", "sam_preprocessing"):
@@ -2143,12 +2148,14 @@ Your guidance: '''
             tool_inventory=format_tool_inventory("image_analysis", active_skills=active_skills),
         )
         skill_sections = state.get("skill_sections")
-        if skill_sections and skill_sections.get("analysis"):
+        # Prefer `implementation` for codegen (see the generate-script path).
+        codegen_recipe = (skill_sections or {}).get("implementation") or (skill_sections or {}).get("analysis")
+        if codegen_recipe:
             level = state.get("_annealing_level", 0)
             preamble = self._SKILL_STRICTNESS_SCHEDULE[
                 min(level, len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
             ].format(name=state.get("skill_name", "skill"))
-            prompt += "\n\n" + preamble + skill_sections["analysis"]
+            prompt += "\n\n" + preamble + codegen_recipe
 
         response = self.model.generate_content(prompt)
         result, error = self._parse(response)


### PR DESCRIPTION
## Summary

Makes the curve-fitting and image-analysis code generators inject the active
skill's **`implementation`** section (the runnable-recipe role) instead of the
legacy **`analysis`** name — matching the hyperspectral agent (which already does)
and CLAUDE.md's stated direction ("Going forward, prefer `implementation`").

For a domain scientist: this guarantees that a skill's runnable recipe (e.g. "use
a Shirley background, fit Voigt profiles, call `fit_axial_powder`") reaches the
generated code, even for skills that deliberately separate "what kind of system
is this?" (`analysis`) from "the script recipe" (`implementation`).

**Behavior is unchanged for every current skill.** The skill loader folds
`analysis` ↔ `implementation` (copies content to the missing one) when a skill
authors only one of the pair — which all current curve-fitting and image-analysis
skills do — so `implementation` already holds the recipe. The change only affects
skills that author *both* as distinct sections (today: sim skills `amber`,
`lammps`, `chgnet`), where codegen previously got `analysis` (characterization)
instead of `implementation` (the recipe).

---

<!-- Technical details for AI reviewers -->
## Technical details

Four codegen injection sites, all changed to:
```python
codegen_recipe = (skill_sections or {}).get("implementation") or (skill_sections or {}).get("analysis")
```
- `controllers/curve_fitting_controllers.py` — `_generate_fitting_script` and the
  correction-prompt path.
- `controllers/image_analysis_controllers.py` — the generate and correction paths.
- `controllers/hyperspectral_controllers.py` — **already** injects
  `_render_skill_block(state, "implementation")`; unchanged. This PR brings the
  other two analysis agents in line.

Synonym fold reference: `skills/loader.py:172-182` (copies `implementation`↔
`analysis` when exactly one is authored; leaves both when distinct).

**Validation:** offline tests pass (`test_skill_loader`, `test_epr_axial_powder`,
16 total). No live test — for every current (single-section) skill the injected
content is byte-identical to before (the fold guarantees `implementation` ==
`analysis`); only future dual-section skills see a difference, and there it's the
intended correction.

**Relation to #215:** independent and complementary. #215 moves preprocessing into
the fit script (which relies on the skill section reaching codegen — already true
via the path this PR hardens). Branched off `main`; no overlap with #215's lines.
