### PR TITLE
Bump version to 0.0.45

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scilink"
-version = "0.0.44"
+version = "0.0.45"
 authors = [
   { name="SciLink Team", email="maxim.ziatdinov@gmail.com" },
 ]


### PR DESCRIPTION
Version bump 0.0.44 → 0.0.45, covering the hyperspectral decomposition/codegen work merged this cycle (#214–#220). Single-line change to `pyproject.toml`.