### PR TITLE
Replace per-item script-adaptation regex with per-item working dir + canonical filenames

### DIFF
--- a/scilink/agents/exp_agents/_locked_exec.py
+++ b/scilink/agents/exp_agents/_locked_exec.py
@@ -1,0 +1,72 @@
+"""Shared locked-script execution for the series-based foundation agents.
+
+Both the curve-fitting and image-analysis agents lock one LLM-generated script
+after planning and reuse it across every item in a series. The reuse used to be
+done by **regex-rewriting the generated source** per item (the data path, the
+visualization filename, and a `glob.glob('*.npy')` neutralization) — fragile,
+because a path the regex didn't anticipate silently made the script read the
+wrong item.
+
+This module replaces that with a simple, robust contract: run the locked script
+**verbatim** in a per-item working directory where the primary data is staged
+under a canonical name (``data.npy``) and the script writes a canonical
+``visualization.png``. No source rewriting, no cross-item glob hazard (each cwd
+holds only that item's files). The codegen prompts tell the model to read
+``data.npy`` from the working directory and save ``visualization.png``; a guard
+(:func:`script_uses_canonical_input`) rejects a script that ignores the contract,
+so a non-conforming script fails the caller's existing verify/retry loop rather
+than silently mis-reading.
+
+Marker parsing stays with each caller (curve-fitting and image analysis use
+different markers and post-processing), so this helper only owns the part that
+was actually duplicated and fragile.
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+DATA_NAME = "data.npy"
+VIZ_NAME = "visualization.png"
+
+
+def script_uses_canonical_input(script: str, data_name: str = DATA_NAME) -> bool:
+    """True if the generated script references the canonical input filename.
+
+    Cheap guard against a script that hardcodes some other path instead of
+    reading the staged ``data.npy`` from the working directory."""
+    return bool(script) and data_name in script
+
+
+def stage_and_run(executor, script, primary_array, item_dir, *,
+                  data_name: str = DATA_NAME, viz_name: str = VIZ_NAME,
+                  aux: dict = None) -> dict:
+    """Stage ``primary_array`` as ``data_name`` in ``item_dir`` and run ``script``
+    VERBATIM there (working_dir=item_dir), then collect the canonical viz.
+
+    ``aux`` (optional) maps extra canonical filenames -> arrays to stage alongside
+    the primary (e.g. weights). Returns a dict with the raw executor result, its
+    stdout/status, and the located visualization path/bytes — the caller parses
+    its own stdout marker and assembles its result dict.
+    """
+    item_dir = Path(item_dir)
+    item_dir.mkdir(parents=True, exist_ok=True)
+    np.save(item_dir / data_name, primary_array)
+    for name, arr in (aux or {}).items():
+        np.save(item_dir / name, arr)
+
+    viz = item_dir / viz_name
+    viz.unlink(missing_ok=True)   # clear any stale viz before the run
+
+    exec_res = executor.execute_script(script, working_dir=str(item_dir))
+
+    has_viz = viz.exists()
+    return {
+        "exec": exec_res,
+        "status": exec_res.get("status"),
+        "stdout": exec_res.get("stdout", "") or "",
+        "stderr": exec_res.get("stderr", "") or "",
+        "visualization_path": str(viz) if has_viz else None,
+        "visualization_bytes": viz.read_bytes() if has_viz else None,
+        "item_dir": str(item_dir),
+    }

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -31,6 +31,8 @@ from datetime import datetime
 from typing import Callable, Optional, Any, Dict, List
 import numpy as np
 
+from .._locked_exec import stage_and_run, script_uses_canonical_input, DATA_NAME
+
 
 def _active_skill_names(state: dict) -> list[str]:
     """Return names of all currently-loaded skills from a pipeline state dict.
