### PR TITLE
Keep mode-selector buttons on one row (fix wrapping at high DPI / narrow widths)

### DIFF
--- a/scilink/ui/theme.py
+++ b/scilink/ui/theme.py
@@ -123,6 +123,18 @@ div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) {
 div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div {
     margin-top: -2rem !important;
 }
+/* Mode selector — keep the buttons on one row.
+   Streamlit columns are flex items with a built-in min-width and the row
+   wraps by default; at higher OS display scaling / narrower windows the
+   buttons' combined min-width exceeds the centered column and the row wraps
+   (reproduces on some machines, not others). Force no-wrap and let the
+   columns shrink so the buttons stay on a single line. */
+div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div [data-testid="stHorizontalBlock"] {
+    flex-wrap: nowrap !important;
+}
+div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div [data-testid="stHorizontalBlock"] > [data-testid="stColumn"] {
+    min-width: 0 !important;
+}
 /* Sidebar buttons — original purple */
 section[data-testid="stSidebar"] .stButton > button {
     background-color: #6200EE;
@@ -620,6 +632,18 @@ div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) {
 }
 div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div {
     margin-top: -2rem !important;
+}
+/* Mode selector — keep the buttons on one row.
+   Streamlit columns are flex items with a built-in min-width and the row
+   wraps by default; at higher OS display scaling / narrower windows the
+   buttons' combined min-width exceeds the centered column and the row wraps
+   (reproduces on some machines, not others). Force no-wrap and let the
+   columns shrink so the buttons stay on a single line. */
+div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div [data-testid="stHorizontalBlock"] {
+    flex-wrap: nowrap !important;
+}
+div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div [data-testid="stHorizontalBlock"] > [data-testid="stColumn"] {
+    min-width: 0 !important;
 }
 /* Mode selector secondary buttons — outlined purple */
 div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div .stButton > button[kind="secondary"] {


### PR DESCRIPTION
## Summary

Fixes the mode-selector buttons (Analyze / Plan / Simulate, plus the Explore icon row) wrapping onto multiple lines for some users. It was reported on both Windows and macOS while rendering fine for others — the cause is display-scale dependent, so it reproduces on some machines and not others. This pins the buttons to a single row.

## Technical details

The mode selector (`scilink/ui/app.py`) builds the row as nested `st.columns` inside a 1:2:1 layout, so the buttons live in the centered column. Streamlit renders each column as a flex item with a built-in `min-width`, and the horizontal block defaults to `flex-wrap: wrap`. At higher OS display scaling (Windows 125–150%) or narrower windows, the buttons' combined min-width exceeds the centered column and the row wraps.

Fix is CSS-only in `scilink/ui/theme.py`, scoped to the mode selector via the existing `.mode-selector-anchor` marker so nothing else is affected:
- `flex-wrap: nowrap` on the selector's `stHorizontalBlock`
- `min-width: 0` on its child `stColumn`s so they shrink instead of forcing a wrap (buttons already carry `white-space: nowrap`)

Applied to both the dark and light theme blocks. No `app.py` change needed.

Note: this is display-scale dependent and does not reproduce on every machine; verified the CSS is syntactically valid and correctly scoped, but visual confirmation is best done by an affected user (or by zooming the browser to 125–150% / narrowing the window to reproduce the wrap, then confirming it is gone on this branch).
