### PR TITLE
Show the orchestrator's reasoning before each tool call (analysis + meta)

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1604,8 +1604,17 @@ class AnalysisOrchestratorAgent:
         if not content:
             return
         text = content.strip() if isinstance(content, str) else str(content).strip()
-        if text:
-            print(f"  💭 {text}")
+        if not text:
+            return
+        import sys
+        # Dim + italic (muted cyan) so the prose is visually distinct from the
+        # structural tool-call log — but only on a real terminal, else the raw
+        # escape codes would litter captured/redirected output. Blank lines
+        # before and after set the thought apart from the tool call it triggers.
+        style, reset = (("\033[2;3;36m", "\033[0m")
+                        if sys.stdout.isatty() else ("", ""))
+        body = text.replace("\n", "\n     ")  # indent continuation lines
+        print(f"\n  {style}💭 {body}{reset}\n")
 
     def _handle_litellm_chat(self, user_input: str) -> str:
         """Handle chat with LiteLLM models with manual function calling loop."""

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1573,11 +1573,13 @@ class AnalysisOrchestratorAgent:
                     } for tc in message.tool_calls
                 ]
             })
-            
+
+            self._print_assistant_reasoning(message.content)
+
             for tool_call in message.tool_calls:
                 func_name = tool_call.function.name
                 args = json.loads(tool_call.function.arguments)
-                
+
                 print(f"  🔧 Calling tool: {func_name}")
                 
                 result = self.tools.execute_tool(func_name, **args)
@@ -1590,6 +1592,20 @@ class AnalysisOrchestratorAgent:
         
         self._last_chat_hit_iter_cap = True
         return "⚠️ Maximum tool iterations reached. Please simplify your request."
+
+    def _print_assistant_reasoning(self, content) -> None:
+        """Surface the LLM's interim reasoning that accompanies a tool call.
+
+        Without this the console jumps straight to "🔧 Calling tool: …", so a
+        deliberate step — e.g. re-running an analysis to verify a methodological
+        concern — reads like a silent loop. The text is already in history; this
+        just shows it so the user can see *why* the next tool is being called.
+        """
+        if not content:
+            return
+        text = content.strip() if isinstance(content, str) else str(content).strip()
+        if text:
+            print(f"  💭 {text}")
 
     def _handle_litellm_chat(self, user_input: str) -> str:
         """Handle chat with LiteLLM models with manual function calling loop."""
@@ -1665,14 +1681,16 @@ class AnalysisOrchestratorAgent:
                 ]
             }
             self.messages.append(assistant_msg)
-            
+
+            self._print_assistant_reasoning(content)
+
             for tool_call in tool_calls:
                 func_name = tool_call.function.name
                 try:
                     args = json.loads(tool_call.function.arguments)
                 except json.JSONDecodeError:
                     args = {}
-                
+
                 print(f"  🔧 Calling tool: {func_name}")
                 
                 result = self.tools.execute_tool(func_name, **args)

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1247,6 +1247,8 @@ class MetaOrchestratorAgent:
                 ],
             })
 
+            self._print_assistant_reasoning(message.content)
+
             for tool_call in message.tool_calls:
                 func_name = tool_call.function.name
                 try:
@@ -1265,6 +1267,20 @@ class MetaOrchestratorAgent:
 
         self._last_chat_hit_iter_cap = True
         return "⚠️ Maximum tool iterations reached. Please simplify your request."
+
+    def _print_assistant_reasoning(self, content) -> None:
+        """Surface the LLM's interim reasoning that accompanies a tool call.
+
+        Without this the console jumps straight to "🔧 Calling tool: …", so a
+        deliberate step reads like a silent loop. The text is already in
+        history; this just shows it so the user can see *why* the next tool is
+        being called.
+        """
+        if not content:
+            return
+        text = content.strip() if isinstance(content, str) else str(content).strip()
+        if text:
+            print(f"  💭 {text}")
 
     def _handle_litellm_chat(self, user_input: str) -> str:
         """Handle chat with LiteLLM models — manual tool-calling loop."""
@@ -1336,6 +1352,8 @@ class MetaOrchestratorAgent:
                     } for tc in tool_calls
                 ],
             })
+
+            self._print_assistant_reasoning(content)
 
             for tool_call in tool_calls:
                 func_name = tool_call.function.name

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1279,8 +1279,17 @@ class MetaOrchestratorAgent:
         if not content:
             return
         text = content.strip() if isinstance(content, str) else str(content).strip()
