### PR TITLE
Meta agent: split combined data+metadata files before delegating

### DIFF
--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -42,6 +42,7 @@ from ...skills._shared.image_analysis_tools import (
     load_image_data,
     image_to_thumbnail_bytes,
     create_image_montage,
+    extract_image_metadata,
 )
 from ._deprecation import normalize_params
 from ...skills.loader import load_skill
@@ -394,6 +395,17 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         handled_system_info, series_metadata = self._extract_series_metadata(
             handled_system_info, series_metadata
         )
+
+        # Recover embedded file metadata (e.g. TIFF tags / ImageDescription) that
+        # OpenCV-based pixel loading drops, and fold it into system_info without
+        # overriding user-provided keys. Best-effort; first image is representative.
+        if input_type == "file_paths" and image_paths:
+            embedded = extract_image_metadata(image_paths[0])
+            if embedded:
+                handled_system_info.setdefault("embedded_file_metadata", embedded)
+                self.logger.info(
+                    f"   🏷️  Recovered embedded metadata from {Path(image_paths[0]).name}"
+                )
 
         # Build initial state
         state = {

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -118,18 +118,23 @@ attempt to delegate simulation work.
   specialist's batch tools engage — never one delegation per file.
 - `inspect_uploads` is for routing only — do not use its output to interpret
   or analyze the data yourself; hand that to the specialist.
-- When a SINGLE uploaded file holds BOTH the data and its metadata mixed
-  together (an HDF5/NeXus with attributes, a `.npz` with data+meta keys, a
-  CSV/text with a header/comment metadata block, a vendor container), call
-  `prepare_inputs` on it to split it losslessly into a data file + a metadata
-  JSON, then delegate with those two paths. `prepare_inputs` is your ONLY
-  code-generation tool and it is STRICTLY limited to lossless file
-  repackaging (round-trip verified) — NEVER analysis, transformation, or
-  computation. You do not write or run any other code; all data processing is
-  delegated. If it errors (could not produce a verified lossless split), do NOT
-  silently delegate — tell the user you could not safely split the file and ask
-  how to proceed (e.g. analyze it as-is, or supply the data and metadata as
-  separate files). Only fall back to delegating as-is if no user is available.
+- When an uploaded file holds BOTH the data and its metadata mixed together
+  (an HDF5/NeXus with attributes, a `.npz`/`.mat` with data+meta keys, a
+  CSV/text with a header/comment metadata block, a TIFF with tags/
+  ImageDescription), call `prepare_inputs` on it to split it losslessly into a
+  data file + a metadata JSON, then delegate with those two paths. When SEVERAL
+  such combined files are the same kind (or the user says they're a batch/
+  series), pass them all as a LIST to `prepare_inputs` in ONE call — it splits
+  them with a shared, reused recipe and returns one (data, metadata) pair per
+  file — then make ONE batched delegation (never one prep or delegation per
+  file). `prepare_inputs` is your ONLY code-generation tool and it is STRICTLY
+  limited to lossless file repackaging (round-trip verified) — NEVER analysis,
+  transformation, or computation. You do not write or run any other code; all
+  data processing is delegated. If it errors, do NOT silently delegate — tell
+  the user you could not safely split the file(s) and ask how to proceed (e.g.
+  analyze as-is, or supply the data and metadata separately); for a `partial`
+  batch result, surface which files failed and ask. Only fall back to
+  delegating as-is if no user is available.
 
 **EXPERIMENTAL METADATA:**
 - Experimental data needs metadata — measurement technique, instrument,

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -118,6 +118,18 @@ attempt to delegate simulation work.
   specialist's batch tools engage — never one delegation per file.
 - `inspect_uploads` is for routing only — do not use its output to interpret
   or analyze the data yourself; hand that to the specialist.
+- When a SINGLE uploaded file holds BOTH the data and its metadata mixed
+  together (an HDF5/NeXus with attributes, a `.npz` with data+meta keys, a
+  CSV/text with a header/comment metadata block, a vendor container), call
+  `prepare_inputs` on it to split it losslessly into a data file + a metadata
+  JSON, then delegate with those two paths. `prepare_inputs` is your ONLY
+  code-generation tool and it is STRICTLY limited to lossless file
+  repackaging (round-trip verified) — NEVER analysis, transformation, or
+  computation. You do not write or run any other code; all data processing is
+  delegated. If it errors (could not produce a verified lossless split), do NOT
+  silently delegate — tell the user you could not safely split the file and ask
+  how to proceed (e.g. analyze it as-is, or supply the data and metadata as
+  separate files). Only fall back to delegating as-is if no user is available.
 
 **EXPERIMENTAL METADATA:**
 - Experimental data needs metadata — measurement technique, instrument,

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -29,6 +29,20 @@ _PROBE_MAX_FILES = 60
 _PROBE_TEXT_HEAD = 400
 
 
+def _has_comment_header(path: Path) -> bool:
+    """True if the file's first non-blank line is a ``#`` comment — a quick signal
+    that a CSV/text carries a leading metadata header block worth splitting out."""
+    try:
+        with open(path, "r", errors="replace") as fh:
+            for line in fh:
+                s = line.strip()
+                if s:
+                    return s.startswith("#")
+    except OSError:
+        return False
+    return False
+
+
 def _probe_file(path: Path) -> Dict[str, Any]:
     """Content-probe a single file for routing. Never raises — any failure
     is reported in the returned dict's ``note`` field."""
@@ -43,6 +57,38 @@ def _probe_file(path: Path) -> Dict[str, Any]:
             import numpy as np
             arr = np.load(path, mmap_mode="r", allow_pickle=False)
             info.update(kind="array", shape=list(arr.shape), dtype=str(arr.dtype))
+        elif ext == ".npz":
+            import numpy as np
+            with np.load(path, allow_pickle=False) as z:
+                files = list(z.files)
+                info.update(kind="npz", keys=sorted(files))
+                try:
+                    info["shapes"] = {k: list(z[k].shape) for k in files[:40]}
+                except Exception:  # noqa: BLE001 - shapes are a best-effort extra
+                    pass
+        elif ext in (".h5", ".hdf5", ".nxs", ".nx"):
+            import h5py
+            names: list = []
+            with h5py.File(path, "r") as f:
+                f.visititems(lambda n, o: names.append(n))
+                root_attrs = sorted(f.attrs.keys())
+            info.update(kind="hdf5", datasets=sorted(names)[:80],
+                        root_attrs=root_attrs[:40])
+        elif ext == ".mat":
+            # whosmat reads the directory without loading arrays (cheap); v7.3
+            # .mat are HDF5 and raise NotImplementedError → probe via h5py.
+            try:
+                from scipy.io import whosmat
+                info.update(kind="mat",
+                            keys=sorted(n for n, _, _ in whosmat(path)),
+                            mat_version="<=v7")
+            except NotImplementedError:
+                import h5py
+                names = []
+                with h5py.File(path, "r") as f:
+                    f.visititems(lambda n, o: names.append(n))
+                info.update(kind="hdf5", datasets=sorted(names)[:80],
+                            mat_version="v7.3")
         elif ext in (".tif", ".tiff", ".png", ".jpg", ".jpeg"):
             from PIL import Image
             with Image.open(path) as im:
@@ -50,12 +96,19 @@ def _probe_file(path: Path) -> Dict[str, Any]:
                             mode=im.mode, n_frames=getattr(im, "n_frames", 1))
         elif ext in (".csv", ".tsv"):
             import pandas as pd
-            df = pd.read_csv(path, sep="\t" if ext == ".tsv" else ",", nrows=200)
+            sep = "\t" if ext == ".tsv" else ","
+            # comment="#" skips a leading metadata/comment header block — the
+            # canonical "combined" CSV (instrument/ImageJ exports) — so the probed
+            # columns reflect the real table, not the first comment line. Without
+            # it, combined CSVs get garbage column signatures and fail to cluster.
+            df = pd.read_csv(path, sep=sep, nrows=200, comment="#",
+                             skip_blank_lines=True)
             info.update(kind="table", n_columns=int(df.shape[1]),
                         sampled_rows=int(df.shape[0]),
                         columns=[str(c) for c in df.columns[:40]],
                         dtypes={str(c): str(t)
-                                for c, t in list(df.dtypes.items())[:40]})
+                                for c, t in list(df.dtypes.items())[:40]},
+                        has_comment_header=_has_comment_header(path))
         elif ext == ".xlsx":
             import pandas as pd
             df = pd.read_excel(path, nrows=200)
@@ -408,63 +461,82 @@ class MetaOrchestratorTools:
         # repackaging before delegation: split a single combined data+metadata
         # file into a data file + a metadata JSON. Round-trip verified; NEVER
         # used for analysis/computation — that is always delegated.
-        def prepare_inputs(path: str) -> str:
-            from ...utils.file_prep import prepare_inputs as _split_file
+        def prepare_inputs(path) -> str:
+            from ...utils.file_prep import (prepare_inputs as _split_file,
+                                            prepare_inputs_batch as _split_batch)
             from ...executors import ScriptExecutor, require_sandbox_approval
-            p = Path(path)
-            if not p.exists() or not p.is_file():
+            paths = [path] if isinstance(path, str) else list(path or [])
+            if not paths:
                 return json.dumps({"status": "error",
-                                   "message": f"File not found: {p}"})
+                                   "message": "No file path provided."})
+            pths = [Path(p) for p in paths]
+            missing = [str(p) for p in pths if not (p.exists() and p.is_file())]
+            if missing:
+                return json.dumps({"status": "error",
+                                   "message": "File(s) not found: " + ", ".join(missing)})
             if not require_sandbox_approval(
                 context="Meta agent file preparation (lossless data/metadata split)"
             ):
                 return json.dumps({
                     "status": "error",
-                    "message": "Code execution declined; cannot prepare the file. "
-                               "Delegate it to the specialist as-is.",
+                    "message": "Code execution declined; cannot prepare the file(s). "
+                               "Delegate them to the specialist as-is.",
                 })
