### PR TITLE
fit_pattern: fast, robust full-pattern XRD fitting for one-off and in-situ series

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2030,6 +2030,7 @@ class AnalysisOrchestratorTools:
             reuse_locked_script: bool = False,
             literature_file: str = None,
             r2_threshold: float = None,
+            max_verification_iterations: int = None,
         ) -> str:
             """
             Execute analysis with the selected or specified agent.
@@ -2524,6 +2525,19 @@ class AnalysisOrchestratorTools:
                             f"   r2_threshold={r2_threshold} ignored: "
                             f"{self.AGENT_NAMES.get(agent_id, 'agent')} has no R² gate."
                         )
+                if max_verification_iterations is not None:
+                    # Thoroughness / turnaround override. 0 bypasses LLM
+                    # verification (fast/in-situ), higher = more refinement
+                    # (thorough/post-experiment). Only forward to agents whose
+                    # analyze() accepts it (currently CurveFitting).
+                    import inspect as _inspect
+                    if "max_verification_iterations" in _inspect.signature(agent.analyze).parameters:
+                        analyze_kwargs["max_verification_iterations"] = int(max_verification_iterations)
+                    else:
+                        self.logger.info(
+                            f"   max_verification_iterations={max_verification_iterations} ignored: "
+                            f"{self.AGENT_NAMES.get(agent_id, 'agent')} has no verification loop."
+                        )
                 result = agent.analyze(**analyze_kwargs)
                 
                 # === Store result ===
@@ -2810,6 +2824,24 @@ class AnalysisOrchestratorTools:
                         "skill's R² gate (a warning is logged on conflict), but it "
                         "will NOT replace a skill that scores by a non-R² metric. "
                         "Leave unset for standard analyses."
+                    )
+                },
+                "max_verification_iterations": {
+                    "type": "integer",
+                    "description": (
+                        "CurveFitting agent only. Controls how thorough the "
+                        "fit-verification/refinement loop is — the speed-vs-rigor "
+                        "knob. Set it ONLY when the user asks about turnaround or "
+                        "checking depth; leave unset for the standard (thorough) "
+                        "default. Map the user's intent: a fast / quick / in-situ / "
+                        "real-time / 'good enough' turnaround → 1 (a single check, "
+                        "no refinement loop); 'skip/bypass/no verification' → 0 "
+                        "(accept the first good fit with no LLM verification at "
+                        "all); an explicit count (e.g. 'two verification steps') → "
+                        "that integer; thorough / careful / publication / "
+                        "post-experiment analysis → leave unset (defaults to 7). "
+                        "Often paired with r2_threshold (e.g. 'use R²=0.98 and a "
+                        "single verification step')."
                     )
                 }
             },

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -3433,7 +3433,20 @@ Return JSON with:
 
             # --- Verification loop (for anchor spectra: first overall or first in regime) ---
             fit_was_approved = False
-            if _is_anchor:
+            if (_is_anchor and self.max_verification_iterations <= 0
+                    and best_result and best_result.get("success")):
+                # Explicit verification bypass (max_verification_iterations=0):
+                # the caller asked for a fast / in-situ turnaround. Accept the
+                # initial successful fit as-is, with no LLM verification or
+                # refit loop. Only triggers at <= 0, so the default thorough
+                # path (>= 1) is unaffected. A failed/degenerate initial fit
+                # (no success) still falls through to the loop below for the
+                # recovery path rather than locking garbage.
+                self.logger.info(
+                    f"   ⏩ Verification bypassed (max_verification_iterations=0); "
+                    f"accepting initial fit (R² = {best_r2:.4f})")
+                fit_was_approved = True
+            elif _is_anchor:
                 # Skip verification ONLY when there is no successful fit to work
                 # with. A fit that executed but is degenerate (low/zero R²) must
                 # still enter the loop: the verifier + adaptive annealing (which

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -300,6 +300,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         r2_threshold: Optional[float] = None,
         max_model_retries: Optional[int] = None,
         outlier_sigma: Optional[float] = None,
+        max_verification_iterations: Optional[int] = None,
         quality_gate: "QualityGate | dict | None" = None,
         **kwargs,
     ) -> Dict[str, Any]:
@@ -437,6 +438,14 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         effective_r2_threshold = r2_threshold if r2_threshold is not None else self.r2_threshold
         effective_max_retries = max_model_retries if max_model_retries is not None else self.max_model_retries
         effective_outlier_sigma = outlier_sigma if outlier_sigma is not None else self.outlier_sigma
+        # Per-call thoroughness override (fast/in-situ vs thorough/post-experiment).
+        # 0 => bypass LLM verification entirely; 1 => single check, no refit loop;
+        # higher => more refinement passes. Falls back to the construction default.
+        effective_max_verification = (
+            max_verification_iterations if max_verification_iterations is not None
+            else self.max_verification_iterations)
+        if effective_max_verification < 0:
+            raise ValueError("max_verification_iterations must be >= 0")
 
         # Resolve task_mode — caller sets this explicitly (standalone user or
         # orchestrator). Defaults to "fitting" when unset.
@@ -732,7 +741,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             r2_threshold=effective_r2_threshold,
             max_model_retries=effective_max_retries,
             outlier_sigma=effective_outlier_sigma,
-            max_verification_iterations=self.max_verification_iterations,
+            max_verification_iterations=effective_max_verification,
             parallel_workers=self.parallel_workers,
         )
         

--- a/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
+++ b/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
@@ -58,14 +58,15 @@ TOOL_SPEC = ToolSpec(
         "fit_pattern(exp_two_theta, exp_intensity, peak_centers=None, "
         "background='snip', snip_iterations='auto', prominence_frac=0.02, "
         "max_peaks=30, min_distance_deg=0.15, init_fwhm_deg=0.2, "
-        "center_leeway_deg=0.3, max_fwhm_deg=3.0) -> dict"
+        "center_leeway_deg=0.3, max_fwhm_deg=3.0, "
+        "peak_shape='split_pseudo_voigt') -> dict"
     ),
     parameters={
         "exp_two_theta": {"type": "list[float]", "description": "Experimental 2-theta grid (degrees)."},
         "exp_intensity": {"type": "list[float]", "description": "Raw experimental intensity (same length). Background is handled internally."},
         "peak_centers": {
             "type": "list[float] | None",
-            "description": "Fixed peak centers to fit (degrees). None => auto-detect all significant peaks. Pass a locked list to keep the model identical across an in-situ series.",
+            "description": "Fixed peak centers to fit (degrees). None (recommended) => auto-detect all significant peaks. For a series/in-situ run, leave None on EVERY frame: the auto-detect re-finds peaks per frame so the same call follows peak shifts/intensity changes/appearance and generalises across the series. Do NOT hardcode a center list to 'lock the model' — a frozen list drifts out of its windows within a phase and breaks across a transition. Pass an explicit list only for a one-off re-fit of a single known-stable pattern.",
         },
         "background": {"type": "str", "description": "'snip' (default), 'polynomial', or 'none' (data already background-subtracted)."},
         "snip_iterations": {"type": "int | str", "description": "SNIP iteration count. 'auto' (default) sweeps a few counts and keeps the one with the cleanest residual at the best R² — avoids apex over-subtraction on sharp peaks without hand-tuning. Pass an int to fix it (e.g. reuse the value reported in background_method to skip the sweep on locked series frames)."},
@@ -75,17 +76,20 @@ TOOL_SPEC = ToolSpec(
         "init_fwhm_deg": {"type": "float", "description": "Initial FWHM guess per peak (degrees). Default 0.2 (typical CuKa)."},
         "center_leeway_deg": {"type": "float", "description": "Each center may move +/- this much during the fit (degrees). Default 0.3."},
         "max_fwhm_deg": {"type": "float", "description": "Upper bound on fitted FWHM (degrees). Default 3.0."},
+        "peak_shape": {"type": "str", "description": "'split_pseudo_voigt' (default) fits one extra width per peak to capture axial-divergence asymmetry — markedly lower residual on strong sharp lab-CuKa peaks, and it degenerates to symmetric when the data is symmetric (so it generalises safely). 'pseudo_voigt' forces a symmetric profile (fewer parameters; use only if asymmetry is known absent, e.g. synchrotron data)."},
     },
     required=["exp_two_theta", "exp_intensity"],
     returns=(
         "dict with 'r_squared' (GLOBAL, over the whole corrected pattern), "
         "'residual_rms_over_noise' (global residual RMS / estimated point "
         "noise — the verifier's key statistic; < ~3 is clean), 'n_peaks', "
-        "'peaks' (list of dicts: center, fwhm, amplitude (height), area, eta, "
-        "each sorted by 2-theta), 'peak_centers' (the centers actually fit — "
-        "feed back as the locked list for the next series frame), "
-        "'intensity_corrected', 'fit_curve' (model evaluated on the full grid; "
-        "use for the visualization), 'background_method'."
+        "'peaks' (list of dicts: center, fwhm (mean width; for Scherrer/W-H), "
+        "amplitude (height), area, eta, sorted by 2-theta; split mode adds "
+        "fwhm_left, fwhm_right, and asymmetry=(fwhm_right-fwhm_left)/sum), "
+        "'peak_centers' (the centers actually fit — feed back as the locked "
+        "list for the next series frame), 'intensity_corrected', 'fit_curve' "
+        "(model evaluated on the full grid; use for the visualization), "
+        "'background_method', 'peak_shape'."
     ),
     when_to_use=(
         "Default tool for fitting a full XRD pattern and for every frame of an "
@@ -119,6 +123,33 @@ def _pv_area(amp, fwhm, eta):
     return float(eta * l + (1.0 - eta) * g)
 
 
+def _split_pseudo_voigt(x, amp, cen, fwhm_l, fwhm_r, eta):
+    """Asymmetric (split) pseudo-Voigt: left of the centre uses fwhm_l, right
+    uses fwhm_r (height-parameterised, continuous at the apex). Captures the
+    axial-divergence peak asymmetry of lab-CuKa patterns. Degenerates to a
+    symmetric pseudo-Voigt when fwhm_l == fwhm_r, so it does not impose
+    asymmetry on data that has none."""
+    fwhm = np.where(x < cen, fwhm_l, fwhm_r)
+    sigma = fwhm * _FWHM_TO_SIGMA
+    gauss = np.exp(-((x - cen) ** 2) / (2.0 * sigma ** 2))
+    gamma = fwhm / 2.0
+    lorentz = gamma ** 2 / ((x - cen) ** 2 + gamma ** 2)
+    return amp * (eta * lorentz + (1.0 - eta) * gauss)
+
+
+def _multi_split(x, *p):
+    n = (len(p) - 2) // 5
+    out = p[-2] * x + p[-1]
+    for i in range(n):
+        out = out + _split_pseudo_voigt(x, *p[5 * i:5 * i + 5])
+    return out
+
+
+def _split_pv_area(amp, fwhm_l, fwhm_r, eta):
+    # Each side is half of a symmetric pseudo-Voigt of that width.
+    return 0.5 * (_pv_area(amp, fwhm_l, eta) + _pv_area(amp, fwhm_r, eta))
+
+
 def _detect_centers(x, ycorr, step, prominence_frac, max_peaks, min_distance_deg):
     """Auto-detect significant peak centers on a background-corrected pattern."""
     noise = _estimate_noise(ycorr)
@@ -149,7 +180,11 @@ def fit_pattern(
     init_fwhm_deg: float = 0.2,
     center_leeway_deg: float = 0.3,
     max_fwhm_deg: float = 3.0,
+    peak_shape: str = "split_pseudo_voigt",
 ) -> dict[str, Any]:
+    if peak_shape not in ("split_pseudo_voigt", "pseudo_voigt"):
+        raise ValueError(
+            f"peak_shape must be 'split_pseudo_voigt' or 'pseudo_voigt'; got {peak_shape!r}")
     x = np.asarray(exp_two_theta, dtype=float)
     y = np.asarray(exp_intensity, dtype=float)
     if x.shape != y.shape:
@@ -166,6 +201,7 @@ def fit_pattern(
         prominence_frac=prominence_frac, max_peaks=max_peaks,
         min_distance_deg=min_distance_deg, init_fwhm_deg=init_fwhm_deg,
         center_leeway_deg=center_leeway_deg, max_fwhm_deg=max_fwhm_deg,
+        peak_shape=peak_shape,
     )
 
     # --- background + fit ---
@@ -237,8 +273,16 @@ def _fit_corrected(
     init_fwhm_deg: float,
     center_leeway_deg: float,
     max_fwhm_deg: float,
+    peak_shape: str = "split_pseudo_voigt",
 ) -> dict[str, Any]:
-    """Global multi-peak fit of an already background-corrected pattern."""
+    """Global multi-peak fit of an already background-corrected pattern.
+
+    peak_shape: 'split_pseudo_voigt' (default; one extra width per peak for
+    axial-divergence asymmetry) or 'pseudo_voigt' (symmetric). Split degenerates
+    to symmetric when the data is symmetric, so it generalises safely."""
+    split = peak_shape == "split_pseudo_voigt"
+    model = _multi_split if split else _multi
+    fwhm_lo = max(2.0 * step, 0.02)
     noise = _estimate_noise(ycorr)
 
     if centers_locked is not None:
@@ -249,17 +293,23 @@ def _fit_corrected(
     if not centers:
         raise ValueError("no peaks detected; lower prominence_frac or pass peak_centers")
 
+    # Per-parameter scale keeps the TRF optimiser from thrashing (amplitudes
+    # ~1e5 vs centres ~30 vs FWHM ~0.3). One extra width param per peak in split
+    # mode.
     p0, lo, hi, scale = [], [], [], []
     for c in centers:
         j = int(np.argmin(np.abs(x - c)))
         amp0 = max(ycorr[j], noise)
-        p0 += [amp0, c, init_fwhm_deg, 0.5]
-        lo += [0.0, c - center_leeway_deg, max(2.0 * step, 0.02), 0.0]
-        hi += [5.0 * amp0 + 1.0, c + center_leeway_deg, max_fwhm_deg, 1.0]
-        # Per-parameter scale: amplitudes span ~1e5 while centers ~30 and FWHM
-        # ~0.3. Without x_scale the TRF optimiser thrashes (seconds -> minutes
-        # on busy frames). Scale each param by its natural magnitude.
-        scale += [amp0, center_leeway_deg, init_fwhm_deg, 1.0]
+        if split:
+            p0 += [amp0, c, init_fwhm_deg, init_fwhm_deg, 0.5]
+            lo += [0.0, c - center_leeway_deg, fwhm_lo, fwhm_lo, 0.0]
+            hi += [5.0 * amp0 + 1.0, c + center_leeway_deg, max_fwhm_deg, max_fwhm_deg, 1.0]
+            scale += [amp0, center_leeway_deg, init_fwhm_deg, init_fwhm_deg, 1.0]
+        else:
+            p0 += [amp0, c, init_fwhm_deg, 0.5]
+            lo += [0.0, c - center_leeway_deg, fwhm_lo, 0.0]
+            hi += [5.0 * amp0 + 1.0, c + center_leeway_deg, max_fwhm_deg, 1.0]
+            scale += [amp0, center_leeway_deg, init_fwhm_deg, 1.0]
     p0 += [0.0, 0.0]                       # linear baseline slope, intercept
     lo += [-np.inf, -np.inf]
     hi += [np.inf, np.inf]
@@ -267,7 +317,7 @@ def _fit_corrected(
 
     try:
         popt, _ = curve_fit(
-            _multi, x, ycorr, p0=p0, bounds=(lo, hi),
+            model, x, ycorr, p0=p0, bounds=(lo, hi),
             x_scale=scale, ftol=1e-4, xtol=1e-4, maxfev=20000,
         )
     except (RuntimeError, ValueError) as e:
@@ -275,7 +325,7 @@ def _fit_corrected(
         # returns *something* fittable rather than aborting the whole run.
         try:
             popt, _ = curve_fit(
-                _multi, x, ycorr, p0=p0, bounds=(lo, hi),
+                model, x, ycorr, p0=p0, bounds=(lo, hi),
                 x_scale=scale, ftol=1e-2, xtol=1e-2, maxfev=40000,
             )
         except (RuntimeError, ValueError):
@@ -284,20 +334,34 @@ def _fit_corrected(
                 "fewer peaks (raise prominence_frac) or pass explicit peak_centers."
             ) from e
 
-    fit_curve = _multi(x, *popt)
+    fit_curve = model(x, *popt)
     resid = ycorr - fit_curve
     ss_res = float(np.sum(resid ** 2))
     ss_tot = float(np.sum((ycorr - ycorr.mean()) ** 2))
     r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
     rms_over_noise = float(np.sqrt(np.mean(resid ** 2)) / noise)
 
+    stride = 5 if split else 4
     peaks = []
     for i in range(len(centers)):
-        amp, cen, fwhm, eta = popt[4 * i:4 * i + 4]
-        peaks.append({
-            "center": float(cen), "fwhm": float(fwhm), "amplitude": float(amp),
-            "eta": float(eta), "area": _pv_area(amp, fwhm, eta),
-        })
+        params = popt[stride * i:stride * i + stride]
+        if split:
+            amp, cen, fwhm_l, fwhm_r, eta = params
+            fwhm = 0.5 * (fwhm_l + fwhm_r)
+            denom = fwhm_l + fwhm_r
+            entry = {
+                "center": float(cen), "fwhm": float(fwhm), "amplitude": float(amp),
+                "eta": float(eta), "area": _split_pv_area(amp, fwhm_l, fwhm_r, eta),
+                "fwhm_left": float(fwhm_l), "fwhm_right": float(fwhm_r),
+                "asymmetry": float((fwhm_r - fwhm_l) / denom) if denom else 0.0,
+            }
+        else:
+            amp, cen, fwhm, eta = params
+            entry = {
+                "center": float(cen), "fwhm": float(fwhm), "amplitude": float(amp),
+                "eta": float(eta), "area": _pv_area(amp, fwhm, eta),
+            }
+        peaks.append(entry)
     peaks.sort(key=lambda d: d["center"])
 
     return {
@@ -309,4 +373,5 @@ def _fit_corrected(
         "intensity_corrected": [float(v) for v in ycorr],
         "fit_curve": [float(v) for v in fit_curve],
         "noise_estimate": noise,
+        "peak_shape": peak_shape,
     }

--- a/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
+++ b/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
@@ -1,0 +1,312 @@
+"""``fit_pattern`` tool — single global multi-peak pseudo-Voigt fit of a whole
+XRD pattern.
+
+Motivation
+----------
+``fit_profile`` fits one peak (or one overlapping cluster) per window and
+returns a per-window R². Stitching many window fits together leaves every
+*unmodelled* reflection as a large spike in the **global** residual — and the
+curve-fitting agent's verifier judges the global residual, not per-window R².
+On a busy pattern that mismatch drives many rejected refinement iterations.
+
+``fit_pattern`` closes that gap: it detects *all* significant peaks in one pass,
+fits them **simultaneously** as a sum of height-parameterised pseudo-Voigts on a
+linear baseline (background-subtracted first), seeds each amplitude from the
+measured apex so sharp peaks are never clipped, and reports the **global** R²
+plus a residual-RMS-over-noise figure — the same quantities the verifier checks.
+One fast call (~1 s for ~20 peaks over a few-thousand-point scan) typically lands
+a clean global fit on the first attempt.
+
+In-situ series
+--------------
+For a temperature/time ramp, establish the peak list once on a high-SNR frame
+(``auto_detect``), then pass that fixed list back as ``peak_centers`` for every
+subsequent frame. The model stays locked and consistent across the series while
+each frame is still a single fast fit — warm-started, comparable frame to frame.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Sequence
+
+import numpy as np
+from scipy.optimize import curve_fit
+from scipy.signal import find_peaks
+
+from ..._shared._spec import ToolSpec
+from .background import fit_background
+
+_logger = logging.getLogger(__name__)
+
+_FWHM_TO_SIGMA = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
+
+
+TOOL_SPEC = ToolSpec(
+    name="fit_pattern",
+    description=(
+        "Global multi-peak pseudo-Voigt fit of a whole XRD pattern in one "
+        "call. Auto-detects all significant peaks (or uses a supplied locked "
+        "list), subtracts background, fits every peak simultaneously on a "
+        "linear baseline with apex-seeded amplitudes, and returns the GLOBAL "
+        "R-squared, residual-RMS-over-noise, and per-peak center/FWHM/height/"
+        "area/eta. Use this for full-pattern fitting and for in-situ series; "
+        "use fit_profile only to drill into a single stubborn cluster."
+    ),
+    import_line="from scilink.skills.curve_fitting.xrd_profile.fit_pattern import fit_pattern",
+    signature=(
+        "fit_pattern(exp_two_theta, exp_intensity, peak_centers=None, "
+        "background='snip', snip_iterations='auto', prominence_frac=0.02, "
+        "max_peaks=30, min_distance_deg=0.15, init_fwhm_deg=0.2, "
+        "center_leeway_deg=0.3, max_fwhm_deg=3.0) -> dict"
+    ),
+    parameters={
+        "exp_two_theta": {"type": "list[float]", "description": "Experimental 2-theta grid (degrees)."},
+        "exp_intensity": {"type": "list[float]", "description": "Raw experimental intensity (same length). Background is handled internally."},
+        "peak_centers": {
+            "type": "list[float] | None",
+            "description": "Fixed peak centers to fit (degrees). None => auto-detect all significant peaks. Pass a locked list to keep the model identical across an in-situ series.",
+        },
+        "background": {"type": "str", "description": "'snip' (default), 'polynomial', or 'none' (data already background-subtracted)."},
+        "snip_iterations": {"type": "int | str", "description": "SNIP iteration count. 'auto' (default) sweeps a few counts and keeps the one with the cleanest residual at the best R² — avoids apex over-subtraction on sharp peaks without hand-tuning. Pass an int to fix it (e.g. reuse the value reported in background_method to skip the sweep on locked series frames)."},
+        "prominence_frac": {"type": "float", "description": "Auto-detect: min peak prominence as a fraction of the corrected pattern range. Default 0.02 (2%). Lower (0.01) to catch weak reflections the verifier may flag as unmodelled residual; raise (0.03) if noise peaks are being fit."},
+        "max_peaks": {"type": "int", "description": "Auto-detect cap. Default 30."},
+        "min_distance_deg": {"type": "float", "description": "Auto-detect: minimum separation between peaks (degrees). Default 0.15."},
+        "init_fwhm_deg": {"type": "float", "description": "Initial FWHM guess per peak (degrees). Default 0.2 (typical CuKa)."},
+        "center_leeway_deg": {"type": "float", "description": "Each center may move +/- this much during the fit (degrees). Default 0.3."},
+        "max_fwhm_deg": {"type": "float", "description": "Upper bound on fitted FWHM (degrees). Default 3.0."},
+    },
+    required=["exp_two_theta", "exp_intensity"],
+    returns=(
+        "dict with 'r_squared' (GLOBAL, over the whole corrected pattern), "
+        "'residual_rms_over_noise' (global residual RMS / estimated point "
+        "noise — the verifier's key statistic; < ~3 is clean), 'n_peaks', "
+        "'peaks' (list of dicts: center, fwhm, amplitude (height), area, eta, "
+        "each sorted by 2-theta), 'peak_centers' (the centers actually fit — "
+        "feed back as the locked list for the next series frame), "
+        "'intensity_corrected', 'fit_curve' (model evaluated on the full grid; "
+        "use for the visualization), 'background_method'."
+    ),
+    when_to_use=(
+        "Default tool for fitting a full XRD pattern and for every frame of an "
+        "in-situ series. Detect peaks once on a strong frame, then pass "
+        "peak_centers to lock the model across the series."
+    ),
+)
+
+
+def _pseudo_voigt(x, amp, cen, fwhm, eta):
+    """Height-parameterised pseudo-Voigt: amp is the peak height; eta in [0,1]
+    mixes Lorentzian (eta=1) and Gaussian (eta=0)."""
+    sigma = fwhm * _FWHM_TO_SIGMA
+    gauss = np.exp(-((x - cen) ** 2) / (2.0 * sigma ** 2))
+    gamma = fwhm / 2.0
+    lorentz = gamma ** 2 / ((x - cen) ** 2 + gamma ** 2)
+    return amp * (eta * lorentz + (1.0 - eta) * gauss)
+
+
+def _multi(x, *p):
+    n = (len(p) - 2) // 4
+    out = p[-2] * x + p[-1]
+    for i in range(n):
+        out = out + _pseudo_voigt(x, *p[4 * i:4 * i + 4])
+    return out
+
+
+def _pv_area(amp, fwhm, eta):
+    g = amp * fwhm * np.sqrt(np.pi / (4.0 * np.log(2.0)))
+    l = amp * fwhm * np.pi / 2.0
+    return float(eta * l + (1.0 - eta) * g)
+
+
+def _detect_centers(x, ycorr, step, prominence_frac, max_peaks, min_distance_deg):
+    """Auto-detect significant peak centers on a background-corrected pattern."""
+    noise = _estimate_noise(ycorr)
+    prom = max(prominence_frac * (ycorr.max() - ycorr.min()), 3.0 * noise)
+    dist = max(1, int(round(min_distance_deg / step)))
+    idx, _ = find_peaks(ycorr, prominence=prom, distance=dist)
+    idx = idx[np.argsort(ycorr[idx])[::-1][:max_peaks]]
+    return sorted(float(x[i]) for i in idx)
+
+
+def _estimate_noise(y):
+    """Robust per-point noise from first differences (MAD estimator).
+    diff of white noise has std sqrt(2)*sigma; MAD->std uses 1.4826."""
+    d = np.diff(y)
+    mad = np.median(np.abs(d - np.median(d)))
+    return float(1.4826 * mad / np.sqrt(2.0)) or 1.0
+
+
+def fit_pattern(
+    exp_two_theta: Sequence[float],
+    exp_intensity: Sequence[float],
+    peak_centers: Optional[Sequence[float]] = None,
+    background: str = "snip",
+    snip_iterations: Any = "auto",
+    prominence_frac: float = 0.02,
+    max_peaks: int = 30,
+    min_distance_deg: float = 0.15,
+    init_fwhm_deg: float = 0.2,
+    center_leeway_deg: float = 0.3,
+    max_fwhm_deg: float = 3.0,
+) -> dict[str, Any]:
+    x = np.asarray(exp_two_theta, dtype=float)
+    y = np.asarray(exp_intensity, dtype=float)
+    if x.shape != y.shape:
+        raise ValueError("exp_two_theta and exp_intensity must have the same length")
+    if x.size < 10:
+        raise ValueError("pattern too short to fit")
+    step = float(np.median(np.diff(x)))
+
+    centers_locked = (
+        [float(c) for c in peak_centers]
+        if peak_centers is not None and len(peak_centers) > 0 else None
+    )
+    fit_kw = dict(
+        prominence_frac=prominence_frac, max_peaks=max_peaks,
+        min_distance_deg=min_distance_deg, init_fwhm_deg=init_fwhm_deg,
+        center_leeway_deg=center_leeway_deg, max_fwhm_deg=max_fwhm_deg,
+    )
+
+    # --- background + fit ---
+    if background == "none":
+        best = _fit_corrected(x, y.copy(), centers_locked, step, **fit_kw)
+        best["background_method"] = "none"
+    elif background == "polynomial":
+        bg = fit_background(x.tolist(), y.tolist(), method="polynomial")
+        ycorr = np.asarray(bg["intensity_corrected"], dtype=float)
+        best = _fit_corrected(x, ycorr, centers_locked, step, **fit_kw)
+        best["background_method"] = "polynomial"
+    elif background == "snip":
+        # SNIP iteration count trades off two ways: too many iterations eat into
+        # the base of SHARP peaks (apex over-subtraction -> the residual spikes
+        # the verifier flags), too few leave broad-background curvature (R²
+        # collapses). The optimum is pattern-dependent, so sweep a few counts
+        # and keep the one that minimises residual-RMS/noise while staying within
+        # 0.01 R² of the best — instead of forcing the agent to hand-tune it.
+        if snip_iterations == "auto":
+            iters_list = [6, 10, 16, 24]
+        else:
+            iters_list = [int(snip_iterations)]
+        # Detect the peak list ONCE on the most-aggressive background so the set
+        # of peaks stays fixed while the sweep varies only the fit background.
+        # (Low-iteration backgrounds leave baseline ripple that would otherwise
+        # inflate the detected peak count.) A caller-supplied list overrides.
+        if centers_locked is None:
+            ref_bg = fit_background(
+                x.tolist(), y.tolist(), method="snip", iterations=max(iters_list))
+            centers_for_sweep = _detect_centers(
+                x, np.asarray(ref_bg["intensity_corrected"], dtype=float), step,
+                prominence_frac, max_peaks, min_distance_deg)
+        else:
+            centers_for_sweep = centers_locked
+        trials = []
+        for it in iters_list:
+            bg = fit_background(x.tolist(), y.tolist(), method="snip", iterations=it)
+            ycorr = np.asarray(bg["intensity_corrected"], dtype=float)
+            try:
+                res = _fit_corrected(x, ycorr, centers_for_sweep, step, **fit_kw)
+            except (RuntimeError, ValueError):
+                continue
+            res["_iters"] = it
+            trials.append(res)
+        if not trials:
+            raise RuntimeError("fit_pattern: no SNIP iteration count converged")
+        # Favour R² first (attempt-1 must clear the acceptance gate, especially
+        # in fast/low-iteration mode); only take a cleaner-residual background
+        # when its R² is within a hair (0.002) of the best, i.e. essentially
+        # free. An earlier 0.01 band over-favoured cleanliness and capped R².
+        best_r2 = max(t["r_squared"] for t in trials)
+        eligible = [t for t in trials if t["r_squared"] >= best_r2 - 0.002]
+        best = min(eligible, key=lambda t: t["residual_rms_over_noise"])
+        best["background_method"] = f"snip(iterations={best.pop('_iters')})"
+    else:
+        raise ValueError(f"Unknown background: {background!r}")
+
+    return best
+
+
+def _fit_corrected(
+    x: np.ndarray,
+    ycorr: np.ndarray,
+    centers_locked: Optional[list],
+    step: float,
+    prominence_frac: float,
+    max_peaks: int,
+    min_distance_deg: float,
+    init_fwhm_deg: float,
+    center_leeway_deg: float,
+    max_fwhm_deg: float,
+) -> dict[str, Any]:
+    """Global multi-peak fit of an already background-corrected pattern."""
+    noise = _estimate_noise(ycorr)
+
+    if centers_locked is not None:
+        centers = list(centers_locked)
+    else:
+        centers = _detect_centers(
+            x, ycorr, step, prominence_frac, max_peaks, min_distance_deg)
+    if not centers:
+        raise ValueError("no peaks detected; lower prominence_frac or pass peak_centers")
+
+    p0, lo, hi, scale = [], [], [], []
+    for c in centers:
+        j = int(np.argmin(np.abs(x - c)))
+        amp0 = max(ycorr[j], noise)
+        p0 += [amp0, c, init_fwhm_deg, 0.5]
+        lo += [0.0, c - center_leeway_deg, max(2.0 * step, 0.02), 0.0]
+        hi += [5.0 * amp0 + 1.0, c + center_leeway_deg, max_fwhm_deg, 1.0]
+        # Per-parameter scale: amplitudes span ~1e5 while centers ~30 and FWHM
+        # ~0.3. Without x_scale the TRF optimiser thrashes (seconds -> minutes
+        # on busy frames). Scale each param by its natural magnitude.
+        scale += [amp0, center_leeway_deg, init_fwhm_deg, 1.0]
+    p0 += [0.0, 0.0]                       # linear baseline slope, intercept
+    lo += [-np.inf, -np.inf]
+    hi += [np.inf, np.inf]
+    scale += [max(amp0, 1.0), max(ycorr.max(), 1.0)]
+
+    try:
+        popt, _ = curve_fit(
+            _multi, x, ycorr, p0=p0, bounds=(lo, hi),
+            x_scale=scale, ftol=1e-4, xtol=1e-4, maxfev=20000,
+        )
+    except (RuntimeError, ValueError) as e:
+        # Last resort: looser convergence so a single hard frame in a series
+        # returns *something* fittable rather than aborting the whole run.
+        try:
+            popt, _ = curve_fit(
+                _multi, x, ycorr, p0=p0, bounds=(lo, hi),
+                x_scale=scale, ftol=1e-2, xtol=1e-2, maxfev=40000,
+            )
+        except (RuntimeError, ValueError):
+            raise RuntimeError(
+                f"fit_pattern failed to converge on {len(centers)} peaks. Try "
+                "fewer peaks (raise prominence_frac) or pass explicit peak_centers."
+            ) from e
+
+    fit_curve = _multi(x, *popt)
+    resid = ycorr - fit_curve
+    ss_res = float(np.sum(resid ** 2))
+    ss_tot = float(np.sum((ycorr - ycorr.mean()) ** 2))
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
+    rms_over_noise = float(np.sqrt(np.mean(resid ** 2)) / noise)
+
+    peaks = []
+    for i in range(len(centers)):
+        amp, cen, fwhm, eta = popt[4 * i:4 * i + 4]
+        peaks.append({
+            "center": float(cen), "fwhm": float(fwhm), "amplitude": float(amp),
+            "eta": float(eta), "area": _pv_area(amp, fwhm, eta),
+        })
+    peaks.sort(key=lambda d: d["center"])
+
+    return {
+        "r_squared": float(r2),
+        "residual_rms_over_noise": rms_over_noise,
+        "n_peaks": len(centers),
+        "peaks": peaks,
+        "peak_centers": [p["center"] for p in peaks],
+        "intensity_corrected": [float(v) for v in ycorr],
+        "fit_curve": [float(v) for v in fit_curve],
+        "noise_estimate": noise,
+    }

