### PR TITLE
Curve fitting: handle >2-column data with system_info-guided column selection

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -260,6 +260,63 @@ def _append_auxiliary_context(prompt: list, state: dict) -> None:
         })
 
 
+def _append_column_structure(prompt: list, state: dict) -> None:
+    """Surface a >2-column file's structure so the planner can choose X/Y and
+    decide how to treat extra columns. No-op for ordinary <=2-column data."""
+    info = state.get("column_info")
+    if not info:
+        return
+    lines = [
+        f"\n## Column Structure",
+        f"This data file has {info['n_columns']} columns "
+        f"({'named' if info.get('names_known') else 'unnamed — referenced by index'}). "
+        "Decide which column is X and which is Y to fit, and note the role of the rest.",
+    ]
+    for c in info.get("per_column", []):
+        rng = (f"[{c['min']:.6g}, {c['max']:.6g}]"
+               if c.get("min") is not None else "(non-numeric)")
+        mono = ", monotonic" if c.get("monotonic") else ""
+        lines.append(f"- index {c['index']} \"{c['name']}\": range {rng}{mono}")
+    preview = info.get("preview_rows")
+    if preview:
+        lines.append("First rows: " + json.dumps(preview))
+    prompt.append("\n".join(lines))
+
+
+def _resolve_column_mapping(state: dict):
+    """Resolve the LLM's column_mapping against column_info into concrete indices.
+
+    Returns ``{x_index, y_index, names, note, extras}`` or None — None means fall
+    back to the deterministic heuristic (unresolvable / missing / x==y)."""
+    info = state.get("column_info")
+    cm = state.get("column_mapping")
+    if not info or not isinstance(cm, dict):
+        return None
+    names = info.get("names") or []
+    n = info["n_columns"]
+
+    def resolve(ref):
+        if isinstance(ref, bool):
+            return None
+        if isinstance(ref, int) and 0 <= ref < n:
+            return ref
+        if isinstance(ref, str):
+            low = ref.strip().lower()
+            for i, c in enumerate(names):
+                if str(c).strip().lower() == low:
+                    return i
+            if low.isdigit() and 0 <= int(low) < n:
+                return int(low)
+        return None
+
+    xi, yi = resolve(cm.get("x")), resolve(cm.get("y"))
+    if xi is None or yi is None or xi == yi:
+        return None
+    return {"x_index": xi, "y_index": yi, "names": names,
+            "note": state.get("column_mapping_note", ""),
+            "extras": cm.get("extras", [])}
+
+
 def _append_fit_domain_guidance(prompt: list, state: dict) -> None:
     """Surface a custom processing instruction to the planner as fit-domain
     guidance.
@@ -1216,6 +1273,44 @@ class HumanFeedbackRefinementController:
             state["_refine_feedback"] = feedback
             return state
 
+    def _apply_column_mapping_to_arrays(self, state: dict, mapping: dict) -> None:
+        """Re-slice in-memory array/DataFrame inputs to the LLM-chosen (x, y).
+
+        File inputs re-load lazily with the locked mapping (see the load path), so
+        only array/DataFrame inputs — whose data was reduced heuristically at
+        ingestion — need this in-memory correction. No-op otherwise.
+        """
+        raw = state.get("raw_first_spectrum_full")
+        if raw is None:
+            return
+        raw = np.asarray(raw)
+        if raw.ndim != 2:
+            return
+        if raw.shape[0] < raw.shape[1]:          # orient to (n_points, n_cols)
+            raw = raw.T
+        xi, yi = mapping["x_index"], mapping["y_index"]
+        if xi >= raw.shape[1] or yi >= raw.shape[1]:
+            return
+        xy = np.vstack([raw[:, xi], raw[:, yi]])  # (2, n)
+        stack = state.get("spectrum_stack")
+        if stack is not None and stack.shape[0] >= 1:
+            new_stack = stack.copy()
+            new_stack[0] = xy
+            state["spectrum_stack"] = new_stack
+        state["curve_data"] = xy
+        x, y = xy[0], xy[1]
+        state["data_statistics"] = {
+            "n_points": int(len(x)),
+            "x_range": [float(np.nanmin(x)), float(np.nanmax(x))],
+            "y_range": [float(np.nanmin(y)), float(np.nanmax(y))],
+            "y_mean": float(np.nanmean(y)),
+            "y_std": float(np.nanstd(y)),
+            "has_nans": bool(np.any(np.isnan(xy))),
+        }
+        self.logger.info(
+            f"  Re-sliced in-memory data to X=col {xi}, Y=col {yi} per column mapping."
+        )
+
     def _plan_analysis(self, state: dict) -> dict:
         prompt = [
             self.instructions,
@@ -1227,6 +1322,7 @@ class HumanFeedbackRefinementController:
 
         _append_objective_context(prompt, state)
         _append_fit_domain_guidance(prompt, state)
+        _append_column_structure(prompt, state)
 
         if state.get("analysis_hints"):
             prompt.append(f"\n## User Guidance\n{state['analysis_hints']}")
@@ -1273,6 +1369,17 @@ class HumanFeedbackRefinementController:
         state["parameters_to_extract"] = result.get("parameters_to_extract", [])
         state["fitting_strategy"] = result.get("fitting_strategy", "Standard fitting")
         state["literature_query"] = result.get("literature_query")
+
+        # Multi-column inputs: record the LLM's column decision (resolved + locked
+        # later). Only present when a Column Structure block was shown.
+        if state.get("column_info"):
+            state["column_mapping"] = result.get("column_mapping")
+            state["column_mapping_note"] = result.get("column_mapping_note", "")
+            if state["column_mapping"]:
+                self.logger.info(
+                    f"  Column mapping (LLM): {state['column_mapping']} "
+                    f"— {state['column_mapping_note']}"
+                )
 
         # Extract series analysis plan if present
         self._extract_series_plan(state, result)
@@ -1560,11 +1667,29 @@ class HumanFeedbackRefinementController:
                     self.logger.warning("  Max iterations reached.")
                     print("⚠️  Max refinements reached. Proceeding with current plan.")
 
+            # Resolve + lock the column mapping (>2-col inputs only). It applies to
+            # every spectrum (column roles are a file-structure property), so store
+            # it at a stable key the load path reads, and re-slice array/DataFrame
+            # inputs whose data is already in memory.
+            column_mapping = _resolve_column_mapping(state)
+            state["column_mapping_locked"] = column_mapping
+            if column_mapping:
+                self.logger.info(
+                    f"  ✅ Locked column mapping: X=col {column_mapping['x_index']}, "
+                    f"Y=col {column_mapping['y_index']}."
+                )
+                self._apply_column_mapping_to_arrays(state, column_mapping)
+            elif state.get("column_info"):
+                self.logger.info(
+                    "  Column mapping unresolved/absent — heuristic X/Y selection."
+                )
+
             state["locked_fitting_config"] = {
                 "analysis_approach": state.get("analysis_approach"),
                 "physical_model": state.get("physical_model"),
                 "parameters_to_extract": state.get("parameters_to_extract", []),
                 "fitting_strategy": state.get("fitting_strategy"),
+                "column_mapping": column_mapping,
             }
 
             # Build per-regime configs if series plan has multiple regimes
@@ -1584,6 +1709,8 @@ class HumanFeedbackRefinementController:
                         "fitting_strategy": regime.get(
                             "fitting_strategy", state.get("fitting_strategy")
                         ),
+                        # Column roles are a file property — same across regimes.
+                        "column_mapping": column_mapping,
                     }
                     for idx in regime.get("spectrum_indices", []):
                         regime_configs[idx] = regime_config
@@ -1614,7 +1741,9 @@ class HumanFeedbackRefinementController:
                 "physical_model": state.get("physical_model"),
                 "parameters_to_extract": state.get("parameters_to_extract", []),
                 "fitting_strategy": state.get("fitting_strategy"),
+                "column_mapping": None,
             }
+            state["column_mapping_locked"] = None
             state["series_analysis_plan"] = None
             state["regime_configs"] = None
 
@@ -2027,11 +2156,19 @@ Your guidance: '''
             "has_nans": bool(np.any(np.isnan(curve_data))),
         }
 
-    def _load_curve_data(self, data_path: str) -> np.ndarray:
-        """Load curve data from file, handling various formats."""
+    def _load_curve_data(self, data_path: str, column_mapping: dict = None) -> np.ndarray:
+        """Load curve data from file, handling various formats. When a locked
+        ``column_mapping`` is given (>2-col inputs), it selects the LLM-chosen
+        X/Y columns; otherwise the deterministic heuristic applies."""
         # Try using the project's load_curve_data function first
         try:
             from ....skills._shared.curve_fitting_tools import load_curve_data
+            if column_mapping:
+                return load_curve_data(
+                    data_path,
+                    system_info={"x_column": column_mapping.get("x_index"),
+                                 "y_column": column_mapping.get("y_index")},
+                    column_names=column_mapping.get("names"))
             return load_curve_data(data_path)
         except ImportError:
             pass
@@ -3777,7 +3914,8 @@ Return JSON with:
             else:
                 data_path = spectrum_paths[idx]
                 spectrum_name = Path(data_path).stem
-                curve_data = self._load_curve_data(data_path)
+                curve_data = self._load_curve_data(
+                    data_path, column_mapping=state.get("column_mapping_locked"))
 
             # Raw data is fed straight to the fit script, which owns preprocessing
             # (see docs/preprocessing_in_fit_loop.md). No separate preprocessing
@@ -4315,13 +4453,14 @@ class AdaptiveRefitController:
             conformance_instructions=conformance_instructions,
         )
 
-    def _load_spectrum(self, idx, spectrum_paths, spectrum_stack):
-        """Load spectrum data for re-analysis."""
+    def _load_spectrum(self, idx, spectrum_paths, spectrum_stack, column_mapping=None):
+        """Load spectrum data for re-analysis (honors the locked column mapping)."""
         if spectrum_stack is not None:
             return spectrum_stack[idx]
         if spectrum_paths and idx < len(spectrum_paths):
             try:
-                return self._fitting_helper._load_curve_data(spectrum_paths[idx])
+                return self._fitting_helper._load_curve_data(
+                    spectrum_paths[idx], column_mapping=column_mapping)
             except Exception as e:
                 self.logger.error(f"Failed to load {spectrum_paths[idx]}: {e}")
                 return None
@@ -4501,7 +4640,9 @@ class AdaptiveRefitController:
             name = entry["name"]
             self.logger.info(f"  Re-fitting [{idx}] {name} with '{target_model}'")
 
-            curve_data = self._load_spectrum(idx, spectrum_paths, spectrum_stack)
+            curve_data = self._load_spectrum(
+                idx, spectrum_paths, spectrum_stack,
+                column_mapping=state.get("column_mapping_locked"))
             if curve_data is None:
                 continue
 
@@ -4617,7 +4758,9 @@ class AdaptiveRefitController:
 
             self.logger.info(f"\n  Re-analyzing [{idx}] {name} (original R²={original_r2})")
 
-            curve_data = self._load_spectrum(idx, spectrum_paths, spectrum_stack)
+            curve_data = self._load_spectrum(
+                idx, spectrum_paths, spectrum_stack,
+                column_mapping=state.get("column_mapping_locked"))
             if curve_data is None:
                 self.logger.warning(f"  Could not load spectrum data for {name}, skipping")
                 continue

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -40,6 +40,7 @@ from .preprocess import CurvePreprocessingAgent
 from .pipelines.curve_fitting_pipelines import create_unified_curve_fitting_pipeline
 from ...skills._shared.curve_fitting_tools import (
     load_curve_data, plot_curve_to_bytes, select_xy_columns,
+    describe_columns, sniff_column_names,
 )
 from ._deprecation import normalize_params
 from ...skills.loader import load_skill
@@ -436,9 +437,16 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # orchestrator). Defaults to "fitting" when unset.
         effective_task_mode = self._resolve_task_mode(task_mode)
         
+        # Column structure for the planner (only populated for >2-col inputs);
+        # the LLM decides X/Y at planning, the heuristic is the fallback. The raw
+        # full first spectrum is retained so the lock step can re-slice array/
+        # DataFrame inputs (file inputs re-load with the locked mapping lazily).
+        column_info = None
+        raw_first_spectrum_full = None
+
         # Convert DataFrame to a 2-column (x, y) array. With >2 numeric columns,
-        # the X/Y pair is selected from column names + system_info hints rather
-        # than blindly taking the first two.
+        # capture the column structure for the planner, then heuristic-reduce for
+        # the planning plot/stats (the LLM's choice is applied at lock).
         if isinstance(data, pd.DataFrame):
             numeric_cols = data.select_dtypes(include="number")
             if numeric_cols.shape[1] < 2:
@@ -448,9 +456,11 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                               "details": f"Expected at least 2 numeric columns, got {numeric_cols.shape[1]}"},
                     "output_directory": str(self.output_dir)
                 }
-            data = select_xy_columns(numeric_cols.to_numpy(), system_info=system_info,
-                                     logger_=self.logger,
-                                     column_names=[str(c) for c in numeric_cols.columns])
+            _col_names = [str(c) for c in numeric_cols.columns]
+            raw_first_spectrum_full = numeric_cols.to_numpy()
+            column_info = describe_columns(raw_first_spectrum_full, names=_col_names)
+            data = select_xy_columns(raw_first_spectrum_full, system_info=system_info,
+                                     logger_=self.logger, column_names=_col_names)
 
         # Parse input
         data_path, data_paths, data_array, error = self._parse_data_input(data)
@@ -488,7 +498,14 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                     # Shape (n, 2): single spectrum, transpose
                     spectrum_stack = spectrum_stack.T[np.newaxis, :, :]
                 else:
-                    # >2 columns (e.g. x, y, error): select the X/Y pair, drop rest.
+                    # >2 columns (e.g. x, y, error): capture structure for the
+                    # planner, retain the raw (oriented to n_points×n_cols), then
+                    # heuristic-reduce; the LLM's choice is applied at lock.
+                    raw_first_spectrum_full = (
+                        spectrum_stack.T if spectrum_stack.shape[0] < spectrum_stack.shape[1]
+                        else spectrum_stack
+                    )
+                    column_info = describe_columns(raw_first_spectrum_full)
                     xy = select_xy_columns(spectrum_stack, system_info=system_info,
                                            logger_=self.logger)
                     spectrum_stack = xy.T[np.newaxis, :, :]
@@ -524,6 +541,14 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             try:
                 first_spectrum = load_curve_data(spectrum_paths[0], system_info=system_info)
                 first_spectrum_name = Path(spectrum_paths[0]).stem
+                # Capture the raw column structure for the planner (best-effort);
+                # the per-spectrum fit re-loads lazily with the locked mapping.
+                try:
+                    _raw0 = load_curve_data(spectrum_paths[0], auto_orient=False)
+                    column_info = describe_columns(
+                        _raw0, names=sniff_column_names(spectrum_paths[0]))
+                except Exception:
+                    column_info = None
             except Exception as e:
                 return {
                     "status": "error",
@@ -653,6 +678,12 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "data_statistics": data_statistics,
             "first_spectrum_preprocessed": first_spectrum_preprocess_quality is not None,
             "first_spectrum_preprocess_quality": first_spectrum_preprocess_quality,
+
+            # Multi-column (>2) inputs: full column structure for the planner to
+            # choose X/Y from, and the retained raw first spectrum for array/
+            # DataFrame re-slice at lock. Both None for the common <=2-col case.
+            "column_info": column_info,
+            "raw_first_spectrum_full": raw_first_spectrum_full,
 
             # Pipeline state
             "analysis_images": [{"label": "First Spectrum", "data": original_plot_bytes}],

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -38,7 +38,9 @@ from ...executors import ScriptExecutor, require_sandbox_approval
 from ..lit_agents.literature_agent import FittingModelLiteratureAgent
 from .preprocess import CurvePreprocessingAgent
 from .pipelines.curve_fitting_pipelines import create_unified_curve_fitting_pipeline
-from ...skills._shared.curve_fitting_tools import load_curve_data, plot_curve_to_bytes
+from ...skills._shared.curve_fitting_tools import (
+    load_curve_data, plot_curve_to_bytes, select_xy_columns,
+)
 from ._deprecation import normalize_params
 from ...skills.loader import load_skill
 
@@ -434,7 +436,9 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # orchestrator). Defaults to "fitting" when unset.
         effective_task_mode = self._resolve_task_mode(task_mode)
         
-        # Convert DataFrame to numpy array (first two numeric columns)
+        # Convert DataFrame to a 2-column (x, y) array. With >2 numeric columns,
+        # the X/Y pair is selected from column names + system_info hints rather
+        # than blindly taking the first two.
         if isinstance(data, pd.DataFrame):
             numeric_cols = data.select_dtypes(include="number")
             if numeric_cols.shape[1] < 2:
@@ -444,7 +448,9 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                               "details": f"Expected at least 2 numeric columns, got {numeric_cols.shape[1]}"},
                     "output_directory": str(self.output_dir)
                 }
-            data = numeric_cols.iloc[:, :2].to_numpy()
+            data = select_xy_columns(numeric_cols.to_numpy(), system_info=system_info,
+                                     logger_=self.logger,
+                                     column_names=[str(c) for c in numeric_cols.columns])
 
         # Parse input
         data_path, data_paths, data_array, error = self._parse_data_input(data)
@@ -478,9 +484,14 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 if spectrum_stack.shape[0] == 2:
                     # Shape (2, n): single spectrum with x and y
                     spectrum_stack = spectrum_stack[np.newaxis, :, :]
-                else:
+                elif spectrum_stack.shape[1] == 2:
                     # Shape (n, 2): single spectrum, transpose
                     spectrum_stack = spectrum_stack.T[np.newaxis, :, :]
+                else:
+                    # >2 columns (e.g. x, y, error): select the X/Y pair, drop rest.
+                    xy = select_xy_columns(spectrum_stack, system_info=system_info,
+                                           logger_=self.logger)
+                    spectrum_stack = xy.T[np.newaxis, :, :]
                 self.logger.info(f"2D array provided, converted to shape {spectrum_stack.shape}")
             elif spectrum_stack.ndim != 3:
                 return {
@@ -511,7 +522,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             first_spectrum_name = "spectrum_0000"
         else:
             try:
-                first_spectrum = load_curve_data(spectrum_paths[0])
+                first_spectrum = load_curve_data(spectrum_paths[0], system_info=system_info)
                 first_spectrum_name = Path(spectrum_paths[0]).stem
             except Exception as e:
                 return {

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2082,6 +2082,14 @@ not style preferences.
   the user can refine before the plan is locked
 - This plan will be translated directly into code; any ambiguity forces the code generator to guess
 
+**Column selection (only when a "## Column Structure" section is present below):**
+The data file has more than two columns and NO assumption is made about their
+order. From the listed columns (names, ranges, monotonicity, preview), decide
+which column is the independent variable X and which is the dependent variable Y
+to fit. Note the role of any other columns (e.g. an uncertainty/error column, a
+second channel, an index, an irrelevant column) and how each should be treated.
+Refer to columns by name when names are given, otherwise by index.
+
 **Output Format:**
 ```json
 {
@@ -2090,9 +2098,13 @@ not style preferences.
     "physical_model": "Mathematical form — be specific: state the exact profile/function type, exact number of components, and baseline treatment",
     "parameters_to_extract": ["param1", "param2"],
     "fitting_strategy": "How you will fit (initial guesses, constraints, method)",
-    "literature_query": "Question for literature search to help with fitting, or null if not needed"
+    "literature_query": "Question for literature search to help with fitting, or null if not needed",
+    "column_mapping": {"x": "<column name or index>", "y": "<column name or index>", "extras": [{"ref": "<name or index>", "role": "uncertainty|channel|index|ignore|...", "use": "free-text or 'none'"}]},
+    "column_mapping_note": "Brief rationale for the column-role decision"
 }
 ```
+Include `column_mapping`/`column_mapping_note` ONLY when a "## Column Structure"
+section is present; omit them entirely for ordinary two-column data.
 """
 
 

