### PR TITLE
XRD phase identification (search-match) + in-situ series + microstructure follow-up

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,10 @@ ui = [
     "streamlit>=1.37.0",
 ]
 structure-matching = [
-    "pymatgen>=2024.0",
+    # Cap <2026: pymatgen 2026.x makes pymatgen.analysis a namespace package and
+    # drops bundled pymatgen.analysis.phase_diagram, which breaks the emmet-core /
+    # mp-api import chain (MPRester) that the Materials Project backend needs.
+    "pymatgen>=2024.6.10,<2026",
     "mp-api>=0.45.0",
     "pulp>=2.7.0",
     "pyarrow>=14.0",

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2030,6 +2030,7 @@ class AnalysisOrchestratorTools:
             reuse_locked_script: bool = False,
             literature_file: str = None,
             r2_threshold: float = None,
+            max_verification_iterations: int = None,
         ) -> str:
             """
             Execute analysis with the selected or specified agent.
@@ -2524,6 +2525,19 @@ class AnalysisOrchestratorTools:
                             f"   r2_threshold={r2_threshold} ignored: "
                             f"{self.AGENT_NAMES.get(agent_id, 'agent')} has no R² gate."
                         )
+                if max_verification_iterations is not None:
+                    # Thoroughness / turnaround override. 0 bypasses LLM
+                    # verification (fast/in-situ), higher = more refinement
+                    # (thorough/post-experiment). Only forward to agents whose
+                    # analyze() accepts it (currently CurveFitting).
+                    import inspect as _inspect
+                    if "max_verification_iterations" in _inspect.signature(agent.analyze).parameters:
+                        analyze_kwargs["max_verification_iterations"] = int(max_verification_iterations)
+                    else:
+                        self.logger.info(
+                            f"   max_verification_iterations={max_verification_iterations} ignored: "
+                            f"{self.AGENT_NAMES.get(agent_id, 'agent')} has no verification loop."
+                        )
                 result = agent.analyze(**analyze_kwargs)
                 
                 # === Store result ===
@@ -2810,6 +2824,24 @@ class AnalysisOrchestratorTools:
                         "skill's R² gate (a warning is logged on conflict), but it "
                         "will NOT replace a skill that scores by a non-R² metric. "
                         "Leave unset for standard analyses."
+                    )
+                },
+                "max_verification_iterations": {
+                    "type": "integer",
+                    "description": (
+                        "CurveFitting agent only. Controls how thorough the "
+                        "fit-verification/refinement loop is — the speed-vs-rigor "
+                        "knob. Set it ONLY when the user asks about turnaround or "
+                        "checking depth; leave unset for the standard (thorough) "
+                        "default. Map the user's intent: a fast / quick / in-situ / "
+                        "real-time / 'good enough' turnaround → 1 (a single check, "
+                        "no refinement loop); 'skip/bypass/no verification' → 0 "
+                        "(accept the first good fit with no LLM verification at "
+                        "all); an explicit count (e.g. 'two verification steps') → "
+                        "that integer; thorough / careful / publication / "
+                        "post-experiment analysis → leave unset (defaults to 7). "
+                        "Often paired with r2_threshold (e.g. 'use R²=0.98 and a "
+                        "single verification step')."
                     )
                 }
             },

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -3433,7 +3433,20 @@ Return JSON with:
 
             # --- Verification loop (for anchor spectra: first overall or first in regime) ---
             fit_was_approved = False
-            if _is_anchor:
+            if (_is_anchor and self.max_verification_iterations <= 0
+                    and best_result and best_result.get("success")):
+                # Explicit verification bypass (max_verification_iterations=0):
+                # the caller asked for a fast / in-situ turnaround. Accept the
+                # initial successful fit as-is, with no LLM verification or
+                # refit loop. Only triggers at <= 0, so the default thorough
+                # path (>= 1) is unaffected. A failed/degenerate initial fit
+                # (no success) still falls through to the loop below for the
+                # recovery path rather than locking garbage.
+                self.logger.info(
+                    f"   ⏩ Verification bypassed (max_verification_iterations=0); "
+                    f"accepting initial fit (R² = {best_r2:.4f})")
+                fit_was_approved = True
+            elif _is_anchor:
                 # Skip verification ONLY when there is no successful fit to work
                 # with. A fit that executed but is degenerate (low/zero R²) must
                 # still enter the loop: the verifier + adaptive annealing (which

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -4220,13 +4220,22 @@ Return JSON with:
         mode_str = "SINGLE SPECTRUM" if is_single else f"SERIES ({num_spectra} spectra)"
         self.logger.info("")
         self.logger.info(f"⚙️ FITTING: {mode_str}")
-        _accept = float(self.r2_threshold)
-        _floor = max(_accept - self._r2_soft_margin(_accept), 0.0)
-        self.logger.info(
-            f"   R² targets: accept ≥ {_accept:.3f} (with clean residuals); "
-            f"hard-reject below {_floor:.3f}; soft band {_floor:.3f}–{_accept:.3f} "
-            f"(verifier may reject on physics)"
-        )
+        _gate_obj = _gate(state)
+        if _gate_obj.metric == "r_squared":
+            _accept = float(self.r2_threshold)
+            _floor = max(_accept - self._r2_soft_margin(_accept), 0.0)
+            self.logger.info(
+                f"   R² targets: accept ≥ {_accept:.3f} (with clean residuals); "
+                f"hard-reject below {_floor:.3f}; soft band {_floor:.3f}–{_accept:.3f} "
+                f"(verifier may reject on physics)"
+            )
+        else:
+            _cmp = "≥" if _gate_obj.direction == "higher_is_better" else "≤"
+            self.logger.info(
+                f"   Quality: {_gate_obj.metric} {_cmp} {_gate_obj.accept_threshold:.3f} "
+                f"accepts ({_gate_obj.direction}); skill scoring is the verification "
+                f"(curve-fit R² verifier bypassed)."
+            )
         self.logger.info(f"   Max verification iterations: {self.max_verification_iterations}")
         if not is_single:
             self.logger.info(f"   Outlier detection: {self.outlier_sigma}σ")
@@ -5131,6 +5140,24 @@ class AdaptiveRefitController:
             return state
 
         if state.get("is_single_spectrum", True):
+            return state
+
+        # Scoring-gated (non-R²) skills — e.g. XRD phase identification — lock a
+        # phase set on the anchor frame by design. Adaptive refit re-derives the
+        # model per frame (for ID that means re-identifying), which defeats the
+        # lock; and a lower score on a later frame is the physical signal (a phase
+        # being consumed / a transformation), NOT a bad fit to repair. So skip the
+        # refit for these — the flagged frames are surfaced in the report for
+        # interpretation instead. (This is also what eliminated the pathological
+        # 100+ min "re-analysis" grind on real in-situ series: each flagged frame
+        # was being re-fit under the R² verification loop.) R² skills (all curve
+        # fitting) are unaffected — they fall through to the refit below.
+        if _gate(state).metric != "r_squared":
+            self.logger.info(
+                "\n🔄 Adaptive refit: scoring-gated skill (non-R² gate) — the phase "
+                "set is locked by design; skipping per-frame model re-derivation. "
+                "Lower per-frame scores are reported as physical evolution."
+            )
             return state
 
         flagged_spectra = state.get("flagged_spectra", [])

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -300,6 +300,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         r2_threshold: Optional[float] = None,
         max_model_retries: Optional[int] = None,
         outlier_sigma: Optional[float] = None,
+        max_verification_iterations: Optional[int] = None,
         quality_gate: "QualityGate | dict | None" = None,
         **kwargs,
     ) -> Dict[str, Any]:
@@ -437,6 +438,14 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         effective_r2_threshold = r2_threshold if r2_threshold is not None else self.r2_threshold
         effective_max_retries = max_model_retries if max_model_retries is not None else self.max_model_retries
         effective_outlier_sigma = outlier_sigma if outlier_sigma is not None else self.outlier_sigma
+        # Per-call thoroughness override (fast/in-situ vs thorough/post-experiment).
+        # 0 => bypass LLM verification entirely; 1 => single check, no refit loop;
+        # higher => more refinement passes. Falls back to the construction default.
+        effective_max_verification = (
+            max_verification_iterations if max_verification_iterations is not None
+            else self.max_verification_iterations)
+        if effective_max_verification < 0:
+            raise ValueError("max_verification_iterations must be >= 0")
 
         # Resolve task_mode — caller sets this explicitly (standalone user or
         # orchestrator). Defaults to "fitting" when unset.
@@ -732,7 +741,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             r2_threshold=effective_r2_threshold,
             max_model_retries=effective_max_retries,
             outlier_sigma=effective_outlier_sigma,
-            max_verification_iterations=self.max_verification_iterations,
+            max_verification_iterations=effective_max_verification,
             parallel_workers=self.parallel_workers,
         )
         

--- a/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
+++ b/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
@@ -58,14 +58,15 @@ TOOL_SPEC = ToolSpec(
         "fit_pattern(exp_two_theta, exp_intensity, peak_centers=None, "
         "background='snip', snip_iterations='auto', prominence_frac=0.02, "
         "max_peaks=30, min_distance_deg=0.15, init_fwhm_deg=0.2, "
-        "center_leeway_deg=0.3, max_fwhm_deg=3.0) -> dict"
+        "center_leeway_deg=0.3, max_fwhm_deg=3.0, "
+        "peak_shape='split_pseudo_voigt') -> dict"
     ),
     parameters={
         "exp_two_theta": {"type": "list[float]", "description": "Experimental 2-theta grid (degrees)."},
         "exp_intensity": {"type": "list[float]", "description": "Raw experimental intensity (same length). Background is handled internally."},
         "peak_centers": {
             "type": "list[float] | None",
-            "description": "Fixed peak centers to fit (degrees). None => auto-detect all significant peaks. Pass a locked list to keep the model identical across an in-situ series.",
+            "description": "Fixed peak centers to fit (degrees). None (recommended) => auto-detect all significant peaks. For a series/in-situ run, leave None on EVERY frame: the auto-detect re-finds peaks per frame so the same call follows peak shifts/intensity changes/appearance and generalises across the series. Do NOT hardcode a center list to 'lock the model' — a frozen list drifts out of its windows within a phase and breaks across a transition. Pass an explicit list only for a one-off re-fit of a single known-stable pattern.",
         },
         "background": {"type": "str", "description": "'snip' (default), 'polynomial', or 'none' (data already background-subtracted)."},
         "snip_iterations": {"type": "int | str", "description": "SNIP iteration count. 'auto' (default) sweeps a few counts and keeps the one with the cleanest residual at the best R² — avoids apex over-subtraction on sharp peaks without hand-tuning. Pass an int to fix it (e.g. reuse the value reported in background_method to skip the sweep on locked series frames)."},
@@ -75,17 +76,20 @@ TOOL_SPEC = ToolSpec(
         "init_fwhm_deg": {"type": "float", "description": "Initial FWHM guess per peak (degrees). Default 0.2 (typical CuKa)."},
         "center_leeway_deg": {"type": "float", "description": "Each center may move +/- this much during the fit (degrees). Default 0.3."},
         "max_fwhm_deg": {"type": "float", "description": "Upper bound on fitted FWHM (degrees). Default 3.0."},
+        "peak_shape": {"type": "str", "description": "'split_pseudo_voigt' (default) fits one extra width per peak to capture axial-divergence asymmetry — markedly lower residual on strong sharp lab-CuKa peaks, and it degenerates to symmetric when the data is symmetric (so it generalises safely). 'pseudo_voigt' forces a symmetric profile (fewer parameters; use only if asymmetry is known absent, e.g. synchrotron data)."},
     },
     required=["exp_two_theta", "exp_intensity"],
     returns=(
         "dict with 'r_squared' (GLOBAL, over the whole corrected pattern), "
         "'residual_rms_over_noise' (global residual RMS / estimated point "
         "noise — the verifier's key statistic; < ~3 is clean), 'n_peaks', "
-        "'peaks' (list of dicts: center, fwhm, amplitude (height), area, eta, "
-        "each sorted by 2-theta), 'peak_centers' (the centers actually fit — "
-        "feed back as the locked list for the next series frame), "
-        "'intensity_corrected', 'fit_curve' (model evaluated on the full grid; "
-        "use for the visualization), 'background_method'."
+        "'peaks' (list of dicts: center, fwhm (mean width; for Scherrer/W-H), "
+        "amplitude (height), area, eta, sorted by 2-theta; split mode adds "
+        "fwhm_left, fwhm_right, and asymmetry=(fwhm_right-fwhm_left)/sum), "
+        "'peak_centers' (the centers actually fit — feed back as the locked "
+        "list for the next series frame), 'intensity_corrected', 'fit_curve' "
+        "(model evaluated on the full grid; use for the visualization), "
+        "'background_method', 'peak_shape'."
     ),
     when_to_use=(
         "Default tool for fitting a full XRD pattern and for every frame of an "
@@ -119,6 +123,33 @@ def _pv_area(amp, fwhm, eta):
     return float(eta * l + (1.0 - eta) * g)
 
 
+def _split_pseudo_voigt(x, amp, cen, fwhm_l, fwhm_r, eta):
+    """Asymmetric (split) pseudo-Voigt: left of the centre uses fwhm_l, right
+    uses fwhm_r (height-parameterised, continuous at the apex). Captures the
+    axial-divergence peak asymmetry of lab-CuKa patterns. Degenerates to a
+    symmetric pseudo-Voigt when fwhm_l == fwhm_r, so it does not impose
+    asymmetry on data that has none."""
+    fwhm = np.where(x < cen, fwhm_l, fwhm_r)
+    sigma = fwhm * _FWHM_TO_SIGMA
+    gauss = np.exp(-((x - cen) ** 2) / (2.0 * sigma ** 2))
+    gamma = fwhm / 2.0
+    lorentz = gamma ** 2 / ((x - cen) ** 2 + gamma ** 2)
+    return amp * (eta * lorentz + (1.0 - eta) * gauss)
+
+
+def _multi_split(x, *p):
+    n = (len(p) - 2) // 5
+    out = p[-2] * x + p[-1]
+    for i in range(n):
+        out = out + _split_pseudo_voigt(x, *p[5 * i:5 * i + 5])
+    return out
+
+
+def _split_pv_area(amp, fwhm_l, fwhm_r, eta):
+    # Each side is half of a symmetric pseudo-Voigt of that width.
+    return 0.5 * (_pv_area(amp, fwhm_l, eta) + _pv_area(amp, fwhm_r, eta))
+
+
 def _detect_centers(x, ycorr, step, prominence_frac, max_peaks, min_distance_deg):
     """Auto-detect significant peak centers on a background-corrected pattern."""
     noise = _estimate_noise(ycorr)
@@ -149,7 +180,11 @@ def fit_pattern(
     init_fwhm_deg: float = 0.2,
     center_leeway_deg: float = 0.3,
     max_fwhm_deg: float = 3.0,
+    peak_shape: str = "split_pseudo_voigt",
 ) -> dict[str, Any]:
+    if peak_shape not in ("split_pseudo_voigt", "pseudo_voigt"):
+        raise ValueError(
+            f"peak_shape must be 'split_pseudo_voigt' or 'pseudo_voigt'; got {peak_shape!r}")
     x = np.asarray(exp_two_theta, dtype=float)
     y = np.asarray(exp_intensity, dtype=float)
     if x.shape != y.shape:
@@ -166,6 +201,7 @@ def fit_pattern(
         prominence_frac=prominence_frac, max_peaks=max_peaks,
         min_distance_deg=min_distance_deg, init_fwhm_deg=init_fwhm_deg,
         center_leeway_deg=center_leeway_deg, max_fwhm_deg=max_fwhm_deg,
+        peak_shape=peak_shape,
     )
 
     # --- background + fit ---
@@ -237,8 +273,16 @@ def _fit_corrected(
     init_fwhm_deg: float,
     center_leeway_deg: float,
     max_fwhm_deg: float,
+    peak_shape: str = "split_pseudo_voigt",
 ) -> dict[str, Any]:
-    """Global multi-peak fit of an already background-corrected pattern."""
+    """Global multi-peak fit of an already background-corrected pattern.
+
+    peak_shape: 'split_pseudo_voigt' (default; one extra width per peak for
+    axial-divergence asymmetry) or 'pseudo_voigt' (symmetric). Split degenerates
+    to symmetric when the data is symmetric, so it generalises safely."""
+    split = peak_shape == "split_pseudo_voigt"
+    model = _multi_split if split else _multi
+    fwhm_lo = max(2.0 * step, 0.02)
     noise = _estimate_noise(ycorr)
 
     if centers_locked is not None:
@@ -249,17 +293,23 @@ def _fit_corrected(
     if not centers:
         raise ValueError("no peaks detected; lower prominence_frac or pass peak_centers")
 
+    # Per-parameter scale keeps the TRF optimiser from thrashing (amplitudes
+    # ~1e5 vs centres ~30 vs FWHM ~0.3). One extra width param per peak in split
+    # mode.
     p0, lo, hi, scale = [], [], [], []
     for c in centers:
         j = int(np.argmin(np.abs(x - c)))
         amp0 = max(ycorr[j], noise)
-        p0 += [amp0, c, init_fwhm_deg, 0.5]
-        lo += [0.0, c - center_leeway_deg, max(2.0 * step, 0.02), 0.0]
-        hi += [5.0 * amp0 + 1.0, c + center_leeway_deg, max_fwhm_deg, 1.0]
-        # Per-parameter scale: amplitudes span ~1e5 while centers ~30 and FWHM
-        # ~0.3. Without x_scale the TRF optimiser thrashes (seconds -> minutes
-        # on busy frames). Scale each param by its natural magnitude.
-        scale += [amp0, center_leeway_deg, init_fwhm_deg, 1.0]
+        if split:
+            p0 += [amp0, c, init_fwhm_deg, init_fwhm_deg, 0.5]
+            lo += [0.0, c - center_leeway_deg, fwhm_lo, fwhm_lo, 0.0]
+            hi += [5.0 * amp0 + 1.0, c + center_leeway_deg, max_fwhm_deg, max_fwhm_deg, 1.0]
+            scale += [amp0, center_leeway_deg, init_fwhm_deg, init_fwhm_deg, 1.0]
+        else:
+            p0 += [amp0, c, init_fwhm_deg, 0.5]
+            lo += [0.0, c - center_leeway_deg, fwhm_lo, 0.0]
+            hi += [5.0 * amp0 + 1.0, c + center_leeway_deg, max_fwhm_deg, 1.0]
+            scale += [amp0, center_leeway_deg, init_fwhm_deg, 1.0]
     p0 += [0.0, 0.0]                       # linear baseline slope, intercept
     lo += [-np.inf, -np.inf]
     hi += [np.inf, np.inf]
@@ -267,7 +317,7 @@ def _fit_corrected(
 
     try:
         popt, _ = curve_fit(
-            _multi, x, ycorr, p0=p0, bounds=(lo, hi),
+            model, x, ycorr, p0=p0, bounds=(lo, hi),
             x_scale=scale, ftol=1e-4, xtol=1e-4, maxfev=20000,
         )
     except (RuntimeError, ValueError) as e:
@@ -275,7 +325,7 @@ def _fit_corrected(
         # returns *something* fittable rather than aborting the whole run.
         try:
             popt, _ = curve_fit(
-                _multi, x, ycorr, p0=p0, bounds=(lo, hi),
+                model, x, ycorr, p0=p0, bounds=(lo, hi),
                 x_scale=scale, ftol=1e-2, xtol=1e-2, maxfev=40000,
             )
         except (RuntimeError, ValueError):
@@ -284,20 +334,34 @@ def _fit_corrected(
                 "fewer peaks (raise prominence_frac) or pass explicit peak_centers."
             ) from e
 
-    fit_curve = _multi(x, *popt)
+    fit_curve = model(x, *popt)
     resid = ycorr - fit_curve
     ss_res = float(np.sum(resid ** 2))
     ss_tot = float(np.sum((ycorr - ycorr.mean()) ** 2))
     r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
     rms_over_noise = float(np.sqrt(np.mean(resid ** 2)) / noise)
 
+    stride = 5 if split else 4
     peaks = []
     for i in range(len(centers)):
-        amp, cen, fwhm, eta = popt[4 * i:4 * i + 4]
-        peaks.append({
-            "center": float(cen), "fwhm": float(fwhm), "amplitude": float(amp),
-            "eta": float(eta), "area": _pv_area(amp, fwhm, eta),
-        })
+        params = popt[stride * i:stride * i + stride]
+        if split:
+            amp, cen, fwhm_l, fwhm_r, eta = params
+            fwhm = 0.5 * (fwhm_l + fwhm_r)
+            denom = fwhm_l + fwhm_r
+            entry = {
+                "center": float(cen), "fwhm": float(fwhm), "amplitude": float(amp),
+                "eta": float(eta), "area": _split_pv_area(amp, fwhm_l, fwhm_r, eta),
+                "fwhm_left": float(fwhm_l), "fwhm_right": float(fwhm_r),
+                "asymmetry": float((fwhm_r - fwhm_l) / denom) if denom else 0.0,
+            }
+        else:
+            amp, cen, fwhm, eta = params
+            entry = {
+                "center": float(cen), "fwhm": float(fwhm), "amplitude": float(amp),
+                "eta": float(eta), "area": _pv_area(amp, fwhm, eta),
+            }
+        peaks.append(entry)
     peaks.sort(key=lambda d: d["center"])
 
     return {
@@ -309,4 +373,5 @@ def _fit_corrected(
         "intensity_corrected": [float(v) for v in ycorr],
         "fit_curve": [float(v) for v in fit_curve],
         "noise_estimate": noise,
+        "peak_shape": peak_shape,
     }

--- a/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
+++ b/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
@@ -1,0 +1,312 @@
+"""``fit_pattern`` tool — single global multi-peak pseudo-Voigt fit of a whole
+XRD pattern.
+
+Motivation
+----------
+``fit_profile`` fits one peak (or one overlapping cluster) per window and
+returns a per-window R². Stitching many window fits together leaves every
+*unmodelled* reflection as a large spike in the **global** residual — and the
+curve-fitting agent's verifier judges the global residual, not per-window R².
+On a busy pattern that mismatch drives many rejected refinement iterations.
+
+``fit_pattern`` closes that gap: it detects *all* significant peaks in one pass,
+fits them **simultaneously** as a sum of height-parameterised pseudo-Voigts on a
+linear baseline (background-subtracted first), seeds each amplitude from the
+measured apex so sharp peaks are never clipped, and reports the **global** R²
+plus a residual-RMS-over-noise figure — the same quantities the verifier checks.
+One fast call (~1 s for ~20 peaks over a few-thousand-point scan) typically lands
+a clean global fit on the first attempt.
+
+In-situ series
+--------------
+For a temperature/time ramp, establish the peak list once on a high-SNR frame
+(``auto_detect``), then pass that fixed list back as ``peak_centers`` for every
+subsequent frame. The model stays locked and consistent across the series while
+each frame is still a single fast fit — warm-started, comparable frame to frame.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Sequence
+
+import numpy as np
+from scipy.optimize import curve_fit
+from scipy.signal import find_peaks
+
+from ..._shared._spec import ToolSpec
+from .background import fit_background
+
+_logger = logging.getLogger(__name__)
+
+_FWHM_TO_SIGMA = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2.0)))
+
+
+TOOL_SPEC = ToolSpec(
+    name="fit_pattern",
+    description=(
+        "Global multi-peak pseudo-Voigt fit of a whole XRD pattern in one "
+        "call. Auto-detects all significant peaks (or uses a supplied locked "
+        "list), subtracts background, fits every peak simultaneously on a "
+        "linear baseline with apex-seeded amplitudes, and returns the GLOBAL "
+        "R-squared, residual-RMS-over-noise, and per-peak center/FWHM/height/"
+        "area/eta. Use this for full-pattern fitting and for in-situ series; "
+        "use fit_profile only to drill into a single stubborn cluster."
+    ),
+    import_line="from scilink.skills.curve_fitting.xrd_profile.fit_pattern import fit_pattern",
+    signature=(
+        "fit_pattern(exp_two_theta, exp_intensity, peak_centers=None, "
+        "background='snip', snip_iterations='auto', prominence_frac=0.02, "
+        "max_peaks=30, min_distance_deg=0.15, init_fwhm_deg=0.2, "
+        "center_leeway_deg=0.3, max_fwhm_deg=3.0) -> dict"
+    ),
+    parameters={
+        "exp_two_theta": {"type": "list[float]", "description": "Experimental 2-theta grid (degrees)."},
+        "exp_intensity": {"type": "list[float]", "description": "Raw experimental intensity (same length). Background is handled internally."},
+        "peak_centers": {
+            "type": "list[float] | None",
+            "description": "Fixed peak centers to fit (degrees). None => auto-detect all significant peaks. Pass a locked list to keep the model identical across an in-situ series.",
+        },
+        "background": {"type": "str", "description": "'snip' (default), 'polynomial', or 'none' (data already background-subtracted)."},
+        "snip_iterations": {"type": "int | str", "description": "SNIP iteration count. 'auto' (default) sweeps a few counts and keeps the one with the cleanest residual at the best R² — avoids apex over-subtraction on sharp peaks without hand-tuning. Pass an int to fix it (e.g. reuse the value reported in background_method to skip the sweep on locked series frames)."},
+        "prominence_frac": {"type": "float", "description": "Auto-detect: min peak prominence as a fraction of the corrected pattern range. Default 0.02 (2%). Lower (0.01) to catch weak reflections the verifier may flag as unmodelled residual; raise (0.03) if noise peaks are being fit."},
+        "max_peaks": {"type": "int", "description": "Auto-detect cap. Default 30."},
+        "min_distance_deg": {"type": "float", "description": "Auto-detect: minimum separation between peaks (degrees). Default 0.15."},
+        "init_fwhm_deg": {"type": "float", "description": "Initial FWHM guess per peak (degrees). Default 0.2 (typical CuKa)."},
+        "center_leeway_deg": {"type": "float", "description": "Each center may move +/- this much during the fit (degrees). Default 0.3."},
+        "max_fwhm_deg": {"type": "float", "description": "Upper bound on fitted FWHM (degrees). Default 3.0."},
+    },
+    required=["exp_two_theta", "exp_intensity"],
+    returns=(
+        "dict with 'r_squared' (GLOBAL, over the whole corrected pattern), "
+        "'residual_rms_over_noise' (global residual RMS / estimated point "
+        "noise — the verifier's key statistic; < ~3 is clean), 'n_peaks', "
+        "'peaks' (list of dicts: center, fwhm, amplitude (height), area, eta, "
+        "each sorted by 2-theta), 'peak_centers' (the centers actually fit — "
+        "feed back as the locked list for the next series frame), "
+        "'intensity_corrected', 'fit_curve' (model evaluated on the full grid; "
+        "use for the visualization), 'background_method'."
+    ),
+    when_to_use=(
+        "Default tool for fitting a full XRD pattern and for every frame of an "
+        "in-situ series. Detect peaks once on a strong frame, then pass "
+        "peak_centers to lock the model across the series."
+    ),
+)
+
+
+def _pseudo_voigt(x, amp, cen, fwhm, eta):
+    """Height-parameterised pseudo-Voigt: amp is the peak height; eta in [0,1]
+    mixes Lorentzian (eta=1) and Gaussian (eta=0)."""
+    sigma = fwhm * _FWHM_TO_SIGMA
+    gauss = np.exp(-((x - cen) ** 2) / (2.0 * sigma ** 2))
+    gamma = fwhm / 2.0
+    lorentz = gamma ** 2 / ((x - cen) ** 2 + gamma ** 2)
+    return amp * (eta * lorentz + (1.0 - eta) * gauss)
+
+
+def _multi(x, *p):
+    n = (len(p) - 2) // 4
+    out = p[-2] * x + p[-1]
+    for i in range(n):
+        out = out + _pseudo_voigt(x, *p[4 * i:4 * i + 4])
+    return out
+
+
+def _pv_area(amp, fwhm, eta):
+    g = amp * fwhm * np.sqrt(np.pi / (4.0 * np.log(2.0)))
+    l = amp * fwhm * np.pi / 2.0
+    return float(eta * l + (1.0 - eta) * g)
+
+
+def _detect_centers(x, ycorr, step, prominence_frac, max_peaks, min_distance_deg):
+    """Auto-detect significant peak centers on a background-corrected pattern."""
+    noise = _estimate_noise(ycorr)
+    prom = max(prominence_frac * (ycorr.max() - ycorr.min()), 3.0 * noise)
+    dist = max(1, int(round(min_distance_deg / step)))
+    idx, _ = find_peaks(ycorr, prominence=prom, distance=dist)
+    idx = idx[np.argsort(ycorr[idx])[::-1][:max_peaks]]
+    return sorted(float(x[i]) for i in idx)
+
+
+def _estimate_noise(y):
+    """Robust per-point noise from first differences (MAD estimator).
+    diff of white noise has std sqrt(2)*sigma; MAD->std uses 1.4826."""
+    d = np.diff(y)
+    mad = np.median(np.abs(d - np.median(d)))
+    return float(1.4826 * mad / np.sqrt(2.0)) or 1.0
+
+
+def fit_pattern(
+    exp_two_theta: Sequence[float],
+    exp_intensity: Sequence[float],
+    peak_centers: Optional[Sequence[float]] = None,
+    background: str = "snip",
+    snip_iterations: Any = "auto",
+    prominence_frac: float = 0.02,
+    max_peaks: int = 30,
+    min_distance_deg: float = 0.15,
+    init_fwhm_deg: float = 0.2,
+    center_leeway_deg: float = 0.3,
+    max_fwhm_deg: float = 3.0,
+) -> dict[str, Any]:
+    x = np.asarray(exp_two_theta, dtype=float)
+    y = np.asarray(exp_intensity, dtype=float)
+    if x.shape != y.shape:
+        raise ValueError("exp_two_theta and exp_intensity must have the same length")
+    if x.size < 10:
+        raise ValueError("pattern too short to fit")
+    step = float(np.median(np.diff(x)))
+
+    centers_locked = (
+        [float(c) for c in peak_centers]
+        if peak_centers is not None and len(peak_centers) > 0 else None
+    )
+    fit_kw = dict(
+        prominence_frac=prominence_frac, max_peaks=max_peaks,
+        min_distance_deg=min_distance_deg, init_fwhm_deg=init_fwhm_deg,
+        center_leeway_deg=center_leeway_deg, max_fwhm_deg=max_fwhm_deg,
+    )
+
+    # --- background + fit ---
+    if background == "none":
+        best = _fit_corrected(x, y.copy(), centers_locked, step, **fit_kw)
+        best["background_method"] = "none"
+    elif background == "polynomial":
+        bg = fit_background(x.tolist(), y.tolist(), method="polynomial")
+        ycorr = np.asarray(bg["intensity_corrected"], dtype=float)
+        best = _fit_corrected(x, ycorr, centers_locked, step, **fit_kw)
+        best["background_method"] = "polynomial"
+    elif background == "snip":
+        # SNIP iteration count trades off two ways: too many iterations eat into
+        # the base of SHARP peaks (apex over-subtraction -> the residual spikes
+        # the verifier flags), too few leave broad-background curvature (R²
+        # collapses). The optimum is pattern-dependent, so sweep a few counts
+        # and keep the one that minimises residual-RMS/noise while staying within
+        # 0.01 R² of the best — instead of forcing the agent to hand-tune it.
+        if snip_iterations == "auto":
+            iters_list = [6, 10, 16, 24]
+        else:
+            iters_list = [int(snip_iterations)]
+        # Detect the peak list ONCE on the most-aggressive background so the set
+        # of peaks stays fixed while the sweep varies only the fit background.
+        # (Low-iteration backgrounds leave baseline ripple that would otherwise
+        # inflate the detected peak count.) A caller-supplied list overrides.
+        if centers_locked is None:
+            ref_bg = fit_background(
+                x.tolist(), y.tolist(), method="snip", iterations=max(iters_list))
+            centers_for_sweep = _detect_centers(
+                x, np.asarray(ref_bg["intensity_corrected"], dtype=float), step,
+                prominence_frac, max_peaks, min_distance_deg)
+        else:
+            centers_for_sweep = centers_locked
+        trials = []
+        for it in iters_list:
+            bg = fit_background(x.tolist(), y.tolist(), method="snip", iterations=it)
+            ycorr = np.asarray(bg["intensity_corrected"], dtype=float)
+            try:
+                res = _fit_corrected(x, ycorr, centers_for_sweep, step, **fit_kw)
+            except (RuntimeError, ValueError):
+                continue
+            res["_iters"] = it
+            trials.append(res)
+        if not trials:
+            raise RuntimeError("fit_pattern: no SNIP iteration count converged")
+        # Favour R² first (attempt-1 must clear the acceptance gate, especially
+        # in fast/low-iteration mode); only take a cleaner-residual background
+        # when its R² is within a hair (0.002) of the best, i.e. essentially
+        # free. An earlier 0.01 band over-favoured cleanliness and capped R².
+        best_r2 = max(t["r_squared"] for t in trials)
+        eligible = [t for t in trials if t["r_squared"] >= best_r2 - 0.002]
+        best = min(eligible, key=lambda t: t["residual_rms_over_noise"])
+        best["background_method"] = f"snip(iterations={best.pop('_iters')})"
+    else:
+        raise ValueError(f"Unknown background: {background!r}")
+
+    return best
+
+
+def _fit_corrected(
+    x: np.ndarray,
+    ycorr: np.ndarray,
+    centers_locked: Optional[list],
+    step: float,
+    prominence_frac: float,
+    max_peaks: int,
+    min_distance_deg: float,
+    init_fwhm_deg: float,
+    center_leeway_deg: float,
+    max_fwhm_deg: float,
+) -> dict[str, Any]:
+    """Global multi-peak fit of an already background-corrected pattern."""
+    noise = _estimate_noise(ycorr)
+
+    if centers_locked is not None:
+        centers = list(centers_locked)
+    else:
+        centers = _detect_centers(
+            x, ycorr, step, prominence_frac, max_peaks, min_distance_deg)
+    if not centers:
+        raise ValueError("no peaks detected; lower prominence_frac or pass peak_centers")
+
+    p0, lo, hi, scale = [], [], [], []
+    for c in centers:
+        j = int(np.argmin(np.abs(x - c)))
+        amp0 = max(ycorr[j], noise)
+        p0 += [amp0, c, init_fwhm_deg, 0.5]
+        lo += [0.0, c - center_leeway_deg, max(2.0 * step, 0.02), 0.0]
+        hi += [5.0 * amp0 + 1.0, c + center_leeway_deg, max_fwhm_deg, 1.0]
+        # Per-parameter scale: amplitudes span ~1e5 while centers ~30 and FWHM
+        # ~0.3. Without x_scale the TRF optimiser thrashes (seconds -> minutes
+        # on busy frames). Scale each param by its natural magnitude.
+        scale += [amp0, center_leeway_deg, init_fwhm_deg, 1.0]
+    p0 += [0.0, 0.0]                       # linear baseline slope, intercept
+    lo += [-np.inf, -np.inf]
+    hi += [np.inf, np.inf]
+    scale += [max(amp0, 1.0), max(ycorr.max(), 1.0)]
+
+    try:
+        popt, _ = curve_fit(
+            _multi, x, ycorr, p0=p0, bounds=(lo, hi),
+            x_scale=scale, ftol=1e-4, xtol=1e-4, maxfev=20000,
+        )
+    except (RuntimeError, ValueError) as e:
+        # Last resort: looser convergence so a single hard frame in a series
+        # returns *something* fittable rather than aborting the whole run.
+        try:
+            popt, _ = curve_fit(
+                _multi, x, ycorr, p0=p0, bounds=(lo, hi),
+                x_scale=scale, ftol=1e-2, xtol=1e-2, maxfev=40000,
+            )
+        except (RuntimeError, ValueError):
+            raise RuntimeError(
+                f"fit_pattern failed to converge on {len(centers)} peaks. Try "
+                "fewer peaks (raise prominence_frac) or pass explicit peak_centers."
+            ) from e
+
+    fit_curve = _multi(x, *popt)
+    resid = ycorr - fit_curve
+    ss_res = float(np.sum(resid ** 2))
+    ss_tot = float(np.sum((ycorr - ycorr.mean()) ** 2))
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
+    rms_over_noise = float(np.sqrt(np.mean(resid ** 2)) / noise)
+
+    peaks = []
+    for i in range(len(centers)):
+        amp, cen, fwhm, eta = popt[4 * i:4 * i + 4]
+        peaks.append({
+            "center": float(cen), "fwhm": float(fwhm), "amplitude": float(amp),
+            "eta": float(eta), "area": _pv_area(amp, fwhm, eta),
+        })
+    peaks.sort(key=lambda d: d["center"])
+
+    return {
+        "r_squared": float(r2),
+        "residual_rms_over_noise": rms_over_noise,
+        "n_peaks": len(centers),
+        "peaks": peaks,
+        "peak_centers": [p["center"] for p in peaks],
+        "intensity_corrected": [float(v) for v in ycorr],
+        "fit_curve": [float(v) for v in fit_curve],
+        "noise_estimate": noise,
+    }

