### PR TITLE
Auxiliary operand: multi-auxiliary (str|list) + image-analysis surface + single auxiliary_items model (#226)

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -227,24 +227,48 @@ def _append_deviation_note(prompt: list, fit_results: dict) -> None:
     )
 
 
+def _sanitize_aux_name(label: str, idx: int) -> str:
+    """Filesystem-safe stem for a per-auxiliary temp file."""
+    safe = re.sub(r'[^0-9A-Za-z_-]', '_', str(label)).strip('_')
+    return safe or f"aux{idx}"
+
+
+def _auxiliary_display_items(state: dict) -> list:
+    """Auxiliary datasets to show the LLM as context. Uses the multi-aux
+    ``auxiliary_items`` list when present, else synthesizes one entry from the
+    legacy flat keys (back-compat). Only items with a rendered plot. (#226)"""
+    items = state.get("auxiliary_items")
+    if not items:
+        if not state.get("auxiliary_plot_bytes"):
+            return []
+        items = [{
+            "label": state.get("auxiliary_label", "Auxiliary data"),
+            "summary": state.get("auxiliary_summary", ""),
+            "plot_bytes": state.get("auxiliary_plot_bytes"),
+            "mime_type": state.get("auxiliary_mime_type", "image/png"),
+        }]
+    return [it for it in items if it.get("plot_bytes")]
+
+
 def _append_auxiliary_context(prompt: list, state: dict) -> None:
-    """Append auxiliary reference data to an LLM prompt if available."""
-    if not state.get("auxiliary_plot_bytes"):
+    """Append auxiliary reference dataset(s) to an LLM prompt if available."""
+    items = _auxiliary_display_items(state)
+    if not items:
         return
-    label = state.get("auxiliary_label", "Auxiliary data")
-    summary = state.get("auxiliary_summary", "")
-    prompt.append(f"\n## Auxiliary Reference Data: {label}")
+    prompt.append("\n## Auxiliary Reference Data")
     prompt.append(
-        f"The user provided this auxiliary reference data: {label}. "
-        "Take it into account in your analysis and interpretation, but do NOT "
-        "fit or quantitatively analyze this auxiliary data."
+        "The user provided the following auxiliary reference dataset(s). Take "
+        "them into account in your analysis and interpretation, but do NOT fit "
+        "or quantitatively analyze the auxiliary data as if it were a measurement."
     )
-    if summary:
-        prompt.append(f"\nData summary: {summary}")
-    prompt.append({
-        "mime_type": state.get("auxiliary_mime_type", "image/png"),
-        "data": state["auxiliary_plot_bytes"]
-    })
+    for it in items:
+        prompt.append(f"\n### {it.get('label', 'Auxiliary data')}")
+        if it.get("summary"):
+            prompt.append(f"Data summary: {it['summary']}")
+        prompt.append({
+            "mime_type": it.get("mime_type", "image/png"),
+            "data": it["plot_bytes"],
+        })
 
 
 def _append_fit_domain_guidance(prompt: list, state: dict) -> None:
@@ -1771,45 +1795,52 @@ Your guidance: '''
         if prior_runs:
             context_parts.append(prior_runs)
 
-        # Optional auxiliary operand (#226): when a 1D auxiliary curve is aligned
-        # with the primary (same length), write it next to the spectrum and offer
-        # it to the generated script as an optional operand (e.g. baseline/
-        # reference subtraction). Otherwise it stays context-only (no resampling
-        # in v1) — the rendered plot still reaches the planning/interpretation LLM.
-        auxiliary_block = ""
-        aux_arr = state.get("auxiliary_array")
-        aux_axis = state.get("auxiliary_axis")
-        if aux_arr is not None and aux_axis is not None:
-            aux_arr = np.asarray(aux_arr)
-            aux_axis = np.asarray(aux_axis)
-            if aux_arr.ndim == 1 and aux_arr.shape[0] == stats["n_points"]:
-                aux_path = self.output_dir / "temp_auxiliary.npy"
-                np.save(aux_path, np.column_stack([aux_axis, aux_arr]))
-                label = state.get("auxiliary_label") or "reference"
-                auxiliary_block = (
-                    "\n**Optional reference/baseline operand:**\n"
-                    f"- Path: `{aux_path}` — a 2-column [x, y] NumPy array, "
-                    f"{aux_arr.shape[0]} points, on the same x-axis as the primary "
-                    f"(x range [{float(np.nanmin(aux_axis)):.6g}, "
-                    f"{float(np.nanmax(aux_axis)):.6g}]).\n"
-                    f"- This is \"{label}\". You MAY load it and use it numerically — "
-                    "e.g. subtract or divide its y-column from the primary — ONLY if "
-                    "your method needs it (background/baseline removal, normalization). "
-                    "The primary data is the base input; the reference is optional, "
-                    "never required.\n"
-                    "- Do NOT report findings about the reference as if it were a "
-                    "measurement; it is an operand for transforming the primary.\n"
+        # Optional auxiliary operand(s) (#226): for each 1D auxiliary curve aligned
+        # with the primary (same length), write it next to the spectrum and list
+        # it in a manifest the generated script MAY use (e.g. baseline subtraction,
+        # reference division). Misaligned ones stay context-only (no resampling in
+        # v1) — their rendered plot still reaches the planning/interpretation LLM.
+        operand_lines = []
+        for j, it in enumerate(state.get("auxiliary_items") or []):
+            arr = it.get("array")
+            axis = it.get("axis")
+            label = it.get("label") or f"reference_{j}"
+            if arr is None or axis is None:
+                continue
+            arr = np.asarray(arr)
+            axis = np.asarray(axis)
+            if arr.ndim == 1 and arr.shape[0] == stats["n_points"]:
+                safe = _sanitize_aux_name(label, j)
+                aux_path = self.output_dir / f"temp_auxiliary_{safe}.npy"
+                np.save(aux_path, np.column_stack([axis, arr]))
+                operand_lines.append(
+                    f"- \"{label}\": `{aux_path}` — a 2-column [x, y] array, "
+                    f"{arr.shape[0]} points, same x-axis as the primary "
+                    f"(x range [{float(np.nanmin(axis)):.6g}, {float(np.nanmax(axis)):.6g}])."
                 )
                 self.logger.info(
-                    f"🧩 Offering auxiliary '{label}' ({aux_arr.shape[0]} pts) as an "
+                    f"🧩 Offering auxiliary '{label}' ({arr.shape[0]} pts) as an "
                     f"optional fit-script operand."
                 )
             else:
                 self.logger.info(
-                    f"Auxiliary present but not aligned with the primary "
-                    f"({getattr(aux_arr, 'shape', None)} vs {stats['n_points']} pts); "
+                    f"Auxiliary '{label}' not aligned with the primary "
+                    f"({getattr(arr, 'shape', None)} vs {stats['n_points']} pts); "
                     f"kept as context only (not a fit-script operand)."
                 )
+
+        auxiliary_block = ""
+        if operand_lines:
+            auxiliary_block = (
+                "\n**Optional reference/baseline operand(s):**\n"
+                + "\n".join(operand_lines)
+                + "\n- You MAY load any of these and use it numerically — e.g. "
+                "subtract or divide its y-column from the primary — ONLY if your "
+                "method needs it (background/baseline removal, normalization). The "
+                "primary data is the base input; references are optional, never "
+                "required. Do NOT report findings about a reference as if it were a "
+                "measurement; it is an operand for transforming the primary.\n"
+            )
 
         prompt = self.script_instructions.format(
             analysis_approach=config.get("analysis_approach", "Fit the data"),
@@ -4425,6 +4456,11 @@ class AdaptiveRefitController:
             "auxiliary_label": state.get("auxiliary_label"),
             "auxiliary_summary": state.get("auxiliary_summary"),
             "auxiliary_mime_type": state.get("auxiliary_mime_type"),
+            # Multi-aux: carry the full item list + first-item operand arrays so
+            # operands flow through this sub-state path too (#226).
+            "auxiliary_items": state.get("auxiliary_items", []),
+            "auxiliary_array": state.get("auxiliary_array"),
+            "auxiliary_axis": state.get("auxiliary_axis"),
             "prior_knowledge": state.get("prior_knowledge", []),
             "analysis_images": [],
         }

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -234,20 +234,9 @@ def _sanitize_aux_name(label: str, idx: int) -> str:
 
 
 def _auxiliary_display_items(state: dict) -> list:
-    """Auxiliary datasets to show the LLM as context. Uses the multi-aux
-    ``auxiliary_items`` list when present, else synthesizes one entry from the
-    legacy flat keys (back-compat). Only items with a rendered plot. (#226)"""
-    items = state.get("auxiliary_items")
-    if not items:
-        if not state.get("auxiliary_plot_bytes"):
-            return []
-        items = [{
-            "label": state.get("auxiliary_label", "Auxiliary data"),
-            "summary": state.get("auxiliary_summary", ""),
-            "plot_bytes": state.get("auxiliary_plot_bytes"),
-            "mime_type": state.get("auxiliary_mime_type", "image/png"),
-        }]
-    return [it for it in items if it.get("plot_bytes")]
+    """Auxiliary datasets to show the LLM as context — items with a rendered
+    plot, from the multi-aux ``auxiliary_items`` list. (#226)"""
+    return [it for it in (state.get("auxiliary_items") or []) if it.get("plot_bytes")]
 
 
 def _append_auxiliary_context(prompt: list, state: dict) -> None:
@@ -4452,15 +4441,9 @@ class AdaptiveRefitController:
             "analysis_objective": state.get("analysis_objective"),
             "skill_name": state.get("skill_name"),
             "skill_sections": state.get("skill_sections"),
-            "auxiliary_plot_bytes": state.get("auxiliary_plot_bytes"),
-            "auxiliary_label": state.get("auxiliary_label"),
-            "auxiliary_summary": state.get("auxiliary_summary"),
-            "auxiliary_mime_type": state.get("auxiliary_mime_type"),
-            # Multi-aux: carry the full item list + first-item operand arrays so
-            # operands flow through this sub-state path too (#226).
+            # Carry the multi-aux item list so display + operands flow through
+            # this sub-state path too (#226).
             "auxiliary_items": state.get("auxiliary_items", []),
-            "auxiliary_array": state.get("auxiliary_array"),
-            "auxiliary_axis": state.get("auxiliary_axis"),
             "prior_knowledge": state.get("prior_knowledge", []),
             "analysis_images": [],
         }

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -113,24 +113,45 @@ def _append_prior_knowledge_context(prompt: list, state: dict) -> None:
                 prompt.append(f"- {f}")
 
 
+def _auxiliary_display_items(state: dict) -> list:
+    """Return the auxiliary datasets to show the LLM as context.
+
+    Uses the multi-aux ``auxiliary_items`` list when present, else synthesizes a
+    one-element list from the legacy flat keys (back-compat). Only items with a
+    rendered plot are returned. (#226)
+    """
+    items = state.get("auxiliary_items")
+    if not items:
+        if not state.get("auxiliary_plot_bytes"):
+            return []
+        items = [{
+            "label": state.get("auxiliary_label", "Auxiliary data"),
+            "summary": state.get("auxiliary_summary", ""),
+            "plot_bytes": state.get("auxiliary_plot_bytes"),
+            "mime_type": state.get("auxiliary_mime_type", "image/png"),
+        }]
+    return [it for it in items if it.get("plot_bytes")]
+
+
 def _append_auxiliary_context(prompt: list, state: dict) -> None:
-    """Append auxiliary reference data to an LLM prompt if available."""
-    if not state.get("auxiliary_plot_bytes"):
+    """Append auxiliary reference dataset(s) to an LLM prompt if available."""
+    items = _auxiliary_display_items(state)
+    if not items:
         return
-    label = state.get("auxiliary_label", "Auxiliary data")
-    summary = state.get("auxiliary_summary", "")
-    prompt.append(f"\n## Auxiliary Reference Data: {label}")
+    prompt.append("\n## Auxiliary Reference Data")
     prompt.append(
-        f"The user provided this auxiliary reference data: {label}. "
-        "Take it into account in your analysis and interpretation, but do NOT "
-        "fit or quantitatively analyze this auxiliary data."
+        "The user provided the following auxiliary reference dataset(s). Take "
+        "them into account in your analysis and interpretation, but do NOT fit "
+        "or quantitatively analyze the auxiliary data as if it were a measurement."
     )
-    if summary:
-        prompt.append(f"\nData summary: {summary}")
-    prompt.append({
-        "mime_type": state.get("auxiliary_mime_type", "image/png"),
-        "data": state["auxiliary_plot_bytes"]
-    })
+    for it in items:
+        prompt.append(f"\n### {it.get('label', 'Auxiliary data')}")
+        if it.get("summary"):
+            prompt.append(f"Data summary: {it['summary']}")
+        prompt.append({
+            "mime_type": it.get("mime_type", "image/png"),
+            "data": it["plot_bytes"],
+        })
 
 
 def _append_objective_context(prompt: list, state: dict) -> None:
@@ -1858,33 +1879,34 @@ class RunDynamicAnalysisController:
                 self.logger.warning(f"Could not build reconstruction cube: {e}")
                 reconstruction = None
 
-        # Offer a shape-aligned auxiliary dataset as an OPTIONAL numerical
-        # operand (issue #226): the user-supplied companion (reference/baseline/
-        # other channel) the generated code MAY divide by / mask with. Kept as
-        # context-only (NOT an operand) when it can't be aligned to the primary
-        # — v1 does no resampling. Raw `data` stays the base input.
+        # Offer shape-aligned auxiliary dataset(s) as OPTIONAL numerical operands
+        # (issue #226): the user-supplied companions (reference/baseline/other
+        # channels) the generated code MAY divide by / subtract / mask with,
+        # keyed by label. Each is kept context-only (NOT an operand) when it can't
+        # be aligned to the primary — v1 does no resampling. Raw `data` stays base.
         auxiliary_operands = {}
-        aux_arr = state.get("auxiliary_array")
-        if aux_arr is not None:
-            aux_arr = np.asarray(aux_arr)
-            h_, w_, e_ = optimal_data.shape
-            label = state.get("auxiliary_label") or "auxiliary"
+        h_, w_, e_ = optimal_data.shape
+        for it in (state.get("auxiliary_items") or []):
+            arr = it.get("array")
+            if arr is None:
+                continue
+            arr = np.asarray(arr)
+            label = it.get("label") or "auxiliary"
             aligned = (
-                (aux_arr.ndim == 1 and aux_arr.shape[0] == e_)   # reference spectrum (per channel)
-                or (aux_arr.ndim == 2 and aux_arr.shape == (h_, w_))  # per-pixel map (mask/normalize)
-                or (aux_arr.shape == optimal_data.shape)         # full companion cube
+                (arr.ndim == 1 and arr.shape[0] == e_)            # reference spectrum (per channel)
+                or (arr.ndim == 2 and arr.shape == (h_, w_))      # per-pixel map (mask/normalize)
+                or (arr.shape == optimal_data.shape)              # full companion cube
             )
             if aligned:
-                auxiliary_operands[label] = aux_arr
+                auxiliary_operands[label] = arr
                 self.logger.info(
-                    f"🧩 Offering auxiliary '{label}' {aux_arr.shape} as an "
-                    f"optional codegen operand."
+                    f"🧩 Offering auxiliary '{label}' {arr.shape} as an optional "
+                    f"codegen operand."
                 )
             else:
                 self.logger.info(
-                    f"Auxiliary '{label}' shape {aux_arr.shape} not aligned with "
-                    f"primary {optimal_data.shape}; kept as context only "
-                    f"(not a codegen operand)."
+                    f"Auxiliary '{label}' shape {arr.shape} not aligned with primary "
+                    f"{optimal_data.shape}; kept as context only (not an operand)."
                 )
 
         # --- MAIN LOOP: Process each target description separately ---

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -114,23 +114,9 @@ def _append_prior_knowledge_context(prompt: list, state: dict) -> None:
 
 
 def _auxiliary_display_items(state: dict) -> list:
-    """Return the auxiliary datasets to show the LLM as context.
-
-    Uses the multi-aux ``auxiliary_items`` list when present, else synthesizes a
-    one-element list from the legacy flat keys (back-compat). Only items with a
-    rendered plot are returned. (#226)
-    """
-    items = state.get("auxiliary_items")
-    if not items:
-        if not state.get("auxiliary_plot_bytes"):
-            return []
-        items = [{
-            "label": state.get("auxiliary_label", "Auxiliary data"),
-            "summary": state.get("auxiliary_summary", ""),
-            "plot_bytes": state.get("auxiliary_plot_bytes"),
-            "mime_type": state.get("auxiliary_mime_type", "image/png"),
-        }]
-    return [it for it in items if it.get("plot_bytes")]
+    """Auxiliary datasets to show the LLM as context — items with a rendered
+    plot, from the multi-aux ``auxiliary_items`` list. (#226)"""
+    return [it for it in (state.get("auxiliary_items") or []) if it.get("plot_bytes")]
 
 
 def _append_auxiliary_context(prompt: list, state: dict) -> None:

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -214,24 +214,37 @@ def build_verification_prompt_with_history(
     return "\n".join(lines)
 
 
+def _sanitize_aux_name(label: str, idx: int) -> str:
+    """Filesystem-safe stem for a per-auxiliary temp file."""
+    safe = re.sub(r'[^0-9A-Za-z_-]', '_', str(label)).strip('_')
+    return safe or f"aux{idx}"
+
+
+def _auxiliary_display_items(state: dict) -> list:
+    """Auxiliary datasets to show the LLM as context — items with a rendered
+    plot, from the multi-aux ``auxiliary_items`` list. (#226)"""
+    return [it for it in (state.get("auxiliary_items") or []) if it.get("plot_bytes")]
+
+
 def _append_auxiliary_context(prompt: list, state: dict) -> None:
-    """Append auxiliary reference data to an LLM prompt if available."""
-    if not state.get("auxiliary_plot_bytes"):
+    """Append auxiliary reference dataset(s) to an LLM prompt if available."""
+    items = _auxiliary_display_items(state)
+    if not items:
         return
-    label = state.get("auxiliary_label", "Auxiliary data")
-    summary = state.get("auxiliary_summary", "")
-    prompt.append(f"\n## Auxiliary Reference Data: {label}")
+    prompt.append("\n## Auxiliary Reference Data")
     prompt.append(
-        f"The user provided this auxiliary reference data: {label}. "
-        "Take it into account in your analysis and interpretation, but do NOT "
-        "fit or quantitatively analyze this auxiliary data."
+        "The user provided the following auxiliary reference dataset(s). Take "
+        "them into account in your analysis and interpretation, but do NOT fit "
+        "or quantitatively analyze the auxiliary data as if it were a measurement."
     )
-    if summary:
-        prompt.append(f"\nData summary: {summary}")
-    prompt.append({
-        "mime_type": state.get("auxiliary_mime_type", "image/png"),
-        "data": state["auxiliary_plot_bytes"]
-    })
+    for it in items:
+        prompt.append(f"\n### {it.get('label', 'Auxiliary data')}")
+        if it.get("summary"):
+            prompt.append(f"Data summary: {it['summary']}")
+        prompt.append({
+            "mime_type": it.get("mime_type", "image/png"),
+            "data": it["plot_bytes"],
+        })
 
 
 def _append_tool_inventory(
@@ -2095,10 +2108,60 @@ Your guidance: '''
                         lines.append(f"- `{path_str}`")
                 context_parts.append("\n".join(lines))
 
