### PR TITLE
Block cross-modality skill leaks; guard curve-fit crash on total fit failure

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -2992,6 +2992,12 @@ Return JSON with the refined fitting approach:
             return config
 
     def _get_human_feedback_for_poor_fit(self, state: dict, best_result: dict, all_attempts: List[dict]) -> Optional[dict]:
+        # No successful fit to review (every attempt failed → best_result is None).
+        # Don't solicit poor-fit feedback on a non-existent fit; let the caller
+        # fall through to graceful failure handling rather than dereferencing None.
+        if not best_result:
+            self.logger.warning("   All fitting attempts failed — no fit to review; skipping poor-fit feedback.")
+            return None
         models_tried = "\n".join([f"  - {a['model']}: R² = {a['r2']:.4f}" for a in all_attempts])
         
         print("")
@@ -3701,7 +3707,9 @@ Return JSON with:
         # level is reached when refits stall.
 
         # --- Human feedback for poor fit (if enabled) ---
-        if self.enable_human_feedback and _is_anchor:
+        # Guard `best_result`: when every fitting attempt failed it is None, and
+        # there is no fit to review — skip straight to graceful failure handling.
+        if self.enable_human_feedback and _is_anchor and best_result:
             feedback_result = self._get_human_feedback_for_poor_fit(state, best_result, all_attempts)
 
             if feedback_result:

--- a/scilink/skills/loader.py
+++ b/scilink/skills/loader.py
@@ -33,6 +33,14 @@ _SKILLS_DIR = Path(__file__).parent
 
 _KNOWN_SECTIONS = {"overview", "planning", "analysis", "interpretation", "validation", "implementation"}
 
+# The three analysis modalities each operate on a different data shape
+# (1D curves / 2D images / 3D datacubes); their skills are NOT interchangeable.
+# A bare-name cross-domain fallback must not pull, e.g., the hyperspectral `eels`
+# datacube skill into CurveFittingAgent. Genuinely cross-cutting skills live in
+# OTHER (non-modality) domains (e.g. structure_matching/xrd) and stay usable
+# cross-domain.
+_MODALITY_DOMAINS = frozenset({"curve_fitting", "image_analysis", "hyperspectral"})
+
 _FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
 _logger = logging.getLogger(__name__)
@@ -241,6 +249,13 @@ def _resolve_skill_path(skill: str, domain: str) -> Path:
             return bundle
 
     matches = _find_skill_across_domains(skill)
+    # Block cross-modality leaks: when the requesting agent is one analysis
+    # modality, drop fallback matches that belong to a DIFFERENT modality (a
+    # skill authored for another data shape). Non-modality (cross-cutting)
+    # domains are unaffected and remain usable cross-domain.
+    if domain in _MODALITY_DOMAINS:
+        foreign = _MODALITY_DOMAINS - {domain}
+        matches = [m for m in matches if m.parent.parent.name not in foreign]
     if len(matches) == 1:
         _logger.debug(
             "Skill '%s' not found in domain '%s' — resolved cross-domain to %s.",


### PR DESCRIPTION
## Summary

Two robustness fixes, both surfaced by an orchestrator run that sent a 1-D EELS core-loss spectrum to the **curve-fitting** agent:

1. The agent silently loaded the **hyperspectral `eels`** skill — a skill written for 3-D STEM datacubes — into a 1-D curve fit.
2. When every fitting attempt for the spectrum failed, the pipeline **crashed** (`'NoneType' object has no attribute 'get'`) instead of reporting a clean failure.

Neither is caused by the recent #245 fix; both are pre-existing and independent of #243/#244.

## Technical details

### 1. Skill loader — block cross-modality fallback (`scilink/skills/loader.py`)
`_resolve_skill_path` resolves a bare skill name in the requested domain first, then **falls back to a cross-domain search** — by design, so cross-cutting skills (e.g. `structure_matching/xrd`) are usable from any agent. But the three **analysis modalities** — `curve_fitting` (1-D), `image_analysis` (2-D), `hyperspectral` (3-D datacube) — operate on different data shapes and their skills are **not interchangeable**. Because there is no `curve_fitting/eels`, the fallback loaded `hyperspectral/eels` into `CurveFittingAgent`.

Fix: a new `_MODALITY_DOMAINS = {curve_fitting, image_analysis, hyperspectral}`; when the requesting domain is one of these, drop fallback matches belonging to a *different* modality. Non-modality (cross-cutting) domains are unaffected.

A now-blocked bare name raises `FileNotFoundError`, which `_load_skills_to_state` already catches → the agent proceeds on its **baseline** expertise (which fits 1-D EELS well — validated at R²≈0.99 in earlier direct-model runs).

Unit-checked:
- `eels`→curve **BLOCKED**, `afm`→curve **BLOCKED**, `eels`→image **BLOCKED**
- `eels`→hyperspectral **loads** (in-domain), `epr`→curve **loads** (in-domain)
- `xrd`→curve **still loads** `structure_matching/xrd` (cross-cutting preserved)

### 2. Curve-fit — guard total-fit-failure in the poor-fit feedback path (`curve_fitting_controllers.py`)
When every attempt for the anchor spectrum fails, `best_result` is `None`. The below-threshold human-feedback handler dereferenced it (`best_result.get("visualization_bytes")`), crashing the `UnifiedSeriesProcessingController` step. (Only triggers with human-feedback enabled — e.g. a meta/autopilot delegation — which is why headless test runs didn't hit it.)

Fix: guard the call site (`and best_result`) and the handler top, so a total failure falls through to the existing graceful-failure handling.

**Verified safe — behavior changes only in the all-attempts-failed case:**
- `best_result` is only ever `None` (no successful fit) or a **non-empty successful dict** — it's never an empty/falsy non-None dict (every assignment is gated on `result["success"]`). So `and best_result` ≡ `and best_result is not None`.
- For any real fit — *including a degenerate R²=0 one* (a truthy dict) — the condition is unchanged → the handler is still called exactly as before. Composes cleanly with #245.
- The handler has a single caller (now guarded), so the handler-top `if not best_result: return None` is purely defensive.
- `return None` matches the existing contract (callers treat a falsy return as "no actionable feedback → fall through").
- The pre-fix `best_result is None` path *always* crashed, so no working behavior is removed.

`tests/test_curve_fitting_stdout_parser.py` (10) pass; package imports.

## Follow-up (out of scope)
Authoring a real `curve_fitting/eels` skill (1-D core-loss fitting is common) would let curve fitting use EELS-specific guidance instead of just baseline. This PR only stops the wrong-modality leak.
