### PR TITLE
Codegen prompts: warn that the sandbox runs NumPy 2.x (np.trapz removed)

### DIFF
--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -276,7 +276,8 @@ Your code will run in a restricted `exec()` sandbox.
 1. **NO External Imports:** Do not import `os`, `sys`, `matplotlib`, or `warnings`. The sandbox does not support them.
 2. **SciPy Submodules:** If you need a specific SciPy submodule that is NOT in the shortcuts list (e.g., `scipy.interpolate` or `scipy.integrate`), you MUST write `import scipy.interpolate` **inside** your function definition before using it.
 3. **Standard Math:** Use `np.exp`, `np.log`, etc., instead of the `math` library.
-4. **Return Format:** You must return a dictionary, not a print statement or a plot.
+4. **NumPy 2.x:** This sandbox runs NumPy 2.x, where aliases removed in NumPy 2.0 raise `AttributeError` — notably use `np.trapezoid` (NOT `np.trapz`); prefer `scipy.integrate.trapezoid` for integration.
+5. **Return Format:** You must return a dictionary, not a print statement or a plot.
 
 ### 4. YOUR GOAL
 Write a function `{signature}` that:

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2189,6 +2189,7 @@ plan as specified and let the retry pipeline handle actual runtime failures.
 {tool_inventory}
 
 **Available Libraries:** numpy, pandas, scipy, lmfit, matplotlib, json
+*(NumPy 2.x: aliases removed in NumPy 2.0 raise `AttributeError` — use `np.trapezoid` not `np.trapz`; prefer `scipy.integrate.trapezoid` for integration.)*
 
 **Requirements:**
 1. Load data (handle .npy, .csv, .txt). The data you load is RAW — no preprocessing
@@ -2259,6 +2260,7 @@ FITTING_SCRIPT_CORRECTION_INSTRUCTIONS = """Fix this failed script.
 {tool_inventory}
 
 **Available Libraries:** numpy, pandas, scipy, lmfit, matplotlib, json
+*(NumPy 2.x: aliases removed in NumPy 2.0 raise `AttributeError` — use `np.trapezoid` not `np.trapz`; prefer `scipy.integrate.trapezoid` for integration.)*
 
 **CRITICAL:** Fix only the execution error. Do NOT change the fitting model, its parameters, or the overall analysis approach. The model is locked for series consistency.
 


### PR DESCRIPTION
## Summary

Model-generated analysis code keeps reaching for `np.trapz`, which **NumPy 2.0 removed** (renamed `np.trapezoid`). The sandbox here runs NumPy 2.4, so every such script `AttributeError`s — burning a failed attempt + a full retry (LLM call) each time. Observed live in hyperspectral XRD code-gen.

Fix: add a one-line NumPy 2.x note to the **baseline code-gen prompts**, which every run sees regardless of which skill (if any) is active.

## Why the baseline prompt, not the skills

This is an environment/version constraint, not domain knowledge:
- it hits **all** code-gen surfaces (hyperspectral `analyze_feature`, curve-fit script, its correction retry), and
- it hits **skill-less** runs (the default baseline code-gen).

Putting it in skill markdowns would duplicate it across every skill file *and* miss skill-less runs. The agent-owned baseline prompt is the single correct home.

## Changes

- `controllers/hyperspectral_controllers.py` — `build_code_generation_prompt` → "### 3. CODING CONSTRAINTS" gains a NumPy 2.x item (`np.trapezoid` not `np.trapz`).
- `instruct.py` — `FITTING_SCRIPT_INSTRUCTIONS` and `FITTING_SCRIPT_CORRECTION_INSTRUCTIONS` "Available Libraries" lines gain the same note.

One concise factual line per surface (principle + the concrete offender), not an enumerated alias list — per the repo's prompt-patch convention. Image-analysis code-gen can get the same note if it proves to hit it.