### PR TITLE
Follow-up analyses are agent-judged: make locked-script reuse (#172) opt-in

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -299,21 +299,28 @@ examine_data returns data_type:
   succeeded, say so plainly — do not fabricate quantitative findings from a
   file's description or metadata.
 - Before launching a fresh `run_analysis`, consider whether a prior analysis from
-  `list_results()` already covers the new request's prerequisites (e.g. existing
-  segmentation, fits, abundance maps). If so, pass its `output_directory` via
-  `prior_analysis_paths` so the new run can build on it instead of recomputing.
+  `list_results()` is relevant to the new request (existing segmentation, fits,
+  abundance maps, or a result to verify / deepen). If so, pass its
+  `output_directory` via `prior_analysis_paths`: the prior run becomes REFERENCE
+  MATERIAL and the agent decides whether to reuse, adapt, or rewrite its script
+  for the new goal. For a verification or re-examination the agent re-derives the
+  result independently — do NOT expect or force a verbatim re-run, since
+  re-running the script that produced a result cannot verify it.
 
 **INCREMENTAL MEASUREMENT SERIES (locked extraction-script reuse):**
 - When the new data is the NEXT MEASUREMENT of an existing measurement series —
   the same kind of unit as a prior run, only the control parameters differ
   (e.g. a new point added to a Bayesian-optimization / closed-loop campaign) —
-  pass that prior run's `output_directory` via `prior_analysis_paths`. The agent
-  reuses the prior run's locked extraction recipe (fitting script / image
-  pipeline) verbatim, so the new feature row has the SAME columns as the rest of
-  the campaign — which a downstream feature-table / BO append strictly requires.
-- Decide deliberately whether the new data IS a continuation. If it is a
-  different kind of measurement, do NOT pass `prior_analysis_paths` — a fresh
-  analysis is correct; forcing the prior recipe would extract the wrong things.
+  pass that prior run's `output_directory` via `prior_analysis_paths` AND set
+  `reuse_locked_script=true`. The agent then reuses the prior run's locked
+  extraction recipe (fitting script / image pipeline) verbatim, so the new
+  feature row has the SAME columns as the rest of the campaign — which a
+  downstream feature-table / BO append strictly requires.
+- `reuse_locked_script` is ONLY for this continuation case. Decide deliberately:
+  for a verification, a deeper analysis, or a different kind of measurement,
+  leave it false (the default) — the agent treats the prior run as reference and
+  derives the result itself; forcing the prior recipe would extract the wrong
+  things or merely reproduce the result you meant to check.
 - After such a run, READ the `reuse_validity` field in the `run_analysis`
   result and act on its `verdict`:
   - `good` — the reused recipe fits the new measurement well; proceed normally.
@@ -321,7 +328,7 @@ examine_data returns data_type:
     reused recipe fits this measurement poorly. Surface the `reuse_warning` to
     the user: the new measurement may not belong to this series, or conditions
     shifted. If you judge it is genuinely a different measurement, re-run
-    `run_analysis` WITHOUT `prior_analysis_paths` for a correct fresh analysis.
+    `run_analysis` WITHOUT `reuse_locked_script` for a correct fresh analysis.
   - `script_failed` — the reused recipe could not run and the model/pipeline was
     re-derived from scratch, so the feature columns may differ from the
     campaign. Flag this clearly to the user — a campaign append may break.

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2011,6 +2011,7 @@ class AnalysisOrchestratorTools:
             series_metadata: str = None,
             task_mode: str = None,
             prior_analysis_paths: List[str] = None,
+            reuse_locked_script: bool = False,
             literature_file: str = None,
             r2_threshold: float = None,
         ) -> str:
@@ -2491,6 +2492,8 @@ class AnalysisOrchestratorTools:
                     analyze_kwargs["prior_knowledge"] = self.orch.active_knowledge
                 if prior_analysis_paths:
                     analyze_kwargs["prior_analysis_paths"] = prior_analysis_paths
+                if reuse_locked_script:
+                    analyze_kwargs["reuse_locked_script"] = True
                 if literature_file:
                     analyze_kwargs["literature_file"] = literature_file
                 if r2_threshold is not None:
@@ -2735,23 +2738,36 @@ class AnalysisOrchestratorTools:
                         "the curve-fitting agent — for a prior curve-fit run "
                         "the saved fitting script and fit summary are surfaced "
                         "to its planning and script-generation stages.\n"