--- a/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
+++ b/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
@@ -140,11 +140,11 @@ WAVELENGTH_ANGSTROM = 1.5406  # CuKa1; replace from metadata if available
 INSTRUMENTAL_FWHM_DEG = 0.05  # from LaB6/Si standard; 0.0 if unknown
 
 # ---- Step 2: One global multi-peak fit (background handled inside) ----
+# Let fit_pattern DETECT the peaks (do not hardcode centers): the same call
+# then generalises unchanged to every frame of a series. See "In-situ / series".
 fit = fit_pattern(
     two_theta.tolist(), intensity.tolist(),
     background='snip',          # 'none' if data is already background-subtracted
-    # peak_centers=LOCKED_LIST, # pass a fixed list ONLY within a confirmed
-    #                           # single-phase regime; omit to auto-detect.
 )
 peaks = fit['peaks']            # each: center, fwhm, amplitude, area, eta
 r_squared = fit['r_squared']    # GLOBAL R²
@@ -189,15 +189,23 @@ print("FIT_RESULTS_JSON: " + json.dumps({
 }))
 ```
 
-**In-situ / series use.** `fit_pattern` is one fast call per frame, so it
-drops straight into the agent's per-spectrum series loop. **Auto-detect
-(omit `peak_centers`) is the robust default** — it re-finds peaks on every
-frame, so it survives a phase transition and composes with the agent's
-adaptive-refit path. Pass a fixed `peak_centers` list **only** inside a
-regime you have confirmed is a single stable phase (e.g. tracking thermal
-expansion / line-broadening of one phase), where a locked peak set buys
-frame-to-frame parameter consistency. Do **not** lock one list across a
-reaction or transition — the peaks themselves change.
+**In-situ / series use — lock the method, not the values.** `fit_pattern` is
+one fast call per frame, so it drops straight into the agent's per-spectrum
+series loop. The locked series script **must call `fit_pattern` with
+`peak_centers=None` (auto-detect)** — lock the *recipe* (the `fit_pattern` call
+and its settings), never a hardcoded list of peak centers. Auto-detect re-finds
+the peaks on every frame, so the one script follows peak shifts (thermal
+expansion), intensity changes (phase fraction), and appearance/disappearance,
+and composes with the agent's regime-segmentation and adaptive-refit paths. A
+**value-locked** script — hardcoded `SEED_CENTERS` / an explicit `peak_centers`
+list frozen from frame 1 — does **not** generalise: centers drift out of their
+windows even within one phase, and break entirely across a reaction or
+transition (measured: a list locked from a post-transition frame scored
+R²≈0.5–0.7 on pre-transition frames). Frame-to-frame **consistency comes from
+the identical method plus aligning the detected peaks across frames in
+interpretation, not from frozen centers.** Only pass an explicit `peak_centers`
+for a one-off re-fit of a single known-stable pattern — never as the series
+default.
 
 For speed across a long series: the default `snip_iterations='auto'` sweeps
 a few background widths per frame (~4× the fit cost). Once the establishing
@@ -205,10 +213,19 @@ frame reports its choice (in `background_method`, e.g. `snip(iterations=10)`),
 pass that integer as `snip_iterations` on the remaining frames to skip the
 sweep — back to ~1 s/frame with the same background treatment.
 
-**Drilling into a stubborn cluster.** `fit_pattern` resolves most overlaps,
-but for a tight doublet that the global fit smears, refit just that window
-with `fit_profile(peak_init=[c1, c2])` (joint two-component fit) and splice
-the result back.
+**Unresolved doublet? Tune detection, don't drill.** `fit_pattern` already
+fits all peaks jointly with an asymmetric (split pseudo-Voigt) shape, so it
+resolves overlaps and peak asymmetry in one consistent global model. If a tight
+doublet is smeared because auto-detect merged it, fix it the **method-locked**
+way: lower `min_distance_deg` (so closely-spaced maxima are detected separately)
+and/or lower `prominence_frac` (so the weaker partner is found) — these stay
+generalisable across a series because the recipe still auto-detects per frame.
+Do **not** splice in a separate `fit_profile` window fit: `fit_profile` uses a
+*symmetric* profile, so its result conflicts with the global split-PV fit and
+reintroduces exactly the asymmetric residual the global model removed (this
+drives avoidable verifier iterations). Reserve `fit_profile` only for one-off
+inspection of a single peak
+outside the main fit.
 
 **NumPy compatibility.** Use `np.trapezoid` (not removed `np.trapz`).
 
@@ -260,14 +277,18 @@ refined FWHMs from this skill can be passed in to sharpen the scoring.
 
 ## validation
 
-**Know when the fit is done.** Once the global R² ≥ ~0.99 and every visible
-reflection is modelled (no *unmodelled*-peak spikes in the residual), residual
-that remains concentrated at the apex of the few sharpest, highest-count peaks
-is the expected limit of a single symmetric pseudo-Voigt — accept it rather
-than spending refinement iterations chasing it. Re-fitting an already-resolved
-single peak with a narrower `fit_profile` window typically *worsens* the global
-fit; reserve `fit_profile` drilling for genuinely unresolved overlapping
-doublets, not for sharp peaks the global fit already captures.
+**Know when the fit is done.** `fit_pattern`'s default split (asymmetric)
+pseudo-Voigt already captures sharp-peak asymmetry, so once the global R² ≥ ~0.99
+and every visible reflection is modelled (no *unmodelled*-peak spikes in the
+residual), small residual at the apex of the few sharpest, highest-count peaks
+is the irreducible profile limit — accept it rather than spending refinement
+iterations chasing it. Do **not** re-fit individual peaks with a symmetric
+`fit_profile` window: it conflicts with the global split-PV model and
+reintroduces asymmetric residual, *worsening* the fit and adding iterations. If a
+peak is genuinely missing, lower `prominence_frac` (and/or `min_distance_deg`) so
+auto-detect catches it and re-run the single global `fit_pattern` — keep the
+recipe auto-detecting (so it still generalises frame-to-frame), not spliced
+sub-fits or hardcoded centers.
 
 **Per-peak fit checks:**
 - `r_squared` ≥ 0.95 for each fit accepts; 0.85–0.95 marginal; below

--- a/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
+++ b/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
@@ -36,6 +36,12 @@ orientation correction; whole-pattern Le Bail fitting.
 
 ## planning
 
+**Default mechanism: global full-pattern fit.** Plan for a single
+`fit_pattern` call that detects and fits all significant peaks at once
+(background subtraction included), not a per-peak `fit_profile` loop. The
+points below shape *that* fit — how many peaks matter, when Williamson-Hall
+is admissible, which background — rather than a peak-by-peak procedure.
+
 **How many peaks to fit:**
 - Scherrer alone: 3–5 strongest, well-isolated peaks is enough — report
   size per peak and the mean.
@@ -95,33 +101,35 @@ for nanocrystalline patterns with peaks several times broader than the
 
 ## implementation
 
-**CRITICAL: profile fitting workflow.** The per-item analysis script
-must follow this sequence:
+**Default path: one global fit with `fit_pattern`.** Prefer `fit_pattern`
+over a per-peak `fit_profile` loop. It detects *all* significant peaks in
+one pass and fits them **simultaneously** on a shared baseline, so the
+reported R² and residual are **global** (over the whole pattern) — the same
+quantity the verifier judges. A per-peak loop reports per-window R², which
+hides every unmodelled reflection as a global-residual spike and triggers
+avoidable refinement iterations. `fit_pattern` seeds each amplitude from the
+measured apex (sharp peaks are never clipped) and scales parameters
+internally, so a busy pattern fits in ~1 s.
+
+**CRITICAL workflow:**
 
 1. Load experimental 2θ + intensity arrays.
-2. Subtract background via `fit_background`.
-3. Detect candidate peak centers via `extract_peaks` (reused from
-   `structure_matching/xrd`) — this gives a starting list to fit.
-4. For each peak, fit a pseudo-Voigt via `fit_profile` on a window
-   around the center.
-5. Per-peak Scherrer crystallite size via `scherrer`.
-6. If ≥ 5 peaks span a useful 2θ range, run `williamson_hall` for
-   size + strain.
-7. Emit `FIT_RESULTS_JSON: {...}` with per-peak results + aggregated
-   metrics (mean per-peak R², Scherrer mean, W-H size/strain).
+2. `fit_pattern` (handles background + detection + global fit in one call).
+3. Per-peak Scherrer crystallite size via `scherrer` on the returned FWHMs.
+4. If ≥ 5 peaks span a useful 2θ range, run `williamson_hall`.
+5. Emit `FIT_RESULTS_JSON: {...}` carrying the **global** R² from
+   `fit_pattern` (not a mean of per-window R²s) plus per-peak results.
 
-**Complete profile-fitting template:**
+**Complete full-pattern template:**
 
 ```python
 import json
 import numpy as np
 
 from scilink.skills._shared.curve_fitting_tools import load_curve_data
