### PR TITLE
Skill-reuse quality + robustness fixes (persistent-memory follow-up)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,15 @@ ENV GOOGLE_API_KEY=""
 ENV FUTUREHOUSE_API_KEY=""
 ENV MP_API_KEY=""
 
+# Persistent memory: graduated + auto-distilled skills live here. Declared as a
+# VOLUME so it is easy to persist across container restarts. WITHOUT a mounted
+# volume this dir is ephemeral and learned skills are lost when the container
+# exits — mount it to keep them, e.g.:
+#   docker run -v ~/.scilink:/home/scilinkuser/.scilink scilink ...
+# (or set SCILINK_HOME to a mounted path).
+RUN mkdir -p /home/scilinkuser/.scilink
+VOLUME ["/home/scilinkuser/.scilink"]
+
 # Ensure the non-root user owns all the files in its home directory.
 RUN chown -R scilinkuser:scilinkgroup /home/scilinkuser
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,32 @@ Register additional `BaseAnalysisAgent` subclasses:
 scilink analyze --agents ./my_xrd_agent.py
 ```
 
+### Persistent Memory
+
+SciLink agents learn from hard problems and keep that knowledge across sessions.
+Graduated and auto-distilled skills are stored under **`~/.scilink/`** (override
+with `$SCILINK_HOME`) — outside the installed package, so they survive a `pip`
+upgrade and are auto-discovered on every future run. Manage them with:
+
+```bash
+scilink memory list                 # graduated/auto-distilled skills
+scilink memory staged               # raw T=2 solutions awaiting distillation
+scilink memory upgrade <domain>/<id> --into <domain>/<name>   # enrich an existing skill
+scilink memory consolidate <domain>/<technique>              # distill N into a new skill
+scilink memory promote <domain>/<name>                       # make a provisional skill auto-routable
+```
+
+> **Docker:** the store lives in the container's home (`~/.scilink`), which is
+> **ephemeral** — learned skills are lost when the container exits unless you
+> mount a volume. The image declares it as a `VOLUME`; persist it with, e.g.:
+>
+> ```bash
+> docker run -v ~/.scilink:/home/scilinkuser/.scilink scilink ...
+> # or: docker run -e SCILINK_HOME=/data -v scilink-mem:/data scilink ...
+> ```
+>
+> Without a mount, SciLink logs a one-time warning that memory won't persist.
+
 ---
 
 # Planning Agents

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2885,8 +2885,9 @@ dataset's specific paths and magic numbers. Where the examples differ, note what
 when to choose each option (this is the value of having several examples). Explain why the \
 naive/default plan was insufficient.
 
-The best example's working script is appended verbatim to the implementation section by the \
-system as a reference — do NOT paste scripts back; write the generalized recipe.
+Each example includes a `working_script_excerpt` so you can extract the reusable procedure \
+from real code. Do NOT paste any script back verbatim — write a CONCISE, generalized recipe \
+(the skill is read into the prompt every run, so keep it tight; no one-off dataset code).
 
 Return a JSON object with exactly the following keys. Use markdown within values when helpful \
 (lists, inline code), but no section headings (`##`) or YAML frontmatter — the caller adds those.

--- a/scilink/skills/_shared/_graduation.py
+++ b/scilink/skills/_shared/_graduation.py
@@ -29,12 +29,60 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from ..loader import graduated_skills_dir
+
+
+def safe_path_component(value: str, *, fallback: str = "unknown") -> str:
+    """Sanitize a string used as a single filesystem path component.
+
+    `domain` / `skill_name` / `technique` are joined into paths under the
+    persistent store. A value like ``"../../evil"`` would escape the store, so
+    strip directory separators and parent refs, keeping only a flat, safe token.
+    """
+    base = Path(str(value)).name              # drops any dir part, incl. ".."
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", base).strip("._-")
+    return cleaned or fallback
+
+
+_EPHEMERAL_WARNED = False
+
+
+def warn_if_ephemeral_store() -> None:
+    """Warn ONCE if the persistent store likely won't persist.
+
+    SciLink is commonly run in Docker; inside a container the default home
+    (``~/.scilink``) lives on the ephemeral container filesystem, so graduated/
+    staged skills vanish when the container exits — silently defeating the whole
+    "persistent memory" promise. We can't reliably detect a bind-mount, so we use
+    a conservative heuristic: in a container AND ``$SCILINK_HOME`` is unset →
+    advise mounting a volume. Advisory only; never blocks or relocates.
+    """
+    global _EPHEMERAL_WARNED
+    if _EPHEMERAL_WARNED or os.environ.get("SCILINK_HOME"):
+        return
+    in_container = os.path.exists("/.dockerenv")
+    if not in_container:
+        try:
+            with open("/proc/1/cgroup") as fh:
+                in_container = "docker" in fh.read() or "kubepods" in fh.read()
+        except OSError:
+            in_container = False
+    if in_container:
+        _EPHEMERAL_WARNED = True
+        from ..loader import scilink_home
+        logging.warning(
+            "Persistent memory at %s is on the container filesystem and will NOT "
+            "survive container restarts. Mount a volume (e.g. "
+            "`-v ~/.scilink:/home/scilinkuser/.scilink`) or set $SCILINK_HOME to a "
+            "mounted path to keep graduated/distilled skills.",
+            scilink_home(),
+        )
 
 # Backward-compatible module constant. Prefer calling
 # ``graduated_skills_dir()`` (honors $SCILINK_HOME dynamically); this is
