### PR TITLE
Experienced-user R² threshold override (chat/orchestrator + programmatic)

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2012,6 +2012,7 @@ class AnalysisOrchestratorTools:
             task_mode: str = None,
             prior_analysis_paths: List[str] = None,
             literature_file: str = None,
+            r2_threshold: float = None,
         ) -> str:
             """
             Execute analysis with the selected or specified agent.
@@ -2489,6 +2490,18 @@ class AnalysisOrchestratorTools:
                     analyze_kwargs["prior_analysis_paths"] = prior_analysis_paths
                 if literature_file:
                     analyze_kwargs["literature_file"] = literature_file
+                if r2_threshold is not None:
+                    # Experienced-user R² override. Only forward to agents whose
+                    # analyze() accepts it (currently CurveFitting); others have
+                    # no R² gate, so ignore it rather than error.
+                    import inspect as _inspect
+                    if "r2_threshold" in _inspect.signature(agent.analyze).parameters:
+                        analyze_kwargs["r2_threshold"] = float(r2_threshold)
+                    else:
+                        self.logger.info(
+                            f"   r2_threshold={r2_threshold} ignored: "
+                            f"{self.AGENT_NAMES.get(agent_id, 'agent')} has no R² gate."
+                        )
                 result = agent.analyze(**analyze_kwargs)
                 
                 # === Store result ===
@@ -2732,6 +2745,18 @@ class AnalysisOrchestratorTools:
                         "`task_mode='identification'` to preserve the unbiased "
                         "fit; in that case the literature still informs Stage-2 "
                         "candidate enumeration."
+                    )
+                },
+                "r2_threshold": {
+                    "type": "number",
+                    "description": (
+                        "CurveFitting agent only. Experienced-user override of the "
+                        "R² acceptance threshold (between 0 and 1, e.g. 0.90). Use "
+                        "ONLY when the user explicitly asks to loosen or tighten the "
+                        "fit-quality bar. It overrides the default and any active "
+                        "skill's R² gate (a warning is logged on conflict), but it "
+                        "will NOT replace a skill that scores by a non-R² metric. "
+                        "Leave unset for standard analyses."
                     )
                 }
             },

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -570,7 +570,12 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             call_override=quality_gate,
             agent_default=self.quality_gate,
             skill_meta=first_skill_meta,
-            legacy_threshold=effective_r2_threshold,
+            # An explicit analyze(r2_threshold=...) is an experienced-user
+            # override that wins over a skill gate (with the metric guard);
+            # the constructor default stays the low-priority legacy threshold.
+            user_threshold=r2_threshold,
+            legacy_threshold=self.r2_threshold,
+            logger=self.logger,
         )
         # When the resolved gate is r_squared, keep the legacy accept value
         # exactly as today so every existing controller path runs unchanged.

--- a/scilink/agents/exp_agents/quality_gate.py
+++ b/scilink/agents/exp_agents/quality_gate.py
@@ -152,32 +152,65 @@ def resolve_gate(
     call_override: Optional[Any] = None,
     agent_default: Optional[Any] = None,
     skill_meta: Optional[dict] = None,
+    user_threshold: Optional[float] = None,
     legacy_threshold: Optional[float] = None,
+    logger: Optional[Any] = None,
 ) -> QualityGate:
-    """Resolve the effective gate from all four sources.
+    """Resolve the effective gate from all sources.
 
     Priority (highest first):
-      1. ``call_override`` — explicit ``analyze(quality_gate=...)`` arg
-      2. ``agent_default`` — ``CurveFittingAgent(quality_gate=...)`` arg
-      3. ``skill_meta['quality_gate']`` — frontmatter block from the
-         active skill (or the first loaded skill in a multi-skill set).
-      4. ``legacy_threshold`` — when set, builds a QualityGate(metric=
-         'r_squared', accept_threshold=value). This handles the
-         pre-existing ``r2_threshold`` kwarg on analyze() / __init__.
-      5. :data:`R_SQUARED_DEFAULT`.
+      1. ``call_override`` — explicit ``analyze(quality_gate=...)`` arg (a full
+         gate, possibly with a non-R² metric — deliberate, wins over everything).
+      2. ``agent_default`` — ``CurveFittingAgent(quality_gate=...)`` arg.
+      3. ``user_threshold`` — an experienced user's explicit numeric R² override
+         (e.g. ``analyze(r2_threshold=...)`` from the UI/chat). Wins over a skill
+         gate, but ONLY for the threshold value. **Metric guard:** if the active
+         skill scores by a non-``r_squared`` metric, a bare R² number must not
+         silently replace that metric — the override is ignored (skill gate kept)
+         and a warning is logged. Changing the metric requires an explicit
+         ``quality_gate`` (layer 1), not a threshold number.
+      4. ``skill_meta['quality_gate']`` — frontmatter block from the active skill
+         (or the first loaded skill in a multi-skill set).
+      5. ``legacy_threshold`` — the agent constructor's ``r2_threshold`` default;
+         builds a ``QualityGate(metric='r_squared', accept_threshold=value)``.
+      6. :data:`R_SQUARED_DEFAULT`.
 
     Each layer can be either a :class:`QualityGate` instance or a plain
     dict (matching the dataclass fields). Dicts are coerced via
-    :func:`from_mapping`. ``None`` at any layer falls through.
+    :func:`from_mapping`. ``None`` at any layer falls through. ``logger`` (if
+    provided) receives a warning when a user R² override conflicts with, or is
+    blocked by, a skill gate.
     """
     for source in (call_override, agent_default):
         gate = _coerce(source)
         if gate is not None:
             return gate
