### PR TITLE
Curve-fit: auxiliary data as an optional fit-script operand (#226, step 2)

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1771,6 +1771,46 @@ Your guidance: '''
         if prior_runs:
             context_parts.append(prior_runs)
 
+        # Optional auxiliary operand (#226): when a 1D auxiliary curve is aligned
+        # with the primary (same length), write it next to the spectrum and offer
+        # it to the generated script as an optional operand (e.g. baseline/
+        # reference subtraction). Otherwise it stays context-only (no resampling
+        # in v1) — the rendered plot still reaches the planning/interpretation LLM.
+        auxiliary_block = ""
+        aux_arr = state.get("auxiliary_array")
+        aux_axis = state.get("auxiliary_axis")
+        if aux_arr is not None and aux_axis is not None:
+            aux_arr = np.asarray(aux_arr)
+            aux_axis = np.asarray(aux_axis)
+            if aux_arr.ndim == 1 and aux_arr.shape[0] == stats["n_points"]:
+                aux_path = self.output_dir / "temp_auxiliary.npy"
+                np.save(aux_path, np.column_stack([aux_axis, aux_arr]))
+                label = state.get("auxiliary_label") or "reference"
+                auxiliary_block = (
+                    "\n**Optional reference/baseline operand:**\n"
+                    f"- Path: `{aux_path}` — a 2-column [x, y] NumPy array, "
+                    f"{aux_arr.shape[0]} points, on the same x-axis as the primary "
+                    f"(x range [{float(np.nanmin(aux_axis)):.6g}, "
+                    f"{float(np.nanmax(aux_axis)):.6g}]).\n"
+                    f"- This is \"{label}\". You MAY load it and use it numerically — "
+                    "e.g. subtract or divide its y-column from the primary — ONLY if "
+                    "your method needs it (background/baseline removal, normalization). "
+                    "The primary data is the base input; the reference is optional, "
+                    "never required.\n"
+                    "- Do NOT report findings about the reference as if it were a "
+                    "measurement; it is an operand for transforming the primary.\n"
+                )
+                self.logger.info(
+                    f"🧩 Offering auxiliary '{label}' ({aux_arr.shape[0]} pts) as an "
+                    f"optional fit-script operand."
+                )
+            else:
+                self.logger.info(
+                    f"Auxiliary present but not aligned with the primary "
+                    f"({getattr(aux_arr, 'shape', None)} vs {stats['n_points']} pts); "
+                    f"kept as context only (not a fit-script operand)."
+                )
+
         prompt = self.script_instructions.format(
             analysis_approach=config.get("analysis_approach", "Fit the data"),
             physical_model=config.get("physical_model", "Appropriate model"),
@@ -1783,6 +1823,7 @@ Your guidance: '''
             x_max=stats["x_range"][1],
             y_min=stats["y_range"][0],
             y_max=stats["y_range"][1],
+            auxiliary_block=auxiliary_block,
             tool_inventory=_tool_inventory_text(state),
         )
 

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -534,6 +534,8 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "auxiliary_label": None,
             "auxiliary_summary": None,
             "auxiliary_mime_type": None,
+            "auxiliary_array": None,
+            "auxiliary_axis": None,
         }
         if auxiliary_data:
             aux_state = self._load_auxiliary_data(auxiliary_data, auxiliary_label)
@@ -805,6 +807,12 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "auxiliary_label": auxiliary_label or Path(auxiliary_data).stem,
             "auxiliary_summary": None,
             "auxiliary_mime_type": None,
+            # Raw numbers retained so the generated fit script may use the
+            # auxiliary as an OPTIONAL operand (e.g. baseline subtraction), not
+            # only as a rendered picture. ``auxiliary_axis`` holds the x-axis of
+            # a 1D curve (for alignment); None for images. (#226)
+            "auxiliary_array": None,
+            "auxiliary_axis": None,
         }
 
         if not os.path.exists(auxiliary_data):
@@ -866,6 +874,8 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                     f"X range: [{float(np.nanmin(x)):.4g}, {float(np.nanmax(x)):.4g}]. "
                     f"Y range: [{float(np.nanmin(y)):.4g}, {float(np.nanmax(y)):.4g}]."
                 )