@@ -1977,35 +1979,6 @@ Your guidance: '''
             self.logger.debug("Plan conformance check failed: %s", exc)
             return None
 
-    def _adapt_script_for_spectrum(self, base_script: str, data_path: str, output_prefix: str) -> str:
-        # Forward slashes so Windows paths like 'C:\Users\...' don't trigger
-        # re.sub's backslash-escape interpretation in the replacement string.
-        data_path = data_path.replace('\\', '/')
-        adapted = base_script
-        adapted = adapted.replace('fit_visualization.png', f'{output_prefix}_fit.png')
-        adapted = re.sub(r'spectrum_\d{4}_fit\.png', f'{output_prefix}_fit.png', adapted)
-        adapted = re.sub(r'spectrum_\d{4}_T\d+K_fit\.png', f'{output_prefix}_fit.png', adapted)
-        adapted = re.sub(
-            r'np\.load\s*\(\s*["\'"].*?temp_spectrum_\d+\.npy["\'"]\s*\)',
-            f'np.load("{data_path}")',
-            adapted
-        )
-        adapted = re.sub(r'(["\'"]).*?temp_spectrum_\d+\.npy\1', f'"{data_path}"', adapted)
-        adapted = re.sub(r'DATA_PATH\s*=\s*["\'"].*?["\'"]', f'DATA_PATH = "{data_path}"', adapted)
-        adapted = re.sub(r'data_path\s*=\s*["\'"].*?["\'"]', f'data_path = "{data_path}"', adapted)
-        # Neutralize LLM-introduced `glob.glob('*.npy')` fallbacks: in parallel
-        # fan-out, multiple spectra's temp files coexist briefly, and a glob
-        # for `*.npy` can find a sibling spectrum's file instead of the
-        # adapted one. Constrain each glob to the pinned data_path. The
-        # `[^()]` class refuses to span nested parens so calls like
-        # `glob.glob(os.path.join(d, '*.npy'))` are left intact rather than
-        # being chopped mid-expression.
-        adapted = re.sub(
-            r'glob\.glob\s*\([^()]*\.npy[^()]*\)',
-            f'["{data_path}"]',
-            adapted,
-        )
-        return adapted
 
     def _compute_statistics(self, curve_data: np.ndarray) -> dict:
         if curve_data.ndim == 1:
@@ -2092,37 +2065,34 @@ Your guidance: '''
         refine_from_issues: Optional[list] = None,
     ) -> dict:
         stats = self._compute_statistics(curve_data)
-        temp_data_path = self.output_dir / f"temp_spectrum_{spectrum_idx}.npy"
-        np.save(temp_data_path, curve_data)
+        # Per-spectrum working dir: the locked script runs VERBATIM here with data
+        # staged as the canonical DATA_NAME and viz written canonically — no
+        # per-spectrum source rewriting, no cross-item glob hazard.
         output_prefix = f"spectrum_{spectrum_idx:04d}"
-        
-        # Clean up any existing visualization files for this spectrum to ensure fresh output
-        for old_viz in [
-            self.output_dir / f"{output_prefix}_fit.png",
-            self.output_dir / "fit_visualization.png",
-        ]:
-            if old_viz.exists():
-                try:
-                    os.remove(old_viz)
-                except:
-                    pass
-        
+        item_dir = self.output_dir / output_prefix
+
         script = None
         last_error = ""
-        exec_result = None
+        run = None
         script_errors: list[dict] = []
 
         for attempt in range(1, self.MAX_ATTEMPTS + 1):
             try:
                 if base_script is not None and attempt == 1:
-                    script = self._adapt_script_for_spectrum(base_script, str(temp_data_path), output_prefix)
+                    script = base_script   # reuse VERBATIM (loads DATA_NAME from cwd)
                 elif attempt == 1:
                     script = self._generate_fitting_script(
-                        state, str(temp_data_path), stats,
+                        state, DATA_NAME, stats,
                         prior_script=refine_from_script,
                         prior_r2=refine_from_r2,
                         prior_issues=refine_from_issues,
                     )
+                    if not script_uses_canonical_input(script):
+                        last_error = (
+                            f"Script must load the data from '{DATA_NAME}' in the "
+                            "current working directory (np.load), not another path."
+                        )
+                        continue
                     # Check conformance with locked plan on fresh generation
                     conformance = self._check_plan_conformance(state, script)
                     if conformance and not conformance.get("conformant", True):
