### PR TITLE
Console output: agent-answer class + reasoning display (analysis · meta · planning; sim documented)

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1303,7 +1303,7 @@ class AnalysisOrchestratorAgent:
             else:
                 response_text = self._handle_litellm_chat(user_input)
             
-            print(f"🤖 Agent: {response_text}")
+            self._print_agent_answer(response_text)
             self._save_history()
             
             if self.message_count > 80:
@@ -1615,6 +1615,20 @@ class AnalysisOrchestratorAgent:
                         if sys.stdout.isatty() else ("", ""))
         body = text.replace("\n", "\n     ")  # indent continuation lines
         print(f"\n  {style}💭 {body}{reset}\n")
+
+    def _print_agent_answer(self, text) -> None:
+        """Print the agent's final answer — a *deliverable*, the third output
+        class alongside structural logs and `_print_assistant_reasoning`'s 💭
+        asides. Reasoning is de-emphasized (dim); an answer is the payload, so
+        its header is emphasized (bold + bright). `_agent_label` (default
+        "Agent") lets the meta name the delegated specialist, e.g. "Analysis
+        specialist", so a child's answer is not mistaken for the meta's own.
+        """
+        import sys
+        label = getattr(self, "_agent_label", "Agent")
+        bold, reset = ("\033[1;96m", "\033[0m") if sys.stdout.isatty() else ("", "")
+        print(f"\n{bold}🤖 {label}:{reset}")
+        print(text if text is not None else "")
 
     def _handle_litellm_chat(self, user_input: str) -> str:
         """Handle chat with LiteLLM models with manual function calling loop."""

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -546,6 +546,10 @@ class MetaOrchestratorAgent:
                 autonomy_level=AutonomyLevel.CO_PILOT,
                 data_dir=None,
             )
+            # Label its answers as the specialist's — a delegated child's final
+            # answer is a deliverable in the meta's verbose stream, not the
+            # meta's own user-facing response.
+            self._children["planning"]._agent_label = "Planning specialist"
             # Share skills / custom tools / MCP servers registered on the meta.
             self._propagate_extensions_to_child(self._children["planning"])
         return self._children["planning"]

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -506,6 +506,10 @@ class MetaOrchestratorAgent:
                 restore_checkpoint=restore,
                 analysis_mode=AnalysisMode.CO_PILOT,
             )
+            # Label its answers as the specialist's — in the meta's verbose
+            # stream a child's final answer is a delegated deliverable, not the
+            # meta's own user-facing response.
+            self._children["analysis"]._agent_label = "Analysis specialist"
             # Share skills / custom tools / MCP servers registered on the meta.
             self._propagate_extensions_to_child(self._children["analysis"])
         return self._children["analysis"]

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -1214,7 +1214,7 @@ class PlanningOrchestratorAgent:
                 # Use the same manual tool handling approach for LiteLLM
                 response_text = self._handle_litellm_chat(user_input)
             
-            print(f"🤖 Agent: {response_text}")
+            self._print_agent_answer(response_text)
             self._save_history()
             
             if self.message_count > 80:
@@ -1558,6 +1558,18 @@ class PlanningOrchestratorAgent:
                         if sys.stdout.isatty() else ("", ""))
         body = text.replace("\n", "\n     ")  # indent continuation lines
         print(f"\n  {style}💭 {body}{reset}\n")
+
+    def _print_agent_answer(self, text) -> None:
+        """Print the agent's final answer — a deliverable, emphasized (bold +
+        bright) to stand apart from 💭 reasoning (a dim aside) and structural
+        logs. `_agent_label` (default "Agent") lets the meta name the delegated
+        specialist (e.g. "Planning specialist") so a child's answer is not
+        mistaken for the meta's own user-facing response."""
+        import sys
+        label = getattr(self, "_agent_label", "Agent")
+        bold, reset = ("\033[1;96m", "\033[0m") if sys.stdout.isatty() else ("", "")
+        print(f"\n{bold}🤖 {label}:{reset}")
+        print(text if text is not None else "")
 
     def _handle_litellm_chat(self, user_input: str) -> str:
         """Handle chat with LiteLLM models with manual function calling loop."""

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -1520,6 +1520,8 @@ class PlanningOrchestratorAgent:
                 ]
             })
 