--- a/scilink/skills/_shared/curve_fitting_tools.py
+++ b/scilink/skills/_shared/curve_fitting_tools.py
@@ -129,8 +129,75 @@ def select_xy_columns(data, system_info=None, logger_=None, column_names=None) -
     return _try_orient_xy(np.column_stack([arr[:, xi], arr[:, yi]]))
 
 
+def describe_columns(data, names=None):
+    """Describe a >2-column table for the planning LLM, or None for <=2 columns.
+
+    Oriented to (n_points, n_cols) to match :func:`select_xy_columns`, so the
+    column indices the LLM returns line up with selection. Names are used when
+    provided (DataFrame/CSV header), else positional ``col_i``.
+    """
+    arr = np.asarray(data)
+    if arr.ndim != 2:
+        return None
+    if arr.shape[0] < arr.shape[1]:   # orient: many more points than columns
+        arr = arr.T
+    n_cols = arr.shape[1]
+    if n_cols <= 2:
+        return None
+    names_known = bool(names) and len(names) >= n_cols
+    names = ([str(c) for c in names[:n_cols]] if names_known
+             else [f"col_{i}" for i in range(n_cols)])
+    per_column = []
+    for i in range(n_cols):
+        col = arr[:, i]
+        is_num = np.issubdtype(col.dtype, np.number)
+        finite = col[np.isfinite(col)] if is_num else col
+        mono = (is_num and col.size >= 2
+                and (np.all(np.diff(col) > 0) or np.all(np.diff(col) < 0)))
+        per_column.append({
+            "index": i, "name": names[i],
+            "min": float(np.min(finite)) if is_num and finite.size else None,
+            "max": float(np.max(finite)) if is_num and finite.size else None,
+            "monotonic": bool(mono),
+        })
+    return {"n_columns": n_cols, "names": names, "names_known": names_known,
+            "per_column": per_column, "preview_rows": arr[:5].tolist()}
+
+
+def sniff_column_names(data_path):
+    """Best-effort header sniff for a delimited text file → column names or None.
+
+    None for headerless files (every header token parses as a number) and for
+    formats without a textual header (.npy / binary)."""
+    ext = os.path.splitext(str(data_path))[1].lower()
+    if ext not in (".csv", ".tsv", ".dat", ".txt"):
+        return None
+    try:
+        import pandas as pd
+        sep = "\t" if ext == ".tsv" else ("," if ext == ".csv" else r"\s+")
+        df = pd.read_csv(data_path, sep=sep, comment="#", nrows=5, engine="python")
+        cols = [str(c) for c in df.columns]
+
+        def _isnum(s):
+            cands = [s]
+            if s.count(".") > 1:           # drop pandas '.N' duplicate-name suffix
+                cands.append(s.rsplit(".", 1)[0])
+            for c in cands:
+                try:
+                    float(c); return True
+                except ValueError:
+                    pass
+            return False
+        # If most "names" parse as numbers, there was no header row (the data row
+        # was misread as the header) → positional names are the safe choice.
+        numeric = sum(_isnum(c) for c in cols)
+        return None if numeric * 2 >= len(cols) else cols
+    except Exception:
+        return None
+
+
 def load_curve_data(data_path: str, auto_orient: bool = True,
-                    system_info: dict = None) -> np.ndarray:
+                    system_info: dict = None, column_names: list = None) -> np.ndarray:
     """
     Robustly loads curve data (X, Y) from various file formats.
     Handles .npy, .h5/.hdf5/.nxs (NeXus), CSV, TSV, and whitespace separation
@@ -141,14 +208,16 @@ def load_curve_data(data_path: str, auto_orient: bool = True,
     oriented so the monotonic (X) column comes first, and a >2-column table (an
     extra error/weight column, multiple channels) is reduced to the chosen X/Y
     pair — guided by ``system_info`` (``x_column``/``y_column`` or ``columns``)
-    when given, else by an axis-name / monotonicity heuristic. Pass
-    ``auto_orient=False`` for legacy raw-layout behavior (no reduction).
+    and ``column_names`` when given, else by an axis-name / monotonicity
+    heuristic. Pass ``auto_orient=False`` for legacy raw-layout behavior.
     """
     if not os.path.exists(data_path):
         raise FileNotFoundError(f"File not found: {data_path}")
 
     def _finish(arr):
