### PR TITLE
Add Amazon Bedrock as a selectable model provider in the UI

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1583,7 +1583,8 @@ class AnalysisOrchestratorAgent:
     def _handle_litellm_chat(self, user_input: str) -> str:
         """Handle chat with LiteLLM models with manual function calling loop."""
         import litellm
-        
+        from ...wrappers.litellm_wrapper import litellm_completion
+
         self.messages.append({"role": "user", "content": user_input})
         
         if len(self.messages) > 120:
@@ -1600,7 +1601,7 @@ class AnalysisOrchestratorAgent:
             print(f"  ⏳ Waiting for orchestrator response ...")
             
             try:
-                response = litellm.completion(
+                response = litellm_completion(
                     model=self.model.model,
                     messages=self.messages,
                     tools=self.tools_for_model,
@@ -1625,7 +1626,7 @@ class AnalysisOrchestratorAgent:
                 if not content and iteration > 0:
                     # LLM returned empty text after tool calls — ask for a summary
                     self.messages.append({"role": "user", "content": "Please briefly summarize what you just did and suggest next steps."})
-                    followup = litellm.completion(
+                    followup = litellm_completion(
                         model=self.model.model,
                         messages=self.messages,
                         tools=self.tools_for_model,

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1229,6 +1229,7 @@ class MetaOrchestratorAgent:
     def _handle_litellm_chat(self, user_input: str) -> str:
         """Handle chat with LiteLLM models — manual tool-calling loop."""
         import litellm
+        from ...wrappers.litellm_wrapper import litellm_completion
 
         self.messages.append({"role": "user", "content": user_input})
 
@@ -1244,7 +1245,7 @@ class MetaOrchestratorAgent:
             print(f"  ⏳ Waiting for meta-orchestrator response ...")
 
             try:
-                response = litellm.completion(
+                response = litellm_completion(
                     model=self.model.model,
                     messages=self.messages,
                     tools=self.tools_for_model,
@@ -1271,7 +1272,7 @@ class MetaOrchestratorAgent:
                         "role": "user",
                         "content": "Please briefly summarize what you just did and suggest next steps.",
                     })
-                    followup = litellm.completion(
+                    followup = litellm_completion(
                         model=self.model.model,
                         messages=self.messages,
                         tools=self.tools_for_model,

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -1540,6 +1540,7 @@ class PlanningOrchestratorAgent:
     def _handle_litellm_chat(self, user_input: str) -> str:
         """Handle chat with LiteLLM models with manual function calling loop."""
         import litellm
+        from ...wrappers.litellm_wrapper import litellm_completion
         
         self.messages.append({"role": "user", "content": user_input})
         
@@ -1563,7 +1564,7 @@ class PlanningOrchestratorAgent:
 
             print(f"  ⏳ Waiting for orchestrator response ...")
 
-            response = litellm.completion(
+            response = litellm_completion(
                 model=self.model.model,
                 messages=self.messages,
                 tools=self.tools_for_model,

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -812,6 +812,7 @@ class SimulationOrchestratorAgent:
     def _handle_litellm_chat(self, user_input: str) -> str:
         """Chat with LiteLLM models with manual function calling loop."""
         import litellm
+        from ...wrappers.litellm_wrapper import litellm_completion
 
         self.messages.append({"role": "user", "content": user_input})
 
@@ -827,7 +828,7 @@ class SimulationOrchestratorAgent:
             print(f"  ⏳ Waiting for orchestrator response ...")
 
             try:
-                response = litellm.completion(
+                response = litellm_completion(
                     model=self.model.model,
                     messages=self.messages,
                     tools=self.tools_for_model,
@@ -854,7 +855,7 @@ class SimulationOrchestratorAgent:
                         "role": "user",
                         "content": "Please briefly summarize what you just did and suggest next steps.",
                     })
-                    followup = litellm.completion(
+                    followup = litellm_completion(
                         model=self.model.model,
                         messages=self.messages,
                         tools=self.tools_for_model,

--- a/scilink/agents/sim_agents/structure_agent.py
+++ b/scilink/agents/sim_agents/structure_agent.py
@@ -322,9 +322,10 @@ class StructureGenerator:
                                    *, api_key, model_name):
         """Tool-call loop using LiteLLM (public-API path)."""
         import litellm
+        from ...wrappers.litellm_wrapper import litellm_completion
 
         for _ in range(MAX_MP_RESOLVER_ITERATIONS):
-            resp = litellm.completion(
+            resp = litellm_completion(
                 model=model_name,
                 messages=messages,
                 tools=tools,

--- a/scilink/providers.py
+++ b/scilink/providers.py
@@ -1,0 +1,172 @@
+# scilink/providers.py
+
+"""Per-provider UI fields + credential routing.
+
+Streamlit-free on purpose so core code and the UI can both import it.
+
+Each :class:`ProviderSpec` declares two things:
+
+1. **What extra inputs to collect** in the UI (``fields``) for a model that
+   belongs to that provider, and what to call the pasted secret (``key_label``).
+2. **How the pasted secret + collected field values map onto LiteLLM**
+   (``apply`` -> :class:`ProviderAuth`): some providers want the secret as the
+   ``api_key`` kwarg (OpenAI/Anthropic/Gemini), some want it in an environment
+   variable (Bedrock's bearer token), and some need extra completion kwargs
+   (Azure's ``api_version``, Vertex's project/location).
+
+Only ``bedrock`` and the ``direct`` fallback are live today. Azure / Vertex are
+documented stubs: wiring them up additionally needs a ``model_kwargs``
+passthrough on the LiteLLM wrapper (see ``ProviderAuth.model_kwargs``), which
+Bedrock does not require because its token and region ride environment
+variables that boto3 reads automatically.
+"""
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Optional, Tuple
+
+
+# US AWS regions for Bedrock Claude. Scoped to US for now; add other
+# geographies (eu-*, ap-*) when cross-region availability is needed.
+BEDROCK_REGIONS: Tuple[str, ...] = (
+    "us-east-1",
+    "us-east-2",
+    "us-west-2",
+)
+
+
+@dataclass(frozen=True)
+class ProviderField:
+    """A provider-specific input rendered in the UI only when that provider is selected."""
+
+    name: str                       # values key + session-state suffix, e.g. "region"
+    label: str                      # UI label, e.g. "AWS region"
+    kind: str = "select"            # "select" | "text"
+    options: Tuple[str, ...] = ()   # choices for kind == "select"
+    default: str = ""               # default value / preselected option
+    help: str = ""                  # tooltip
+
+
+@dataclass
+class ProviderAuth:
+    """How to authenticate a call, produced by :meth:`ProviderSpec.apply`."""
+
+    api_key: Optional[str] = None                       # -> agent constructor / litellm api_key
+    env: Dict[str, str] = field(default_factory=dict)   # -> os.environ updates
+    model_kwargs: Dict[str, str] = field(default_factory=dict)  # -> litellm.completion (FUTURE)
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    name: str
+    matches: Callable[[str], bool]            # model string -> belongs to this provider?
+    apply: Callable[..., ProviderAuth]        # (pasted_key, values, base_url) -> ProviderAuth
+    key_label: str = "API key"                # what to call the pasted secret in the UI
+    fields: Tuple[ProviderField, ...] = ()    # extra UI fields for this provider
+    cred_env: Tuple[str, ...] = ()            # env vars signalling ambient credentials
+    cred_error: str = "Provide an API key or set the appropriate environment variable."
+
+
+# --- routing functions -------------------------------------------------------
+
+def _direct_apply(pasted_key, values, base_url):
+    """OpenAI / Anthropic / Gemini: the pasted key is litellm's api_key (today's behavior)."""
+    return ProviderAuth(api_key=pasted_key)
+
+
+def _bedrock_apply(pasted_key, values, base_url):
+    """Bedrock: token + region ride env vars; api_key MUST be None.
+
+    If api_key is set, litellm uses it instead of the AWS credential chain and
+    Bedrock auth fails silently. boto3 reads AWS_BEARER_TOKEN_BEDROCK and
+    AWS_REGION_NAME from the environment, so nothing below the sidebar changes.
+    """
+    return ProviderAuth(
+        api_key=None,
+        env={
+            "AWS_BEARER_TOKEN_BEDROCK": pasted_key or "",
+            "AWS_REGION_NAME": (values.get("region") or "us-east-1"),
+        },
+    )
+
+
+# --- registry ----------------------------------------------------------------
+
+PROVIDERS: Tuple[ProviderSpec, ...] = (
+    ProviderSpec(
+        name="bedrock",
+        matches=lambda m: m.startswith("bedrock/"),
+        apply=_bedrock_apply,
+        key_label="Bedrock API key",
+        fields=(
+            ProviderField(
+                name="region",
+                label="AWS region",
+                kind="select",
+                options=BEDROCK_REGIONS,
+                default="us-east-1",
+                help=("Must match the region your AWS console was set to when "
+                      "you generated the key (shown top-right of the console, "
+                      "e.g. 'N. Virginia' = us-east-1). The key itself does not "
+                      "encode the region."),
+            ),
+        ),
+        cred_env=("AWS_BEARER_TOKEN_BEDROCK", "AWS_ACCESS_KEY_ID"),
+        cred_error=("Paste your Bedrock API key, or set AWS credentials "
+                    "(AWS_BEARER_TOKEN_BEDROCK, or AWS_ACCESS_KEY_ID + "
+                    "AWS_SECRET_ACCESS_KEY) in the environment."),
+    ),
+
+    # ---- FUTURE (stubbed) — each additionally needs the model_kwargs ----
+    # ---- passthrough on LiteLLMGenerativeModel (see module docstring). ----
+    #
+    # def _azure_apply(pasted_key, values, base_url):
+    #     # endpoint reuses the existing Base URL field (passed as api_base)
+    #     return ProviderAuth(
+    #         api_key=pasted_key,
+    #         model_kwargs={"api_version": values.get("api_version") or "2024-02-15-preview"},
+    #     )
+    #
+    # ProviderSpec(
+    #     name="azure",
+    #     matches=lambda m: m.startswith("azure/"),
+    #     apply=_azure_apply,
+    #     fields=(ProviderField("api_version", "API version", "text",
+    #                           default="2024-02-15-preview"),),
+    # ),
+    #
+    # def _vertex_apply(pasted_key, values, base_url):
+    #     return ProviderAuth(
+    #         api_key=None,
+    #         env={"GOOGLE_APPLICATION_CREDENTIALS": pasted_key or ""},
+    #         model_kwargs={"vertex_project": values.get("project"),
+    #                       "vertex_location": values.get("location") or "us-central1"},
+    #     )
+    #
+    # ProviderSpec(
+    #     name="vertex_ai",
+    #     matches=lambda m: m.startswith("vertex_ai/"),
+    #     apply=_vertex_apply,
+    #     key_label="Path to service-account JSON",
+    #     fields=(ProviderField("project", "GCP project", "text"),
+    #             ProviderField("location", "Location", "text", default="us-central1")),
+    # ),
+)
+
+
+_DEFAULT = ProviderSpec(
+    name="direct",
+    matches=lambda m: True,
+    apply=_direct_apply,
+    cred_env=("GEMINI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"),
+    cred_error=("Provide an API key or set an environment variable "
+                "(GEMINI_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY)."),
+)
+
+
+def provider_for(model: str) -> ProviderSpec:
+    """Return the spec for ``model``'s provider, or the direct-key fallback."""
+    model = model or ""
+    for spec in PROVIDERS:
+        if spec.matches(model):
+            return spec
+    return _DEFAULT

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -19,6 +19,7 @@ from ..config import (
     SUPPORTED_PLANNING_DATA_EXTENSIONS,
     extra_data_extensions_for,
 )
+from ...providers import provider_for
 
 
 _LOGO_DIR = Path(__file__).resolve().parent.parent / "assets"
@@ -220,7 +221,18 @@ def render_sidebar() -> None:
             model = st.text_input("Model name", key="cfg_model_custom", disabled=_locked)
         else:
             model = preset
-        api_key = st.text_input("API key", type="password", key="cfg_api_key", disabled=_locked)
+        spec = provider_for(model)
+        api_key = st.text_input(spec.key_label, type="password", key="cfg_api_key", disabled=_locked)
+        # Provider-specific inputs (e.g. AWS region for Bedrock) — rendered only
+        # for the matching provider; nothing extra shows for direct API providers.
+        for _pf in spec.fields:
+            if _pf.kind == "select":
+                _idx = _pf.options.index(_pf.default) if _pf.default in _pf.options else 0
+                st.selectbox(_pf.label, _pf.options, index=_idx,
+                             key=f"cfg_prov_{_pf.name}", help=_pf.help, disabled=_locked)
+            else:
+                st.text_input(_pf.label, value=_pf.default,
+                              key=f"cfg_prov_{_pf.name}", help=_pf.help, disabled=_locked)
         base_url = st.text_input("Base URL (optional)", key="cfg_base_url", disabled=_locked)
         fh_api_key = st.text_input("FutureHouse API key (optional)", type="password", key="cfg_fh_api_key", disabled=_locked)
         mp_api_key = st.text_input("Materials Project API key (optional)", type="password", key="cfg_mp_api_key", disabled=_locked)
@@ -660,9 +672,20 @@ def start_session(model: str, api_key: str, base_url: str, mode: str, fh_api_key
     import scilink
     import scilink.executors as executors
 
-    resolved_key = api_key or os.environ.get("GEMINI_API_KEY") or os.environ.get("OPENAI_API_KEY") or os.environ.get("ANTHROPIC_API_KEY")
-    if not resolved_key and not base_url:
-        st.sidebar.error("Provide an API key or set an environment variable (GEMINI_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY).")
+    spec = provider_for(model)
+    field_values = {f.name: st.session_state.get(f"cfg_prov_{f.name}", f.default) for f in spec.fields}
+    auth = spec.apply(pasted_key=api_key, values=field_values, base_url=base_url)
+    os.environ.update({k: v for k, v in auth.env.items() if v})
+
+    if auth.env:
+        # Env-var providers (e.g. Bedrock) authenticate via os.environ; the agent
+        # must receive api_key=None so litellm uses that credential chain.
+        resolved_key = None
+    else:
+        resolved_key = auth.api_key or os.environ.get("GEMINI_API_KEY") or os.environ.get("OPENAI_API_KEY") or os.environ.get("ANTHROPIC_API_KEY")
+
+    if not (api_key or base_url or any(os.environ.get(e) for e in spec.cred_env)):
+        st.sidebar.error(spec.cred_error)
         return
 
     # Optional MP key: register so DFTOrchestrator's auto-discovery picks it up
@@ -899,17 +922,23 @@ def resume_session(
     import scilink
     import scilink.executors as executors
 
-    resolved_key = (
-        api_key
-        or os.environ.get("GEMINI_API_KEY")
-        or os.environ.get("OPENAI_API_KEY")
-        or os.environ.get("ANTHROPIC_API_KEY")
-    )
-    if not resolved_key and not base_url:
-        st.sidebar.error(
-            "Provide an API key or set an environment variable "
-            "(GEMINI_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY)."
+    spec = provider_for(model)
+    field_values = {f.name: st.session_state.get(f"cfg_prov_{f.name}", f.default) for f in spec.fields}
+    auth = spec.apply(pasted_key=api_key, values=field_values, base_url=base_url)
+    os.environ.update({k: v for k, v in auth.env.items() if v})
+
+    if auth.env:
+        resolved_key = None
+    else:
+        resolved_key = (
+            auth.api_key
+            or os.environ.get("GEMINI_API_KEY")
+            or os.environ.get("OPENAI_API_KEY")
+            or os.environ.get("ANTHROPIC_API_KEY")
         )
+
+    if not (api_key or base_url or any(os.environ.get(e) for e in spec.cred_env)):
+        st.sidebar.error(spec.cred_error)
         return
 
     # Optional MP key registration (see start_session for rationale).
@@ -1158,19 +1187,30 @@ def _start_simulate_session(
     fh_api_key: str,
 ) -> None:
     """Lightweight session init for simulate mode (no heavy agent)."""
-    resolved_key = (
-        api_key
-        or os.environ.get("OPENAI_API_KEY")
-        or os.environ.get("ANTHROPIC_API_KEY")
-        or os.environ.get("GOOGLE_API_KEY")
-        or os.environ.get("GEMINI_API_KEY")
-    )
-    if not resolved_key and not base_url:
+    spec = provider_for(model)
+    field_values = {f.name: st.session_state.get(f"cfg_prov_{f.name}", f.default) for f in spec.fields}
+    auth = spec.apply(pasted_key=api_key, values=field_values, base_url=base_url)
+    os.environ.update({k: v for k, v in auth.env.items() if v})
+
+    if auth.env:
+        resolved_key = None
+    else:
+        resolved_key = (
+            auth.api_key
+            or os.environ.get("OPENAI_API_KEY")
+            or os.environ.get("ANTHROPIC_API_KEY")
+            or os.environ.get("GOOGLE_API_KEY")
+            or os.environ.get("GEMINI_API_KEY")
+        )
+
+    if not (api_key or base_url or any(os.environ.get(e) for e in spec.cred_env)):
         st.sidebar.error("Provide an API key or set an environment variable.")
         return
 
-    # Set API key in environment so the simulation agent can find it
-    if api_key:
+    # Direct providers: export the typed key to the conventional vendor env var
+    # so the simulation agent can discover it. Env-var providers (e.g. Bedrock)
+    # already populated os.environ above, so skip the substring mapping.
+    if api_key and not auth.env:
         _m = model.lower()
         if any(x in _m for x in ("gpt", "o1", "o3", "o4")):
             os.environ.setdefault("OPENAI_API_KEY", api_key)

--- a/scilink/ui/config.py
+++ b/scilink/ui/config.py
@@ -6,6 +6,12 @@ MODEL_OPTIONS = [
     "claude-opus-4-6",
     "gemini-3.1-pro-preview",
     "gpt-5.4",
+    # Amazon Bedrock (Claude Opus 4.6) via the US geo cross-region inference
+    # profile (exact ID from the AWS model card; Opus 4.6 has no date stamp and
+    # uses a bare ``-v1`` suffix — no ``:0``). Invoke-able only through an
+    # inference profile, hence the ``us.`` prefix. For EU/AU keys swap the
+    # prefix: ``eu.``/``au.``. (Base model ID: anthropic.claude-opus-4-6-v1.)
+    "bedrock/us.anthropic.claude-opus-4-6-v1",
 ]
 
 EMBEDDING_MODEL_OPTIONS = [

--- a/scilink/wrappers/litellm_wrapper.py
+++ b/scilink/wrappers/litellm_wrapper.py
@@ -144,8 +144,33 @@ def _check_litellm():
     import logging
     logging.getLogger("LiteLLM").setLevel(logging.WARNING)
     logging.getLogger("litellm").setLevel(logging.WARNING)
-    
+
     litellm.suppress_debug_info = True
+
+
+def _scope_drop_params(model) -> None:
+    """Enable LiteLLM param-dropping only for Bedrock models.
+
+    Bedrock rejects OpenAI-style params (e.g. ``tool_choice``) that Anthropic /
+    OpenAI / Gemini accept. Scoping ``drop_params`` to ``bedrock/*`` keeps the
+    strict error-on-unsupported behavior for every other provider, so a typo or
+    a genuinely-unsupported param still surfaces as an error there. Set per call
+    (not once globally) so a mixed-model session — e.g. a Bedrock chat model
+    alongside a Gemini/OpenAI embedding model — routes each call correctly.
+    """
+    if litellm is not None:
+        litellm.drop_params = str(model or "").startswith("bedrock/")
+
+
+def litellm_completion(*args, **kwargs):
+    """``litellm.completion`` with Bedrock-scoped param dropping.
+
+    Drop-in replacement for direct ``litellm.completion`` calls; see
+    :func:`_scope_drop_params`. Reads the target model from the ``model`` kwarg
+    (or first positional arg) and scopes param-dropping to it before the call.
+    """
+    _scope_drop_params(kwargs.get("model") or (args[0] if args else None))
+    return litellm.completion(*args, **kwargs)
 
 
 class LiteLLMGenerativeModel:
@@ -262,6 +287,7 @@ class LiteLLMGenerativeModel:
         
         try:
             _t0 = time.perf_counter()
+            _scope_drop_params(self.model)
             response = litellm.completion(
                 model=self.model,
                 messages=messages,
@@ -592,6 +618,7 @@ class LiteLLMChatSession:
         params = self._model._build_params(generation_config, self._model.tools)
         
         _t0 = time.perf_counter()
+        _scope_drop_params(self._model.model)
         response = litellm.completion(
             model=self._model.model,
             messages=messages,


### PR DESCRIPTION
## Summary

Lets users run SciLink on **Claude Opus 4.6 served via Amazon Bedrock**, chosen straight from the UI. Pick the Bedrock model in the sidebar dropdown, paste your Bedrock API key, select your US region, and launch — no environment-variable exports and no `aws configure` needed. Direct API providers (Anthropic / OpenAI / Gemini) are completely unchanged, and the existing default model is untouched.

Why this shape: the natural way to add Bedrock is also the natural way to add Azure or Vertex later, so this introduces a tiny **provider registry** rather than a one-off Bedrock branch. Each provider declares what extra inputs the UI should collect (Bedrock needs a region; direct providers need nothing) and how the pasted key maps onto the underlying call. Bedrock is the first entry; Azure and Vertex are scaffolded as commented stubs.

Verified end-to-end: a Bedrock Opus 4.6 chat session completes a full round trip.

A couple of Bedrock-specific facts that shaped the design:
- **The region isn't in the key.** Bedrock API keys don't encode their region, so it can't be auto-detected — hence the region dropdown (with help text pointing to the AWS console's region selector). US regions only for now.
- **Bedrock rejects a parameter SciLink always sends** (`tool_choice`). We drop it *only for Bedrock calls*, so every other provider keeps strict error-on-unsupported behavior.

---

## Technical details

**New `scilink/providers.py`** (streamlit-free, so core and UI can both import it):
- `ProviderSpec` declares `fields` (extra UI inputs), `key_label`, `cred_env` (env vars signalling ambient credentials), and `apply(pasted_key, values, base_url) -> ProviderAuth(api_key, env, model_kwargs)`. `provider_for(model)` matches by prefix, falling back to a `direct` spec (today's behavior: key → `api_key`).
- **Bedrock routing** (`_bedrock_apply`): pasted key → `AWS_BEARER_TOKEN_BEDROCK` env, region → `AWS_REGION_NAME` env, `api_key=None`. The `api_key=None` is load-bearing — a non-None value makes LiteLLM bypass the AWS credential chain and fail silently.
- `BEDROCK_REGIONS = us-east-1 (default), us-east-2, us-west-2` (the US regions in the `us.` geo inference profile; `us-west-1` excluded — no Claude there and not in the profile).

**UI wiring** (`scilink/ui/config.py`, `scilink/ui/components/sidebar.py`):
- Adds `bedrock/us.anthropic.claude-opus-4-6-v1` to `MODEL_OPTIONS` — the US geo inference-profile ID from the AWS model card. Opus 4.6 is invoke-able only via an inference profile and carries no date stamp / no `:0` suffix (it's the last Bedrock model with a bare `-v1`).
- Key field relabels per provider; `spec.fields` render conditionally, so the region dropdown appears only for a `bedrock/` model (and also for a `bedrock/…` typed into the Custom field, since it keys off the resolved model string).
- `start_session`, `resume_session`, and `_start_simulate_session` each call `spec.apply`, `os.environ.update(auth.env)`, gate on `spec.cred_env`, and pass `resolved_key=None` when env-var auth is used.

**Bedrock-scoped param dropping** (`scilink/wrappers/litellm_wrapper.py` + 5 orchestrators):
- `_scope_drop_params(model)` sets `litellm.drop_params = model.startswith("bedrock/")`; a `litellm_completion(*a, **k)` shim applies it before the call. The orchestrators' direct `litellm.completion` calls route through the shim; the wrapper's two `generate_content` paths scope inline.
- **Per-call, not a module global** — a Bedrock chat session also constructs non-Bedrock model objects (Gemini/OpenAI embeddings); a sticky global would flip and break the next call. Verified interleaved: bedrock→drop, gemini/openai/anthropic→no-drop, non-sticky.
- Dropping `tool_choice` is behavior-neutral: the only values sent are `"auto"`/`"none"`, and `"auto"` is already Bedrock's default.

**Known limits / follow-ups:**
- Bedrock has no server-side JSON mode (`response_mime_type`); analyze/plan have it disabled (`param_gen_config=None`) and sim has a text fallback, so no functionality is lost.
- Azure/Vertex (commented stubs) will additionally need a `model_kwargs` passthrough threaded constructor → `LiteLLMGenerativeModel` → `litellm.completion` (`api_version`, `vertex_project/location`) — the one structural change Bedrock did **not** require. After that, new providers are pure-data registry entries.
- Embeddings are unaffected by the chat-model choice; analyze-mode KB flows still use a Gemini/OpenAI embedding key.
