### PR TITLE
Fix Bedrock codegen truncation + response mangling; robust compile-checked parsing (#238)

### DIFF
--- a/scilink/agents/exp_agents/base_agent.py
+++ b/scilink/agents/exp_agents/base_agent.py
@@ -135,6 +135,17 @@ class LLMAgentMixin:
                 "details": str(e)
             }
     
+    def _parse_codegen_response(self, response: Any, field: str = "script") -> Tuple[Optional[dict], Optional[dict]]:
+        """Parse a codegen (script-generation) response — see ``utils.codegen_parse``.
+
+        Script-first + compile-checked, with distinct truncation detection. Use
+        this instead of ``_parse_llm_response`` for script/code generation;
+        structured-JSON responses (plans, validation, conformance) keep using
+        ``_parse_llm_response``.
+        """
+        from ...utils.codegen_parse import parse_codegen_response
+        return parse_codegen_response(response, field=field, logger=self.logger)
+
     def _extract_text_from_response(self, response: Any) -> str:
         """Extract text content from various LLM response formats."""
         if hasattr(response, 'text'):

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -32,6 +32,7 @@ from typing import Callable, Optional, Any, Dict, List
 import numpy as np
 
 from .._locked_exec import stage_and_run, script_uses_canonical_input, DATA_NAME
+from ....utils.codegen_parse import parse_codegen_response
 
 
 def _active_skill_names(state: dict) -> list[str]:
@@ -2094,7 +2095,7 @@ Your guidance: '''
             )
 
         response = self.model.generate_content(prompt)
-        result, error = self._parse(response)
+        result, error = parse_codegen_response(response, field="script", logger=self.logger)
 
         if error or not result or "script" not in result:
             raise ValueError(f"Script generation failed: {error or 'no script'}")
@@ -2122,7 +2123,7 @@ Your guidance: '''
             prompt += "\n\n" + preamble + codegen_recipe
 
         response = self.model.generate_content(prompt)
-        result, error = self._parse(response)
+        result, error = parse_codegen_response(response, field="script", logger=self.logger)
 
         if error or not result or "script" not in result:
             raise ValueError(f"Correction failed: {error or 'no script'}")
@@ -5045,7 +5046,7 @@ Return JSON with:
         
         try:
             response = self.model.generate_content(contents=[prompt], generation_config=self.generation_config, safety_settings=self.safety_settings)
-            result_json, error_dict = self._parse(response)
+            result_json, error_dict = parse_codegen_response(response, field="script", logger=self.logger)
             if error_dict and not (result_json and 'script' in result_json):
                 return None
             return result_json
@@ -5089,7 +5090,7 @@ Return JSON with: {{"diagnosis": "...", "script": "corrected script"}}
         
         try:
             response = self.model.generate_content(contents=[prompt], generation_config=self.generation_config, safety_settings=self.safety_settings)