-        return select_xy_columns(arr, system_info=system_info) if auto_orient else arr
+        return (select_xy_columns(arr, system_info=system_info,
+                                  column_names=column_names)
+                if auto_orient else arr)
 
     # Native numpy format
     if data_path.endswith('.npy'):

--- a/scilink/skills/_shared/curve_fitting_tools.py
+++ b/scilink/skills/_shared/curve_fitting_tools.py
@@ -38,25 +38,121 @@ def _try_orient_xy(data: np.ndarray) -> np.ndarray:
     return data
 
 
-def load_curve_data(data_path: str, auto_orient: bool = True) -> np.ndarray:
+# Column-name fragments that strongly suggest the independent (X) variable, used
+# to pick X from a >2-column table when no explicit hint is given.
+_X_AXIS_HINTS = (
+    "2theta", "two_theta", "twotheta", "theta", "angle", "wavelength", "wavenumber",
+    "energy", "ev", "raman", "shift", "time", "freq", "frequency", "temperature",
+    "temp", "field", "position", "distance", "voltage", "bias", "delay", "q", "x",
+)
+# Fragments suggesting a column is NOT the signal (uncertainty/weight columns) —
+# avoided when choosing Y.
+_NON_Y_HINTS = ("err", "error", "sigma", "std", "uncert", "weight", "noise")
+
+
+def _choose_xy_indices(arr, system_info, column_names, log):
+    """Pick (x_index, y_index) from a >2-column array.
+
+    Priority: (1) explicit ``x_column``/``y_column`` in system_info (name or
+    index); (2) a column whose name matches an axis hint as X + first non-error
+    column as Y; (3) the single monotonic column as X; (4) first two columns.
+    """
+    n = arr.shape[1]
+    si = system_info if isinstance(system_info, dict) else {}
+    names = column_names or si.get("columns")
+    low = [str(c).strip().lower() for c in names[:n]] if names and len(names) >= n else None
+
+    def resolve(spec):
+        if isinstance(spec, bool):
+            return None
+        if isinstance(spec, int) and 0 <= spec < n:
+            return spec
+        if isinstance(spec, str) and low:
+            for i, c in enumerate(low):
+                if c == spec.strip().lower():
+                    return i
+        return None
+
+    xi, yi = resolve(si.get("x_column")), resolve(si.get("y_column"))
+    if xi is not None and yi is not None and xi != yi:
+        return xi, yi
+
+    if low:  # name-hint heuristic
+        x_guess = next((i for i, c in enumerate(low)
+                        if any(h in c for h in _X_AXIS_HINTS)), None)
+        if x_guess is not None:
+            y_guess = next((i for i in range(n) if i != x_guess
+                            and not any(b in low[i] for b in _NON_Y_HINTS)),
+                           next((i for i in range(n) if i != x_guess), None))
+            return x_guess, y_guess
+
+    for i in range(n):  # monotonic-column heuristic
+        col = arr[:, i]
+        if col.size >= 2 and np.all(np.isfinite(col)) and \
+                (np.all(np.diff(col) > 0) or np.all(np.diff(col) < 0)):
+            return i, next(j for j in range(n) if j != i)
+
+    return 0, 1  # default: first two columns
+
+
+def select_xy_columns(data, system_info=None, logger_=None, column_names=None) -> np.ndarray:
+    """Reduce array-like curve data to a 2-column ``(x, y)`` array.
+
+    Curve fitting is a 1D (x, y) operation, but real files arrive with extra
+    columns (an error/weight column, multiple channels) or in row layout. This
+    centralizes the reduction: 1D → ``(index, y)``; row-major ``(2, N)`` →
+    transposed; ``(N, 2)`` → oriented; ``(N, M>2)`` → X/Y selected (see
+    ``_choose_xy_indices``) and the rest dropped (logged). Column SELECTION is an
+    analysis decision and so lives here — lossless file-prep keeps all columns.
+    """
+    log = logger_ or logger
+    arr = np.asarray(data)
+    if arr.ndim == 1:
+        return np.column_stack([np.arange(arr.size), arr])
+    if arr.ndim != 2:
+        raise ValueError(f"Expected 1D or 2D curve data, got {arr.ndim}D")
+    # Orient to (n_points, n_cols): curve data has many more points than columns.
+    if arr.shape[0] < arr.shape[1]:
+        arr = arr.T
+    n_cols = arr.shape[1]
+    if n_cols == 1:
+        return np.column_stack([np.arange(arr.shape[0]), arr[:, 0]])
+    if n_cols == 2:
+        return _try_orient_xy(np.ascontiguousarray(arr))
+    xi, yi = _choose_xy_indices(arr, system_info, column_names, log)
+    if log:
+        cols_desc = f" ({column_names})" if column_names else ""
+        log.warning(
+            f"select_xy_columns: {n_cols}-column data{cols_desc} reduced to "
+            f"(X=col {xi}, Y=col {yi}); other columns dropped for fitting."
+        )
+    return _try_orient_xy(np.column_stack([arr[:, xi], arr[:, yi]]))
+
+
+def load_curve_data(data_path: str, auto_orient: bool = True,
+                    system_info: dict = None) -> np.ndarray:
     """
     Robustly loads curve data (X, Y) from various file formats.
     Handles .npy, .h5/.hdf5/.nxs (NeXus), CSV, TSV, and whitespace separation
     automatically.
 
-    When ``auto_orient`` is True (default), a 2-column result whose first
-    column is non-monotonic but second column is monotonic is reoriented so
-    X comes first — fixing inputs where intensity precedes the independent
-    variable (e.g. CSVs whose header is ``intensity, time``). Pass
-    ``auto_orient=False`` for legacy raw-layout behavior.
+    When ``auto_orient`` is True (default), the result is normalized to a
+    2-column ``(X, Y)`` array via :func:`select_xy_columns`: a 2-column array is
+    oriented so the monotonic (X) column comes first, and a >2-column table (an
+    extra error/weight column, multiple channels) is reduced to the chosen X/Y
+    pair — guided by ``system_info`` (``x_column``/``y_column`` or ``columns``)
+    when given, else by an axis-name / monotonicity heuristic. Pass
+    ``auto_orient=False`` for legacy raw-layout behavior (no reduction).
     """
     if not os.path.exists(data_path):
         raise FileNotFoundError(f"File not found: {data_path}")
 
