### PR TITLE
Curve-fit metric integrity: canonical R², artifact + series_fit_results consistency after refit

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -127,6 +127,40 @@ def _residual_diagnostics(x, y, fit, n_windows: int = 16):
         return None
 
 
+def _canonical_r2(y, fit):
+    """R² of the *saved* fitted curve vs the data, over the finite,
+    length-matched points (same alignment guards as ``_residual_diagnostics``).
+
+    This is computed from the canonical ``data.npy`` / ``fit.npy`` arrays — the
+    exact curve that is plotted and shown to the verifier — so it can't diverge
+    from the displayed fit the way a script's self-reported R² can. Returns
+    ``None`` when the arrays can't be aligned (length mismatch, e.g. a partial
+    fit saved as a short array) or there is too little finite signal, so the
+    caller keeps the self-reported value. Callers use it to raise a
+    broken-low self-report (``max(self, recompute)``) — never to lower a
+    deliberate windowed/partial fit's number.
+    """
+    try:
+        y = np.asarray(y, float).ravel()
+        fit = np.asarray(fit, float)
+        if fit.ndim == 2:                       # accept [N,2] -> take y column
+            fit = fit[:, -1]
+        fit = fit.ravel()
+        if fit.shape[0] != y.shape[0]:
+            return None
+        m = np.isfinite(y) & np.isfinite(fit)
+        if int(m.sum()) < 8:
+            return None
+        yy, ff = y[m], fit[m]
+        ss_tot = float(np.sum((yy - yy.mean()) ** 2))
+        if ss_tot <= 0:
+            return None
+        ss_res = float(np.sum((yy - ff) ** 2))
+        return 1.0 - ss_res / ss_tot
+    except Exception:
+        return None
+
+
 def _format_residual_diagnostics(diag) -> str:
     """Compact text block of residual diagnostics for the verifier prompt — gives
     the LLM numbers to reason over instead of eyeballing a compressed plot."""
@@ -2529,6 +2563,7 @@ Your guidance: '''
         # reliable per-region structure metrics the verifier can reason over instead
         # of eyeballing a dynamic-range-crushed plot. Skipped silently if fit.npy
         # is absent (older/refit scripts) so this never breaks the fit path.
+        fit_quality = dict(fit_results.get("fit_quality", {}) or {})
         residual_diag = None
         try:
             fit_path = Path(item_dir) / FIT_NAME
@@ -2539,7 +2574,30 @@ Your guidance: '''
                 else:
                     yy = cd.ravel()
                     xx = np.arange(yy.shape[0], dtype=float)
-                residual_diag = _residual_diagnostics(xx, yy, np.load(fit_path))
+                fit_arr = np.load(fit_path)
+                residual_diag = _residual_diagnostics(xx, yy, fit_arr)
+
+                # Trust the saved fit over a broken self-reported R². The
+                # self-report is computed inside the (LLM-generated) script and
+                # can diverge from the curve it actually saved/plotted. We only
+                # override UPWARD — a recompute higher than the self-report means
+                # the saved fit is genuinely better than the script claimed. A
+                # *lower* recompute is left alone: it usually means a deliberate
+                # windowed/partial fit, where the script's own (windowed) number
+                # is the meaningful one. None (length mismatch / no signal) also
+                # keeps the self-report.
+                recomputed_r2 = _canonical_r2(yy, fit_arr)
+                self_r2 = fit_quality.get("r_squared")
+                if recomputed_r2 is not None:
+                    if isinstance(self_r2, (int, float)) and abs(recomputed_r2 - self_r2) > 0.05:
+                        self.logger.info(
+                            f"   ⚠️  R² from saved fit ({recomputed_r2:.4f}) "
+                            f"diverges from self-reported ({self_r2:.4f})."
+                        )
+                    if self_r2 is None or recomputed_r2 > self_r2:
+                        if isinstance(self_r2, (int, float)):
+                            fit_quality["r_squared_self_reported"] = self_r2
+                        fit_quality["r_squared"] = recomputed_r2
         except Exception:
             residual_diag = None
 
