### PR TITLE
Prefill API keys in the UI based on environment variables

### DIFF
--- a/scilink/auth.py
+++ b/scilink/auth.py
@@ -117,28 +117,6 @@ def find_env_var_for_model(model_name: str) -> Optional[tuple]:
     return find_env_var(provider) if provider else None
 
 
-# LLM vendor providers, in the order to fall back through when no provider was
-# matched to the selected model (used for credential prefill).
-VENDOR_PROVIDERS = ('openai', 'anthropic', 'google')
-
-
-def find_first_vendor_env() -> Optional[tuple]:
-    """
-    Find the first set vendor LLM env var, regardless of model.
-
-    Lets the UI surface a single exported key even when it does not match the
-    currently-selected model's provider (the user then picks a matching model).
-
-    Returns:
-        ``(env_var_name, value)`` or None if no vendor key is set.
-    """
-    for provider in VENDOR_PROVIDERS:
-        found = find_env_var(provider)
-        if found:
-            return found
-    return None
-
-
 class APIKeyManager:
     """Simple API key management with environment variable auto-discovery."""
     

--- a/scilink/auth.py
+++ b/scilink/auth.py
@@ -58,11 +58,14 @@ def infer_provider(model_name: str) -> Optional[str]:
     # Infer from model name patterns
     if model_lower.startswith(('gpt-', 'o1-', 'o3-')):
         return 'openai'
+    # OpenAI embedding family: text-embedding-ada-002, text-embedding-3-*, ...
+    if model_lower.startswith('text-embedding-'):
+        return 'openai'
     if model_lower.startswith('claude'):
         return 'anthropic'
     if 'gemini' in model_lower:
         return 'google'
-    
+
     return None
 
 

--- a/scilink/auth.py
+++ b/scilink/auth.py
@@ -23,6 +23,10 @@ ENV_VARS = {
 # Internal proxy key (separate from provider keys)
 INTERNAL_PROXY_KEY = 'SCILINK_API_KEY'
 
+# Internal proxy base URL — pairs with INTERNAL_PROXY_KEY so the proxy path
+# can be configured entirely from the environment (e.g. container deployments).
+INTERNAL_PROXY_BASE_URL = 'SCILINK_BASE_URL'
+
 
 def infer_provider(model_name: str) -> Optional[str]:
     """
@@ -65,11 +69,52 @@ def infer_provider(model_name: str) -> Optional[str]:
 def get_internal_proxy_key() -> Optional[str]:
     """
     Get API key for internal proxy deployments.
-    
+
     Returns:
         SCILINK_API_KEY value or None
     """
     return os.getenv(INTERNAL_PROXY_KEY)
+
+
+def get_internal_proxy_base_url() -> Optional[str]:
+    """
+    Get the base URL for internal proxy deployments.
+
+    Returns:
+        SCILINK_BASE_URL value or None
+    """
+    return os.getenv(INTERNAL_PROXY_BASE_URL)
+
+
+def find_env_var(service: str) -> Optional[tuple]:
+    """
+    Find the first set environment variable for a service.
+
+    Unlike ``get_api_key``, this returns the variable *name* alongside the
+    value, so callers (e.g. the UI) can show which env var supplied a key.
+
+    Args:
+        service: One of the keys in ``ENV_VARS`` (e.g. 'openai', 'futurehouse').
+
+    Returns:
+        ``(env_var_name, value)`` for the first set variable, or None.
+    """
+    for var_name in ENV_VARS.get(service, []):
+        value = os.getenv(var_name)
+        if value:
+            return var_name, value
+    return None
+
+
+def find_env_var_for_model(model_name: str) -> Optional[tuple]:
+    """
+    Find the set vendor env var matching a model's inferred provider.
+
+    Returns:
+        ``(env_var_name, value)`` or None (no provider inferred, or none set).
+    """
+    provider = infer_provider(model_name)
+    return find_env_var(provider) if provider else None
 
 
 class APIKeyManager:

--- a/scilink/auth.py
+++ b/scilink/auth.py
@@ -117,6 +117,28 @@ def find_env_var_for_model(model_name: str) -> Optional[tuple]:
     return find_env_var(provider) if provider else None
 
 
+# LLM vendor providers, in the order to fall back through when no provider was
+# matched to the selected model (used for credential prefill).
+VENDOR_PROVIDERS = ('openai', 'anthropic', 'google')
+
+
+def find_first_vendor_env() -> Optional[tuple]:
+    """
+    Find the first set vendor LLM env var, regardless of model.
+
+    Lets the UI surface a single exported key even when it does not match the
+    currently-selected model's provider (the user then picks a matching model).
+
+    Returns:
+        ``(env_var_name, value)`` or None if no vendor key is set.
+    """
+    for provider in VENDOR_PROVIDERS:
+        found = find_env_var(provider)
+        if found:
+            return found
+    return None
+
+
 class APIKeyManager:
     """Simple API key management with environment variable auto-discovery."""
     

--- a/scilink/auth.py
+++ b/scilink/auth.py
@@ -8,7 +8,24 @@ import os
 from typing import Optional, Dict
 
 
-# Environment variable names per provider
+# Environment variable names per provider.
+#
+# To register a new provider for credential prefill (three independent rungs —
+# populate only the ones the vendor actually needs):
+#
+#   1. Add an entry here: provider identity (lowercase) -> env var name(s) in
+#      preference order. List multiple names when a vendor accepts more than
+#      one (see 'google', which honours both GEMINI_API_KEY and GOOGLE_API_KEY).
+#      Note that the env-var name is NOT derivable from the provider key in
+#      general — 'bedrock' uses AWS_BEARER_TOKEN_BEDROCK, 'materials_project'
+#      uses MP_API_KEY — so the explicit mapping is load-bearing, not redundant.
+#   2. If LiteLLM names this vendor's models with a "<prefix>/..." form, add
+#      the prefix -> provider mapping in `infer_provider`'s prefix_map. The
+#      prefix need not equal the provider identity ('gemini' and 'google'
+#      prefixes both resolve to provider 'google').
+#   3. If unprefixed model names should also map (e.g. 'gpt-5' -> openai,
+#      'claude-opus-*' -> anthropic), add a startswith / substring check in
+#      `infer_provider`.
 ENV_VARS = {
     # LLM Providers
     'google': ['GEMINI_API_KEY', 'GOOGLE_API_KEY'],

--- a/scilink/auth.py
+++ b/scilink/auth.py
@@ -14,7 +14,11 @@ ENV_VARS = {
     'google': ['GEMINI_API_KEY', 'GOOGLE_API_KEY'],
     'openai': ['OPENAI_API_KEY'],
     'anthropic': ['ANTHROPIC_API_KEY'],
-    
+    # AWS Bedrock uses a single bearer token; full AWS credential discovery
+    # (AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY [+ AWS_SESSION_TOKEN]) is
+    # handled separately by boto3 and is out of scope for the prefill.
+    'bedrock': ['AWS_BEARER_TOKEN_BEDROCK'],
+
     # Other Services
     'futurehouse': ['FUTUREHOUSE_API_KEY'],
     'materials_project': ['MP_API_KEY', 'MATERIALS_PROJECT_API_KEY'],
@@ -36,14 +40,15 @@ def infer_provider(model_name: str) -> Optional[str]:
         model_name: Model string (e.g., "gemini/gemini-2.0-flash", "gpt-4o")
     
     Returns:
-        Provider name ('google', 'openai', 'anthropic') or None
+        Provider name ('google', 'openai', 'anthropic', 'bedrock') or None
     """
     if not model_name:
         return None
-        
+
     model_lower = model_name.lower()
-    
-    # Explicit prefix (e.g., "gemini/gemini-2.0-flash", "openai/gpt-4o")
+
+    # Explicit prefix (e.g., "gemini/gemini-2.0-flash", "openai/gpt-4o",
+    # "bedrock/anthropic.claude-3-sonnet-20240229-v1:0")
     if '/' in model_name:
         prefix = model_lower.split('/')[0]
         prefix_map = {
@@ -51,6 +56,7 @@ def infer_provider(model_name: str) -> Optional[str]:
             'google': 'google',
             'openai': 'openai',
             'anthropic': 'anthropic',
+            'bedrock': 'bedrock',
         }
         if prefix in prefix_map:
             return prefix_map[prefix]

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -276,6 +276,10 @@ def render_sidebar() -> None:
         base_url = st.text_input("Base URL (optional)", key="cfg_base_url", disabled=_locked)
         if _env_src.get("base_url"):
             st.caption(f"✓ loaded from `{_env_src['base_url']}`")
+        elif _env_src.get("api_key") == "SCILINK_API_KEY" and not base_url:
+            # Proxy key was prefilled but no base URL is set — the proxy path
+            # needs one, and vendors reject the proxy key without it.
+            st.caption("⚠️ Proxy key detected — set a Base URL (or export `SCILINK_BASE_URL`) to use it.")
         fh_api_key = st.text_input("FutureHouse API key (optional)", type="password", key="cfg_fh_api_key", disabled=_locked)
         if _env_src.get("fh"):
             st.caption(f"✓ loaded from `{_env_src['fh']}`")

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -74,6 +74,32 @@ def _seed_credentials_from_env(model: str) -> dict:
     return sources
 
 
+def _seed_embedding_credential_from_env(embedding_model: str) -> str | None:
+    """Prefill ``cfg_embedding_api_key`` from the env var matching the embedding
+    model's provider.
+
+    Same dynamic-refresh / don't-clobber semantics as the main API key: the
+    field is re-resolved every render and refreshed via ``reconcile_autofill``
+    when the user switches embedding models to another vendor (e.g.
+    ``text-embedding-3-small`` → ``gemini-embedding-001``), but a value the user
+    typed themselves is preserved.
+
+    Returns the env var name when one was detected and the field still holds
+    the auto-filled value (for the "✓ from X" caption), else ``None``.
+    """
+    from ..config import resolve_embedding_prefill, reconcile_autofill
+
+    val, src = resolve_embedding_prefill(embedding_model)
+    new_val, new_auto = reconcile_autofill(
+        st.session_state.get("cfg_embedding_api_key"),
+        st.session_state.get("_cfg_embedding_api_key_autofill"),
+        val,
+    )
+    st.session_state["cfg_embedding_api_key"] = new_val
+    st.session_state["_cfg_embedding_api_key_autofill"] = new_auto
+    return src if (src and new_val == val) else None
+
+
 def _render_hpc_connection() -> None:
     """Compact HPC connection controls for the sidebar."""
     try:
@@ -318,13 +344,26 @@ def render_sidebar() -> None:
             )
             if st.session_state.get("cfg_embedding_preset") == "Custom":
                 st.text_input("Embedding model name", key="cfg_embedding_custom", disabled=_locked)
