### PR TITLE
Series plan: drop empty regimes + backfill per-regime fields

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1430,11 +1430,16 @@ class HumanFeedbackRefinementController:
                     range_str = f" ({min(valid_vals)}-{max(valid_vals)} {unit})" if valid_vals else ""
                 else:
                     range_str = ""
+                # Fall back to the top-level plan fields so a regime the LLM left
+                # sparse never renders as all-N/A.
+                model = regime.get("physical_model") or series_plan.get("physical_model") or "N/A"
+                strategy = regime.get("fitting_strategy") or series_plan.get("fitting_strategy") or "N/A"
+                params = regime.get("parameters_to_extract") or series_plan.get("parameters_to_extract", [])
                 print(f"\n  Regime {i}: {regime.get('name', 'Unnamed')}")
                 print(f"    Spectra: indices {indices}{range_str}")
-                print(f"    Model: {regime.get('physical_model', 'N/A')}")
-                print(f"    Strategy: {regime.get('fitting_strategy', 'N/A')}")
-                print(f"    Parameters: {', '.join(regime.get('parameters_to_extract', []))}")
+                print(f"    Model: {model}")
+                print(f"    Strategy: {strategy}")
+                print(f"    Parameters: {', '.join(params)}")
 
             transitions = series_plan.get("transition_points", [])
             if transitions:
@@ -1752,6 +1757,34 @@ class HumanFeedbackRefinementController:
             regimes[0]["spectrum_indices"] = sorted(
                 set(regimes[0]["spectrum_indices"]) | missing
             )
+
+        # Drop regimes that ended up fitting no spectra. The LLM sometimes names
+        # an aspirational regime (e.g. "split doublet") but commits every
+        # spectrum to one regime; the orphan-reassignment above then leaves the
+        # other empty. An empty regime fits nothing — it would pollute the banner,
+        # the report, the regime-locking step, and the per-index regime loops — so
+        # it is removed here rather than carried forward.
+        dropped = [r.get("name", "unnamed") for r in regimes if not r["spectrum_indices"]]
+        regimes = [r for r in regimes if r["spectrum_indices"]]
+        series_plan["regimes"] = regimes
+        if dropped:
+            self.logger.warning(
+                f"  Dropped {len(dropped)} empty regime(s) (no spectra assigned): {dropped}"
+            )
+        if not regimes:
+            state["series_analysis_plan"] = None
+            return
+
+        # Backfill per-regime model/strategy/params from the top-level plan when
+        # the LLM populated only the top level — otherwise the display and report
+        # show "N/A" for a regime whose model is in fact known.
+        for regime in regimes:
+            if not regime.get("physical_model"):
+                regime["physical_model"] = series_plan.get("physical_model")
+            if not regime.get("fitting_strategy"):
+                regime["fitting_strategy"] = series_plan.get("fitting_strategy")
+            if not regime.get("parameters_to_extract"):
+                regime["parameters_to_extract"] = series_plan.get("parameters_to_extract", [])
 
         state["series_analysis_plan"] = series_plan
         self.logger.info(


### PR DESCRIPTION
## Summary (for scientists)

A series-fitting run printed a confusing regime plan like this:

```
Regime 1: Single-band A1(TO)     Spectra: indices [0,1,2,3,4]   Model: N/A
Regime 2: Split A1(TO) doublet   Spectra: indices []            Model: N/A
```

Two cosmetic-but-misleading problems: a **second regime with no spectra** (it looks like detection half-failed), and **Model / Strategy / Parameters showing "N/A"** even though the plan did have a model. The actual fit was correct — all five spectra were fit under Regime 1 — but the displayed plan made it look broken.

This happens because the planner LLM sometimes *names* an aspirational regime (e.g. a high-temperature "split doublet") but then assigns every spectrum to the first regime, leaving the second empty; and it sometimes fills the model/strategy/parameters at the top level of the plan instead of repeating them inside each regime.

After this fix:
- regimes that end up fitting **no spectra are dropped** (with a log line), so the banner/report only show regimes that actually fit something;
- each regime's **model/strategy/parameters fall back to the top-level plan** when the LLM left them blank, so they no longer read "N/A" when the model is in fact known.

Fitting results are unchanged — this is plan hygiene and presentation only.

<!-- TECHNICAL DETAILS BELOW -->
---

## Technical details

All changes in `scilink/agents/exp_agents/controllers/curve_fitting_controllers.py`, `HumanFeedbackRefinementController`.

**`_extract_series_plan` (~:1746-1782).** After the existing index-clip + orphan-reassignment to `regimes[0]`:
- filter `regimes = [r for r in regimes if r["spectrum_indices"]]`; log dropped regime names; null the plan only if `not regimes`. (The orphan-reassignment runs *first*, so `regimes[0]` is never the empty one — a lone out-of-range regime becomes full-coverage rather than vanishing.)
- backfill `physical_model` / `fitting_strategy` / `parameters_to_extract` on each surviving regime from the top-level `series_plan` when falsy.

**Display (~:1433-1442).** `regime.get(field) or series_plan.get(field) or "N/A"` for model/strategy/params, so a checkpoint-restored or otherwise un-backfilled plan still renders sensibly.

Why this isn't a parse bug (#260 class): the regime `name` survived intact while only indices/fields were empty, which rules out a JSON-load drop — it's the LLM under-filling plus `_extract_series_plan` not validating per-regime content. The empty regime previously flowed into the regime-locking step (`:~1891-1914`) and the per-index regime loops (`:~4170, :4203, :4390`), so dropping it removes a no-op locked pipeline as well as the misleading banner.

**Verification.** Direct unit exercise of `_extract_series_plan` (no API):
- degenerate case (regime 1 = `[0,1,2]`, regime 2 = out-of-range `[7,8]` → `[]`, fields top-level only) → 1 regime, all 5 indices, backfilled model/params ✓
- genuine two populated regimes with own fields → unchanged ✓
- lone out-of-range regime → orphan-reassignment fills it, valid 1-regime plan ✓
- single spectrum → `None` ✓

Independent of the open skill-selection / R²-integrity PRs.