### PR TITLE
Series regimes authoritative + None-model crash guard

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1780,7 +1780,9 @@ class HumanFeedbackRefinementController:
         # show "N/A" for a regime whose model is in fact known.
         for regime in regimes:
             if not regime.get("physical_model"):
-                regime["physical_model"] = series_plan.get("physical_model")
+                regime["physical_model"] = (
+                    series_plan.get("physical_model") or "Model to be determined from the data"
+                )
             if not regime.get("fitting_strategy"):
                 regime["fitting_strategy"] = series_plan.get("fitting_strategy")
             if not regime.get("parameters_to_extract"):
@@ -1914,7 +1916,7 @@ class HumanFeedbackRefinementController:
 
             state["locked_fitting_config"] = {
                 "analysis_approach": state.get("analysis_approach"),
-                "physical_model": state.get("physical_model"),
+                "physical_model": state.get("physical_model") or "Model to be determined from the data",
                 "parameters_to_extract": state.get("parameters_to_extract", []),
                 "fitting_strategy": state.get("fitting_strategy"),
                 "column_mapping": column_mapping,
@@ -3409,8 +3411,8 @@ Return JSON with:
 
         # --- Initial fit (skills mandatory at T=0) ---
         state["_annealing_level"] = 0
-        initial_model = state.get('locked_fitting_config', {}).get('physical_model', 'Initial model')
-        self.logger.info(f"   Attempt 1: {initial_model[:80]}...")
+        initial_model = state.get('locked_fitting_config', {}).get('physical_model') or 'Initial model'
+        self.logger.info(f"   Attempt 1: {str(initial_model)[:80]}...")
 
         result = self._fit_single_spectrum(
             state=state, curve_data=curve_data, data_path=data_path,

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2130,7 +2130,7 @@ Add a `"series_analysis_plan"` field to your JSON response:
 {{
     "observations": "...",
     "analysis_approach": "...",
-    "physical_model": "primary model (for the first/majority regime)",
+    "physical_model": "the model for the first/majority regime as a concrete one-line summary — never null (the regimes list below is authoritative and drives the fit)",
     "parameters_to_extract": ["param1", "param2"],
     "fitting_strategy": "...",
     "literature_query": "...",
@@ -2157,6 +2157,12 @@ Add a `"series_analysis_plan"` field to your JSON response:
 ```
 
 **Rules:**
+- The `regimes` list is AUTHORITATIVE — it is what drives the fit. The top-level
+  `physical_model` / `fitting_strategy` are only a human-readable summary. If your
+  reasoning concludes N distinct regimes, emit exactly N entries in `regimes`, each
+  with its own `physical_model` / `fitting_strategy` / `parameters_to_extract`. Do NOT
+  describe a regime in the prose that you do not materialize as a structured entry, and
+  do not fold temperatures the prose treats differently into one regime.
 - Every spectrum index (0 through {num_spectra_minus_1}) must appear in exactly ONE regime.
 - Each regime must have at least one spectrum.
 - Only use multiple regimes when you can clearly see different spectral character.


### PR DESCRIPTION
## Summary (for scientists)

Two related series-fitting robustness fixes (the original "domain priors" content was dropped — see note below):

1. **The structured regime list is what drives the fit.** When a series spans qualitatively different regimes (e.g. a band that splits into a doublet with temperature), the plan's prose summary and the structured regime list could disagree, and the structured list (which actually controls fitting) sometimes under-counted what the reasoning concluded. The planner is now told the structured `regimes` list is authoritative and must match the reasoning.

2. **A crash guard.** While iterating on (1), a wording change let the planner leave the top-level model field empty, which crashed the series fit (`'NoneType' object is not subscriptable`). Fixed with non-null fallbacks so an empty model never crashes the run.

No change to fitting math — planning-contract text + null-safety only.

<!-- TECHNICAL DETAILS BELOW -->
---

## Technical details

**Reworked from the original PR.** Live testing on opus-4-8/Bedrock showed the orchestrator already treats metadata-listed expected features as hypotheses (reports their absence as a finding, doesn't re-run to chase them) without a prompt guardrail — so the original orchestrator-side "domain priors are hypotheses" principle and the curve-fit planning echo were **dropped**. The actual domain-prior fix (metadata-converter faithful extraction) ships as a separate PR.

`scilink/agents/exp_agents/instruct.py` — `SERIES_REGIME_PLANNING_SUPPLEMENT`:
- New first Rule: the `regimes` list is authoritative and drives the fit; top-level `physical_model`/`fitting_strategy` are summary only; emit exactly N structured regimes if the reasoning concludes N; don't fold temperatures the prose treats differently into one regime.
- Schema comment for top-level `physical_model` changed to require a concrete, non-null one-line summary (the old "summary, regimes authoritative" wording induced the null below).

`scilink/agents/exp_agents/controllers/curve_fitting_controllers.py` — null-safety for `physical_model`:
- `:3414` `... .get('physical_model') or 'Initial model'` + `str(...)[:80]` at the log site (the crash point).
- `:1919` `locked_fitting_config` physical_model `or "Model to be determined from the data"`.
- `:1784` per-regime backfill physical_model `or "Model to be determined from the data"`.

**Verification (live, opus-4-8/Bedrock):** individual + orchestrator series runs complete cleanly (previously crashed on the single-regime path); uniform series → single model (no over-split); doublet series → fits stay in measured range. Deterministic regression: backfill never yields a null model. Builds on #262 (empty-regime drop/backfill), already in main.