-            try:
-                probe = _probe_file(p)
-            except Exception:
-                probe = None
-            result = _split_file(
-                p,
-                model=self.orch.model,
-                executor=ScriptExecutor(timeout=120),
-                output_dir=self.orch.base_dir / "prepared",
-                probe=probe,
-                logger=self.logger,
-                max_retries=2,  # 3 attempts total — binary containers (HDF5/.mat)
-                                # often need a correction pass; the round-trip net
-                                # keeps a bad accept unlikely, so retries are cheap.
-            )
+            probes = []
+            for p in pths:
+                try:
+                    probes.append(_probe_file(p))
+                except Exception:  # noqa: BLE001
+                    probes.append(None)
+            out_dir = self.orch.base_dir / "prepared"
+            executor = ScriptExecutor(timeout=120)
+            # max_retries=2 → 3 attempts: binary containers often need a correction
+            # pass; the round-trip net keeps a bad accept unlikely, so retries cheap.
+            if len(pths) == 1:
+                result = _split_file(pths[0], model=self.orch.model, executor=executor,
+                                     output_dir=out_dir, probe=probes[0],
+                                     logger=self.logger, max_retries=2)
+            else:
+                result = _split_batch(pths, model=self.orch.model, executor=executor,
+                                      output_dir=out_dir, probes=probes,
+                                      logger=self.logger, max_retries=2)
             return json.dumps(result, default=str)
 
         self._register_tool(
             func=prepare_inputs,
             name="prepare_inputs",
             description=(
-                "Split ONE combined file that holds BOTH data and metadata into a "
-                "separate data file + metadata JSON, so the specialist receives a "
-                "clean (data, metadata) pair. Returns data_path + metadata_path; "
-                "thread them into the next delegate_to_* call. Use after "
-                "inspect_uploads when a probe shows data and metadata mixed in one "
-                "file (HDF5/NeXus with attributes, .npz with data+meta keys, a "
-                "CSV/text with a header/comment metadata block, a vendor container). "
-                "This is the META AGENT'S ONLY code-generation tool and it is "
-                "STRICTLY LIMITED to lossless file repackaging: the generated code "
-                "may only separate existing data from metadata and is round-trip "
-                "verified (the reconstruction must match the original) — it NEVER "
-                "transforms, computes, fits, or analyzes. All analysis is delegated. "
-                "On error (no verified lossless split), do NOT silently delegate — "
-                "tell the user and ask how to proceed (analyze as-is, or supply data "
-                "and metadata separately); fall back to as-is only if no user."
+                "Split combined file(s) that hold BOTH data and metadata into a "
+                "separate data file + metadata JSON each, so the specialist receives "
+                "clean (data, metadata) pairs. Single file → returns data_path + "
+                "metadata_path. Pass a LIST of paths to split several SAME-TYPE files "
+                "in ONE call → returns a per-file 'results' list + a 'summary'; thread "
+                "the pairs into ONE batched delegation (never loop one delegation per "
+                "file). In batch mode a single split is generated and reused across "
+                "structurally identical files (each still round-trip verified), so it "
+                "is cheaper and yields a uniform schema; a file that doesn't match "
+                "falls back to its own split. Use after inspect_uploads when a probe "
+                "shows data and metadata mixed in one file (HDF5/NeXus with attributes, "
+                ".npz/.mat with data+meta keys, a CSV/text with a header/comment "
+                "metadata block, a TIFF with tags/ImageDescription). This is the META "
+                "AGENT'S ONLY code-generation tool and it is STRICTLY LIMITED to "
+                "lossless file repackaging: the generated code may only separate "
+                "existing data from metadata and is round-trip verified (the "
+                "reconstruction must match the original) — it NEVER transforms, "
+                "computes, fits, or analyzes. All analysis is delegated. On error (no "
+                "verified lossless split), do NOT silently delegate — tell the user "
+                "and ask how to proceed (analyze as-is, or supply data and metadata "
+                "separately); fall back to as-is only if no user. With a 'partial' "
+                "batch result, surface which files failed and ask how to proceed."
             ),
             parameters={
                 "path": {
-                    "type": "string",
+                    "type": ["string", "array"],
+                    "items": {"type": "string"},
                     "description": (
-                        "Absolute path to the combined data+metadata file to split."
+                        "Absolute path to the combined data+metadata file to split, "
+                        "OR a list of absolute paths to split several same-type files "
+                        "in one batched call."
                     ),
                 },
             },

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -43,6 +43,31 @@ def _has_comment_header(path: Path) -> bool:
     return False
 
 
+def _probe_delimited_text(path: Path, max_rows: int = 200):
+    """Probe a .dat/.txt as a delimited NUMERIC table, skipping a #/comment header.
+
+    Returns ``{n_columns, sampled_rows, dtypes}`` (positional dtypes, since such
+    files are usually headerless) when the body parses as numeric data, else None
+    (prose). A column counts as numeric when >80% of its sampled values parse as
+    numbers — tolerant of a single column-name header row above the data.
+    """
+    import pandas as pd
+    for sep in (r"\s+", ","):
+        try:
+            df = pd.read_csv(path, sep=sep, comment="#", header=None, nrows=max_rows,
+                             skip_blank_lines=True, engine="python")
+        except Exception:  # noqa: BLE001 - try the next separator
+            continue
+        if df.shape[0] < 3 or df.shape[1] < 1:
+            continue
+        frac_numeric = df.apply(pd.to_numeric, errors="coerce").notna().mean(axis=0)
+        ncols = int((frac_numeric > 0.8).sum())
+        if ncols >= 1:
+            return {"n_columns": ncols, "sampled_rows": int(df.shape[0]),
+                    "dtypes": {str(i): "float64" for i in range(ncols)}}
+    return None
+
+
 def _probe_file(path: Path) -> Dict[str, Any]:
     """Content-probe a single file for routing. Never raises — any failure
     is reported in the returned dict's ``note`` field."""
@@ -144,7 +169,20 @@ def _probe_file(path: Path) -> Dict[str, Any]:
                 info["text_head"] = doc_info["text"][:_PROBE_TEXT_HEAD].strip()
             except Exception as e:  # noqa: BLE001 - optional reader / bad docx
                 info["note"] = f"text probe unavailable: {e}"
-        elif ext in (".md", ".txt"):
+        elif ext in (".dat", ".txt"):
+            # .dat/.txt is often a delimited numeric table (frequently with a
+            # leading comment/metadata header) but may be prose. Probe it as a
+            # table when it parses as numeric data — so combined .dat/.txt files
+            # cluster like CSV in batch prep — else fall back to text.
+            parsed = _probe_delimited_text(path)
+            if parsed:
+                info.update(kind="table",
+                            has_comment_header=_has_comment_header(path), **parsed)
+            else:
+                text = path.read_text(errors="replace")
+                info.update(kind="text", n_chars=len(text),
+                            text_head=text[:_PROBE_TEXT_HEAD].strip())
+        elif ext == ".md":
             text = path.read_text(errors="replace")
             info.update(kind="text", n_chars=len(text),
                         text_head=text[:_PROBE_TEXT_HEAD].strip())

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -403,6 +403,71 @@ class MetaOrchestratorTools:
             required=[],
         )
 
+        # ----- prepare_inputs (lossless data/metadata split) ------------------
+        # The meta's ONLY code-generation surface, restricted to LOSSLESS file
+        # repackaging before delegation: split a single combined data+metadata
+        # file into a data file + a metadata JSON. Round-trip verified; NEVER
+        # used for analysis/computation — that is always delegated.
+        def prepare_inputs(path: str) -> str:
+            from ...utils.file_prep import prepare_inputs as _split_file
+            from ...executors import ScriptExecutor, require_sandbox_approval
+            p = Path(path)
+            if not p.exists() or not p.is_file():
+                return json.dumps({"status": "error",
+                                   "message": f"File not found: {p}"})
+            if not require_sandbox_approval(
+                context="Meta agent file preparation (lossless data/metadata split)"
+            ):
+                return json.dumps({
+                    "status": "error",
+                    "message": "Code execution declined; cannot prepare the file. "
+                               "Delegate it to the specialist as-is.",
+                })
+            try:
+                probe = _probe_file(p)
+            except Exception:
+                probe = None
+            result = _split_file(
+                p,
+                model=self.orch.model,
+                executor=ScriptExecutor(timeout=120),
+                output_dir=self.orch.base_dir / "prepared",
+                probe=probe,
+                logger=getattr(self.orch, "logger", None),
+            )
+            return json.dumps(result, default=str)
+
+        self._register_tool(
+            func=prepare_inputs,
+            name="prepare_inputs",
+            description=(
+                "Split ONE combined file that holds BOTH data and metadata into a "
+                "separate data file + metadata JSON, so the specialist receives a "
+                "clean (data, metadata) pair. Returns data_path + metadata_path; "
+                "thread them into the next delegate_to_* call. Use after "
+                "inspect_uploads when a probe shows data and metadata mixed in one "
+                "file (HDF5/NeXus with attributes, .npz with data+meta keys, a "
+                "CSV/text with a header/comment metadata block, a vendor container). "
+                "This is the META AGENT'S ONLY code-generation tool and it is "
+                "STRICTLY LIMITED to lossless file repackaging: the generated code "
+                "may only separate existing data from metadata and is round-trip "
+                "verified (the reconstruction must match the original) — it NEVER "
+                "transforms, computes, fits, or analyzes. All analysis is delegated. "
+                "On error (no verified lossless split), do NOT silently delegate — "
+                "tell the user and ask how to proceed (analyze as-is, or supply data "
+                "and metadata separately); fall back to as-is only if no user."
+            ),
+            parameters={
+                "path": {
+                    "type": "string",
+                    "description": (
+                        "Absolute path to the combined data+metadata file to split."
+                    ),
+                },
+            },
+            required=["path"],
+        )
+
         # ----- view_image -----------------------------------------------------
         # Generic "view & describe an arbitrary image" — the meta itself has no
         # multimodal input path, so this is how a notebook photo / diagram /

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -433,7 +433,10 @@ class MetaOrchestratorTools:
                 executor=ScriptExecutor(timeout=120),
                 output_dir=self.orch.base_dir / "prepared",
                 probe=probe,
-                logger=getattr(self.orch, "logger", None),
+                logger=self.logger,
+                max_retries=2,  # 3 attempts total — binary containers (HDF5/.mat)
+                                # often need a correction pass; the round-trip net
+                                # keeps a bad accept unlikely, so retries are cheap.
             )
             return json.dumps(result, default=str)
 

--- a/scilink/skills/_shared/image_analysis_tools.py
+++ b/scilink/skills/_shared/image_analysis_tools.py
@@ -43,6 +43,101 @@ def load_image_data(image_path: str) -> np.ndarray:
     return img
 
 
