### PR TITLE
Fix empty-but-successful synthesis: narrative salvage + meta guardrail + regime markers

### DIFF
--- a/scilink/agents/exp_agents/base_agent.py
+++ b/scilink/agents/exp_agents/base_agent.py
@@ -146,6 +146,77 @@ class LLMAgentMixin:
         from ...utils.codegen_parse import parse_codegen_response
         return parse_codegen_response(response, field=field, logger=self.logger)
 
+    def _salvage_synthesis_fields(self, response: Any) -> Optional[dict]:
+        """Best-effort recovery of synthesis fields from a malformed-JSON response.
+
+        The synthesis step asks for a structured object whose dominant field is a
+        long free-text narrative (``detailed_analysis``). Some providers return
+        that narrative with unescaped quotes/newlines, so strict JSON parsing
+        fails and the whole payload would otherwise be dropped to ``{"error": …}``
+        — yielding a ``success`` result with empty findings (and, for the meta
+        agent, a re-delegation loop). This recovers the narrative by string-
+        boundary extraction (tolerant of stray quotes, the dominant failure mode)
+        plus the ``scientific_claims`` / ``candidate_identifications`` list when
+        its JSON array parses cleanly. Returns ``None`` when no usable narrative
+        can be recovered, so the caller keeps the original parse error.
+        """
+        import re
+        try:
+            raw = self._extract_text_from_response(response) or ""
+        except Exception:
+            return None
+        if not raw.strip():
+            return None
+
+        recovered: dict = {}
+
+        # detailed_analysis: take the string value from its key up to the next
+        # top-level key or the closing brace, tolerating unescaped inner quotes.
+        m = re.search(r'"detailed_analysis"\s*:\s*"', raw)
+        if m:
+            rest = raw[m.end():]
+            end_markers = [
+                r'"\s*,\s*"[A-Za-z_][A-Za-z0-9_]*"\s*:',  # next top-level key
+                r'"\s*\}\s*$',                            # final closing brace
+            ]
+            cut = None
+            for pat in end_markers:
+                mm = re.search(pat, rest)
+                if mm:
+                    cut = mm.start() if cut is None else min(cut, mm.start())
+            narrative = rest[:cut] if cut is not None else rest
+            narrative = (narrative
+                         .replace('\\n', '\n').replace('\\t', '\t')
+                         .replace('\\r', '\r').replace('\\"', '"')
+                         .replace('\\\\', '\\'))
+            narrative = narrative.strip().rstrip('}').strip().rstrip('"').strip()
+            if len(narrative) >= 40:
+                recovered["detailed_analysis"] = narrative
+
+        # scientific_claims / candidate_identifications: recover the array only
+        # if it parses cleanly (secondary; failure here just omits the field).
+        for key in ("scientific_claims", "candidate_identifications"):
+            am = re.search(r'"' + key + r'"\s*:\s*\[', raw)
+            if not am:
+                continue
+            i = raw.index('[', am.start())
+            depth = 0
+            for j in range(i, len(raw)):
+                if raw[j] == '[':
+                    depth += 1
+                elif raw[j] == ']':
+                    depth -= 1
+                    if depth == 0:
+                        break
+            try:
+                arr = json.loads(raw[i:j + 1])
+                if isinstance(arr, list):
+                    recovered[key] = arr
+            except Exception:
+                pass
+
+        return recovered if recovered.get("detailed_analysis") else None
+
     def _extract_text_from_response(self, response: Any) -> str:
         """Extract text content from various LLM response formats."""
         if hasattr(response, 'text'):

--- a/scilink/agents/exp_agents/base_agent.py
+++ b/scilink/agents/exp_agents/base_agent.py
@@ -147,75 +147,22 @@ class LLMAgentMixin:
         return parse_codegen_response(response, field=field, logger=self.logger)
 
     def _salvage_synthesis_fields(self, response: Any) -> Optional[dict]:
-        """Best-effort recovery of synthesis fields from a malformed-JSON response.
+        """Best-effort recovery of synthesis fields — see ``utils.synthesis_parse``.
 
