### PR TITLE
UI: disable the chat input until a conversation exists (no duplicate goal box at start)

### DIFF
--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -842,20 +842,23 @@ else:
             )
 
     _has_conversation = bool(st.session_state.chat_messages)
-    # plan and meta accept a free-text goal with no prior upload.
-    _free_start_modes = ("plan", "meta")
-    if st.session_state.app_mode == "meta":
-        _chat_placeholder = "Describe your research goal..."
-    elif st.session_state.app_mode == "plan":
-        _chat_placeholder = "Message the planning agent..."
-    elif _has_conversation:
-        _chat_placeholder = "Message the analysis agent..."
-    else:
+    # Every mode has a dedicated start screen (goal field + a Start/Analyze
+    # button) in render_pre_chat_uploads, so the bottom chat input is for
+    # *continuing* a conversation and stays disabled until one exists.
+    # (Previously plan/meta left it enabled at the start, duplicating the start
+    # form and dropping any text typed into it.)
+    _chat_disabled = task.is_running or not _has_conversation
+    if _has_conversation:
+        if st.session_state.app_mode == "meta":
+            _chat_placeholder = "Message mission control..."
+        elif st.session_state.app_mode == "plan":
+            _chat_placeholder = "Message the planning agent..."
+        else:
+            _chat_placeholder = "Message the analysis agent..."
+    elif st.session_state.app_mode == "analyze":
         _chat_placeholder = "Upload data and click Analyze to start"
-
-    _chat_disabled = task.is_running or (
-        not _has_conversation and st.session_state.app_mode not in _free_start_modes
-    )
+    else:
+        _chat_placeholder = "Enter your goal in the form above to start"
     # Render the chat input inside the Chat tab container. A top-level
     # st.chat_input is pinned to the bottom of the whole app and shows on
     # every tab; scoping it to chat_tab keeps it on the Chat tab only.


### PR DESCRIPTION
## Summary

At the start of a **meta** (and **plan**) session the UI showed *two* goal inputs: the dedicated start form (with its own goal field + Start button) **and** the bottom "Describe your research goal…" chat box. The form's button is the real entry point, so text typed into the bottom box at that point was redundant/dropped. This disables the bottom chat input until a conversation exists, leaving each mode's form as the sole way to start.

## Technical details

Every mode's start screen (`render_pre_chat_uploads` → `_render_analyze_uploads` / `_render_planning_uploads` / `_render_meta_uploads`) has its own goal field and submit button: **Analyze** (`:79`), **Start Planning** + `planning_objective` (`:190`), **Start** + `meta_objective` (`:352`). So no mode depends on the bottom `st.chat_input` to *start* — it's only for *continuing* a conversation.

Previously `app.py` put `plan`/`meta` in `_free_start_modes`, leaving the bottom input enabled before any conversation — duplicating the form and dropping text typed into it. The fix:

```python
_chat_disabled = task.is_running or not _has_conversation
```

(removing the `_free_start_modes` special-case), with conversation-aware placeholders ("Message mission control…" / "Message the planning agent…" / "Message the analysis agent…" once started; a form-pointing hint before). `analyze` is unchanged — it was already disabled at the start and keeps its "Upload data and click Analyze to start" hint.

### Scope
- Reported for **meta**; also fixes **plan** (identical pattern). If plan's free-text chat-start was intentional, revert that one line.
- Pure UI gating change in `app.py`; no agent/behavior change.