+def _jsonify_tag(value):
+    """Coerce a PIL TIFF tag value into a JSON-friendly form."""
+    try:
+        from PIL.TiffImagePlugin import IFDRational
+    except Exception:
+        IFDRational = ()
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if IFDRational and isinstance(value, IFDRational):
+        return float(value)
+    if isinstance(value, tuple):
+        return [_jsonify_tag(v) for v in value]
+    return value
+
+
+def _parse_image_description(desc: str):
+    """Parse an ImageDescription block into structured metadata when possible.
+
+    Handles the two common scientific conventions: ImageJ's ``key=value`` lines
+    and OME-TIFF's embedded XML (kept verbatim, not parsed, to avoid a dependency).
+    """
+    if not isinstance(desc, str) or not desc.strip():
+        return None
+    stripped = desc.lstrip()
+    if stripped.startswith("<?xml") or stripped.startswith("<OME"):
+        return {"format": "ome-xml", "xml": desc}
+    if "=" in desc and "\n" in desc:  # ImageJ-style key=value block
+        kv = {}
+        for line in desc.splitlines():
+            if "=" in line:
+                k, v = line.split("=", 1)
+                kv[k.strip()] = v.strip()
+        if kv:
+            return {"format": "imagej", "fields": kv}
+    return None
+
+
+def _pixel_size_from_tags(named: dict):
+    """Derive pixel size from TIFF resolution tags (best effort)."""
+    xres, yres = named.get("XResolution"), named.get("YResolution")
+    if not xres or not yres:
+        return None
+    unit = {1: "none", 2: "inch", 3: "cm"}.get(named.get("ResolutionUnit"), "unknown")
+    try:
+        return {"x": 1.0 / float(xres), "y": 1.0 / float(yres),
+                "unit": f"per_{unit}" if unit not in ("none", "unknown") else unit}
+    except (ZeroDivisionError, TypeError, ValueError):
+        return None
+
+
+def extract_image_metadata(image_path: str) -> dict:
+    """Best-effort recovery of embedded metadata from an image file.
+
+    ``load_image_data`` reads pixels with OpenCV, which discards TIFF tags /
+    ImageDescription — the common carrier of scientific calibration and
+    acquisition parameters (pixel size, instrument, ImageJ/OME-XML blocks). This
+    recovers them so they can flow into ``system_info``. TIFF-focused today;
+    returns ``{}`` for other formats or when nothing readable is present. Never
+    raises — embedded metadata is best-effort, not load-critical.
+    """
+    ext = os.path.splitext(image_path)[1].lower()
+    if ext not in (".tif", ".tiff"):
+        return {}
+    try:
+        from PIL import Image
+        from PIL.TiffTags import TAGS as TIFF_TAGS
+    except Exception:
+        return {}
+    meta: dict = {}
+    try:
+        with Image.open(image_path) as im:
+            tags = getattr(im, "tag_v2", None)
+            if not tags:
+                return {}
+            named = {TIFF_TAGS.get(tid, str(tid)): _jsonify_tag(val)
+                     for tid, val in tags.items()}
+            desc = named.get("ImageDescription")
+            if desc:
+                meta["image_description"] = desc
+                parsed = _parse_image_description(desc)
+                if parsed:
+                    meta["image_description_parsed"] = parsed
+            for tag, key in (("Software", "software"), ("DateTime", "datetime"),
+                             ("Make", "make"), ("Model", "model")):
+                if named.get(tag):
+                    meta[key] = named[tag]
+            px = _pixel_size_from_tags(named)
+            if px:
+                meta["pixel_size"] = px
+            meta["tiff_tags"] = named
+    except Exception:
+        return {}
+    return meta
+
+
 def image_to_thumbnail_bytes(
     image: np.ndarray, max_dim: int = MAX_THUMBNAIL_DIM, quality: int = 85
 ) -> bytes:

--- a/scilink/utils/file_prep.py
+++ b/scilink/utils/file_prep.py
@@ -1,5 +1,8 @@
 """Codegen-backed file preparation: split a combined data+metadata file into
-separate data + metadata files BEFORE delegation to a specialist.
+separate data + metadata files BEFORE delegation to a specialist. ``prepare_inputs``
+handles one file; ``prepare_inputs_batch`` handles many, generating one verified
+split per structural cluster and reusing it (round-trip verified per file) across
+structurally identical siblings.
 
 STRICT SCOPE — this is the meta agent's ONLY code-generation surface, and it is
 restricted to **lossless file repackaging**. The generated script may separate
@@ -47,9 +50,17 @@ _PROMPT = '''You prepare a scientific data file for downstream analysis by
 SEPARATING its data from its metadata. This is a LOSSLESS REPACKAGING step ONLY —
 you are NOT analyzing anything.
 
-Input file: {path}
+PATHS ARE PROVIDED AT RUNTIME — DO NOT HARDCODE ANY FILE PATH. A dict named
+`_PREP` is already defined ABOVE your code; read every path from it:
+  _PREP["input"]        # the combined file to read
+  _PREP["out_dir"]      # directory to write the data file into
+  _PREP["metadata_out"] # exact path to write the metadata JSON
+  _PREP["recon_out"]    # exact path to write the reconstruction
+Your script MUST reference `_PREP[...]` for ALL paths and MUST NOT contain any
+literal path string. (This lets the SAME script be reused across structurally
+identical files — so write it generically against the probe, not this one file.)
 
-Structural probe (evidence — do not assume beyond it):
+Structural probe of a representative input (evidence — do not assume beyond it):
 {probe}
 
 Common layouts you may encounter (illustrative, not exhaustive — let the probe
@@ -64,13 +75,13 @@ decide):
 Identify which bytes/keys/lines are data vs metadata from the probe, then:
 
 Write a Python script that:
-1. Reads the input file.
+1. Reads the input file at `_PREP["input"]`.
 2. Splits it into (a) the primary numerical DATA (the array / table / signal) and
    (b) the METADATA — everything that is NOT the data values: headers, attributes,
    comments, units, calibration, axes, acquisition parameters, etc.
-3. Writes the DATA to a file whose path you choose under the output directory
-   "{out_dir}" — use `.npy` for an array/cube or `.csv` for a table.
-4. Writes the METADATA to "{metadata_out}" as a single JSON object. Put the
+3. Writes the DATA to a file UNDER `_PREP["out_dir"]` (choose a basename and join
+   it with `_PREP["out_dir"]`) — use `.npy` for an array/cube or `.csv` for a table.
+4. Writes the METADATA to `_PREP["metadata_out"]` as a single JSON object. Put the
    HUMAN-MEANINGFUL scientific metadata at the TOP LEVEL with clean keys
    (technique, instrument, sample, units, axes, wavelength, ...). If you need
    extra bookkeeping to reconstruct the original byte-for-byte (line endings,
@@ -81,14 +92,15 @@ Write a Python script that:
    TOP LEVEL and, if needed, also record its placement under "_reconstruction";
    do not relegate it to "_reconstruction" alone.
 5. RECONSTRUCTS the original file from those two outputs and writes it to
-   "{recon_out}" (same format as the input). We will verify it matches the input.
-6. Prints exactly one line:
-   PREP_RESULT_JSON:{{"data_out": "<abs path>", "metadata_out": "{metadata_out}", "recon_out": "{recon_out}"}}
+   `_PREP["recon_out"]` (same format as the input). We will verify it matches.
+6. Prints exactly one line (the ACTUAL data path you wrote):
+   PREP_RESULT_JSON:{{"data_out": "<abs path to the data file you wrote>"}}
 
 HARD CONSTRAINTS (a violation fails verification):
 - DO NOT transform, scale, normalize, filter, fit, resample, denoise, crop, or
   analyze the data. The data you write MUST be the original values, unchanged.
 - The reconstruction MUST reproduce the original file's data and metadata.
+- Reference paths ONLY via `_PREP[...]`; no literal path strings anywhere.
 - Allowed libraries ONLY: numpy, pandas, json, csv, struct, io, re, h5py,
   scipy.io (for MATLAB .mat read/write ONLY), PIL/Pillow (for TIFF tags /
   ImageDescription), os, pathlib. Do NOT import analysis libraries — sklearn,
@@ -386,110 +398,229 @@ def _verify(input_path: Path, data_out: Path, meta_out: Path,
     return True, "lossless split verified"
 
 
-def prepare_inputs(input_path, model, executor, output_dir, probe=None,
-                   logger=None, max_retries: int = 1) -> dict:
-    """Split a combined data+metadata file into data + metadata files (codegen).
+def _file_paths(input_path: Path, output_dir: Path) -> dict:
+    """Per-file output paths in a collision-safe subdir keyed on the absolute path.
 
-    Args:
-        input_path: the combined file to split.
-        model: LLM with ``.generate_content(prompt).text``.
-        executor: a ``ScriptExecutor`` (runs the generated script in a sandbox).
-        output_dir: directory for the outputs.
-        probe: optional structural probe dict (e.g. from the meta's file probe);
-            a compact fallback is used when omitted.
-        logger: optional logger.
-        max_retries: extra attempts after the first (default 1).
-
-    Returns a dict: on success ``{status:"success", data_path, metadata_path,
-    attempts}``; otherwise ``{status:"error", message, attempts}``. The
-    reconstruction used for the round-trip check is deleted once verified.
-    The caller decides how to handle an error — the meta surfaces it to the user
-    and asks how to proceed rather than silently delegating an unsplit file.
+    Two uploads sharing a basename (runA/scan.tif and runB/scan.tif) get distinct
+    subdirs so they never clobber each other's data/metadata/recon outputs.
     """
-    input_path = Path(input_path)
-    output_dir = Path(output_dir)
     stem = re.sub(r"[^0-9A-Za-z_-]", "_", input_path.stem) or "input"
-    # Per-file subdirectory keyed on the absolute path: two uploads sharing a
-    # basename (e.g. runA/scan.tif and runB/scan.tif) must not clobber each
-    # other's metadata/recon/data outputs in a shared "prepared/" dir.
     key = hashlib.sha1(str(input_path.resolve()).encode()).hexdigest()[:8]
-    file_out = output_dir / f"{stem}_{key}"
+    file_out = Path(output_dir) / f"{stem}_{key}"
     file_out.mkdir(parents=True, exist_ok=True)
-    metadata_out = file_out / f"{stem}_metadata.json"
-    recon_out = file_out / f"{stem}_reconstructed{input_path.suffix}"
+    return {
+        "input": str(input_path),
+        "out_dir": str(file_out),
+        "metadata_out": str(file_out / f"{stem}_metadata.json"),
+        "recon_out": str(file_out / f"{stem}_reconstructed{input_path.suffix}"),
+    }
 
+
+def _build_prompt(probe, input_path: Path) -> str:
     probe_str = json.dumps(probe, indent=2, default=str) if probe else \
         f"(no probe) extension={input_path.suffix}, size={input_path.stat().st_size} bytes"
-    base_prompt = _PROMPT.format(
-        path=str(input_path), probe=probe_str, out_dir=str(file_out),
-        metadata_out=str(metadata_out), recon_out=str(recon_out),
-    )
+    return _PROMPT.format(probe=probe_str)
 
