### PR TITLE
Hyperspectral: codegen gets the raw cube; preprocessing folded into the decomposition tool

### DIFF
--- a/docs/hyperspectral_codegen_relocation.md
+++ b/docs/hyperspectral_codegen_relocation.md
@@ -1,0 +1,183 @@
+# Design note: hyperspectral preprocessing & denoising — into the decomposition tool and codegen
+
+**Status:** proposal (not implemented). Companion to the curve-fitting work
+(`docs/preprocessing_in_fit_loop.md` / PR #215), but **deliberately a different
+shape** — see "How this differs from curve fitting."
+
+**Scope:** `HyperspectralAnalysisAgent` (EELS / datacubes). Retire the standalone
+preprocessing stage by **folding it into the decomposition tool**, and give the
+per-pixel codegen ownership of a separate, fittability-oriented denoising.
+**Decomposition itself is NOT relocated** — it stays the iterative,
+model-bearing loop it already is.
+
+---
+
+## TL;DR
+
+The hyperspectral iteration pipeline has a standalone preprocessing stage
+(despike/clip/mask menu) feeding a 6-substage decomposition block (NMF/PCA/ICA
+with an LLM elbow/component selection), feeding a codegen stage that already
+generates per-pixel fitting code. This plan:
+
+1. **Retires the standalone preprocessing stage** and **folds it into the
+   decomposition tool** — preprocessing exists to make the cube *decomposable*,
+   so it belongs with decomposition, as **explicit deterministic primitives the
+   (already model-bearing) decomposition step selects** (despike / clip-iff-
+   non-negative / mask-threshold / normalize). Not a separate pipeline stage; not
+   free-form codegen.
+2. **Leaves decomposition as the iterative loop** (it has a real
+   decompose → re-plan feedback edge; flattening it would lose the LLM-in-the-loop
+   component selection).
+3. **Gives the codegen the RAW cube + decomposition outputs + SNR/prep-note** (not
+   the decomposition-cleaned cube), and makes it **own a second, free-form
+   denoising whose goal is simply: make the per-pixel spectra fittable.**
+
+Two denoisings, two goals, two mechanisms — kept separate on purpose.
+
+## Current architecture (evidence)
+
+Iteration pipeline (`pipelines/hyperspectral_pipelines.py`):
+
+| # | Stage | Today |
+|---|---|---|
+| 1 | `RunPreprocessingController` → `HyperspectralPreprocessingAgent._apply_preprocessing` | **standalone preprocessing**: despike (median filter) / clip-negatives (iff `signal_is_nonnegative`) / mask-threshold menu, selected by an LLM strategy call. Emits `state["data_quality"]` (SNR + reasoning) and `state["preprocessing_mask"]`. |
+| 2a–2f | component-param estimate → test-loop → elbow → LLM picks n → final unmix → validation | **decomposition** (NMF/PCA/ICA via `SpectralUnmixer`), with an **LLM-in-the-loop component selection** (elbow plot → pick n). |
+| 3a–3d | prompt / interpret / **refinement decision** / human feedback | the refinement decision (what to extract) **depends on the decomposition output** → this is the decompose ↔ re-plan feedback edge. |
+| 3e | `RunDynamicAnalysisController` | **codegen**: writes per-pixel `analyze_feature()`, injects skill `implementation`, `exec` sandbox, per-map visual QC + retry. Receives data from `get_optimal_analysis_data`. |
+
+Three facts that shape the plan:
+- **Decomposition is the core analytical step and is interleaved with planning**
+  (3a–3c react to 2a–2f). It is *not* feed-forward → it stays a loop.
+- **A codegen + visual-QC machine already exists** (3e). It already injects the
+  skill `implementation` section and sandboxes execution.
+- **PCA denoising was already removed.** `get_optimal_analysis_data`
+  (`eels.py:1243`) used to PCA-denoise the cube before codegen; its docstring
+  states it was removed because it "could silently remove real spectral features
+  … the custom code was specifically asked to model." It now returns the **raw
+  cube + an SNR note** and defers noise handling to the codegen. This plan
+  continues that direction.
+
+## How this differs from curve fitting (#215)
+
+Curve fitting was feed-forward → preprocessing folded into the single fit script.
+Hyperspectral is **not**, for two reasons, so the shape is different:
+- **Decomposition is interleaved with planning** → it stays a loop step, not a
+  leaf the planner calls once.
+- **Preprocessing here serves decomposition** (a bounded, mechanical goal with a
+  structured mask output) → it belongs *inside the decomposition tool* as
+  **explicit primitives**, not as free-form codegen the way curve preprocessing
+  became. (Free-form is reserved for the open-ended *post*-decomposition
+  fittability denoising.)
+
+## Target architecture
+
+```
+planner (rough: method hint, skill-guided)
+  → DECOMPOSITION TOOL   (model-bearing; owns its own prep)
+        raw cube
+          → internal prep: explicit deterministic primitives the tool's LLM
+            SELECTS (despike / clip-iff-nonneg / mask-threshold / normalize),
+            informed by SNR + technique + skill; deterministically APPLIED
+          → NMF/PCA/ICA + elbow + LLM component selection + validation
+        emits: components, abundance_maps, reconstruction, validation,
+               AND data-quality metadata (SNR, mask, short prep-note)
+  → re-plan on decomposition output            (the feedback edge — preserved)
+  → CODEGEN  (per-pixel fitting)
+        receives: RAW cube  +  decomposition outputs (components / abundances /
+                  reconstruction)  +  SNR  +  prep-note
+        owns: free-form, per-task denoising whose goal is FITTABLE spectra
+              (may fit raw, the reconstruction, or its own denoise — its call)
+```
+
+### Decision 1 — preprocessing folds into the decomposition tool (explicit primitives)
+- Retire `RunPreprocessingController` as a stage and `_apply_preprocessing` as a
+  standalone menu. The **decomposition tool** does the prep internally.
+- Prep is **explicit deterministic primitives, LLM-selected** — NOT free-form
+  codegen — because the op set is bounded and mechanical, masking yields a
+  structured mask consumed downstream, and NMF mechanics make some ops
+  semantically required:
+  - **clip-negatives:** deterministic, applies **iff**
+    `axis_spec.signal_is_nonnegative` (today's rule).
+  - **despike / mask-threshold / normalize:** the *selection + parameters* are
+    chosen by the decomposition step's LLM (from SNR, technique, skill — e.g.
+    "don't mask the vacuum region", "align the zero-loss peak"); deterministically
+    applied.
+- This prep is **internal to the tool** (it serves good components) and must
+  **not** overwrite the cube handed to codegen.
+
+### Decision 2 — decomposition stays the iterative loop
+- The component selection (test-loop → elbow → LLM picks n) is preserved; the
+  refinement decision keeps consuming decomposition output. Do **not** linearize
+  to planner→decompose→codegen.
+
+### Decision 3 — codegen receives RAW, not the decomposition-cleaned cube
+- Base data to codegen = the **raw** cube (after only the deterministic loader:
+  format/units/NaN). **Not** the decomposition-prep-cleaned cube — that cleaning
+  (masking, clipping, despike thresholds) was tuned **for decomposition** and can
+  be wrong for per-pixel fitting (the same "preprocessing biases the observable"
+  problem, moved one stage over).
+- Codegen **also** receives the decomposition **outputs as optional inputs**
+  (components, abundance maps, the rank-k **reconstruction**) + the **SNR** + a
+  **prep-note** of what decomposition-prep was applied — so it can choose to fit
+  the reconstruction (denoised) or replicate universally-good ops (e.g. cosmic-ray
+  despike) without inheriting the decomposition-specific ones.
+
+### Decision 4 — codegen owns post-decomposition denoising (free-form, fittability)
+- Goal is narrow and clear: **make the spectra fittable.** The generated code
+  decides per task (fit raw / fit reconstruction / its own gentle denoise),
+  guided by skill + the "don't erase the feature you're fitting" guardrail.
+- **Never a silent global step** — the removed-PCA-denoise is the precedent. The
+  denoised reconstruction is *offered as an option*, not forced.
+
+## The info-flow contract (must preserve)
+
+Today the standalone preprocessing emits metadata that flows downstream:
+`SNR → component-selection planning` (`hyperspectral_controllers.py:378-379`) and
+`processing-note + mask → codegen` (`get_optimal_analysis_data` / build prompt).
+When prep folds into the decomposition tool, **the tool must still emit**:
+- `components`, `abundance_maps`, `reconstruction`, `validation`;
+- `data_quality` = **SNR recomputed deterministically** after prep (not LLM-
+  asserted) + reasoning;
+- the **mask**;
+- a short **prep-note** (operations applied).
+
+These feed the re-planning (component/extraction decisions) and the codegen prompt
+exactly as today — so nothing downstream loses information. (The prep-note is
+richer than today's terse strategy, so planning/codegen become *better* informed.)
+
+## Migration (incremental)
+
+1. **Expose decomposition (incl. its prep) as a single model-bearing tool/step**
+   that encapsulates today's 2a–2f *and* the prep primitives, emitting the
+   metadata contract above. The prep primitives are explicit functions
+   (despike/clip/mask/normalize) the tool selects.
+2. **Stop running the standalone `RunPreprocessingController`**; the decomposition
+   tool owns prep. Keep a thin deterministic loader (format/units/NaN).
+3. **Feed codegen RAW + decomposition outputs + SNR + prep-note** (extend
+   `get_optimal_analysis_data`'s contract — it already returns raw + SNR; add the
+   reconstruction/components/prep-note as available inputs).
+4. **Codegen owns fittability denoising** — prompt it that any denoising is its
+   choice for fittability, offered the reconstruction, never forced; reuse the
+   existing visual-QC judge (raw-vs-processed view for whatever it applies).
+
+Steps 1–2 are the load-bearing change; 3–4 wire the codegen contract.
+
+## Tradeoffs and risks
+
+- **Preserve the elbow / component-count LLM judgment** inside the decomposition
+  tool — it's a real strength; don't degrade it to "model guesses n."
+- **Bigger blast radius than #215** (a whole stage retired into a tool; the
+  iteration loop touched). Stage it; keep `final_components` /
+  `final_abundance_maps` and the `data_quality`/`mask` state contracts intact.
+- **Don't reintroduce silent denoising** (PCA-reconstruction or aggressive
+  smoothing) anywhere global — only as an explicit, codegen-chosen option.
+- **Decomposition-prep ≠ fitting cube**: enforce that the tool does not overwrite
+  the raw cube the codegen receives.
+
+## Non-goals
+
+- Not relocating decomposition out of the loop, and not making it a pure-numeric
+  leaf (it keeps its LLM component selection).
+- Not making decomposition prep free-form codegen — it's explicit primitives.
+- Not forcing reconstruction-denoising on the codegen — it's an option.
+- Not changing the synthesis pipeline beyond the inputs it receives.

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -300,15 +300,34 @@ def _sanitize_filename(text: str) -> str:
 
 class RunPreprocessingController:
     """
-    [🛠️ Tool Step]
-    Runs the HyperspectralPreprocessingAgent.
+    [🛠️ Tool Step] The decomposition tool's own input-prep substage.
+
+    Cleans the cube *for decomposition* (despike / clip-iff-non-negative /
+    mask-threshold) and emits the SNR + mask metadata the component planner
+    consumes. It is no longer a standalone, universal preprocessing stage:
+    the per-pixel codegen receives the RAW cube and owns its own fittability
+    denoising. So this runs only when decomposition will run (gated on
+    ``skip_decomposition``). See docs/hyperspectral_codegen_relocation.md.
     """
     def __init__(self, logger: logging.Logger, preprocessor: HyperspectralPreprocessingAgent):
         self.logger = logger
         self.preprocessor = preprocessor
 
     def execute(self, state: dict) -> dict:
-        self.logger.info("\n\n🛠️ --- CALLING TOOL: PREPROCESSING AGENT --- 🛠️\n")
+        if state.get("error_dict"):
+            return state
+        self.logger.info("\n\n🛠️ --- DECOMPOSITION PREP (clean cube for decomposition) --- 🛠️\n")
+
+        # If decomposition is skipped, the per-pixel codegen uses the RAW cube
+        # anyway — no decomposition-prep is needed. Just surface SNR/mask so any
+        # downstream prompt that reads them stays populated.
+        if state.get("skip_decomposition"):
+            self.logger.info("Decomposition skipped → no decomposition-prep (codegen uses the raw cube).")
+            if "preprocessing_mask" not in state:
+                state["preprocessing_mask"] = np.ones(state["hspy_data"].shape[:2], dtype=bool)
+            state.setdefault("data_quality", {"reasoning": "Decomposition skipped; raw data used downstream."})
+            return state
+
         if not self.preprocessor:
             self.logger.warning("Preprocessing skipped: agent not initialized.")
             state["data_quality"] = {"reasoning": "Preprocessing skipped: agent not initialized."}
@@ -373,6 +392,20 @@ class GetInitialComponentParamsController:
 
         h, w, e = state["hspy_data"].shape
         data_quality = state.get("data_quality", {})
