### PR TITLE
Drop temperature/top_p for Claude Opus ≥ 4.8 (deprecated — Bedrock 400s)

### DIFF
--- a/scilink/wrappers/litellm_wrapper.py
+++ b/scilink/wrappers/litellm_wrapper.py
@@ -47,6 +47,28 @@ def _is_openai_reasoning_model(model: str) -> bool:
     name = model.split('/', 1)[-1]
     return bool(_REASONING_MODEL_RE.match(name))
 
+
+# Anthropic deprecated the temperature/top_p sampling knobs starting with Claude
+# Opus 4.8; assume every Opus at or beyond 4.8 (4.9, 5.x, …) does the same.
+# Bedrock 400s on these ("`temperature` is deprecated for this model"); other
+# providers may ignore rather than error. Like the OpenAI reasoning models, omit
+# the params for them. Earlier Opus (<=4.7) and other families are untouched.
+# Version parsed from the name so it covers every provider prefix
+# (bedrock/us.anthropic.claude-opus-4-8, anthropic/claude-opus-4-9, …) and a
+# trailing variant tag (…-4-8-1m).
+_OPUS_VERSION_RE = re.compile(r'claude-opus-(\d+)(?:-(\d+))?', re.IGNORECASE)
+
+
+def _model_deprecates_sampling(model: str) -> bool:
+    if not model:
+        return False
+    m = _OPUS_VERSION_RE.search(model)
+    if not m:
+        return False
+    major = int(m.group(1))
+    minor = int(m.group(2)) if m.group(2) else 0
+    return (major, minor) >= (4, 8)
+
 try:
     from PIL import Image
 except ImportError:
@@ -446,9 +468,10 @@ class LiteLLMGenerativeModel:
                 "frequency_penalty": "frequency_penalty",
             }
 
-            reasoning = _is_openai_reasoning_model(self.model)
+            omit_sampling = (_is_openai_reasoning_model(self.model)
+                             or _model_deprecates_sampling(self.model))
             for old, new in mapping.items():
-                if reasoning and old in ("temperature", "top_p"):
+                if omit_sampling and old in ("temperature", "top_p"):
                     continue
                 val = cfg.get(old)
                 if val is not None:


### PR DESCRIPTION
## Summary (for scientists)

In planning mode on Bedrock opus-4-8, the knowledge-query tool was failing with `BedrockException: 'temperature' is deprecated for this model`. Opus 4.8 no longer accepts the `temperature`/`top_p` sampling knobs, but the planning knowledge-query / scalarizer code passes `temperature=0.0` (for deterministic extraction), so those calls 400'd. (Analysis mode never set `temperature`, so it was unaffected — which also confirms the model works fine without it.) The agent limped along by reading files directly, but the tool was broken.

This makes the LiteLLM wrapper **omit `temperature`/`top_p` for Opus ≥ 4.8**, exactly as it already does for OpenAI reasoning models — so callers can keep passing `temperature` harmlessly and the right thing happens per-model.

<!-- TECHNICAL DETAILS BELOW -->
---

## Technical details

`scilink/wrappers/litellm_wrapper.py`:
- New `_model_deprecates_sampling(model)` — parses the Opus version from the model name (`claude-opus-(\d+)(?:-(\d+))?`) and returns `True` when `(major, minor) >= (4, 8)`. The deprecation starts at 4.8 and every later Opus (4.9, 5.x, …) is assumed to inherit it, so it's a **version compare, not an exact match**. Works across provider prefixes (`bedrock/us.anthropic.…`, `anthropic/…`, bare) and tolerates a trailing variant tag (`…-4-8-1m`).
- `_build_params`: `omit_sampling = _is_openai_reasoning_model(...) or _model_deprecates_sampling(...)`; when set, `temperature`/`top_p` are skipped from the mapping (mirrors the existing reasoning-model handling at the same site).

**Scope / blast radius:** fires only for Opus ≥ 4.8. Earlier Opus (≤4.7), other Claude families (sonnet/haiku), and every non-Anthropic model are byte-for-byte unchanged. Pairs with #238 (the Bedrock `maxTokens` fix) as the second Bedrock-surfaced param-handling carve-out.

**Why version-compare + model-name match:** the deprecation is model-level (not transport-level), so matching the name fixes the direct-Anthropic path too; and assuming-forward (≥4.8) means a future opus-4-9 / 5-x won't reintroduce the 400 and need another patch. Kept to the **Opus** family only — sonnet/haiku deprecation is unconfirmed, so they're left supporting `temperature` rather than silently stripped.

**Verification:**
- Unit — dropped for `opus-4-8` / `4-9` / `4-10` / `5-0` / `5` / `…-4-8-1m` across `bedrock/` and `anthropic/` prefixes; **kept** for `opus-4-6`, `opus-4-7`, `sonnet-4-6`, `gpt-4o`.
- Live (opus-4-8 / Bedrock) — a `generate_content(..., generation_config={"temperature": 0.0})` call (previously a 400) now returns normally.