+
+            # Match the embedding model to its provider env var (text-embedding-*
+            # -> OPENAI_API_KEY, gemini-embedding-* -> GEMINI/GOOGLE_API_KEY).
+            _emb_preset = st.session_state.get("cfg_embedding_preset", "")
+            _emb_model = (
+                st.session_state.get("cfg_embedding_custom", "")
+                if _emb_preset == "Custom" else _emb_preset
+            )
+            _emb_src = _seed_embedding_credential_from_env(_emb_model) if not _locked else None
+
             st.text_input(
                 "Embedding API key (optional)",
                 type="password",
                 key="cfg_embedding_api_key",
                 disabled=_locked,
             )
-            st.caption("\u2139\ufe0f Leave blank to use the main API key")
+            if _emb_src:
+                st.caption(f"\u2713 loaded from `{_emb_src}`")
+            else:
+                st.caption("\u2139\ufe0f Leave blank to use the main API key")
 
         # The meta-agent has only two autonomy levels (a delegation is a
         # one-shot run_task, so the modes' step-by-step co-pilot does not

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -39,21 +39,37 @@ def _seed_credentials_from_env(model: str) -> dict:
     ``setdefault`` is used so a value the user has already typed is never
     clobbered (the widget keys don't exist yet on the first render).
     """
-    from ..config import resolve_prefill
+    from ..config import resolve_prefill, reconcile_autofill
 
     resolved = resolve_prefill(model, st.session_state.get("cfg_base_url", ""))
-
-    field_to_state_key = {
-        "api_key": "cfg_api_key",
-        "base_url": "cfg_base_url",
-        "fh": "cfg_fh_api_key",
-        "mp": "cfg_mp_api_key",
-    }
     sources: dict = {}
-    for field, state_key in field_to_state_key.items():
+
+    # Main API key: its resolved value depends on the selected model's provider,
+    # so re-resolve on every render and refresh the field when the model changes
+    # vendors — but never overwrite a key the user typed. reconcile_autofill
+    # decides; `_cfg_api_key_autofill` records what we last auto-filled so a
+    # hand-edited value is recognised and preserved.
+    api_val, api_src = resolved["api_key"]
+    new_val, new_auto = reconcile_autofill(
+        st.session_state.get("cfg_api_key"),
+        st.session_state.get("_cfg_api_key_autofill"),
+        api_val,
+    )
+    st.session_state["cfg_api_key"] = new_val          # set before the widget renders
+    st.session_state["_cfg_api_key_autofill"] = new_auto
+    if api_src and new_val == api_val:
+        sources["api_key"] = api_src
+
+    # base_url / FutureHouse / Materials Project keys are model-independent —
+    # seed once (setdefault never clobbers a typed value).
+    for field, state_key in (
+        ("base_url", "cfg_base_url"),
+        ("fh", "cfg_fh_api_key"),
+        ("mp", "cfg_mp_api_key"),
+    ):
         value, src = resolved[field]
         st.session_state.setdefault(state_key, value)
-        if src:
+        if src and st.session_state.get(state_key) == value:
             sources[field] = src
     return sources
 

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -26,6 +26,38 @@ _LOGO_DIR = Path(__file__).resolve().parent.parent / "assets"
 _LOGO_DARK = _LOGO_DIR / "scilink_logo_v3_dark.svg"
 _LOGO_LIGHT = _LOGO_DIR / "scilink_logo_v3_light.svg"
 
+
+def _seed_credentials_from_env(model: str) -> dict:
+    """Prefill the credential fields from environment variables (once).
+
+    Thin Streamlit wrapper over ``config.resolve_prefill`` (which owns the
+    resolution rules, incl. the proxy-vs-vendor safety guard). Seeds the
+    ``cfg_*`` session-state keys so the password widgets render with the
+    detected value, and returns ``{field: env_var_name}`` for the fields that
+    came from the environment (used to show a "✓ from X" caption).
+
+    ``setdefault`` is used so a value the user has already typed is never
+    clobbered (the widget keys don't exist yet on the first render).
+    """
+    from ..config import resolve_prefill
+
+    resolved = resolve_prefill(model, st.session_state.get("cfg_base_url", ""))
+
+    field_to_state_key = {
+        "api_key": "cfg_api_key",
+        "base_url": "cfg_base_url",
+        "fh": "cfg_fh_api_key",
+        "mp": "cfg_mp_api_key",
+    }
+    sources: dict = {}
+    for field, state_key in field_to_state_key.items():
+        value, src = resolved[field]
+        st.session_state.setdefault(state_key, value)
+        if src:
+            sources[field] = src
+    return sources
+
+
 def _render_hpc_connection() -> None:
     """Compact HPC connection controls for the sidebar."""
     try:
@@ -222,7 +254,15 @@ def render_sidebar() -> None:
         else:
             model = preset
         spec = provider_for(model)
+
+        # Prefill credential fields from environment variables (once, before
+        # the widgets render). Returns {field: env_var_name} for fields that
+        # were sourced from the env, so we can show where each value came from.
+        _env_src = _seed_credentials_from_env(model) if not _locked else {}
+
         api_key = st.text_input(spec.key_label, type="password", key="cfg_api_key", disabled=_locked)
+        if _env_src.get("api_key"):
+            st.caption(f"✓ loaded from `{_env_src['api_key']}`")
         # Provider-specific inputs (e.g. AWS region for Bedrock) — rendered only
         # for the matching provider; nothing extra shows for direct API providers.
         for _pf in spec.fields:
@@ -234,8 +274,14 @@ def render_sidebar() -> None:
                 st.text_input(_pf.label, value=_pf.default,
                               key=f"cfg_prov_{_pf.name}", help=_pf.help, disabled=_locked)
         base_url = st.text_input("Base URL (optional)", key="cfg_base_url", disabled=_locked)
+        if _env_src.get("base_url"):
+            st.caption(f"✓ loaded from `{_env_src['base_url']}`")
         fh_api_key = st.text_input("FutureHouse API key (optional)", type="password", key="cfg_fh_api_key", disabled=_locked)
+        if _env_src.get("fh"):
+            st.caption(f"✓ loaded from `{_env_src['fh']}`")
         mp_api_key = st.text_input("Materials Project API key (optional)", type="password", key="cfg_mp_api_key", disabled=_locked)
+        if _env_src.get("mp"):
+            st.caption(f"✓ loaded from `{_env_src['mp']}`")
 
         from scilink.ui._features import simulate_enabled
         if simulate_enabled():

--- a/scilink/ui/config.py
+++ b/scilink/ui/config.py
@@ -1,6 +1,9 @@
 """Shared constants and defaults for the SciLink Streamlit UI."""
 
 from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+from .. import auth
 
 MODEL_OPTIONS = [
     "claude-opus-4-6",
@@ -88,3 +91,54 @@ SUPPORTED_META_EXTENSIONS = tuple(sorted(set(
 
 AVATAR_USER = str(Path(__file__).resolve().parent / "assets" / "avatar_user.svg")
 AVATAR_AGENT = str(Path(__file__).resolve().parent / "assets" / "avatar_agent.svg")
+
+
+# ── Credential prefill resolution ────────────────────────────────
+
+def resolve_prefill(
+    model: str, existing_base_url: str = ""
+) -> Dict[str, Tuple[str, Optional[str]]]:
+    """Resolve which environment variables prefill the credential form fields.
+
+    Pure function — no Streamlit / session_state — so the resolution rules
+    (especially the proxy-vs-vendor safety guard) are unit-testable in
+    isolation. The sidebar wraps this to seed widget state and render captions.
+
+    Returns ``{field: (value, env_var_name_or_None)}`` for fields
+    ``api_key``, ``base_url``, ``fh``, ``mp``. ``env_var_name`` is the variable
+    a value came from (for a "✓ from X" caption), or ``None`` when nothing was
+    detected for that field.
+
+    Resolution mirrors the backend's API-key handling:
+      - Proxy path: ``SCILINK_API_KEY`` fills the main key ONLY when a base URL
+        is available (``SCILINK_BASE_URL`` env, or one the user already entered),
+        because the proxy key is rejected by vendor endpoints without a base
+        URL. It is never routed to a vendor on its own.
+      - Otherwise the main key is the vendor key matching the model's provider
+        (``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY`` / ``GEMINI_API_KEY`` …).
+      - ``base_url`` prefills from ``SCILINK_BASE_URL`` when set.
+      - FutureHouse / Materials Project keys come from their own env vars,
+        independent of the model.
+    """
+    proxy_key = auth.get_internal_proxy_key()
+    proxy_url = auth.get_internal_proxy_base_url()
+
+    if proxy_key and (proxy_url or existing_base_url):
+        api: Tuple[str, Optional[str]] = (proxy_key, auth.INTERNAL_PROXY_KEY)
+    else:
+        found = auth.find_env_var_for_model(model)
+        api = (found[1], found[0]) if found else ("", None)
+
+    base: Tuple[str, Optional[str]] = (
+        (proxy_url, auth.INTERNAL_PROXY_BASE_URL) if proxy_url else ("", None)
+    )
+
+    fh = auth.find_env_var("futurehouse")
+    mp = auth.find_env_var("materials_project")
+
+    return {
+        "api_key": api,
+        "base_url": base,
+        "fh": (fh[1], fh[0]) if fh else ("", None),
+        "mp": (mp[1], mp[0]) if mp else ("", None),
+    }

--- a/scilink/ui/config.py
+++ b/scilink/ui/config.py
@@ -109,11 +109,12 @@ def resolve_prefill(
     a value came from (for a "✓ from X" caption), or ``None`` when nothing was
     detected for that field.
 
-    Goal: whenever *any* credential exists in the environment, the main key
-    field is populated, so the user sees it and the session can start (the
-    backend short-circuits on a non-empty key). Proxy-vs-vendor *correctness*
-    is enforced by the backend (``require_vendor_credentials``), not by hiding
-    keys here. Main-key precedence:
+    A key is prefilled only when the environment variable that *correctly*
+    corresponds to the current selection is set — never by borrowing an
+    unrelated vendor's key. If the matching variable is absent the field is
+    left empty (the user sets the right env var or types a key). Proxy-vs-vendor
+    correctness is also enforced by the backend (``require_vendor_credentials``).
+    Main-key precedence:
 
       1. Proxy pair — ``SCILINK_API_KEY`` when a base URL is available
          (``SCILINK_BASE_URL`` env or one already entered): a fully-configured
@@ -122,8 +123,7 @@ def resolve_prefill(
          (``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY`` / ``GEMINI_API_KEY`` …).
       3. ``SCILINK_API_KEY`` on its own — a proxy deployment whose base URL will
          be supplied separately (the sidebar warns that one is still needed).
-      4. The first available vendor key, even if it does not match the selected
-         model (the user then picks a matching model).
+      4. Otherwise empty — no mismatched key is substituted.
 
     ``base_url`` prefills from ``SCILINK_BASE_URL`` when set; FutureHouse /
     Materials Project keys come from their own env vars, independent of the
@@ -146,8 +146,7 @@ def resolve_prefill(
     elif proxy_key:
         api = (proxy_key, auth.INTERNAL_PROXY_KEY)
     else:
-        vendor_kv = auth.find_first_vendor_env()
-        api = (vendor_kv[1], vendor_kv[0]) if vendor_kv else ("", None)
+        api = ("", None)
 
     fh = auth.find_env_var("futurehouse")
     mp = auth.find_env_var("materials_project")
@@ -158,3 +157,28 @@ def resolve_prefill(
         "fh": (fh[1], fh[0]) if fh else ("", None),
         "mp": (mp[1], mp[0]) if mp else ("", None),
     }
+
+
+def reconcile_autofill(
+    current: Optional[str], prev_autofill: Optional[str], resolved: str
+) -> Tuple[str, str]:
+    """Reconcile an auto-prefilled field when the resolved value may have changed.
+
+    Pure function — no Streamlit. Used for the main API-key field, whose
+    resolved value depends on the selected model's provider: switching the model
+    to another vendor should refresh the key, but only when the user has not
+    typed their own value over the prefill.
+
+    Args:
+        current: the field's current value (``None`` if it has never existed).
+        prev_autofill: the value we last auto-filled into the field.
+        resolved: the value the env resolution now yields for the current model.
+
+    Returns ``(value, autofill)`` to store. The field is refreshed to
+    ``resolved`` when it still holds what we last auto-filled (``prev_autofill``)
+    — i.e. it has not been hand-edited — or when it has never been set. A
+    user-edited (or deliberately cleared) field is left untouched.
+    """
+    if current is None or current == (prev_autofill or ""):
+        return resolved, resolved
+    return current, (prev_autofill or "")

--- a/scilink/ui/config.py
+++ b/scilink/ui/config.py
@@ -100,38 +100,54 @@ def resolve_prefill(
 ) -> Dict[str, Tuple[str, Optional[str]]]:
     """Resolve which environment variables prefill the credential form fields.
 
-    Pure function — no Streamlit / session_state — so the resolution rules
-    (especially the proxy-vs-vendor safety guard) are unit-testable in
-    isolation. The sidebar wraps this to seed widget state and render captions.
+    Pure function — no Streamlit / session_state — so the precedence rules are
+    unit-testable in isolation. The sidebar wraps this to seed widget state and
+    render captions.
 
     Returns ``{field: (value, env_var_name_or_None)}`` for fields
     ``api_key``, ``base_url``, ``fh``, ``mp``. ``env_var_name`` is the variable
     a value came from (for a "✓ from X" caption), or ``None`` when nothing was
     detected for that field.
 
-    Resolution mirrors the backend's API-key handling:
-      - Proxy path: ``SCILINK_API_KEY`` fills the main key ONLY when a base URL
-        is available (``SCILINK_BASE_URL`` env, or one the user already entered),
-        because the proxy key is rejected by vendor endpoints without a base
-        URL. It is never routed to a vendor on its own.
-      - Otherwise the main key is the vendor key matching the model's provider
-        (``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY`` / ``GEMINI_API_KEY`` …).
-      - ``base_url`` prefills from ``SCILINK_BASE_URL`` when set.
-      - FutureHouse / Materials Project keys come from their own env vars,
-        independent of the model.
+    Goal: whenever *any* credential exists in the environment, the main key
+    field is populated, so the user sees it and the session can start (the
+    backend short-circuits on a non-empty key). Proxy-vs-vendor *correctness*
+    is enforced by the backend (``require_vendor_credentials``), not by hiding
+    keys here. Main-key precedence:
+
+      1. Proxy pair — ``SCILINK_API_KEY`` when a base URL is available
+         (``SCILINK_BASE_URL`` env or one already entered): a fully-configured
+         proxy deployment.
+      2. The vendor key matching the selected model's provider
+         (``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY`` / ``GEMINI_API_KEY`` …).
+      3. ``SCILINK_API_KEY`` on its own — a proxy deployment whose base URL will
+         be supplied separately (the sidebar warns that one is still needed).
+      4. The first available vendor key, even if it does not match the selected
+         model (the user then picks a matching model).
+
+    ``base_url`` prefills from ``SCILINK_BASE_URL`` when set; FutureHouse /
+    Materials Project keys come from their own env vars, independent of the
+    model.
     """
     proxy_key = auth.get_internal_proxy_key()
     proxy_url = auth.get_internal_proxy_base_url()
-
-    if proxy_key and (proxy_url or existing_base_url):
-        api: Tuple[str, Optional[str]] = (proxy_key, auth.INTERNAL_PROXY_KEY)
-    else:
-        found = auth.find_env_var_for_model(model)
-        api = (found[1], found[0]) if found else ("", None)
+    base_available = bool(proxy_url or existing_base_url)
 
     base: Tuple[str, Optional[str]] = (
         (proxy_url, auth.INTERNAL_PROXY_BASE_URL) if proxy_url else ("", None)
     )
+
+    provider_kv = auth.find_env_var_for_model(model)
+
+    if proxy_key and base_available:
+        api: Tuple[str, Optional[str]] = (proxy_key, auth.INTERNAL_PROXY_KEY)
+    elif provider_kv:
+        api = (provider_kv[1], provider_kv[0])
+    elif proxy_key:
+        api = (proxy_key, auth.INTERNAL_PROXY_KEY)
+    else:
+        vendor_kv = auth.find_first_vendor_env()
+        api = (vendor_kv[1], vendor_kv[0]) if vendor_kv else ("", None)
 
     fh = auth.find_env_var("futurehouse")
     mp = auth.find_env_var("materials_project")

--- a/scilink/ui/config.py
+++ b/scilink/ui/config.py
@@ -159,6 +159,28 @@ def resolve_prefill(
     }
 
 
+def resolve_embedding_prefill(
+    embedding_model: str,
+) -> Tuple[str, Optional[str]]:
+    """Resolve which env var prefills the embedding API key field.
+
+    Mirrors the main key's provider-matching heuristic but without the proxy
+    machinery (there is no embedding-specific proxy concept): the embedding
+    model name is mapped to a provider via ``infer_provider`` (handles
+    ``text-embedding-*`` → OpenAI and ``gemini-embedding-*`` → Google) and the
+    matching env var, if set, fills the field. Otherwise empty.
+
+    Returns ``(value, env_var_name_or_None)`` — same shape as the entries in
+    :func:`resolve_prefill`. The sidebar wraps this and feeds it through
+    :func:`reconcile_autofill` so switching the embedding model refreshes the
+    field without clobbering a value the user typed.
+    """
+    if not embedding_model:
+        return ("", None)
+    kv = auth.find_env_var_for_model(embedding_model)
+    return (kv[1], kv[0]) if kv else ("", None)
+
+
 def reconcile_autofill(
     current: Optional[str], prev_autofill: Optional[str], resolved: str
 ) -> Tuple[str, str]:

--- a/tests/test_credential_prefill.py
+++ b/tests/test_credential_prefill.py
@@ -17,7 +17,7 @@ and tests opt back in with monkeypatch.setenv.
 import pytest
 
 from scilink import auth
-from scilink.ui.config import resolve_prefill
+from scilink.ui.config import resolve_prefill, reconcile_autofill
 
 
 _RELEVANT_VARS = [
@@ -84,15 +84,6 @@ def test_get_internal_proxy_base_url(clean_env):
     assert auth.INTERNAL_PROXY_BASE_URL == "SCILINK_BASE_URL"
 
 
-def test_find_first_vendor_env(clean_env):
-    assert auth.find_first_vendor_env() is None
-    clean_env.setenv("GOOGLE_API_KEY", "g-key")
-    assert auth.find_first_vendor_env() == ("GOOGLE_API_KEY", "g-key")
-    # VENDOR_PROVIDERS order (openai, anthropic, google) decides the winner.
-    clean_env.setenv("OPENAI_API_KEY", "o-key")
-    assert auth.find_first_vendor_env() == ("OPENAI_API_KEY", "o-key")
-
-
 # ─── Tier 2: resolve_prefill field resolution ──────────────────────
 
 
@@ -147,12 +138,15 @@ def test_proxy_key_surfaced_without_base_url_when_no_vendor(clean_env):
     assert out["api_key"] == ("proxy-key", "SCILINK_API_KEY")
 
 
-def test_vendor_fallback_when_no_provider_match(clean_env):
-    """A single exported vendor key surfaces even when it does not match the
-    selected model's provider (default model is claude; only GOOGLE is set)."""
+def test_no_prefill_when_provider_key_missing(clean_env):
+    """A vendor key that does NOT match the selected model's provider must not
+    be borrowed: default model is claude, only GOOGLE is set → field stays
+    empty rather than prefilling the wrong key."""
     clean_env.setenv("GOOGLE_API_KEY", "g-key")
     out = resolve_prefill("claude-opus-4-6")
-    assert out["api_key"] == ("g-key", "GOOGLE_API_KEY")
+    assert out["api_key"] == ("", None)
+    # The matching model DOES prefill it.
+    assert resolve_prefill("gemini-3.1-pro-preview")["api_key"] == ("g-key", "GOOGLE_API_KEY")
 
 
 def test_service_keys_resolve_independently_of_model(clean_env):
@@ -181,3 +175,37 @@ def test_base_url_prefilled_independently_of_proxy_key(clean_env):
     out = resolve_prefill("gpt-5.4")
     assert out["base_url"] == ("https://proxy/v1", "SCILINK_BASE_URL")
     assert out["api_key"] == ("sk-oai", "OPENAI_API_KEY")
+
+
+# ─── reconcile_autofill: dynamic refresh on model/vendor change ────
+
+
+def test_reconcile_first_seed():
+    """Field never existed (None) → adopt the resolved value."""
+    assert reconcile_autofill(None, None, "k-anthropic") == ("k-anthropic", "k-anthropic")
+
+
+def test_reconcile_refreshes_when_unedited():
+    """Field still holds the last auto-filled value → switching vendors
+    refreshes it to the newly-resolved key. This is the reported bug."""
+    assert reconcile_autofill("k-anthropic", "k-anthropic", "k-openai") == ("k-openai", "k-openai")
+
+
+def test_reconcile_preserves_user_typed_value():
+    """A hand-typed value differs from the last auto-fill → never overwritten."""
+    assert reconcile_autofill("my-typed-key", "k-anthropic", "k-openai") == ("my-typed-key", "k-anthropic")
+
+
+def test_reconcile_preserves_cleared_field():
+    """A deliberately cleared field (was auto-filled, now empty) stays empty."""
+    assert reconcile_autofill("", "k-anthropic", "k-openai") == ("", "k-anthropic")
+
+
+def test_reconcile_populates_when_provider_gains_key():
+    """Field auto-filled empty (no key for prior model) → switching to a model
+    whose provider key IS set populates it."""
+    assert reconcile_autofill("", "", "k-openai") == ("k-openai", "k-openai")
+
+
+def test_reconcile_idempotent_when_value_unchanged():
+    assert reconcile_autofill("k-anthropic", "k-anthropic", "k-anthropic") == ("k-anthropic", "k-anthropic")

--- a/tests/test_credential_prefill.py
+++ b/tests/test_credential_prefill.py
@@ -26,6 +26,7 @@ _RELEVANT_VARS = [
     "SCILINK_API_KEY", "SCILINK_BASE_URL",
     "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
     "GEMINI_API_KEY", "GOOGLE_API_KEY",
+    "AWS_BEARER_TOKEN_BEDROCK",
     "FUTUREHOUSE_API_KEY", "MP_API_KEY", "MATERIALS_PROJECT_API_KEY",
 ]
 
@@ -254,3 +255,37 @@ def test_resolve_embedding_prefill_unknown_model_returns_empty(clean_env):
     clean_env.setenv("OPENAI_API_KEY", "sk-oai")
     clean_env.setenv("ANTHROPIC_API_KEY", "sk-ant")
     assert resolve_embedding_prefill("some-local-embedder") == ("", None)
+
+
+# ─── AWS Bedrock model-name pattern ────────────────────────────────
+
+
+def test_infer_provider_recognises_bedrock_prefix():
+    """bedrock/<vendor>.<model> is the LiteLLM convention for AWS Bedrock."""
+    assert auth.infer_provider("bedrock/anthropic.claude-3-sonnet-20240229-v1:0") == "bedrock"
+    assert auth.infer_provider("bedrock/amazon.titan-text-express-v1") == "bedrock"
+    assert auth.infer_provider("bedrock/meta.llama3-70b-instruct-v1:0") == "bedrock"
+
+
+def test_find_env_var_bedrock(clean_env):
+    """The Bedrock provider maps to AWS_BEARER_TOKEN_BEDROCK in ENV_VARS."""
+    assert auth.find_env_var("bedrock") is None
+    clean_env.setenv("AWS_BEARER_TOKEN_BEDROCK", "aws-token")
+    assert auth.find_env_var("bedrock") == ("AWS_BEARER_TOKEN_BEDROCK", "aws-token")
+
+
+def test_resolve_prefill_bedrock_model_uses_bearer_token(clean_env):
+    """Selecting a Bedrock model surfaces AWS_BEARER_TOKEN_BEDROCK into the
+    API-key field (the gap Sarah called out: previously the field stayed empty
+    for Bedrock users)."""
+    clean_env.setenv("AWS_BEARER_TOKEN_BEDROCK", "aws-token")
+    out = resolve_prefill("bedrock/anthropic.claude-3-sonnet-20240229-v1:0")
+    assert out["api_key"] == ("aws-token", "AWS_BEARER_TOKEN_BEDROCK")
+
+
+def test_resolve_prefill_bedrock_model_no_token_stays_empty(clean_env):
+    """Bedrock model selected, bearer token absent → field stays empty rather
+    than borrowing another vendor's key."""
+    clean_env.setenv("ANTHROPIC_API_KEY", "sk-ant")  # unrelated key set
+    out = resolve_prefill("bedrock/anthropic.claude-3-sonnet-20240229-v1:0")
+    assert out["api_key"] == ("", None)

--- a/tests/test_credential_prefill.py
+++ b/tests/test_credential_prefill.py
@@ -84,6 +84,15 @@ def test_get_internal_proxy_base_url(clean_env):
     assert auth.INTERNAL_PROXY_BASE_URL == "SCILINK_BASE_URL"
 
 
+def test_find_first_vendor_env(clean_env):
+    assert auth.find_first_vendor_env() is None
+    clean_env.setenv("GOOGLE_API_KEY", "g-key")
+    assert auth.find_first_vendor_env() == ("GOOGLE_API_KEY", "g-key")
+    # VENDOR_PROVIDERS order (openai, anthropic, google) decides the winner.
+    clean_env.setenv("OPENAI_API_KEY", "o-key")
+    assert auth.find_first_vendor_env() == ("OPENAI_API_KEY", "o-key")
+
+
 # ─── Tier 2: resolve_prefill field resolution ──────────────────────
 
 
@@ -120,22 +129,30 @@ def test_proxy_key_used_when_base_url_already_entered(clean_env):
     assert out["base_url"] == ("", None)
 
 
-def test_proxy_key_NOT_used_without_base_url_falls_back_to_vendor(clean_env):
-    """SAFETY GUARD: a proxy key with no base URL anywhere must NOT fill the
-    main field (vendors reject it). The vendor key is used instead."""
+def test_provider_match_wins_over_proxy_without_base_url(clean_env):
+    """With no base URL, a vendor key matching the model's provider is preferred
+    over the proxy key (correct pairing without a manual base URL)."""
     clean_env.setenv("SCILINK_API_KEY", "proxy-key")
     clean_env.setenv("ANTHROPIC_API_KEY", "sk-ant")
     out = resolve_prefill("claude-opus-4-6")  # no base url anywhere
     assert out["api_key"] == ("sk-ant", "ANTHROPIC_API_KEY")
-    assert out["api_key"][0] != "proxy-key"
 
 
-def test_proxy_key_without_base_url_and_no_vendor_is_empty(clean_env):
-    """Proxy key, no base URL, no vendor key → main field left empty (never the
-    proxy key on a vendor path)."""
+def test_proxy_key_surfaced_without_base_url_when_no_vendor(clean_env):
+    """Proxy key set, no base URL, no vendor key → the proxy key IS surfaced so
+    the field is populated and the session can start. (The sidebar warns that a
+    base URL is still needed; the backend enforces proxy-vs-vendor safety.)"""
     clean_env.setenv("SCILINK_API_KEY", "proxy-key")
     out = resolve_prefill("claude-opus-4-6")
-    assert out["api_key"] == ("", None)
+    assert out["api_key"] == ("proxy-key", "SCILINK_API_KEY")
+
+
+def test_vendor_fallback_when_no_provider_match(clean_env):
+    """A single exported vendor key surfaces even when it does not match the
+    selected model's provider (default model is claude; only GOOGLE is set)."""
+    clean_env.setenv("GOOGLE_API_KEY", "g-key")
+    out = resolve_prefill("claude-opus-4-6")
+    assert out["api_key"] == ("g-key", "GOOGLE_API_KEY")
 
 
 def test_service_keys_resolve_independently_of_model(clean_env):

--- a/tests/test_credential_prefill.py
+++ b/tests/test_credential_prefill.py
@@ -1,0 +1,166 @@
+"""
+Hermetic tests for environment-variable prefill of the UI credential form.
+
+Two tiers, no Streamlit required (resolve_prefill lives in the Streamlit-free
+scilink.ui.config module):
+
+  Tier 1 — auth.py env discovery helpers (find_env_var, find_env_var_for_model,
+           get_internal_proxy_base_url) and their precedence.
+  Tier 2 — config.resolve_prefill: the field-by-field resolution that the
+           sidebar wraps, with emphasis on the proxy-vs-vendor SAFETY GUARD
+           (the proxy key must never fill the main field without a base URL).
+
+Env isolation: the clean_env fixture clears every variable these paths read,
+and tests opt back in with monkeypatch.setenv.
+"""
+
+import pytest
+
+from scilink import auth
+from scilink.ui.config import resolve_prefill
+
+
+_RELEVANT_VARS = [
+    "SCILINK_API_KEY", "SCILINK_BASE_URL",
+    "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY", "GOOGLE_API_KEY",
+    "FUTUREHOUSE_API_KEY", "MP_API_KEY", "MATERIALS_PROJECT_API_KEY",
+]
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Remove every credential env var these code paths read."""
+    for var in _RELEVANT_VARS:
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+# ─── Tier 1: auth.py env-discovery helpers ─────────────────────────
+
+
+def test_find_env_var_returns_name_and_value(clean_env):
+    clean_env.setenv("OPENAI_API_KEY", "sk-openai")
+    assert auth.find_env_var("openai") == ("OPENAI_API_KEY", "sk-openai")
+
+
+def test_find_env_var_none_when_unset(clean_env):
+    assert auth.find_env_var("openai") is None
+    assert auth.find_env_var("materials_project") is None
+
+
+def test_find_env_var_precedence_first_listed_wins(clean_env):
+    """google lists GEMINI_API_KEY before GOOGLE_API_KEY → GEMINI wins."""
+    clean_env.setenv("GOOGLE_API_KEY", "g-google")
+    assert auth.find_env_var("google") == ("GOOGLE_API_KEY", "g-google")
+    clean_env.setenv("GEMINI_API_KEY", "g-gemini")
+    assert auth.find_env_var("google") == ("GEMINI_API_KEY", "g-gemini")
+
+
+@pytest.mark.parametrize(
+    "model, env_var, provider_key",
+    [
+        ("claude-opus-4-6", "ANTHROPIC_API_KEY", "sk-ant"),
+        ("gpt-5.4", "OPENAI_API_KEY", "sk-oai"),
+        ("gemini-3.1-pro-preview", "GEMINI_API_KEY", "sk-gem"),
+        ("openai/gpt-4o", "OPENAI_API_KEY", "sk-oai2"),
+    ],
+)
+def test_find_env_var_for_model_maps_provider(clean_env, model, env_var, provider_key):
+    clean_env.setenv(env_var, provider_key)
+    assert auth.find_env_var_for_model(model) == (env_var, provider_key)
+
+
+def test_find_env_var_for_model_unknown_or_empty(clean_env):
+    clean_env.setenv("OPENAI_API_KEY", "sk-oai")
+    assert auth.find_env_var_for_model("") is None
+    assert auth.find_env_var_for_model("some-local-llama") is None
+
+
+def test_get_internal_proxy_base_url(clean_env):
+    assert auth.get_internal_proxy_base_url() is None
+    clean_env.setenv("SCILINK_BASE_URL", "https://proxy.example/v1")
+    assert auth.get_internal_proxy_base_url() == "https://proxy.example/v1"
+    assert auth.INTERNAL_PROXY_BASE_URL == "SCILINK_BASE_URL"
+
+
+# ─── Tier 2: resolve_prefill field resolution ──────────────────────
+
+
+def test_vendor_key_resolves_for_model(clean_env):
+    clean_env.setenv("ANTHROPIC_API_KEY", "sk-ant")
+    out = resolve_prefill("claude-opus-4-6")
+    assert out["api_key"] == ("sk-ant", "ANTHROPIC_API_KEY")
+    assert out["base_url"] == ("", None)
+
+
+def test_vendor_key_matches_chosen_provider_not_others(clean_env):
+    """With multiple vendor keys set, only the model's provider key is used."""
+    clean_env.setenv("ANTHROPIC_API_KEY", "sk-ant")
+    clean_env.setenv("OPENAI_API_KEY", "sk-oai")
+    assert resolve_prefill("gpt-5.4")["api_key"] == ("sk-oai", "OPENAI_API_KEY")
+    assert resolve_prefill("claude-opus-4-6")["api_key"] == ("sk-ant", "ANTHROPIC_API_KEY")
+
+
+def test_proxy_pair_used_when_base_url_in_env(clean_env):
+    """SCILINK_API_KEY + SCILINK_BASE_URL → proxy key fills the main field."""
+    clean_env.setenv("SCILINK_API_KEY", "proxy-key")
+    clean_env.setenv("SCILINK_BASE_URL", "https://proxy/v1")
+    out = resolve_prefill("claude-opus-4-6")
+    assert out["api_key"] == ("proxy-key", "SCILINK_API_KEY")
+    assert out["base_url"] == ("https://proxy/v1", "SCILINK_BASE_URL")
+
+
+def test_proxy_key_used_when_base_url_already_entered(clean_env):
+    """A base URL the user already typed also enables the proxy path."""
+    clean_env.setenv("SCILINK_API_KEY", "proxy-key")
+    out = resolve_prefill("claude-opus-4-6", existing_base_url="https://typed/v1")
+    assert out["api_key"] == ("proxy-key", "SCILINK_API_KEY")
+    # No SCILINK_BASE_URL env → base_url field itself is not prefilled.
+    assert out["base_url"] == ("", None)
+
+
+def test_proxy_key_NOT_used_without_base_url_falls_back_to_vendor(clean_env):
+    """SAFETY GUARD: a proxy key with no base URL anywhere must NOT fill the
+    main field (vendors reject it). The vendor key is used instead."""
+    clean_env.setenv("SCILINK_API_KEY", "proxy-key")
+    clean_env.setenv("ANTHROPIC_API_KEY", "sk-ant")
+    out = resolve_prefill("claude-opus-4-6")  # no base url anywhere
+    assert out["api_key"] == ("sk-ant", "ANTHROPIC_API_KEY")
+    assert out["api_key"][0] != "proxy-key"
+
+
+def test_proxy_key_without_base_url_and_no_vendor_is_empty(clean_env):
+    """Proxy key, no base URL, no vendor key → main field left empty (never the
+    proxy key on a vendor path)."""
+    clean_env.setenv("SCILINK_API_KEY", "proxy-key")
+    out = resolve_prefill("claude-opus-4-6")
+    assert out["api_key"] == ("", None)
+
+
+def test_service_keys_resolve_independently_of_model(clean_env):
+    clean_env.setenv("FUTUREHOUSE_API_KEY", "fh-key")
+    clean_env.setenv("MP_API_KEY", "mp-key")
+    out = resolve_prefill("gpt-5.4")
+    assert out["fh"] == ("fh-key", "FUTUREHOUSE_API_KEY")
+    assert out["mp"] == ("mp-key", "MP_API_KEY")
+
+
+def test_all_fields_empty_when_nothing_set(clean_env):
+    out = resolve_prefill("claude-opus-4-6")
+    assert out == {
+        "api_key": ("", None),
+        "base_url": ("", None),
+        "fh": ("", None),
+        "mp": ("", None),
+    }
+
+
+def test_base_url_prefilled_independently_of_proxy_key(clean_env):
+    """SCILINK_BASE_URL set without SCILINK_API_KEY: base_url is still surfaced,
+    and the main field falls back to the vendor key."""
+    clean_env.setenv("SCILINK_BASE_URL", "https://proxy/v1")
+    clean_env.setenv("OPENAI_API_KEY", "sk-oai")
+    out = resolve_prefill("gpt-5.4")
+    assert out["base_url"] == ("https://proxy/v1", "SCILINK_BASE_URL")
+    assert out["api_key"] == ("sk-oai", "OPENAI_API_KEY")

--- a/tests/test_credential_prefill.py
+++ b/tests/test_credential_prefill.py
@@ -17,7 +17,9 @@ and tests opt back in with monkeypatch.setenv.
 import pytest
 
 from scilink import auth
-from scilink.ui.config import resolve_prefill, reconcile_autofill
+from scilink.ui.config import (
+    resolve_prefill, reconcile_autofill, resolve_embedding_prefill,
+)
 
 
 _RELEVANT_VARS = [
@@ -209,3 +211,46 @@ def test_reconcile_populates_when_provider_gains_key():
 
 def test_reconcile_idempotent_when_value_unchanged():
     assert reconcile_autofill("k-anthropic", "k-anthropic", "k-anthropic") == ("k-anthropic", "k-anthropic")
+
+
+# ─── Embedding model → provider env var ────────────────────────────
+
+
+def test_infer_provider_recognises_openai_embeddings():
+    assert auth.infer_provider("text-embedding-3-small") == "openai"
+    assert auth.infer_provider("text-embedding-3-large") == "openai"
+    assert auth.infer_provider("text-embedding-ada-002") == "openai"
+
+
+def test_infer_provider_recognises_google_embeddings():
+    assert auth.infer_provider("gemini-embedding-001") == "google"
+
+
+def test_resolve_embedding_prefill_openai(clean_env):
+    clean_env.setenv("OPENAI_API_KEY", "sk-oai")
+    assert resolve_embedding_prefill("text-embedding-3-small") == ("sk-oai", "OPENAI_API_KEY")
+
+
+def test_resolve_embedding_prefill_google(clean_env):
+    clean_env.setenv("GEMINI_API_KEY", "g-gem")
+    assert resolve_embedding_prefill("gemini-embedding-001") == ("g-gem", "GEMINI_API_KEY")
+
+
+def test_resolve_embedding_prefill_no_match_when_env_missing(clean_env):
+    """The matching env var is absent → leave the field empty (no borrowing)."""
+    clean_env.setenv("GOOGLE_API_KEY", "g-key")
+    assert resolve_embedding_prefill("text-embedding-3-small") == ("", None)
+
+
+def test_resolve_embedding_prefill_no_model_returns_empty(clean_env):
+    clean_env.setenv("OPENAI_API_KEY", "sk-oai")
+    assert resolve_embedding_prefill("") == ("", None)
+    assert resolve_embedding_prefill(None) == ("", None)
+
+
+def test_resolve_embedding_prefill_unknown_model_returns_empty(clean_env):
+    """A model name whose provider can't be inferred returns empty even when
+    vendor env vars are set."""
+    clean_env.setenv("OPENAI_API_KEY", "sk-oai")
+    clean_env.setenv("ANTHROPIC_API_KEY", "sk-ant")
+    assert resolve_embedding_prefill("some-local-embedder") == ("", None)


### PR DESCRIPTION
Hi!

Thanks again for the nice workshop yesterday. While interacting with and testing the SciLink UI, I was bothered by the fact that I had to copy the API key every time by hand. So I had Claude implement some changes and the API key is now dynamically prefilled based on the set environment variables. If the variable is not set, the field is left empty. Works also for the Embedding key.

Not sure if this is of interest for this repo, so feel free to decline if this is not according to your own ideas :). And please let me know if I can improve something more.

Best,
Paul