+        if not data_quality.get("snr_estimate"):
+            # Decomposition-prep now runs AFTER this estimate (it is the
+            # decomposition's own prep substage), so derive SNR from the raw cube
+            # here. See docs/hyperspectral_codegen_relocation.md.
+            try:
+                _snr = float(tools.estimate_global_snr(state["hspy_data"]))
+                data_quality = {
+                    "snr_estimate": round(_snr, 1),
+                    "reasoning": f"SNR estimated from the raw cube (≈{_snr:.1f}); "
+                                 f"decomposition preprocessing runs next.",
+                }
+                state["data_quality"] = data_quality
+            except Exception as _e:
+                self.logger.debug(f"raw SNR estimate failed: {_e}")
         axis_spec = resolve_axis_spec(state.get("system_info"))
 
         prompt_parts = [self.instructions]

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -260,7 +260,11 @@ Write a function `analyze_feature(data, axis)` that:
 
 ### ADDITIONAL NOTES
 The variable `hspy_data` passed to your function contains: **{processing_note}**.
-If performing derivative-based operations (like `find_peaks` or `curve_fit`) on noisy data, consider applying appropriate smoothing to ensure convergence.
+This is the RAW cube — no smoothing/clipping/despiking has been applied for you
+(any cleaning done for decomposition is NOT in this array). Apply whatever
+noise/spike/negative handling you judge necessary for a stable per-pixel fit —
+the goal is fittable spectra — but do NOT erase the feature you are measuring.
+If performing derivative-based operations (like `find_peaks` or `curve_fit`) on noisy data, apply appropriate smoothing to ensure convergence.
 {hints_section}
 ### REQUIRED RETURN FORMAT
 {{
@@ -1620,7 +1624,11 @@ class RunDynamicAnalysisController:
         all_valid_maps = []
         all_valid_meta = []
 
-        optimal_data, processing_note = tools.get_optimal_analysis_data(state["hspy_data"])
+        # Feed the per-pixel codegen the RAW cube, not the cube cleaned for
+        # decomposition (despike/clip/mask is tuned for NMF and can distort the
+        # features being fit — e.g. clipping real low-loss negatives). The codegen
+        # owns its own fittability denoising. See docs/hyperspectral_codegen_relocation.md.
+        optimal_data, processing_note = tools.get_optimal_analysis_data(state["original_hspy_data"])
         self.logger.info(f"📊 Dynamic Analysis Prep: {processing_note}")
         
         # --- MAIN LOOP: Process each target description separately ---

--- a/scilink/agents/exp_agents/pipelines/hyperspectral_pipelines.py
+++ b/scilink/agents/exp_agents/pipelines/hyperspectral_pipelines.py
@@ -42,19 +42,27 @@ def create_hyperspectral_iteration_pipeline(
 
     pipeline = []
 
-    # --- 1. PREPROCESSING (Only on first iteration) ---
-    if settings.get('run_preprocessing', True):
-        pipeline.append(RunPreprocessingController(logger, preprocessor))
-
-    # --- 2. SPECTRAL UNMIXING ---
+    # --- SPECTRAL DECOMPOSITION (owns its own input prep) ---
+    # Preprocessing is no longer a standalone universal stage: it cleans the cube
+    # *for decomposition* and is the decomposition tool's first substage. The
+    # per-pixel codegen receives the RAW cube and owns its own fittability
+    # denoising. See docs/hyperspectral_codegen_relocation.md.
     if settings.get('enabled', True):
 
-        # 2a. Auto-component workflow
+        # [🧠 LLM] Initial component/method guess — also decides skip_decomposition,
+        # using SNR estimated from the raw cube (prep runs after this).
         if settings.get('auto_components', True):
-            # [🧠 LLM] Get initial component guess
             pipeline.append(GetInitialComponentParamsController(
                 model, logger, generation_config, safety_settings, parse_fn
             ))
+
+        # [🛠️ Tool] Decomposition's own prep substage — runs after the skip
+        # decision; internally gated on `skip_decomposition`.
+        if settings.get('run_preprocessing', True):
+            pipeline.append(RunPreprocessingController(logger, preprocessor))
+
+        # Rest of the auto-component workflow operates on the cleaned cube.
+        if settings.get('auto_components', True):
             # [🛠️ Tool] Run NMF loop to get errors
             pipeline.append(RunComponentTestLoopController(logger, settings))
             # [🛠️ Tool] Create elbow plot from errors
@@ -64,10 +72,10 @@ def create_hyperspectral_iteration_pipeline(
                 model, logger, generation_config, safety_settings, parse_fn
             ))
 
-        # 2b. [🛠️ Tool] Run final NMF
+        # [🛠️ Tool] Run final NMF
         pipeline.append(RunFinalSpectralUnmixingController(logger, settings))
 
-        # 2c. [🛠️ Tool] Create all plots for analysis
+        # [🛠️ Tool] Create all plots for analysis
         pipeline.append(CreateAnalysisPlotsController(logger, settings))
 
     # --- 3. ITERATION ANALYSIS & REFINEMENT DECISION ---


### PR DESCRIPTION
## Summary

Applies the curve-fitting relocation philosophy (#215) to the **hyperspectral
agent**, in two validated increments, plus the design note. The two denoisings
are now cleanly separated by goal: **decomposition cleans its own input**, and
the **per-pixel codegen receives the RAW cube and owns its fittability denoising.**

**The problem (observed on the real EELS LSPR cube):** preprocessing was a
standalone stage whose despike/clip/mask-cleaned cube fed *both* decomposition
*and* the per-pixel fitting. In the baseline run it clipped real low-loss
negatives to 0 — so the fitting code never saw the true signal (preprocessing
silently biasing the observable).

**Increment 1 — codegen gets raw** (`controllers/hyperspectral_controllers.py`):
`RunDynamicAnalysisController` now feeds `analyze_feature` the RAW cube
(`state["original_hspy_data"]`), not the decomposition-cleaned cube, and the
codegen prompt tells it the data is raw and it owns any noise/spike/negative
handling needed for a stable fit (without erasing the measured feature).

**Increment 2 — preprocessing folded into the decomposition tool** (controllers +
`pipelines/hyperspectral_pipelines.py`): the standalone preprocessing stage is
retired. Prep is now the decomposition tool's gated first substage — it runs only
when decomposition runs (`skip_decomposition`), cleans the cube *for
decomposition*, and emits the SNR + mask metadata the component planner consumes.
`GetInitialComponentParamsController` (2a) estimates SNR from the **raw** cube for
its method/n/skip decision (prep now runs after it).

**Validated** (claude-opus-4-6, `examples/eels_plasmons_demo`, ~7 min/run, no
regression): baseline 418s → inc1 407s → inc2 442s, each `success` with 2 claims +
LSPR maps. Inc1 log: `Dynamic Analysis Prep: Raw Data (… SNR≈3.6)` and the
generated `analyze_feature` self-smooths `y_raw`. Inc2 log shows the new order
`ESTIMATE → DECOMPOSITION PREP → TEST LOOP → SELECT → …`.

Design note: `docs/hyperspectral_codegen_relocation.md`.

## Follow-ups (filed as issues, not in this PR)
- #219 — offer the decomposition **reconstruction** as an explicit codegen input option
- #220 — **package** the decomposition stages (2a–2f + prep) into one cohesive tool
- #221 — refactor decomposition prep into **named explicit primitives** + richer prep-note

**Decomposition itself is intentionally NOT relocated** — it stays the iterative,
model-bearing loop (the decompose↔re-plan feedback edge), per the design note.

---

<!-- Technical details for AI reviewers -->
## Technical details
- `RunDynamicAnalysisController`: `get_optimal_analysis_data(state["original_hspy_data"])`; codegen prompt adds the "raw, you own fittability denoising" clause.
- `pipelines/hyperspectral_pipelines.py`: `RunPreprocessingController` moved from a top-level stage to inside the `enabled` decomposition block, after the `auto_components` estimate (2a) and before the unmixing loop; gated by `run_preprocessing`.
- `GetInitialComponentParamsController`: computes `tools.estimate_global_snr(state["hspy_data"])` (raw) into `data_quality` when absent.
- `RunPreprocessingController`: docstring reframed as "DECOMPOSITION PREP"; early-returns when `skip_decomposition` (surfacing SNR/mask) so prep only runs for decomposition.