-        The synthesis step asks for a structured object whose dominant field is a
-        long free-text narrative (``detailed_analysis``). Some providers return
-        that narrative with unescaped quotes/newlines, so strict JSON parsing
-        fails and the whole payload would otherwise be dropped to ``{"error": …}``
-        — yielding a ``success`` result with empty findings (and, for the meta
-        agent, a re-delegation loop). This recovers the narrative by string-
-        boundary extraction (tolerant of stray quotes, the dominant failure mode)
-        plus the ``scientific_claims`` / ``candidate_identifications`` list when
-        its JSON array parses cleanly. Returns ``None`` when no usable narrative
-        can be recovered, so the caller keeps the original parse error.
+        When the synthesis step's strict ``_parse_llm_response`` fails (commonly
+        an unescaped quote/newline in the long ``detailed_analysis`` narrative),
+        this recovers the narrative (and the claims list when clean) instead of
+        dropping the whole payload to ``{"error": …}`` — which would yield a
+        ``success`` result with empty findings and, under the meta agent, a
+        re-delegation loop. Returns ``None`` when nothing usable is recovered, so
+        the caller keeps the original parse error.
         """
-        import re
+        from ...utils.synthesis_parse import salvage_synthesis_fields
         try:
             raw = self._extract_text_from_response(response) or ""
         except Exception:
             return None
-        if not raw.strip():
-            return None
-
-        recovered: dict = {}
-
-        # detailed_analysis: take the string value from its key up to the next
-        # top-level key or the closing brace, tolerating unescaped inner quotes.
-        m = re.search(r'"detailed_analysis"\s*:\s*"', raw)
-        if m:
-            rest = raw[m.end():]
-            end_markers = [
-                r'"\s*,\s*"[A-Za-z_][A-Za-z0-9_]*"\s*:',  # next top-level key
-                r'"\s*\}\s*$',                            # final closing brace
-            ]
-            cut = None
-            for pat in end_markers:
-                mm = re.search(pat, rest)
-                if mm:
-                    cut = mm.start() if cut is None else min(cut, mm.start())
-            narrative = rest[:cut] if cut is not None else rest
-            narrative = (narrative
-                         .replace('\\n', '\n').replace('\\t', '\t')
-                         .replace('\\r', '\r').replace('\\"', '"')
-                         .replace('\\\\', '\\'))
-            narrative = narrative.strip().rstrip('}').strip().rstrip('"').strip()
-            if len(narrative) >= 40:
-                recovered["detailed_analysis"] = narrative
-
-        # scientific_claims / candidate_identifications: recover the array only
-        # if it parses cleanly (secondary; failure here just omits the field).
-        for key in ("scientific_claims", "candidate_identifications"):
-            am = re.search(r'"' + key + r'"\s*:\s*\[', raw)
-            if not am:
-                continue
-            i = raw.index('[', am.start())
-            depth = 0
-            for j in range(i, len(raw)):
-                if raw[j] == '[':
-                    depth += 1
-                elif raw[j] == ']':
-                    depth -= 1
-                    if depth == 0:
-                        break
-            try:
-                arr = json.loads(raw[i:j + 1])
-                if isinstance(arr, list):
-                    recovered[key] = arr
-            except Exception:
-                pass
-
-        return recovered if recovered.get("detailed_analysis") else None
+        return salvage_synthesis_fields(raw)
 
     def _extract_text_from_response(self, response: Any) -> str:
         """Extract text content from various LLM response formats."""

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -4088,13 +4088,37 @@ Return JSON with:
         series_plan = state.get("series_analysis_plan")
         regime_configs = state.get("regime_configs")
 
+        # Regime-boundary markers, keyed by the regime's first spectrum index.
+        # Emitted as the loop reaches each boundary so transitions are visible
+        # while the fit streams — not only in the upfront plan (the inline
+        # "(regime: …)" tag alone made boundaries hard to spot in the log).
+        regime_markers: Dict[int, list] = {}
         if series_plan and regime_configs:
             first_in_regime: set = set()
-            for regime in series_plan.get("regimes", []):
+            regimes = series_plan.get("regimes", [])
+            series_metadata = state.get("series_metadata", {})
+            _values = series_metadata.get("values", [])
+            _unit = series_metadata.get("unit", "")
+            for rnum, regime in enumerate(regimes, 1):
                 indices = sorted(regime.get("spectrum_indices", []))
-                if indices:
-                    first_in_regime.add(indices[0])
-            self.logger.info(f"   Regimes: {len(series_plan.get('regimes', []))}")
+                if not indices:
+                    continue
+                first_in_regime.add(indices[0])
+                if len(regimes) > 1:
+                    rng = ""
+                    if _values:
+                        vv = [_values[i] for i in indices if i < len(_values)]
+                        if vv:
+                            unit_str = f" {_unit}" if _unit else ""
+                            span = f"{min(vv)}" if min(vv) == max(vv) else f"{min(vv)}-{max(vv)}"
+                            rng = f" ({span}{unit_str})"
+                    bar = "  " + "─" * 56
+                    regime_markers[indices[0]] = [
+                        "", bar,
+                        f"  ▸ Regime {rnum}/{len(regimes)}: {regime.get('name', 'Unnamed')}{rng}",
+                        bar,
+                    ]
+            self.logger.info(f"   Regimes: {len(regimes)}")
             self.logger.info(
                 f"   First-in-regime spectra (full QC): {sorted(first_in_regime)}"
             )
@@ -4153,6 +4177,10 @@ Return JSON with:
 
             # Temporarily set the config for this spectrum
             state["locked_fitting_config"] = spectrum_config
+
+            # Regime-transition marker at each regime boundary.
+            for _line in regime_markers.get(idx, ()):
+                self.logger.info(_line)
 
             if is_single:
                 self.logger.info(f"Fitting: {spectrum_name}")

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -5588,8 +5588,13 @@ same trend.
             result_json, error_dict = self._parse(response)
 
             if error_dict:
-                self.logger.error(f"Synthesis failed: {error_dict}")
-                state["synthesis_result"] = {"error": str(error_dict)}
+                salvaged = self._salvage_synthesis_fields(response)
+                if salvaged:
+                    self.logger.warning("Synthesis JSON parse failed; salvaged detailed_analysis from raw text.")
+                    state["synthesis_result"] = salvaged
+                else:
+                    self.logger.error(f"Synthesis failed: {error_dict}")
+                    state["synthesis_result"] = {"error": str(error_dict)}
             else:
                 state["synthesis_result"] = result_json
                 self.logger.info("✅ Single spectrum synthesis complete.")
@@ -5752,8 +5757,13 @@ same trend.
             result_json, error_dict = self._parse(response)
 
             if error_dict:
-                self.logger.error(f"Series synthesis failed: {error_dict}")
-                state["synthesis_result"] = {"error": str(error_dict)}
+                salvaged = self._salvage_synthesis_fields(response)
+                if salvaged:
+                    self.logger.warning("Series synthesis JSON parse failed; salvaged detailed_analysis from raw text.")
+                    state["synthesis_result"] = salvaged
+                else:
+                    self.logger.error(f"Series synthesis failed: {error_dict}")
+                    state["synthesis_result"] = {"error": str(error_dict)}
             else:
                 state["synthesis_result"] = result_json
                 self.logger.info("✅ Series synthesis complete.")

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -4112,12 +4112,9 @@ Return JSON with:
                             unit_str = f" {_unit}" if _unit else ""
                             span = f"{min(vv)}" if min(vv) == max(vv) else f"{min(vv)}-{max(vv)}"
                             rng = f" ({span}{unit_str})"
-                    bar = "  " + "─" * 56
-                    regime_markers[indices[0]] = [
-                        "", bar,
-                        f"  ▸ Regime {rnum}/{len(regimes)}: {regime.get('name', 'Unnamed')}{rng}",
-                        bar,
-                    ]
+                    line = f"  ▸ Regime {rnum}/{len(regimes)}: {regime.get('name', 'Unnamed')}{rng}"
+                    bar = "  " + "─" * max(len(line) - 2, 0)  # rule spans the text width
+                    regime_markers[indices[0]] = ["", bar, line, bar]
             self.logger.info(f"   Regimes: {len(regimes)}")
             self.logger.info(
                 f"   First-in-regime spectra (full QC): {sorted(first_in_regime)}"
@@ -5532,7 +5529,7 @@ same trend.
 
     def _synthesize_single_spectrum(self, state: dict) -> dict:
         self.logger.info("")
-        self.logger.info("🔬 SINGLE SPECTRUM INTERPRETATION (staged)")
+        self.logger.info("🔬 SINGLE SPECTRUM INTERPRETATION")
 
         from ..instruct import (
             FITTING_INTERPRETATION_STAGE1,
@@ -5634,7 +5631,7 @@ same trend.
 
     def _synthesize_series(self, state: dict) -> dict:
         self.logger.info("")
-        self.logger.info("🔬 SERIES SYNTHESIS (staged)")
+        self.logger.info("🔬 SERIES SYNTHESIS")
 
         from ..instruct import (
             ID_MODE_INTERPRETATION_STAGE1_ADDENDUM,

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -5855,8 +5855,13 @@ Return JSON with:
             result_json, error_dict = self._parse(response)
 
             if error_dict:
-                self.logger.error(f"Synthesis failed: {error_dict}")
-                state["synthesis_result"] = {"error": str(error_dict)}
+                salvaged = self._salvage_synthesis_fields(response)
+                if salvaged:
+                    self.logger.warning("Synthesis JSON parse failed; salvaged detailed_analysis from raw text.")
+                    state["synthesis_result"] = salvaged
+                else:
+                    self.logger.error(f"Synthesis failed: {error_dict}")
+                    state["synthesis_result"] = {"error": str(error_dict)}
             else:
                 state["synthesis_result"] = result_json
                 self.logger.info("Single image synthesis complete.")
@@ -6029,8 +6034,13 @@ Return JSON with:
             result_json, error_dict = self._parse(response)
 
             if error_dict:
-                self.logger.error(f"Series synthesis failed: {error_dict}")
-                state["synthesis_result"] = {"error": str(error_dict)}
+                salvaged = self._salvage_synthesis_fields(response)
+                if salvaged:
+                    self.logger.warning("Series synthesis JSON parse failed; salvaged detailed_analysis from raw text.")
+                    state["synthesis_result"] = salvaged
+                else:
+                    self.logger.error(f"Series synthesis failed: {error_dict}")
+                    state["synthesis_result"] = {"error": str(error_dict)}
             else:
                 state["synthesis_result"] = result_json
                 self.logger.info("Series synthesis complete.")

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -960,6 +960,29 @@ class MetaOrchestratorAgent:
         }
         if result.get("error"):
             summary["error"] = result["error"]
+        # Guardrail against the "empty-but-successful" state: a child can report
+        # status="success" yet return no extractable findings (e.g. a synthesis
+        # parse failure left detailed_analysis/scientific_claims blank). Left
+        # unflagged, the meta LLM reads the empty result and re-delegates the
+        # identical task — re-running the same data the same way reproduces the
+        # same empty result, i.e. a loop. Surface it explicitly so the LLM
+        # changes course instead of retrying blindly. Findings presence is keyed
+        # on key_findings/summary, NOT files_produced — the run can emit files
+        # (fit scripts, plots) while the interpretation came back empty.
+        has_findings = bool(summary["key_findings"]) or bool((summary["summary"] or "").strip())
+        if summary["status"] == "success" and not has_findings:
+            summary["findings_status"] = "empty_but_successful"
+            note = (
+                "Delegation reported success but returned no extractable findings "
+                "(empty key_findings and summary). Do NOT re-delegate the identical "
+                "task expecting a different result — re-running the same data the "
+                "same way reproduces the same empty result. Inspect files_produced, "
+                "report the gap to the user, or change the approach."
+            )
+            warnings = list(summary.get("warnings") or [])
+            if note not in warnings:
+                warnings.append(note)
+            summary["warnings"] = warnings
         # Domain-specific field, passed through lightly.
         if "analyses" in result:
             summary["analyses"] = result["analyses"]

--- a/scilink/utils/synthesis_parse.py
+++ b/scilink/utils/synthesis_parse.py
@@ -1,0 +1,84 @@
+"""Tolerant salvage of synthesis-style structured LLM responses.
+
+Sibling of :mod:`codegen_parse`: where that recovers a malformed JSON *script*
+field, this recovers the narrative + claims of a synthesis / interpretation
+response when strict JSON parsing fails. The synthesis step asks for an object
+whose dominant field is a long free-text narrative (``detailed_analysis``);
+some providers return it with unescaped quotes or newlines, so strict parsing
+fails and the whole payload would otherwise be discarded — leaving a
+``success`` result with empty findings (and, under the meta agent, a
+re-delegation loop). See ``BaseAnalysisAgent._salvage_synthesis_fields`` for the
+wiring.
+"""
+
+import json
+import re
+from typing import Optional
+
+from .codegen_parse import _unescape
+
+_MIN_NARRATIVE = 40
+_NEXT_KEY = re.compile(r'"\s*,\s*"[A-Za-z_][A-Za-z0-9_]*"\s*:')  # value -> next top-level key
+_FINAL_BRACE = re.compile(r'"\s*\}\s*$')                          # value -> closing brace
+
+
+def _salvage_narrative(raw: str) -> Optional[str]:
+    """Recover the ``detailed_analysis`` string up to the next top-level key or
+    the closing brace, tolerating unescaped inner quotes (the dominant mode)."""
+    m = re.search(r'"detailed_analysis"\s*:\s*"', raw)
+    if not m:
+        return None
+    rest = raw[m.end():]
+    cut = None
+    for rx in (_NEXT_KEY, _FINAL_BRACE):
+        mm = rx.search(rest)
+        if mm:
+            cut = mm.start() if cut is None else min(cut, mm.start())
+    body = rest[:cut] if cut is not None else rest
+    body = body.strip().rstrip('}').strip().rstrip('"')
+    narrative = _unescape(body).strip()
+    return narrative if len(narrative) >= _MIN_NARRATIVE else None
+
+
+def _salvage_array(raw: str, key: str) -> Optional[list]:
+    """Recover a JSON array field by bracket balancing; accept only if it parses
+    cleanly (secondary — failure just omits the field)."""
+    am = re.search(r'"' + key + r'"\s*:\s*\[', raw)
+    if not am:
+        return None
+    i = raw.index('[', am.start())
+    depth = 0
+    j = i
+    for j in range(i, len(raw)):
+        if raw[j] == '[':
+            depth += 1
+        elif raw[j] == ']':
+            depth -= 1
+            if depth == 0:
+                break
+    try:
+        arr = json.loads(raw[i:j + 1])
+        return arr if isinstance(arr, list) else None
+    except Exception:
+        return None
+
+
+def salvage_synthesis_fields(raw_text: str) -> Optional[dict]:
+    """Best-effort recovery of synthesis fields from a malformed-JSON response.
+
+    Returns a dict with ``detailed_analysis`` (always, when recovery succeeds)
+    plus ``scientific_claims`` / ``candidate_identifications`` when their arrays
+    parse cleanly. Returns ``None`` when no usable narrative can be recovered, so
+    the caller keeps the original parse error rather than accepting garbage.
+    """
+    if not raw_text or not raw_text.strip():
+        return None
+    narrative = _salvage_narrative(raw_text)
+    if not narrative:
+        return None
+    recovered = {"detailed_analysis": narrative}
+    for key in ("scientific_claims", "candidate_identifications"):
+        arr = _salvage_array(raw_text, key)
+        if arr is not None:
+            recovered[key] = arr
+    return recovered


### PR DESCRIPTION
## Summary (for scientists)

When you run a curve-fit or image series, the agent fits each spectrum/frame and then writes a single **synthesis** — the human-readable narrative plus the scientific claims that the whole series supports. We found a case (a BaTiO₃ Raman temperature series, run through the Explore/meta agent) where all five per-temperature fits succeeded with the correct per-regime models and the right single→doublet trend, yet the final report came back with an **empty narrative and no claims** — while still reporting "success".

The cause: the synthesis model occasionally returns text the strict JSON reader can't parse (most often an unescaped quote or newline inside the long narrative — e.g. writing *the band at "450 cm⁻¹"*). When that happened, the entire synthesis was thrown away and replaced with an error, so the findings came back blank even though the fits were fine. Under the Explore agent this was worse: it saw an empty-but-successful result and **re-ran the same data**, looping.

This PR fixes it three ways:

1. **Recover the narrative instead of discarding it.** If the synthesis text won't parse strictly, we now salvage the narrative (and the claims list when it's clean) rather than dropping everything. The fits' interpretation survives.
2. **Stop the re-analysis loop.** The Explore agent now recognizes a "succeeded but produced no findings" result and is told *not* to blindly re-run the same data — it reports the gap or changes approach instead.
3. **Clearer series progress.** The streaming fit log now shows a labelled marker each time it crosses into a new regime (e.g. `▸ Regime 2/3: broadened (200 K)`), so you can see the transitions as they happen instead of squinting at an inline tag.

No change to how a normal, clean run behaves.

---
<!-- Technical details (for AI reviewers) -->
## Technical details

Root cause was confirmed against a real artifact: `meta_session_20260531_155750/analysis/.../analysis_uploads_CurveFit_..._001/analysis_results.json` had `status:"success"`, `detailed_analysis:""`, `scientific_claims:[]`, with 5 successful `individual_results`. Mechanism: `_synthesize_series`/`_synthesize_single_spectrum` (`curve_fitting_controllers.py`) call `self._parse(response)` (= `base_agent._parse_llm_response`, the 4-strategy strict parser, **no salvage**); on `error_dict` they set `state["synthesis_result"] = {"error": …}`; `curve_fitting_agent._compile_results` then reads `synthesis.get("detailed_analysis")` / `("scientific_claims", [])` → empty; top-level `status` stays `"success"`. Intermittent (an opus-4-8 rerun on identical data parsed cleanly), i.e. stochastic malformed JSON, dominated by unescaped inner quotes/newlines in the `detailed_analysis` string.

**1. `BaseAnalysisAgent._salvage_synthesis_fields(response)`** (`base_agent.py`, after `_parse_codegen_response`). Best-effort recovery on parse failure:
- `detailed_analysis`: regex-locate the key, take the value up to the next top-level key (`r'"\s*,\s*"[A-Za-z_]\w*"\s*:'`) or final brace, unescape `\n\t\r\" \\`, accept if ≥40 chars (tolerant of unescaped inner quotes — the dominant mode).
- `scientific_claims` / `candidate_identifications`: bracket-balanced slice, accepted only if it `json.loads` cleanly (secondary; failure just omits the field).
- Returns `None` unless a usable `detailed_analysis` was recovered, so the caller keeps the original error — no silent garbage.

Wired into all four synthesis sites: curve single (`curve_fitting_controllers.py` ~5588), curve series (~5752), image single (`image_analysis_controllers.py` ~5855), image series (~6029). Pattern: on `error_dict`, attempt salvage → on success store salvaged dict + `warning` log; else fall through to the prior `{"error": …}`. Hyperspectral synthesis has no `synthesis_result={"error"}` site, so untouched.

**2. Meta guardrail** in `MetaOrchestratorAgent._summarize_delegation_result` (`meta_orchestrator.py`) — the single chokepoint rendering every delegation result back to the meta LLM. When `status=="success"` and `not (key_findings or summary.strip())`, set `findings_status="empty_but_successful"` and append a warning instructing the LLM not to re-delegate the identical task. Findings presence keyed on `key_findings`/`summary`, **not** `files_produced` (the run can emit fit scripts/plots while interpretation is empty — exactly this failure). Advisory (flag + warning), not a hard block — the meta is LLM-driven and a false positive must not wedge it.

**3. Regime markers** in the series fitting loop (`curve_fitting_controllers.py` ~4087/~4156). Build `regime_markers: Dict[int, list]` keyed by each regime's first-spectrum index (only when `len(regimes) > 1`), emit at the boundary via `regime_markers.get(idx, ())`. Range from `series_metadata` values/unit, equal endpoints collapsed (`(200 K)`). Inline `(regime: name)` tag retained.

### Validation
- `_salvage_synthesis_fields` unit-tested (byte-identical logic): unescaped inner quotes → full recovery + claims; unescaped newlines → recovered; mid-narrative truncation → partial recovery; ID-mode `candidate_identifications`; clean JSON; garbage / <40-char → `None`.
- Guardrail logic tested: empty-but-success (files present, no findings) → flagged; success-with-findings / success-with-summary-only / error-status → not flagged; `None` summary/findings → flagged without crash.
- Regime markers rendered against the BaTiO₃ 3-regime / 5-spectrum layout; single-spectrum regime collapses range.
- AST-parsed all four edited files.

### Known limits
- Salvage is heuristic; the ≥40-char gate and clean-`json.loads` requirement bound it, and `None`-on-failure preserves today's behavior (caller keeps the error). A truncated narrative is recovered partial (better than empty) but still partial — the `finish_reason`/truncation detection from #240 lives only on the codegen path, not here.
- Guardrail is advisory; a determined meta LLM can still re-delegate, but it now does so against an explicit warning rather than blind.