-        if text:
-            print(f"  💭 {text}")
+        if not text:
+            return
+        import sys
+        # Dim + italic (muted cyan) so the prose is visually distinct from the
+        # structural tool-call log — but only on a real terminal, else the raw
+        # escape codes would litter captured/redirected output. Blank lines
+        # before and after set the thought apart from the tool call it triggers.
+        style, reset = (("\033[2;3;36m", "\033[0m")
+                        if sys.stdout.isatty() else ("", ""))
+        body = text.replace("\n", "\n     ")  # indent continuation lines
+        print(f"\n  {style}💭 {body}{reset}\n")
 
     def _handle_litellm_chat(self, user_input: str) -> str:
         """Handle chat with LiteLLM models — manual tool-calling loop."""

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -19,6 +19,34 @@ from scilink.ui.output_capture import AgentStoppedError, OutputCapture
 from scilink.ui.theme import inject_theme
 from scilink.ui.config import AVATAR_USER, AVATAR_AGENT, APP_MODES, SESSION_DIR_PREFIXES
 
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove terminal ANSI styling. The agent emits it for the console; in the
+    HTML log pane / st.code it would otherwise render as literal escape codes."""
+    return _ANSI_RE.sub("", text or "")
+
+
+def _log_to_html(text: str) -> str:
+    """ANSI-strip a captured log and HTML-escape it, rendering the agent's 💭
+    reasoning lines (and their indented continuations) in italic muted cyan so
+    they read as prose — the HTML equivalent of the terminal's dim+italic."""
+    import html as _html
+
+    out, in_thought = [], False
+    for line in _strip_ansi(text).split("\n"):
+        if line.lstrip().startswith("💭"):
+            in_thought = True
+        elif in_thought and not line.startswith("     "):
+            in_thought = False
+        esc = _html.escape(line)
+        if in_thought:
+            esc = f'<span style="color:#6ec1e4;font-style:italic">{esc}</span>'
+        out.append(esc)
+    return "\n".join(out)
+
+
 def _escape_tildes(text: str) -> str:
     """Escape tildes outside LaTeX ($...$, $$...$$) to prevent Markdown strikethrough."""
     # Split on LaTeX delimiters, preserving them
@@ -531,7 +559,7 @@ else:
                         )
                 if msg.get("verbose"):
                     with st.expander("Verbose output"):
-                        st.code(msg["verbose"], language="text")
+                        st.code(_strip_ansi(msg["verbose"]), language="text")
     
         # ── Agent monitoring fragment ─────────────────────────────────
         # Uses @st.fragment to rerun only this section (not the full page)
@@ -803,10 +831,8 @@ else:
     })();
     </script>""", height=1)
                     if show:
-                        import html as _html
-    
                         tail = "\n".join(live.split("\n")[-200:])
-                        escaped = _html.escape(tail)
+                        escaped = _log_to_html(tail)
                         st.iframe( 
                             f'<pre style="height:280px;overflow-y:auto;margin:0;'
                             f"background:#1e1e1e;padding:8px;border-radius:4px;"


### PR DESCRIPTION
## Summary (for scientists)

While watching a run, the console would finish one analysis and then — with no explanation — start a second `run_analysis`, which looked exactly like a bug or a re-analysis loop. In fact the agent had a good reason (e.g. *"the first fit only captured the central band; let me re-run to check whether the other modes are genuinely absent"*) — that reasoning was recorded in the session history, it just **wasn't printed to the screen**.

This change surfaces that reasoning. Now, before the agent calls a tool, the console shows a `💭` line with *why* it's about to do so, so a deliberate verification step no longer reads as a silent loop.

Display-only — it does not change what the agent does, only what you see.

<!-- TECHNICAL DETAILS BELOW -->
---

## Technical details

Both `AnalysisOrchestratorAgent` and `MetaOrchestratorAgent` have two tool-calling loops (internal-proxy path + LiteLLM path). In all four, the assistant message's `content` (the interim reasoning that accompanies `tool_calls`) was appended to `self.messages` but never printed — only `🔧 Calling tool: <name>` was. So an assistant turn that returned *both* reasoning text and a tool call showed only the tool name.

Added `_print_assistant_reasoning(content)` to each orchestrator and called it right after the assistant message is appended, before the tool loop:
- `scilink/agents/exp_agents/analysis_orchestrator.py` — helper + calls in `_handle_chat` (proxy) and `_handle_litellm_chat`.
- `scilink/agents/meta_agent/meta_orchestrator.py` — same, both loops.

The helper no-ops on empty/`None` content and strips whitespace, so turns with only tool calls (no prose) print nothing extra. No control-flow change; history payloads are untouched.

Scope: **analysis + meta only.** `planning_orchestrator.py` and `sim_agents/simulation_orchestrator.py` share the identical loop and will get the same one-line treatment in a follow-up (deliberately deferred).

**Verification.** `py_compile` on both files; direct unit call of `_print_assistant_reasoning` confirms it prints `  💭 <text>` for real content and emits nothing for `""`/`None`.