### PR TITLE
Plan validation: run data-check without a skill, use scout overlay for series, guard malformed regimes

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1534,14 +1534,15 @@ class HumanFeedbackRefinementController:
         return state
 
     def _validate_plan(self, state: dict) -> dict:
-        """Validate the proposed fitting plan against data and skill rules.
+        """Validate the proposed fitting plan against the data (and skill rules
+        when a skill is loaded).
 
-        Mirrors ImageAnalysisAgent's _validate_plan. Only runs when skill
-        rules are present — without skills there's nothing to enforce.
+        Always runs (matching ImageAnalysisAgent): the data-grounded sanity
+        check — do the planned peaks exist, is the plot consistent with the
+        model — is useful even without a skill. Skill-conformance is enforced
+        only when skill rules are present (the validation prompt applies the
+        "MANDATORY Domain Skill Rules" clause conditionally).
         """
-        if not state.get("skill_sections"):
-            return state
-
         from ..instruct import CURVE_FITTING_PLAN_VALIDATION_PROMPT
 
         regime_section = ""
@@ -1567,9 +1568,13 @@ class HumanFeedbackRefinementController:
         prompt_parts = [prompt_text]
         _append_skill_context(prompt_parts, state, "planning")
 
-        if state.get("original_plot_bytes"):
+        # For a series, show the multi-spectrum scout overlay (the single
+        # first-spectrum plot is uninformative — and can render blank — for a
+        # series); fall back to the single-spectrum plot otherwise.
+        data_plot = state.get("scout_overlay_plot") or state.get("original_plot_bytes")
+        if data_plot:
             prompt_parts.append("\n**Data:**")
-            prompt_parts.append({"mime_type": "image/png", "data": state["original_plot_bytes"]})
+            prompt_parts.append({"mime_type": "image/png", "data": data_plot})
 
         try:
             response = self.model.generate_content(
@@ -1676,12 +1681,16 @@ class HumanFeedbackRefinementController:
     def _extract_series_plan(self, state: dict, result: dict) -> None:
         """Extract and validate series_analysis_plan from LLM response."""
         series_plan = result.get("series_analysis_plan")
-        if not series_plan or state.get("is_single_spectrum", True):
+        if not isinstance(series_plan, dict) or state.get("is_single_spectrum", True):
             state["series_analysis_plan"] = None
             return
 
         num_spectra = state.get("num_spectra", 1)
-        regimes = series_plan.get("regimes", [])
+        # Defensively drop malformed (non-dict) regimes — an LLM/validator
+        # revision can return a regime as a bare string, which would otherwise
+        # crash regime.get(...) below.
+        regimes = [r for r in series_plan.get("regimes", []) if isinstance(r, dict)]
+        series_plan["regimes"] = regimes
 
         if not regimes:
             state["series_analysis_plan"] = None

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -1416,12 +1416,16 @@ class ImagePlanningController:
     def _extract_series_plan(self, state: dict, result: dict) -> None:
         """Extract and validate series_analysis_plan from LLM response."""
         series_plan = result.get("series_analysis_plan")
-        if not series_plan or state.get("is_single_image", True):
+        if not isinstance(series_plan, dict) or state.get("is_single_image", True):
             state["series_analysis_plan"] = None
             return
 
         num_images = state.get("num_images", 1)
-        regimes = series_plan.get("regimes", [])
+        # Defensively drop malformed (non-dict) regimes — an LLM/validator
+        # revision can return a regime as a bare string, which would otherwise
+        # crash regime.get(...) below.
+        regimes = [r for r in series_plan.get("regimes", []) if isinstance(r, dict)]
+        series_plan["regimes"] = regimes
 
         if not regimes:
             state["series_analysis_plan"] = None


### PR DESCRIPTION
## Summary

Three fixes to the (curve-fitting) plan-validation step, surfaced by a series run where the validator was shown a **blank plot** and then **crashed**, silently discarding its feedback:

1. A skill-less run got **no plan validation at all** — not even "do the planned peaks exist in the data?".
2. For a series, the validator was shown the single first-spectrum plot (uninformative / blank), not the multi-spectrum overlay.
3. A malformed validator revision crashed the step.

## Technical details (`curve_fitting_controllers.py`, + shared guard in `image_analysis_controllers.py`)

**1 — Decouple the data-grounded check from skill presence.** `_validate_plan` returned early when no skill was loaded:
```python
if not state.get("skill_sections"): return state   # removed
```
But the validation prompt is data-first and applies skill-conformance **conditionally** (*"IF MANDATORY Domain Skill Rules are provided below …"*), so it reads fine without a skill. Removing the gate means the **data-grounded sanity check runs on every run**; skill-conformance is still enforced only when skill rules are present. This matches **ImageAnalysisAgent**, whose `_validate_plan` already runs unconditionally (curve was the outlier).

**2 — Scout overlay for series.** `_validate_plan` passed `original_plot_bytes` (the single first-spectrum plot — uninformative, and blank for this series; the validator literally reported *"the provided data plot is blank"*). Now it prefers `scout_overlay_plot` (the multi-spectrum overlay), falling back to the single plot.

**3 — Guard `_extract_series_plan` against malformed regimes.** When the validator returned a revised `series_analysis_plan` whose `regimes` weren't dicts (an entry was a bare string), `regime.get(...)` raised `'str' object has no attribute 'get'` → caught as *"Plan validation failed … keeping plan"* → the revision was silently dropped. Now a non-dict `series_analysis_plan` or non-dict regime entries are filtered defensively. Applied to **both** curve and image (image validates unconditionally → more exposed; same latent pattern).

## Verification
- Unit-tested the regime guard: mixed (string + valid dict) → drops the string, keeps the valid regime, no crash; all-malformed → `series_analysis_plan=None`; `series_analysis_plan` itself a string (the exact validator crash) → `None`; well-formed plan → unchanged.
- `tests/test_curve_fitting_stdout_parser.py` (10) pass; package imports.

## Context / not in scope
The trigger was a same-domain but technique-wrong skill (`xrd_profile` auto-selected for Raman data, because `curve_fitting` has no Raman skill). That **technique-aware skill-selection** gap is the larger follow-up, tracked in a separate issue — not addressed here. (Independent of #248/#249.)