+            self._print_assistant_reasoning(message.content)
+
             for tool_call in message.tool_calls:
                 func_name = tool_call.function.name
                 args = json.loads(tool_call.function.arguments)
@@ -1536,6 +1538,26 @@ class PlanningOrchestratorAgent:
 
         self._last_chat_hit_iter_cap = True
         return "⚠️ Maximum tool iterations reached. Please simplify your request."
+
+    def _print_assistant_reasoning(self, content) -> None:
+        """Surface the LLM's interim reasoning that accompanies a tool call.
+
+        Without this the console jumps straight to "🔧 Calling tool: …", so a
+        deliberate step reads like a silent loop. The text is already in
+        history; this just shows it so the user can see *why* the next tool is
+        being called. Rendered dim+italic and set off by blank lines so the
+        prose is visually distinct from the structural tool-call log.
+        """
+        if not content:
+            return
+        text = content.strip() if isinstance(content, str) else str(content).strip()
+        if not text:
+            return
+        import sys
+        style, reset = (("\033[2;3;36m", "\033[0m")
+                        if sys.stdout.isatty() else ("", ""))
+        body = text.replace("\n", "\n     ")  # indent continuation lines
+        print(f"\n  {style}💭 {body}{reset}\n")
 
     def _handle_litellm_chat(self, user_input: str) -> str:
         """Handle chat with LiteLLM models with manual function calling loop."""
@@ -1601,7 +1623,9 @@ class PlanningOrchestratorAgent:
                 ]
             }
             self.messages.append(assistant_msg)
-            
+
+            self._print_assistant_reasoning(content)
+
             # Execute each tool call
             for tool_call in tool_calls:
                 func_name = tool_call.function.name
@@ -1609,7 +1633,7 @@ class PlanningOrchestratorAgent:
                     args = json.loads(tool_call.function.arguments)
                 except json.JSONDecodeError:
                     args = {}
-                
+
                 print(f"  🔧 Calling tool: {func_name}")
                 
                 result = self.tools.execute_tool(func_name, **args)

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -411,6 +411,27 @@ class SimulationOrchestratorAgent:
 
     def chat(self, user_input: str) -> str:
         """Interactive chat — used by the CLI and UI."""
+        # ── Console display features not yet wired here (parity TODO) ──────────
+        # Analysis, meta, and planning distinguish three console output classes;
+        # this orchestrator currently emits only structural logs. To bring it to
+        # parity, mirror AnalysisOrchestratorAgent:
+        #   1. 💭 Reasoning — copy `_print_assistant_reasoning(self, content)` and
+        #      call it after appending each assistant message and BEFORE the tool
+        #      loop in BOTH handlers (the two `for tool_call in …` sites in
+        #      `_handle_openai_chat` / `_handle_litellm_chat`). Shows the interim
+        #      reasoning dim+italic so a deliberate step doesn't read as a silent
+        #      jump to "🔧 Calling tool".
+        #   2. 🤖 Answer — copy `_print_agent_answer(self, text)` and call
+        #      `self._print_agent_answer(response)` just before `return response`
+        #      below. NB: unlike analysis/planning (which print "🤖 Agent:" in
+        #      chat()), this chat() returns the answer un-printed, so this is an
+        #      ADD, not a replace.
+        #   3. Meta attribution — when the deferred `delegate_to_simulation` seam
+        #      creates the sim child, set
+        #      `child._agent_label = "Simulation specialist"` (mirrors the
+        #      analysis/planning children in MetaOrchestratorAgent).
+        #   4. UI — no change needed; `ui/app.py::_log_to_html` already styles 💭
+        #      (dim italic) and the 🤖 header (bold) regardless of source.
         self._last_chat_hit_iter_cap = False
         if self.use_openai:
             response = self._handle_openai_chat(user_input)

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -29,14 +29,20 @@ def _strip_ansi(text: str) -> str:
 
 
 def _log_to_html(text: str) -> str:
-    """ANSI-strip a captured log and HTML-escape it, rendering the agent's 💭
-    reasoning lines (and their indented continuations) in italic muted cyan so
-    they read as prose — the HTML equivalent of the terminal's dim+italic."""
+    """ANSI-strip a captured log and HTML-escape it. The agent's 💭 reasoning
+    lines render dim+italic (a muted aside); the 🤖 answer header renders
+    bold+bright (the deliverable) — the HTML equivalents of the terminal styling."""
     import html as _html
 
     out, in_thought = [], False
     for line in _strip_ansi(text).split("\n"):
-        if line.lstrip().startswith("💭"):
+        stripped = line.lstrip()
+        if stripped.startswith("🤖"):
+            # Final-answer header — emphasized, and it ends any reasoning block.
+            in_thought = False
+            out.append(f'<span style="color:#7fdfff;font-weight:bold">{_html.escape(line)}</span>')
+            continue
+        if stripped.startswith("💭"):
             in_thought = True
         elif in_thought and not line.startswith("     "):
             in_thought = False


### PR DESCRIPTION
## Summary (for scientists)

The verbose console stream now distinguishes three kinds of output instead of two:
- **logs** — what the system is doing (`📍 STEP`, `🔧 Calling tool`) — plain
- **reasoning** — the agent thinking before it acts (`💭 …`) — dim + italic (a muted aside)
- **answer** — the agent's actual response (`🤖 …`) — **bold + bright** (the deliverable)

Previously the answer — the most important content — was the *least* distinguished, and in **meta mode** a delegated specialist's full answer sat in the verbose log looking like noise. Now reasoning and answers carry opposite emphasis (aside vs. payload), and a delegated answer is attributed to its specialist (`🤖 Analysis specialist:` / `🤖 Planning specialist:`) so it's not confused with the meta's own user-facing response.

Implemented for **analysis, meta, and planning**. **Simulation is deferred** but the extension recipe is documented (in code and noted below).

<!-- TECHNICAL DETAILS BELOW -->
---

## Technical details

Visual language: **dim-italic = reasoning · plain = logs · bold-bright = answer.** Two reusable helpers, mirrored across orchestrators; the UI translates the ANSI to HTML.

- `analysis_orchestrator.py`: `_print_agent_answer(text)` — emphasized header (`\033[1;96m`, TTY-guarded) + body; label from `getattr(self,"_agent_label","Agent")`. Replaces the plain `print("🤖 Agent: …")` at the `chat()` return. (Its `💭` reasoning shipped in #263.)
- `planning_orchestrator.py`: adds **both** `_print_assistant_reasoning` (💭, wired into both tool loops) **and** `_print_agent_answer` (🤖, at the final-answer print). Planning's `🤖 Agent: Hiring sub-agents…` status line is left plain on purpose (it's progress, not a deliverable).
- `meta_orchestrator.py`: sets `_agent_label = "Analysis specialist"` / `"Planning specialist"` on the respective children at creation.
- `ui/app.py` `_log_to_html`: a `🤖` header renders bold+bright (`#7fdfff`) and ends any open `💭` block; `💭` stays dim+italic. Source-agnostic.

## Extending to simulation mode

Sim is the only mode still emitting plain logs. **Full recipe is in `sim_agents/simulation_orchestrator.py::chat()`** — in brief: copy the two helpers, wire `_print_assistant_reasoning` into both tool loops, **add** `_print_agent_answer(response)` before `return response` (sim returns un-printed, so it's an add not a replace), set `_agent_label = "Simulation specialist"` at the `delegate_to_simulation` seam; the UI needs no change. @sarah-allec 

## Verification
All touched files compile. Unit checks: terminal headers bold-bright with correct labels; `_log_to_html` renders `🤖` bold, `💭` dim-italic, `🔧` plain.