### PR TITLE
Fit-quality integrity: robust (median/MAD) outlier detection + anti-window-narrowing prompt

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -4053,33 +4053,38 @@ Return JSON with:
             return []
         
         r2_array = np.array(r2_values)
-        mean_r2 = np.mean(r2_array)
-        std_r2 = np.std(r2_array)
-        
+        # Robust center/scale (median + MAD). A single bad fit can't mask itself
+        # by inflating the statistic the way mean/std let it — with mean/std a
+        # lone outlier in an n-point series caps at √(n-1)σ (exactly 2.0 for
+        # n=5), so it could never exceed a 2σ threshold and got mislabeled
+        # "consistent with series". MAD is unaffected by the outlier itself.
+        median_r2 = float(np.median(r2_array))
+        mad = float(np.median(np.abs(r2_array - median_r2)))
+        # 1.4826·MAD ≈ σ for normal data; floor it so a near-identical series
+        # (MAD≈0) doesn't flag trivial scatter while a real gap still registers.
+        robust_scale = max(1.4826 * mad, 0.02)
+
         flagged = []
-        
+
         for r in series_results:
             if not r["success"]:
                 flagged.append({
                     "index": r["index"], "name": r["name"], "reason": "fit_failed",
-                    "r_squared": None, "series_mean": float(mean_r2), "series_std": float(std_r2),
+                    "r_squared": None, "series_mean": median_r2, "series_std": robust_scale,
                     "deviation_sigma": None,
                     "recommendation": "Check data quality and consider manual inspection. The fitting script failed to execute successfully."
                 })
                 continue
-            
+
             r2 = r.get("fit_quality", {}).get("r_squared")
             if r2 is None:
                 continue
-            
+
             below_threshold = r2 < self.r2_threshold
-            
-            if std_r2 > 0.001:
-                deviation_sigma = (mean_r2 - r2) / std_r2
-                is_outlier = deviation_sigma > self.outlier_sigma
-            else:
-                deviation_sigma = 0
-                is_outlier = False
+            # Robust z-score; only a fit *below* the series median can be an
+            # outlier (a better-than-typical fit is never flagged).
+            deviation_sigma = (median_r2 - r2) / robust_scale
+            is_outlier = deviation_sigma > self.outlier_sigma
             
             if below_threshold or is_outlier:
                 if is_outlier and not below_threshold:
@@ -4087,14 +4092,14 @@ Return JSON with:
                     recommendation = "Fit quality significantly worse than series average. Possible causes: phase transition, sample change, or instrument artifact. Consider detailed inspection - may indicate interesting physics."
                 elif below_threshold and not is_outlier:
                     reason = "below_threshold"
-                    recommendation = "Fit quality below threshold but consistent with series. The chosen model may not be optimal for this data type."
+                    recommendation = "Fit quality below threshold but in line with the rest of the series (R² is not a statistical outlier) — the chosen model may be suboptimal for this data type."
                 else:
                     reason = "outlier_and_below_threshold"
                     recommendation = "Significant fit quality issue. This spectrum behaves differently from others in the series. Strongly recommend manual review - could indicate interesting physics, phase transition, or data quality issue."
-                
+
                 flagged.append({
                     "index": r["index"], "name": r["name"], "reason": reason,
-                    "r_squared": float(r2), "series_mean": float(mean_r2), "series_std": float(std_r2),
+                    "r_squared": float(r2), "series_mean": median_r2, "series_std": robust_scale,
                     "deviation_sigma": float(deviation_sigma) if deviation_sigma else None,
                     "recommendation": recommendation
                 })
@@ -4116,7 +4121,7 @@ Return JSON with:
             lines.append(f"R² range: {min(r2_values):.4f} - {max(r2_values):.4f}")
             lines.append(f"R² mean ± std: {np.mean(r2_values):.4f} ± {np.std(r2_values):.4f}")
             lines.append(f"Quality threshold: {self.r2_threshold}")
-            lines.append(f"Outlier detection: {self.outlier_sigma}σ below mean")
+            lines.append(f"Outlier detection: {self.outlier_sigma}σ below median (robust/MAD)")
             lines.append("")
         
         by_reason = {}
@@ -4140,9 +4145,9 @@ Return JSON with:
             for f in items:
                 lines.append(f"  • {f['name']} (index {f['index']})")
                 if f["r_squared"] is not None:
-                    lines.append(f"    R² = {f['r_squared']:.4f} (series mean: {f['series_mean']:.4f})")
+                    lines.append(f"    R² = {f['r_squared']:.4f} (series median: {f['series_mean']:.4f})")
                     if f["deviation_sigma"] is not None:
-                        lines.append(f"    Deviation: {f['deviation_sigma']:.1f}σ below mean")
+                        lines.append(f"    Deviation: {f['deviation_sigma']:.1f}σ below median")
                 lines.append(f"    → {f['recommendation']}")
                 lines.append("")
         
@@ -6011,9 +6016,9 @@ class UnifiedCurveReportController:
             html += f'<span class="flagged-badge" style="background-color: {color};">{label}</span></div>'
             
             if f.get("r_squared") is not None:
-                html += f'<p><strong>R²:</strong> {f["r_squared"]:.4f} (series mean: {f["series_mean"]:.4f})</p>'
+                html += f'<p><strong>R²:</strong> {f["r_squared"]:.4f} (series median: {f["series_mean"]:.4f})</p>'
                 if f.get("deviation_sigma") is not None:
-                    html += f'<p><strong>Deviation:</strong> {f["deviation_sigma"]:.1f}σ below mean</p>'
+                    html += f'<p><strong>Deviation:</strong> {f["deviation_sigma"]:.1f}σ below median</p>'
             
             html += f'<p class="flagged-recommendation">{f["recommendation"]}</p>'
             

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2090,6 +2090,11 @@ to fit. Note the role of any other columns (e.g. an uncertainty/error column, a
 second channel, an index, an irrelevant column) and how each should be treated.
 Refer to columns by name when names are given, otherwise by index.
 
+**Fit the full measured range.** Plan to fit the complete spectrum / full
+physically-relevant range; do not truncate the data or narrow the window to a
+sub-region to obtain a higher R² unless there is a clear physics reason or the
+user explicitly asked.
+
 **Output Format:**
 ```json
 {
@@ -2225,7 +2230,11 @@ plan as specified and let the retry pipeline handle actual runtime failures.
      noisy (noise large relative to signal); prefer none for clean data, and never
      on derivative spectra (see above).
    If you preprocess, keep both the raw and processed arrays so you can plot them.
-3. Implement your fitting approach (fit over the plan's fit domain).
+3. Implement your fitting approach over the plan's fit domain. Fit the FULL
+   measured range — do NOT truncate the data or narrow the fit window to raise R²
+   (e.g. fitting one peak while ignoring real signal elsewhere) unless there is a
+   clear physics reason or the user explicitly requested it; report R² over the
+   full domain you are modelling, not a hand-picked sub-region.
 4. Compute R² and RMSE
 5. Save `visualization.png` (in the current working directory): data + fit + residuals (show individual components if multiple peaks).
    **Make the residual diagnosable** (the reviewer reads this plot): put residuals
@@ -2285,7 +2294,7 @@ FITTING_SCRIPT_CORRECTION_INSTRUCTIONS = """Fix this failed script.
 **Available Libraries:** numpy, pandas, scipy, lmfit, matplotlib, json
 *(NumPy 2.x: aliases removed in NumPy 2.0 raise `AttributeError` — use `np.trapezoid` not `np.trapz`; prefer `scipy.integrate.trapezoid` for integration.)*
 
-**CRITICAL:** Fix only the execution error. Do NOT change the fitting model, its parameters, or the overall analysis approach. The model is locked for series consistency.
+**CRITICAL:** Fix only the execution error. Do NOT change the fitting model, its parameters, the fit domain/window, or the overall analysis approach — and never narrow the window or truncate the data to raise R². The model is locked for series consistency.
 
 **I/O contract (do not deviate):** the data is `data.npy` in the current working directory — load it with `np.load` (do NOT look for .csv/.txt/.dat or glob for other files); save the plot to `visualization.png`; print one line `FIT_RESULTS_JSON:{{...}}` with the fit results. Missing any of these fails the run. Also keep saving `fit.npy` (1-D fitted curve at the `data.npy` x-points, length N) if the script you are fixing already did — it feeds the reviewer's residual diagnostics.
 


### PR DESCRIPTION
## Summary (for scientists)

Two related fixes to how the curve-fitter judges and reports fit quality across a series:

1. **A clearly-bad fit was being labelled "consistent with series."** A spectrum that fit far worse than its neighbours (e.g. R²=0.09 among 0.99s) was *not* flagged as an outlier and got the message *"below threshold but consistent with series."* Now it's correctly flagged as an outlier.
2. **The agent could "cheat" R² by narrowing the fit window.** A refit fit only one peak of a clear doublet, scored R²=0.9977 on that sliver while ignoring the obvious second peak. The codegen prompts now forbid truncating data / narrowing the window to raise R² unless there's a clear physics reason or the user asks.

## Technical details

**1 — robust outlier detection (`_detect_outliers`).** The test used mean + std over all spectra, so a single bad fit *masked itself* (inflating std, dragging the mean toward itself). A lone outlier among `n` points caps at √(n−1)σ — exactly 2.0 for a 5-spectrum series — so with a strict `> 2σ` threshold it could **never** be flagged, and fell into the `below_threshold and not is_outlier` branch ("consistent with series"). Switched to **median + 1.4826·MAD** (floored at 0.02 so a near-identical series doesn't flag trivial scatter). MAD is unaffected by the outlier, so 0.09-among-0.99s reads ~45σ below median → `outlier_and_below_threshold`. Verified: uniform-low series and genuine trends stay un-flagged; all-good flags nothing. Reworded the message and switched the reported stat from mean→median (log + HTML).

**2 — anti-window-narrowing prompt.** A refit narrowed its window to one peak (self-reported windowed R²=0.9977; full-data R²≈0.08) and was adopted. Added the principle to all three curve-fit codegen-path prompts (`FITTING_SCRIPT_INSTRUCTIONS` step 3 — the adaptive refit reuses this; the planning prompt; `FITTING_SCRIPT_CORRECTION_INSTRUCTIONS`): fit the full measured range; do not truncate the data or narrow the window to raise R² unless physics requires it or the user explicitly asked; report R² over the full domain modelled.

### Known limit
- The prompt is a deterrent, not a hard guarantee. If a model narrows the window anyway, its over-reported windowed R² is still recorded (the #254 recompute is upward-only), so it looks in-line with the series and the outlier test won't catch it. The deterministic backstop (both-directions canonical recompute) was discussed and deliberately not implemented in favour of the prompt approach.