+
+def _prep_header(paths: dict) -> str:
+    """Runtime `_PREP` path bindings prepended to a generated split body, so one
+    generically-written body can be reused verbatim across structurally identical
+    files (only this header changes per file)."""
+    return "_PREP = " + json.dumps({k: str(v) for k, v in paths.items()}) + "\n"
+
+
+def _generate_split_script(prompt: str, model) -> tuple:
+    """One codegen attempt → (script_body, "") or (None, rejection_reason)."""
+    try:
+        script = _extract_script(model.generate_content(prompt).text)
+    except Exception as e:  # noqa: BLE001
+        return None, f"code generation failed: {e}"
+    if not script:
+        return None, "model returned no script"
+    guard = _static_guard(script)
+    if guard:
+        return None, guard
+    if "_PREP" not in script:
+        return None, ("script must read paths from the _PREP dict, not hardcode "
+                      "them — reference _PREP['input'/'out_dir'/'metadata_out'/'recon_out']")
+    return script, ""
+
+
+def _apply_and_verify(body: str, input_path: Path, paths: dict, executor) -> tuple:
+    """Run a (path-parameterized) body for one file and verify losslessness.
+
+    Returns ``(True, {data_path, metadata_path})`` or ``(False, reason)``. No LLM
+    call — this is what lets a verified body be reused across a batch cheaply.
+    """
+    script = _prep_header(paths) + body
+    exec_res = executor.execute_script(script, working_dir=paths["out_dir"])
+    if exec_res.get("status") != "success":
+        return False, f"script execution failed: {exec_res.get('message', '')[:600]}"
+    m = re.search(r"PREP_RESULT_JSON:(\{.*\})", exec_res.get("stdout", ""))
+    if not m:
+        return False, "script did not print PREP_RESULT_JSON with the data path"
+    try:
+        result = json.loads(m.group(1))
+    except json.JSONDecodeError as e:
+        return False, f"PREP_RESULT_JSON not valid JSON: {e}"
+    data_out = Path(result.get("data_out", ""))
+    ok, reason = _verify(input_path, data_out,
+                         Path(paths["metadata_out"]), Path(paths["recon_out"]))
+    if not ok:
+        return False, reason
+    Path(paths["recon_out"]).unlink(missing_ok=True)  # only needed for the check
+    return True, {"data_path": str(data_out), "metadata_path": paths["metadata_out"]}
+
+
+def _prepare_one(input_path: Path, paths: dict, base_prompt: str, model, executor,
+                 logger, max_retries: int) -> tuple:
+    """Generate+verify a split for one file, with retries feeding back failures.
+
+    Returns ``(result_dict, verified_body_or_None)`` — the body is handed back so
+    a batch can reuse it on structurally identical siblings.
+    """
     prompt = base_prompt
     last_reason = ""
     for attempt in range(1, max_retries + 2):
         if logger:
-            logger.info(f"📦 File prep (attempt {attempt}): generating split script for {input_path.name}")
-        try:
-            script = _extract_script(model.generate_content(prompt).text)
-        except Exception as e:
-            last_reason = f"code generation failed: {e}"
-            prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{last_reason}\nFix it."
-            continue
-        if not script:
-            last_reason = "model returned no script"
-            prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{last_reason}\nFix it."
-            continue
-
-        guard = _static_guard(script)
-        if guard:
-            last_reason = guard
+            logger.info(f"📦 File prep (attempt {attempt}): generating split for {input_path.name}")
+        body, reason = _generate_split_script(prompt, model)
+        if body is None:
+            last_reason = reason
             if logger:
-                logger.warning(f"📦 File prep rejected: {guard}")
-            prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{guard}\nUse IO/parsing libraries only."
+                logger.warning(f"📦 File prep rejected: {reason}")
+            prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{reason}\nFix it."
             continue
-
-        exec_res = executor.execute_script(script, working_dir=str(file_out))
-        if exec_res.get("status") != "success":
-            last_reason = f"script execution failed: {exec_res.get('message', '')[:600]}"
-            prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{last_reason}\nFix the script."
-            continue
-
-        m = re.search(r"PREP_RESULT_JSON:(\{.*\})", exec_res.get("stdout", ""))
-        if not m:
-            last_reason = "script did not print PREP_RESULT_JSON with the output paths"
-            prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{last_reason}\nPrint the result line."
-            continue
-        try:
-            result = json.loads(m.group(1))
-        except json.JSONDecodeError as e:
-            last_reason = f"PREP_RESULT_JSON not valid JSON: {e}"
-            prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{last_reason}\nFix the output line."
-            continue
-
-        data_out = Path(result.get("data_out", ""))
-        ok, reason = _verify(input_path, data_out, metadata_out, recon_out)
+        ok, res = _apply_and_verify(body, input_path, paths, executor)
         if ok:
-            # The reconstruction was only needed for the round-trip check; it is a
-            # full duplicate of the input, so drop it rather than leave it behind.
-            recon_out.unlink(missing_ok=True)
             if logger:
-                logger.info(f"✅ File prep OK ({reason}): data={data_out}, metadata={metadata_out}")
-            return {
-                "status": "success",
-                "data_path": str(data_out),
-                "metadata_path": str(metadata_out),
-                "attempts": attempt,
-            }
-        last_reason = reason
+                logger.info(f"✅ File prep OK: data={res['data_path']}")
+            return {"status": "success", **res, "attempts": attempt}, body
+        last_reason = res
         if logger:
-            logger.warning(f"📦 File prep verification failed: {reason}")
-        prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{reason}\nProduce a lossless split."
+            logger.warning(f"📦 File prep verification failed: {res}")
+        prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{res}\nProduce a lossless split."
 
-    recon_out.unlink(missing_ok=True)  # drop any leftover from the last attempt
+    Path(paths["recon_out"]).unlink(missing_ok=True)
     return {
         "status": "error",
         "message": f"Could not produce a verified lossless split after "
                    f"{max_retries + 1} attempt(s): {last_reason}",
         "attempts": max_retries + 1,
+    }, None
+
+
+def prepare_inputs(input_path, model, executor, output_dir, probe=None,
+                   logger=None, max_retries: int = 1) -> dict:
+    """Split ONE combined data+metadata file into data + metadata files (codegen).
+
+    Returns ``{status:"success", data_path, metadata_path, attempts}`` or
+    ``{status:"error", message, attempts}``. The reconstruction used for the
+    round-trip check is deleted once verified. The caller decides how to handle an
+    error — the meta surfaces it to the user rather than delegating an unsplit file.
+    """
+    input_path = Path(input_path)
+    paths = _file_paths(input_path, Path(output_dir))
+    base_prompt = _build_prompt(probe, input_path)
+    result, _ = _prepare_one(input_path, paths, base_prompt, model, executor,
+                             logger, max_retries)
+    return result
+
+
+def _signature(probe):
+    """Structural fingerprint for clustering — same signature ⇒ one split script
+    can serve all. Keyed on STRUCTURE (ndim/dtype, columns, container keys), not
+    exact dimensions, so same-kind/different-size files still cluster. Returns
+    None when there's no structural confidence (→ caller treats the file as solo).
+    """
+    if not probe:
+        return None
+    ext, kind = probe.get("ext"), probe.get("kind")
+    if kind == "array":
+        return (ext, "array", len(probe.get("shape") or []), probe.get("dtype"))
+    if kind == "image":
+        return (ext, "image", probe.get("mode"), probe.get("n_frames"))
+    if kind == "table":
+        return (ext, "table", tuple(probe.get("columns") or []),
+                tuple(sorted((probe.get("dtypes") or {}).items())))
+    if kind == "npz":
+        return (ext, "npz", tuple(sorted(probe.get("keys") or [])))
+    if kind == "mat":
+        return (ext, "mat", tuple(sorted(probe.get("keys") or [])))
+    if kind == "hdf5":
+        return (ext, "hdf5", tuple(sorted(probe.get("datasets") or [])))
+    if kind == "json":
+        return (ext, "json", tuple(sorted(probe.get("top_level_keys") or [])))
+    return None
+
+
+def prepare_inputs_batch(input_paths, model, executor, output_dir, probes=None,
+                         logger=None, max_retries: int = 1) -> dict:
+    """Split MANY combined files, reusing one verified split per structural cluster.
+
+    Files are clustered by :func:`_signature`; the cluster's first file drives a
+    codegen, and the verified body is reused (no LLM) on its siblings — each still
+    round-trip verified. A sibling the shared body can't reproduce falls back to
+    its own codegen, so a heterogeneous "batch" still splits correctly.
+
+    Returns ``{status, results:[{file, status, ...}], summary:{...}}`` where
+    ``status`` is ``success`` (all ok), ``partial`` (some failed), or ``error``
+    (all failed). ``probes`` (parallel to ``input_paths``) sharpen clustering;
+    without them files default to per-file (no reuse).
+    """
+    input_paths = [Path(p) for p in input_paths]
+    if probes is None:
+        probes = [None] * len(input_paths)
+    output_dir = Path(output_dir)
+
+    clusters: dict = {}
+    for i, pr in enumerate(probes):
+        sig = _signature(pr)
+        if sig is None:                       # no structural confidence → solo
+            sig = ("__solo__", i)
+        clusters.setdefault(sig, []).append(i)
+
+    results = [None] * len(input_paths)
+    n_codegens = n_reused = n_fallback = 0
+
+    for idxs in clusters.values():
+        first = idxs[0]
+        base_prompt = _build_prompt(probes[first], input_paths[first])
+        res, body = _prepare_one(input_paths[first], _file_paths(input_paths[first], output_dir),
+                                 base_prompt, model, executor, logger, max_retries)
+        n_codegens += 1
+        results[first] = {"file": str(input_paths[first]), "reused": False, **res}
+
+        for j in idxs[1:]:
+            paths_j = _file_paths(input_paths[j], output_dir)
+            if body is not None:
+                ok, r = _apply_and_verify(body, input_paths[j], paths_j, executor)
+                if ok:
+                    n_reused += 1
+                    results[j] = {"file": str(input_paths[j]), "status": "success",
+                                  "reused": True, "attempts": 0, **r}
+                    if logger:
+                        logger.info(f"♻️  Reused split for {input_paths[j].name}")
+                    continue
+                if logger:
+                    logger.warning(f"📦 Reuse failed for {input_paths[j].name} ({r}); regenerating")
+            # Fallback: this sibling isn't actually the same shape — solo codegen.
+            bp = _build_prompt(probes[j], input_paths[j])
+            res_j, _ = _prepare_one(input_paths[j], paths_j, bp, model, executor,
+                                    logger, max_retries)
+            n_codegens += 1
+            n_fallback += 1
+            results[j] = {"file": str(input_paths[j]), "reused": False, **res_j}
+
+    n_failed = sum(1 for r in results if r.get("status") != "success")
+    status = ("success" if n_failed == 0
+              else "error" if n_failed == len(results) else "partial")
+    return {
+        "status": status,
+        "results": results,
+        "summary": {
+            "n_files": len(input_paths), "n_clusters": len(clusters),
+            "n_codegens": n_codegens, "n_reused": n_reused,
+            "n_fallback": n_fallback, "n_failed": n_failed,
+        },
     }