@@ -2151,49 +2121,42 @@ Your guidance: '''
                     script, diagnosis = self._correct_script(state, script, last_error)
                     script_errors.append({"error": last_error, "diagnosis": diagnosis})
 
-                exec_result = self.executor.execute_script(script, working_dir=str(self.output_dir))
+                run = stage_and_run(self.executor, script, curve_data, item_dir)
+                exec_result = run["exec"]
 
-                if exec_result.get("status") == "success":
-                    # Check if the script actually produced the expected outputs
-                    stdout = exec_result.get("stdout", "")
-                    has_fit_results = "FIT_RESULTS_JSON:" in stdout
-                    
-                    # Check for visualization file
-                    viz_path = self.output_dir / f"{output_prefix}_fit.png"
-                    if not viz_path.exists():
-                        viz_path = self.output_dir / "fit_visualization.png"
-                    has_visualization = viz_path.exists()
-                    
+                if run["status"] == "success":
+                    has_fit_results = "FIT_RESULTS_JSON:" in run["stdout"]
+                    has_visualization = run["visualization_path"] is not None
+
                     if has_fit_results and has_visualization:
-                        # Script truly succeeded - produced expected outputs
                         break
                     else:
-                        # Script ran but didn't produce expected outputs
                         missing = []
                         if not has_fit_results:
                             missing.append("FIT_RESULTS_JSON output")
                         if not has_visualization:
                             missing.append("visualization file")
-                        last_error = f"Script executed but did not produce expected outputs. Missing: {', '.join(missing)}. The script must print 'FIT_RESULTS_JSON:{{...}}' with fit results and save a visualization to '{output_prefix}_fit.png'."
+                        last_error = (
+                            f"Script executed but did not produce expected outputs. "
+                            f"Missing: {', '.join(missing)}. The script must print "
+                            f"'FIT_RESULTS_JSON:{{...}}' with fit results and save "
+                            f"'visualization.png' in the working directory."
+                        )
                         self.logger.warning(f"    ⚠️ Attempt {attempt}: Script ran but missing outputs: {', '.join(missing)}")
-                        if attempt >= self.MAX_ATTEMPTS:
-                            # Last attempt also failed to produce outputs
-                            exec_result["status"] = "failed"
-                            exec_result["message"] = last_error
                 else:
                     last_error = exec_result.get("message", "Unknown error")
                     self.logger.warning(f"    ⚠️ Attempt {attempt} failed: {last_error[:100]}")
             except Exception as e:
                 last_error = str(e)
                 self.logger.error(f"    ❌ Attempt {attempt} error: {e}")
-        
-        if temp_data_path.exists():
-            try:
-                os.remove(temp_data_path)
-            except:
-                pass
-        
-        if exec_result is None or exec_result.get("status") != "success":
+
+        # Success iff the final run produced BOTH the marker and the viz (matches
+        # the break condition); run["status"] alone is a snapshot and can be
+        # "success" even when outputs are missing.
+        ok = (run is not None and run["status"] == "success"
+              and run["visualization_path"] is not None
+              and "FIT_RESULTS_JSON:" in run["stdout"])
+        if not ok:
             return {
                 "index": spectrum_idx,
                 "name": spectrum_name,
@@ -2204,22 +2167,9 @@ Your guidance: '''
                 "script": script,
                 "script_errors": script_errors,
             }