@@ -2551,7 +2609,7 @@ Your guidance: '''
             "error": None,
             "model_type": fit_results.get("model_type"),
             "parameters": fit_results.get("parameters", {}),
-            "fit_quality": fit_results.get("fit_quality", {}),
+            "fit_quality": fit_quality,
             "deviation_note": fit_results.get("deviation_note") or fit_results.get("summary"),
             "visualization_path": run["visualization_path"],
             "visualization_bytes": run["visualization_bytes"],

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1936,6 +1936,44 @@ class HumanFeedbackRefinementController:
         return state
 
 
+def _write_series_fit_results(output_dir, state, series_results, quality_settings):
+    """Write ``series_fit_results.json`` from the current ``series_results``.
+
+    Called after initial fitting AND re-called after the adaptive refit, so the
+    file reflects adopted refits. It feeds the BO/planning feature table
+    (``write_feature_table``) and the #172 prior-run reference summary
+    (``_load_prior_curve_fit_state``); a stale copy would carry pre-refit values
+    for refitted spectra. Counts are recomputed from ``series_results`` so the
+    re-write stays correct regardless of caller.
+    """
+    output_dir = Path(output_dir)
+    rows = [r for r in series_results if isinstance(r, dict)]
+    num_spectra = len(rows)
+    successful = sum(1 for r in rows if r.get("success"))
+    flagged_count = sum(1 for r in rows if r.get("flagged"))
+    serializable_results = [
+        {k: v for k, v in r.items() if k not in ("visualization_bytes", "_winning_config")}
+        for r in rows
+    ]
+    payload = {
+        "timestamp": datetime.now().isoformat(),
+        "total_spectra": num_spectra,
+        "successful": successful,
+        "flagged_count": flagged_count,
+        "is_single_spectrum": state.get("is_single_spectrum", num_spectra <= 1),
+        "series_metadata": state.get("series_metadata", {}),
+        "quality_settings": quality_settings or {},
+        "locked_config": state.get("locked_fitting_config"),
+        "series_analysis_plan": state.get("series_analysis_plan"),
+        "locked_preprocessing_strategy": state.get("locked_preprocessing_strategy"),
+        "results": serializable_results,
+    }
+    results_path = output_dir / "series_fit_results.json"
+    with open(results_path, "w") as f:
+        json.dump(payload, f, indent=2, default=str)
+    return str(results_path)
+
+
 class UnifiedSeriesProcessingController:
     """
     Processes ALL spectra using the locked fitting model.
@@ -4507,33 +4545,15 @@ Return JSON with:
         if flagged_count > 0:
             self.logger.warning(f"⚠️ {flagged_count} spectra flagged for review")
         
-        results_path = self.output_dir / "series_fit_results.json"
-        with open(results_path, 'w') as f:
-            serializable_results = []
-            for r in series_results:
-                r_copy = {k: v for k, v in r.items() if k not in ("visualization_bytes", "_winning_config")}
-                serializable_results.append(r_copy)
-            
-            json.dump({
-                "timestamp": datetime.now().isoformat(),
-                "total_spectra": num_spectra,
-                "successful": successful,
-                "flagged_count": flagged_count,
-                "is_single_spectrum": is_single,
-                "series_metadata": state.get("series_metadata", {}),
-                "quality_settings": {
-                    "r2_threshold": self.r2_threshold,
-                    "max_model_retries": self.max_model_retries,
-                    "outlier_sigma": self.outlier_sigma,
-                },
-                "locked_config": state.get("locked_fitting_config"),
-                "series_analysis_plan": state.get("series_analysis_plan"),
-                "locked_preprocessing_strategy": state.get("locked_preprocessing_strategy"),
-                "results": serializable_results
-            }, f, indent=2, default=str)
-        
-        state["series_results_path"] = str(results_path)
-        
+        state["series_results_path"] = _write_series_fit_results(
+            self.output_dir, state, series_results,
+            quality_settings={
+                "r2_threshold": self.r2_threshold,
+                "max_model_retries": self.max_model_retries,
+                "outlier_sigma": self.outlier_sigma,
+            },
+        )
+
         return state
     
     def _wrap_text(self, text: str, width: int = 70) -> list:
@@ -5214,6 +5234,21 @@ class AdaptiveRefitController:
 
         improved_count = sum(1 for r in refit_summary if r["improved"])
         self.logger.info(f"\n🔄 Adaptive refit complete: {improved_count}/{len(refit_candidates)} spectra improved")
+
+        # Refresh series_fit_results.json so adopted refits are reflected. It was
+        # written before this step (post-initial-fit) and feeds the BO/planning
+        # feature table and the #172 prior-run reference summary; without this,
+        # refitted spectra would carry their pre-refit values there.
+        if improved_count > 0:
+            fh = self._fitting_helper
+            _write_series_fit_results(
+                self.output_dir, state, series_results,
+                quality_settings={
+                    "r2_threshold": fh.r2_threshold,
+                    "max_model_retries": fh.max_model_retries,
+                    "outlier_sigma": fh.outlier_sigma,
+                },
+            )
 
         return state
 

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -5135,6 +5135,24 @@ class AdaptiveRefitController:
                 })
             else:
                 self.logger.info(f"  No improvement: R² {original_r2} → {new_r2:.4f}, keeping original")
+                # The refit ran in the same spectrum directory and overwrote the
+                # kept fit's visualization.png. Restore the kept fit's plot so the
+                # report shows the fit whose metrics it records — not the
+                # discarded refit's. (fit.npy is a transient consumed only at fit
+                # time for residual diagnostics and never read afterwards, so it
+                # is left as-is.)
+                kept = series_results[idx] if idx < len(series_results) else None
+                if isinstance(kept, dict):
+                    vpath = kept.get("visualization_path")
+                    vbytes = kept.get("visualization_bytes")
+                    if vpath and vbytes:
+                        try:
+                            with open(vpath, "wb") as fh:
+                                fh.write(vbytes)
+                        except Exception as e:  # noqa: BLE001
+                            self.logger.warning(
+                                f"  Could not restore original plot for {name}: {e}"
+                            )
                 refit_summary.append({
                     "index": idx, "name": name,
                     "original_r2": original_r2, "new_r2": new_r2,


### PR DESCRIPTION
## Summary (for scientists)

When the curve-fitter flags a poor spectrum and the **adaptive refit** produces a better fit, three small bookkeeping gaps could make the run *look* wrong or feed stale numbers downstream — even when the actual fit was good. This PR closes them so what's recorded, displayed, and handed to the planner always matches the fit the agent actually accepted.

Concretely (seen on a BaTiO₃ Raman temperature series):
1. A genuinely **excellent refit was reported with a wrong R²** because the fitting script's *self-reported* R² had miscomputed (it diverged from the curve the script actually saved). That bad number could discard the good fit or flag it.
2. The **plot shown** for a spectrum could be from a *discarded* attempt while the numbers were from the kept one.
3. The per-spectrum **feature table** that feeds optimization/planning could carry a refitted spectrum's *pre-refit* values.

All three are now consistent. No change to a normal clean run.

---
<!-- Technical details (for AI reviewers) -->
## Technical details

Three independent but related fixes in `curve_fitting_controllers.py` (curve-fit only; image uses an LLM `quality_score`, not an array-derived R²).

**1. Canonical R², override-only-upward** (`_canonical_r2` + wiring in `_fit_single_spectrum`). The recorded `fit_quality.r_squared` came straight from the script's `FIT_RESULTS_JSON` self-report, computed on the script's internal/windowed object, which can diverge from the `fit.npy` it saves (the curve that's plotted and verified). Observed: a refit with a clean R²≈0.996 saved fit self-reported `0.0000`, so keep-better did `0.09 → 0.0000` and discarded the good doublet. Fix: recompute R² from the canonical `(data.npy, fit.npy)` over the **finite, length-matched** points (same guards as `_residual_diagnostics`), and use `max(self_report, recompute)`.
- **Upward-only is deliberate**: a *lower* full-grid recompute usually means a legitimate **windowed/partial fit** (e.g. follow-up on one region) whose own windowed number is the right one — so we never override downward. Length mismatch / no finite signal → keep the self-report. Self-report preserved under `r_squared_self_reported`; divergences logged.
- Skill (non-R²) gate metrics untouched (only `r_squared` is recomputed).

**2. Restore the kept plot when a refit is discarded** (`AdaptiveRefitController`). The refit runs in the same spectrum dir and overwrites `visualization.png`; on discard ("keeping original"), the kept fit's recorded metrics stayed but its plot had been clobbered. Fix: on discard, re-write the kept result's `visualization_bytes` (already on the result) back to its `visualization_path`. (`fit.npy` is a transient consumed only at fit time for residual diagnostics and never read afterward, so it's left as-is. The within-loop best-vs-last case was already handled by the existing `best_result` re-persist.)

**3. Refresh `series_fit_results.json` after the refit.** It was written at end-of-initial-fitting (`UnifiedSeriesProcessingController`), before the refit, and never refreshed — so refitted spectra showed pre-refit R²/model/params there. That file feeds `write_feature_table` (BO/planning feature table, `analysis_orchestrator_tools.py:2563`) and `_load_prior_curve_fit_state` (#172 reference summary). Fix: extract the writer to a module-level `_write_series_fit_results(...)` (recomputes counts from `series_results`) and re-invoke it at the end of `AdaptiveRefitController.execute` when a refit was adopted. (`analysis_results.json` and `scripts/` were already post-refit and correct; the #172 reused *script* comes from `scripts/`, so reuse execution was unaffected.)

### Validation
- Unit: `_canonical_r2` against the real spec_250K arrays → 0.996; override fires only upward; partial fit (self 0.97 vs recompute 0.40) keeps 0.97; length mismatch / NaN-windowed handled. `_write_series_fit_results` writes post-refit values, strips `visualization_bytes`, recomputes counts.
- Live (Bedrock opus-4-8, BaTiO₃ series ×3 + 1 meta session): regression PASS — `recorded ≈ recompute` for all spectra, refits adopted (e.g. `0.61→0.997`), none falsely flagged. Note: the stochastic broken-self-report (`0.0000`) didn't recur in those runs, so fix #1's corrective path is covered by the unit test against the captured arrays rather than a live trigger.

### Scope / not included
- Curve-fit only. Image analysis has no analogous R² self-report divergence (`quality_score` is the verdict).
- The orchestrator selecting a wrong-*technique* skill (e.g. `xrd_profile` for Raman) is a **separate** open issue (technique-aware skill selection, #251) — not addressed here.