### PR TITLE
Technique-aware skill selection: instruct the orchestrator (#251, part 1)

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -135,6 +135,13 @@ def _build_skill_description(agent_registry: dict = None,
     if custom_skills:
         parts.append(f"Custom skills: {sorted(custom_skills.keys())}.")
 
+    parts.append(
+        "Only select a skill whose measurement technique matches the data's "
+        "technique (each skill names its technique in its description above); if "
+        "none matches, omit `skill` and let the agent's baseline handle it — do "
+        "not substitute the nearest-sounding skill."
+    )
+
     return " ".join(parts)
 
 


### PR DESCRIPTION
## Summary (for scientists)

The analysis orchestrator picks which "skill" (technique-specific fitting knowledge) to apply. On a Raman BaTiO₃ run it loaded the **XRD** skill (`xrd_profile`) even though it had correctly noted in its own reasoning *"this is Raman."* The fix tells it, in one line, to only use a skill whose technique actually matches the data — and otherwise use no skill (the agent's general baseline still fits the data fine).

## Technical details

The `run_analysis` `skill` parameter is **LLM-selected** by the orchestrator, and the per-skill blurbs it reads already name each technique (`'xrd_profile' — p-XRD profile fitting…`, `'epr' — CW-EPR…`, `'xps' — X-ray photoelectron…`). The model is clearly capable of the judgment — observed live, its narrative said *"use `xrd_profile`… no, this is Raman"* — yet the tool call still passed `skill: "xrd_profile"`. So the gap was a missing directive, not missing information.

Fix: one sentence appended to `_build_skill_description` (`analysis_orchestrator_tools.py`):
> *"Only select a skill whose measurement technique matches the data's technique (each skill names its technique in its description above); if none matches, omit `skill` and let the agent's baseline handle it — do not substitute the nearest-sounding skill."*

This matches how skills are actually chosen (orchestrator LLM) and follows the repo's prompt-patch convention — state the principle; escalate to structural enforcement only if a sentence proves insufficient. (A deterministic frontmatter-`technique` gate was prototyped and reverted as heavier than warranted; it remains the documented escalation if the prompt proves unreliable, since the LLM did once contradict its own reasoning.)

### Scope
- Addresses #251 **part 1** (technique-aware selection). The other half — **add a `curve_fitting/raman` skill** so there's a correct target instead of the selector grasping at the nearest one — is deferred.
- One-line prompt change; no code/skill-loading behavior change. The multi-skill loading path and the cross-modality `_MODALITY_DOMAINS` guard (#249) are untouched.