-                        "LOCKED EXTRACTION-SCRIPT REUSE: when the new data is "
-                        "the NEXT MEASUREMENT of the SAME measurement series as "
-                        "the prior run — the same kind of unit, only the "
-                        "control parameters differ (a new point in a "
-                        "Bayesian-optimization / closed-loop campaign) — the "
-                        "agent reuses the prior run's locked extraction script "
-                        "verbatim instead of re-deriving the model/pipeline. "
-                        "This guarantees the new feature row has the SAME "
-                        "columns as the campaign, which the planning-side "
-                        "feature-table append strictly requires. ONLY pass "
-                        "prior_analysis_paths when the new data genuinely "
-                        "continues that series; if it is a different kind of "
-                        "measurement, do NOT pass it (a fresh analysis is "
-                        "correct — forcing the prior recipe would be wrong). "
-                        "The run reports a `reuse_validity` verdict "
-                        "(`good` / `poor` / `script_failed`) — read it and act "
-                        "on a non-`good` verdict (see the system guidance)."
+                        "By default the prior run is REFERENCE MATERIAL: the "
+                        "agent decides for itself whether to reuse, adapt, or "
+                        "rewrite the prior script given the goal. Pass this for "
+                        "ANY follow-up that should build on a prior run — "
+                        "verification, deeper analysis, or extending a series. "
+                        "For a verification / re-examination the agent derives "
+                        "the result independently (re-running the script that "
+                        "produced a result cannot verify it). To FORCE verbatim "
+                        "reuse of the prior locked extraction script, ALSO set "
+                        "`reuse_locked_script=true` (see that parameter)."
+                    )
+                },
+                "reuse_locked_script": {
+                    "type": "boolean",
+                    "description": (
+                        "Opt-in, default false. Set true ONLY when the new data "
+                        "is the NEXT MEASUREMENT of the SAME series as a run in "
+                        "`prior_analysis_paths` — the same kind of unit, only "
+                        "the control parameters differ (a new point in a "
+                        "Bayesian-optimization / closed-loop campaign). It forces "
+                        "the agent to reuse that run's locked extraction script "
+                        "VERBATIM instead of re-deriving the model, guaranteeing "
+                        "the new feature row has the SAME columns as the campaign "
+                        "(which the planning-side feature-table append strictly "
+                        "requires). The run then reports a `reuse_validity` "
+                        "verdict (`good` / `poor` / `script_failed`) — read it "
+                        "and act on a non-`good` verdict. Do NOT set it for "
+                        "verification or deeper-analysis follow-ups, or for a "
+                        "different kind of measurement — leave it false so the "
+                        "agent decides how to use the prior run as reference."
                     )
                 },
                 "literature_file": {

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -642,8 +642,13 @@ def _prior_curve_fit_block(state: dict) -> str:
     return (
         "\n## Prior Curve-Fit Runs\n"
         "Artifacts from earlier curve-fit analyses, provided as reference. "
-        "When the new data is the same kind of measurement, the saved "
-        "fitting script below can be reused for a consistent fit.\n"
+        "Decide for yourself how to use them given the goal: reuse the saved "
+        "script as-is to extend/reproduce a consistent fit, adapt it if the "
+        "model needs adjusting, or write a fresh script. If the goal is to "
+        "VERIFY or re-examine a prior result, derive the fit independently "
+        "rather than re-running the prior script — treat the prior numbers as a "
+        "hypothesis to test, since re-running the script that produced them "
+        "only reproduces them.\n"
         + "\n".join(blocks)
     )
 
@@ -4105,17 +4110,33 @@ Return JSON with:
         # earlier curve-fit run, the spectrum-0 anchor reuses that run's saved
         # fitting script instead of re-deriving the model. Skipped for
         # multi-regime runs (a single prior script has no regime mapping).
-        reuse_script, reuse_source = _first_prior_curve_fit_script(state)
+        # Locked-script reuse (#172) is an explicit opt-in (reuse_locked_script),
+        # not the default for a prior run being supplied. By default a follow-up
+        # that names prior_analysis_paths is AGENT-JUDGED: the prior fit summary +
+        # script are surfaced as reference in codegen and the agent decides
+        # whether to reuse, adapt, or rewrite. Verbatim reuse is for extending an
+        # ongoing campaign with a fixed model/feature schema — it cannot verify or
+        # deepen a prior result (re-running the script that produced it only
+        # reproduces it).
+        if state.get("reuse_locked_script"):
+            reuse_script, reuse_source = _first_prior_curve_fit_script(state)
+        else:
+            reuse_script, reuse_source = None, None
         if reuse_script and regime_configs:
             self.logger.info(
-                "   ♻️  Prior curve-fit run supplied, but this run is "
-                "multi-regime — locked-script reuse skipped."
+                "   ♻️  Locked-script reuse requested, but this run is "
+                "multi-regime — reuse skipped."
             )
             reuse_script, reuse_source = None, None
         elif reuse_script:
             self.logger.info(
-                f"   ♻️  Prior curve-fit run '{reuse_source}' supplied — the "
-                f"anchor will reuse its locked fitting script (#172)."
+                f"   ♻️  Locked-script reuse (opt-in) — anchor will reuse the "
+                f"fitting script from prior run '{reuse_source}' (#172)."
+            )
+        elif state.get("prior_analysis_paths"):
+            self.logger.info(
+                "   🧭 Prior curve-fit run(s) supplied as reference — the agent "
+                "will decide whether to reuse, adapt, or rewrite the fit."
             )
 
         results_by_idx: Dict[int, dict] = {}

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -4319,7 +4319,14 @@ Return JSON: {{"change_type": "cosmetic" | "analytical" | "rewrite", \
         # earlier image-analysis run, the image-0 anchor reuses that run's
         # saved analysis script instead of re-deriving the pipeline. Skipped
         # for multi-regime runs (a single prior script has no regime mapping).
-        reuse_script, reuse_source = _first_prior_image_script(state)
+        # #172 locked-script reuse is now an explicit opt-in. Without it a
+        # follow-up is agent-judged: the prior run (incl. its script) is
+        # surfaced as reference in codegen and the agent decides reuse / adapt /
+        # rewrite. Verbatim reuse cannot verify or deepen a prior result.
+        if state.get("reuse_locked_script"):
+            reuse_script, reuse_source = _first_prior_image_script(state)
+        else:
+            reuse_script, reuse_source = None, None
         if reuse_script and regime_configs:
             self.logger.info(
                 "   ♻️  Prior image-analysis run supplied, but this run is "

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -288,8 +288,13 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # Prior knowledge from reference analyses
         prior_knowledge: Optional[List[Dict[str, Any]]] = None,
         # Prior curve-fit runs whose saved artifacts (fitting script, fit
-        # summary) the new run may consume as reference.
+        # summary) the new run may consume as reference. By default these are
+        # agent-judged reference material (reuse / adapt / rewrite is the
+        # agent's call). Set ``reuse_locked_script=True`` ONLY to force verbatim
+        # reuse of the prior locked script — for extending an ongoing campaign
+        # with a fixed model / feature-table schema (#172).
         prior_analysis_paths: Optional[List[str]] = None,
+        reuse_locked_script: bool = False,
         literature_file: Optional[str] = None,
         # Quality control overrides (optional)
         r2_threshold: Optional[float] = None,
@@ -667,6 +672,9 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
 
             # Prior curve-fit runs — artifacts surfaced to planner / script-gen
             "prior_analysis_paths": prior_analysis_paths or [],
+            # Opt-in: force verbatim reuse of the prior locked script (#172).
+            # Default False — prior runs are agent-judged reference material.
+            "reuse_locked_script": bool(reuse_locked_script),
 
             # Effective quality gate (curve_fit_controllers reads via _gate()).
             "quality_gate": effective_gate,

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -237,6 +237,11 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         skill: Optional[str] = None,
         prior_knowledge: Optional[List[Dict[str, Any]]] = None,
         prior_analysis_paths: Optional[List[str]] = None,
+        # Opt-in: force verbatim reuse of the prior locked analysis script
+        # (#172) — for extending an ongoing campaign with a fixed analysis /
+        # feature-table schema. Default False: prior runs are agent-judged
+        # reference material (reuse / adapt / rewrite is the agent's call).
+        reuse_locked_script: bool = False,
         literature_file: Optional[str] = None,
         # Quality control overrides
         outlier_sigma: Optional[float] = None,
@@ -427,6 +432,9 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             # Prior knowledge
             "prior_knowledge": prior_knowledge or [],
             "prior_analysis_paths": prior_analysis_paths or [],
+            # Opt-in verbatim reuse of the prior locked script (#172); default
+            # False — prior runs are agent-judged reference material.
+            "reuse_locked_script": bool(reuse_locked_script),
             # First image (for planning)
             "image_path": (
                 image_paths[0] if image_paths else first_image_name
@@ -1049,6 +1057,11 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "prior_analysis_paths": tier1_state.get(
                 "prior_analysis_paths", []
             ),
+            # NB: deliberately NOT carrying reuse_locked_script into Tier 2.
+            # Tier 2 is the "build on Tier 1, go deeper" pass — it must never
+            # verbatim-reuse the locked script (that would defeat deepening).
+            # Absent here, the controller's state.get(...) defaults to
+            # agent-judged (no reuse), which is correct.
             # Sub-agent results
             "fft_preprocessing": None,
             "sam_preprocessing": None,


### PR DESCRIPTION
## Summary (for scientists)

When you ask the agent for a **follow-up** on a previous analysis — *"verify that fit,"* *"look deeper at this"* — it should be able to look at the earlier data and scripts and **decide for itself** whether to reuse them, tweak them, or start over, depending on what you actually asked for.

It wasn't doing that. As soon as a follow-up referenced a prior run, the agent **re-ran the prior run's exact script, unchanged**, and kept the result no matter what. That's the right thing for one narrow case — adding the next measurement to an ongoing campaign where every point must be processed identically — but it's wrong for everything else. A *verification* that re-runs the very script that produced a result can only reproduce that result; it can't check it. We saw this live: a *"verify the previous fit"* request on a pair of EPR spectra came back with a byte-identical script, the same R², and the same numbers on the same data — confirming nothing.

This PR makes that reuse an **explicit opt-in**. By default, a follow-up now treats the prior run as *reference material*: the agent sees the earlier fit summary and script and chooses to reuse, adapt, or rewrite. For a verification it derives the result independently. The verbatim-reuse behavior is still available — you just turn it on deliberately, for the incremental-campaign case where keeping an identical feature table across points genuinely requires it.

Works the same for spectra (curve fitting) and images, in both single and series runs.

---
<!-- Technical details (for AI reviewers) -->
## Technical details

**Root cause.** #172 locked-script reuse fired off the mere presence of `prior_analysis_paths`. In each controller's `execute()`, `reuse_script` was resolved unconditionally (`_first_prior_curve_fit_script` / `_first_prior_image_script`), then the anchor fast-path (`curve _fit_with_quality_control` / `image _process_single_image`, the `if reuse_script and _is_anchor:` branch) ran the prior script **verbatim**, kept the result regardless of R²/vision-score, and **returned before code generation**. So the agent never reached the codegen step where it could adapt or rewrite. Confirmed against a live artifact: meta-session `..._174132`, delegation `_002` ("VERIFICATION/QC re-analysis"), `prior_analysis_paths=[_001]`, **same** `data_path` → byte-identical `scripts/fitting_script.py`, identical `r_squared=0.96175`, identical params.

**Fix.** Gate `reuse_script` resolution behind an explicit `reuse_locked_script` flag (default `False`):
- `curve_fitting_controllers.py` / `image_analysis_controllers.py` `execute()`: `if state.get("reuse_locked_script"): reuse_script = _first_prior_*_script(state) else: None`. Placed before the per-item loop, **not** guarded by `is_single`, so it applies to single (`num=1`) and series uniformly. `reuse_script` is consumed only at the anchor (`reuse_script if idx == 0 else None`); within-series propagation (anchor's locked model → items 1..N) is a separate downstream mechanism and is untouched. The pre-existing multi-regime skip (`if reuse_script and regime_configs`) still applies.
- `CurveFittingAgent.analyze` / `ImageAnalysisAgent.analyze`: new `reuse_locked_script: bool = False` param → state. Image **tier-2** deliberately does NOT carry the flag (a deepening pass must never verbatim-reuse).
- `analysis_orchestrator_tools.py` `run_analysis`: new `reuse_locked_script` param + dispatch + schema doc. All three analysis `analyze()` methods accept `**kwargs`, so the shared dispatch is crash-safe even for agents that ignore the flag.
- `analysis_orchestrator.py` system guidance: corrected to distinguish `prior_analysis_paths` (reference material — agent decides reuse/adapt/rewrite; verification → derive independently) from `reuse_locked_script=true` (incremental-campaign verbatim reuse); the `poor` `reuse_validity` recovery now re-runs WITHOUT `reuse_locked_script`.
- `curve` `_prior_curve_fit_block` prompt reworded from "the saved script can be reused for a consistent fit" to an explicit reuse/adapt/rewrite decision, incl. "if verifying, derive independently — re-running the script that produced a result only reproduces it." (Curve inlines the prior script text into the prompt; image surfaces it as a loadable path in the codegen file listing via the `*.py` glob over `scripts/`, so image's agent-judged path is equally capable — no image prompt change needed.)

**Scope.** curve_fitting (observed failure) + image_analysis (mechanism is identical — same unconditional resolution, same verbatim-keep fast-path, same codegen bypass — so the same latent defect; image fix kept minimal: the gate + param only).

**Coverage:** single & series × curve & image — the gate is in the shared `execute()` (no separate single path) and is mode-agnostic; anchor-only consumption preserves series propagation; multi-regime already skips reuse.

**Behavior unchanged when:** no `prior_analysis_paths` (byte-identical to before); `reuse_locked_script=true` (verbatim reuse + `reuse_validity` verdict, as before).

### Known limits / not included
- The two `tests/test_172_*_reuse_live.py` files (which assert the reuse contract) are not in this PR — they are untracked locally and not on `main`. The contract-matching edit they need is `reuse_locked_script=True` at the prior-analysis call site.
- The default flip means any caller that relied on `prior_analysis_paths` alone to trigger reuse must now also pass `reuse_locked_script=true`; orchestrator guidance and the tool doc are updated accordingly.