### PR TITLE
Metadata converter: faithful extraction, no fabricated domain knowledge

### DIFF
--- a/scilink/agents/exp_agents/metadata_converter.py
+++ b/scilink/agents/exp_agents/metadata_converter.py
@@ -172,6 +172,8 @@ Identify Experiment Type: First, determine the general experiment_type (e.g., Mi
 
 Fill Core Fields: Populate the required fields: experiment_type, experiment (including technique), and sample (including material). Extract other details like instrument or conditions into experiment.details or sample.description if available.
 
+Faithful Extraction — DO NOT FABRICATE (CRITICAL): Record ONLY information stated in the description. Do NOT add, infer, or enrich the metadata with domain knowledge the source text does not contain — in particular, do NOT invent expected/characteristic peak positions, known phase transitions, typical parameter values, or literature constants for the named material. Downstream analysis treats sample.description and experiment.details as factual experimental context and will try to act on any peaks/features named there, so fabricated expectations actively mislead it. If the author explicitly provided such details (expected peaks, transitions, prior values), preserve them verbatim — the rule is to neither invent nor drop. When unsure whether a detail came from the text or from your own knowledge, leave it out.
+
 Fill Conditional Fields based on Type:
 
 If Microscopy: Focus on extracting spatial_info (field of view and units). Omit or use null for spectroscopy/curve fields if not relevant.


### PR DESCRIPTION
## Summary (for scientists)

When you describe an experiment in plain language, SciLink's metadata converter turns it into a structured record. The problem: that converter was **adding textbook facts you never stated**. From "BaTiO₃, Raman" it would write into the sample description *"characteristic Raman modes expected near 170, 270, 305, 520, 720 cm⁻¹."* The downstream analysis treats the metadata as factual experimental context, so it then tried to fit those modes — most of which weren't in the data or were outside the measured range — and re-ran chasing them. (This was the true origin of the "why does it keep re-analyzing?" behavior.)

This fix makes the converter **extract faithfully**: it records only what you actually wrote, and never invents expected peaks, phase transitions, typical values, or literature constants for the named material. Details you *do* provide (including expected peaks you state explicitly) are preserved verbatim.

Single-file, prompt-only change.

<!-- TECHNICAL DETAILS BELOW -->
---

## Technical details

`scilink/agents/exp_agents/metadata_converter.py` — added a "Faithful Extraction — DO NOT FABRICATE" instruction to the extraction prompt. Root cause: `sample.description` / `experiment.details` are unconstrained free-text fields, the prompt routed "other details" into them with no faithfulness constraint, and `check_schema_conformance` validates structure only (key presence/types), never whether free-text content is grounded in the source. So a helpful-LLM default filled the prose with domain knowledge that downstream consumers then acted on as fact.

The instruction: record only stated information; do not add/infer/enrich with domain knowledge absent from the source (expected peak positions, phase transitions, typical values, literature constants); preserve author-provided details verbatim (neither invent nor drop); when unsure of provenance, omit.

This replaces the orchestrator-side "domain priors are hypotheses" principle from the original #264 (dropped — live runs showed the orchestrator already handles metadata expectations as hypotheses without it). Fixes the root (fabrication at metadata creation) rather than the symptom (downstream chasing).

**Verification (live, opus-4-8/Bedrock):**
- Fabrication battery — BaTiO₃, Si, graphene (all Raman), anatase TiO₂ (XRD), VO₂ (Raman T-series), polystyrene (FTIR), UV-Vis: **6/6 source-grounded**, zero invented peaks/transitions.
- Preservation control — when the author explicitly states the expected modes, all five are preserved verbatim.
- Minor known residual: ubiquitous constants tightly bound to a stated term can still appear (e.g. the Cu Kα wavelength for "Cu K-alpha") — benign (correct, not a misleading fitting target); not addressed here.