### PR TITLE
Hyperspectral: one cohesive decomposition tool (#220) + reconstruction as optional codegen input (#219)

### DIFF
--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -3,6 +3,7 @@ import numpy as np
 import json
 import os
 import re
+import inspect
 from datetime import datetime
 import base64
 import cv2
@@ -167,6 +168,7 @@ def build_code_generation_prompt(
     objective: str | None = None,
     required_outputs: list[str] | None = None,
     skill_implementation: str | None = None,
+    reconstruction_available: bool = False,
 ) -> str:
     skill_section = ""
     if skill_implementation:
@@ -217,6 +219,30 @@ Frame your feature extraction around answering this objective. Prioritize extrac
 The user has indicated interest in: {hints}
 Prioritize this guidance in your analysis, but also capture any other significant features present in the data.
 """
+    signature = (
+        "analyze_feature(data, axis, reconstruction=None)"
+        if reconstruction_available
+        else "analyze_feature(data, axis)"
+    )
+
+    reconstruction_section = ""
+    if reconstruction_available:
+        reconstruction_section = f"""
+
+### OPTIONAL DENOISED INPUT — `reconstruction`
+Your function is also handed a third argument, `reconstruction`: the rank-k
+decomposition (NMF/PCA/ICA) approximation of the cube, same shape as `data`
+({h}, {w}, {e}). It is a **denoised** version of the data, but it lives in the
+decomposition's processed intensity space — so trust it for *shape*-based
+quantities (peak position, peak width, edge onset) on noisy features, and use
+the RAW `data` for anything intensity/quantification-related.
+
+This is an **option, not a requirement**: `data` (raw) is always the base input.
+Use `reconstruction` only when the raw signal for your feature is too noisy to
+fit reliably; otherwise fit `data` directly. `reconstruction` may be `None` —
+always guard with `if reconstruction is not None:` before using it.
+"""
+
     return f"""
 You are a Python Data Scientist specialized in Spectroscopy.
 The standard NMF tool failed to model a spectral feature described as: "{target_desc}".
@@ -253,7 +279,7 @@ Your code will run in a restricted `exec()` sandbox.
 4. **Return Format:** You must return a dictionary, not a print statement or a plot.
 
 ### 4. YOUR GOAL
-Write a function `analyze_feature(data, axis)` that:
+Write a function `{signature}` that:
 1. Reshapes data to (pixels, energy).
 2. Implements the specific math required.
 3. Returns a DICTIONARY containing the results.
@@ -265,7 +291,7 @@ This is the RAW cube — no smoothing/clipping/despiking has been applied for yo
 noise/spike/negative handling you judge necessary for a stable per-pixel fit —
 the goal is fittable spectra — but do NOT erase the feature you are measuring.
 If performing derivative-based operations (like `find_peaks` or `curve_fit`) on noisy data, apply appropriate smoothing to ensure convergence.
-{hints_section}
+{reconstruction_section}{hints_section}
 ### REQUIRED RETURN FORMAT
 {{
     "maps": {{
@@ -297,6 +323,38 @@ def _sanitize_filename(text: str) -> str:
     # Replace spaces with underscores, remove non-alphanumeric chars except _ and -
     safe_text = re.sub(r'[^\w\-\_]', '', text.replace(" ", "_"))
     return safe_text
+
+
+def _invoke_analyze_feature(func, data, axis, reconstruction):
+    """Call the generated ``analyze_feature``, passing the optional rank-k
+    ``reconstruction`` only when the function actually declares it.
+
+    The reconstruction is an *option*, not a contract (issue #219): a function
+    that keeps the legacy two-argument signature is valid and simply fits the
+    raw ``data``. We never force the third argument on such a function — doing
+    so would raise ``TypeError`` and break a perfectly good 2-arg fit.
+    """
+    if reconstruction is None:
+        return func(data, axis)
+    try:
+        params = inspect.signature(func).parameters
+    except (TypeError, ValueError):
+        return func(data, axis)
+    accepts_var_kw = any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+    )
+    if "reconstruction" in params or accepts_var_kw:
+        return func(data, axis, reconstruction=reconstruction)
+    positional = [
+        p for p in params.values()
+        if p.kind in (inspect.Parameter.POSITIONAL_ONLY,
+                      inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    if len(positional) >= 3 or any(
+        p.kind == inspect.Parameter.VAR_POSITIONAL for p in params.values()
+    ):
+        return func(data, axis, reconstruction)
+    return func(data, axis)
 
 class RunPreprocessingController:
     """
@@ -906,7 +964,72 @@ class CreateAnalysisPlotsController:
                 self.logger.warning(f"Failed to create structure overlays: {e}")
 
         self.logger.info("✅ Tool Complete: Final analysis plots created and saved.")
-        return state    
+        return state
+
+class DecompositionController:
+    """
+    [🧩 Composite Step] The cohesive spectral-decomposition step.
+
+    Wraps the whole decomposition sub-pipeline — its own input prep, initial
+    component/method estimation, the elbow scan, the LLM component selection,
+    the final unmixing, and the validation plots — behind one controller that
+    leaves the decomposition contract in ``state`` (``final_components``,
+    ``final_abundance_maps``, ``final_reconstruction_error``, ``data_quality``
+    SNR, ``preprocessing_mask``). The per-pixel codegen downstream reads that
+    contract; this remains a model-bearing step *inside* the iteration loop, so
+    the decompose↔re-plan feedback edge is preserved (see issue #220 and
+    docs/hyperspectral_codegen_relocation.md).
+
+    Internally it composes the same sub-controllers that previously sat as
+    separate pipeline entries, run in order. Each sub-controller already guards
+    on ``error_dict`` and ``skip_decomposition``, so the composite is a thin
+    sequential driver — gating on ``auto_components`` / ``run_preprocessing`` is
+    applied here at construction time exactly as the pipeline factory did before.
+    """
+    def __init__(self, model, logger, generation_config, safety_settings,
+                 settings: dict, preprocessor: HyperspectralPreprocessingAgent,
+                 parse_fn: Callable):
+        self.logger = logger
+
+        stages = []
+        # [🧠 LLM] Initial component/method guess — also decides
+        # skip_decomposition, using SNR estimated from the raw cube
+        # (prep runs after this).
+        if settings.get('auto_components', True):
+            stages.append(GetInitialComponentParamsController(
+                model, logger, generation_config, safety_settings, parse_fn
+            ))
+
+        # [🛠️ Tool] Decomposition's own prep substage — runs after the skip
+        # decision; internally gated on skip_decomposition.
+        if settings.get('run_preprocessing', True):
+            stages.append(RunPreprocessingController(logger, preprocessor))
+
+        # Rest of the auto-component workflow operates on the cleaned cube.
+        if settings.get('auto_components', True):
+            stages.append(RunComponentTestLoopController(logger, settings))
+            stages.append(CreateElbowPlotController(logger, settings))
+            stages.append(GetFinalComponentSelectionController(
+                model, logger, generation_config, safety_settings, parse_fn
+            ))
+
+        stages.append(RunFinalSpectralUnmixingController(logger, settings))
+        stages.append(CreateAnalysisPlotsController(logger, settings))
+
+        self.stages = stages
+
+    def execute(self, state: dict) -> dict:
+        if state.get("error_dict"):
+            return state
+        self.logger.info("\n\n🧩 --- SPECTRAL DECOMPOSITION (cohesive step) --- 🧩\n")
+        for stage in self.stages:
+            state = stage.execute(state)
+            if state.get("error_dict"):
+                self.logger.warning(
+                    f"Decomposition halted: {stage.__class__.__name__} reported an error."
+                )
+                break
+        return state
 
 class BuildHyperspectralPromptController:
     """
@@ -1663,7 +1786,32 @@ class RunDynamicAnalysisController:
         # owns its own fittability denoising. See docs/hyperspectral_codegen_relocation.md.
         optimal_data, processing_note = tools.get_optimal_analysis_data(state["original_hspy_data"])
         self.logger.info(f"📊 Dynamic Analysis Prep: {processing_note}")
-        
+
+        # Offer the rank-k decomposition reconstruction as an OPTIONAL, denoised
+        # fit target alongside the raw cube (issue #219). The generated code may
+        # use it for shape-based features on noisy data, but raw stays the base
+        # input. None when decomposition was skipped or produced no components.
+        reconstruction = None
+        components = state.get("final_components")
+        abundance_maps = state.get("final_abundance_maps")
+        if components is not None and abundance_maps is not None:
+            try:
+                reconstruction = tools.reconstruct_cube(components, abundance_maps)
+                if reconstruction.shape != optimal_data.shape:
+                    self.logger.warning(
+                        f"Reconstruction shape {reconstruction.shape} != raw "
+                        f"{optimal_data.shape}; not offering it to codegen."
+                    )
+                    reconstruction = None
+                else:
+                    self.logger.info(
+                        "🧩 Offering rank-k decomposition reconstruction as an "
+                        "optional denoised codegen input."
+                    )
+            except Exception as e:
+                self.logger.warning(f"Could not build reconstruction cube: {e}")
+                reconstruction = None
+
         # --- MAIN LOOP: Process each target description separately ---
         for i, target in enumerate(custom_targets, 1):
             target_desc = target.get("description", "Analyze feature")
@@ -1695,6 +1843,7 @@ class RunDynamicAnalysisController:
                 # baseline, library choice). Empty string when no skill is
                 # active or no implementation section is defined.
                 skill_implementation=_render_skill_block(state, "implementation"),
+                reconstruction_available=reconstruction is not None,
             )
 
             # Append a preprocessing-mask hint when one exists and identifies
@@ -1758,7 +1907,9 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                         # --- D. RUN ON DATA ---
                         self.logger.info(f"    Executing generated code (timeout: {self.executor_timeout}s)...")
                         func = local_scope["analyze_feature"]
-                        result_dict = func(optimal_data, state["energy_axis"])
+                        result_dict = _invoke_analyze_feature(
+                            func, optimal_data, state["energy_axis"], reconstruction
+                        )
                     
                     # Validation
                     if not isinstance(result_dict, dict): raise ValueError("Function return must be a dict.")

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -374,7 +374,7 @@ class RunPreprocessingController:
     def execute(self, state: dict) -> dict:
         if state.get("error_dict"):
             return state
-        self.logger.info("\n\n🛠️ --- DECOMPOSITION PREP (clean cube for decomposition) --- 🛠️\n")
+        self.logger.info("\n\n🛠️ --- DECOMPOSITION PREP --- 🛠️\n")
 
         # If decomposition is skipped, the per-pixel codegen uses the RAW cube
         # anyway — no decomposition-prep is needed. Just surface SNR/mask so any
@@ -1021,7 +1021,7 @@ class DecompositionController:
     def execute(self, state: dict) -> dict:
         if state.get("error_dict"):
             return state
-        self.logger.info("\n\n🧩 --- SPECTRAL DECOMPOSITION (cohesive step) --- 🧩\n")
+        self.logger.info("\n\n🧩 --- SPECTRAL DECOMPOSITION --- 🧩\n")
         for stage in self.stages:
             state = stage.execute(state)
             if state.get("error_dict"):

--- a/scilink/agents/exp_agents/pipelines/hyperspectral_pipelines.py
+++ b/scilink/agents/exp_agents/pipelines/hyperspectral_pipelines.py
@@ -1,13 +1,7 @@
 import logging
 from typing import Callable, List
 from ..controllers.hyperspectral_controllers import (
-    RunPreprocessingController,
-    GetInitialComponentParamsController,
-    RunComponentTestLoopController,
-    CreateElbowPlotController,
-    GetFinalComponentSelectionController,
-    RunFinalSpectralUnmixingController,
-    CreateAnalysisPlotsController,
+    DecompositionController,
     BuildHyperspectralPromptController,
     RunDynamicAnalysisController,
     SelectRefinementTargetController,
@@ -42,41 +36,18 @@ def create_hyperspectral_iteration_pipeline(
 
     pipeline = []
 
-    # --- SPECTRAL DECOMPOSITION (owns its own input prep) ---
-    # Preprocessing is no longer a standalone universal stage: it cleans the cube
-    # *for decomposition* and is the decomposition tool's first substage. The
-    # per-pixel codegen receives the RAW cube and owns its own fittability
-    # denoising. See docs/hyperspectral_codegen_relocation.md.
+    # --- SPECTRAL DECOMPOSITION (one cohesive, model-bearing step) ---
+    # The decomposition is a single composite controller that owns its own input
+    # prep, component estimation, elbow scan, LLM selection, final unmixing, and
+    # validation plots, and leaves the decomposition contract in `state`. It
+    # cleans the cube *for decomposition* internally; the per-pixel codegen
+    # downstream receives the RAW cube and owns its own fittability denoising.
+    # See issue #220 / docs/hyperspectral_codegen_relocation.md.
     if settings.get('enabled', True):
-
-        # [🧠 LLM] Initial component/method guess — also decides skip_decomposition,
-        # using SNR estimated from the raw cube (prep runs after this).
-        if settings.get('auto_components', True):
-            pipeline.append(GetInitialComponentParamsController(
-                model, logger, generation_config, safety_settings, parse_fn
-            ))
-
-        # [🛠️ Tool] Decomposition's own prep substage — runs after the skip
-        # decision; internally gated on `skip_decomposition`.
-        if settings.get('run_preprocessing', True):
-            pipeline.append(RunPreprocessingController(logger, preprocessor))
-
-        # Rest of the auto-component workflow operates on the cleaned cube.
-        if settings.get('auto_components', True):
-            # [🛠️ Tool] Run NMF loop to get errors
-            pipeline.append(RunComponentTestLoopController(logger, settings))
-            # [🛠️ Tool] Create elbow plot from errors
-            pipeline.append(CreateElbowPlotController(logger, settings))
-            # [🛠️ LLM] Select final n_components from elbow plot
-            pipeline.append(GetFinalComponentSelectionController(
-                model, logger, generation_config, safety_settings, parse_fn
-            ))
-
-        # [🛠️ Tool] Run final NMF
-        pipeline.append(RunFinalSpectralUnmixingController(logger, settings))
-
-        # [🛠️ Tool] Create all plots for analysis
-        pipeline.append(CreateAnalysisPlotsController(logger, settings))
+        pipeline.append(DecompositionController(
+            model, logger, generation_config, safety_settings,
+            settings, preprocessor, parse_fn
+        ))
 
     # --- 3. ITERATION ANALYSIS & REFINEMENT DECISION ---
 

--- a/scilink/skills/hyperspectral/eels/eels.py
+++ b/scilink/skills/hyperspectral/eels/eels.py
@@ -1260,3 +1260,24 @@ def get_optimal_analysis_data(hspy_data: np.ndarray) -> tuple[np.ndarray, str]:
         quality = "Very Low"
     note = f"Raw Data ({quality} quality, SNR≈{snr:.1f})"
     return hspy_data, note
+
+
+def reconstruct_cube(components: np.ndarray, abundance_maps: np.ndarray) -> np.ndarray:
+    """Rank-k reconstruction of the data cube from a decomposition.
+
+    Args:
+        components: ``(n_components, n_channels)`` spectral signatures.
+        abundance_maps: ``(H, W, n_components)`` spatial loadings.
+
+    Returns:
+        ``(H, W, n_channels)`` reconstructed cube = ``abundance_maps @ components``.
+
+    This is the decomposition's denoised, rank-k approximation of the data.
+    It lives in whatever intensity space the decomposition was fit in — which
+    may be normalized/clipped relative to the raw cube — so it is reliable for
+    *shape*-based features (peak position, width) but its absolute intensity
+    scale should not be trusted for quantification. Offered to the per-pixel
+    codegen as an *optional* fit target for noisy features (issue #219); the
+    raw cube remains the base input.
+    """
+    return abundance_maps @ components


### PR DESCRIPTION
Re-targets to `main`. The original PR (#223) was stacked on `hyperspectral-relocation-plan` (#218) and merged into that branch **after** #218 had already merged to `main` — so its commits never reached `main`. This PR carries the identical two commits (`7b2691a` + `c294186`) onto `main`. Closes #220, #219.

## Summary (for scientists)

1. **The spectral decomposition is now one tool, not six loose steps (#220).** The six former per-iteration controllers (component estimation, input prep, elbow scan, selection, final unmixing, validation plots) are wrapped in a single cohesive decomposition step that does all of that internally and returns the components, abundance maps, reconstruction error, SNR, and mask. Same work, one box; it stays a model-bearing step inside the analysis loop (the decompose→re-plan feedback is preserved).

2. **The denoised decomposition reconstruction is offered to the per-pixel code generator (#219).** When the agent writes custom per-pixel fitting code it now also receives the rank-k reconstruction (a denoised cube) as an *optional* input. Raw stays the base; the model may reach for the reconstruction on noisy features. In the live run (SNR≈3.6) the generated code did exactly this — fit peak **position/width** from the reconstruction, peak **intensity** from raw.

---

## Technical details (for AI reviewers)

### #220 — `DecompositionController` composite
- New `DecompositionController` in `hyperspectral_controllers.py` composes the existing sub-controllers in original order with the same construction-time gating (`auto_components`, `run_preprocessing`); `execute` runs them sequentially, short-circuiting on `error_dict`.
- `hyperspectral_pipelines.py`: `enabled` block appends the single composite; imports trimmed. Iteration pipeline **12 → 6** steps. Behavior-preserving; same emitted state contract. No other module imports the moved controllers.

### #219 — reconstruction as optional codegen input
- `eels.py`: `reconstruct_cube(components, abundance_maps)` → `abundance_maps @ components`, shape `(H, W, e)`; equal to the accumulation loop in `create_validated_component_pair_reconstruction`.
- `RunDynamicAnalysisController.execute`: builds `reconstruction` when components/maps exist (None on skip or shape-mismatch), passes `reconstruction_available=` to `build_code_generation_prompt`, invokes via `_invoke_analyze_feature(...)`.
- `_invoke_analyze_feature` (uses `inspect.signature`): passes `reconstruction` only when the function declares it (named param, `**kwargs`, 3rd positional, or `*args`); else legacy 2-arg call — option never forced.
- `build_code_generation_prompt(..., reconstruction_available=False)`: toggles the documented signature and adds an "OPTIONAL DENOISED INPUT" block (raw is base; reconstruction for shape on noisy features; `None`-guard required). Reconstruction is in the decomposition's processed intensity space — flagged reliable for shape, not absolute intensity.

### Verification
- Unit: `reconstruct_cube` shape/equality; `_invoke_analyze_feature` dispatch across 2-arg / kwarg / positional / `**kwargs` / None; prompt-signature toggle; pipeline contains exactly one `DecompositionController`.
- Live (`examples/eels_plasmons_demo`, `claude-opus-4-6`): cohesive decomposition auto-selected 5 NMF components + all validation plots; refinement requested 1 `custom_code` task; reconstruction offered; generated `analyze_feature(data, axis, reconstruction=None)` used reconstruction for position/FWHM and raw for intensity; **4 maps QC-passed**. Run tail hit a transient LLM-connection hang on the post-hoc self-reflection critic — a fail-open step unrelated to these changes.

### Notes
- Also drops internal refactoring jargon from two log headers (`(cohesive step)`, `(clean cube for decomposition)`).
- One commit covers both issues (entangled in `hyperspectral_controllers.py`; a split would break the intermediate). #221 untouched.