+                result["auxiliary_array"] = np.asarray(y, dtype=float)
+                result["auxiliary_axis"] = np.asarray(x, dtype=float)
 
                 plot_info = {"title": result["auxiliary_label"]}
                 plot_data = np.column_stack([x, y])
@@ -885,6 +895,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                     f"Image with shape {img.shape} "
                     f"(dtype: {img.dtype})."
                 )
+                result["auxiliary_array"] = img
                 if img.ndim == 3:
                     import cv2
                     img_gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2185,7 +2185,7 @@ plan as specified and let the retry pipeline handle actual runtime failures.
 - Points: {n_points}
 - X: [{x_min:.6g}, {x_max:.6g}]
 - Y: [{y_min:.6g}, {y_max:.6g}]
-
+{auxiliary_block}
 {tool_inventory}
 
 **Available Libraries:** numpy, pandas, scipy, lmfit, matplotlib, json


### PR DESCRIPTION
Second increment of #226 (curve-fitting agent). Mirrors the hyperspectral step (#228). Image surface, `run_analysis` schema, meta awareness, and multi-auxiliary remain.

## Summary (for scientists)

A companion dataset passed as `auxiliary_data` was only *shown to the model* as a picture — it could inform interpretation but the numbers never reached the fit. This makes it usable **numerically**: when the auxiliary curve lines up with the primary, the generated fit script can now *use* it — e.g. subtract an empty-sample/background baseline or divide by a reference before fitting. It stays optional: the primary is always the base, and the script only reaches for it when the method needs it.

Validated live on a 1D **XRD** pattern (three Bragg peaks on a large air-scatter + amorphous background) plus an **empty-sample baseline**. The generated fit script loaded the baseline, subtracted it (with an x-grid alignment guard + interpolation fallback), fit three Pseudo-Voigt peaks, and the verifier approved at **R² = 0.987** on the first attempt.

## Technical details (for AI reviewers)

- `curve_fitting_agent.py::_load_auxiliary_data` now also retains `auxiliary_array` (raw y) and `auxiliary_axis` (x); default `aux_state` carries the two keys so they spread into pipeline `state` via the existing `**aux_state`.
- `controllers/curve_fitting_controllers.py::UnifiedSeriesProcessingController._generate_fitting_script`: when a 1D auxiliary is **length-aligned** with the primary (`len == stats["n_points"]`), it writes `temp_auxiliary.npy` (a 2-col `[x, y]` array) next to `temp_spectrum_{idx}.npy` and fills an `{auxiliary_block}`; otherwise the block is empty (auxiliary stays context-only — the rendered plot still reaches planning/interpretation via `_append_auxiliary_context`). No resampling in v1.
- `instruct.py::FITTING_SCRIPT_INSTRUCTIONS` gains an `{auxiliary_block}` placeholder after the Data block. The block documents the operand as an **optional** reference/baseline the script MAY subtract/divide, with the dual-role rule (operand to transform the primary, **not** a measurement to report on). Only one `.format()` site consumes the template (`AdaptiveRefitController` delegates to the same controller), so the new key is supplied in one place.

**Live validation** (`claude-opus-4-6`): `🧩 Offering auxiliary 'empty-sample baseline' (600 pts)` fired; the generated script did `np.load('.../temp_auxiliary.npy')` → `y_subtracted = y_data - y_baseline` (with `np.allclose` x-grid check + `interp1d` fallback) → 3 Pseudo-Voigt fit; **R² = 0.987, verifier-approved, 1 attempt, status: success** end-to-end (report generated).

**Unit-tested:** template `.format()` with/without the block; curve-fit array+axis retention.

### Known limits / scope
- Curve-fit only. Image surface, `run_analysis` schema widening, meta awareness, and the multi-auxiliary `str | list[str]` widening are the remaining #226 steps.
- The aux file is written in `_generate_fitting_script` (fresh-generation path); the locked-script-reuse path (`_adapt_script_for_spectrum`) relies on the file persisting from first generation — fine for single spectra and standard series, noted for completeness.
- v1 gates on length alignment; auto-resampling deferred (the model's own interp fallback notwithstanding).