### PR TITLE
Curve-fit: let a degenerate-but-successful anchor fit enter verification (no skip→lock)

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -3283,8 +3283,16 @@ Return JSON with:
             # --- Verification loop (for anchor spectra: first overall or first in regime) ---
             fit_was_approved = False
             if _is_anchor:
-                if not best_result or not best_result.get("success") or best_r2 < 0.1:
-                    self.logger.warning(f"   Initial fit failed or R² too low ({best_r2:.4f}), skipping verification")
+                # Skip verification ONLY when there is no successful fit to work
+                # with. A fit that executed but is degenerate (low/zero R²) must
+                # still enter the loop: the verifier + adaptive annealing (which
+                # reaches hot/fresh-generation) + residual diagnostics are the
+                # recovery path for a "ran-but-garbage" fit. Previously a
+                # `best_r2 < 0.1` clause skipped these cases, locking a degenerate
+                # script with no recovery (and, in a series, reusing it for every
+                # spectrum). Matches image-analysis, which gates on success only. (#245)
+                if not best_result or not best_result.get("success"):
+                    self.logger.warning(f"   Initial fit failed (no successful result, R²={best_r2:.4f}), skipping verification")
                 else:
                     # Adaptive annealing state: start frozen, escalate via
                     # three complementary mechanisms so hot annealing


### PR DESCRIPTION
## Summary

When a curve fit *executes* but lands on a garbage result (R²≈0), the agent used to lock that fit and move on — with no attempt to recover it. In a series, that bad anchor script was then reused for every spectrum, so the whole run came out R²=0. This fixes that: a fit that ran but is degenerate now goes through the normal verification/refinement loop, which can recover it.

Resolves #245.

## Technical details

**The gate** (`curve_fitting_controllers.py`, anchor-spectrum verification):
```python
# before
if not best_result or not best_result.get("success") or best_r2 < 0.1:
    # skip verification
# after
if not best_result or not best_result.get("success"):
    # skip verification only when there is NO successful fit
```

`_fit_single_spectrum` returns `success=True` whenever the script executes and emits `FIT_RESULTS_JSON` + a viz — independent of R². The old `or best_r2 < 0.1` clause therefore skipped the verification loop for a *ran-but-degenerate* fit, locking it and (in a series) propagating it. But the verifier + adaptive annealing (which reaches hot/fresh-generation via #241) + residual diagnostics (#242) are exactly the recovery mechanism for such a fit — skipped precisely when the fit was worst.

Fix: gate on `success` only, dropping the R² clause — matching image-analysis, which skips solely on `not best_result.get("success")` (no low-score clause). A degenerate-but-successful anchor now enters the loop; a genuine failure (no successful result) still skips, as before.

**Verification (live, Bedrock opus-4-6 — the exact case that motivated this):** a 3-peak temperature series whose initial codegen lands at R²=0.
- *Before:* skipped verification → locked the R²=0 script → 3/3 spectra R²=0.
- *After:* the degenerate anchor enters verification → the verifier flags it, annealing escalates, the refit regenerates a working script → **R²=0 → 0.9941**, then the other spectra reuse the now-good script.

Healthy fits (R² ≥ 0.1) are unchanged — they entered verification before and still do.

**Scope / known limit.** This recovers the case where the codegen produces a *runnable* (if degenerate) script. The separate case where *every* codegen attempt is non-compilable (observed intermittently on Bedrock opus-4-6, whose long JSON-escaped scripts can have collapsed indentation) leaves no successful fit to recover — that's a codegen-contract problem tracked in #243 (fence migration), not this gate. Independent of #243/#244.
