### PR TITLE
Prompt: don't default to two symmetric peaks to absorb a band's asymmetry

### DIFF
--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2054,8 +2054,10 @@ meaning is always preferred over a complex model with marginally better fit stat
 - Treat R² as a sanity check, not an optimization target. An R² of 0.96 with 3 physically
   meaningful components is far superior to R² of 0.99 with 6 components where half are
   fitting noise or compensating for an incorrect baseline.
-- If residuals show systematic structure, first reconsider the baseline or peak shape
-  (e.g., Voigt vs Gaussian) before adding more peaks.
+- If residuals show systematic structure, first reconsider the baseline, then the lineshape,
+  before adding peaks. Structured residuals on a band may reflect one mode with an asymmetric
+  lineshape (Pearson VII, skewed Voigt, Fano) or a genuine additional component — judge on
+  physical grounds; don't default to two symmetric peaks merely to absorb asymmetry or tails.
 
 **Domain Skill Rules (when provided):** If a "MANDATORY Domain Skill Rules" section appears \
 below, its rules are MANDATORY constraints on your analysis plan. These rules encode validated \


### PR DESCRIPTION
## Summary (for scientists)

A recurring over-fit on both synthetic and real spectra: a mildly **asymmetric or heavy-tailed band** that a symmetric peak shape can't quite match gets modeled as **two closely-spaced symmetric peaks** instead of one asymmetric lineshape. R² barely changes, but the feature table gains a **spurious mode** — two fake peaks where there's one.

This is a one-line, prompt-only nudge at the planning step: when a symmetric profile leaves structured residuals, the leftover structure may be **one mode best captured by an asymmetric lineshape** (Pearson VII, skewed Voigt, Fano) **or a genuine extra component such as a shoulder** — the model should judge on physical grounds and not *default* to two symmetric peaks just to absorb the asymmetry.

Deliberately **balanced**: it does not say "one maximum = one component." Genuine shoulders and overlapping modes (which don't form a separate maximum) remain legitimate — they're still governed by the existing "name the physical origin AND clearly visible" rule.

<!-- TECHNICAL DETAILS BELOW -->
---

## Technical details

`scilink/agents/exp_agents/instruct.py` — `CURVE_ANALYSIS_INSTRUCTIONS`, Physics-First Modeling. The existing line said only "reconsider the baseline or peak shape (Voigt vs Gaussian) before adding more peaks" — both Voigt and Gaussian are *symmetric*, so it offered no way to handle asymmetry except splitting. Reworded to surface the asymmetric-lineshape option and the shoulder alternative, with the decision left to physics and an explicit "don't default to two symmetric peaks to absorb asymmetry."

Scope notes:
- **Prompt-only**, single decision point. No deterministic check, no code-path change (per design discussion: prompt over machinery).
- **Verifier prompt left unchanged.** An earlier draft tightened `FIT_VERIFICATION_PROMPT`'s under-resolved bullet and added a "separately resolved maximum" gate — both reverted as too strong (they would suppress legitimate shoulders / overlapping peaks). The verifier's original "add a physically-nameable component or change the peak shape" is already balanced.
- The cause it targets: the verifier's under-resolved feedback and the symmetric-only lineshape menu together nudged the planner to split; surfacing the asymmetric option removes that incentive at the source without forbidding real multi-component structure.

No automated test (prompt-only, behavioral). Worth a live spot-check on an asymmetric single band (should stay one asymmetric mode) and a genuine shoulder/doublet (should remain multi-component).