--- a/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
+++ b/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
@@ -140,11 +140,11 @@ WAVELENGTH_ANGSTROM = 1.5406  # CuKa1; replace from metadata if available
 INSTRUMENTAL_FWHM_DEG = 0.05  # from LaB6/Si standard; 0.0 if unknown
 
 # ---- Step 2: One global multi-peak fit (background handled inside) ----
+# Let fit_pattern DETECT the peaks (do not hardcode centers): the same call
+# then generalises unchanged to every frame of a series. See "In-situ / series".
 fit = fit_pattern(
     two_theta.tolist(), intensity.tolist(),
     background='snip',          # 'none' if data is already background-subtracted
-    # peak_centers=LOCKED_LIST, # pass a fixed list ONLY within a confirmed
-    #                           # single-phase regime; omit to auto-detect.
 )
 peaks = fit['peaks']            # each: center, fwhm, amplitude, area, eta
 r_squared = fit['r_squared']    # GLOBAL R²
@@ -189,15 +189,23 @@ print("FIT_RESULTS_JSON: " + json.dumps({
 }))
 ```
 
-**In-situ / series use.** `fit_pattern` is one fast call per frame, so it
-drops straight into the agent's per-spectrum series loop. **Auto-detect
-(omit `peak_centers`) is the robust default** — it re-finds peaks on every
-frame, so it survives a phase transition and composes with the agent's
-adaptive-refit path. Pass a fixed `peak_centers` list **only** inside a
-regime you have confirmed is a single stable phase (e.g. tracking thermal
-expansion / line-broadening of one phase), where a locked peak set buys
-frame-to-frame parameter consistency. Do **not** lock one list across a
-reaction or transition — the peaks themselves change.
+**In-situ / series use — lock the method, not the values.** `fit_pattern` is
+one fast call per frame, so it drops straight into the agent's per-spectrum
+series loop. The locked series script **must call `fit_pattern` with
+`peak_centers=None` (auto-detect)** — lock the *recipe* (the `fit_pattern` call
+and its settings), never a hardcoded list of peak centers. Auto-detect re-finds
+the peaks on every frame, so the one script follows peak shifts (thermal
+expansion), intensity changes (phase fraction), and appearance/disappearance,
+and composes with the agent's regime-segmentation and adaptive-refit paths. A
+**value-locked** script — hardcoded `SEED_CENTERS` / an explicit `peak_centers`
+list frozen from frame 1 — does **not** generalise: centers drift out of their
+windows even within one phase, and break entirely across a reaction or
+transition (measured: a list locked from a post-transition frame scored
+R²≈0.5–0.7 on pre-transition frames). Frame-to-frame **consistency comes from
+the identical method plus aligning the detected peaks across frames in
+interpretation, not from frozen centers.** Only pass an explicit `peak_centers`
+for a one-off re-fit of a single known-stable pattern — never as the series
+default.
 
 For speed across a long series: the default `snip_iterations='auto'` sweeps
 a few background widths per frame (~4× the fit cost). Once the establishing
@@ -205,10 +213,19 @@ frame reports its choice (in `background_method`, e.g. `snip(iterations=10)`),
 pass that integer as `snip_iterations` on the remaining frames to skip the
 sweep — back to ~1 s/frame with the same background treatment.
 
-**Drilling into a stubborn cluster.** `fit_pattern` resolves most overlaps,
-but for a tight doublet that the global fit smears, refit just that window
-with `fit_profile(peak_init=[c1, c2])` (joint two-component fit) and splice
-the result back.
+**Unresolved doublet? Tune detection, don't drill.** `fit_pattern` already
+fits all peaks jointly with an asymmetric (split pseudo-Voigt) shape, so it
+resolves overlaps and peak asymmetry in one consistent global model. If a tight
+doublet is smeared because auto-detect merged it, fix it the **method-locked**
+way: lower `min_distance_deg` (so closely-spaced maxima are detected separately)
+and/or lower `prominence_frac` (so the weaker partner is found) — these stay
+generalisable across a series because the recipe still auto-detects per frame.
+Do **not** splice in a separate `fit_profile` window fit: `fit_profile` uses a
+*symmetric* profile, so its result conflicts with the global split-PV fit and
+reintroduces exactly the asymmetric residual the global model removed (this
+drives avoidable verifier iterations). Reserve `fit_profile` only for one-off
+inspection of a single peak
+outside the main fit.
 
 **NumPy compatibility.** Use `np.trapezoid` (not removed `np.trapz`).
 
@@ -260,14 +277,18 @@ refined FWHMs from this skill can be passed in to sharpen the scoring.
 
 ## validation
 
-**Know when the fit is done.** Once the global R² ≥ ~0.99 and every visible
-reflection is modelled (no *unmodelled*-peak spikes in the residual), residual
-that remains concentrated at the apex of the few sharpest, highest-count peaks
-is the expected limit of a single symmetric pseudo-Voigt — accept it rather
-than spending refinement iterations chasing it. Re-fitting an already-resolved
-single peak with a narrower `fit_profile` window typically *worsens* the global
-fit; reserve `fit_profile` drilling for genuinely unresolved overlapping
-doublets, not for sharp peaks the global fit already captures.
+**Know when the fit is done.** `fit_pattern`'s default split (asymmetric)
+pseudo-Voigt already captures sharp-peak asymmetry, so once the global R² ≥ ~0.99
+and every visible reflection is modelled (no *unmodelled*-peak spikes in the
+residual), small residual at the apex of the few sharpest, highest-count peaks
+is the irreducible profile limit — accept it rather than spending refinement
+iterations chasing it. Do **not** re-fit individual peaks with a symmetric
+`fit_profile` window: it conflicts with the global split-PV model and
+reintroduces asymmetric residual, *worsening* the fit and adding iterations. If a
+peak is genuinely missing, lower `prominence_frac` (and/or `min_distance_deg`) so
+auto-detect catches it and re-run the single global `fit_pattern` — keep the
+recipe auto-detecting (so it still generalises frame-to-frame), not spliced
+sub-fits or hardcoded centers.
 
 **Per-peak fit checks:**
 - `r_squared` ≥ 0.95 for each fit accepts; 0.85–0.95 marginal; below

--- a/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
+++ b/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
@@ -36,6 +36,12 @@ orientation correction; whole-pattern Le Bail fitting.
 
 ## planning
 
+**Default mechanism: global full-pattern fit.** Plan for a single
+`fit_pattern` call that detects and fits all significant peaks at once
+(background subtraction included), not a per-peak `fit_profile` loop. The
+points below shape *that* fit — how many peaks matter, when Williamson-Hall
+is admissible, which background — rather than a peak-by-peak procedure.
+
 **How many peaks to fit:**
 - Scherrer alone: 3–5 strongest, well-isolated peaks is enough — report
   size per peak and the mean.
@@ -95,33 +101,35 @@ for nanocrystalline patterns with peaks several times broader than the
 
 ## implementation
 
-**CRITICAL: profile fitting workflow.** The per-item analysis script
-must follow this sequence:
+**Default path: one global fit with `fit_pattern`.** Prefer `fit_pattern`
+over a per-peak `fit_profile` loop. It detects *all* significant peaks in
+one pass and fits them **simultaneously** on a shared baseline, so the
+reported R² and residual are **global** (over the whole pattern) — the same
+quantity the verifier judges. A per-peak loop reports per-window R², which
+hides every unmodelled reflection as a global-residual spike and triggers
+avoidable refinement iterations. `fit_pattern` seeds each amplitude from the
+measured apex (sharp peaks are never clipped) and scales parameters
+internally, so a busy pattern fits in ~1 s.
+
+**CRITICAL workflow:**
 
 1. Load experimental 2θ + intensity arrays.
-2. Subtract background via `fit_background`.
-3. Detect candidate peak centers via `extract_peaks` (reused from
-   `structure_matching/xrd`) — this gives a starting list to fit.
-4. For each peak, fit a pseudo-Voigt via `fit_profile` on a window
-   around the center.
-5. Per-peak Scherrer crystallite size via `scherrer`.
-6. If ≥ 5 peaks span a useful 2θ range, run `williamson_hall` for
-   size + strain.
-7. Emit `FIT_RESULTS_JSON: {...}` with per-peak results + aggregated
-   metrics (mean per-peak R², Scherrer mean, W-H size/strain).
+2. `fit_pattern` (handles background + detection + global fit in one call).
+3. Per-peak Scherrer crystallite size via `scherrer` on the returned FWHMs.
+4. If ≥ 5 peaks span a useful 2θ range, run `williamson_hall`.
+5. Emit `FIT_RESULTS_JSON: {...}` carrying the **global** R² from
+   `fit_pattern` (not a mean of per-window R²s) plus per-peak results.
 
-**Complete profile-fitting template:**
+**Complete full-pattern template:**
 
 ```python
 import json
 import numpy as np
 
 from scilink.skills._shared.curve_fitting_tools import load_curve_data