-    if skill_meta:
-        gate = _coerce(skill_meta.get("quality_gate"))
-        if gate is not None:
-            return gate
+
+    skill_gate = _coerce((skill_meta or {}).get("quality_gate")) if skill_meta else None
+
+    # Experienced-user numeric R² override (layer 3): wins over the skill gate,
+    # but only as a threshold — never silently swaps a skill's non-R² metric.
+    if user_threshold is not None:
+        if skill_gate is not None and skill_gate.metric != "r_squared":
+            if logger is not None:
+                logger.warning(
+                    f"   R² override {float(user_threshold):.3f} ignored: the active "
+                    f"skill scores by '{skill_gate.metric}', not R². Keeping the "
+                    f"skill's quality gate. (To change the metric, pass an explicit "
+                    f"quality_gate; to change the threshold, configure it on the skill.)"
+                )
+            return skill_gate
+        if (logger is not None and skill_gate is not None
+                and skill_gate.metric == "r_squared"
+                and abs(skill_gate.accept_threshold - float(user_threshold)) > 1e-9):
+            logger.warning(
+                f"   Using user R² override {float(user_threshold):.3f} "
+                f"(active skill recommends {skill_gate.accept_threshold:.3f})."
+            )
+        return R_SQUARED_DEFAULT.with_accept_threshold(float(user_threshold))
+
+    if skill_gate is not None:
+        return skill_gate
     if legacy_threshold is not None:
         return R_SQUARED_DEFAULT.with_accept_threshold(float(legacy_threshold))
     return R_SQUARED_DEFAULT

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -168,3 +168,57 @@ def test_from_mapping_minimal():
                        "hard_reject_threshold": 0.4})
     assert g.metric == "figure_of_merit"
     assert g.direction == "higher_is_better"  # defaulted
