### PR TITLE
Recover codegen side fields (analysis_approach/key_metrics/…) when the script value breaks json.loads

### DIFF
--- a/scilink/utils/codegen_parse.py
+++ b/scilink/utils/codegen_parse.py
@@ -217,8 +217,10 @@ def parse_codegen_response(response, field: str = "script", logger=None):
         }
 
     result = {field: script}
-    # Best-effort side fields (diagnosis/summary/...) from well-formed JSON.
+    # Best-effort side fields (diagnosis/summary/analysis_approach/...) from
+    # well-formed JSON.
     cleaned = _strip_fences(raw)
+    parsed_ok = False
     for candidate in (raw, cleaned, _escape_newlines_in_strings(cleaned)):
         try:
             obj = json.loads(candidate)
@@ -228,5 +230,25 @@ def parse_codegen_response(response, field: str = "script", logger=None):
             for key, value in obj.items():
                 if key != field and key not in result:
                     result[key] = value
+            parsed_ok = True
             break
+    if not parsed_ok:
+        # The (large, escaped) script value is usually what breaks json.loads,
+        # which would silently drop the side fields. By convention the script is
+        # the LAST key, so the side fields sit in a well-formed prefix — parse
+        # that to recover them (e.g. trend's analysis_approach / key_metrics,
+        # correction's diagnosis) instead of losing them when the script string
+        # is malformed. The prefix contains no script text, so no false matches.
+        m = re.search(r',?\s*"' + re.escape(field) + r'"\s*:', cleaned)
+        if m:
+            prefix = cleaned[:m.start()].rstrip().rstrip(",").rstrip()
+            if prefix.startswith("{"):
+                try:
+                    obj = json.loads(prefix + "}")
+                except (json.JSONDecodeError, ValueError):
+                    obj = None
+                if isinstance(obj, dict):
+                    for key, value in obj.items():
+                        if key != field and key not in result:
+                            result[key] = value
     return result, None


### PR DESCRIPTION
## Summary

The trend-analysis step intermittently logged **`Approach: unknown` / `Metrics: []`** (and recorded empty trend metadata in the report), even though the trend script ran fine. Root cause: the codegen response parser dropped the response's side fields whenever the script string broke JSON parsing.

## Technical details

`parse_codegen_response` (`utils/codegen_parse.py`, from #240) salvages the **script** robustly (compile-checked, tolerant of malformed escaping), but recovered **side fields** (`analysis_approach`, `key_metrics`, `flagged_handling`, `diagnosis`, …) only via a clean `json.loads` of the *entire* response (`:219-231`). The script is a large escaped string; any JSON-breaking char in it (unescaped quote, `f"{...}"`, etc.) makes all `json.loads` attempts fail, so the merge loop never runs and `result = {"script": …}` — side fields silently lost. Intermittent: depends on whether the script string happened to be JSON-clean.

Impact was metadata-only — the trend regression/`parameter_trends.png` come from the script's execution output, not these fields; but `trend_analysis_results` (`approach`, `metrics_tracked`, `flagged_handling`) and the report's trend description went blank.

Fix: when the whole-response `json.loads` fails, recover side fields from the **well-formed prefix before the script field**. The script is the last key by convention (`"script"` last in the trend/correction schemas), so the prefix is clean JSON containing no script text → no false matches. The script itself is unchanged (still extracted by `extract_script`). This fixes dropped side fields for *every* codegen caller, not just trend.

Verified: a malformed script-last response now recovers `analysis_approach` + `key_metrics` + `flagged_handling`; clean JSON still merges as before.