@@ -271,6 +319,10 @@ def graduate_to_skill_file(
         word_count, and a soft warning if the file is getting long.
     """
     skills_root = skills_root or graduated_skills_dir()
+    warn_if_ephemeral_store()
+    # Guard against path-traversal: domain/skill_name are filesystem components.
+    domain = safe_path_component(domain, fallback="unknown_domain")
+    skill_name = safe_path_component(skill_name, fallback="unnamed_skill")
     domain_dir = skills_root / domain
     skill_dir = domain_dir / skill_name
     skill_dir.mkdir(parents=True, exist_ok=True)

--- a/scilink/skills/_shared/_memory.py
+++ b/scilink/skills/_shared/_memory.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from ..loader import graduated_skills_dir, load_skill
+from ._graduation import safe_path_component
 
 # Captures the frontmatter body with EXACTLY one trailing newline after the
 # closing fence, so ``text[match.end():]`` preserves the rest of the file
@@ -31,6 +32,9 @@ _FRONTMATTER_BLOCK_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
 
 def _bundle_path(domain: str, name: str, *, root: Optional[Path] = None) -> Path:
     root = root or graduated_skills_dir()
+    # domain/name are filesystem components — sanitize against path traversal.
+    domain = safe_path_component(domain, fallback="unknown_domain")
+    name = safe_path_component(name, fallback="unnamed_skill")
     return root / domain / name / f"{name}.md"
 
 

--- a/scilink/skills/_shared/_staging.py
+++ b/scilink/skills/_shared/_staging.py
@@ -22,8 +22,8 @@ import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
-from ..loader import scilink_home, load_skill, list_skills
-from ._graduation import graduate_to_skill_file
+from ..loader import scilink_home, load_skill, list_skills, graduated_skills_dir
+from ._graduation import graduate_to_skill_file, safe_path_component, warn_if_ephemeral_store
 
 
 def staging_dir() -> Path:
@@ -32,7 +32,8 @@ def staging_dir() -> Path:
 
 
 def _domain_dir(domain: str, *, root: Optional[Path] = None) -> Path:
-    return (root or staging_dir()) / domain
+    # domain is a filesystem component — sanitize to prevent path traversal.
+    return (root or staging_dir()) / safe_path_component(domain, fallback="unknown_domain")
 
 
 # ──────────────────────────────────────────────────────────────
@@ -52,6 +53,7 @@ def stage_solution(
     etc.); ``technique`` is the normalized grouping label. The stored JSON adds
     ``id``, ``domain``, ``technique``.
     """
+    warn_if_ephemeral_store()
     d = _domain_dir(domain, root=root)
     d.mkdir(parents=True, exist_ok=True)
     sid = uuid.uuid4().hex[:8]
@@ -169,21 +171,26 @@ def _script_of(rec: Dict[str, Any]) -> str:
     return (rec.get("working_script") or rec.get("script") or "").strip()
 
 
-def _ref_block(rec: Dict[str, Any], *, label: str = "fit") -> str:
-    script = _script_of(rec)
-    if not script:
-        return ""
-    return (
-        f"### Reference implementation (verbatim {label} that produced this skill)\n\n"
-        "```python\n" + script + "\n```"
-    )
+# How much of the working script to show the LLM as *input* (so it can extract
+# the reusable recipe from real code). The script is NOT copied verbatim into the
+# saved skill — doing so bloated reused skills (a ~1500-word one-shot script) and
+# empirically degraded the next run by over-constraining it. Distill, don't dump.
+_SCRIPT_PROMPT_CHARS = 4000
 
 
 def _record_for_prompt(rec: Dict[str, Any]) -> Dict[str, Any]:
-    """A record trimmed for the LLM prompt — drop bookkeeping + the (large)
-    script, which is appended verbatim separately."""
+    """A record trimmed for the LLM prompt — drop bookkeeping; include a
+    length-capped working script so the LLM can generalize from real code without
+    the full script being echoed into the saved skill."""
     drop = {"id", "domain", "technique", "working_script", "script", "created_at"}
-    return {k: v for k, v in rec.items() if k not in drop}
+    out = {k: v for k, v in rec.items() if k not in drop}
+    script = _script_of(rec)
+    if script:
+        out["working_script_excerpt"] = (
+            script if len(script) <= _SCRIPT_PROMPT_CHARS
+            else script[:_SCRIPT_PROMPT_CHARS] + "\n# … (truncated; full script in the staging record)"
+        )
+    return out
 
 
 # ──────────────────────────────────────────────────────────────
@@ -205,15 +212,28 @@ def upgrade_skill_from_staged(
     """Enrich an existing skill from one (or a few) staged solution(s).
 
     The target skill must already exist, so ``graduate_to_skill_file`` takes its
-    update/merge branch — the same path the demo exercises (EELS v1→v2). The
-    verbatim script of the first staged record is appended as a reference. On
-    success the consumed staged records are removed.
+    update/merge branch — the same path the demo exercises (EELS v1→v2). The LLM
+    sees the staged solution's (capped) script as input and distills a reusable
+    recipe; the full verbatim script is deliberately NOT copied into the skill
+    (that bloated reused skills and degraded the next run). On success the
+    consumed staged records are removed.
     """
     recs = [r for r in (get_staged(domain, sid, root=root) for sid in staged_ids) if r]
     if not recs:
         return {"status": "error", "message": "No staged records found for the given ids."}
 
-    primary = recs[0]
+    # "Upgrade" means enrich an EXISTING skill. Require the target to exist so a
+    # typo'd --into doesn't silently create a brand-new skill (and waste an LLM
+    # call). Use consolidate / a fresh graduation to make a new skill instead.
+    target_md = ((skills_root or graduated_skills_dir())
+                 / safe_path_component(target_domain) / safe_path_component(target_name)
+                 / f"{safe_path_component(target_name)}.md")
+    if not target_md.exists():
+        return {"status": "error",
+                "message": (f"Target skill '{target_domain}/{target_name}' does not exist — "
+                            f"upgrade enriches an existing skill. Check the name, or use "
+                            f"consolidate to create a new skill.")}
+
     knowledge_entry = {
         "new_t2_solutions": [_record_for_prompt(r) for r in recs],
     }
@@ -225,7 +245,6 @@ def upgrade_skill_from_staged(
         fresh_template=fresh_template,
         update_template=update_template,
         skills_root=skills_root,
-        append_sections={"implementation": _ref_block(primary)},
     )
     if result.get("status") == "success":
         remove_staged(domain, [r["id"] for r in recs if r.get("id")], root=root)
@@ -236,17 +255,6 @@ def upgrade_skill_from_staged(
 # ──────────────────────────────────────────────────────────────
 # new-skill@N — consolidate N staged solutions into a NEW skill
 # ──────────────────────────────────────────────────────────────
-
-def _best_record(recs: List[Dict[str, Any]]) -> Dict[str, Any]:
-    """Pick the highest-quality staged record (r_squared or quality_score)."""
-    def _metric(r: Dict[str, Any]) -> float:
-        for k in ("r_squared", "quality_score", "metric"):
-            v = r.get(k)
-            if isinstance(v, (int, float)):
-                return float(v)
-        return 0.0
-    return max(recs, key=_metric)
-
 
 def consolidate_technique(
     domain: str,
@@ -260,16 +268,17 @@ def consolidate_technique(
 ) -> Dict[str, Any]:
     """Distill all staged solutions for one technique into a single new skill.
 
-    Builds a multi-example knowledge entry, calls ``graduate_to_skill_file`` with
-    the consolidation template (skill name ``auto_<technique>``), appends the best
-    example's script verbatim, tags ``provenance=t2_consolidated`` + ``n_examples``,
-    and removes the consumed staged records.
+    Builds a multi-example knowledge entry (each example's capped script included
+    as input so the LLM generalizes from real code), calls ``graduate_to_skill_file``
+    with the consolidation template (skill name ``auto_<technique>``), tags
+    ``provenance=t2_consolidated`` + ``n_examples``, and removes the consumed staged
+    records. The full verbatim scripts are NOT copied into the skill (kept concise
+    and reusable; scripts remain in the staging records).
     """
     recs = list_staged(domain, technique, root=root)
     if not recs:
         return {"status": "error", "message": f"No staged solutions for {domain}/{technique}."}
 
-    best = _best_record(recs)
     knowledge_entry = {
         "technique": technique,
         "n_examples": len(recs),
@@ -289,7 +298,6 @@ def consolidate_technique(
             "provenance": "t2_consolidated",
             "n_examples": len(recs),
         },
-        append_sections={"implementation": _ref_block(best)},
     )
     if result.get("status") == "success":
         remove_staged(domain, [r["id"] for r in recs if r.get("id")], root=root)


### PR DESCRIPTION
# Skill-reuse quality + robustness fixes (post-merge follow-up to persistent memory)

## Summary (for scientists)

Follow-up hardening of the persistent-memory / self-evolution feature, found by a
focused live + offline bug hunt after the initial merge. The headline fix makes a
learned skill actually *help* the next run instead of bloating the prompt; the
rest close correctness, safety, and Docker-persistence gaps.

**What's fixed:**

- **Learned skills stay concise (the important one).** When a hard-won T=2 solution
  was merged into a skill, the entire verbatim ~1500-word one-shot script was being
  copied into the skill. Re-injecting that dataset-specific code into the next run's
  prompt *over-constrained* the agent and measurably degraded it (in a live A/B the
  "enriched" skill scored worse than the thin one). Now the model **reads** the
  script as input and distills a concise, generalized recipe; the verbatim script is
  not dumped into the skill (it remains in the staging record).
- **Persistent memory under Docker.** The store lives in `~/.scilink`, which is
  ephemeral inside a container — learned skills silently vanished on exit. The image
  now declares the store as a `VOLUME`, the README documents how to mount it, and
  SciLink logs a one-time warning when it detects an unmounted container store.
- **Safer & more predictable:** path-traversal hardening on stored skill paths;
  `upgrade --into <skill>` now errors if the target doesn't exist (instead of
  silently creating a new skill and wasting an LLM call).

## Technical details

### Reuse-quality (anti-bloat)
- `_staging.upgrade_skill_from_staged` / `consolidate_technique`: dropped the
  `append_sections={"implementation": <verbatim script>}` dump. Instead
  `_record_for_prompt` now includes a length-capped `working_script_excerpt`
  (`_SCRIPT_PROMPT_CHARS=4000`) so the LLM generalizes from real code without the
  script being echoed into the saved skill. Removed dead `_ref_block`/`_best_record`;
  `T2_CONSOLIDATION_INSTRUCTIONS` reworded ("write a concise recipe; do not paste
  scripts").

### Path-traversal hardening
- New `safe_path_component()` in `_graduation.py`; applied where `domain`/`skill_name`/
  `name` become filesystem components in `_graduation.graduate_to_skill_file`,
  `_staging._domain_dir`, and `_memory._bundle_path`. A `domain="../../evil"` previously
  wrote JSON outside the store; now contained.

### Docker / ephemeral-store advisory
- `warn_if_ephemeral_store()` (called at the staging + graduation write sites): warns
  once when in a container (`/.dockerenv` or cgroup) with `$SCILINK_HOME` unset.
  Advisory only — never blocks or relocates. Dockerfile adds `VOLUME
  ["/home/scilinkuser/.scilink"]`; README gains a "Persistent Memory" + Docker section.

### Correctness
- `upgrade_skill_from_staged` now verifies the target skill bundle exists before the
  LLM call; returns a clear error (and preserves the staged record) otherwise.
- Fixed a latent crash: `_graduation.py` used `os.*` without importing `os`; removed a
  duplicate `import re`.

### Validation
- Local pytest module (33 cases): bloat fix (script in prompt, not in skill),
  path-traversal containment + `safe_path_component`, ephemeral-store warning
  (container/no-container/once), upgrade-into-missing guard, plus the prior staging/
  upgrade/consolidate/meta coverage. All passing.
- Live (Bedrock opus-4-8): confirmed the bloat fix at the artifact level — feeding a
  deliberately large (~120-line) script through the fixed `upgrade` path yields a
  concise skill (v1 113 → v2 254 words; `implementation` ≈ 20 words; **no verbatim
  script leaked**). This directly removes the mechanism behind the earlier reuse
  regression. The full thin-vs-enriched head-to-head on EELS remains **inconclusive**
  — EELS is an easy/variable task for the agent (the thin skill already reaches
  R²≈0.999 at low temperature), so it doesn't reliably show a reuse delta either way;
  the runs progressed but exceeded the test's wall-clock guard. Not claimed as a win.

### Notes / limitations
- The ephemeral-store check is a heuristic (container + `$SCILINK_HOME` unset); it
  can't detect a bind-mount, so a mounted container without `$SCILINK_HOME` may still
  warn. Advisory only.
- Test module kept local (not in the diff), consistent with the prior PR.
