### PR TITLE
Skill technique-match rule belongs in the system prompt, not a buried param tail (#251)

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -269,7 +269,11 @@ examine_data returns data_type:
 2. `load_metadata` (can pass directory path) or `convert_metadata`
 3. Decide agent (ask user if disambiguation_needed=true)
 4. `select_agent`
-5. `run_analysis`
+5. `run_analysis`. **Skill selection is technique-gated:** only pass a `skill`
+   whose declared technique matches the data's measurement technique (each
+   skill names its technique in the `skill` parameter's `[technique: …]` tag).
+   If no skill's technique matches the data, pass NO skill — the agent's
+   baseline fits it correctly. Never fall back to the nearest-sounding skill.
 6. Present results
 7. For deeper follow-up analysis on images, call `run_analysis` again with
    `prior_analysis_paths` set to the prior `output_directory`; the agent will


### PR DESCRIPTION
## Summary

The orchestrator kept selecting `xrd_profile` for Raman data despite #255 (the instruction) and #258 (the `[technique: …]` tag). Root cause is **structural placement**, not the model failing to read: both lived only in the `run_analysis` `skill` *parameter* description — one sentence at the **tail of a ~5.4k-char cross-domain skill catalog** (char 5091/5383). The orchestrator's decisions are framed by its **system prompt**, which had **no skill-selection guidance at all** (its "Check metadata technique" tree only routes to an *agent*). So when filling the `skill` arg the model skimmed the long catalog and grabbed the nearest-sounding entry; a lone rule at the end of that blob was too weak to override it.

## Fix

State the rule where the decision is actually formed — the system prompt's Standard Workflow, at the `run_analysis` step: only pass a `skill` whose declared technique matches the data's measurement technique; if none matches, pass no skill (baseline handles it); never fall back to the nearest-sounding skill. The param `[technique: …]` tag (#258) and param sentence (#255) now *reinforce* a rule the model has already read in its system prompt.

## Note for testing
A running Streamlit/`scilink` process does **not** hot-reload merged code — the UI must be **restarted** to pick up this (and #255/#258). If recent reruns happened in the same long-lived process, none of these were active yet, which on its own explains the repeated `xrd_profile` loads.

If, after a restart with this merged, it *still* selects a technique-mismatched skill, the prompt approach has been given its best placement and the deterministic loader gate (prototyped earlier, set aside) is the warranted fallback.