+    def _finish(arr):
+        return select_xy_columns(arr, system_info=system_info) if auto_orient else arr
+
     # Native numpy format
     if data_path.endswith('.npy'):
-        data = np.load(data_path)
-        return _try_orient_xy(data) if auto_orient else data
+        return _finish(np.load(data_path))
 
     # NeXus / HDF5 — pull the signal and (when present) its axis so we
     # can return (X, Y) pairs for callers that expect a 2D layout.
@@ -65,7 +161,7 @@ def load_curve_data(data_path: str, auto_orient: bool = True) -> np.ndarray:
         signal, axes = load_hdf5_signal(data_path, return_axes=True)
         if signal.ndim == 1 and axes and axes[0] is not None and axes[0].size == signal.size:
             return np.column_stack([axes[0], signal])
-        return _try_orient_xy(signal) if auto_orient else signal
+        return _finish(signal)
 
     attempts = [
         dict(),                                # whitespace-delimited, no header
@@ -78,7 +174,7 @@ def load_curve_data(data_path: str, auto_orient: bool = True) -> np.ndarray:
         try:
             data = np.loadtxt(data_path, **kw)
             if data.size > 0:
-                return _try_orient_xy(data) if auto_orient else data
+                return _finish(data)
         except Exception:
             pass
 


### PR DESCRIPTION
Make the curve-fitting agent accept data files with more than two columns.

## Summary (for scientists)

Curve fitting is a 1D operation — it needs an X column (e.g. 2θ, energy, wavelength, time) and a Y column (intensity/signal). But real exports often carry a third column (e.g. a measurement error/weight) or several channels. Until now SciLink either **errored** ("Unexpected data shape") on such a file or silently grabbed the first two columns — which is wrong when, say, the file is `[index, x, y]` or the signal you want isn't the second column.

Now the agent reduces any multi-column file to the correct `(x, y)` pair. If you tell it which columns to use (e.g. `x_column: "energy"`, `y_column: "intensity"`), it uses those; otherwise it picks sensibly — recognizing common axis names (2θ, energy, wavelength, …) as X, avoiding an obvious error column for Y, and falling back to the monotonic column or the first two. The extra columns are dropped only for the fit (your file is untouched), and the choice is logged.

This pairs with the meta file-prep work (#232): that step keeps all columns and records their names in metadata; this step consumes those names to pick the right pair.

## Technical details (for AI reviewers)

**`select_xy_columns(data, system_info=None, logger_=None, column_names=None) -> (N, 2)`** in `scilink/skills/_shared/curve_fitting_tools.py` — the single source of truth for "array-like → 2-column (x, y)":
- 1D → `(arange, y)`; row-major `(2, N)` → transposed; `(N, 2)` → `_try_orient_xy`; `(N, M>2)` → X/Y selected via `_choose_xy_indices`, others dropped (warn-logged). Orientation: arrays with `shape[0] < shape[1]` are transposed (curve data has many more points than columns).
- `_choose_xy_indices` priority: (1) explicit `system_info["x_column"]`/`["y_column"]` (int index or column name); (2) column-name axis hint (`_X_AXIS_HINTS`) for X + first non-error column (`_NON_Y_HINTS`) for Y; (3) the single monotonic column as X; (4) first two columns.

**Wiring:**
- `load_curve_data(path, auto_orient=True, system_info=None)` routes every array return through `select_xy_columns`, so a >2-column file loaded from *any* call site reduces to `(x, y)` (heuristic when `system_info` isn't threaded, guided when it is). Legacy `auto_orient=False` still returns raw layout.
- `curve_fitting_agent.analyze()`: the DataFrame branch (was `numeric_cols.iloc[:, :2]`) and the direct-array `(N, M>2)` branch (was `else:` → transposed-as-if-2-col → downstream `raise`) now call `select_xy_columns` with column names + `system_info`; the first-spectrum path load passes `system_info`. The pre-existing `shape[0]==2 / shape[1]==2 / else: raise "Unexpected data shape"` branches remain as defensive guards — they now receive ≤2-column data because reduction happens upstream.

**Scope:** column selection is an analysis decision, so it lives in the curve-fitting agent — lossless file-prep (#232) deliberately keeps every column and records names. Controllers' internal `load_curve_data(path)` calls reduce via the loader default (heuristic); `system_info`-guided selection is wired at the `analyze()` entry points where the hint is in scope.

### Validation
- **Deterministic:** `select_xy_columns` across 1D / `(2,N)` / `(N,2)` / `(N,3)` with explicit-index, column-name (Y correctly avoids the `error` column), monotonic, and first-two-default selection; `load_curve_data` on a 3-column `.dat` → `(N, 2)`; the `analyze()` ingestion branch reduces `(N,3)` → a `(1, 2, N)` stack with faithful X/Y (so the downstream shape-branches see valid 2-row data, no `raise`). Module imports cleanly.
- **Live (end-to-end, `claude-opus-4-8`):** a 3-column `.dat` (energy, intensity, error) run through the full `agent.analyze()` pipeline with `system_info={x_column: energy, y_column: intensity}` — no "Unexpected data shape" error; the agent fit a Single Gaussian + constant background with **R² = 0.9998, RMSE = 0.048**, i.e. it fit intensity vs energy and ignored the error column (a wrong-column pick would have collapsed R²).

### Known limits / follow-ups
- Heuristic X/Y selection is best-effort; the reliable path is an explicit `x_column`/`y_column` (or column names) in `system_info`.
- Controllers' internal loads use the heuristic (no `system_info` threaded); threading it through `_load_curve_data` is a possible follow-up if guided selection is wanted at every load site.


## Update: LLM-driven column selection (Phase 1)

Beyond the heuristic above, the **planning LLM** now decides the column mapping for >2-column files (no hardcoded column taxonomy). At ingestion the full column structure (`describe_columns`: names, per-column stats, monotonicity, preview; names sniffed from DataFrame / CSV header / positional) is captured into `state["column_info"]` *before* the heuristic reduction. The planning prompt (`CURVE_ANALYSIS_INSTRUCTIONS`) gains an optional "## Column Structure" block and `column_mapping`/`column_mapping_note` output fields; `_plan_analysis` shows the block and parses the choice. The lock (`_resolve_column_mapping`) turns the LLM's pick into concrete indices (falling back to the heuristic on unresolvable/`x==y`), stores it in `column_mapping_locked` + the locked/regime configs, and re-slices in-memory array/DataFrame inputs. The per-spectrum loaders (`_load_curve_data`, refit `_load_spectrum`) apply the locked mapping, so the fit reloads honor it (file series + adaptive refit + parallel). The heuristic `select_xy_columns` is now the *executor* of the LLM's choice (threaded as `x_column`/`y_column`) and the *fallback* when absent. The ~7 downstream 2-column sites are untouched (primary stays 2-col); extra columns are recorded in `column_mapping["extras"]` but not yet used.

**Live (claude-opus-4-8):** a 3-column file `[energy_eV, transmittance (decoy monotonic), absorbance (Gaussian peak)]` with **no** explicit x/y hint — the LLM chose X=`energy_eV`, Y=`absorbance` (col 2, *not* the heuristic's `transmittance`), recorded `transmittance` as a complementary channel (A = -log10 T), and the fit was a Gaussian peak at **R²=0.9998**. Proves the LLM decision drives the fit over the heuristic.

### Deferred to a follow-up PR (Phase 2)
*Using* the LLM-selected extra columns in the fit (e.g. an uncertainty column as fit weights, or a second channel) via per-spectrum auxiliary operands. Kept separate: it touches codegen prompt semantics, the per-spectrum materialization, adaptive-refit + parallel plumbing, and a fragile per-spectrum script-adaptation regex (silent-wrong-weights risk). `column_mapping["extras"]` is already captured here, so Phase 2 only needs to act on it.