-        
-        fit_results = _parse_script_markers(exec_result.get("stdout"))
-        
-        viz_path = self.output_dir / f"{output_prefix}_fit.png"
-        if not viz_path.exists():
-            viz_path = self.output_dir / "fit_visualization.png"
-        
-        viz_bytes = None
-        if viz_path.exists():
-            with open(viz_path, "rb") as f:
-                viz_bytes = f.read()
-            final_viz_path = self.output_dir / f"{output_prefix}_fit.png"
-            if viz_path != final_viz_path:
-                viz_path.rename(final_viz_path)
-            viz_path = final_viz_path
-        
+
+        fit_results = _parse_script_markers(run["stdout"])
+
         return {
             "index": spectrum_idx,
             "name": spectrum_name,
@@ -2230,8 +2180,8 @@ Your guidance: '''
             "parameters": fit_results.get("parameters", {}),
             "fit_quality": fit_results.get("fit_quality", {}),
             "deviation_note": fit_results.get("deviation_note") or fit_results.get("summary"),
-            "visualization_path": str(viz_path) if viz_path.exists() else None,
-            "visualization_bytes": viz_bytes,
+            "visualization_path": run["visualization_path"],
+            "visualization_bytes": run["visualization_bytes"],
             "statistics": stats,
             "script": script,
             "script_errors": script_errors,

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -31,6 +31,8 @@ from datetime import datetime
 from typing import Callable, Optional, Any, Dict, List
 import numpy as np
 
+from .._locked_exec import stage_and_run, script_uses_canonical_input, DATA_NAME, VIZ_NAME
+
 
 # Anthropic's API rejects images over 5 MB. Cap below that with headroom
 # for base64 expansion and other margin so generated visualizations don't
@@ -2285,38 +2287,6 @@ Your guidance: '''
             self.logger.debug("Plan conformance check failed: %s", exc)
             return None
 
-    def _adapt_script_for_image(self, base_script: str, data_path: str, output_prefix: str) -> str:
-        """Adapt a base analysis script for a different image in the series."""
-        # Forward slashes so Windows paths like 'C:\Users\...' don't trigger
-        # re.sub's backslash-escape interpretation in the replacement string.
-        data_path = data_path.replace('\\', '/')
-        adapted = base_script
-        # Replace visualization output filenames
-        adapted = adapted.replace('analysis_visualization.png', f'{output_prefix}_analysis.png')
-        adapted = re.sub(r'image_\d{4}_analysis\.png', f'{output_prefix}_analysis.png', adapted)
-        # Replace data path references
-        adapted = re.sub(
-            r'np\.load\s*\(\s*["\'"].*?temp_image_\d+\.npy["\'"]\s*\)',
-            f'np.load("{data_path}")',
-            adapted
-        )
-        adapted = re.sub(r'(["\'"]).*?temp_image_\d+\.npy\1', f'"{data_path}"', adapted)
-        adapted = re.sub(r'DATA_PATH\s*=\s*["\'"].*?["\'"]', f'DATA_PATH = "{data_path}"', adapted)
-        adapted = re.sub(r'data_path\s*=\s*["\'"].*?["\'"]', f'data_path = "{data_path}"', adapted)
-        # Neutralize LLM-introduced `glob.glob('*.npy')` fallbacks: in parallel
-        # fan-out, multiple images' temp files coexist briefly, and a glob
-        # for `*.npy` can find a sibling image's file instead of the
-        # adapted one. Constrain each glob to the pinned data_path. The
-        # `[^()]` class refuses to span nested parens so calls like
-        # `glob.glob(os.path.join(d, '*.npy'))` are left intact rather than
-        # being chopped mid-expression.
-        adapted = re.sub(
-            r'glob\.glob\s*\([^()]*\.npy[^()]*\)',
-            f'["{data_path}"]',
-            adapted,
-        )
-        return adapted
-
     @staticmethod
     def _load_image_data(image_path: str) -> np.ndarray:
         """Load image data from file, handling various formats."""
@@ -2345,10 +2315,10 @@ Your guidance: '''
 
         Two independent ways to carry a previous script forward:
 
-        - ``base_script`` — series-level adaptation. When provided, the first
-          attempt substitutes data paths / output names via
-          ``_adapt_script_for_image`` without invoking the LLM. Used to
-          keep pipeline consistent across images in a series.
+        - ``base_script`` — series-level reuse. When provided, the first attempt
+          runs it VERBATIM (no LLM) in this image's working directory, where the
+          image is staged as the canonical ``data.npy``. Used to keep the
+          pipeline consistent across images in a series.
         - ``refine_from_script`` — refinement-iteration adaptation. When
           provided, the first attempt calls ``_generate_analysis_script``
           with ``base_script=refine_from_script`` so the refinement prompt
@@ -2361,45 +2331,36 @@ Your guidance: '''
         """
         stats = compute_image_statistics(image_data)
 
-        # Create working directory for this image
+        # Per-image working directory: the locked script runs VERBATIM here with the
+        # image staged as the canonical DATA_NAME and the viz written canonically —
+        # no per-image source rewriting, no cross-item glob hazard.
         working_dir = self.output_dir / f"image_{image_idx:04d}"
         working_dir.mkdir(parents=True, exist_ok=True)
-
-        # Save image as .npy for the script to load
-        temp_data_path = working_dir / f"temp_image_{image_idx}.npy"
-        np.save(temp_data_path, image_data)
         output_prefix = f"image_{image_idx:04d}"
-
-        # Clean up any existing visualization files for this image
-        for old_viz in [
-            working_dir / f"{output_prefix}_analysis.png",
-            working_dir / "analysis_visualization.png",
-        ]:
-            if old_viz.exists():
-                try:
-                    os.remove(old_viz)
-                except Exception:
-                    pass
 
         script = None
         last_error = ""
-        exec_result = None
+        run = None
         script_errors = []
         last_diagnosis = None
 
         for attempt in range(1, self.MAX_ATTEMPTS + 1):
             try:
                 if base_script is not None and attempt == 1:
-                    script = self._adapt_script_for_image(
-                        base_script, str(temp_data_path), output_prefix
-                    )
+                    script = base_script   # reuse VERBATIM (loads DATA_NAME from cwd)
                 elif attempt == 1:
                     script = self._generate_analysis_script(
                         state,
-                        str(temp_data_path),
+                        DATA_NAME,
                         stats,
                         base_script=refine_from_script,
                     )
+                    if not script_uses_canonical_input(script):
+                        last_error = (
+                            f"Script must load the image from '{DATA_NAME}' in the "
+                            "current working directory (np.load), not another path."
+                        )
+                        continue
                     # Check conformance with locked plan on fresh generation
                     conformance = self._check_conformance(state, script)
                     if conformance and not conformance.get("conformant", True):
@@ -2432,19 +2393,12 @@ Your guidance: '''
                 # Sanitize the script
                 script = self._sanitize_script(script)
 
-                exec_result = self.executor.execute_script(
-                    script, working_dir=str(working_dir)
-                )
+                run = stage_and_run(self.executor, script, image_data, working_dir)
+                exec_result = run["exec"]
 
-                if exec_result.get("status") == "success":
-                    stdout = exec_result.get("stdout", "")
-                    has_results = "IMAGE_ANALYSIS_RESULTS_JSON:" in stdout
-
-                    # Check for visualization file
-                    viz_path = working_dir / f"{output_prefix}_analysis.png"
-                    if not viz_path.exists():
-                        viz_path = working_dir / "analysis_visualization.png"
-                    has_visualization = viz_path.exists()
+                if run["status"] == "success":
+                    has_results = "IMAGE_ANALYSIS_RESULTS_JSON:" in run["stdout"]
+                    has_visualization = run["visualization_path"] is not None
 
                     if has_results and has_visualization:
                         break
@@ -2458,8 +2412,7 @@ Your guidance: '''
                             f"Script executed but did not produce expected outputs. "
                             f"Missing: {', '.join(missing)}. The script must print "
                             f"'IMAGE_ANALYSIS_RESULTS_JSON:{{...}}' with analysis results "
-                            f"and save a visualization to '{output_prefix}_analysis.png' "
-                            f"or 'analysis_visualization.png'."
+                            f"and save 'visualization.png' in the working directory."
                         )
                         self.logger.warning(
                             f"    Attempt {attempt}: Script ran but missing outputs: "
@@ -2471,9 +2424,6 @@ Your guidance: '''
                             "fix": (last_diagnosis or "")[:300] or None,
                         })
                         last_diagnosis = None
-                        if attempt >= self.MAX_ATTEMPTS:
-                            exec_result["status"] = "failed"
-                            exec_result["message"] = last_error
                 else:
                     last_error = exec_result.get("message", "Unknown error")
                     self.logger.warning(
@@ -2494,14 +2444,12 @@ Your guidance: '''
                     "fix": None,
                 })
 
-        # Clean up temp data file
-        if temp_data_path.exists():
-            try:
-                os.remove(temp_data_path)
-            except Exception:
-                pass
-
-        if exec_result is None or exec_result.get("status") != "success":
+        # Success iff the final run produced BOTH the marker and the viz (matches
+        # the break condition); run["status"] alone is a snapshot.
+        ok = (run is not None and run["status"] == "success"
+              and run["visualization_path"] is not None
+              and "IMAGE_ANALYSIS_RESULTS_JSON:" in run["stdout"])
+        if not ok:
             return {
                 "index": image_idx,
                 "name": image_name,
@@ -2515,7 +2463,7 @@ Your guidance: '''
 
         # Parse results from stdout
         analysis_results = {}
-        for line in (exec_result.get("stdout") or "").splitlines():
+        for line in run["stdout"].splitlines():
             if line.startswith("IMAGE_ANALYSIS_RESULTS_JSON:"):
                 try:
                     analysis_results = json.loads(
@@ -2524,20 +2472,6 @@ Your guidance: '''
                 except json.JSONDecodeError:
                     pass
                 break
-
-        # Read visualization file
-        viz_path = working_dir / f"{output_prefix}_analysis.png"
-        if not viz_path.exists():
-            viz_path = working_dir / "analysis_visualization.png"
-
-        viz_bytes = None
-        if viz_path.exists():
-            with open(viz_path, "rb") as f:
-                viz_bytes = f.read()
-            final_viz_path = working_dir / f"{output_prefix}_analysis.png"
-            if viz_path != final_viz_path:
-                viz_path.rename(final_viz_path)
-            viz_path = final_viz_path
 
         return {
             "index": image_idx,
@@ -2550,8 +2484,8 @@ Your guidance: '''
             "quality_metrics": analysis_results.get("quality_metrics", {}),
             "summary": analysis_results.get("summary"),
             "saved_arrays": analysis_results.get("saved_arrays", {}),
-            "visualization_path": str(viz_path) if viz_path.exists() else None,
-            "visualization_bytes": viz_bytes,
+            "visualization_path": run["visualization_path"],
+            "visualization_bytes": run["visualization_bytes"],
             "statistics": stats,
             "script": script,
             "script_errors": script_errors,
@@ -3887,43 +3821,16 @@ Return JSON: {{"change_type": "cosmetic" | "analytical" | "rewrite", \
                         self.logger.info(f"    Change type: {change_type}")
                     patched_script = result["script"]
 
-                    # Execute the patched script
+                    # Execute the patched script VERBATIM in the per-image dir
                     working_dir = self.output_dir / f"image_{image_idx:04d}"
-                    working_dir.mkdir(parents=True, exist_ok=True)
-                    temp_data_path = working_dir / f"temp_image_{image_idx}.npy"
-                    np.save(temp_data_path, image_data)
-                    output_prefix = f"image_{image_idx:04d}"
-
-                    # Remove old viz files before running the patched
-                    # script so we only find genuinely new output.
-                    # On revert the original is restored from in-memory
-                    # visualization_bytes.
-                    canonical_viz = working_dir / f"{output_prefix}_analysis.png"
-                    for old_viz in [
-                        canonical_viz,
-                        working_dir / "analysis_visualization.png",
-                    ]:
-                        if old_viz.exists():
-                            try:
-                                os.remove(old_viz)
-                            except Exception:
-                                pass
-
+                    canonical_viz = working_dir / VIZ_NAME
                     patched_script = self._sanitize_script(patched_script)
-                    exec_result = self.executor.execute_script(
-                        patched_script, working_dir=str(working_dir)
-                    )
+                    run = stage_and_run(self.executor, patched_script, image_data, working_dir)
+                    exec_result = run["exec"]
 
-                    if temp_data_path.exists():
-                        try:
-                            os.remove(temp_data_path)
-                        except Exception:
-                            pass
-
-                    if exec_result.get("status") == "success":
-                        stdout = exec_result.get("stdout", "")
+                    if run["status"] == "success":
                         analysis_results = {}
-                        for line in stdout.splitlines():
+                        for line in run["stdout"].splitlines():
                             if line.startswith("IMAGE_ANALYSIS_RESULTS_JSON:"):
                                 try:
                                     analysis_results = json.loads(
@@ -3935,20 +3842,7 @@ Return JSON: {{"change_type": "cosmetic" | "analytical" | "rewrite", \
                                     pass
                                 break
 
-                        viz_path = canonical_viz
-                        if not viz_path.exists():
-                            viz_path = working_dir / "analysis_visualization.png"
-
-                        viz_bytes = None
-                        if viz_path.exists():
-                            with open(viz_path, "rb") as f:
-                                viz_bytes = f.read()
-                            # Normalize to canonical name
-                            if viz_path != canonical_viz:
-                                try:
-                                    viz_path.replace(canonical_viz)
-                                except Exception:
-                                    pass
+                        viz_bytes = run["visualization_bytes"]
 
                         if analysis_results and viz_bytes:
                             user_guided_result = {

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2181,7 +2181,7 @@ plan as specified and let the retry pipeline handle actual runtime failures.
 **Context:** {context}
 
 **Data:**
-- Path: `{data_path}`
+- Path: `{data_path}` (a numpy array in the CURRENT WORKING DIRECTORY — `np.load` it)
 - Points: {n_points}
 - X: [{x_min:.6g}, {x_max:.6g}]
 - Y: [{y_min:.6g}, {y_max:.6g}]
@@ -2215,7 +2215,7 @@ plan as specified and let the retry pipeline handle actual runtime failures.
    If you preprocess, keep both the raw and processed arrays so you can plot them.
 3. Implement your fitting approach (fit over the plan's fit domain).
 4. Compute R² and RMSE
-5. Save `fit_visualization.png`: data + fit + residuals (show individual components if multiple peaks).
+5. Save `visualization.png` (in the current working directory): data + fit + residuals (show individual components if multiple peaks).
    If you applied any preprocessing, ALSO plot the raw data faintly (light grey,
    low alpha) so the reviewer can confirm preprocessing did not distort the
    fitted features.
@@ -3153,7 +3153,7 @@ code.
 **Context:** {context}
 
 **Data:**
-- Path: `{data_path}`
+- Path: `{data_path}` (a numpy array in the CURRENT WORKING DIRECTORY — `np.load` it)
 - Shape: {shape}
 - dtype: {dtype}
 - Intensity range: [{intensity_min}, {intensity_max}]
@@ -3162,12 +3162,11 @@ code.
 {tool_inventory}
 
 **Requirements:**
-1. Load image: use `np.load(path)` for .npy, or `cv2.imread(path, cv2.IMREAD_UNCHANGED)` \
-for standard formats (remember cv2 loads BGR — convert to RGB if 3-channel color). \
+1. Load the image array with `np.load("{data_path}")` from the current working directory. \
 Check the image shape — it may have 2 or more channels that are not RGB. Access channels \
 via `image[:,:,0]`, `image[:,:,1]`, etc. Do not assume grayscale or RGB.
 2. Implement the analysis pipeline
-3. Save visualization(s): `analysis_visualization.png` showing original image alongside \
+3. Save visualization(s): `visualization.png` showing original image alongside \
 key analysis results. Use subplots with clear labels. For basic/foundational analyses, \
 keep it concise (2-4 subplots). For complex analyses with multiple derived quantities, \
 up to 6 subplots is acceptable. For segmentation tasks, the first subplot MUST show the \


### PR DESCRIPTION
Replace the fragile per-item script-adaptation regex in both series-based analysis agents with a robust per-item working directory + canonical filenames.

## Summary (for scientists)

When SciLink fits a *series* of spectra (or analyzes a series of images), it writes one analysis script for the first item and reuses it for the rest. Previously that reuse worked by **find-and-replacing text inside the generated code** to point it at each item's file. That's brittle: if the model wrote the file path in a way the text-replacement didn't expect, the script could silently run on the **wrong item's data** — a wrong result with no error.

This change makes the reuse robust: each item now runs in its **own folder** where its data is always called `data.npy` and the figure is always saved as `visualization.png`. The script is reused **unchanged** — there's nothing to rewrite, and one item can't accidentally pick up another's data. Same behavior for single datasets; safer and cleaner for series and parallel runs.

## Technical details (for AI reviewers)

**Problem.** `_adapt_script_for_spectrum` (`curve_fitting_controllers.py`) and `_adapt_script_for_image` (`image_analysis_controllers.py`) were near-identical regex rewriters: they substituted `np.load("temp_*_<idx>.npy")` / `DATA_PATH=`/`data_path=`, rewrote the per-item viz filename, and neutralized `glob.glob('*.npy')` (needed because all items shared one `output_dir`). A path spelled in an unanticipated way (f-string, `Path(...)`, indirect var) silently made the adapted script read the wrong item — silent-wrong-data, not a crash.

**Fix.** New shared helper `scilink/agents/exp_agents/_locked_exec.py`:
- `stage_and_run(executor, script, primary_array, item_dir, *, data_name="data.npy", viz_name="visualization.png", aux=None)` — `mkdir item_dir` → `np.save(item_dir/data.npy)` → run the script **verbatim** with `working_dir=item_dir` → locate `item_dir/visualization.png`. Returns the raw exec result + stdout + viz path/bytes; the caller parses its own stdout marker (curve `FIT_RESULTS_JSON` / DB matches; image `IMAGE_ANALYSIS_RESULTS_JSON`).
- `script_uses_canonical_input(script)` — guard; a script that doesn't reference `data.npy` is rejected and falls into the existing verify/retry (fail-loud) instead of silently mis-reading.

**Integration.**
- `curve_fitting_controllers.py::_fit_single_spectrum` now runs in `output_dir/spectrum_NNNN/` via the helper; `_adapt_script_for_spectrum` + glob neutralization deleted.
- `image_analysis_controllers.py::_process_single_image` and the user-guided refit branch of `_execute_and_verify` use the helper (the image agent already had per-item dirs); `_adapt_script_for_image` + glob neutralization deleted.
- `instruct.py`: both codegen prompts (`FITTING_SCRIPT_INSTRUCTIONS`, `IMAGE_ANALYSIS_SCRIPT_INSTRUCTIONS`) now instruct "load `data.npy` from the working directory; save `visualization.png`".
- Robustness fix: success is now "the run produced both the stdout marker and the viz" — the old `exec_result["status"]="failed"` mutation on a missing-output last attempt no longer flips the helper's status **snapshot**, so that check was made explicit.
- Unchanged: downstream report/synthesis reads `visualization_path`/`visualization_bytes` from the result dict; auxiliary operands stay absolute-path (never adapted). The quality-review artifacts (`quality_review_fit.png` etc.) still write to `output_dir` from in-memory bytes. The `TrendAnalysisController` `output_dir.glob('*.png')` filter is unaffected (per-item viz now lives in subdirs, outside the non-recursive glob).

Net **−85 lines** (two regex copies removed; one ~80-line helper added).

### Validation (live, `claude-opus-4-8`) — single + series for BOTH agents
- **Curve:** single (R²=0.9997, viz under `spectrum_0000/`); series-2; and **series-3 in PARALLEL** with distinct true peak centers — each spectrum's fitted center matched its OWN true center (−2.0→−2.0008, 0.0→8.7e-5, 2.0→1.9996) with viz in its own `spectrum_NNNN/` dir, **proving no cross-item contamination** (the failure mode the old regex risked).
- **Image:** single + series-2, viz under each `image_NNNN/`.
- **Unit:** `stage_and_run` stages data, runs verbatim, isolates two items in separate dirs, locates the viz; `script_uses_canonical_input` accept/reject.

### Scope
- Branch off `main`, independent of #232/#233 (touches different functions). Expect a mechanical merge with #233 in `curve_fitting_controllers.py`.
- Makes any future per-item second file (e.g. weights/masks) trivial and safe — just another canonical name staged into `item_dir`, no new rewrite rule (relevant to the #233 Phase-2 follow-up).