+
+
+# --- user_threshold override (experienced-user R²) ---------------------------
+
+class _CaptureLogger:
+    def __init__(self): self.warnings = []
+    def warning(self, msg): self.warnings.append(msg)
+
+
+def test_user_threshold_overrides_skill_r2_gate():
+    """A user R² override beats a skill's r_squared gate, and warns."""
+    skill_meta = {"quality_gate": {"metric": "r_squared", "accept_threshold": 0.90,
+                                   "hard_reject_threshold": 0.75}}
+    log = _CaptureLogger()
+    resolved = resolve_gate(skill_meta=skill_meta, user_threshold=0.85, logger=log)
+    assert resolved.metric == "r_squared"
+    assert resolved.accept_threshold == pytest.approx(0.85)
+    assert any("recommends 0.900" in w for w in log.warnings)
+
+
+def test_user_threshold_metric_guard_keeps_skill_gate():
+    """A bare R² override must NOT replace a skill's non-r_squared metric."""
+    skill_meta = {"quality_gate": {"metric": "figure_of_merit", "accept_threshold": 0.7,
+                                   "hard_reject_threshold": 0.4}}
+    log = _CaptureLogger()
+    resolved = resolve_gate(skill_meta=skill_meta, user_threshold=0.85, logger=log)
+    assert resolved.metric == "figure_of_merit"          # skill gate kept
+    assert resolved.accept_threshold == pytest.approx(0.7)
+    assert any("ignored" in w and "figure_of_merit" in w for w in log.warnings)
+
+
+def test_user_threshold_applies_with_no_skill():
+    resolved = resolve_gate(user_threshold=0.88, legacy_threshold=0.95)
+    assert resolved.metric == "r_squared"
+    assert resolved.accept_threshold == pytest.approx(0.88)
+
+
+def test_explicit_quality_gate_still_beats_user_threshold():
+    """An explicit quality_gate (full gate) outranks a numeric R² override."""
+    call_gate = QualityGate(metric="cost", accept_threshold=0.2,
+                            hard_reject_threshold=0.5, direction="lower_is_better")
+    resolved = resolve_gate(call_override=call_gate, user_threshold=0.85,
+                            skill_meta={"quality_gate": {"metric": "r_squared",
+                                                         "accept_threshold": 0.9,
+                                                         "hard_reject_threshold": 0.75}})
+    assert resolved.metric == "cost"
+
+
+def test_no_user_threshold_preserves_skill_over_legacy():
+    """Sanity: without a user override, skill still beats legacy (unchanged)."""
+    skill_meta = {"quality_gate": {"metric": "r_squared", "accept_threshold": 0.90,
+                                   "hard_reject_threshold": 0.75}}
+    resolved = resolve_gate(skill_meta=skill_meta, legacy_threshold=0.95)
+    assert resolved.accept_threshold == pytest.approx(0.90)  # skill, not legacy


### PR DESCRIPTION
## Summary

Lets an **experienced user override the curve-fit R² acceptance threshold** — the
thing that previously had no UI/chat lever (only a skill's `quality_gate` or the
programmatic API could change it).

A user can now say, in chat: *"this data is noisy — use an R² threshold of 0.85"*,
and it flows through to the fit's quality gate. With the agreed safeguards:
- The override **wins over a skill's R² gate** (a warning is logged on conflict —
  trust the expert, but make the skill's recommendation visible).
- **Metric guard:** it will **not** silently replace a skill that scores by a
  *non-R²* metric (e.g. a structure-match figure-of-merit). There, the bare R²
  number is ignored and a warning is logged; changing the metric still requires an
  explicit `quality_gate`.

The UI is chat-driven, so this already works in the UI via the chat box (validated
end-to-end). A dedicated sidebar widget is an optional follow-up.

---

<!-- Technical details for AI reviewers -->
## Technical details

- `quality_gate.resolve_gate`: new `user_threshold` layer between `agent_default`
  and `skill_meta` (priority: call_override → agent_default → **user_threshold** →
  skill → legacy_threshold → default). Metric guard: if a skill gate exists with
  `metric != "r_squared"`, the numeric override is dropped and the skill gate
  returned; warnings go to an optional `logger`. Behavior is byte-identical when
  no `user_threshold` is passed (existing tests unchanged).
- `curve_fitting_agent.analyze`: passes the explicit `r2_threshold` arg as
  `user_threshold`, the constructor default as `legacy_threshold`, and `self.logger`.
- `analysis_orchestrator_tools.run_analysis`: new `r2_threshold` tool param (LLM
  schema + signature + forward), forwarded only to agents whose `analyze()`
  accepts it (signature-guarded; CurveFitting only — others log-and-ignore, since
  image/hyperspectral have no R² gate).
- `tests/test_quality_gate.py`: +5 tests; 23 pass total.

**Validation:** 23 unit tests pass. Orchestrator-mode live run (claude-opus-4-6) as
an experienced user asking in chat to loosen R² to 0.85 → the LLM called
`run_analysis`, and the curve-fit run logged `R² ≥ 0.850 accepts` (default is 0.95;
no skill active, so 0.85 came from the override). Full path verified: chat →
run_analysis → analyze → resolve_gate.

**Follow-up (optional):** a deterministic UI sidebar control (an orchestrator-level
`default_r2_threshold` that `run_analysis` falls back to + a `st.number_input`).
Not needed for the feature — the chat path already works in the UI.
