### PR TITLE
Use Claude Opus 4.8 for the Bedrock UI model option

### DIFF
--- a/scilink/ui/config.py
+++ b/scilink/ui/config.py
@@ -6,12 +6,12 @@ MODEL_OPTIONS = [
     "claude-opus-4-6",
     "gemini-3.1-pro-preview",
     "gpt-5.4",
-    # Amazon Bedrock (Claude Opus 4.6) via the US geo cross-region inference
-    # profile (exact ID from the AWS model card; Opus 4.6 has no date stamp and
-    # uses a bare ``-v1`` suffix — no ``:0``). Invoke-able only through an
-    # inference profile, hence the ``us.`` prefix. For EU/AU keys swap the
-    # prefix: ``eu.``/``au.``. (Base model ID: anthropic.claude-opus-4-6-v1.)
-    "bedrock/us.anthropic.claude-opus-4-6-v1",
+    # Amazon Bedrock (Claude Opus 4.8) via the US geo cross-region inference
+    # profile (exact ID from the AWS model card; Opus 4.8 has no date stamp and
+    # no version suffix). Invoke-able only through an inference profile, hence
+    # the ``us.`` prefix. For EU/JP/AU keys swap the prefix:
+    # ``eu.``/``jp.``/``au.``. (Base model ID: anthropic.claude-opus-4-8.)
+    "bedrock/us.anthropic.claude-opus-4-8",
 ]
 
 EMBEDDING_MODEL_OPTIONS = [


### PR DESCRIPTION
## Summary

Updates the **Amazon Bedrock** entry in the UI model dropdown from Claude **Opus 4.6** to **Opus 4.8**. Users selecting Bedrock now get Anthropic's latest Opus model. The direct-API options (Anthropic / Gemini / OpenAI) and the pre-selected default are unchanged.

Builds on the Bedrock provider support merged in #236.

## Technical details

`scilink/ui/config.py` `MODEL_OPTIONS`: swap `bedrock/us.anthropic.claude-opus-4-6-v1` → `bedrock/us.anthropic.claude-opus-4-8`.

The ID is taken verbatim from the AWS Opus 4.8 model card's "Programmatic Access" table (US geo cross-region inference profile). Opus 4.8 drops **both** the date stamp and the version suffix — 4.6 was the last Bedrock Claude ID to carry `-v1` — so the correct inference-profile ID is the bare `us.anthropic.claude-opus-4-8` (base model ID `anthropic.claude-opus-4-8`). The accompanying comment is updated, including the EU/JP/AU prefix variants (`eu.`/`jp.`/`au.`).

No other files change; the provider registry, region dropdown, and Bedrock-scoped `drop_params` from #236 all apply unchanged. Opus 4.8 is invoke-able only via an inference profile, which the existing `bedrock/` routing already handles.
