### PR TITLE
Fix #234 regression: align secondary codegen prompts with the data.npy/visualization.png contract

### DIFF
--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2276,7 +2276,9 @@ FITTING_SCRIPT_CORRECTION_INSTRUCTIONS = """Fix this failed script.
 
 **CRITICAL:** Fix only the execution error. Do NOT change the fitting model, its parameters, or the overall analysis approach. The model is locked for series consistency.
 
-**Plot labels must be neutral** if your fix touches `fit_visualization.png`: \
+**I/O contract (do not deviate):** the data is `data.npy` in the current working directory — load it with `np.load` (do NOT look for .csv/.txt/.dat or glob for other files); save the plot to `visualization.png`; print one line `FIT_RESULTS_JSON:{{...}}` with the fit results. Missing any of these fails the run.
+
+**Plot labels must be neutral** if your fix touches `visualization.png`: \
 use "Data"/"Fit"/"Component N"/"Residuals" only — no material names, no peak assignments, no model names in titles/legends/annotations.
 
 **Response:** Return only `{{"diagnosis": "...", "script": "..."}}`
@@ -2297,8 +2299,8 @@ PLAN_CONFORMANCE_CHECK_INSTRUCTIONS = """You are verifying that a Python script 
 ```
 
 **EXECUTION CONTRACT (read before judging the script):**
-The script fits **exactly one spectrum at a time** — the data file already
-written to `temp_spectrum_<idx>.npy` for the current spectrum.  When the
+The script fits **exactly one spectrum at a time** — the data file is staged
+as `data.npy` in the current working directory.  When the
 plan is for a series, the agent invokes the same script per spectrum and
 aggregates results at a higher layer; scripts must NOT loop over multiple
 spectrum files, build cross-spectrum trends or comparisons, or
@@ -3269,12 +3271,11 @@ rewrite the analysis portion accordingly — but do not rewrite more than the \
 refined plan calls for.
 
 **Requirements:**
-1. Load image: use `np.load(path)` for .npy, or `cv2.imread(path, cv2.IMREAD_UNCHANGED)` \
-for standard formats (remember cv2 loads BGR — convert to RGB if 3-channel color). \
+1. Load the image array `data.npy` from the current working directory (`np.load`). \
 Check the image shape — it may have 2 or more channels that are not RGB. Access channels \
 via `image[:,:,0]`, `image[:,:,1]`, etc. Do not assume grayscale or RGB.
 2. Implement the refined analysis pipeline.
-3. Save visualization(s): `analysis_visualization.png` showing original image alongside \
+3. Save visualization(s): `visualization.png` showing original image alongside \
 key analysis results. Use subplots with clear labels. All visualizations must be saved \
 to the current working directory. Use `dpi=100`.
 4. Save key output arrays to the current working directory as `.npy` files. \


### PR DESCRIPTION
Fix a regression from #234: the secondary codegen prompts (retry/correction, conformance, image refinement) still referenced the pre-refactor artifact names, so failed-fit recovery and refinement paths flailed on filenames.

## Summary (for scientists)

#234 standardized generated analysis scripts to load `data.npy` and save `visualization.png` in a per-item folder. The *main* prompts were updated, but three *secondary* prompts (used only when a first attempt fails and the agent retries/refines) were missed — they still told the model to save `fit_visualization.png` and that the data lived at the old path. In a real curve-fit run this caused noisy retry cascades: the recovery LLM guessed `data.csv`/`.txt`/`.dat`, hit "file not found", and only discovered `data.npy` after several failed attempts (and wrote a stray `fit_visualization.png`). The fit still completed, but with avoidable errors. This aligns those prompts with the canonical contract.

## Technical details (for AI reviewers)

Three stale references in `scilink/agents/exp_agents/instruct.py`, all from #234's incomplete update:

- **`FITTING_SCRIPT_CORRECTION_INSTRUCTIONS`** (curve retry): `fit_visualization.png` → `visualization.png`, **and** added an explicit I/O contract — "data is `data.npy` in the cwd (don't look for .csv/.txt/.dat), save `visualization.png`, print `FIT_RESULTS_JSON:{...}`" — so corrections stop guessing the data filename (the root of the `data.csv` flailing, since the correction prompt never stated the data path).
- **`PLAN_CONFORMANCE_CHECK_INSTRUCTIONS`** (curve): execution-contract text said the data was at `temp_spectrum_<idx>.npy` → now `data.npy` in the working directory.
- **`IMAGE_ANALYSIS_SCRIPT_REFINEMENT_PROMPT`** (image refine/Tier-2): load `data.npy` from the cwd (was generic `np.load(path)` / `cv2.imread`); save `visualization.png` (was `analysis_visualization.png`). **Latent** — #234's image tests used `analysis_depth="basic"`, so the refinement path never ran.

No code changes — prompt-text only. The `_locked_exec` helper / per-item-dir contract from #234 is unchanged; this just makes the secondary prompts speak the same contract.

### Root-cause note
The gap: #234's tests (and the Phase-2 tests) exercised the **main** codegen path with clean fits, never the **correction/refinement** path. The correct move when changing the I/O contract was to grep for *all* `fit_visualization.png`/`temp_*`/`analysis_visualization.png` references, not just update the main prompt.

### Validation
- **Live (claude-opus-4-8), the exact failing spectrum** (Ti L₂,₃ + O K EELS): re-ran on the original session's `spectrum.npy` → `status: success`, `spectrum_0000/` contains only `data.npy` + `visualization.png` (no stray `fit_visualization.png`), no `data.csv` flailing.
- Stale-reference grep across `instruct.py` + controllers is now clean (the remaining `quality_review_fit.png` and the trend-filter `_fit.png` exclude are intentional and unrelated).

### Out of scope (separate, pre-existing issues this exposed)
- A refinement-codegen response can come back as bare/truncated Python (huge ~32-parameter models overflow the output limit), tripping the JSON parser — independent of the canonical-name contract.
- Hard high-parameter Voigt/EELS fits can converge to R²≈0 — a modeling-difficulty issue, not a naming one.