+        # Optional auxiliary operand(s) (#226): for each co-registered companion
+        # image aligned with the primary (same H×W), write it next to the image
+        # and list it in a manifest the generated script MAY use (e.g. a
+        # topography channel masking/informing a phase image). Misaligned ones
+        # stay context-only (no resampling in v1).
+        primary_shape = tuple(stats.get("shape") or ())
+        operand_lines = []
+        for j, it in enumerate(state.get("auxiliary_items") or []):
+            arr = it.get("array")
+            label = it.get("label") or f"reference_{j}"
+            if arr is None:
+                continue
+            arr = np.asarray(arr)
+            aligned = (
+                len(primary_shape) >= 2
+                and arr.ndim >= 2
+                and tuple(arr.shape[:2]) == primary_shape[:2]
+            )
+            if aligned:
+                safe = _sanitize_aux_name(label, j)
+                aux_path = Path(data_path).parent / f"temp_auxiliary_{safe}.npy"
+                np.save(aux_path, arr)
+                operand_lines.append(
+                    f"- \"{label}\": `{aux_path}` — a co-registered array of shape "
+                    f"{tuple(arr.shape)} (same H×W as the primary image)."
+                )
+                self.logger.info(
+                    f"🧩 Offering auxiliary '{label}' {tuple(arr.shape)} as an "
+                    f"optional image-script operand."
+                )
+            else:
+                self.logger.info(
+                    f"Auxiliary '{label}' shape {tuple(arr.shape)} not aligned with "
+                    f"primary {primary_shape}; kept as context only (not an operand)."
+                )
+
+        auxiliary_block = ""
+        if operand_lines:
+            auxiliary_block = (
+                "\n**Optional companion operand(s):**\n"
+                + "\n".join(operand_lines)
+                + "\n- You MAY load any of these (np.load) and use it numerically — "
+                "e.g. mask, normalize, divide, or correlate it with the primary — "
+                "ONLY if your method needs it. The primary image is the base input; "
+                "companions are optional, never required. Do NOT report findings "
+                "about a companion as if it were the measurement; it is an operand "
+                "for analyzing the primary.\n"
+            )
+
         from ....skills._shared._registry import format_tool_inventory
 
         active_skills = _active_skill_names(state)
         format_kwargs = dict(
+            auxiliary_block=auxiliary_block,
             analysis_approach=config.get("analysis_approach", "Analyze the image"),
             processing_pipeline=config.get("processing_pipeline", "Standard processing"),
             features_to_extract=", ".join(config.get("features_to_extract", [])) or "relevant features",
@@ -4955,10 +5018,7 @@ class ImageAdaptiveRefitController:
             "analysis_objective": state.get("analysis_objective"),
             "skill_name": state.get("skill_name"),
             "skill_sections": state.get("skill_sections"),
-            "auxiliary_plot_bytes": state.get("auxiliary_plot_bytes"),
-            "auxiliary_label": state.get("auxiliary_label"),
-            "auxiliary_summary": state.get("auxiliary_summary"),
-            "auxiliary_mime_type": state.get("auxiliary_mime_type"),
+            "auxiliary_items": state.get("auxiliary_items", []),
             "prior_knowledge": state.get("prior_knowledge", []),
             "analysis_images": [],
         }

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -51,6 +51,24 @@ from .instruct import (
 logger = logging.getLogger(__name__)
 
 
+def _empty_auxiliary_state() -> dict:
+    """Default auxiliary state — no companion datasets loaded.
+
+    ``auxiliary_items`` is the multi-auxiliary list (each entry has label /
+    array / axis / plot_bytes / summary / mime_type); the flat ``auxiliary_*``
+    keys mirror the first item for back-compat with single-aux readers. (#226)
+    """
+    return {
+        "auxiliary_items": [],
+        "auxiliary_plot_bytes": None,
+        "auxiliary_label": None,
+        "auxiliary_summary": None,
+        "auxiliary_mime_type": None,
+        "auxiliary_array": None,
+        "auxiliary_axis": None,
+    }
+
+
 class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
     """
     Unified Curve Fitting Agent for spectroscopic analysis.
@@ -271,8 +289,8 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         objective: str | None = None,
         hints: str | None = None,
         series_metadata: Optional[dict] = None,
-        auxiliary_data: Optional[str] = None,
-        auxiliary_label: Optional[str] = None,
+        auxiliary_data: Optional[Union[str, List[str]]] = None,
+        auxiliary_label: Optional[Union[str, List[str]]] = None,
         # Domain skill
         skill: Optional[str] = None,
         # Prior knowledge from reference analyses
@@ -528,19 +546,14 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # Compute statistics for first spectrum
         data_statistics = self._compute_statistics(processed_first_spectrum)
         
-        # Load auxiliary data if provided
-        aux_state = {
-            "auxiliary_plot_bytes": None,
-            "auxiliary_label": None,
-            "auxiliary_summary": None,
-            "auxiliary_mime_type": None,
-            "auxiliary_array": None,
-            "auxiliary_axis": None,
-        }
+        # Load auxiliary data if provided (one or several companion datasets)
+        aux_state = _empty_auxiliary_state()
         if auxiliary_data:
-            aux_state = self._load_auxiliary_data(auxiliary_data, auxiliary_label)
-            if aux_state.get("auxiliary_plot_bytes"):
-                self.logger.info(f"   Auxiliary data loaded: {aux_state['auxiliary_label']}")
+            aux_state = self._load_auxiliary_items(auxiliary_data, auxiliary_label)
+            n = len(aux_state.get("auxiliary_items", []))
+            if n:
+                names = ", ".join(it["label"] for it in aux_state["auxiliary_items"])
+                self.logger.info(f"   Auxiliary data loaded ({n}): {names}")
 
         # Load skill(s) if provided. ``skill`` accepts a single name/path or
         # a list — see PR 3 multi-skill support. Singular state fields
@@ -788,6 +801,50 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "y_std": float(np.nanstd(y)),
             "has_nans": bool(np.any(np.isnan(curve_data))),
         }
+
+    def _load_auxiliary_items(self, auxiliary_data, auxiliary_label) -> dict:
+        """Load one or several auxiliary datasets into the multi-aux state.
+
+        Accepts ``str | list[str]`` for both ``auxiliary_data`` and
+        ``auxiliary_label`` (parallel lists). Each file is loaded via
+        ``_load_auxiliary_data``; labels are made unique (auto-named ``aux_<i>``
+        when missing) and become the operand keys downstream. (#226)
+        """
+        paths = list(auxiliary_data) if isinstance(auxiliary_data, (list, tuple)) else [auxiliary_data]
+        labels = list(auxiliary_label) if isinstance(auxiliary_label, (list, tuple)) else [auxiliary_label]
+
+        items = []
+        used = set()
+        for i, p in enumerate(paths):
+            lbl = labels[i] if i < len(labels) else None
+            one = self._load_auxiliary_data(p, lbl)
+            name = one.get("auxiliary_label") or f"aux_{i}"
+            base, k = name, 1
+            while name in used:
+                name = f"{base}_{k}"; k += 1
+            used.add(name)
+            items.append({
+                "label": name,
+                "array": one.get("auxiliary_array"),
+                "axis": one.get("auxiliary_axis"),
+                "plot_bytes": one.get("auxiliary_plot_bytes"),
+                "summary": one.get("auxiliary_summary"),
+                "mime_type": one.get("auxiliary_mime_type"),
+            })
+
+        state = _empty_auxiliary_state()
+        state["auxiliary_items"] = items
+        if items:  # mirror first item into the flat keys (back-compat)
+            f = items[0]
+            state.update({
+                "auxiliary_plot_bytes": f["plot_bytes"],
+                "auxiliary_label": f["label"],
+                "auxiliary_summary": f["summary"],
+                "auxiliary_mime_type": f["mime_type"],
+                "auxiliary_array": f["array"],
+                "auxiliary_axis": f["axis"],
+            })
+        return state
 
     def _load_auxiliary_data(
         self, auxiliary_data: str, auxiliary_label: Optional[str]

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -52,21 +52,10 @@ logger = logging.getLogger(__name__)
 
 
 def _empty_auxiliary_state() -> dict:
-    """Default auxiliary state — no companion datasets loaded.
-
-    ``auxiliary_items`` is the multi-auxiliary list (each entry has label /
-    array / axis / plot_bytes / summary / mime_type); the flat ``auxiliary_*``
-    keys mirror the first item for back-compat with single-aux readers. (#226)
-    """
-    return {
-        "auxiliary_items": [],
-        "auxiliary_plot_bytes": None,
-        "auxiliary_label": None,
-        "auxiliary_summary": None,
-        "auxiliary_mime_type": None,
-        "auxiliary_array": None,
-        "auxiliary_axis": None,
-    }
+    """Default auxiliary state — no companion datasets loaded. ``auxiliary_items``
+    is the list of per-dataset dicts (label / array / axis / plot_bytes /
+    summary / mime_type); labels become operand keys downstream. (#226)"""
+    return {"auxiliary_items": []}
 
 
 class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
@@ -832,19 +821,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 "mime_type": one.get("auxiliary_mime_type"),
             })
 
-        state = _empty_auxiliary_state()
-        state["auxiliary_items"] = items
-        if items:  # mirror first item into the flat keys (back-compat)
-            f = items[0]
-            state.update({
-                "auxiliary_plot_bytes": f["plot_bytes"],
-                "auxiliary_label": f["label"],
-                "auxiliary_summary": f["summary"],
-                "auxiliary_mime_type": f["mime_type"],
-                "auxiliary_array": f["array"],
-                "auxiliary_axis": f["axis"],
-            })
-        return state
+        return {"auxiliary_items": items}
 
     def _load_auxiliary_data(
         self, auxiliary_data: str, auxiliary_label: Optional[str]

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -29,21 +29,10 @@ from ._deprecation import normalize_params
 
 
 def _empty_auxiliary_state() -> dict:
-    """Default auxiliary state — no companion datasets loaded.
-
-    ``auxiliary_items`` is the multi-auxiliary list (each entry has label /
-    array / axis / plot_bytes / summary / mime_type). The flat ``auxiliary_*``
-    keys mirror the first item for back-compat with single-aux readers. (#226)
-    """
-    return {
-        "auxiliary_items": [],
-        "auxiliary_plot_bytes": None,
-        "auxiliary_label": None,
-        "auxiliary_summary": None,
-        "auxiliary_mime_type": None,
-        "auxiliary_array": None,
-        "auxiliary_axis": None,
-    }
+    """Default auxiliary state — no companion datasets loaded. ``auxiliary_items``
+    is the list of per-dataset dicts (label / array / axis / plot_bytes /
+    summary / mime_type); labels become operand keys downstream. (#226)"""
+    return {"auxiliary_items": []}
 
 
 class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
@@ -529,19 +518,7 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 "mime_type": one.get("auxiliary_mime_type"),
             })
 
-        state = _empty_auxiliary_state()
-        state["auxiliary_items"] = items
-        if items:  # mirror first item into the flat keys (back-compat)
-            f = items[0]
-            state.update({
-                "auxiliary_plot_bytes": f["plot_bytes"],
-                "auxiliary_label": f["label"],
-                "auxiliary_summary": f["summary"],
-                "auxiliary_mime_type": f["mime_type"],
-                "auxiliary_array": f["array"],
-                "auxiliary_axis": f["axis"],
-            })
-        return state
+        return {"auxiliary_items": items}
 
     def _load_auxiliary_data(
         self, auxiliary_data: str, auxiliary_label: str | None

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -28,6 +28,24 @@ from ...skills.loader import load_skill
 from ._deprecation import normalize_params
 
 
+def _empty_auxiliary_state() -> dict:
+    """Default auxiliary state — no companion datasets loaded.
+
+    ``auxiliary_items`` is the multi-auxiliary list (each entry has label /
+    array / axis / plot_bytes / summary / mime_type). The flat ``auxiliary_*``
+    keys mirror the first item for back-compat with single-aux readers. (#226)
+    """
+    return {
+        "auxiliary_items": [],
+        "auxiliary_plot_bytes": None,
+        "auxiliary_label": None,
+        "auxiliary_summary": None,
+        "auxiliary_mime_type": None,
+        "auxiliary_array": None,
+        "auxiliary_axis": None,
+    }
+
+
 class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
     """
     Hyperspectral Analysis Agent.
@@ -175,8 +193,8 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         hints: str | None = None,
         skill: str | None = None,
         prior_knowledge: list | None = None,
-        auxiliary_data: str | None = None,
-        auxiliary_label: str | None = None,
+        auxiliary_data: str | list[str] | None = None,
+        auxiliary_label: str | list[str] | None = None,
         **kwargs
     ) -> Dict[str, Any]:
         """
@@ -272,23 +290,16 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # — see PR 3 multi-skill support.
         skill_state = self._load_skills_to_state(skill, domain="hyperspectral")
 
-        # Load auxiliary data if provided
-        auxiliary_state = {
-            "auxiliary_plot_bytes": None,
-            "auxiliary_label": None,
-            "auxiliary_summary": None,
-            "auxiliary_mime_type": None,
-            "auxiliary_array": None,
-            "auxiliary_axis": None,
-        }
+        # Load auxiliary data if provided (one or several companion datasets).
+        auxiliary_state = _empty_auxiliary_state()
         if auxiliary_data:
-            auxiliary_state = self._load_auxiliary_data(
+            auxiliary_state = self._load_auxiliary_items(
                 auxiliary_data, auxiliary_label
             )
-            if auxiliary_state.get("auxiliary_plot_bytes"):
-                self.logger.info(
-                    f"   Auxiliary data loaded: {auxiliary_state['auxiliary_label']}"
-                )
+            n = len(auxiliary_state.get("auxiliary_items", []))
+            if n:
+                names = ", ".join(it["label"] for it in auxiliary_state["auxiliary_items"])
+                self.logger.info(f"   Auxiliary data loaded ({n}): {names}")
 
         self.logger.info(f"\n{'='*80}")
         self.logger.info(f"🔬 HYPERSPECTRAL ANALYSIS")
@@ -488,6 +499,50 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             self.logger.error(f"Failed to load data from {data_path}: {e}")
             raise
 
+    def _load_auxiliary_items(self, auxiliary_data, auxiliary_label) -> dict:
+        """Load one or several auxiliary datasets into the multi-aux state.
+
+        Accepts ``str | list[str]`` for both ``auxiliary_data`` and
+        ``auxiliary_label`` (parallel lists). Each file is loaded via
+        ``_load_auxiliary_data``; labels are made unique (auto-named ``aux_<i>``
+        when missing). Labels become the operand keys downstream. (#226)
+        """
+        paths = list(auxiliary_data) if isinstance(auxiliary_data, (list, tuple)) else [auxiliary_data]
+        labels = list(auxiliary_label) if isinstance(auxiliary_label, (list, tuple)) else [auxiliary_label]
+
+        items = []
+        used = set()
+        for i, p in enumerate(paths):
+            lbl = labels[i] if i < len(labels) else None
+            one = self._load_auxiliary_data(p, lbl)
+            name = one.get("auxiliary_label") or f"aux_{i}"
+            base, k = name, 1
+            while name in used:
+                name = f"{base}_{k}"; k += 1
+            used.add(name)
+            items.append({
+                "label": name,
+                "array": one.get("auxiliary_array"),
+                "axis": one.get("auxiliary_axis"),
+                "plot_bytes": one.get("auxiliary_plot_bytes"),
+                "summary": one.get("auxiliary_summary"),
+                "mime_type": one.get("auxiliary_mime_type"),
+            })
+
+        state = _empty_auxiliary_state()
+        state["auxiliary_items"] = items
+        if items:  # mirror first item into the flat keys (back-compat)
+            f = items[0]
+            state.update({
+                "auxiliary_plot_bytes": f["plot_bytes"],
+                "auxiliary_label": f["label"],
+                "auxiliary_summary": f["summary"],
+                "auxiliary_mime_type": f["mime_type"],
+                "auxiliary_array": f["array"],
+                "auxiliary_axis": f["axis"],
+            })
+        return state
+
     def _load_auxiliary_data(
         self, auxiliary_data: str, auxiliary_label: str | None
     ) -> dict:
@@ -624,14 +679,7 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         if skill_state is None:
             skill_state = {"skill_name": None, "skill_sections": None, "skills_loaded": []}
         if auxiliary_state is None:
-            auxiliary_state = {
-                "auxiliary_plot_bytes": None,
-                "auxiliary_label": None,
-                "auxiliary_summary": None,
-                "auxiliary_mime_type": None,
-                "auxiliary_array": None,
-                "auxiliary_axis": None,
-            }
+            auxiliary_state = _empty_auxiliary_state()
 
         try:
             self.logger.info(f"--- Starting analysis pipeline for {data_path} ---")

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -59,6 +59,13 @@ from .instruct import (
 logger = logging.getLogger(__name__)
 
 
+def _empty_auxiliary_state() -> dict:
+    """Default auxiliary state — no companion datasets loaded. ``auxiliary_items``
+    is the list of per-dataset dicts (label / array / axis / plot_bytes /
+    summary / mime_type); labels become operand keys downstream. (#226)"""
+    return {"auxiliary_items": []}
+
+
 class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
     """
     Unified Image Analysis Agent for general-purpose scientific image analysis.
@@ -224,8 +231,8 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         objective: str | None = None,
         hints: str | None = None,
         series_metadata: Optional[dict] = None,
-        auxiliary_data: Optional[str] = None,
-        auxiliary_label: Optional[str] = None,
+        auxiliary_data: Optional[Union[str, List[str]]] = None,
+        auxiliary_label: Optional[Union[str, List[str]]] = None,
         skill: Optional[str] = None,
         prior_knowledge: Optional[List[Dict[str, Any]]] = None,
         prior_analysis_paths: Optional[List[str]] = None,
@@ -369,19 +376,14 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # Compute statistics
         image_statistics = self._compute_image_statistics(first_image)
 
-        # Load auxiliary data if provided
-        aux_state = {
-            "auxiliary_plot_bytes": None,
-            "auxiliary_label": None,
-            "auxiliary_summary": None,
-            "auxiliary_mime_type": None,
-        }
+        # Load auxiliary data if provided (one or several companion datasets)
+        aux_state = _empty_auxiliary_state()
         if auxiliary_data:
-            aux_state = self._load_auxiliary_data(auxiliary_data, auxiliary_label)
-            if aux_state.get("auxiliary_plot_bytes"):
-                self.logger.info(
-                    f"   📎 Auxiliary data loaded: {aux_state['auxiliary_label']}"
-                )
+            aux_state = self._load_auxiliary_items(auxiliary_data, auxiliary_label)
+            n = len(aux_state.get("auxiliary_items", []))
+            if n:
+                names = ", ".join(it["label"] for it in aux_state["auxiliary_items"])
+                self.logger.info(f"   📎 Auxiliary data loaded ({n}): {names}")
 
         # Load skill(s) if provided. Accepts a single name/path or a list
         # — see PR 3 multi-skill support.
@@ -614,15 +616,52 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         """Compute statistics for an image."""
         return compute_image_statistics(image)
 
+    def _load_auxiliary_items(self, auxiliary_data, auxiliary_label) -> dict:
+        """Load one or several auxiliary datasets into the multi-aux state.
+
+        Accepts ``str | list[str]`` for both args (parallel lists). Each file is
+        loaded via ``_load_auxiliary_data``; labels are deduped (auto-named
+        ``aux_<i>``) and become operand keys downstream. (#226)
+        """
+        paths = list(auxiliary_data) if isinstance(auxiliary_data, (list, tuple)) else [auxiliary_data]
+        labels = list(auxiliary_label) if isinstance(auxiliary_label, (list, tuple)) else [auxiliary_label]
+
+        items = []
+        used = set()
+        for i, p in enumerate(paths):
+            lbl = labels[i] if i < len(labels) else None
+            one = self._load_auxiliary_data(p, lbl)
+            name = one.get("auxiliary_label") or f"aux_{i}"
+            base, k = name, 1
+            while name in used:
+                name = f"{base}_{k}"; k += 1
+            used.add(name)
+            items.append({
+                "label": name,
+                "array": one.get("auxiliary_array"),
+                "axis": one.get("auxiliary_axis"),
+                "plot_bytes": one.get("auxiliary_plot_bytes"),
+                "summary": one.get("auxiliary_summary"),
+                "mime_type": one.get("auxiliary_mime_type"),
+            })
+        return {"auxiliary_items": items}
+
     def _load_auxiliary_data(
         self, auxiliary_data: str, auxiliary_label: Optional[str]
     ) -> dict:
-        """Load auxiliary data and return state fields for pipeline injection."""
+        """Load one auxiliary dataset (internal per-file contract).
+
+        Returns plot bytes + summary for the LLM AND the raw ``auxiliary_array``
+        (+ ``auxiliary_axis`` for 1D curves) so a co-registered companion may be
+        used as an optional numerical operand by generated code. (#226)
+        """
         result = {
             "auxiliary_plot_bytes": None,
             "auxiliary_label": auxiliary_label or Path(auxiliary_data).stem,
             "auxiliary_summary": None,
             "auxiliary_mime_type": None,
+            "auxiliary_array": None,
+            "auxiliary_axis": None,
         }
 
         if not os.path.exists(auxiliary_data):
@@ -639,6 +678,7 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 result["auxiliary_summary"] = (
                     f"Image with shape {img.shape} (dtype: {img.dtype})."
                 )
+                result["auxiliary_array"] = img
                 result["auxiliary_plot_bytes"] = image_to_thumbnail_bytes(img)
                 result["auxiliary_mime_type"] = "image/jpeg"
 
@@ -663,6 +703,8 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                     f"X: [{float(np.nanmin(x)):.4g}, {float(np.nanmax(x)):.4g}]. "
                     f"Y: [{float(np.nanmin(y)):.4g}, {float(np.nanmax(y)):.4g}]."
                 )
+                result["auxiliary_array"] = np.asarray(y, dtype=float)
+                result["auxiliary_axis"] = np.asarray(x, dtype=float)
 
                 plot_info = {"title": result["auxiliary_label"]}
                 plot_data = np.column_stack([x, y])

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -3157,6 +3157,7 @@ code.
 - Shape: {shape}
 - dtype: {dtype}
 - Intensity range: [{intensity_min}, {intensity_max}]
+{auxiliary_block}
 
 {tool_inventory}
 
@@ -3236,6 +3237,7 @@ code.
 - Shape: {shape}
 - dtype: {dtype}
 - Intensity range: [{intensity_min}, {intensity_max}]
+{auxiliary_block}
 
 {tool_inventory}
 


### PR DESCRIPTION
Builds on #228 (hyperspectral) + #229 (curve-fit), now on `main`. Completes the **agent-side** of #226. Remaining after this: only the `run_analysis` schema widening + meta awareness.

## Summary (for scientists)

Two things:

1. **Pass more than one companion dataset.** `auxiliary_data` (and `auxiliary_label`) now accept a list, and each labeled dataset becomes a separate operand the generated code can use differently — e.g. *subtract* an empty-sample background **and** *divide* by an incident-beam reference in the same fit.
2. **Image analysis can now use a companion channel numerically.** Previously only the spectral agents could; now a co-registered channel (e.g. AFM **topography**) can be passed alongside a **phase** image and used to build a mask / inform the analysis — "one channel informs another."

Also consolidates the internals to a single representation so there's no longer a parallel single-vs-multi code path.

## Technical details (for AI reviewers)

### Multi-auxiliary
- `auxiliary_data` / `auxiliary_label` widened to `str | list[str]` on all three agents (mirrors multi-skill `str | list[str]`).
- New `_load_auxiliary_items` (per agent) normalizes to parallel lists, loads each via `_load_auxiliary_data`, **dedups labels** (auto-named `aux_<i>`), and stores `state["auxiliary_items"]` — a list of `{label, array, axis, plot_bytes, summary, mime_type}`. Labels become operand keys.
- `_append_auxiliary_context` loops over `auxiliary_items`. Operand builders iterate it: hyperspectral builds a multi-entry `auxiliary={label: array}` dict passed via `_invoke_analyze_feature`; curve-fit/image write one `temp_auxiliary_<label>.npy` per aligned item and list them in the script manifest (`{auxiliary_block}`). Alignment-gated (no resampling in v1); misaligned → context-only.

### Image-analysis surface (new)
- `image_analysis_agent._load_auxiliary_data` retains `auxiliary_array` (+ axis for curves); `_generate_analysis_script` writes co-registered companions aligned in H×W and injects `{auxiliary_block}` into both image script templates (`IMAGE_ANALYSIS_SCRIPT_INSTRUCTIONS` + refinement).

### Single `auxiliary_items` model (flat-key retirement)
- The legacy flat `auxiliary_*` **state** keys are removed: `_empty_auxiliary_state` → `{auxiliary_items: []}`; no item[0] mirroring; `_auxiliary_display_items` is items-only (no flat fallback); curve-fit + image pass-through sub-states carry `auxiliary_items`. The per-file `_load_auxiliary_data` keeps its internal return keys (read by `_load_auxiliary_items`). Verified: zero remaining state readers of the flat keys.

### Live validation (`claude-opus-4-6`, all `status: success`)
- **Multi-aux, two-operand XRD** (curve-fit): script did `(raw - dark_baseline) / I0` — subtract one operand, divide by another — R²=0.991.
- **Image AFM topography→phase**: script `threshold_otsu(topography)` → mask applied to phase; grain-vs-matrix phase + area fraction.
- **Regressions after flat-key removal**: hyperspectral single-aux (4/4 maps) and curve-fit two-operand (R²=0.991) — unbroken.
- Unit-tested: 3-agent loaders (list / single-str / dedup), display items-only, image template formatting.

### Scope / remaining
- Agent surfaces complete (all three). Remaining #226: `run_analysis` schema widening + meta awareness (orchestrator/meta layer).
- v1 gates on exact alignment; auto-resampling deferred.