### PR TITLE
Fix dead hot-annealing fresh-generation trigger in curve fitting

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -3141,6 +3141,15 @@ Return JSON with:
                     #       hot level by the end of the budget regardless of
                     #       what the rate/patience say.
                     _annealing_level = 0
+                    # Annealing level at which the PREVIOUS refit actually ran.
+                    # Used to detect the escalation INTO the hot level (see the
+                    # fresh-generation trigger below). Must track the prior
+                    # refit's level — not a same-iteration snapshot of
+                    # _annealing_level — because escalation happens at the end of
+                    # an iteration, so a start-of-iteration snapshot already
+                    # equals the (escalated) current level and never registers a
+                    # transition. Mirrors image_analysis's _previous_annealing_level.
+                    _previous_annealing_level = 0
                     _prev_best_r2 = best_r2
                     _n_anneal_levels = len(self._CONSTRAINT_ANNEALING_SCHEDULE)
                     _PATIENCE = 2
@@ -3293,7 +3302,7 @@ Return JSON with:
                         # so the LLM can restructure freely.
                         _just_escalated_to_hot = (
                             _annealing_level >= _n_anneal_levels - 1
-                            and _cur_level < _n_anneal_levels - 1
+                            and _previous_annealing_level < _n_anneal_levels - 1
                         )
                         _refine_from = (
                             None if _just_escalated_to_hot
@@ -3315,6 +3324,11 @@ Return JSON with:
                             refine_from_r2=best_r2,
                             refine_from_issues=verification.get("issues_found", []),
                         )
+                        # Record the level this refit ran at, so the next
+                        # iteration can detect the escalation into hot. Updated
+                        # only on an actual refit (not the no-config-change
+                        # escalate-and-continue branch above).
+                        _previous_annealing_level = _annealing_level
 
                         if verified_result["success"]:
                             verified_r2 = verified_result.get("fit_quality", {}).get("r_squared") or 0


### PR DESCRIPTION
## Summary

When a curve fit needs the model *restructured* (not just its parameters nudged) — e.g. an EELS edge that needs extra fine-structure peaks — the verification loop is supposed to grant the LLM a clean, from-scratch regeneration once it escalates to the "hot" annealing level. That escalation never actually triggered the fresh generation: the loop always refined the previous script, at every temperature. As a result, the model *architecture* chosen on the first fit was effectively frozen for the whole run, even when the loop had escalated to maximum freedom.

This was observed live on a Ti L₂,₃ + O K-edge EELS spectrum: the loop reached the hot level by verification 4 and ran to 7, but every iteration logged "refining prior script" and never "fresh generation — hot annealing", so it kept tuning step shape and masking instead of restructuring.

After this fix the fresh generation fires exactly once, on the iteration the loop first reaches the hot level — giving the model its intended chance to rebuild.

---

## Technical details

**Bug.** In `curve_fitting_controllers.py`, the verification loop computes:
```python
_just_escalated_to_hot = (
    _annealing_level >= _n_anneal_levels - 1
    and _cur_level < _n_anneal_levels - 1          # <-- always equal to _annealing_level here
)
_refine_from = None if _just_escalated_to_hot else (best_result or {}).get("script")
```
`_cur_level = _annealing_level` is snapshotted at the **start** of each iteration. Annealing escalation happens at the **end** of an iteration (rate/patience/floor triggers, after the refit). So by the time the check runs, `_cur_level == _annealing_level` always, and the condition `(_annealing_level >= n-1 and _cur_level < n-1)` is unsatisfiable. The `_refine_from = None` (fresh-generation) branch is dead code; the loop always anchors on `best_result.script` ("preserve scaffolding, modify components/guesses/bounds") regardless of temperature.

Confirmed against a real run's full stdout: **0** occurrences of "fresh generation — hot annealing", **5** of "refining prior script".

**Fix.** Track the annealing level at which the **previous refit** actually ran (`_previous_annealing_level`), updated only after a real refit (not the no-config-change escalate-and-continue branch), and test the hot transition against it:
```python
_just_escalated_to_hot = (
    _annealing_level >= _n_anneal_levels - 1
    and _previous_annealing_level < _n_anneal_levels - 1
)
```
This is exactly the pattern `image_analysis_controllers.py` already uses correctly (`_previous_annealing_level`, set after `_process_single_image`) — so this change brings curve fitting into line with the image agent rather than inventing a new mechanism.

**Verification.** Replaying the observed run's per-refit level sequence `[0,0,1,2,2,2,2]` (n_levels=3, hot=2):

| iter | level | old trigger | fixed trigger |
|---|---|---|---|
| 1–3 | 0,0,1 | False | False |
| 4 | 2 | **False (bug)** | **True** |
| 5–7 | 2,2,2 | False | False |

Old: 0 fresh generations. Fixed: exactly 1, on the first refit at the hot level, and correctly not re-firing on subsequent hot iterations (the intended one-shot-at-transition behavior). `py_compile` clean.

**Scope / non-goals.** This restores the loop's ability to *execute* a structural rebuild when it reaches hot. It does not, by itself, make the verifier *request* more model components — in the observed run the verifier diagnosed the residuals as edge-onset/spike issues and never proposed added peaks, so seeding the right structure (issue #239) and a verifier nudge to consider under-resolved components remain the larger levers for that specific case. Independent of the codegen-parsing fix in #240 (different file region).