-            result_json, _ = self._parse(response)
+            result_json, _ = parse_codegen_response(response, field="script", logger=self.logger)
             if result_json:
                 self.logger.info(f"   📋 Diagnosis: {result_json.get('diagnosis', 'N/A')}")
                 return result_json.get("script")

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -28,6 +28,7 @@ from ..instruct import (
 
 from ....skills.hyperspectral.eels.eels import AGENT_METADATA_KEYS_TO_STRIP
 from ....executors import ExecutionTimeout
+from ....utils.codegen_parse import parse_codegen_response
 
 
 def _render_skill_block(state: dict, stage: str) -> str:
@@ -1964,8 +1965,8 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                     # --- B. GENERATE CODE ---
                     self.logger.info(f"    (Attempt {retries+1}) Asking LLM to write code...")
                     response = self.model.generate_content(current_prompt, generation_config=self.generation_config)
-                    result_json, _ = self._parse_llm_response(response)
-                    code_str = result_json.get("code", "")
+                    result_json, _ = parse_codegen_response(response, field="code", logger=self.logger)
+                    code_str = (result_json or {}).get("code", "")
                     
                     # --- C. SANDBOX SETUP ---
                     local_scope = {}

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -32,6 +32,7 @@ from typing import Callable, Optional, Any, Dict, List
 import numpy as np
 
 from .._locked_exec import stage_and_run, script_uses_canonical_input, DATA_NAME, VIZ_NAME
+from ....utils.codegen_parse import parse_codegen_response
 
 
 # Anthropic's API rejects images over 5 MB. Cap below that with headroom
@@ -2185,7 +2186,7 @@ Your guidance: '''
             prompt = self.script_instructions.format(**format_kwargs)
 
         response = self.model.generate_content(prompt)
-        result, error = self._parse(response)
+        result, error = parse_codegen_response(response, field="script", logger=self.logger)
 
         if error or not result or "script" not in result:
             raise ValueError(f"Script generation failed: {error or 'no script'}")
@@ -2223,7 +2224,7 @@ Your guidance: '''
             prompt += "\n\n" + preamble + codegen_recipe
 
         response = self.model.generate_content(prompt)
-        result, error = self._parse(response)
+        result, error = parse_codegen_response(response, field="script", logger=self.logger)
 
         if error or not result or "script" not in result:
             raise ValueError(f"Correction failed: {error or 'no script'}")
@@ -3808,7 +3809,7 @@ Return JSON: {{"change_type": "cosmetic" | "analytical" | "rewrite", \
 
             try:
                 response = self.model.generate_content(prompt)
-                result, error = self._parse(response)
+                result, error = parse_codegen_response(response, field="script", logger=self.logger)
 
                 if not error and result and result.get("script"):
                     diagnosis = result.get("diagnosis", "")

--- a/scilink/agents/sim_agents/structure_agent.py
+++ b/scilink/agents/sim_agents/structure_agent.py
@@ -18,6 +18,7 @@ from .instruct import (
 )
 from .utils import save_generated_script, MaterialsProjectHelper, MP_SEARCH_TOOL_SCHEMA
 from ...executors import ScriptExecutor, DEFAULT_TIMEOUT
+from ...utils.codegen_parse import parse_codegen_response
 
 from ._deprecation import normalize_params
 
@@ -577,12 +578,17 @@ class StructureGenerator:
                 if attempt > 1:
                     print(f"      🔧 Fixing script issues (attempt {attempt}/{MAX_INTERNAL_SCRIPT_EXEC_CORRECTION_ATTEMPTS})")
                 
-                # Generate script via JSON response
-                response_data = self._generate_json(current_prompt)
-                script_content = response_data.get("script_content")
-                
+                # Generate script via robust, compile-checked extraction (#238):
+                # tolerates JSON-escaping breakage and flags truncation distinctly.
+                response = self.model.generate_content(current_prompt, generation_config=self.generation_config)
+                result_data, parse_error = parse_codegen_response(response, field="script_content", logger=self.logger)
+                script_content = (result_data or {}).get("script_content")
+
                 if not script_content:
-                    last_error_message = f"LLM response missing 'script_content' (attempt {attempt})"
+                    last_error_message = (
+                        (parse_error or {}).get("error")
+                        or f"LLM response missing 'script_content' (attempt {attempt})"
+                    )
                     self.logger.error(last_error_message)
                     if attempt == MAX_INTERNAL_SCRIPT_EXEC_CORRECTION_ATTEMPTS:
                         break

--- a/scilink/utils/codegen_parse.py
+++ b/scilink/utils/codegen_parse.py
@@ -1,0 +1,232 @@
+"""Robust extraction of generated code from LLM codegen responses (#238).
+
+Codegen prompts ask the model to return the whole script as a single JSON-escaped
+string (``{"script": "...escaped python..."}``; field name varies — ``code`` for
+hyperspectral, ``script_content`` for structure). For large/complex scripts that
+contract is brittle: the model mis-escapes quotes/newlines/braces, so ``json.loads``
+fails, and the generic balanced-brace parser in ``base_agent`` then latches onto an
+embedded ``results = {...}`` literal and returns a ``script``-less dict.
+
+``extract_script`` is script-first, not JSON-first: it pulls the code value
+directly and **compile-checks** it (``ast.parse`` — syntax only, never executes).
+The compile-check is the discriminator — a complete-but-mis-escaped script
+compiles (escaping recovered); a truncated one does not, so the caller can treat a
+``None`` return plus a length finish_reason as truncation rather than a parse bug.
+"""
+
+import ast
+import json
+import re
+from typing import Optional
+
+
+def _compiles(script: Optional[str]) -> bool:
+    """True iff *script* is non-empty and parses as valid Python (syntax only)."""
+    if not script or not script.strip():
+        return False
+    try:
+        ast.parse(script)
+        return True
+    except (SyntaxError, ValueError):
+        return False
+
+
+def _strip_fences(text: str) -> str:
+    t = text.strip()
+    if t.startswith("```json"):
+        t = t[7:]
+    elif t.startswith("```"):
+        t = t[3:]
+    if t.endswith("```"):
+        t = t[:-3]
+    return t.strip()
+
+
+def _escape_newlines_in_strings(text: str) -> str:
+    """Escape raw newlines/tabs inside double-quoted strings (mirrors base_agent).
+
+    Recovers the common case where the model emitted a real newline inside the
+    JSON string value instead of ``\\n``.
+    """
+    def repl(match):
+        content = match.group(1)
+        content = content.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+        return '"' + content + '"'
+
+    return re.sub(r'"((?:[^"\\]|\\.)*?)"', repl, text, flags=re.DOTALL)
+
+
+def _from_strict_json(text: str, field: str) -> Optional[str]:
+    """Fast path: the response is valid (or newline-fixable) JSON with *field*."""
+    cleaned = _strip_fences(text)
+    for candidate in (text, cleaned, _escape_newlines_in_strings(cleaned)):
+        try:
+            obj = json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(obj, dict):
+            val = obj.get(field)
+            if isinstance(val, str) and _compiles(val):
+                return val
+    return None
+
+
+def _unescape(s: str) -> str:
+    """Un-escape a JSON-string body, tolerating partially-broken escaping."""
+    try:
+        return json.loads('"' + s + '"')
+    except (json.JSONDecodeError, ValueError):
+        out = s.replace("\\\\", "\x00")          # protect escaped backslashes
+        out = (out.replace("\\n", "\n").replace("\\r", "\r").replace("\\t", "\t")
+                  .replace('\\"', '"').replace("\\'", "'").replace("\\/", "/"))
+        return out.replace("\x00", "\\")
+
+
+def _salvage_json_string(text: str, field: str) -> Optional[str]:
+    """Extract the *field* string value from malformed JSON, script-first.
+
+    Locates ``"<field>": "`` anywhere in the text, then tries each plausible
+    closing quote (one followed by JSON structure ``,`` / ``}`` / ``]``, longest
+    candidate first) and the last quote overall, accepting the first whose
+    un-escaped body compiles. Never keys off braces, so an embedded ``{...}``
+    literal in the script cannot derail it.
+    """
+    key = re.search(r'"' + re.escape(field) + r'"\s*:\s*"', text)
+    if not key:
+        return None
+    body = text[key.end():]
+    closes = {m.start() for m in re.finditer(r'"\s*[,}\]]', body)}
+    last_q = body.rfind('"')
+    if last_q >= 0:
+        closes.add(last_q)
+    for rel in sorted(closes, reverse=True):
+        candidate = _unescape(body[:rel])
+        if _compiles(candidate):
+            return candidate
+    return None
+
+
+def _from_fence(text: str) -> Optional[str]:
+    """A fenced ```python (or bare ```) block whose contents compile."""
+    for pattern in (r'```python\s*([\s\S]*?)\s*```', r'```\s*([\s\S]*?)\s*```'):
+        for match in re.findall(pattern, text, re.DOTALL):
+            script = match.strip()
+            if _compiles(script):
+                return script
+    return None
+
+
+def _from_bare(text: str) -> Optional[str]:
+    """The whole response as bare code, if it compiles and isn't a JSON object."""
+    script = text.strip()
+    if script.startswith("{") and script.endswith("}"):
+        return None  # looks like a (malformed) JSON object, not a bare script
+    return script if _compiles(script) else None
+
+
+def extract_script(raw_text: str, field: str = "script") -> Optional[str]:
+    """Extract a compilable script from a codegen response, or ``None``.
+
+    Order: strict JSON -> salvage malformed JSON -> fenced code block -> bare code.
+    Returns the first candidate that parses as valid Python; ``None`` means nothing
+    compiled (likely truncation or an unrecoverable response).
+    """
+    if not raw_text or not raw_text.strip():
+        return None
+    for value in (
+        _from_strict_json(raw_text, field),
+        _salvage_json_string(raw_text, field),
+        _from_fence(raw_text),
+        _from_bare(raw_text),
+    ):
+        if value is not None:
+            return value
+    return None
+
+
+def _response_text(response) -> str:
+    """Best-effort text from a wrapper response, preferring the UNCLEANED output.
+
+    ``raw_text`` is the model's original output before the wrapper's ``_clean_text``
+    runs; codegen needs it because ``_clean_text``'s embedded-JSON extraction can
+    slice a raw script that contains ``{`` braces (f-strings, dict literals),
+    dropping everything before the first brace (#238). Falls back to ``.text`` for
+    responses that predate the raw_text field or come from other sources.
+    """
+    raw = getattr(response, "raw_text", None)
+    if raw:
+        return raw
+    txt = getattr(response, "text", None)
+    if txt:
+        return txt
+    choices = getattr(response, "choices", None)
+    if choices:
+        msg = getattr(choices[0], "message", None)
+        if msg is not None and getattr(msg, "content", None):
+            return msg.content
+    return str(response) if response is not None else ""
+
+
+def _is_truncated(response) -> bool:
+    """True iff the response was cut off at the output-token limit (finish_reason=length)."""
+    cand = getattr(response, "candidates", None)
+    if cand:
+        try:
+            return getattr(cand[0], "finish_reason", None) == 0
+        except Exception:
+            return False
+    return False
+
+
+def parse_codegen_response(response, field: str = "script", logger=None):
+    """Parse a codegen response into ``({field: script, **side_fields}, None)``
+    or ``(None, error_dict)``.
+
+    Script-first and compile-checked via :func:`extract_script`, so an embedded
+    ``{...}`` literal can't derail extraction. Detects truncation
+    (``finish_reason == length``) and reports it as a distinct error so the retry
+    loop asks for a more compact script instead of misreading it as a parse bug.
+    Drop-in replacement for the codegen call sites' ``self._parse(response)`` —
+    returns a dict keyed by *field* (plus any side fields recovered from
+    well-formed JSON, e.g. ``diagnosis``/``summary``).
+    """
+    if _is_truncated(response):
+        if logger:
+            logger.error("Codegen output truncated (finish_reason=length).")
+        return None, {
+            "error": "LLM output truncated (finish_reason=length)",
+            "details": ("The generated script hit the model's output-token limit and "
+                        "was cut off before completing. Regenerate a more compact "
+                        "script (reuse helper functions, fewer inline literals)."),
+            "truncated": True,
+        }
+
+    raw = _response_text(response)
+    if not raw or not raw.strip():
+        return None, {"error": "Empty response from LLM", "details": "Response text was empty"}
+
+    script = extract_script(raw, field=field)
+    if script is None:
+        if logger:
+            snippet = raw[:500] + "..." if len(raw) > 500 else raw
+            logger.error(f"Codegen extraction failed (field='{field}'). Snippet: {snippet}")
+        return None, {
+            "error": f"Failed to extract a valid '{field}' from LLM response",
+            "details": "No compilable script found (malformed escaping or truncated output).",
+            "raw_response": raw[:2000],
+        }
+
+    result = {field: script}
+    # Best-effort side fields (diagnosis/summary/...) from well-formed JSON.
+    cleaned = _strip_fences(raw)
+    for candidate in (raw, cleaned, _escape_newlines_in_strings(cleaned)):
+        try:
+            obj = json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                if key != field and key not in result:
+                    result[key] = value
+            break
+    return result, None

--- a/scilink/wrappers/litellm_wrapper.py
+++ b/scilink/wrappers/litellm_wrapper.py
@@ -60,6 +60,31 @@ except ImportError:
     litellm = None
 
 
+# Fallback output ceiling for Bedrock models litellm cannot map (e.g. opus-4-6 in
+# litellm 1.83.10). Matches the known Bedrock opus-4-1 ceiling; ~5-8x the headroom
+# a generated analysis/fit script needs and within modern Claude-on-Bedrock limits.
+DEFAULT_MAX_OUTPUT_TOKENS = 32000
+
+
+def _resolve_max_output_tokens(model: str) -> int:
+    """Best-effort max output tokens for a model (Bedrock path only — see #238).
+
+    litellm fills ``max_tokens`` with the model's registered ceiling for direct
+    Anthropic/OpenAI/Gemini, but the Bedrock converse transform omits ``maxTokens``
+    when unset, so Bedrock falls back to a low server-side default and truncates
+    large generations. Returns litellm's registered ceiling when the model is
+    mapped (e.g. Bedrock opus-4-1 -> 32000), else ``DEFAULT_MAX_OUTPUT_TOKENS``. A
+    litellm upgrade that maps the model makes this resolve to the true ceiling.
+    """
+    try:
+        mt = litellm.get_max_tokens(model)
+        if mt:
+            return int(mt)
+    except Exception:
+        pass
+    return DEFAULT_MAX_OUTPUT_TOKENS
+
+
 def _ensure_gemini_api_key():
     """
     Ensure GEMINI_API_KEY is set for LiteLLM.
@@ -428,10 +453,17 @@ class LiteLLMGenerativeModel:
                 val = cfg.get(old)
                 if val is not None:
                     params[new] = val
-        
+
+        # Bedrock omits maxTokens when unset -> a low server-side default truncates
+        # large outputs (#238). Request the model's max on the Bedrock path only;
+        # every other provider already gets a sane ceiling from litellm, so leave
+        # their requests untouched. An explicit max_output_tokens above still wins.
+        if "max_tokens" not in params and str(self.model or "").startswith("bedrock/"):
+            params["max_tokens"] = _resolve_max_output_tokens(self.model)
+
         if tools:
             params["tools"] = tools
-        
+
         return params
     
     def _to_legacy_response(self, response, is_stream: bool = False):
@@ -458,10 +490,12 @@ class LiteLLMGenerativeModel:
                 message = getattr(choice, "delta", None)
             
             text = ""
+            raw_text = ""
             if message:
                 content = getattr(message, "content", None)
                 if content:
-                    text = self._clean_text(str(content))
+                    raw_text = str(content)
+                    text = self._clean_text(raw_text)
             
             tool_calls = getattr(message, "tool_calls", None) if message else None
             if tool_calls:
@@ -481,22 +515,29 @@ class LiteLLMGenerativeModel:
                         ))
             
             if text:
-                parts.append(SimpleNamespace(text=text, function_call=None))
-            
+                parts.append(SimpleNamespace(text=text, function_call=None, raw_text=raw_text))
+
             finish_reason = getattr(choice, "finish_reason", "stop")
             finish_map = {"stop": 1, "length": 0, "tool_calls": 2, "content_filter": 3}
             fr_int = finish_map.get(finish_reason, 1) if finish_reason else 1
-            
+
             content = SimpleNamespace(parts=parts, role="model")
             candidates.append(SimpleNamespace(content=content, finish_reason=fr_int))
-        
+
         first_text = ""
+        first_raw = ""
         if candidates and candidates[0].content.parts:
             for part in candidates[0].content.parts:
                 if hasattr(part, "text") and part.text:
                     first_text += part.text
-        
-        return SimpleNamespace(text=first_text, candidates=candidates)
+                if getattr(part, "raw_text", None):
+                    first_raw += part.raw_text
+
+        # raw_text preserves the model's UNCLEANED output. Codegen parsing must use
+        # it: _clean_text's embedded-JSON extraction (Pattern 3) greedily slices from
+        # the first '{' to the last '}', which mangles a raw script containing
+        # f-string/dict braces before the codegen parser ever sees it (#238).
+        return SimpleNamespace(text=first_text, candidates=candidates, raw_text=first_raw)
     
     def _clean_text(self, text: str) -> str:
         """


### PR DESCRIPTION
## Summary

Running a curve-fitting analysis through **Bedrock `claude-opus-4-6`** could fail with `All JSON parsing strategies failed`, repeating on every retry — most visibly on complex refits (e.g. a multi-peak EELS spectrum). The same workflow worked fine on direct Anthropic, which is why it only surfaced after switching to the Bedrock model. This PR fixes the two underlying Bedrock-specific causes and hardens how the agents read LLM-generated code so it survives large, complex scripts.

What you'll notice: complex fits that previously dead-looped on parse errors now complete, and if a script ever does hit the model's output limit the logs say so plainly (`output truncated`) instead of a confusing "couldn't parse" message.

Nothing changes for direct Anthropic / OpenAI / Gemini / the internal proxy — those request paths are untouched.

---

## Technical details

Two independent, **Bedrock-only** root causes (both verified by capturing the outgoing litellm request body against litellm 1.83.10):

**1. Truncation — `maxTokens` omitted on the Bedrock path.**
Codegen calls pass `generation_config=None`, so `_build_params` sets no `max_tokens`.
- Direct Anthropic: litellm's Anthropic transform fills `max_tokens` with the model's registered ceiling (`anthropic/claude-opus-4-x` → **128000**, captured from the request body) → never truncates.
- Bedrock: `bedrock/...claude-opus-4-6` is **unmapped** in litellm 1.83.10 (`get_max_tokens` raises), and the Bedrock converse transform omits `maxTokens` when unset (request body `inferenceConfig: {}`) → falls back to a **low server-side default** → script cut off mid-stream → unterminated `{"script": "...` → parse fails (deterministic, since the cap is fixed).
- Fix: `litellm_wrapper._resolve_max_output_tokens(model)` + `DEFAULT_MAX_OUTPUT_TOKENS = 32000`; `_build_params` injects `max_tokens` **only** when `model.startswith("bedrock/")` and it's unset (mapped → litellm ceiling, unmapped → 32000, matching the known Bedrock opus-4-1 ceiling). Verified: Bedrock body now sends `inferenceConfig.maxTokens == 32000`; Anthropic body unchanged at 128000; OpenAI/Gemini bodies unchanged. An explicit `generation_config.max_output_tokens` still wins.

**2. Response mangling — `_clean_text` slices an inner brace.**
`LiteLLMGenerativeModel._clean_text` (which builds `response.text`) extracts embedded JSON with `re.search(r'(\{[\s\S]*\})', text)` — greedy from the **first `{` to the last `}`**. When Bedrock returns the script as raw code (no JSON wrapper / fence), the first `{` is inside an f-string (`f"...x={x.shape}..."`), so `.text` is sliced from that inner brace and the script's head (imports, etc.) is destroyed *before* the parser runs. Symptom: `raw_response` starting mid-script at `{x.shape}, y=...` (reproduced byte-for-byte).
- Fix: `_to_legacy_response` now preserves the **uncleaned** model output as `response.raw_text` (per-part `raw_text` accumulated into a top-level field); `_clean_text` is left untouched for the JSON-parsing path.

**Robust codegen parsing — `scilink/utils/codegen_parse.py` (new).**
Replaces the brittle JSON-escaped-string contract handling with a script-first, **compile-checked** extractor:
- `extract_script(raw_text, field)`: strict JSON → salvage malformed JSON (`"<field>": "` value, tolerant unescape) → fenced ```python block → bare code; returns the first candidate that `ast.parse`-compiles (syntax only, never executed), else `None`. The compile-check is the escaping-vs-truncation discriminator. **Bypasses the harmful balanced-brace strategy**, so an embedded `results = {...}` literal can no longer be returned in place of the script.
- `parse_codegen_response(response, field, logger)`: prefers `response.raw_text`; checks `finish_reason == length` first → distinct `truncated` error; else `extract_script`; merges side fields (`diagnosis`/`summary`) from well-formed JSON. Returns `(dict_keyed_by_field, error)` — drop-in for the old `self._parse(...)` at codegen sites.
- `base_agent._parse_codegen_response` is a thin delegate (controllers aren't `BaseAnalysisAgent` subclasses, so they import the module function directly).

**Wired codegen sites (field in parens), structured-JSON sites untouched:**
- curve `curve_fitting_controllers.py`: `_generate_fitting_script`, `_correct_script`, `_generate_trend_script`, trend correction (`script`)
- image `image_analysis_controllers.py`: `_generate_analysis_script`, `_correct_script`, `_apply_user_feedback` (`script`)
- hyperspectral `hyperspectral_controllers.py`: custom-analysis codegen loop (`code`, with `(result_json or {}).get` None-guard)
- structure `sim_agents/structure_agent.py::generate_script` (`script_content`, replacing the strict-`json.loads` `_generate_json` call on the codegen path)

**Verification**
- `extract_script` unit: clean JSON; malformed-but-complete (unescaped quotes/newlines/f-string braces) → salvaged + compiles; embedded `results={...}` → returns the script, not the inner dict; fenced; bare; truncated → `None`; `code`/`script_content` field variants; literal-newline JSON.
- Wrapper request-body capture: Bedrock `maxTokens==32000` (was absent), Anthropic 128000 unchanged, explicit `max_output_tokens` wins.
- Mangling repro: `_to_legacy_response` on a raw-code response → `.text` reproduces the `{x.shape}...` fragment; `raw_text` preserved; `parse_codegen_response` recovers the full compilable script.
- Live (opus-4-8, `UNSAFE_EXECUTION_OK`): end-to-end curve fit parses a 181-line / 6.6 KB script; the real correction prompt round-trips a compilable corrected script with `diagnosis` recovered.
- Existing `tests/test_curve_fitting_stdout_parser.py` (10) pass; full package imports.

**Known limits**
- `DEFAULT_MAX_OUTPUT_TOKENS = 32000` for unmapped Bedrock models is a best-effort ceiling; a litellm upgrade that maps opus-4-6 makes `_resolve_max_output_tokens` resolve to the true value automatically. The `finish_reason` detector surfaces any residual truncation as truncation rather than a parse error.
- Salvage is heuristic but gated by the compile-check, so a wrong boundary cut never yields accepted garbage (worst case: falls through to retry, as today).