-from scilink.skills.curve_fitting.xrd_profile.background import fit_background
-from scilink.skills.curve_fitting.xrd_profile.fit_profile import fit_profile
+from scilink.skills.curve_fitting.xrd_profile.fit_pattern import fit_pattern
 from scilink.skills.curve_fitting.xrd_profile.scherrer import scherrer
 from scilink.skills.curve_fitting.xrd_profile.williamson_hall import williamson_hall
-from scilink.skills.structure_matching.xrd.extract_peaks import extract_peaks
 
 # ---- Step 1: Load ----
 data = load_curve_data(DATA_PATH)  # ndarray with X in col 0, Y in col 1
@@ -131,83 +139,76 @@ intensity = np.asarray(data[:, 1], dtype=float)
 WAVELENGTH_ANGSTROM = 1.5406  # CuKa1; replace from metadata if available
 INSTRUMENTAL_FWHM_DEG = 0.05  # from LaB6/Si standard; 0.0 if unknown
 
-# ---- Step 2: Background subtraction ----
-bg = fit_background(two_theta.tolist(), intensity.tolist(), method='snip')
-intensity_sub = np.asarray(bg['intensity_corrected'], dtype=float)
-
-# ---- Step 3: Seed peak list ----
-seed = extract_peaks(
-    two_theta.tolist(), intensity_sub.tolist(),
-    prominence_frac=0.02, max_peaks=10,
+# ---- Step 2: One global multi-peak fit (background handled inside) ----
+fit = fit_pattern(
+    two_theta.tolist(), intensity.tolist(),
+    background='snip',          # 'none' if data is already background-subtracted
+    # peak_centers=LOCKED_LIST, # pass a fixed list ONLY within a confirmed
+    #                           # single-phase regime; omit to auto-detect.
 )
-peak_centers = seed['positions']
+peaks = fit['peaks']            # each: center, fwhm, amplitude, area, eta
+r_squared = fit['r_squared']    # GLOBAL R²
 
-# ---- Step 4: Per-peak pseudo-Voigt fit ----
-fits = []
-for center in peak_centers:
-    result = fit_profile(
-        exp_two_theta=two_theta.tolist(),
-        exp_intensity=intensity_sub.tolist(),
-        peak_init=center,
-        model='pseudo_voigt',
-        window_deg=1.0,
-        background='linear',  # residual baseline inside the window
-    )
-    fits.append(result)
-
-# ---- Step 5: Per-peak Scherrer size ----
+# ---- Step 3: Per-peak Scherrer size ----
 sizes_nm = []
-for f in fits:
-    if f['r_squared'] < 0.9:
-        continue  # don't trust Scherrer on a bad fit
+for p in peaks:
     s = scherrer(
-        fwhm_deg=f['fwhm'],
-        two_theta_deg=f['center'],
+        fwhm_deg=p['fwhm'],
+        two_theta_deg=p['center'],
         wavelength_angstrom=WAVELENGTH_ANGSTROM,
         instrumental_fwhm_deg=INSTRUMENTAL_FWHM_DEG,
     )
     sizes_nm.append(s['size_nm'])
 mean_size_nm = float(np.mean(sizes_nm)) if sizes_nm else None
 
-# ---- Step 6: Williamson-Hall (optional) ----
-wh_input = [
-    {'two_theta': f['center'], 'fwhm': f['fwhm']}
-    for f in fits if f['r_squared'] >= 0.9
-]
-wh = None
-if len(wh_input) >= 5:
-    wh = williamson_hall(
-        peaks=wh_input,
-        wavelength_angstrom=WAVELENGTH_ANGSTROM,
-        instrumental_fwhm_deg=INSTRUMENTAL_FWHM_DEG,
-    )
+# ---- Step 4: Williamson-Hall (optional) ----
+wh_input = [{'two_theta': p['center'], 'fwhm': p['fwhm']} for p in peaks]
+wh = williamson_hall(
+    peaks=wh_input,
+    wavelength_angstrom=WAVELENGTH_ANGSTROM,
+    instrumental_fwhm_deg=INSTRUMENTAL_FWHM_DEG,
+) if len(wh_input) >= 5 else None
 
-# ---- Step 7: Emit ----
-mean_r2 = float(np.mean([f['r_squared'] for f in fits])) if fits else 0.0
+# ---- Step 5: Emit ----
 print("FIT_RESULTS_JSON: " + json.dumps({
     "peaks": [
-        {k: f[k] for k in ('center', 'fwhm', 'amplitude', 'eta', 'r_squared')}
-        for f in fits
+        {k: p[k] for k in ('center', 'fwhm', 'amplitude', 'area', 'eta')}
+        for p in peaks
     ],
     "scherrer_mean_size_nm": mean_size_nm,
     "scherrer_per_peak_nm": sizes_nm,
     "williamson_hall": wh,
     "fit_quality": {
-        "r_squared": mean_r2,
-        "verdict": "accept" if mean_r2 >= 0.95 else (
-            "marginal" if mean_r2 >= 0.85 else "reject"
+        "r_squared": r_squared,                       # GLOBAL
+        "residual_rms_over_noise": fit['residual_rms_over_noise'],
+        "verdict": "accept" if r_squared >= 0.95 else (
+            "marginal" if r_squared >= 0.85 else "reject"
         ),
-        "n_peaks_fitted": len(fits),
-        "n_peaks_used_for_scherrer": len(sizes_nm),
+        "n_peaks_fitted": fit['n_peaks'],
     },
 }))
 ```
 
-**Joint fitting for overlapping peaks.** When `fit_profile` returns
-`r_squared < 0.9` and the residual shows a shoulder on one side of the
-peak, refit that window with two pseudo-Voigt components by passing
-`peak_init=[center1, center2]` (list of two starting centers). The tool
-constructs a composite model.
+**In-situ / series use.** `fit_pattern` is one fast call per frame, so it
+drops straight into the agent's per-spectrum series loop. **Auto-detect
+(omit `peak_centers`) is the robust default** — it re-finds peaks on every
+frame, so it survives a phase transition and composes with the agent's
+adaptive-refit path. Pass a fixed `peak_centers` list **only** inside a
+regime you have confirmed is a single stable phase (e.g. tracking thermal
+expansion / line-broadening of one phase), where a locked peak set buys
+frame-to-frame parameter consistency. Do **not** lock one list across a
+reaction or transition — the peaks themselves change.
+
+For speed across a long series: the default `snip_iterations='auto'` sweeps
+a few background widths per frame (~4× the fit cost). Once the establishing
+frame reports its choice (in `background_method`, e.g. `snip(iterations=10)`),
+pass that integer as `snip_iterations` on the remaining frames to skip the
+sweep — back to ~1 s/frame with the same background treatment.
+
+**Drilling into a stubborn cluster.** `fit_pattern` resolves most overlaps,
+but for a tight doublet that the global fit smears, refit just that window
+with `fit_profile(peak_init=[c1, c2])` (joint two-component fit) and splice
+the result back.
 
 **NumPy compatibility.** Use `np.trapezoid` (not removed `np.trapz`).
 
@@ -258,6 +259,15 @@ crystal phase has not yet been identified, recommend running
 refined FWHMs from this skill can be passed in to sharpen the scoring.
 
 ## validation
+
+**Know when the fit is done.** Once the global R² ≥ ~0.99 and every visible
+reflection is modelled (no *unmodelled*-peak spikes in the residual), residual
+that remains concentrated at the apex of the few sharpest, highest-count peaks
+is the expected limit of a single symmetric pseudo-Voigt — accept it rather
+than spending refinement iterations chasing it. Re-fitting an already-resolved
+single peak with a narrower `fit_profile` window typically *worsens* the global
+fit; reserve `fit_profile` drilling for genuinely unresolved overlapping
+doublets, not for sharp peaks the global fit already captures.
 
 **Per-peak fit checks:**
 - `r_squared` ≥ 0.95 for each fit accepts; 0.85–0.95 marginal; below

--- a/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
+++ b/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
@@ -1,5 +1,5 @@
 ---
-description: p-XRD profile fitting — per-peak pseudo-Voigt fits with FWHM, position, and intensity; Scherrer crystallite size and Williamson-Hall microstrain from the fitted line widths.
+description: 'p-XRD profile fitting — the quantitative follow-up to phase identification: per-peak pseudo-Voigt fits (position, intensity, FWHM), Scherrer crystallite size and Williamson-Hall microstrain, and a Rietveld tier (phase fractions / accurate lattice; engine pending) that refines against the identified-phase CIF.'
 technique: [XRD, "X-ray diffraction", "powder diffraction", pXRD]
 quality_gate:
   metric: r_squared
@@ -11,30 +11,56 @@ quality_gate:
 
 ## overview
 
-Powder X-ray diffraction profile fitting for line-broadening physics.
-Per-peak pseudo-Voigt fits yield calibrated peak positions, intensities,
-and full widths at half maximum (FWHMs). Those widths then feed two
-classical analyses:
+Powder X-ray diffraction profile fitting — **the quantitative follow-up to
+phase identification.** You normally arrive here *after* `structure_matching/
+xrd` has answered "what phase(s) is this?": the identified phase(s) and their
+reference CIF(s) are the prior this skill builds on. (It also runs standalone
+when the phase is already known.)
 
-- **Scherrer equation** for an average crystallite (coherent domain) size
-  from any single peak's broadening:
-  `D = K · λ / (β · cos θ)`.
-- **Williamson-Hall (W-H) plot** for separating size and strain
-  contributions from the 2θ dependence of broadening:
-  `β · cos θ = K · λ / D + 4 · ε · sin θ`.
+The skill is organized as three **depth tiers** — go only as deep as the
+question demands:
 
-This skill is the *profile* half of p-XRD analysis. The *identification*
-half — matching observed peaks to a candidate crystal phase — lives in
-the separate `structure_matching/xrd` skill. The two are designed to be
-co-activated: pass `skill=["xrd", "xrd_profile"]` and the LLM can chain
-profile fitting + phase identification in one analysis script.
+1. **Per-peak profile fit (default).** A global multi-peak (split) pseudo-Voigt
+   fit (`fit_pattern`) yields calibrated peak positions, intensities, and full
+   widths at half maximum (FWHMs). The identified phase's reference peak
+   positions are a strong prior for *which* reflections to expect.
+2. **Microstructure — size & strain.** The fitted FWHMs feed two classical
+   line-broadening analyses:
+   - **Scherrer** — average crystallite (coherent domain) size from a single
+     peak's broadening: `D = K · λ / (β · cos θ)`.
+   - **Williamson-Hall** — separates size and strain from the 2θ dependence of
+     broadening: `β · cos θ = K · λ / D + 4 · ε · sin θ`.
+3. **Rietveld refinement (deepest; engine pending).** Whole-pattern refinement
+   against the matched CIF for quantitative phase fractions (QPA), accurate
+   lattice parameters, and site occupancies. True Rietveld needs a dedicated
+   engine (GSAS-II) — see *planning* for the seam. Tiers 1–2 are always
+   available; tier 3 is a documented escalation, not yet wired.
 
-**Out of scope:** Rietveld refinement (atomic positions / occupancies);
-quantitative phase-fraction analysis (covered in
-`structure_matching/xrd`'s multi-phase MIP path); texture / preferred
-orientation correction; whole-pattern Le Bail fitting.
+Frame the work as: **identify (upstream) → profile-fit (here) → escalate to
+Rietveld only when phase fractions / accurate cell / occupancies are the actual
+deliverable.** Most follow-ups stop at tier 1 or 2.
+
+When both skills are co-activated (`skill=["xrd", "xrd_profile"]`) the LLM can
+chain identification and profile fitting in one script; the sequential
+"identify first, then this" framing above is the same pipeline, just split
+across calls.
+
+**Out of scope:** texture / preferred-orientation correction; whole-pattern
+Le Bail fitting. (Rietveld and quantitative phase fractions are **tier 3
+above**, not out of scope — the structural model comes from the upstream ID
+match; only the refinement *engine* is a pending GSAS-II seam.)
 
 ## planning
+
+**You usually arrive here with an identified phase — use it as a prior.** When
+`structure_matching/xrd` ran first, its result shapes this fit: the matched
+phase's reference peak positions tell you *which* reflections to expect (a
+sanity check on auto-detect, and a seed for a one-off single-pattern refine),
+and the matched CIF is the structural model a tier-3 Rietveld refine needs. Do
+**not** freeze those reference positions into a series script, though — for a
+series keep `fit_pattern` auto-detecting (see "In-situ / series"); the ID tells
+you the *phase*, not frozen centers. If no ID was run and the phase is already
+known, proceed standalone.
 
 **Default mechanism: global full-pattern fit.** Plan for a single
 `fit_pattern` call that detects and fits all significant peaks at once
@@ -98,6 +124,21 @@ FWHMs as `exp_peaks={'positions': [...], 'amplitudes': [...],
 broadening per peak instead of the default uniform FWHM, which matters
 for nanocrystalline patterns with peaks several times broader than the
 0.15° default.
+
+**Escalating to Rietveld (tier 3).** Reach for Rietveld only when the
+deliverable is **quantitative phase fractions (QPA), accurate refined lattice
+parameters, or site occupancies** — not for size/strain, which tiers 1–2 cover.
+Rietveld refines the *whole pattern* against a structural model, so it requires
+the matched CIF from the upstream identification as the starting model (another
+reason ID comes first). True Rietveld is **not** in pymatgen; it needs a
+dedicated engine — GSAS-II via `GSASIIscriptable`. That plugs in through the
+same pluggable-engine pattern already established for simulation
+(`structure_matching/xrd/simulate_xrd.py`'s `_ENGINES` registry): a
+`refine_rietveld(cif, exp_data, ...)` tool behind a lazy import + optional
+`gsas` extra, leaving downstream scoring/reporting unaffected. **Until that
+engine is wired, do not attempt a whole-pattern refine with the kinematic
+tools** — report tiers 1–2 and recommend Rietveld as the explicit next step,
+naming the matched CIF as the model to refine.
 
 ## implementation
 


### PR DESCRIPTION
## What this adds (for an XRD person)

A new **full-pattern profile-fitting** capability for SciLink's curve-fitting agent (`xrd_profile` skill), built for both one-off analysis and **in-situ temperature/time series**. Instead of fitting peaks one at a time, it fits the whole diffraction pattern in a single shot, captures real peak asymmetry, and is designed to run frame-after-frame across a series without re-coding.

### Key methods inside `fit_pattern` (plain XRD language)

- **SNIP background stripping, auto-tuned** — removes the smooth background / fluorescence floor without assuming a polynomial shape, and automatically picks how hard to strip so it doesn't carve into the base of sharp peaks.
- **Automatic peak finding** — locates every significant reflection across the scan by prominence, so weak peaks aren't silently dropped.
- **Whole-pattern (global) fit** — all reflections are fit *simultaneously* on one shared background, not peak-by-peak. Overlapping reflections and the background are handled consistently, and the reported R²/residual describe the *entire* pattern (the same view the quality check uses).
- **Split (asymmetric) pseudo-Voigt line shape** — each reflection is a Gaussian–Lorentzian mix with **independent left/right widths**, capturing the real low-angle peak asymmetry from axial divergence. A symmetric profile leaves a systematic residual at the top of strong sharp peaks; on this data that asymmetry accounted for ~half the residual on the two tallest peaks. (Kα2 splitting was tested and does *not* help — the low-angle Kα1/Kα2 separation is ~0.03°, negligible.)
- **Apex-anchored intensity seeding** — each peak's starting height is read from the measured peak top, so tall sharp reflections aren't clipped during the fit.
- **Crystallite-size / microstrain ready** — returns peak position (2θ → d-spacing), FWHM (plus left/right widths and an asymmetry value), height, integrated intensity, and the Gaussian/Lorentzian mixing — feeding straight into Scherrer size and Williamson–Hall.
- **Series mode = "lock the method, not the values"** — the *same* auto-detecting call runs on every frame of an in-situ ramp, so it follows peak shifts (thermal expansion), intensity changes (phase fraction), and even new/disappearing phases (e.g. precursor → metallic Au) **without re-seeding or re-coding**. Validated across a 53-frame 31→120 °C ramp through a phase transition: R² 0.987–0.994, **0/53 frames below 0.90**.
- **Adjustable thoroughness** — a per-analysis verification budget, plus a "bypass" for fast / real-time in-situ turnaround, lets you trade between a quick good-enough fit and an exhaustive post-experiment one (same agent, same skill).
- **Built to converge fast** — internal parameter scaling spans the huge range between intensities (~10⁵ counts) and angles (~tens of degrees), so a full ~20-peak pattern fits in about a second.

---

## Technical details (for reviewers)

Three commits on this branch:
- `6b503fe` — `fit_pattern` global fitter added to `scilink/skills/curve_fitting/xrd_profile/fit_pattern.py` (auto-discovered via the `TOOL_SPEC` registry; surfaced in orchestrator mode when `xrd_profile` is active).
- `4f949e1` — per-call `max_verification_iterations` plumbed through `CurveFittingAgent.analyze()` → `run_analysis` (mirrors `r2_threshold`; introspected forwarding), with a `<=0` bypass branch in `_fit_with_quality_control` (`curve_fitting_controllers.py`). `0`=bypass, `1`=single check, default `7`=thorough. NL mapping in the `run_analysis` tool schema.
- `6a47a36` — split (asymmetric) pseudo-Voigt as the default `peak_shape`, adaptive SNIP iteration selection (favouring R²), and method-locked series guidance.

**Design / mechanism**
- Model: sum of height-parameterised pseudo-Voigts on a linear baseline, fit with `scipy.optimize.curve_fit` (TRF) using per-parameter `x_scale` + loosened tolerances (eliminates the 15–76 s/frame thrash on busy frames → ~0.8 s/frame symmetric, ~7 s/frame split-with-SNIP-sweep).
- `peak_shape='split_pseudo_voigt'` (default) fits `fwhm_left`/`fwhm_right` per peak; returns `fwhm=(fl+fr)/2` for Scherrer/W-H plus `asymmetry=(fr-fl)/(fr+fl)`. `pseudo_voigt` (symmetric) remains selectable.
- `snip_iterations='auto'` sweeps {6,10,16,24}; peaks detected once on the most-aggressive background (stable count), best background chosen by lowest residual-rms/noise within 0.002 R² of the max (favours R² so attempt-1 clears the gate).
- Returns global `r_squared`, `residual_rms_over_noise` (the verifier's statistics), per-peak params, `peak_centers`, `fit_curve`, `background_method`, `peak_shape`.

**Validation (real IMAuCl4 VT-XRD series + synthetic ground truth)**
- Split vs symmetric on 53 real frames: rms/noise mean 3.7→2.8, R² mean 0.989→0.994, better on 53/53.
- Ground-truth recovery: symmetric synthetic peaks → asymmetry ±0.01, FWHM exact; asymmetric synthetic peaks → recovered fl/fr and asymmetry within ~5%. Generalizes (degenerates to symmetric where there's no asymmetry).
- Method-lock vs value-lock across the series: auto-detect → 0/53 frames <0.90 (mean 0.994); a peak list value-locked from a *sparse* frame → 23/53 frames <0.90 (R² down to 0.47). Method-locking is robust to which frame you start from; value-locking is not. Live-verified the planner now emits `peak_centers=None`.
- Live mode behaviour: bypass (`0`) accepts attempt-1 in ~160 s; thorough (`7`) runs the full verification + judge fallback. Backward compatible (52 relevant unit tests pass; default path unchanged).

**Known limits / follow-ups**
- Split-PV slightly raises the per-regime *anchor* verification cost (more for the verifier to scrutinise); the bulk per-frame cost rises only ~3 s. A skill-scoped speed lever was scoped (capping the annealing level, not the iteration count, to avoid compressing the annealing schedule) but deliberately deferred.
- Mirror the `max_verification_iterations` knob for Image/Hyperspectral agents — tracked in #271.
- Detection over-counts on sparse patterns (30-peak cap fitting sidelobes) — pre-existing, does not affect the real peaks' FWHM.
