### PR TITLE
Surface skill technique to the selector (frontmatter + explicit tag) — #251

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -121,13 +121,21 @@ def _build_skill_description(agent_registry: dict = None,
         for name in names:
             try:
                 parsed = load_skill(name, domain=domain)
-                desc = (parsed.get("meta") or {}).get("description")
+                meta = parsed.get("meta") or {}
+                desc = meta.get("description")
                 if not desc:
                     desc = parsed.get("overview", "").split("\n")[0].strip()
                 # Trim trailing punctuation so the join with ". " below
                 # doesn't produce ".." or ".;".
                 desc = desc.rstrip(".;,") if desc else desc
-                skill_descs.append(f"'{name}' — {desc}" if desc else f"'{name}'")
+                # Surface the declared measurement technique(s) explicitly so the
+                # selector can technique-match instead of inferring from prose.
+                techs = meta.get("technique")
+                if isinstance(techs, str):
+                    techs = [techs]
+                tech_tag = f" [technique: {', '.join(map(str, techs))}]" if techs else ""
+                body = f"{desc}" if desc else ""
+                skill_descs.append(f"'{name}'{tech_tag}" + (f" — {body}" if body else ""))
             except Exception:
                 skill_descs.append(f"'{name}'")
         parts.append(f"Built-in {domain} skills: {'; '.join(skill_descs)}.")
@@ -137,9 +145,10 @@ def _build_skill_description(agent_registry: dict = None,
 
     parts.append(
         "Only select a skill whose measurement technique matches the data's "
-        "technique (each skill names its technique in its description above); if "
-        "none matches, omit `skill` and let the agent's baseline handle it — do "
-        "not substitute the nearest-sounding skill."
+        "technique — compare the data's technique (from the metadata) against "
+        "each skill's `[technique: …]` tag above. If none matches, omit `skill` "
+        "and let the agent's baseline handle it; do not substitute the "
+        "nearest-sounding skill."
     )
 
     return " ".join(parts)

--- a/scilink/skills/curve_fitting/epr/epr.md
+++ b/scilink/skills/curve_fitting/epr/epr.md
@@ -1,5 +1,6 @@
 ---
 description: CW-EPR axial powder fitting for S=1/2 systems at X-band — extracts g_par, g_perp, A_par, and linewidth from the first-derivative spectrum, with an optional second isotropic component for radical/defect contamination near g≈2.
+technique: [EPR, ESR, "electron paramagnetic resonance", "electron spin resonance"]
 quality_gate:
   metric: r_squared
   accept_threshold: 0.90

--- a/scilink/skills/curve_fitting/xps/xps.md
+++ b/scilink/skills/curve_fitting/xps/xps.md
@@ -1,5 +1,6 @@
 ---
 description: X-ray photoelectron spectroscopy peak fitting (Shirley/Tougaard backgrounds, asymmetric line shapes) for chemical-state analysis from binding energies.
+technique: [XPS, "X-ray photoelectron spectroscopy", "photoelectron spectroscopy", ESCA]
 ---
 # XPS Curve Fitting Skill
 

--- a/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
+++ b/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
@@ -1,5 +1,6 @@
 ---
 description: p-XRD profile fitting — per-peak pseudo-Voigt fits with FWHM, position, and intensity; Scherrer crystallite size and Williamson-Hall microstrain from the fitted line widths.
+technique: [XRD, "X-ray diffraction", "powder diffraction", pXRD]
 quality_gate:
   metric: r_squared
   accept_threshold: 0.95


### PR DESCRIPTION
## Summary

Follow-on to #255. Instead of leaving the orchestrator to infer each skill's technique from its description prose, declare the technique explicitly in frontmatter and show it at selection time, so the technique-match instruction has structured data to compare against. No deterministic gate — the orchestrator LLM still chooses; this just makes the correct choice obvious (it can see `xrd_profile [technique: XRD]` is wrong for Raman data).

## Technical details

- **Frontmatter `technique` field** on the curve_fitting skills: `xrd_profile` → `[XRD, X-ray diffraction, powder diffraction, pXRD]`; `epr` → `[EPR, ESR, electron paramagnetic resonance, electron spin resonance]`; `xps` → `[XPS, X-ray photoelectron spectroscopy, photoelectron spectroscopy, ESCA]`. (Parsed into `meta` by the loader, same as the existing `quality_gate` field; no loader behavior change.)
- **`_build_skill_description`** renders it as a `[technique: …]` tag per skill, and the #255 selection instruction now says to compare the data's technique (from metadata) against that tag and omit `skill` if none matches.

Builds on #255 (merged). Pairs the clear instruction with explicit structured technique metadata. Verified the rendered `skill` param shows the tags and the instruction references them.

### Scope
- Addresses #251 part 1 reliability via instruction + metadata, not a deterministic loader gate (prototyped earlier, deliberately not used).
- #251 part 2 (add a `curve_fitting/raman` skill) still deferred.