--- a/scilink/utils/file_prep.py
+++ b/scilink/utils/file_prep.py
@@ -1,0 +1,280 @@
+"""Codegen-backed file preparation: split a combined data+metadata file into
+separate data + metadata files BEFORE delegation to a specialist.
+
+STRICT SCOPE — this is the meta agent's ONLY code-generation surface, and it is
+restricted to **lossless file repackaging**. The generated script may separate
+existing data from metadata and reconstruct the original; it must NOT transform,
+scale, filter, fit, resample, denoise, or analyze anything. Analysis is always
+delegated.
+
+Enforcement is layered, the middle layer mechanical:
+  1. narrow prompt (read input → write data + metadata, values unchanged);
+  2. ROUND-TRIP verification — the script must also reconstruct the original from
+     its two outputs, and we check reconstruction ≈ original. A script that
+     transformed the data cannot round-trip, so "prep only" is enforced, not just
+     requested. If losslessness can't be verified, the split is REJECTED (the
+     caller falls back to delegating the file as-is);
+  3. static import guard (no analysis libraries);
+  4. explicit documentation on the tool.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import numpy as np
+
+# Libraries that signal analysis/computation rather than IO/parsing. A generated
+# prep script importing any of these is rejected before execution.
+_ANALYSIS_IMPORT_DENYLIST = (
+    "sklearn", "scipy.optimize", "scipy.signal", "scipy.ndimage",
+    "scipy.interpolate", "scipy.stats", "lmfit", "torch", "tensorflow",
+    "cv2", "skimage", "statsmodels", "matplotlib",
+)
+
+_PROMPT = '''You prepare a scientific data file for downstream analysis by
+SEPARATING its data from its metadata. This is a LOSSLESS REPACKAGING step ONLY —
+you are NOT analyzing anything.
+
+Input file: {path}
+
+Structural probe (evidence — do not assume beyond it):
+{probe}
+
+Write a Python script that:
+1. Reads the input file.
+2. Splits it into (a) the primary numerical DATA (the array / table / signal) and
+   (b) the METADATA — everything that is NOT the data values: headers, attributes,
+   comments, units, calibration, axes, acquisition parameters, etc.
+3. Writes the DATA to a file whose path you choose under the output directory
+   "{out_dir}" — use `.npy` for an array/cube or `.csv` for a table.
+4. Writes the METADATA to "{metadata_out}" as a single JSON object. Put the
+   HUMAN-MEANINGFUL scientific metadata at the TOP LEVEL with clean keys
+   (technique, instrument, sample, units, axes, wavelength, ...). If you need
+   extra bookkeeping to reconstruct the original byte-for-byte (line endings,
+   dtypes, column order, key order), nest ALL of it under a single
+   "_reconstruction" key so downstream sees clean metadata.
+5. RECONSTRUCTS the original file from those two outputs and writes it to
+   "{recon_out}" (same format as the input). We will verify it matches the input.
+6. Prints exactly one line:
+   PREP_RESULT_JSON:{{"data_out": "<abs path>", "metadata_out": "{metadata_out}", "recon_out": "{recon_out}"}}
+
+HARD CONSTRAINTS (a violation fails verification):
+- DO NOT transform, scale, normalize, filter, fit, resample, denoise, crop, or
+  analyze the data. The data you write MUST be the original values, unchanged.
+- The reconstruction MUST reproduce the original file's data and metadata.
+- Allowed libraries ONLY: numpy, pandas, json, csv, struct, io, re, h5py, os,
+  pathlib. Do NOT import analysis libraries (sklearn, scipy.*, lmfit, torch,
+  cv2, skimage, matplotlib, ...).
+- No network, no plotting.
+
+Respond with a JSON object: {{"script": "<the full python script>"}}
+'''
+
+
+def _extract_script(text: str) -> str:
+    """Pull the script string out of the model response (JSON or fenced)."""
+    if not text:
+        return ""
+    # Prefer a {"script": "..."} JSON object.
+    try:
+        m = re.search(r'\{.*"script".*\}', text, re.DOTALL)
+        if m:
+            return json.loads(m.group(0)).get("script", "")
+    except (json.JSONDecodeError, ValueError):
+        pass
+    # Fall back to a fenced code block.
+    m = re.search(r"```(?:python)?\n(.*?)```", text, re.DOTALL)
+    return m.group(1) if m else text
+
+
+def _static_guard(script: str) -> str | None:
+    """Return a rejection reason if the script imports an analysis library."""
+    for lib in _ANALYSIS_IMPORT_DENYLIST:
+        root = lib.split(".")[0]
+        if re.search(rf"^\s*(import|from)\s+{re.escape(root)}\b", script, re.MULTILINE):
+            return (
+                f"Generated prep script imports a forbidden analysis library "
+                f"('{root}'). File prep must use IO/parsing libraries only."
+            )
+    return None
+
+
+def _roundtrip_ok(original: Path, recon: Path) -> bool:
+    """Tolerant lossless check: does ``recon`` reproduce ``original``?"""
+    try:
+        ob = original.read_bytes()
+        rb = recon.read_bytes()
+    except OSError:
+        return False
+    if ob == rb:
+        return True  # byte-identical
+    ext = original.suffix.lower()
+    try:
+        if ext == ".npy":
+            return np.allclose(np.load(original), np.load(recon), equal_nan=True)
+        if ext == ".npz":
+            a, b = np.load(original), np.load(recon)
+            return set(a.files) == set(b.files) and all(
+                np.allclose(a[k], b[k], equal_nan=True) for k in a.files
+            )
+        if ext in (".csv", ".tsv", ".txt", ".dat"):
+            return _text_equal_tolerant(original.read_text(errors="replace"),
+                                        recon.read_text(errors="replace"))
+    except Exception:
+        return False
+    return False  # unknown/binary that wasn't byte-identical → cannot verify
+
+
+def _text_equal_tolerant(a: str, b: str) -> bool:
+    """Token-wise compare: numbers within tolerance, other tokens exact."""
+    ta, tb = a.split(), b.split()
+    if len(ta) != len(tb):
+        return False
+    for x, y in zip(ta, tb):
+        if x == y:
+            continue
+        try:
+            if np.isclose(float(x), float(y), equal_nan=True):
+                continue
+        except ValueError:
+            pass
+        return False
+    return True
+
+
+def _verify(input_path: Path, result: dict) -> tuple[bool, str]:
+    """Verify the split is well-formed AND lossless. Returns (ok, reason)."""
+    data_out = Path(result.get("data_out", ""))
+    meta_out = Path(result.get("metadata_out", ""))
+    recon_out = Path(result.get("recon_out", ""))
+
+    if not data_out.exists():
+        return False, f"data_out not written: {data_out}"
+    try:
+        if data_out.suffix.lower() == ".npy":
+            arr = np.load(data_out, allow_pickle=False)
+            if arr.size == 0:
+                return False, "data_out array is empty"
+        else:  # tabular
+            if data_out.stat().st_size == 0:
+                return False, "data_out file is empty"
+    except Exception as e:
+        return False, f"data_out does not load as data: {e}"
+
+    if not meta_out.exists():
+        return False, f"metadata_out not written: {meta_out}"
+    try:
+        meta = json.loads(meta_out.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        return False, f"metadata_out is not valid JSON: {e}"
+    if not isinstance(meta, dict) or not meta:
+        return False, "metadata_out is empty or not a JSON object"
+
+    if not recon_out.exists():
+        return False, f"recon_out (round-trip check) not written: {recon_out}"
+    if not _roundtrip_ok(input_path, recon_out):
+        return False, (
+            "round-trip FAILED: reconstruction does not match the original — the "
+            "split is not lossless (or the data was transformed). Rejected."
+        )
+    return True, "lossless split verified"
+
+
+def prepare_inputs(input_path, model, executor, output_dir, probe=None,
+                   logger=None, max_retries: int = 1) -> dict:
+    """Split a combined data+metadata file into data + metadata files (codegen).
+
+    Args:
+        input_path: the combined file to split.
+        model: LLM with ``.generate_content(prompt).text``.
+        executor: a ``ScriptExecutor`` (runs the generated script in a sandbox).
+        output_dir: directory for the outputs.
+        probe: optional structural probe dict (e.g. from the meta's file probe);
+            a compact fallback is used when omitted.
+        logger: optional logger.
+        max_retries: extra attempts after the first (default 1).
+
+    Returns a dict: on success ``{status:"success", data_path, metadata_path,
+    recon_path, attempts}``; otherwise ``{status:"error", message, attempts}``.
+    The caller decides how to handle an error — the meta surfaces it to the user
+    and asks how to proceed rather than silently delegating an unsplit file.
+    """
+    input_path = Path(input_path)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stem = re.sub(r"[^0-9A-Za-z_-]", "_", input_path.stem) or "input"
+    metadata_out = output_dir / f"{stem}_metadata.json"
+    recon_out = output_dir / f"{stem}_reconstructed{input_path.suffix}"
+
+    probe_str = json.dumps(probe, indent=2, default=str) if probe else \
+        f"(no probe) extension={input_path.suffix}, size={input_path.stat().st_size} bytes"
+    base_prompt = _PROMPT.format(
+        path=str(input_path), probe=probe_str, out_dir=str(output_dir),
+        metadata_out=str(metadata_out), recon_out=str(recon_out),
+    )
+
+    prompt = base_prompt
+    last_reason = ""
+    for attempt in range(1, max_retries + 2):
+        if logger:
+            logger.info(f"📦 File prep (attempt {attempt}): generating split script for {input_path.name}")
+        try:
+            script = _extract_script(model.generate_content(prompt).text)
+        except Exception as e:
+            last_reason = f"code generation failed: {e}"
+            prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{last_reason}\nFix it."
+            continue
+        if not script:
+            last_reason = "model returned no script"
+            prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{last_reason}\nFix it."
+            continue
+
+        guard = _static_guard(script)
+        if guard:
+            last_reason = guard
+            if logger:
+                logger.warning(f"📦 File prep rejected: {guard}")
+            prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{guard}\nUse IO/parsing libraries only."
+            continue
+
+        exec_res = executor.execute_script(script, working_dir=str(output_dir))
+        if exec_res.get("status") != "success":
+            last_reason = f"script execution failed: {exec_res.get('message', '')[:600]}"
+            prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{last_reason}\nFix the script."
+            continue
+
+        m = re.search(r"PREP_RESULT_JSON:(\{.*\})", exec_res.get("stdout", ""))
+        if not m:
+            last_reason = "script did not print PREP_RESULT_JSON with the output paths"
+            prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{last_reason}\nPrint the result line."
+            continue
+        try:
+            result = json.loads(m.group(1))
+        except json.JSONDecodeError as e:
+            last_reason = f"PREP_RESULT_JSON not valid JSON: {e}"
+            prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{last_reason}\nFix the output line."
+            continue
+
+        ok, reason = _verify(input_path, result)
+        if ok:
+            if logger:
+                logger.info(f"✅ File prep OK ({reason}): data={result['data_out']}, metadata={metadata_out}")
+            return {
+                "status": "success",
+                "data_path": result["data_out"],
+                "metadata_path": str(metadata_out),
+                "recon_path": str(recon_out),
+                "attempts": attempt,
+            }
+        last_reason = reason
+        if logger:
+            logger.warning(f"📦 File prep verification failed: {reason}")
+        prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{reason}\nProduce a lossless split."
+
+    return {
+        "status": "error",
+        "message": f"Could not produce a verified lossless split after "
+                   f"{max_retries + 1} attempt(s): {last_reason}",
+        "attempts": max_retries + 1,
+    }

--- a/scilink/utils/file_prep.py
+++ b/scilink/utils/file_prep.py
@@ -7,29 +7,39 @@ existing data from metadata and reconstruct the original; it must NOT transform,
 scale, filter, fit, resample, denoise, or analyze anything. Analysis is always
 delegated.
 
-Enforcement is layered, the middle layer mechanical:
+Enforcement is layered:
   1. narrow prompt (read input → write data + metadata, values unchanged);
   2. ROUND-TRIP verification — the script must also reconstruct the original from
-     its two outputs, and we check reconstruction ≈ original. A script that
-     transformed the data cannot round-trip, so "prep only" is enforced, not just
-     requested. If losslessness can't be verified, the split is REJECTED (the
-     caller falls back to delegating the file as-is);
-  3. static import guard (no analysis libraries);
+     its two outputs, and we check reconstruction ≈ original. This confirms a
+     faithful reconstruction PATH exists; it does NOT, by itself, prove the data
+     leg (`data_path`, the file actually delegated) is untransformed, because the
+     reconstruction is produced by the same generated script and is not forced to
+     derive solely from the two split outputs. The data leg's fidelity rests on
+     the prompt + import guard; the round-trip is a strong corroborating signal,
+     not a hermetic proof. If the round-trip can't be verified, the split is
+     REJECTED;
+  3. static import guard (no analysis libraries — note numpy/pandas are allowed
+     and can transform, so this narrows but does not eliminate the surface);
   4. explicit documentation on the tool.
 """
 
+import ast
 import json
 import re
 from pathlib import Path
 
 import numpy as np
 
-# Libraries that signal analysis/computation rather than IO/parsing. A generated
-# prep script importing any of these is rejected before execution.
+# Modules that signal analysis/computation rather than IO/parsing. A generated
+# prep script importing any of these (or a submodule of one) is rejected before
+# execution. Entries are matched by dotted PREFIX, so `scipy.optimize` denies
+# `scipy.optimize.*` but leaves IO-only `scipy.io` / `scipy.sparse` available —
+# the granularity is deliberate (classic MATLAB .mat needs `scipy.io`).
 _ANALYSIS_IMPORT_DENYLIST = (
     "sklearn", "scipy.optimize", "scipy.signal", "scipy.ndimage",
-    "scipy.interpolate", "scipy.stats", "lmfit", "torch", "tensorflow",
-    "cv2", "skimage", "statsmodels", "matplotlib",
+    "scipy.interpolate", "scipy.stats", "scipy.fft", "scipy.fftpack",
+    "lmfit", "torch", "tensorflow", "cv2", "skimage", "statsmodels",
+    "matplotlib",
 )
 
 _PROMPT = '''You prepare a scientific data file for downstream analysis by
@@ -40,6 +50,16 @@ Input file: {path}
 
 Structural probe (evidence — do not assume beyond it):
 {probe}
+
+Common layouts you may encounter (illustrative, not exhaustive — let the probe
+decide):
+- A `.dat`/`.txt`/`.csv` with a metadata HEADER block (comment lines, `key: value`
+  or `key = value` pairs, a units row) ABOVE the numeric data rows.
+- A MATLAB `.mat` (or `.npz`/HDF5) where some keys are arrays (data) and others
+  are scalars/strings (metadata).
+- An HDF5/NeXus dataset carrying metadata in attributes alongside the array.
+- A vendor container interleaving an acquisition-parameter block with the signal.
+Identify which bytes/keys/lines are data vs metadata from the probe, then:
 
 Write a Python script that:
 1. Reads the input file.
@@ -53,7 +73,11 @@ Write a Python script that:
    (technique, instrument, sample, units, axes, wavelength, ...). If you need
    extra bookkeeping to reconstruct the original byte-for-byte (line endings,
    dtypes, column order, key order), nest ALL of it under a single
-   "_reconstruction" key so downstream sees clean metadata.
+   "_reconstruction" key so downstream sees clean metadata. A value can be both
+   meaningful AND needed for reconstruction — when scientific metadata lives in a
+   container's attributes/keys (HDF5 attrs, .npz/.mat keys), surface it at the
+   TOP LEVEL and, if needed, also record its placement under "_reconstruction";
+   do not relegate it to "_reconstruction" alone.
 5. RECONSTRUCTS the original file from those two outputs and writes it to
    "{recon_out}" (same format as the input). We will verify it matches the input.
 6. Prints exactly one line:
@@ -63,9 +87,10 @@ HARD CONSTRAINTS (a violation fails verification):
 - DO NOT transform, scale, normalize, filter, fit, resample, denoise, crop, or
   analyze the data. The data you write MUST be the original values, unchanged.
 - The reconstruction MUST reproduce the original file's data and metadata.
-- Allowed libraries ONLY: numpy, pandas, json, csv, struct, io, re, h5py, os,
-  pathlib. Do NOT import analysis libraries (sklearn, scipy.*, lmfit, torch,
-  cv2, skimage, matplotlib, ...).
+- Allowed libraries ONLY: numpy, pandas, json, csv, struct, io, re, h5py,
+  scipy.io (for MATLAB .mat read/write ONLY), os, pathlib. Do NOT import
+  analysis libraries — sklearn, lmfit, torch, cv2, skimage, matplotlib, or any
+  other scipy submodule (optimize, signal, ndimage, interpolate, stats, fft, ...).
 - No network, no plotting.
 
 Respond with a JSON object: {{"script": "<the full python script>"}}
@@ -88,16 +113,149 @@ def _extract_script(text: str) -> str:
     return m.group(1) if m else text
 
 
-def _static_guard(script: str) -> str | None:
-    """Return a rejection reason if the script imports an analysis library."""
-    for lib in _ANALYSIS_IMPORT_DENYLIST:
-        root = lib.split(".")[0]
-        if re.search(rf"^\s*(import|from)\s+{re.escape(root)}\b", script, re.MULTILINE):
-            return (
-                f"Generated prep script imports a forbidden analysis library "
-                f"('{root}'). File prep must use IO/parsing libraries only."
-            )
+def _denied_module(name: str) -> str | None:
+    """Return the denylist entry a dotted module name matches by prefix, else None.
+
+    ``scipy.optimize`` matches ``scipy.optimize`` and ``scipy.optimize.foo`` but
+    NOT ``scipy.io``; ``sklearn`` matches ``sklearn`` and any ``sklearn.*``.
+    """
+    parts = name.split(".")
+    for entry in _ANALYSIS_IMPORT_DENYLIST:
+        ep = entry.split(".")
+        if parts[: len(ep)] == ep:
+            return entry
     return None
+
+
+def _static_guard(script: str) -> str | None:
+    """Return a rejection reason if the script imports a denied analysis module.
+
+    Parses the script and inspects ``import``/``from`` statements so the dotted
+    denylist is honored precisely (e.g. ``from scipy import optimize`` is caught
+    while ``from scipy import io`` is allowed). Not a sandbox — dynamic imports
+    (``__import__``) are out of scope; the round-trip check is the real net.
+    """
+    try:
+        tree = ast.parse(script)
+    except SyntaxError:
+        # Unparseable code can't run, so it can't do harm; let execution surface
+        # the syntax error. Conservative root-level fallback just in case.
+        for entry in _ANALYSIS_IMPORT_DENYLIST:
+            root = entry.split(".")[0]
+            if re.search(rf"^\s*(import|from)\s+{re.escape(root)}\b", script, re.MULTILINE):
+                return f"Generated prep script imports a forbidden module ('{root}')."
+        return None
+
+    def reason(hit: str) -> str:
+        return (
+            f"Generated prep script imports a forbidden analysis module "
+            f"('{hit}'). File prep must use IO/parsing libraries only."
+        )
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                hit = _denied_module(alias.name)
+                if hit:
+                    return reason(hit)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:  # relative import — not a third-party analysis lib
+                continue
+            mod = node.module or ""
+            hit = _denied_module(mod)
+            if hit:
+                return reason(hit)
+            for alias in node.names:  # from pkg import submod
+                hit = _denied_module(f"{mod}.{alias.name}" if mod else alias.name)
+                if hit:
+                    return reason(hit)
+    return None
+
+
+def _members_equal(a, b) -> bool:
+    """Compare two arrays type-appropriately: numeric within tolerance, else exact.
+
+    Combined containers (e.g. ``.npz``) routinely hold non-numeric members —
+    string/object metadata keys — alongside the numeric data, so a blanket
+    ``np.allclose`` would raise on those and falsely fail the round-trip.
+    """
+    a, b = np.asarray(a), np.asarray(b)
+    if a.shape != b.shape:
+        return False
+    if np.issubdtype(a.dtype, np.number) and np.issubdtype(b.dtype, np.number):
+        return bool(np.allclose(a, b, equal_nan=True))
+    return bool(np.array_equal(a, b))
+
+
+def _attrs_equal(a: dict, b: dict) -> bool:
+    """Compare two attribute dicts (HDF5 attrs / .mat fields) member-wise."""
+    if set(a) != set(b):
+        return False
+    return all(_members_equal(a[k], b[k]) for k in a)
+
+
+def _h5_equal(original: Path, recon: Path) -> bool:
+    """Content-aware HDF5 comparison: a faithful re-write is rarely byte-identical
+    (chunking, compression, attribute/dataset order, timestamps all vary), so we
+    compare the group/dataset tree and attributes instead. ``h5py`` is already an
+    allowed prep library; if it is unavailable we cannot verify → reject.
+    """
+    try:
+        import h5py
+    except Exception:
+        return False
+
+    def collect(f):
+        items = {"/": ("group", None, dict(f.attrs))}
+
+        def visit(name, obj):
+            if isinstance(obj, h5py.Dataset):
+                items[name] = ("dataset", obj[()], dict(obj.attrs))
+            else:  # group
+                items[name] = ("group", None, dict(obj.attrs))
+
+        f.visititems(visit)
+        return items
+
+    try:
+        with h5py.File(original, "r") as fa, h5py.File(recon, "r") as fb:
+            a, b = collect(fa), collect(fb)
+            if set(a) != set(b):
+                return False
+            for k in a:
+                kind_a, val_a, attrs_a = a[k]
+                kind_b, val_b, attrs_b = b[k]
+                if kind_a != kind_b or not _attrs_equal(attrs_a, attrs_b):
+                    return False
+                if kind_a == "dataset" and not _members_equal(val_a, val_b):
+                    return False
+            return True
+    except Exception:
+        return False
+
+
+def _mat_equal(original: Path, recon: Path) -> bool:
+    """Content-aware MATLAB .mat comparison. Classic v5/6/7 .mat go through
+    ``scipy.io.loadmat`` (an IO module, allowed); v7.3 .mat are HDF5 and fall back
+    to :func:`_h5_equal`. Comparison ignores loadmat's ``__header__`` /
+    ``__version__`` / ``__globals__`` bookkeeping (the header carries a timestamp).
+    """
+    try:
+        from scipy.io import loadmat
+    except Exception:
+        return _h5_equal(original, recon)  # scipy absent → try HDF5 (v7.3 .mat)
+    try:
+        a, b = loadmat(original), loadmat(recon)
+    except NotImplementedError:
+        return _h5_equal(original, recon)  # v7.3 .mat is HDF5 under the hood
+    except Exception:
+        return False
+    skip = {"__header__", "__version__", "__globals__"}
+    ka = {k for k in a if k not in skip}
+    kb = {k for k in b if k not in skip}
+    if ka != kb:
+        return False
+    return all(_members_equal(a[k], b[k]) for k in ka)
 
 
 def _roundtrip_ok(original: Path, recon: Path) -> bool:
@@ -112,12 +270,17 @@ def _roundtrip_ok(original: Path, recon: Path) -> bool:
     ext = original.suffix.lower()
     try:
         if ext == ".npy":
-            return np.allclose(np.load(original), np.load(recon), equal_nan=True)
+            return _members_equal(np.load(original, allow_pickle=True),
+                                  np.load(recon, allow_pickle=True))
         if ext == ".npz":
-            a, b = np.load(original), np.load(recon)
+            a, b = np.load(original, allow_pickle=True), np.load(recon, allow_pickle=True)
             return set(a.files) == set(b.files) and all(
-                np.allclose(a[k], b[k], equal_nan=True) for k in a.files
+                _members_equal(a[k], b[k]) for k in a.files
             )
+        if ext in (".h5", ".hdf5", ".nxs", ".nx"):
+            return _h5_equal(original, recon)
+        if ext == ".mat":
+            return _mat_equal(original, recon)
         if ext in (".csv", ".tsv", ".txt", ".dat"):
             return _text_equal_tolerant(original.read_text(errors="replace"),
                                         recon.read_text(errors="replace"))
@@ -143,12 +306,14 @@ def _text_equal_tolerant(a: str, b: str) -> bool:
     return True
 
 
-def _verify(input_path: Path, result: dict) -> tuple[bool, str]:
-    """Verify the split is well-formed AND lossless. Returns (ok, reason)."""
-    data_out = Path(result.get("data_out", ""))
-    meta_out = Path(result.get("metadata_out", ""))
-    recon_out = Path(result.get("recon_out", ""))
+def _verify(input_path: Path, data_out: Path, meta_out: Path,
+            recon_out: Path) -> tuple[bool, str]:
+    """Verify the split is well-formed AND lossless. Returns (ok, reason).
 
+    ``data_out`` is the model's chosen data path (pulled from PREP_RESULT_JSON);
+    ``meta_out`` / ``recon_out`` are the template-fixed paths the caller owns, so
+    we verify (and later return) those rather than trusting the model's echo.
+    """
     if not data_out.exists():
         return False, f"data_out not written: {data_out}"
     try:
@@ -168,6 +333,8 @@ def _verify(input_path: Path, result: dict) -> tuple[bool, str]:
         meta = json.loads(meta_out.read_text())
     except (json.JSONDecodeError, OSError) as e:
         return False, f"metadata_out is not valid JSON: {e}"
+    # Reject empty metadata: a genuinely metadata-light file fails here and the
+    # meta bounces it back to the user rather than delegating a no-op split.
     if not isinstance(meta, dict) or not meta:
         return False, "metadata_out is empty or not a JSON object"
 
@@ -196,7 +363,8 @@ def prepare_inputs(input_path, model, executor, output_dir, probe=None,
         max_retries: extra attempts after the first (default 1).
 
     Returns a dict: on success ``{status:"success", data_path, metadata_path,
-    recon_path, attempts}``; otherwise ``{status:"error", message, attempts}``.
+    attempts}``; otherwise ``{status:"error", message, attempts}``. The
+    reconstruction used for the round-trip check is deleted once verified.
     The caller decides how to handle an error — the meta surfaces it to the user
     and asks how to proceed rather than silently delegating an unsplit file.
     """
@@ -256,15 +424,18 @@ def prepare_inputs(input_path, model, executor, output_dir, probe=None,
             prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{last_reason}\nFix the output line."
             continue
 
-        ok, reason = _verify(input_path, result)
+        data_out = Path(result.get("data_out", ""))
+        ok, reason = _verify(input_path, data_out, metadata_out, recon_out)
         if ok:
+            # The reconstruction was only needed for the round-trip check; it is a
+            # full duplicate of the input, so drop it rather than leave it behind.
+            recon_out.unlink(missing_ok=True)
             if logger:
-                logger.info(f"✅ File prep OK ({reason}): data={result['data_out']}, metadata={metadata_out}")
+                logger.info(f"✅ File prep OK ({reason}): data={data_out}, metadata={metadata_out}")
             return {
                 "status": "success",
-                "data_path": result["data_out"],
+                "data_path": str(data_out),
                 "metadata_path": str(metadata_out),
-                "recon_path": str(recon_out),
                 "attempts": attempt,
             }
         last_reason = reason
@@ -272,6 +443,7 @@ def prepare_inputs(input_path, model, executor, output_dir, probe=None,
             logger.warning(f"📦 File prep verification failed: {reason}")
         prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{reason}\nProduce a lossless split."
 
+    recon_out.unlink(missing_ok=True)  # drop any leftover from the last attempt
     return {
         "status": "error",
         "message": f"Could not produce a verified lossless split after "

--- a/scilink/utils/file_prep.py
+++ b/scilink/utils/file_prep.py
@@ -24,6 +24,7 @@ Enforcement is layered:
 """
 
 import ast
+import hashlib
 import json
 import re
 from pathlib import Path
@@ -407,15 +408,20 @@ def prepare_inputs(input_path, model, executor, output_dir, probe=None,
     """
     input_path = Path(input_path)
     output_dir = Path(output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
     stem = re.sub(r"[^0-9A-Za-z_-]", "_", input_path.stem) or "input"
-    metadata_out = output_dir / f"{stem}_metadata.json"
-    recon_out = output_dir / f"{stem}_reconstructed{input_path.suffix}"
+    # Per-file subdirectory keyed on the absolute path: two uploads sharing a
+    # basename (e.g. runA/scan.tif and runB/scan.tif) must not clobber each
+    # other's metadata/recon/data outputs in a shared "prepared/" dir.
+    key = hashlib.sha1(str(input_path.resolve()).encode()).hexdigest()[:8]
+    file_out = output_dir / f"{stem}_{key}"
+    file_out.mkdir(parents=True, exist_ok=True)
+    metadata_out = file_out / f"{stem}_metadata.json"
+    recon_out = file_out / f"{stem}_reconstructed{input_path.suffix}"
 
     probe_str = json.dumps(probe, indent=2, default=str) if probe else \
         f"(no probe) extension={input_path.suffix}, size={input_path.stat().st_size} bytes"
     base_prompt = _PROMPT.format(
-        path=str(input_path), probe=probe_str, out_dir=str(output_dir),
+        path=str(input_path), probe=probe_str, out_dir=str(file_out),
         metadata_out=str(metadata_out), recon_out=str(recon_out),
     )
 
@@ -443,7 +449,7 @@ def prepare_inputs(input_path, model, executor, output_dir, probe=None,
             prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{guard}\nUse IO/parsing libraries only."
             continue
 
-        exec_res = executor.execute_script(script, working_dir=str(output_dir))
+        exec_res = executor.execute_script(script, working_dir=str(file_out))
         if exec_res.get("status") != "success":
             last_reason = f"script execution failed: {exec_res.get('message', '')[:600]}"
             prompt = base_prompt + f"\n\n### PREVIOUS ATTEMPT FAILED\n{last_reason}\nFix the script."

--- a/scilink/utils/file_prep.py
+++ b/scilink/utils/file_prep.py
@@ -58,7 +58,8 @@ decide):
 - A MATLAB `.mat` (or `.npz`/HDF5) where some keys are arrays (data) and others
   are scalars/strings (metadata).
 - An HDF5/NeXus dataset carrying metadata in attributes alongside the array.
-- A vendor container interleaving an acquisition-parameter block with the signal.
+- A `.tif`/`.tiff` carrying acquisition metadata in TIFF tags / ImageDescription
+  (ImageJ `key=value` block or OME-XML) alongside the pixel array.
 Identify which bytes/keys/lines are data vs metadata from the probe, then:
 
 Write a Python script that:
@@ -88,9 +89,10 @@ HARD CONSTRAINTS (a violation fails verification):
   analyze the data. The data you write MUST be the original values, unchanged.
 - The reconstruction MUST reproduce the original file's data and metadata.
 - Allowed libraries ONLY: numpy, pandas, json, csv, struct, io, re, h5py,
-  scipy.io (for MATLAB .mat read/write ONLY), os, pathlib. Do NOT import
-  analysis libraries — sklearn, lmfit, torch, cv2, skimage, matplotlib, or any
-  other scipy submodule (optimize, signal, ndimage, interpolate, stats, fft, ...).
+  scipy.io (for MATLAB .mat read/write ONLY), PIL/Pillow (for TIFF tags /
+  ImageDescription), os, pathlib. Do NOT import analysis libraries — sklearn,
+  lmfit, torch, cv2, skimage, matplotlib, or any other scipy submodule
+  (optimize, signal, ndimage, interpolate, stats, fft, ...).
 - No network, no plotting.
 
 Respond with a JSON object: {{"script": "<the full python script>"}}
@@ -258,6 +260,39 @@ def _mat_equal(original: Path, recon: Path) -> bool:
     return all(_members_equal(a[k], b[k]) for k in ka)
 
 
+def _tif_equal(original: Path, recon: Path) -> bool:
+    """Content-aware TIFF comparison: pixel array(s) numeric-tolerant, tags exact.
+
+    A faithful TIFF rewrite is rarely byte-identical (encoder, strip/tile layout,
+    tag order), so compare decoded pixels per page plus the tag dict. ``PIL`` is
+    an allowed prep library; if unavailable we cannot verify → reject.
+    """
+    try:
+        from PIL import Image
+    except Exception:
+        return False
+    try:
+        with Image.open(original) as ia, Image.open(recon) as ib:
+            na, nb = getattr(ia, "n_frames", 1), getattr(ib, "n_frames", 1)
+            if na != nb:
+                return False
+            for i in range(na):
+                ia.seek(i)
+                ib.seek(i)
+                if not _members_equal(np.asarray(ia), np.asarray(ib)):
+                    return False
+                ta = dict(getattr(ia, "tag_v2", {}) or {})
+                tb = dict(getattr(ib, "tag_v2", {}) or {})
+                if set(ta) != set(tb):
+                    return False
+                # Tags must be reproduced exactly (metadata losslessness).
+                if any(str(ta[k]) != str(tb.get(k)) for k in ta):
+                    return False
+            return True
+    except Exception:
+        return False
+
+
 def _roundtrip_ok(original: Path, recon: Path) -> bool:
     """Tolerant lossless check: does ``recon`` reproduce ``original``?"""
     try:
@@ -281,6 +316,8 @@ def _roundtrip_ok(original: Path, recon: Path) -> bool:
             return _h5_equal(original, recon)
         if ext == ".mat":
             return _mat_equal(original, recon)
+        if ext in (".tif", ".tiff"):
+            return _tif_equal(original, recon)
         if ext in (".csv", ".tsv", ".txt", ".dat"):
             return _text_equal_tolerant(original.read_text(errors="replace"),
                                         recon.read_text(errors="replace"))


### PR DESCRIPTION
A new, tightly-scoped capability for the **meta agent**: split one file that holds *both* data and metadata into a clean (data, metadata) pair before delegating, so specialists get what their `analyze(data, system_info)` contract expects.

## Summary (for scientists)

Sometimes a single uploaded file carries the data *and* its metadata together — an HDF5/NeXus with attributes, a MATLAB `.mat` or `.npz` with data+meta keys, a `.dat`/`.txt`/`.csv` with a comment/header metadata block, or a TIFF carrying metadata in its tags/ImageDescription. The meta agent can now split that into a data file + a metadata JSON (`prepare_inputs`) and hand both to the specialist. Because real files mix data and metadata in unpredictable ways, the split is **generated per-file by the LLM**, not a fixed parser — but it is held to a hard safety net: the split must **reconstruct the original** (round-trip verified), so a transformed or lossy split is rejected. This is the meta's *only* code-generation surface and it is strictly limited to lossless repackaging — it never analyzes, transforms, or computes; all analysis is delegated.

This PR also closes a related gap: scientific TIFFs carry calibration/acquisition metadata in their tags/ImageDescription, but image loading (OpenCV) was silently dropping it — that metadata is now recovered and handed to the analysis agent as `system_info`.

Multiple combined files of the same kind can be split in one call: SciLink writes one split recipe, verifies it, and reuses it across the rest (re-checking each), so a 50-file batch costs one code generation and yields a uniform, consistent split.

Validated live (`claude-opus-4-6`/`4-8`): combined CSV, `.npz`, HDF5, MATLAB `.mat`, and TIFF files all split losslessly and round-trip verified, with the scientific metadata surfaced as clean top-level fields and reconstruction bookkeeping tucked away.

## Technical details (for AI reviewers)

**Shared helper `scilink/utils/file_prep.py::prepare_inputs(path, model, executor, output_dir, probe, logger, max_retries)`** — `probe → LLM generates a split+reconstruct script → static guard → sandbox exec → VERIFY`, with retries on failure (meta calls it with `max_retries=2` → 3 attempts total).

Enforcement is layered:

1. **Narrow prompt** — read input → write data (`.npy`/`.csv`) + metadata (JSON: scientific fields top-level, reconstruction bookkeeping nested under `_reconstruction`); values unchanged; explicit forbidden ops; allowed-library allowlist. Includes common-layout guidance (header-block text, container formats) and an instruction to surface metadata that lives in container attrs/keys at the top level even when it's also needed for reconstruction.
2. **Round-trip verification (`_verify` / `_roundtrip_ok`)** — the script must also reconstruct the original from its two outputs; we check `reconstruction ≈ original`. **Honest scope:** this confirms a faithful reconstruction *path* exists; it does **not**, by itself, prove the data leg (`data_path`, the file actually delegated) is untransformed, because the reconstruction is produced by the same generated script and is not forced to derive solely from the two split outputs. The data leg's fidelity rests on the prompt + import guard; the round-trip is a strong corroborating signal, not a hermetic proof. If the round-trip can't be verified, the split is **rejected**. `_verify` trusts the caller-owned metadata/recon paths (only `data_out` is model-chosen). Comparison is **content-aware per format**:
   - byte-identical fast path;
   - `.npy`/`.npz`: member-wise via `_members_equal` (numeric → `allclose`, non-numeric → `array_equal`), so string/scalar metadata keys don't crash the check;
   - **HDF5** (`.h5/.hdf5/.nxs/.nx`): recursive group/dataset + attribute comparison via `_h5_equal` (a faithful rewrite is rarely byte-identical — chunking, compression, attr/dataset order, timestamps);
   - **MATLAB `.mat`**: `_mat_equal` — `scipy.io.loadmat` content compare for v5/6/7 (ignoring `__header__`/`__version__`/`__globals__`), HDF5 fallback for v7.3;
   - **TIFF** (`.tif/.tiff`): `_tif_equal` — decoded pixels per page numeric-tolerant, TIFF tags exact (PIL);
   - text (`.csv/.tsv/.txt/.dat`): token-wise numeric-tolerant compare.
3. **Static import guard (`_static_guard`)** — AST-based, denylist matched by **dotted prefix** (`_denied_module`). Catches `import scipy.optimize`, `from scipy.optimize import …`, and `from scipy import optimize`, while allowing IO-only `scipy.io` / `scipy.sparse` (classic `.mat` needs `scipy.io`). Conservative root-level textual fallback for unparseable scripts.

**Batch path — `prepare_inputs_batch` / tool `str | list`.** The meta tool accepts a single path or a list. For a list it clusters by a structural `_signature` (from `_probe_file`: ndim/dtype, table columns, container keys — NOT exact dimensions, so same-kind/different-size files cluster), generates ONE verified split per cluster, and reuses it across siblings via a runtime `_PREP` path-dict header (the body is written generically and re-run verbatim; the static guard rejects a body that hardcodes paths instead of reading `_PREP`). Every reused file is independently round-trip verified; a sibling that can't reuse the shared body falls back to its own codegen. Returns `{status: success|partial|error, results:[{file,status,reused,...}], summary:{n_clusters,n_codegens,n_reused,n_fallback,n_failed}}`. This is what makes a multi-file upload cost one codegen per structural cluster (not per file) and produce a uniform schema — verification, not the grouping guess, is the correctness guarantee, so a wrong grouping only costs an extra codegen. `_probe_file` gained `.npz`/`.h5`/`.hdf5`/`.nxs`/`.mat` branches, a structured `.dat`/`.txt` delimited-table branch, and a `comment="#"` CSV read so combined files cluster correctly. Output collisions are prevented by a per-file subdir keyed on the absolute path hash.

**Analysis-loader TIFF metadata recovery (related fix, analyze side).** `load_image_data` reads pixels with `cv2.imread`, which drops TIFF tags. New `extract_image_metadata()` (`skills/_shared/image_analysis_tools.py`, PIL — already a dependency) parses TIFF tags, `ImageDescription` (ImageJ `key=value` / OME-XML), and resolution-tag pixel size; best-effort, never raises, `{}` for non-TIFF. `ImageAnalysisAgent.analyze()` folds it into `system_info` under `embedded_file_metadata` without overriding user-provided keys. This fixes metadata loss for *all* TIFF inputs (direct uploads), not just meta delegations.

**Thin meta tool `prepare_inputs`** (`meta_orchestrator_tools.py`): reuses `_probe_file`, lazily creates a `ScriptExecutor` behind `require_sandbox_approval`, calls the helper with `max_retries=2`, returns `data_path` + `metadata_path` (recon file is deleted after the check). Tool description + a system-prompt line make the restriction explicit (meta's only codegen; lossless prep before delegation; all analysis delegated).

**Error policy:** on a non-verifiable split the tool returns `status:error`; the meta is instructed to **surface it to the user and ask how to proceed** (analyze as-is, or supply data/metadata separately) — *not* silently delegate an unsplit file (falls back to as-is only if no user is present).

### Validation
- **Live** (`claude-opus-4-8`): combined CSV (comment-header metadata), `.npz` (array + string/scalar meta keys), HDF5 (dataset + attribute metadata), and MATLAB v5 `.mat` (array + string/scalar metadata) — all split losslessly, round-trip verified, 1 attempt each; data leg confirmed faithful against ground truth; scientific metadata top-level, bookkeeping under `_reconstruction`. Live testing surfaced (and this PR fixes) two false-rejection bugs: `.npz` string metadata keys crashing `np.allclose`, and faithful HDF5 rewrites failing byte-identity with no content fallback.
- **Unit/deterministic**: `_static_guard` (dotted-prefix allow/deny incl. `scipy.io` allowed, `from scipy import optimize` denied), `_members_equal`, `_roundtrip_ok` (npy/npz/HDF5/`.mat` accept-lossless / reject-transformed / reject-altered-metadata), `_text_equal_tolerant`, `_verify`, `_extract_script`.

### Scope / boundary
- Implements design Option A (shared helper + thin meta tool); the helper is reusable by the analysis orchestrator if wanted later.
- Heavier than a deterministic util by design — combined data+metadata files are too varied for fixed parsers; codegen+verify is the SciLink-native answer (foundation-agent extensibility loop).
- **Format coverage is bounded by `_roundtrip_ok`.** Content-aware verification exists for `.npy`/`.npz`/HDF5/`.mat`/TIFF/text; **any other extension must reconstruct byte-identically to be accepted.** There are no specialized vendor readers on the allowlist (`numpy, pandas, json, csv, struct, io, re, h5py, scipy.io, PIL, os, pathlib`), so a proprietary "vendor container" is **not** a verified capability — only a simple container the model can parse with `struct`/`numpy` and rebuild byte-for-byte would pass, and that path is untested. Adding a format = adding a content-aware branch to `_roundtrip_ok` (+ a reader to the allowlist).
- Known soft limit: the model reliably preserves all metadata losslessly, but does not always promote *every* container attribute to the top level (it may leave some only under `_reconstruction`). Losslessness is unaffected; this is a presentation preference, nudged by a prompt line rather than enforced.