-from scilink.skills.curve_fitting.xrd_profile.background import fit_background
-from scilink.skills.curve_fitting.xrd_profile.fit_profile import fit_profile
+from scilink.skills.curve_fitting.xrd_profile.fit_pattern import fit_pattern
 from scilink.skills.curve_fitting.xrd_profile.scherrer import scherrer
 from scilink.skills.curve_fitting.xrd_profile.williamson_hall import williamson_hall
-from scilink.skills.structure_matching.xrd.extract_peaks import extract_peaks
 
 # ---- Step 1: Load ----
 data = load_curve_data(DATA_PATH)  # ndarray with X in col 0, Y in col 1
@@ -131,83 +139,76 @@ intensity = np.asarray(data[:, 1], dtype=float)
 WAVELENGTH_ANGSTROM = 1.5406  # CuKa1; replace from metadata if available
 INSTRUMENTAL_FWHM_DEG = 0.05  # from LaB6/Si standard; 0.0 if unknown
 
-# ---- Step 2: Background subtraction ----
-bg = fit_background(two_theta.tolist(), intensity.tolist(), method='snip')
-intensity_sub = np.asarray(bg['intensity_corrected'], dtype=float)
-
-# ---- Step 3: Seed peak list ----
-seed = extract_peaks(
-    two_theta.tolist(), intensity_sub.tolist(),
-    prominence_frac=0.02, max_peaks=10,
+# ---- Step 2: One global multi-peak fit (background handled inside) ----
+fit = fit_pattern(
+    two_theta.tolist(), intensity.tolist(),
+    background='snip',          # 'none' if data is already background-subtracted
+    # peak_centers=LOCKED_LIST, # pass a fixed list ONLY within a confirmed
+    #                           # single-phase regime; omit to auto-detect.
 )
-peak_centers = seed['positions']
+peaks = fit['peaks']            # each: center, fwhm, amplitude, area, eta
+r_squared = fit['r_squared']    # GLOBAL R²
 
-# ---- Step 4: Per-peak pseudo-Voigt fit ----
-fits = []
-for center in peak_centers:
-    result = fit_profile(
-        exp_two_theta=two_theta.tolist(),
-        exp_intensity=intensity_sub.tolist(),
-        peak_init=center,
-        model='pseudo_voigt',
-        window_deg=1.0,
-        background='linear',  # residual baseline inside the window
-    )
-    fits.append(result)
-
-# ---- Step 5: Per-peak Scherrer size ----
+# ---- Step 3: Per-peak Scherrer size ----
 sizes_nm = []
-for f in fits:
-    if f['r_squared'] < 0.9:
-        continue  # don't trust Scherrer on a bad fit
+for p in peaks:
     s = scherrer(
-        fwhm_deg=f['fwhm'],
-        two_theta_deg=f['center'],
+        fwhm_deg=p['fwhm'],
+        two_theta_deg=p['center'],
         wavelength_angstrom=WAVELENGTH_ANGSTROM,
         instrumental_fwhm_deg=INSTRUMENTAL_FWHM_DEG,
     )
     sizes_nm.append(s['size_nm'])
 mean_size_nm = float(np.mean(sizes_nm)) if sizes_nm else None
 
-# ---- Step 6: Williamson-Hall (optional) ----
-wh_input = [
-    {'two_theta': f['center'], 'fwhm': f['fwhm']}
-    for f in fits if f['r_squared'] >= 0.9
-]
-wh = None
-if len(wh_input) >= 5:
-    wh = williamson_hall(
-        peaks=wh_input,
-        wavelength_angstrom=WAVELENGTH_ANGSTROM,
-        instrumental_fwhm_deg=INSTRUMENTAL_FWHM_DEG,
-    )
+# ---- Step 4: Williamson-Hall (optional) ----
+wh_input = [{'two_theta': p['center'], 'fwhm': p['fwhm']} for p in peaks]
+wh = williamson_hall(
+    peaks=wh_input,
+    wavelength_angstrom=WAVELENGTH_ANGSTROM,
+    instrumental_fwhm_deg=INSTRUMENTAL_FWHM_DEG,
+) if len(wh_input) >= 5 else None
 
-# ---- Step 7: Emit ----
-mean_r2 = float(np.mean([f['r_squared'] for f in fits])) if fits else 0.0
+# ---- Step 5: Emit ----
 print("FIT_RESULTS_JSON: " + json.dumps({
     "peaks": [
-        {k: f[k] for k in ('center', 'fwhm', 'amplitude', 'eta', 'r_squared')}
-        for f in fits
+        {k: p[k] for k in ('center', 'fwhm', 'amplitude', 'area', 'eta')}
+        for p in peaks
     ],
     "scherrer_mean_size_nm": mean_size_nm,
     "scherrer_per_peak_nm": sizes_nm,
     "williamson_hall": wh,
     "fit_quality": {
-        "r_squared": mean_r2,
-        "verdict": "accept" if mean_r2 >= 0.95 else (
-            "marginal" if mean_r2 >= 0.85 else "reject"
+        "r_squared": r_squared,                       # GLOBAL
+        "residual_rms_over_noise": fit['residual_rms_over_noise'],
+        "verdict": "accept" if r_squared >= 0.95 else (
+            "marginal" if r_squared >= 0.85 else "reject"
         ),
-        "n_peaks_fitted": len(fits),
-        "n_peaks_used_for_scherrer": len(sizes_nm),
+        "n_peaks_fitted": fit['n_peaks'],
     },
 }))
 ```
 
-**Joint fitting for overlapping peaks.** When `fit_profile` returns
-`r_squared < 0.9` and the residual shows a shoulder on one side of the
-peak, refit that window with two pseudo-Voigt components by passing
-`peak_init=[center1, center2]` (list of two starting centers). The tool
-constructs a composite model.
+**In-situ / series use.** `fit_pattern` is one fast call per frame, so it
+drops straight into the agent's per-spectrum series loop. **Auto-detect
+(omit `peak_centers`) is the robust default** — it re-finds peaks on every
+frame, so it survives a phase transition and composes with the agent's
+adaptive-refit path. Pass a fixed `peak_centers` list **only** inside a
+regime you have confirmed is a single stable phase (e.g. tracking thermal
+expansion / line-broadening of one phase), where a locked peak set buys
+frame-to-frame parameter consistency. Do **not** lock one list across a
+reaction or transition — the peaks themselves change.
+
+For speed across a long series: the default `snip_iterations='auto'` sweeps
+a few background widths per frame (~4× the fit cost). Once the establishing
+frame reports its choice (in `background_method`, e.g. `snip(iterations=10)`),
+pass that integer as `snip_iterations` on the remaining frames to skip the
+sweep — back to ~1 s/frame with the same background treatment.
+
+**Drilling into a stubborn cluster.** `fit_pattern` resolves most overlaps,
+but for a tight doublet that the global fit smears, refit just that window
+with `fit_profile(peak_init=[c1, c2])` (joint two-component fit) and splice
+the result back.
 
 **NumPy compatibility.** Use `np.trapezoid` (not removed `np.trapz`).
 
@@ -258,6 +259,15 @@ crystal phase has not yet been identified, recommend running
 refined FWHMs from this skill can be passed in to sharpen the scoring.
 
 ## validation
+
+**Know when the fit is done.** Once the global R² ≥ ~0.99 and every visible
+reflection is modelled (no *unmodelled*-peak spikes in the residual), residual
+that remains concentrated at the apex of the few sharpest, highest-count peaks
+is the expected limit of a single symmetric pseudo-Voigt — accept it rather
+than spending refinement iterations chasing it. Re-fitting an already-resolved
+single peak with a narrower `fit_profile` window typically *worsens* the global
+fit; reserve `fit_profile` drilling for genuinely unresolved overlapping
+doublets, not for sharp peaks the global fit already captures.
 
 **Per-peak fit checks:**
 - `r_squared` ≥ 0.95 for each fit accepts; 0.85–0.95 marginal; below

--- a/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
+++ b/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
@@ -1,5 +1,5 @@
 ---
-description: p-XRD profile fitting — per-peak pseudo-Voigt fits with FWHM, position, and intensity; Scherrer crystallite size and Williamson-Hall microstrain from the fitted line widths.
+description: 'p-XRD profile fitting — the quantitative follow-up to phase identification: per-peak pseudo-Voigt fits (position, intensity, FWHM), Scherrer crystallite size and Williamson-Hall microstrain, and a Rietveld tier (phase fractions / accurate lattice; engine pending) that refines against the identified-phase CIF.'
 technique: [XRD, "X-ray diffraction", "powder diffraction", pXRD]
 quality_gate:
   metric: r_squared
@@ -11,30 +11,56 @@ quality_gate:
 
 ## overview
 
-Powder X-ray diffraction profile fitting for line-broadening physics.
-Per-peak pseudo-Voigt fits yield calibrated peak positions, intensities,
-and full widths at half maximum (FWHMs). Those widths then feed two
-classical analyses:
+Powder X-ray diffraction profile fitting — **the quantitative follow-up to
+phase identification.** You normally arrive here *after* `structure_matching/
+xrd` has answered "what phase(s) is this?": the identified phase(s) and their
+reference CIF(s) are the prior this skill builds on. (It also runs standalone
+when the phase is already known.)
 
-- **Scherrer equation** for an average crystallite (coherent domain) size
-  from any single peak's broadening:
-  `D = K · λ / (β · cos θ)`.
-- **Williamson-Hall (W-H) plot** for separating size and strain
-  contributions from the 2θ dependence of broadening:
-  `β · cos θ = K · λ / D + 4 · ε · sin θ`.
+The skill is organized as three **depth tiers** — go only as deep as the
+question demands:
 
-This skill is the *profile* half of p-XRD analysis. The *identification*
-half — matching observed peaks to a candidate crystal phase — lives in
-the separate `structure_matching/xrd` skill. The two are designed to be
-co-activated: pass `skill=["xrd", "xrd_profile"]` and the LLM can chain
-profile fitting + phase identification in one analysis script.
+1. **Per-peak profile fit (default).** A global multi-peak (split) pseudo-Voigt
+   fit (`fit_pattern`) yields calibrated peak positions, intensities, and full
+   widths at half maximum (FWHMs). The identified phase's reference peak
+   positions are a strong prior for *which* reflections to expect.
+2. **Microstructure — size & strain.** The fitted FWHMs feed two classical
+   line-broadening analyses:
+   - **Scherrer** — average crystallite (coherent domain) size from a single
+     peak's broadening: `D = K · λ / (β · cos θ)`.
+   - **Williamson-Hall** — separates size and strain from the 2θ dependence of
+     broadening: `β · cos θ = K · λ / D + 4 · ε · sin θ`.
+3. **Rietveld refinement (deepest; engine pending).** Whole-pattern refinement
+   against the matched CIF for quantitative phase fractions (QPA), accurate
+   lattice parameters, and site occupancies. True Rietveld needs a dedicated
+   engine (GSAS-II) — see *planning* for the seam. Tiers 1–2 are always
+   available; tier 3 is a documented escalation, not yet wired.
 
-**Out of scope:** Rietveld refinement (atomic positions / occupancies);
-quantitative phase-fraction analysis (covered in
-`structure_matching/xrd`'s multi-phase MIP path); texture / preferred
-orientation correction; whole-pattern Le Bail fitting.
+Frame the work as: **identify (upstream) → profile-fit (here) → escalate to
+Rietveld only when phase fractions / accurate cell / occupancies are the actual
+deliverable.** Most follow-ups stop at tier 1 or 2.
+
+When both skills are co-activated (`skill=["xrd", "xrd_profile"]`) the LLM can
+chain identification and profile fitting in one script; the sequential
+"identify first, then this" framing above is the same pipeline, just split
+across calls.
+
+**Out of scope:** texture / preferred-orientation correction; whole-pattern
+Le Bail fitting. (Rietveld and quantitative phase fractions are **tier 3
+above**, not out of scope — the structural model comes from the upstream ID
+match; only the refinement *engine* is a pending GSAS-II seam.)
 
 ## planning
+
+**You usually arrive here with an identified phase — use it as a prior.** When
+`structure_matching/xrd` ran first, its result shapes this fit: the matched
+phase's reference peak positions tell you *which* reflections to expect (a
+sanity check on auto-detect, and a seed for a one-off single-pattern refine),
+and the matched CIF is the structural model a tier-3 Rietveld refine needs. Do
+**not** freeze those reference positions into a series script, though — for a
+series keep `fit_pattern` auto-detecting (see "In-situ / series"); the ID tells
+you the *phase*, not frozen centers. If no ID was run and the phase is already
+known, proceed standalone.
 
 **Default mechanism: global full-pattern fit.** Plan for a single
 `fit_pattern` call that detects and fits all significant peaks at once
@@ -98,6 +124,21 @@ FWHMs as `exp_peaks={'positions': [...], 'amplitudes': [...],
 broadening per peak instead of the default uniform FWHM, which matters
 for nanocrystalline patterns with peaks several times broader than the
 0.15° default.
+
+**Escalating to Rietveld (tier 3).** Reach for Rietveld only when the
+deliverable is **quantitative phase fractions (QPA), accurate refined lattice
+parameters, or site occupancies** — not for size/strain, which tiers 1–2 cover.
+Rietveld refines the *whole pattern* against a structural model, so it requires
+the matched CIF from the upstream identification as the starting model (another
+reason ID comes first). True Rietveld is **not** in pymatgen; it needs a
+dedicated engine — GSAS-II via `GSASIIscriptable`. That plugs in through the
+same pluggable-engine pattern already established for simulation
+(`structure_matching/xrd/simulate_xrd.py`'s `_ENGINES` registry): a
+`refine_rietveld(cif, exp_data, ...)` tool behind a lazy import + optional
+`gsas` extra, leaving downstream scoring/reporting unaffected. **Until that
+engine is wired, do not attempt a whole-pattern refine with the kinematic
+tools** — report tiers 1–2 and recommend Rietveld as the explicit next step,
+naming the matched CIF as the model to refine.
 
 ## implementation
 

--- a/scilink/skills/structure_matching/_backends/cod.py
+++ b/scilink/skills/structure_matching/_backends/cod.py
@@ -66,6 +66,25 @@ def _formula_elements(formula: Optional[str]) -> set[str]:
     return elements
 
 
+def _formula_natoms(formula: Optional[str]) -> float:
+    """Total atom count of a COD (reduced) formula string — a structural-
+    simplicity proxy: TiO2 -> 3, Ti9O17 -> 26. Used as a RETRIEVAL tiebreaker so
+    the simplest stoichiometry consistent with the requested chemistry (the most
+    common phase, by an Occam prior) is offered ahead of complex same-composition
+    phases — e.g. anatase/rutile (TiO2) before the Magnéli suboxides (TinO2n-1),
+    which COD's id order otherwise buries. The scorer + widen-on-failure recover
+    genuinely complex phases. Unknown/empty -> inf so it sorts last."""
+    if not formula:
+        return float("inf")
+    total = 0.0
+    for tok in formula.replace("-", " ").split():
+        m = _ELEMENT_TOKEN.match(tok)
+        if m:
+            cnt = tok[len(m.group(1)):]
+            total += float(cnt) if cnt else 1.0
+    return total if total > 0 else float("inf")
+
+
 class CODBackend:
     name = "cod"
 
@@ -151,10 +170,12 @@ class CODBackend:
             if not wanted.issubset(els):
                 continue
             extra = len(els - wanted)
-            scored.append((extra, cid, formula, sg, sg_number))
-        # Tightest composition first (exact match before supersets).
-        scored.sort(key=lambda t: (t[0], t[1]))
-        return [(cid, formula, sg, sg_number) for _, cid, formula, sg, sg_number in scored]
+            scored.append((extra, _formula_natoms(formula), cid, formula, sg, sg_number))
+        # Tightest composition first (exact match before supersets), then
+        # simplest stoichiometry (common phase before complex same-composition),
+        # then id for stability.
+        scored.sort(key=lambda t: (t[0], t[1], t[2]))
+        return [(cid, formula, sg, sg_number) for _, _, cid, formula, sg, sg_number in scored]
 
     def _search_web(self, wanted: set[str], spec: QuerySpec) -> list[tuple]:
         """COD REST element search (no local db). Same vetted domain; returns
@@ -189,11 +210,12 @@ class CODBackend:
                         continue
                 except (TypeError, ValueError):
                     continue
-            scored.append((len(els - wanted), cid, formula, row.get("sg"), sg_number))
+            scored.append((len(els - wanted), _formula_natoms(formula), cid, formula, row.get("sg"), sg_number))
             if len(scored) >= 2000:
                 break
-        scored.sort(key=lambda t: (t[0], t[1]))
-        return [(cid, formula, sg, sg_number) for _, cid, formula, sg, sg_number in scored]
+        # Tightest composition, then simplest stoichiometry, then id.
+        scored.sort(key=lambda t: (t[0], t[1], t[2]))
+        return [(cid, formula, sg, sg_number) for _, _, cid, formula, sg, sg_number in scored]
 
     def _load_structure(self, cid: int):
         cif = self._locate_cif(cid)

--- a/scilink/skills/structure_matching/_backends/cod.py
+++ b/scilink/skills/structure_matching/_backends/cod.py
@@ -1,22 +1,237 @@
-"""Crystallography Open Database backend (stub).
+"""Crystallography Open Database (COD) backend.
 
-COD has a REST API and no authentication requirement. Implementation is
-deferred — the stub exists so the dispatch loop and registry behave the
-same way they will once COD is wired in.
+Queries a local COD SQLite *metadata* snapshot (e.g. ``cod-YYYYMMDD.db3``, the
+single ``data`` table of cell / space-group / formula columns keyed by COD id)
+for candidate structures by chemistry, then materializes each structure's CIF —
+from a local COD CIF archive (``SCILINK_COD_CIF_DIR``, preferred: offline, fast,
+reproducible) or the COD website (fallback). COD is the right source for the
+organic / metal-organic / molecular crystals that the inorganic-DFT databases
+(Materials Project) do not contain.
+
+CIFs are read from a LOCAL COD archive when available (offline, fast,
+reproducible) and otherwise fetched from the COD website. The web fetch is a
+SAFE, narrow operation — NOT arbitrary web browsing: the URL is hardcoded to the
+vetted crystallography.net domain and the only variable is a numeric COD id
+taken from the local db's integer primary key (no injection / no arbitrary
+URLs), and each CIF is a ~10 KB text file. It is therefore enabled by default;
+set SCILINK_COD_ALLOW_WEB=0 to force fully-offline (local-archive-only) operation.
+
+Configuration (env vars):
+  SCILINK_COD_DB        path to the COD SQLite metadata db (required).
+  SCILINK_COD_CIF_DIR   local CIF archive root (preferred CIF source). CIFs are
+                        read here by COD-hashed layout d1/d2d3/d4d5/<id>.cif,
+                        flat <id>.cif, or any <id>.cif under the tree.
+  SCILINK_COD_ALLOW_WEB '0'/'false' disables the crystallography.net fallback
+                        (default on). Use for air-gapped runs with a local
+                        archive.
 """
 
 from __future__ import annotations
 
+import logging
+import os
+import re
+import sqlite3
+import tempfile
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
 from ._base import QuerySpec, StructureCandidate
+
+try:
+    from pymatgen.core import Structure
+    PYMATGEN_AVAILABLE = True
+except ImportError:
+    Structure = None  # type: ignore
+    PYMATGEN_AVAILABLE = False
+
+_logger = logging.getLogger(__name__)
+
+# A COD formula is space-delimited element+count tokens, e.g. "- C6 H10 Au Cl4 N3 -".
+# Counts can be fractional (occupancy/Z averaging), e.g. "H145.17", "Na0.67".
+_ELEMENT_TOKEN = re.compile(r"^([A-Z][a-z]?)[\d.]*$")
+_COD_CIF_URL = "https://www.crystallography.net/cod/{cid}.cif"
+
+
+def _formula_elements(formula: Optional[str]) -> set[str]:
+    """Element symbols in a COD formula string (count suffixes stripped)."""
+    if not formula:
+        return set()
+    elements: set[str] = set()
+    for tok in formula.replace("-", " ").split():
+        m = _ELEMENT_TOKEN.match(tok)
+        if m:
+            elements.add(m.group(1))
+    return elements
 
 
 class CODBackend:
     name = "cod"
 
+    def __init__(self, db_path: Optional[str] = None, cif_dir: Optional[str] = None,
+                 allow_web: Optional[bool] = None):
+        self.db_path = db_path or os.getenv("SCILINK_COD_DB")
+        self.cif_dir = cif_dir or os.getenv("SCILINK_COD_CIF_DIR")
+        if allow_web is None:
+            # Default ON: a CIF fetch from the vetted, domain-locked COD site by
+            # numeric id is a safe small-file download. Opt out for air-gapped.
+            allow_web = os.getenv("SCILINK_COD_ALLOW_WEB", "1").lower() not in ("0", "false", "no")
+        self.allow_web = allow_web
+        self._cache_dir = Path(tempfile.gettempdir()) / "scilink_cod_cifs"
+
+    def _has_local_db(self) -> bool:
+        return bool(self.db_path) and Path(self.db_path).is_file()
+
     def is_available(self) -> bool:
-        return False
+        # Usable with EITHER a local metadata db OR (vetted) web search — a user
+        # without the ~1 GB db can still search COD online.
+        return PYMATGEN_AVAILABLE and (self._has_local_db() or self.allow_web)
 
     def query(self, spec: QuerySpec) -> list[StructureCandidate]:
-        raise NotImplementedError(
-            "CODBackend is a v1 stub. See plan: implementation deferred."
-        )
+        if not self.is_available():
+            return []
+        wanted = {e for e in spec.chemistry}
+        if not wanted:
+            return []
+
+        # Prefer the local db (fast, offline); fall back to COD's REST search
+        # when there is no db.
+        if self._has_local_db():
+            rows = self._search_db(wanted, spec)
+        else:
+            rows = self._search_web(wanted, spec)
+        candidates: list[StructureCandidate] = []
+        for cid, formula, sg, sg_number in rows:
+            struct = self._load_structure(int(cid))
+            if struct is None:
+                continue
+            extra = len(_formula_elements(formula) - wanted)
+            candidates.append(StructureCandidate(
+                id=str(cid),
+                source="cod",
+                formula=(formula or "").strip("- ").strip(),
+                space_group=sg,
+                metadata={
+                    "_structure": struct,
+                    "spacegroup_number": sg_number,
+                    "extra_elements": extra,
+                },
+                # No formation energy in COD; prefer the tightest composition
+                # match (fewest elements beyond those requested).
+                rank_score=1.0 / (1.0 + extra),
+            ))
+            if len(candidates) >= int(spec.top_n):
+                break
+        return candidates
+
+    # -- internals ---------------------------------------------------------
+
+    def _search_db(self, wanted: set[str], spec: QuerySpec) -> list[tuple]:
+        """SQL pre-filter (substring LIKE per element — loose for short symbols
+        like C/N) then Python post-filter on the exact element set, so e.g. a
+        request for C does not leak Cl/Ca/Cu entries."""
+        con = sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True)
+        try:
+            where = " AND ".join("formula LIKE ?" for _ in wanted)
+            params: list = [f"%{e}%" for e in wanted]
+            sql = f"SELECT file, formula, sg, sgNumber FROM data WHERE {where}"
+            if spec.space_group_hints:
+                sql += " AND sgNumber IN (%s)" % ",".join("?" * len(spec.space_group_hints))
+                params += [int(s) for s in spec.space_group_hints]
+            # Pull a generous pre-filter set; the exact-set filter prunes it.
+            sql += " LIMIT 4000"
+            raw = con.execute(sql, params).fetchall()
+        finally:
+            con.close()
+
+        scored: list[tuple] = []
+        for cid, formula, sg, sg_number in raw:
+            els = _formula_elements(formula)
+            if not wanted.issubset(els):
+                continue
+            extra = len(els - wanted)
+            scored.append((extra, cid, formula, sg, sg_number))
+        # Tightest composition first (exact match before supersets).
+        scored.sort(key=lambda t: (t[0], t[1]))
+        return [(cid, formula, sg, sg_number) for _, cid, formula, sg, sg_number in scored]
+
+    def _search_web(self, wanted: set[str], spec: QuerySpec) -> list[tuple]:
+        """COD REST element search (no local db). Same vetted domain; returns
+        the same (id, formula, sg, sgNumber) rows as the local-db path."""
+        import json
+        import urllib.parse
+        params = [(f"el{i}", el) for i, el in enumerate(sorted(wanted), 1)]
+        params.append(("format", "json"))
+        url = "https://www.crystallography.net/cod/result?" + urllib.parse.urlencode(params)
+        try:
+            with urllib.request.urlopen(url, timeout=30) as resp:
+                data = json.load(resp)
+        except Exception as exc:
+            _logger.debug("COD REST search failed: %s", exc)
+            return []
+
+        scored: list[tuple] = []
+        hints = set(int(s) for s in spec.space_group_hints) if spec.space_group_hints else None
+        for row in data:
+            try:
+                cid = int(row["file"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            formula = row.get("formula")
+            els = _formula_elements(formula)
+            if not wanted.issubset(els):
+                continue
+            sg_number = row.get("sgNumber")
+            if hints is not None:
+                try:
+                    if int(sg_number) not in hints:
+                        continue
+                except (TypeError, ValueError):
+                    continue
+            scored.append((len(els - wanted), cid, formula, row.get("sg"), sg_number))
+            if len(scored) >= 2000:
+                break
+        scored.sort(key=lambda t: (t[0], t[1]))
+        return [(cid, formula, sg, sg_number) for _, cid, formula, sg, sg_number in scored]
+
+    def _load_structure(self, cid: int):
+        cif = self._locate_cif(cid)
+        if cif is None:
+            return None
+        try:
+            return Structure.from_file(str(cif))
+        except Exception as exc:
+            _logger.debug("COD %s CIF unparsable: %s", cid, exc)
+            return None
+
+    def _locate_cif(self, cid: int) -> Optional[Path]:
+        sid = str(cid)
+        # 1. Local archive (preferred).
+        if self.cif_dir:
+            root = Path(self.cif_dir)
+            # COD hashed layout: d1/d2d3/d4d5/<id>.cif
+            if len(sid) == 7:
+                hashed = root / sid[0] / sid[1:3] / sid[3:5] / f"{sid}.cif"
+                if hashed.is_file():
+                    return hashed
+            flat = root / f"{sid}.cif"
+            if flat.is_file():
+                return flat
+            hits = list(root.rglob(f"{sid}.cif"))
+            if hits:
+                return hits[0]
+        # 2. COD web fallback (vetted domain, numeric id, ~10 KB file). On by
+        # default; disabled for air-gapped runs.
+        if not self.allow_web:
+            return None
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        cached = self._cache_dir / f"{sid}.cif"
+        if cached.is_file():
+            return cached
+        try:
+            urllib.request.urlretrieve(_COD_CIF_URL.format(cid=sid), cached)
+            return cached
+        except Exception as exc:
+            _logger.debug("COD %s CIF fetch failed: %s", cid, exc)
+            return None

--- a/scilink/skills/structure_matching/xrd/score_match_fast.py
+++ b/scilink/skills/structure_matching/xrd/score_match_fast.py
@@ -15,7 +15,7 @@ import logging
 from typing import Any, Sequence
 
 import numpy as np
-from scipy.signal import correlate
+from scipy.signal import correlate, find_peaks, peak_widths
 
 from ..._shared._spec import ToolSpec
 
@@ -39,7 +39,7 @@ TOOL_SPEC = ToolSpec(
     import_line="from scilink.skills.structure_matching.xrd.score_match_fast import score_xrd_match_fast",
     signature=(
         "score_xrd_match_fast(exp_two_theta, exp_intensity, sim_two_theta, "
-        "sim_intensity, fwhm=0.15, shift_search=(-0.5, 0.5), "
+        "sim_intensity, fwhm='auto', shift_search=(-0.5, 0.5), "
         "scale_search=(0.99, 1.01, 0.0025), background='subtract_min') -> dict"
     ),
     parameters={
@@ -60,8 +60,13 @@ TOOL_SPEC = ToolSpec(
             "description": "Simulated peak intensities (relative) from simulate_xrd_pattern.",
         },
         "fwhm": {
-            "type": "float",
-            "description": "Lorentzian FWHM (degrees) for broadening simulated peaks. Default 0.15.",
+            "type": "float | str",
+            "description": (
+                "Lorentzian FWHM (degrees) for broadening simulated peaks. "
+                "Default 'auto' estimates it from the experimental peak widths "
+                "(floored at 0.15°), so broad nanocrystalline patterns match "
+                "without manual tuning; pass a number to force an exact width."
+            ),
         },
         "shift_search": {
             "type": "tuple",
@@ -96,7 +101,7 @@ def score_xrd_match_fast(
     exp_intensity: Sequence[float],
     sim_two_theta: Sequence[float],
     sim_intensity: Sequence[float],
-    fwhm: float = 0.15,
+    fwhm: float | str = "auto",
     shift_search: tuple = (-0.5, 0.5),
     scale_search: tuple | None = (0.98, 1.02, 0.002),
     background: str = "subtract_min",
@@ -113,16 +118,6 @@ def score_xrd_match_fast(
         raise ValueError("sim_two_theta and sim_intensity must have the same length")
     if exp_x.size < 16:
         raise ValueError("exp_two_theta must contain at least 16 points for cross-correlation")
-    if fwhm <= 0:
-        raise ValueError("fwhm must be positive")
-    if sim_x.size == 0:
-        return {
-            "correlation": 0.0,
-            "fitted_shift": 0.0,
-            "fitted_scale": 1.0,
-            "verdict": "reject",
-            "fwhm_used": float(fwhm),
-        }
 
     if background == "subtract_min":
         exp_y = exp_y - float(np.min(exp_y))
@@ -132,6 +127,29 @@ def score_xrd_match_fast(
     grid_step = float(np.mean(np.diff(exp_x)))
     if grid_step <= 0:
         raise ValueError("exp_two_theta must be monotonically increasing")
+
+    # Resolve the simulated-pattern broadening. 'auto' (default) matches it to
+    # the experimental peak width, so a nanocrystalline (broad) pattern is not
+    # penalised by an over-sharp simulated profile — the failure mode where a
+    # broadened correct phase scores worse than a wrong sharp one. Floored at
+    # 0.15° so sharp patterns are byte-for-byte identical to the historical
+    # fixed default; a numeric value still forces an exact width.
+    if isinstance(fwhm, str):
+        if fwhm != "auto":
+            raise ValueError(f"fwhm must be a positive number or 'auto', got {fwhm!r}")
+        fwhm = _estimate_exp_fwhm(exp_y, grid_step)
+    fwhm = float(fwhm)
+    if fwhm <= 0:
+        raise ValueError("fwhm must be positive")
+
+    if sim_x.size == 0:
+        return {
+            "correlation": 0.0,
+            "fitted_shift": 0.0,
+            "fitted_scale": 1.0,
+            "verdict": "reject",
+            "fwhm_used": float(fwhm),
+        }
 
     scales = _build_scale_grid(scale_search)
 
@@ -186,6 +204,31 @@ def score_xrd_match_fast(
 
 
 # --- numerical helpers --------------------------------------------------------
+
+def _estimate_exp_fwhm(exp_y, grid_step: float, floor: float = 0.15, ceil: float = 1.0) -> float:
+    """Median FWHM (degrees) of the strongest experimental peaks, for adaptive
+    simulated-pattern broadening. Floored so sharp patterns keep the historical
+    0.15° default and only genuinely broad (nanocrystalline) patterns widen;
+    falls back to the floor when too few peaks are resolvable."""
+    try:
+        y = np.asarray(exp_y, dtype=float)
+        ymax = float(y.max())
+        if ymax <= 0:
+            return floor
+        min_sep = max(1, int(round(0.1 / grid_step)))
+        idx, _ = find_peaks(y, prominence=0.05 * ymax, distance=min_sep)
+        if idx.size == 0:
+            return floor
+        widths_samples, _, _, _ = peak_widths(y, idx, rel_height=0.5)
+        fwhms = np.asarray(widths_samples, dtype=float) * grid_step
+        fwhms = fwhms[fwhms > 0]
+        if fwhms.size == 0:
+            return floor
+        return float(min(max(float(np.median(fwhms)), floor), ceil))
+    except Exception:
+        return floor
+
+
 
 def _build_scale_grid(scale_search: tuple | None) -> np.ndarray:
     if scale_search is None:

--- a/scilink/skills/structure_matching/xrd/score_match_robust.py
+++ b/scilink/skills/structure_matching/xrd/score_match_robust.py
@@ -53,6 +53,14 @@ _HANAWALT_MARGINAL_MIN = 0.40
 _MIP_ACCEPT_MAX = 0.25
 _MIP_MARGINAL_MAX = 0.55
 
+# MIP cost weights (intensity-weighted form). The cost penalises the UNEXPLAINED
+# INTENSITY fraction (weak noise peaks the extractor picked up barely count; a
+# missing STRONG reflection still drives cost up) plus the mean matched-peak
+# residual. Replaces the old count-based "each unmatched peak costs a tolerance
+# unit", which let ~10 noise peaks reject an otherwise-correct multi-phase match.
+_COST_UNCOVERED_W = 0.8
+_COST_RESIDUAL_W = 0.2
+
 # Multi-phase MIP: per-phase activation penalty in the MILP objective. Each
 # active phase costs this many "implicit unmatched peaks" — so a phase is
 # only kept when it accounts for more matches than that. Tuned to ~3 peaks:
@@ -378,6 +386,24 @@ def _fit_lattice_scale(exp_pl, sim_pl, tol_deg, scale_search, min_matches: int =
         ):
             best_score, best_scale = score, float(a)
     return best_scale
+
+
+def _weighted_cost(exp_pl: "_PeakList", unmatched_exp, total_residual: float, tol_deg: float) -> float:
+    """Intensity-weighted joint cost in [0, 1] (figure_of_merit = 1 - cost).
+    Penalises the UNEXPLAINED INTENSITY fraction (so weak noise peaks barely
+    count, while a missing strong reflection still drives cost up) plus the mean
+    matched-peak residual. Replaces the old count-based form where each unmatched
+    peak — noise or not — cost a full tolerance unit, which rejected otherwise-
+    correct matches whenever the extractor returned a handful of noise peaks."""
+    total_int = sum(exp_pl.intensities)
+    if total_int > 0:
+        unmatched_int = sum(exp_pl.intensities[i] for i in unmatched_exp)
+        uncovered = unmatched_int / total_int
+    else:
+        uncovered = len(unmatched_exp) / max(exp_pl.n, 1)
+    n_matched = exp_pl.n - len(unmatched_exp)
+    mean_res = (total_residual / n_matched) / tol_deg if n_matched > 0 else 1.0
+    return float(_COST_UNCOVERED_W * uncovered + _COST_RESIDUAL_W * min(mean_res, 1.0))
 
 
 def _score_hanawalt(
@@ -708,11 +734,9 @@ def _solve_mip_for_scale(
             "residual_deg": float(residual),
         })
     unmatched_exp = [i for i in range(nE) if i not in matched_exp_set]
-    # Normalized cost in [0, 1]: each unmatched peak costs tol, each matched
-    # pair costs its residual. Divide by tol * nE so a perfect identification
-    # gives ~0 and total mismatch gives 1.
-    raw_cost = total_residual + tol_deg * len(unmatched_exp)
-    cost = raw_cost / (tol_deg * max(nE, 1))
+    # Intensity-weighted cost (see _weighted_cost): unexplained INTENSITY plus
+    # mean residual, so noise peaks don't reject a correct match.
+    cost = _weighted_cost(exp_pl, unmatched_exp, total_residual, tol_deg)
 
     return {
         "cost": float(cost),
@@ -1143,16 +1167,13 @@ def _solve_multiphase_mip(
         })
 
     unmatched_exp = [i for i in range(nE) if i not in matched_exp_set]
-    # Joint cost: every unmatched EXPERIMENTAL peak costs a tolerance unit,
-    # every matched pair costs its residual. The predicted-but-absent penalty
-    # lives in the MILP OBJECTIVE (it governs SELECTION — which phases activate);
-    # it is deliberately NOT added here, so the reported cost/verdict stays on
-    # the experimental-coverage scale (folding it in over-penalises real
-    # mixtures whose weak reflections the extractor missed). `predicted_coverage`
-    # is surfaced per phase instead, so an over-predicting phase that slips
-    # through is still visible downstream.
-    raw_cost = total_residual + tol_deg * len(unmatched_exp)
-    cost = raw_cost / (tol_deg * max(nE, 1))
+    # Intensity-weighted cost (see _weighted_cost): unexplained INTENSITY plus
+    # mean residual, so the handful of weak noise peaks the extractor returns
+    # no longer rejects an otherwise-correct multi-phase match. The predicted-
+    # but-absent penalty governs SELECTION in the MILP OBJECTIVE (not the cost);
+    # `predicted_coverage` is surfaced per phase so an over-predicting phase that
+    # slips through is still visible downstream.
+    cost = _weighted_cost(exp_pl, unmatched_exp, total_residual, tol_deg)
 
     return {
         "cost": float(cost),

--- a/scilink/skills/structure_matching/xrd/score_match_robust.py
+++ b/scilink/skills/structure_matching/xrd/score_match_robust.py
@@ -739,7 +739,9 @@ TOOL_SPEC_MULTIPHASE = ToolSpec(
     required=["exp_peaks", "candidates"],
     returns=(
         "dict with 'algorithm' ('mip_multiphase'), 'cost' (overall joint "
-        "cost in [0, 1]), 'verdict', 'active_phases' (list of {id, "
+        "cost in [0, 1], lower better), 'figure_of_merit' (1 - cost, "
+        "higher-better mirror so the same quality gate as the single-phase "
+        "scorer reads a multi-phase result), 'verdict', 'active_phases' (list of {id, "
         "formula, coverage, matched_peaks, mean_residual_deg, lattice_scale "
         "— the per-phase fitted lattice scale, ~1.02 for a DFT-relaxed metal}), "
         "'unmatched_exp' (peak indices not explained by any phase), "
@@ -854,6 +856,12 @@ def score_xrd_match_multiphase(
     return {
         "algorithm": "mip_multiphase",
         "cost": float(cost),
+        # Higher-is-better mirror of `cost`, so the same quality gate the
+        # single-phase scorer feeds (metric='figure_of_merit') can read a
+        # multi-phase result. cost in [0,1] (lower better) -> fom = 1 - cost;
+        # the multi-phase accept (cost <= 0.25) maps to fom >= 0.75, above the
+        # 0.70 gate. The authoritative accept/marginal/reject is `verdict`.
+        "figure_of_merit": float(max(0.0, 1.0 - cost)),
         "verdict": verdict,
         "active_phases": active_phases,
         "unmatched_exp": best["unmatched_exp"],
@@ -868,6 +876,7 @@ def _empty_multiphase_result(candidates: list[dict], why: str) -> dict[str, Any]
     return {
         "algorithm": "mip_multiphase",
         "cost": float("inf"),
+        "figure_of_merit": 0.0,
         "verdict": "reject",
         "active_phases": [],
         "unmatched_exp": [],

--- a/scilink/skills/structure_matching/xrd/score_match_robust.py
+++ b/scilink/skills/structure_matching/xrd/score_match_robust.py
@@ -74,6 +74,18 @@ _MULTIPHASE_ACTIVATION_PENALTY = 3.0
 _MULTIPHASE_ABSENT_PENALTY = 3.0
 _STRONG_SIM_FRAC = 0.15
 
+# Single-phase Hanawalt predicted-coverage gate. A phase whose OWN strong
+# reflections are mostly absent from the data is a coincidental few-peak false
+# match (e.g. a wrong-chemistry phase grabbing 2-3 peaks by overlap, or a
+# lattice-scaled near-miss). Down-weight its FoM by predicted_coverage once that
+# drops below _PRED_COV_FULL; at/above it the gate is 1.0 so a real phase (which
+# shows nearly all its strong peaks) is unaffected. This is the single-phase
+# analogue of the multiphase predicted-but-absent penalty. Calibrated to 0.65:
+# real phases (predicted_coverage ~0.89-1.0 even nanocrystalline) keep full FoM,
+# while a wrong-chemistry match (predicted_coverage ~0.46) is cut below the
+# reject threshold instead of scoring a false "marginal".
+_PRED_COV_FULL = 0.65
+
 
 TOOL_SPEC = ToolSpec(
     name="score_xrd_match_robust",
@@ -445,6 +457,26 @@ def _score_hanawalt(
 
     fom = 0.55 * coverage + 0.35 * mean_pos + 0.10 * mean_int
 
+    # Bidirectional gate: of THIS phase's strong reflections, how many appear in
+    # the data? A real phase shows nearly all of them (gate ~1.0); a coincidental
+    # false match leaves most of its own strong peaks unobserved -> gate < 1 ->
+    # FoM cut, so a wrong-chemistry phase can no longer score "marginal" off a
+    # few overlapping peaks.
+    imax = max(sim_pl.intensities) if sim_pl.intensities else 0.0
+    if imax > 0:
+        strong_total = sum(
+            sim_pl.intensities[j] / imax for j in range(sim_pl.n)
+            if sim_pl.intensities[j] / imax >= _STRONG_SIM_FRAC
+        )
+        strong_matched = sum(
+            sim_pl.intensities[j] / imax for j in used_sim
+            if sim_pl.intensities[j] / imax >= _STRONG_SIM_FRAC
+        )
+        predicted_coverage = strong_matched / strong_total if strong_total > 0 else 1.0
+    else:
+        predicted_coverage = 1.0
+    fom = fom * min(1.0, predicted_coverage / _PRED_COV_FULL)
+
     if fom >= _HANAWALT_ACCEPT_MIN:
         verdict = "accept"
     elif fom >= _HANAWALT_MARGINAL_MIN:
@@ -456,6 +488,7 @@ def _score_hanawalt(
         "algorithm": "hanawalt",
         "figure_of_merit": float(fom),
         "coverage": float(coverage),
+        "predicted_coverage": float(predicted_coverage),
         "position_score": float(mean_pos),
         "intensity_score": float(mean_int),
         "verdict": verdict,

--- a/scilink/skills/structure_matching/xrd/score_match_robust.py
+++ b/scilink/skills/structure_matching/xrd/score_match_robust.py
@@ -300,6 +300,15 @@ def _apply_lattice_scale(positions, scale: float):
     return 2.0 * np.degrees(np.arcsin(sin_scaled))
 
 
+def _scaled_peaklist(pl: "_PeakList", scale: float) -> "_PeakList":
+    """A copy of a peak list with positions re-scaled for a lattice parameter."""
+    return _PeakList(
+        positions=[float(p) for p in _apply_lattice_scale(pl.positions, scale)],
+        intensities=list(pl.intensities),
+        intensities_norm=list(pl.intensities_norm),
+    )
+
+
 def _fit_lattice_scale(exp_pl, sim_pl, tol_deg, scale_search, min_matches: int = 2) -> float:
     """Find the single lattice scale that best aligns the simulated peaks to the
     experimental ones (intensity-weighted matched coverage). Bounded to a few %
@@ -718,14 +727,24 @@ TOOL_SPEC_MULTIPHASE = ToolSpec(
             "type": "int",
             "description": "Cap on experimental peaks considered (strongest kept). Default 30 (higher than single-phase since the assignment problem allocates across phases).",
         },
+        "lattice_scale_search": {
+            "type": "tuple",
+            "description": "(min, max, step) PER-PHASE lattice-scale grid (default (0.96, 1.04, 0.002), ±4%). Each phase is aligned independently before the joint assignment, because lattice mismatch is per-phase — e.g. a DFT-relaxed metal (+2%) and an experimental molecular reference (0%) in the same pattern need different scales. This is separate from scale_search/shift_search, which absorb the SHARED instrument zero-shift.",
+        },
+        "fit_lattice_scale": {
+            "type": "bool",
+            "description": "Default True: fit a per-phase lattice scale before the joint assignment (adopted only if it aligns >=2 reflections). Set False to match each phase at its reference lattice as-is.",
+        },
     },
     required=["exp_peaks", "candidates"],
     returns=(
         "dict with 'algorithm' ('mip_multiphase'), 'cost' (overall joint "
         "cost in [0, 1]), 'verdict', 'active_phases' (list of {id, "
-        "formula, coverage, matched_peaks, mean_residual_deg}), "
+        "formula, coverage, matched_peaks, mean_residual_deg, lattice_scale "
+        "— the per-phase fitted lattice scale, ~1.02 for a DFT-relaxed metal}), "
         "'unmatched_exp' (peak indices not explained by any phase), "
-        "'fitted_shift', 'fitted_scale', 'n_exp_peaks', 'n_phases_considered'."
+        "'fitted_shift', 'fitted_scale' (shared instrument terms), "
+        "'n_exp_peaks', 'n_phases_considered'."
     ),
     when_to_use=(
         "Suspected mixtures (system_info / notes mention 'mixture', "
@@ -745,6 +764,8 @@ def score_xrd_match_multiphase(
     scale_search: tuple = (0.99, 1.01, 0.005),
     shift_search: tuple = (-0.4, 0.4),
     max_exp_peaks: int = 30,
+    lattice_scale_search: tuple = (0.96, 1.04, 0.002),
+    fit_lattice_scale: bool = True,
 ) -> dict[str, Any]:
     """Joint multi-phase MIP. See ``TOOL_SPEC_MULTIPHASE`` for full contract."""
     if not PULP_AVAILABLE:
@@ -772,6 +793,20 @@ def score_xrd_match_multiphase(
         ))
     if all(pl.n == 0 for pl in sim_pls):
         return _empty_multiphase_result(candidates, "no simulated peaks")
+
+    # Lattice mismatch is PER-PHASE (a DFT-relaxed metal and an experimental
+    # molecular reference in the same pattern need different scales), so align
+    # each phase independently before the joint assignment. The MILP's shared
+    # scale/shift below then only absorbs the common instrument zero-shift, which
+    # genuinely IS shared (one detector). Without this, a single shared scale
+    # can align at most one phase of a mixture.
+    per_phase_scale = [1.0] * len(sim_pls)
+    if fit_lattice_scale:
+        for i, pl in enumerate(sim_pls):
+            if pl.n:
+                a = _fit_lattice_scale(exp_pl, pl, tol_deg, lattice_scale_search)
+                per_phase_scale[i] = a
+                sim_pls[i] = _scaled_peaklist(pl, a)
 
     scales = _scale_grid(scale_search)
     shift_lo, shift_hi = float(shift_search[0]), float(shift_search[1])
@@ -813,6 +848,7 @@ def score_xrd_match_multiphase(
             "coverage": per_phase["coverage"],
             "matched_peaks": per_phase["matched_peaks"],
             "mean_residual_deg": per_phase["mean_residual_deg"],
+            "lattice_scale": float(per_phase_scale[p_idx]),
         })
 
     return {

--- a/scilink/skills/structure_matching/xrd/score_match_robust.py
+++ b/scilink/skills/structure_matching/xrd/score_match_robust.py
@@ -66,10 +66,13 @@ TOOL_SPEC = ToolSpec(
     description=(
         "Peak-list-based scoring of a simulated XRD pattern against an "
         "experimental one, with selectable algorithm. 'hanawalt' (default) "
-        "is classical figure-of-merit search-match; 'mip' is mixed-integer "
-        "linear programming with joint peak-assignment + zero-shift + "
-        "lattice-scale optimization. Use after the fast tier identifies a "
-        "short list of candidates; this tier is for confident "
+        "is classical figure-of-merit search-match; both algorithms fit a "
+        "single lattice scale so a DFT-relaxed reference cell (Materials "
+        "Project structures sit a few % off the experimental lattice) is "
+        "aligned before matching instead of being falsely rejected. 'mip' is "
+        "mixed-integer linear programming with joint peak-assignment + "
+        "zero-shift + lattice-scale optimization. Use after the fast tier "
+        "identifies a short list of candidates; this tier is for confident "
         "identification on real-lab patterns."
     ),
     import_line="from scilink.skills.structure_matching.xrd.score_match_robust import score_xrd_match_robust",
@@ -77,7 +80,8 @@ TOOL_SPEC = ToolSpec(
         "score_xrd_match_robust(exp_two_theta=None, exp_intensity=None, "
         "exp_peaks=None, sim_two_theta, sim_intensity, algorithm='hanawalt', "
         "tol_deg=0.3, max_exp_peaks=20, max_sim_peaks=30, "
-        "scale_search=(0.99, 1.01, 0.0025), shift_search=(-0.4, 0.4)) -> dict"
+        "scale_search=(0.96, 1.04, 0.002), shift_search=(-0.4, 0.4), "
+        "fit_lattice_scale=True) -> dict"
     ),
     parameters={
         "exp_two_theta": {
@@ -118,11 +122,15 @@ TOOL_SPEC = ToolSpec(
         },
         "scale_search": {
             "type": "tuple",
-            "description": "(min, max, step) lattice-scale grid for MIP. Default (0.98, 1.02, 0.002) — covers ±2% lattice-parameter mismatch (typical between MP DFT-relaxed cells and experimental conditions). Ignored by hanawalt.",
+            "description": "(min, max, step) lattice-scale grid used by BOTH algorithms. Default (0.96, 1.04, 0.002) — covers ±4% lattice-parameter mismatch (DFT-relaxed MP cells are typically 1-3% larger than the experimental cell; thermal expansion adds more). The scale is applied via Bragg's law (sin-theta scaling), not a constant 2-theta shift.",
         },
         "shift_search": {
             "type": "tuple",
             "description": "(min, max) zero-shift bounds for MIP (degrees). Default (-0.4, 0.4). Ignored by hanawalt.",
+        },
+        "fit_lattice_scale": {
+            "type": "bool",
+            "description": "hanawalt only. Default True: fit a single lattice scale (over scale_search) before matching, adopted only if it aligns >=2 reflections so a wrong phase is not force-aligned. Set False to match at the reference lattice as-is (e.g. when the reference is already at experimental conditions).",
         },
     },
     required=["sim_two_theta", "sim_intensity"],
@@ -131,7 +139,10 @@ TOOL_SPEC = ToolSpec(
         "'verdict' ('accept' | 'marginal' | 'reject'), 'matched_peaks' "
         "(list of {exp_idx, sim_idx, exp_pos, sim_pos, residual_deg}), "
         "'unmatched_exp' (list of exp peak indices), 'fitted_shift' "
-        "(degrees; 0 for hanawalt), 'fitted_scale' (1.0 for hanawalt), "
+        "(degrees; 0 for hanawalt), 'fitted_scale' (the fitted lattice scale; "
+        "1.0 = no scaling / reference already at the experimental lattice, "
+        ">1.0 = reference cell larger than experimental, e.g. ~1.02 for a "
+        "DFT-relaxed metal — a value near the search bound warrants review), "
         "'n_exp_peaks', 'n_sim_peaks'."
     ),
     when_to_use=(
@@ -159,8 +170,9 @@ def score_xrd_match_robust(
     tol_deg: float = 0.3,
     max_exp_peaks: int = 20,
     max_sim_peaks: int = 30,
-    scale_search: tuple = (0.98, 1.02, 0.002),
+    scale_search: tuple = (0.96, 1.04, 0.002),
     shift_search: tuple = (-0.4, 0.4),
+    fit_lattice_scale: bool = True,
 ) -> dict[str, Any]:
     """Robust peak-list scoring. See ``TOOL_SPEC`` for full contract."""
     if algorithm not in {"hanawalt", "mip"}:
@@ -177,7 +189,9 @@ def score_xrd_match_robust(
         return _empty_result(algorithm, exp_pl, sim_pl, "no simulated peaks")
 
     if algorithm == "hanawalt":
-        return _score_hanawalt(exp_pl, sim_pl, tol_deg=tol_deg)
+        return _score_hanawalt(
+            exp_pl, sim_pl, tol_deg=tol_deg,
+            scale_search=scale_search if fit_lattice_scale else None)
     return _score_mip(
         exp_pl, sim_pl,
         tol_deg=tol_deg,
@@ -272,14 +286,83 @@ def _empty_result(algorithm: str, exp_pl: _PeakList, sim_pl: _PeakList, why: str
 # Hanawalt search-match
 # ---------------------------------------------------------------------------
 
+def _apply_lattice_scale(positions, scale: float):
+    """Re-position peaks for a lattice-parameter scale `a` via Bragg's law.
+
+    A uniform lattice scaling multiplies every d-spacing, so sin(theta) scales:
+    sin(theta_scaled) = a * sin(theta_orig). This is the physically-correct
+    transform for a DFT-relaxed reference cell (typically a few % larger than
+    the experimental cell) — NOT a constant 2-theta shift, which is wrong away
+    from low angle."""
+    positions = np.asarray(positions, dtype=float)
+    sin_scaled = scale * np.sin(np.radians(positions / 2.0))
+    sin_scaled = np.clip(sin_scaled, -1.0, 1.0)
+    return 2.0 * np.degrees(np.arcsin(sin_scaled))
+
+
+def _fit_lattice_scale(exp_pl, sim_pl, tol_deg, scale_search, min_matches: int = 2) -> float:
+    """Find the single lattice scale that best aligns the simulated peaks to the
+    experimental ones (intensity-weighted matched coverage). Bounded to a few %
+    so a wrong phase can't be force-aligned.
+
+    A non-unity scale is only adopted if it aligns at least ``min_matches`` peaks
+    — a real DFT-relaxed phase snaps *multiple* reflections into place at the
+    right scale, whereas a wrong phase produces at most a lone coincidental
+    alignment that must not be allowed to drive the scale (which would erode
+    discrimination). Falls back to 1.0 (no scaling) otherwise."""
+    lo, hi, step = scale_search
+    scales = np.arange(lo, hi + step / 2.0, step)
+    sim_pos = np.asarray(sim_pl.positions)
+    exp_pos = np.asarray(exp_pl.positions)
+    exp_w = np.sqrt(np.asarray(exp_pl.intensities_norm))
+
+    def _eval(a: float):
+        sp = _apply_lattice_scale(sim_pos, a)
+        used: set[int] = set()
+        score = 0.0
+        n = 0
+        for ep, w in zip(exp_pos, exp_w):
+            res = np.abs(sp - ep)
+            for j in used:
+                res[j] = np.inf
+            j = int(np.argmin(res))
+            if res[j] <= tol_deg:
+                used.add(j)
+                n += 1
+                score += w * (1.0 - res[j] / tol_deg)
+        return score, n
+
+    base_score, _ = _eval(1.0)
+    best_scale, best_score = 1.0, base_score
+    for a in scales:
+        score, n = _eval(float(a))
+        if n < min_matches:
+            continue  # a lone coincidental alignment must not select a scale
+        if score > best_score + 1e-9 or (
+            abs(score - best_score) <= 1e-9 and abs(a - 1.0) < abs(best_scale - 1.0)
+        ):
+            best_score, best_scale = score, float(a)
+    return best_scale
+
+
 def _score_hanawalt(
     exp_pl: _PeakList,
     sim_pl: _PeakList,
     *,
     tol_deg: float,
+    scale_search: tuple | None = None,
 ) -> dict[str, Any]:
-    """Classical Hanawalt-style figure-of-merit with intensity weighting."""
-    sim_positions = np.asarray(sim_pl.positions)
+    """Classical Hanawalt-style figure-of-merit with intensity weighting.
+
+    When ``scale_search`` is given, a single lattice scale is fit first so a
+    DFT-relaxed reference cell (peaks shifted a few % in sin-theta) is aligned
+    to the experimental pattern before matching — otherwise such a reference is
+    falsely rejected even when the phase is clearly present."""
+    fitted_scale = (
+        _fit_lattice_scale(exp_pl, sim_pl, tol_deg, scale_search)
+        if scale_search else 1.0
+    )
+    sim_positions = _apply_lattice_scale(sim_pl.positions, fitted_scale)
     sim_norm = np.asarray(sim_pl.intensities_norm)
     used_sim = set()
     matched_peaks = []
@@ -356,7 +439,7 @@ def _score_hanawalt(
         "matched_peaks": matched_peaks,
         "unmatched_exp": unmatched_exp,
         "fitted_shift": 0.0,
-        "fitted_scale": 1.0,
+        "fitted_scale": float(fitted_scale),
         "n_exp_peaks": exp_pl.n,
         "n_sim_peaks": sim_pl.n,
     }

--- a/scilink/skills/structure_matching/xrd/score_match_robust.py
+++ b/scilink/skills/structure_matching/xrd/score_match_robust.py
@@ -60,6 +60,20 @@ _MIP_MARGINAL_MAX = 0.55
 # real component.
 _MULTIPHASE_ACTIVATION_PENALTY = 3.0
 
+# Multi-phase MIP: predicted-but-absent penalty (BIDIRECTIONAL matching). The
+# bare "maximize matched exp peaks" objective rewards a peak-RICH phase for
+# covering experimental peaks while never charging it for its OWN strong
+# reflections that are absent from the data — so a Magnéli-type suboxide with
+# ~30 reflections can out-cover the true anatase+rutile by overlap. We add a
+# penalty: for each ACTIVE phase, every strong predicted peak (relative
+# intensity >= _STRONG_SIM_FRAC) that is NOT matched to an experimental peak
+# costs `_MULTIPHASE_ABSENT_PENALTY * (its relative intensity)`. A phase whose
+# strong predicted peaks are mostly missing then loses, even if it covers a few
+# experimental peaks. Weak predicted reflections (the long tail, often below
+# detection) are NOT penalised — only the strong ones a real phase must show.
+_MULTIPHASE_ABSENT_PENALTY = 3.0
+_STRONG_SIM_FRAC = 0.15
+
 
 TOOL_SPEC = ToolSpec(
     name="score_xrd_match_robust",
@@ -848,6 +862,7 @@ def score_xrd_match_multiphase(
             "id": cand.get("id", str(p_idx)),
             "formula": cand.get("formula", ""),
             "coverage": per_phase["coverage"],
+            "predicted_coverage": per_phase.get("predicted_coverage", 1.0),
             "matched_peaks": per_phase["matched_peaks"],
             "mean_residual_deg": per_phase["mean_residual_deg"],
             "lattice_scale": float(per_phase_scale[p_idx]),
@@ -886,6 +901,25 @@ def _empty_multiphase_result(candidates: list[dict], why: str) -> dict[str, Any]
         "n_phases_considered": len(candidates),
         "note": why,
     }
+
+
+def _strong_sim_weights(sim_pls: list["_PeakList"]) -> dict[int, list[tuple[int, float]]]:
+    """Per phase, the (sim peak index, relative-intensity weight) list for peaks
+    at >= _STRONG_SIM_FRAC of that phase's maximum intensity — the strong
+    reflections a real phase must show, used by the predicted-but-absent
+    penalty. Weak peaks (the long tail, often below detection) are excluded."""
+    out: dict[int, list[tuple[int, float]]] = {}
+    for p_idx, pl in enumerate(sim_pls):
+        items: list[tuple[int, float]] = []
+        if pl.n and pl.intensities:
+            imax = max(pl.intensities)
+            if imax > 0:
+                for j in range(pl.n):
+                    w = pl.intensities[j] / imax
+                    if w >= _STRONG_SIM_FRAC:
+                        items.append((j, float(w)))
+        out[p_idx] = items
+    return out
 
 
 def _solve_multiphase_mip(
@@ -959,13 +993,8 @@ def _solve_multiphase_mip(
     }
     shift = pulp.LpVariable("shift", lowBound=shift_lo, upBound=shift_hi)
 
-    # Objective: maximize matches, minus per-phase activation cost
-    prob += (
-        pulp.lpSum(x.values())
-        - _MULTIPHASE_ACTIVATION_PENALTY * pulp.lpSum(y.values())
-    )
-
-    # Constraint groupings
+    # Constraint groupings (built before the objective so the predicted-absent
+    # penalty can reference per-(sim-peak, phase) match sums).
     by_i: dict[int, list[tuple[int, int, int]]] = {i: [] for i in range(nE)}
     by_jp: dict[tuple[int, int], list[tuple[int, int, int]]] = {}
     by_p: dict[int, list[tuple[int, int, int]]] = {p_idx: [] for p_idx in range(nP)}
@@ -974,6 +1003,26 @@ def _solve_multiphase_mip(
         by_i[i].append(t)
         by_jp.setdefault((j, p_idx), []).append(t)
         by_p[p_idx].append(t)
+
+    # Strong predicted peaks per phase (relative intensity >= _STRONG_SIM_FRAC),
+    # weighted by relative intensity — the reflections a real phase must show.
+    strong_sim = _strong_sim_weights(sim_pls)
+
+    # Objective: maximize matched exp peaks, minus per-phase activation cost,
+    # minus the predicted-but-absent penalty (BIDIRECTIONAL matching). For an
+    # active phase (y=1) a strong predicted peak j contributes its weight unless
+    # it is matched (Σ_i x[i,j,p] = 1); an inactive phase contributes nothing
+    # (y=0 forces every x[*,j,p]=0, so y - Σx = 0). This is linear in x, y.
+    absent_penalty = pulp.lpSum(
+        w * (y[p_idx] - pulp.lpSum(x[t] for t in by_jp.get((j, p_idx), [])))
+        for p_idx, js in strong_sim.items()
+        for j, w in js
+    )
+    prob += (
+        pulp.lpSum(x.values())
+        - _MULTIPHASE_ACTIVATION_PENALTY * pulp.lpSum(y.values())
+        - _MULTIPHASE_ABSENT_PENALTY * absent_penalty
+    )
 
     for i, triples in by_i.items():
         if triples:
@@ -1017,6 +1066,7 @@ def _solve_multiphase_mip(
         active = pulp.value(y[p_idx]) is not None and pulp.value(y[p_idx]) >= 0.5
         matched_for_phase: list[dict[str, Any]] = []
         phase_matched_exp: set[int] = set()
+        phase_matched_sim: set[int] = set()
         phase_residuals: list[float] = []
         for t in by_p[p_idx]:
             val = pulp.value(x[t])
@@ -1034,6 +1084,7 @@ def _solve_multiphase_mip(
                 "residual_deg": float(residual),
             })
             phase_matched_exp.add(i)
+            phase_matched_sim.add(j)
             phase_residuals.append(residual)
             matched_exp_set.add(i)
             total_residual += residual
@@ -1042,17 +1093,31 @@ def _solve_multiphase_mip(
             sum(exp_pl.intensities[i] for i in phase_matched_exp) / sum(exp_pl.intensities)
             if sum(exp_pl.intensities) > 0 else 0.0
         )
+        # Predicted-coverage: of this phase's STRONG predicted peaks, the
+        # intensity-weighted fraction actually observed. Low predicted-coverage
+        # flags an over-predicting (Magnéli-type) false match.
+        strong = strong_sim.get(p_idx, [])
+        strong_total = sum(w for _, w in strong)
+        absent_w = sum(w for j, w in strong if j not in phase_matched_sim)
+        predicted_coverage = (1.0 - absent_w / strong_total) if strong_total > 0 else 1.0
         per_phase.append({
             "active": bool(active and matched_for_phase),
             "coverage": float(coverage),
+            "predicted_coverage": float(predicted_coverage),
+            "absent_weight": float(absent_w),
             "matched_peaks": matched_for_phase,
             "mean_residual_deg": float(np.mean(phase_residuals)) if phase_residuals else 0.0,
         })
 
     unmatched_exp = [i for i in range(nE) if i not in matched_exp_set]
-    # Normalized joint cost: same shape as single-phase MIP — every
-    # unmatched peak costs a tolerance unit, every matched pair costs its
-    # residual.
+    # Joint cost: every unmatched EXPERIMENTAL peak costs a tolerance unit,
+    # every matched pair costs its residual. The predicted-but-absent penalty
+    # lives in the MILP OBJECTIVE (it governs SELECTION — which phases activate);
+    # it is deliberately NOT added here, so the reported cost/verdict stays on
+    # the experimental-coverage scale (folding it in over-penalises real
+    # mixtures whose weak reflections the extractor missed). `predicted_coverage`
+    # is surfaced per phase instead, so an over-predicting phase that slips
+    # through is still visible downstream.
     raw_cost = total_residual + tol_deg * len(unmatched_exp)
     cost = raw_cost / (tol_deg * max(nE, 1))
 

--- a/scilink/skills/structure_matching/xrd/simulate_xrd.py
+++ b/scilink/skills/structure_matching/xrd/simulate_xrd.py
@@ -28,14 +28,16 @@ _logger = logging.getLogger(__name__)
 TOOL_SPEC = ToolSpec(
     name="simulate_xrd_pattern",
     description=(
-        "Compute the kinematic XRD pattern from a crystal structure using "
-        "pymatgen's XRDCalculator. Returns 2-theta peak positions, relative "
-        "intensities (max = 100), Miller indices, and d-spacings."
+        "Compute an XRD pattern from a crystal structure. Default engine is "
+        "pymatgen's kinematic XRDCalculator; a pluggable 'engine' selects the "
+        "simulator so a heavier backend (e.g. GSAS-II) can be swapped in later "
+        "with no change to downstream scoring. Returns 2-theta peak positions, "
+        "relative intensities (max = 100), Miller indices, and d-spacings."
     ),
     import_line="from scilink.skills.structure_matching.xrd.simulate_xrd import simulate_xrd_pattern",
     signature=(
         "simulate_xrd_pattern(structure_path: str, wavelength: str | float = "
-        "'CuKa', two_theta_range: tuple = (10, 90)) -> dict"
+        "'CuKa', two_theta_range: tuple = (10, 90), engine: str = 'pymatgen') -> dict"
     ),
     parameters={
         "structure_path": {
@@ -53,13 +55,22 @@ TOOL_SPEC = ToolSpec(
             "type": "tuple",
             "description": "(min, max) in degrees. Default (10, 90).",
         },
+        "engine": {
+            "type": "str",
+            "description": (
+                "Simulation backend. 'pymatgen' (default, kinematic, always "
+                "available; sufficient for peak-list identification). Additional "
+                "engines (e.g. GSAS-II) register in this module and return the "
+                "same contract, so scoring is unaffected by the choice."
+            ),
+        },
     },
     required=["structure_path"],
     returns=(
         "dict with 'two_theta' (list[float]), 'intensities' (list[float]; "
         "normalized so max = 100), 'hkls' (list[list[int]]; primary "
         "reflection per peak), 'd_spacings' (list[float]), 'wavelength' "
-        "(Å), 'structure_path' (echo)."
+        "(Å), 'structure_path' (echo), 'engine' (which simulator produced it)."
     ),
     when_to_use=(
         "After search_structures, to generate a simulated pattern from each "
@@ -73,8 +84,34 @@ def simulate_xrd_pattern(
     structure_path: str,
     wavelength: Union[str, float] = "CuKa",
     two_theta_range: tuple = (10, 90),
+    engine: str = "pymatgen",
 ) -> dict[str, Any]:
-    """Compute kinematic XRD pattern. See ``TOOL_SPEC`` for full contract."""
+    """Compute an XRD pattern from a crystal structure. See ``TOOL_SPEC``.
+
+    ``engine`` selects the simulation backend ('pymatgen' default). All engines
+    return the SAME dict contract (two_theta / intensities / hkls / d_spacings /
+    wavelength), so everything downstream — scoring, lattice-scale alignment,
+    matching — is engine-agnostic. Swapping in a different simulator (e.g.
+    GSAS-II) is therefore localized to this module: implement a function with
+    the ``(structure_path, wavelength, two_theta_range) -> dict`` signature and
+    register it in ``_ENGINES`` (optional dependency, lazy-imported). No caller
+    changes."""
+    try:
+        backend = _ENGINES[engine]
+    except KeyError:
+        raise ValueError(
+            f"Unknown XRD simulation engine {engine!r}. Available: "
+            f"{sorted(_ENGINES)}. Register a new engine in "
+            f"scilink.skills.structure_matching.xrd.simulate_xrd._ENGINES."
+        )
+    result = backend(structure_path, wavelength, two_theta_range)
+    result["engine"] = engine
+    return result
+
+
+def _simulate_pymatgen(structure_path, wavelength, two_theta_range) -> dict[str, Any]:
+    """Default engine: pymatgen's kinematic ``XRDCalculator`` (always available
+    with the structure-matching extra; sufficient for peak-list identification)."""
     if not PYMATGEN_XRD_AVAILABLE:
         raise RuntimeError(
             "simulate_xrd_pattern requires pymatgen with XRDCalculator support; "
@@ -95,6 +132,16 @@ def simulate_xrd_pattern(
         "wavelength": float(calc.wavelength),
         "structure_path": structure_path,
     }
+
+
+# XRD simulation-engine registry — the swap point. Each entry maps an engine
+# name to a callable with the same signature and return contract as
+# ``_simulate_pymatgen``. A heavier optional engine (e.g. GSAS-II via
+# GSASIIscriptable) registers here behind a lazy import + optional extra, and
+# downstream code is unaffected because the output dict is identical.
+_ENGINES = {
+    "pymatgen": _simulate_pymatgen,
+}
 
 
 def _primary_hkl(entry: Any) -> list[int]:

--- a/scilink/skills/structure_matching/xrd/xrd.md
+++ b/scilink/skills/structure_matching/xrd/xrd.md
@@ -219,6 +219,16 @@ must follow this exact sequence:
    `DB_MATCHES_JSON:` marker; the framework's stdout parser lifts it
    into `fit_results['db_matches']` automatically.
 
+**Don't profile-fit for identification.** Two common over-builds to avoid:
+- The **fast tier needs no peak extraction** — it cross-correlates the
+  *continuous* (background-subtracted) pattern directly. Subtract the background,
+  then correlate; do not extract or fit peaks before Step 3.
+- For the **robust tier**, use the **light** `extract_peaks` (positions +
+  relative intensities). Do **NOT** fit a pseudo-Voigt profile to every peak —
+  that is the `xrd_profile` skill's specialized job (crystallite size / strain)
+  and is unnecessary for identification, which only needs positions + relative
+  intensities. FWHMs from `extract_peaks` are optional refinement, not a goal.
+
 **Complete two-tier template** — adapt for the active wavelength and
 chemistry hypothesis:
 

--- a/scilink/skills/structure_matching/xrd/xrd.md
+++ b/scilink/skills/structure_matching/xrd/xrd.md
@@ -65,6 +65,14 @@ protocol and the registration helpers.
 
 ## planning
 
+**This is pattern-MATCHING, not fitting.** The deliverable is a ranked candidate
+match plus a `figure_of_merit` (the skill's quality gate) — *not* a fitted model.
+The plan must not list peak-shape fit parameters (pseudo-Voigt mixing `eta`,
+per-peak FWHM / amplitude as fit targets); the only quantitative outputs are the
+matched phase(s), the scorer's `figure_of_merit`, and its fitted zero-shift /
+lattice-scale. Every stage below chains search → simulate → score; no stage fits
+the experimental pattern.
+
 **Two-tier identification workflow** — both tiers usually run, never
 either-alone:
 
@@ -178,26 +186,18 @@ accepts three optional filters that often pay for themselves:
 All three are optional and respected by Materials Project and the
 local CIF backend; COD ignores them.
 
-**Pairing with `curve_fitting/xrd_profile`.** When both skills are
-active in the same run (`skill=["xrd", "xrd_profile"]`), the
-recommended flow is:
-
-1. `extract_peaks` seeds candidate peak centers on the experimental
-   pattern.
-2. `fit_profile` (from `xrd_profile`) fits each peak with a
-   pseudo-Voigt and returns refined center, FWHM, amplitude, and per-
-   peak R².
-3. The refined values are passed to `score_xrd_match_robust` as
-   `exp_peaks={'positions': [...], 'amplitudes': [...], 'fwhms': [...]}`
-   — the existing peak-list input format. No API change needed.
-4. The scorer then ranks candidates against peaks with calibrated
-   widths instead of the default uniform broadening, which matters
-   most for nanocrystalline samples where peaks are 5-10× broader
-   than the 0.15° default.
-
-For data without significant line broadening (well-crystallized,
-sharp peaks), the bridge is unnecessary — `extract_peaks` alone gives
-fine positions and the scorers' defaults work.
+**Profile fitting is a DOWNSTREAM follow-up, not part of identification.**
+Crystallite size / strain (per-peak pseudo-Voigt → Scherrer / Williamson-Hall)
+is the `curve_fitting/xrd_profile` skill's job, run as a **separate step after
+the phase is identified** — never an in-ID fit. Identification needs only peak
+*positions and relative intensities* (the light `extract_peaks`), which the
+scorers consume directly. Do **not** call `fit_profile`, fit pseudo-Voigt peaks,
+or compute per-peak R² inside the identification script: it adds nothing the
+match needs and pulls the run into the curve-fitting pipeline (an R²-shaped
+deliverable the `figure_of_merit` gate then rejects, triggering avoidable
+refinement iterations). When line broadening matters for the match on
+nanocrystalline data, **widen the scorer's `fwhm` (0.3-0.5°)** rather than
+fitting each peak.
 
 ## analysis
 
@@ -228,6 +228,11 @@ must follow this exact sequence:
   that is the `xrd_profile` skill's specialized job (crystallite size / strain)
   and is unnecessary for identification, which only needs positions + relative
   intensities. FWHMs from `extract_peaks` are optional refinement, not a goal.
+- **Emit `figure_of_merit`, never `r_squared`.** The ID gate scores by
+  `figure_of_merit`; there is no curve fit here, so there is no R² to report.
+  For the visualization, overlay the best-match **simulated** pattern (broadened
+  sticks) on the experimental data — do not `curve_fit` a profile for the plot
+  or compute an R² for it.
 
 **Complete two-tier template** — adapt for the active wavelength and
 chemistry hypothesis:

--- a/scilink/skills/structure_matching/xrd/xrd.md
+++ b/scilink/skills/structure_matching/xrd/xrd.md
@@ -133,11 +133,21 @@ single-candidate list — it gracefully reduces to the single-phase MIP
 under that input (with one phase always active) and the joint solver's
 output format is the same.
 
-**Bounding the candidate count.** Always set `search_structures(query={
-"top_n": N, ...})` with N in [3, 10]. More than 10 candidates per
-spectrum bloats simulation cost without adding identification certainty
-— if the answer isn't in the top 5, the chemistry hypothesis is usually
-wrong, not the candidate count.
+**Candidate count — tight first pass, widen on failure.** The cost is the
+per-candidate *simulation*, so keep the FIRST pass cheap: `search_structures(
+query={"top_n": N, ...})` with N in [5, 10]. That already identifies common
+single-polymorph phases.
+
+But if that pass FAILS (best `figure_of_merit` below the accept threshold /
+all candidates marginal-or-reject), the answer is often a phase that the tight
+retrieval simply did not return — a *polymorph-rich* chemistry (e.g. Ti-O has
+many TiO2 polymorphs plus Magnéli suboxides; the right one can be candidate #20,
+not #5). On such a re-plan you SHOULD widen the retrieval — `top_n` up to ~30
+(and/or relax symmetry/lattice filters, or try an alternate chemistry
+hypothesis) — and re-run. This widening is *expected and allowed* on a failed
+pass; do not stay capped at 10 while re-planning a search that returned no
+confident match. (For an in-situ *series*, keep it tight per frame — the
+establishing frame can widen once, then lock the identified phase.)
 
 **Wavelength selection.** Default CuKa unless the experiment metadata
 says otherwise. MoKa is common for high-2θ work. A wavelength mismatch
@@ -195,7 +205,9 @@ fine positions and the scorers' defaults work.
 must follow this exact sequence:
 
 1. Load experimental 2-theta + intensity arrays.
-2. Call `search_structures` once with `top_n` between 3 and 10.
+2. Call `search_structures` with `top_n` 5-10 (first pass). If the run is a
+   re-plan after a failed/low-FoM pass, widen `top_n` up to ~30 and/or relax
+   filters (see "Candidate count — tight first pass, widen on failure").
 3. For each candidate, call `simulate_xrd_pattern` and `score_xrd_match_fast`.
 4. Filter to candidates with `verdict in {'accept', 'marginal'}`.
 5. Call `extract_peaks` once on the experimental pattern.

--- a/scilink/skills/structure_matching/xrd/xrd.md
+++ b/scilink/skills/structure_matching/xrd/xrd.md
@@ -1,5 +1,5 @@
 ---
-description: XRD structure matching — query crystal-structure databases (Materials Project, local CIF), simulate kinematic patterns, score by cross-correlation (fast) and Hanawalt / MIP peak-matching (robust).
+description: XRD phase identification (search-match) — the default first-pass XRD analysis: "what phase(s) is this?". Queries crystal-structure databases (COD, Materials Project, local CIF), simulates kinematic patterns, and scores by cross-correlation (fast) and Hanawalt / MIP peak-matching (robust). Use this for routine phase ID; the xrd_profile skill is the specialized follow-up for line-broadening (crystallite size / strain) once the phase is known.
 quality_gate:
   metric: figure_of_merit
   accept_threshold: 0.70
@@ -11,11 +11,20 @@ quality_gate:
 ## overview
 
 Identify a crystalline phase from an experimental X-ray diffraction (XRD)
-pattern by matching against database structures. The skill ships five
-tools the analysis script chains together:
+pattern by matching against database structures. **This is the default,
+highest-frequency XRD question — "what phase(s) is my sample?" — and the usual
+first pass for any XRD pattern.** Profile fitting (the `xrd_profile` skill:
+per-peak pseudo-Voigt → Scherrer crystallite size / Williamson-Hall strain) is
+the *specialized follow-up* once the phase is known, not the starting point.
 
-- `search_structures` — query Materials Project and / or a local CIF
-  directory for candidate structures (chemistry + symmetry filters).
+The skill ships five tools the analysis script chains together:
+
+- `search_structures` — query the **COD** (Crystallography Open Database — the
+  recommended default: experimental structures, organic + inorganic, no API key),
+  **Materials Project** (computed inorganic; for stability ranking / predicted
+  phases), and / or a local CIF directory for candidate structures (chemistry +
+  symmetry filters). COD's experimental cells avoid the DFT lattice mismatch that
+  MP structures carry.
 - `simulate_xrd_pattern` — kinematic XRD pattern from a CIF via pymatgen
   (CuKa default; any wavelength supported).
 - `score_xrd_match_fast` — **fast tier**. Cross-correlation of the

--- a/scilink/skills/structure_matching/xrd/xrd.md
+++ b/scilink/skills/structure_matching/xrd/xrd.md
@@ -351,15 +351,50 @@ genuinely the right model.
 `simulate_xrd_pattern` call. Pull from experiment metadata when present;
 otherwise default CuKa.
 
-**Peak broadening.** Both scorers use a Lorentzian with FWHM=0.15° by
-default. For low-resolution or strongly broadened experimental patterns
-(nanocrystalline samples), bump `fwhm` to 0.3-0.5° so peaks overlap as
-they do in the data.
+**Peak broadening.** The fast tier's `fwhm` defaults to `'auto'`, which
+estimates the experimental peak width and broadens the simulation to match
+(floored at 0.15°) — so nanocrystalline / low-resolution patterns are handled
+without manual tuning. Pass a number only to force an exact width. The robust
+tier matches on peak *positions* within `tol_deg` (default 0.3°); widen
+`tol_deg` to ~0.5° for very broad peaks whose centers are poorly defined.
 
 **When the robust tier disagrees with the fast tier.** Trust the robust
 tier — it factors out background, scale, and intensity-ratio effects
 that the fast tier folds into the correlation. The fast tier is a
 triage step; the robust tier is the identification.
+
+**In-situ / series — lock the phase set, not the search.** For a
+time/temperature series (operando, a ramp), identify ONCE on the establishing
+(anchor) frame, then score every later frame against that LOCKED phase set — do
+**not** re-search the database per frame (slow, and the candidate ranking can
+flicker frame-to-frame). The agent reuses the anchor's script VERBATIM in a
+per-frame working directory, and the anchor always runs first, so make the script
+**self-locking** via a shared file one directory up (the per-frame dirs are
+siblings under a common parent):
+
+1. Read this frame's pattern from the canonical `data.npy` in the working dir.
+2. Resolve a shared lock path: `lock = Path.cwd().parent / "xrd_locked_phases.json"`.
+3. **Anchor frame (lock absent):** run the normal search → simulate → score
+   identification; once the phase(s) are confirmed, SAVE the matched phase
+   references to `lock` — for each phase its simulated `two_theta` + `intensities`
+   (the `sim_*` keys `score_xrd_match_multiphase` expects), plus `formula`, `id`,
+   and any fitted `lattice_scale`. This is the "lock the identified phase" step.
+4. **Later frames (lock present):** SKIP the search entirely; load the locked
+   phase patterns and run `score_xrd_match_multiphase(exp_peaks=<this frame's
+   extracted peaks>, candidates=<locked phases>)` → per-frame per-phase `coverage`
+   and `lattice_scale`.
+5. Emit `FIT_RESULTS_JSON` with `figure_of_merit` plus, for THIS frame, each
+   phase's `coverage` and `lattice_scale`. Aggregated across frames these trace
+   the **phase-fraction evolution** (coverage rising / falling = a phase growing /
+   disappearing) and **thermal expansion** (lattice_scale drift).
+
+The anchor establishes the lock before any later frame reads it (later frames may
+run in parallel and only READ the lock — no race). Locking the phase *set* — not
+a frozen search, not frozen peak positions — is what generalises: each later frame
+re-extracts its own peaks and re-fits per-phase lattice scale, so the method
+follows peak shifts (thermal expansion) and intensity changes (phase fraction)
+while keeping the *identity* decision fixed from the anchor. (Mirrors the
+`xrd_profile` skill's "lock the method, not the values," adapted to identification.)
 
 ## interpretation
 
@@ -410,6 +445,22 @@ mixture has many resolved peaks per phase. The tool does NOT compute
 quantitative phase fractions (peak-area weighted Rietveld refinement
 is the standard for that); the `coverage` field is a peak-count
 proxy, not a phase fraction. Note this caveat in the report.
+
+**`predicted_coverage` — reject over-predicting false matches.** Each active
+phase reports `predicted_coverage`: the intensity-weighted fraction of *that
+phase's own strong reflections* that are actually present in the data
+(bidirectional matching). A real phase shows nearly all its strong peaks
+(`predicted_coverage` ≈ 0.8–1.0). A **peak-rich wrong phase** (e.g. a Magnéli
+suboxide standing in for TiO₂, or a telluride/alloy standing in for a pure
+metal) explains a few experimental peaks by overlap but leaves most of its OWN
+strong peaks unobserved (`predicted_coverage` ≈ 0.1–0.4). **Treat an active
+phase with `predicted_coverage` below ~0.5 as a likely false match: do not
+report or lock it — widen the search (more candidates / the correct polymorph)
+to find a phase that explains those peaks with high predicted_coverage.** Low
+`coverage` AND low `predicted_coverage` together = the scorer latched onto a
+minority of correctly-positioned peaks while the phase is wrong. (A genuinely
+textured sample can suppress some reflections and lower `predicted_coverage`
+legitimately — weigh it against the residuals and the alternatives.)
 
 ## validation
 

--- a/scilink/skills/structure_matching/xrd/xrd.md
+++ b/scilink/skills/structure_matching/xrd/xrd.md
@@ -1,5 +1,5 @@
 ---
-description: XRD phase identification (search-match) — the default first-pass XRD analysis: "what phase(s) is this?". Queries crystal-structure databases (COD, Materials Project, local CIF), simulates kinematic patterns, and scores by cross-correlation (fast) and Hanawalt / MIP peak-matching (robust). Use this for routine phase ID; the xrd_profile skill is the specialized follow-up for line-broadening (crystallite size / strain) once the phase is known.
+description: 'XRD phase identification (search-match) — the default first-pass XRD analysis answering "what phase(s) is this?". Queries crystal-structure databases (COD, Materials Project, local CIF), simulates kinematic patterns, and scores by cross-correlation (fast) and Hanawalt / MIP peak-matching (robust). Use this for routine phase ID; the xrd_profile skill is the specialized follow-up for line-broadening (crystallite size / strain) once the phase is known.'
 quality_gate:
   metric: figure_of_merit
   accept_threshold: 0.70

--- a/scilink/skills/structure_matching/xrd/xrd.md
+++ b/scilink/skills/structure_matching/xrd/xrd.md
@@ -280,6 +280,27 @@ print("FIT_RESULTS_JSON: " + json.dumps({
 }))
 ```
 
+**Multi-phase emit (REQUIRED when using `score_xrd_match_multiphase`).** The
+multi-phase scorer returns ONE result with `active_phases` (not a ranked
+per-candidate list), plus `figure_of_merit` (= 1 − cost) and `verdict`. The
+quality gate reads `fit_quality.figure_of_merit`, so you MUST surface the
+multi-phase `figure_of_merit` there or the run is hard-rejected as "metric
+missing" regardless of how good the match is:
+
+```python
+mp = score_xrd_match_multiphase(exp_peaks=exp_peaks, candidates=candidates)
+print("FIT_RESULTS_JSON: " + json.dumps({
+    "active_phases": mp["active_phases"],          # each: id, formula, coverage,
+                                                   # matched_peaks, lattice_scale
+    "unmatched_exp": mp["unmatched_exp"],          # peaks no phase explains
+    "fit_quality": {
+        "figure_of_merit": mp["figure_of_merit"],  # gate reads THIS
+        "verdict": mp["verdict"],
+        "cost": mp["cost"],
+    },
+}))
+```
+
 **Background handling.** Both scorers default to subtracting the
 experimental minimum as a flat offset. For patterns with significant
 continuous background (amorphous halo, fluorescence), call

--- a/tests/test_structure_backends.py
+++ b/tests/test_structure_backends.py
@@ -264,12 +264,35 @@ def test_local_query_walks_subdirectories(tmp_path):
     assert len(out) == 1
 
 
-# --- CODBackend (stub) --------------------------------------------------------
+# --- CODBackend (implemented) -------------------------------------------------
 
-def test_cod_stub_not_available():
-    assert CODBackend().is_available() is False
+def test_cod_unavailable_without_db_or_web(monkeypatch):
+    """No local metadata db and web disabled -> not usable."""
+    monkeypatch.delenv("SCILINK_COD_DB", raising=False)
+    b = CODBackend(db_path=None, cif_dir=None, allow_web=False)
+    assert b.is_available() is False
 
 
-def test_cod_stub_query_raises():
-    with pytest.raises(NotImplementedError):
-        CODBackend().query(QuerySpec(chemistry=["Si"]))
+def test_cod_available_via_web(monkeypatch):
+    """No db but web enabled -> usable (REST element search fallback). pymatgen
+    is importorskip'd at module top, so the only remaining gate is allow_web."""
+    monkeypatch.delenv("SCILINK_COD_DB", raising=False)
+    b = CODBackend(db_path=None, cif_dir=None, allow_web=True)
+    assert b.is_available() is True
+
+
+def test_cod_query_returns_empty_when_unavailable(monkeypatch):
+    """An unavailable backend returns [] (no raise) — query is a no-op, not an
+    error, so search_structures can probe it harmlessly."""
+    monkeypatch.delenv("SCILINK_COD_DB", raising=False)
+    b = CODBackend(db_path=None, cif_dir=None, allow_web=False)
+    assert b.query(QuerySpec(chemistry=["Si"])) == []
+
+
+def test_cod_formula_elements_handles_fractional_counts():
+    """COD formula strings carry fractional occupancy/Z counts (e.g. 'H145.17',
+    'Na0.67'); the element parser must strip the numeric suffix including the
+    decimal. Regression for the parser fix."""
+    from scilink.skills.structure_matching._backends.cod import _formula_elements
+    assert _formula_elements("- C6 H145.17 Au Cl4 N3 -") == {"C", "H", "Au", "Cl", "N"}
+    assert _formula_elements("Na0.67 Mn O2") == {"Na", "Mn", "O"}


### PR DESCRIPTION
## Summary (for scientists)

Adds robust **XRD phase identification** to SciLink — *"what phase(s) is this?"* from a powder pattern — plus the natural **microstructure follow-up** (crystallite size / strain) and **in-situ series** tracking.

Typical workflow:
1. **Quick ID** — give it a pattern (+ optional chemistry hint). It searches crystal-structure databases (**COD** — keyless; **Materials Project**; **local CIFs**), simulates kinematic patterns, and reports the matched phase(s) with a confidence score. Handles single-phase and multi-phase mixtures, any common source (Cu/Mo/Co/…), nanocrystalline or well-crystallized samples.
2. **Optional deep analysis** — run the `xrd_profile` follow-up on the same pattern for **crystallite size (Scherrer)** and **microstrain (Williamson–Hall)** from line broadening, via a fast global profile fit; a Rietveld tier is scoped as a documented seam.
3. **In-situ series** — identify on the first frame, **lock the phase set**, and track how the phases evolve across a temperature/time ramp (e.g. a precursor consumed as a product grows).

Built to be trustworthy: a wrong-chemistry or noise pattern is **rejected** ("no confident match"), not force-matched to something plausible.

Validated end-to-end on synthetic patterns across material classes and on a real in-situ IMAuCl₄→Au reduction dataset (identifies the molecular precursor + tracks the ramp).

> Incorporates and **supersedes #272** (the `xrd_profile` / `fit_pattern` fast fitter), merged in so the ID → microstructure chain lives on one branch. #272 can be closed.

---

## Technical details

**Identification skill** (`scilink/skills/structure_matching/xrd/`) — a foundation-agent skill on `CurveFittingAgent`, gated by a `figure_of_merit` `quality_gate` (frontmatter), structurally non-fitting (the script does search→match, never profile-fits / emits R²).

Pipeline: `search_structures` → `simulate_xrd_pattern` (pluggable engine, pymatgen default) → `score_xrd_match_fast` (cross-correlation; `fwhm='auto'` adapts broadening to the data) → `extract_peaks` → `score_xrd_match_robust` (Hanawalt / MIP) and `score_xrd_match_multiphase` (joint MILP).

Databases: `_backends/cod.py` (COD — local sqlite metadata or keyless online element search; CIFs from a local archive or a vetted crystallography.net fetch), `materials_project.py`, `local_cif.py`; extensible via the `StructureBackend` protocol + entry points.

Scoring robustness:
- **Lattice-scale alignment** (`score_match_robust.py`) — Bragg sin-θ scaling so DFT-relaxed references align (≥2-reflection gate prevents force-aligning a wrong phase).
- **Bidirectional matching** — a predicted-but-absent penalty in the multiphase MILP objective + a single-phase `predicted_coverage` gate, so a peak-rich wrong phase can't win by overlap and a wrong-chemistry pattern is rejected instead of scoring a false "marginal".
- **Intensity-weighted cost** — noise peaks don't reject an otherwise-correct match.
- **Retrieval simplicity ranking** (`cod.py`) — the common phase surfaces ahead of complex same-composition phases (e.g. anatase/rutile before Magnéli suboxides).

In-situ series:
- Skill guidance: anchor self-locks the matched phase references to a shared file; later frames skip the search and multiphase-score against the locked set → per-frame coverage + lattice-scale evolution.
- Agent-code (`curve_fitting_controllers.py`): for scoring-gated (non-`r_squared`) skills the Adaptive-Refit controller early-returns (don't re-derive a deliberately-locked phase set per frame) and series target logging is gate-aware. **Keyed on the skill-declared gate metric — the `r_squared` path (all curve fitting + fitting-based ID) is byte-for-byte unchanged.** This cut the real IMAuCl₄ series from 102 min to 8.4 min.

Microstructure follow-up (`scilink/skills/curve_fitting/xrd_profile/`, from #272): reframed as the post-ID deep step (overview tiers profile-fit → size/strain → Rietveld-seam); `fit_pattern.py` global multi-peak (split) pseudo-Voigt fitter + `scherrer.py` + `williamson_hall.py`.

**Validation:** 107 unit tests (gate, verifier-integration, scorer, backends, matching, loader) pass; a 39-scenario standalone suite (25 single-phase across classes, Mo/Co radiation, nanocrystalline, multiphase, negative controls all reject); real IMAuCl₄ series end-to-end in 8.4 min.

**Known limits (follow-ups):** a phase too weak at the *anchor* frame isn't locked (new-phase detection / smarter anchor selection); composition discrimination (pure metal vs dilute alloy — same pattern) is an inherent XRD limit; CLI/UI surfacing of the skills is backend-first and not yet wired.
