### PR TITLE
Persistent-memory review UX: View staged solutions, accumulate-before-consolidate, theme fixes

### DIFF
--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -462,8 +462,25 @@ class MetaOrchestratorTools:
 
             if act == "list_staged":
                 rows = _staging.list_staged()
-                print(f"  🧠 {len(rows)} staged T=2 solution(s) awaiting distillation.")
+                # Per-technique readiness so the LLM accumulates before suggesting a
+                # NEW skill: consolidation needs >= consolidate_min_n() examples of a
+                # technique; a single staged solution is too idiosyncratic to graduate
+                # (upgrading an EXISTING skill via `upgrade` is exempt).
+                need = _staging.consolidate_min_n()
+                by_tech: dict = {}
+                for r in rows:
+                    key = f"{r.get('domain')}/{r.get('technique') or 'unlabeled'}"
+                    by_tech[key] = by_tech.get(key, 0) + 1
+                techniques = [
+                    {"technique": k, "n_staged": n, "ready_to_consolidate": n >= need}
+                    for k, n in sorted(by_tech.items())
+                ]
+                print(f"  🧠 {len(rows)} staged T=2 solution(s) awaiting distillation "
+                      f"({sum(1 for t in techniques if t['ready_to_consolidate'])} "
+                      f"technique(s) ready to consolidate; threshold {need}).")
                 return json.dumps({"status": "success", "action": "list_staged",
+                                   "consolidate_threshold": need,
+                                   "techniques": techniques,
                                    "staged_solutions": rows}, default=str)
 
             try:
@@ -530,7 +547,11 @@ class MetaOrchestratorTools:
                 "`staged_solutions`); skills are produced from staged solutions two "
                 "ways, both review-gated: `upgrade` merges ONE staged solution into an "
                 "EXISTING skill, or `consolidate` distills all staged solutions of a "
-                "technique into a NEW (provisional) skill. Also manages already-"
+                "technique into a NEW (provisional) skill. Prefer `upgrade` when a "
+                "matching skill exists. Do NOT `consolidate` a technique into a new "
+                "skill until it has accumulated enough examples — `list_staged` reports "
+                "`ready_to_consolidate` per technique against `consolidate_threshold`; "
+                "if not ready, leave it staged to accumulate. Also manages already-"
                 "distilled provisional skills. Actions: `list` (provisional skills), "
                 "`list_staged` (staged solutions, by technique), `show` a skill, "
                 "`promote`/`discard` a skill, `upgrade` (needs `staged` + `into`), "

--- a/scilink/cli/memory.py
+++ b/scilink/cli/memory.py
@@ -177,22 +177,59 @@ def _cmd_staged(args) -> int:
 
 
 def _cmd_upgrade(args) -> int:
+    import difflib
     from scilink.agents.exp_agents.instruct import (
         KNOWLEDGE_TO_SKILL_INSTRUCTIONS, SKILL_UPDATE_INSTRUCTIONS,
     )
     domain, sid = _split_ref(args.ref)  # staged ref = <domain>/<id>
     tdomain, tname = _split_ref(args.into)
-    res = _staging.upgrade_skill_from_staged(
+
+    # 1) propose (build the merged skill without writing it)
+    prop = _staging.propose_skill_upgrade(
         domain, [sid], target_domain=tdomain, target_name=tname,
         llm_call=_make_llm_call(args),
         fresh_template=KNOWLEDGE_TO_SKILL_INSTRUCTIONS,
         update_template=SKILL_UPDATE_INSTRUCTIONS,
     )
+    if prop.get("status") != "success":
+        print(f"❌ {prop.get('message', prop)}")
+        return 1
+
+    # 2) show the diff for review (upgrade mutates an existing skill in place)
+    if not args.yes:
+        diff = difflib.unified_diff(
+            prop["existing_content"].splitlines(),
+            prop["proposed_content"].splitlines(),
+            fromfile=f"{tdomain}/{tname} (current)",
+            tofile=f"{tdomain}/{tname} (after upgrade)", lineterm="")
+        print(f"\nProposed upgrade of {tdomain}/{tname} from staged {sid}:\n")
+        printed = False
+        for line in diff:
+            printed = True
+            if line.startswith("+") and not line.startswith("+++"):
+                print(f"\033[32m{line}\033[0m")
+            elif line.startswith("-") and not line.startswith("---"):
+                print(f"\033[31m{line}\033[0m")
+            else:
+                print(line)
+        if not printed:
+            print("(no textual change)")
+        resp = input("\nApply this upgrade? [y/N] ").strip().lower()
+        if resp not in ("y", "yes"):
+            print("Aborted — nothing written, staged solution kept.")
+            return 1
+
+    # 3) apply the approved content (backs up the current file)
+    res = _staging.apply_skill_upgrade(
+        domain, prop["staged_ids"], target_domain=tdomain, target_name=tname,
+        proposed_content=prop["proposed_content"],
+    )
     if res.get("status") != "success":
         print(f"❌ {res.get('message', res)}")
         return 1
-    print(f"✅ Upgraded {tdomain}/{tname} ({res.get('method')}) from staged {sid}.")
+    print(f"✅ Upgraded {tdomain}/{tname} from staged {sid}.")
     print(f"   {res.get('skill_path')}")
+    print(f"   backup: {res.get('backup_path')}")
     return 0
 
 
@@ -267,6 +304,8 @@ def main():
     p_up = sub.add_parser("upgrade", help="Merge a staged solution INTO an existing skill")
     p_up.add_argument("ref", help="Staged solution ref '<domain>/<id>'")
     p_up.add_argument("--into", required=True, help="Target skill '<domain>/<name>'")
+    p_up.add_argument("--yes", action="store_true",
+                      help="Apply without showing the diff / prompting")
     _add_model_args(p_up)
     p_up.set_defaults(func=_cmd_upgrade)
 

--- a/scilink/cli/memory.py
+++ b/scilink/cli/memory.py
@@ -135,11 +135,7 @@ def _cmd_prune(args) -> int:
 
 
 def _consolidate_n() -> int:
-    import os
-    try:
-        return int(os.environ.get("SCILINK_CONSOLIDATE_N", "3"))
-    except ValueError:
-        return 3
+    return _staging.consolidate_min_n()
 
 
 def _cmd_staged(args) -> int:
@@ -154,11 +150,16 @@ def _cmd_staged(args) -> int:
                 rec.get("technique") or "unlabeled", []).append(rec)
     total = 0
     threshold = _consolidate_n()
+    any_ready = False
     for dom, by_tech in sorted(domains.items()):
         for tech, recs in sorted(by_tech.items()):
             total += len(recs)
-            ready = " — ready to consolidate" if len(recs) >= threshold else ""
-            print(f"{dom}/{tech}: {len(recs)} staged{ready}")
+            if len(recs) >= threshold:
+                any_ready = True
+                status = " — ready to consolidate"
+            else:
+                status = f" — accumulating {len(recs)}/{threshold} for a new skill"
+            print(f"{dom}/{tech}: {len(recs)} staged{status}")
             for r in recs:
                 metric = r.get("r_squared") or r.get("quality_score")
                 mtxt = f"  metric={metric}" if metric is not None else ""
@@ -166,9 +167,12 @@ def _cmd_staged(args) -> int:
     if not total:
         print("No staged T=2 solutions.")
     else:
-        print(f"\n{total} staged solution(s). "
-              f"Upgrade an existing skill (`upgrade <domain>/<id> --into ...`) "
-              f"or consolidate (`consolidate <domain>/<technique>`).")
+        # New-skill consolidation accumulates first (>= N of a technique). Upgrading an
+        # existing skill from a single solution is always available.
+        tip = "`upgrade <domain>/<id> --into <domain>/<name>` (enrich an existing skill)"
+        if any_ready:
+            tip += " or `consolidate <domain>/<technique>` (techniques marked ready)"
+        print(f"\n{total} staged solution(s). {tip}.")
     return 0
 
 

--- a/scilink/skills/_shared/_graduation.py
+++ b/scilink/skills/_shared/_graduation.py
@@ -275,6 +275,7 @@ def graduate_to_skill_file(
     skills_root: Optional[Path] = None,
     extra_meta: Optional[Dict[str, Any]] = None,
     append_sections: Optional[Dict[str, str]] = None,
+    write: bool = True,
 ) -> Dict[str, Any]:
     """Graduate a knowledge entry into a skill .md file.
 
@@ -359,6 +360,19 @@ def graduate_to_skill_file(
             existing = (str(parsed.get(key) or "")).strip()
             parsed[key] = f"{existing}\n\n{text}".strip() if existing else text
     skill_content = format_skill_as_markdown(parsed)
+
+    # Build-only mode: return the proposed content WITHOUT writing it, so a
+    # caller can show it for review (used by the upgrade propose/apply flow).
+    if not write:
+        return {
+            "status": "success",
+            "method": "updated" if is_update else "created",
+            "skill_name": skill_name,
+            "domain": domain,
+            "skill_path": str(skill_path),
+            "content": skill_content,
+            "word_count": len(skill_content.split()),
+        }
 
     # Loader-style bundles include __init__.py; harmless for path-loaded
     # skills, but keeps the layout consistent with built-ins.

--- a/scilink/skills/_shared/_staging.py
+++ b/scilink/skills/_shared/_staging.py
@@ -31,6 +31,26 @@ def staging_dir() -> Path:
     return scilink_home() / "distill_staging"
 
 
+# Advisory minimum number of staged solutions of a technique before consolidating
+# them into a NEW skill. Below this, review surfaces accumulate rather than suggest
+# graduation (a single example is usually too idiosyncratic to generalize). Upgrading
+# an EXISTING skill is exempt — that is upgrade@1 by design. The function itself
+# still consolidates whatever is present when explicitly called.
+_DEFAULT_CONSOLIDATE_N = 3
+
+
+def consolidate_min_n() -> int:
+    """Readiness threshold for new-skill consolidation (``$SCILINK_CONSOLIDATE_N``)."""
+    import os
+    raw = os.environ.get("SCILINK_CONSOLIDATE_N", "").strip()
+    if raw:
+        try:
+            return max(1, int(raw))
+        except ValueError:
+            pass
+    return _DEFAULT_CONSOLIDATE_N
+
+
 def _domain_dir(domain: str, *, root: Optional[Path] = None) -> Path:
     # domain is a filesystem component — sanitize to prevent path traversal.
     return (root or staging_dir()) / safe_path_component(domain, fallback="unknown_domain")

--- a/scilink/skills/_shared/_staging.py
+++ b/scilink/skills/_shared/_staging.py
@@ -215,7 +215,119 @@ def _record_for_prompt(rec: Dict[str, Any]) -> Dict[str, Any]:
 
 # ──────────────────────────────────────────────────────────────
 # upgrade@1 — merge staged solution(s) into an EXISTING skill
+#
+# Upgrade mutates an existing (often already-active) skill in place, so it is
+# split into propose → apply for a human-in-the-loop review of the merged
+# content: ``propose_skill_upgrade`` builds the merged skill WITHOUT writing it
+# (returns the proposed text + the current text for a diff); ``apply_skill_upgrade``
+# backs up the current file and writes the approved content. ``upgrade_skill_from_staged``
+# remains as the one-shot (propose+apply) for non-interactive callers.
 # ──────────────────────────────────────────────────────────────
+
+def _skill_md_path(target_domain: str, target_name: str,
+                   skills_root: Optional[Path] = None) -> Path:
+    n = safe_path_component(target_name)
+    return ((skills_root or graduated_skills_dir())
+            / safe_path_component(target_domain) / n / f"{n}.md")
+
+
+def _missing_target_error(target_domain: str, target_name: str) -> Dict[str, Any]:
+    return {"status": "error",
+            "message": (f"Target skill '{target_domain}/{target_name}' does not exist — "
+                        f"upgrade enriches an existing skill. Check the name, or use "
+                        f"consolidate to create a new skill.")}
+
+
+def propose_skill_upgrade(
+    domain: str,
+    staged_ids: List[str],
+    *,
+    target_domain: str,
+    target_name: str,
+    llm_call: Callable[[str], str],
+    fresh_template: str,
+    update_template: str,
+    root: Optional[Path] = None,
+    skills_root: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Build the merged skill for review WITHOUT writing it.
+
+    Returns ``proposed_content`` (the new skill text) and ``existing_content``
+    (the current file) so a caller can show a diff and confirm. Nothing is
+    written and no staged records are consumed until ``apply_skill_upgrade``.
+    """
+    recs = [r for r in (get_staged(domain, sid, root=root) for sid in staged_ids) if r]
+    if not recs:
+        return {"status": "error", "message": "No staged records found for the given ids."}
+
+    target_md = _skill_md_path(target_domain, target_name, skills_root)
+    if not target_md.exists():
+        return _missing_target_error(target_domain, target_name)
+
+    knowledge_entry = {"new_t2_solutions": [_record_for_prompt(r) for r in recs]}
+    result = graduate_to_skill_file(
+        knowledge_entry=knowledge_entry,
+        skill_name=target_name,
+        domain=target_domain,
+        llm_call=llm_call,
+        fresh_template=fresh_template,
+        update_template=update_template,
+        skills_root=skills_root,
+        write=False,
+    )
+    if result.get("status") != "success":
+        return result
+    return {
+        "status": "success",
+        "action": "proposed",
+        "proposed_content": result["content"],
+        "existing_content": target_md.read_text(),
+        "skill_path": str(target_md),
+        "target_domain": target_domain,
+        "target_name": target_name,
+        "staged_ids": [r["id"] for r in recs if r.get("id")],
+        "word_count": result.get("word_count"),
+    }
+
+
+def apply_skill_upgrade(
+    domain: str,
+    staged_ids: List[str],
+    *,
+    target_domain: str,
+    target_name: str,
+    proposed_content: str,
+    root: Optional[Path] = None,
+    skills_root: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Write a previously-proposed upgrade, backing up the current file first.
+
+    The pre-upgrade skill is copied to ``<name>.md.bak`` (so an upgrade can be
+    reverted), the approved ``proposed_content`` is written, and the consumed
+    staged records are removed.
+    """
+    target_md = _skill_md_path(target_domain, target_name, skills_root)
+    if not target_md.exists():
+        return _missing_target_error(target_domain, target_name)
+    # Back up the current version (single last-version undo; .bak is ignored by
+    # the loader, which only discovers <name>.md).
+    backup = target_md.with_name(target_md.name + ".bak")
+    backup.write_text(target_md.read_text())
+    (target_md.parent / "__init__.py").touch()
+    target_md.write_text(proposed_content)
+    removed = remove_staged(domain, staged_ids, root=root)
+    return {
+        "status": "success",
+        "method": "updated",
+        "skill_name": target_name,
+        "domain": target_domain,
+        "skill_path": str(target_md),
+        "backup_path": str(backup),
+        "consumed_staged": list(staged_ids),
+        "n_consumed": removed,
+        "word_count": len(proposed_content.split()),
+    }
+
 
 def upgrade_skill_from_staged(
     domain: str,
@@ -229,47 +341,22 @@ def upgrade_skill_from_staged(
     root: Optional[Path] = None,
     skills_root: Optional[Path] = None,
 ) -> Dict[str, Any]:
-    """Enrich an existing skill from one (or a few) staged solution(s).
+    """One-shot upgrade (propose + apply) for non-interactive callers.
 
-    The target skill must already exist, so ``graduate_to_skill_file`` takes its
-    update/merge branch — the same path the demo exercises (EELS v1→v2). The LLM
-    sees the staged solution's (capped) script as input and distills a reusable
-    recipe; the full verbatim script is deliberately NOT copied into the skill
-    (that bloated reused skills and degraded the next run). On success the
-    consumed staged records are removed.
+    Interactive surfaces should call ``propose_skill_upgrade`` → show the diff →
+    ``apply_skill_upgrade`` so a human reviews the merged content. This wrapper
+    still backs up the pre-upgrade file (via ``apply_skill_upgrade``).
     """
-    recs = [r for r in (get_staged(domain, sid, root=root) for sid in staged_ids) if r]
-    if not recs:
-        return {"status": "error", "message": "No staged records found for the given ids."}
-
-    # "Upgrade" means enrich an EXISTING skill. Require the target to exist so a
-    # typo'd --into doesn't silently create a brand-new skill (and waste an LLM
-    # call). Use consolidate / a fresh graduation to make a new skill instead.
-    target_md = ((skills_root or graduated_skills_dir())
-                 / safe_path_component(target_domain) / safe_path_component(target_name)
-                 / f"{safe_path_component(target_name)}.md")
-    if not target_md.exists():
-        return {"status": "error",
-                "message": (f"Target skill '{target_domain}/{target_name}' does not exist — "
-                            f"upgrade enriches an existing skill. Check the name, or use "
-                            f"consolidate to create a new skill.")}
-
-    knowledge_entry = {
-        "new_t2_solutions": [_record_for_prompt(r) for r in recs],
-    }
-    result = graduate_to_skill_file(
-        knowledge_entry=knowledge_entry,
-        skill_name=target_name,
-        domain=target_domain,
-        llm_call=llm_call,
-        fresh_template=fresh_template,
-        update_template=update_template,
-        skills_root=skills_root,
-    )
-    if result.get("status") == "success":
-        remove_staged(domain, [r["id"] for r in recs if r.get("id")], root=root)
-        result["consumed_staged"] = [r.get("id") for r in recs]
-    return result
+    prop = propose_skill_upgrade(
+        domain, staged_ids, target_domain=target_domain, target_name=target_name,
+        llm_call=llm_call, fresh_template=fresh_template,
+        update_template=update_template, root=root, skills_root=skills_root)
+    if prop.get("status") != "success":
+        return prop
+    return apply_skill_upgrade(
+        domain, prop["staged_ids"], target_domain=target_domain,
+        target_name=target_name, proposed_content=prop["proposed_content"],
+        root=root, skills_root=skills_root)
 
 
 # ──────────────────────────────────────────────────────────────

--- a/scilink/ui/components/skills.py
+++ b/scilink/ui/components/skills.py
@@ -187,20 +187,26 @@ def _render_staged_section() -> None:
             # than stretching across the full-width memory panel.
             targets = [f"{s['domain']}/{s['name']}" for s in _memory.list_memory(domain=domain)]
             c1, c2, _ = st.columns([2, 2, 4])
+            prop_key = f"upgprop::{domain}/{technique}"
             with c1:
                 if targets:
                     tgt = st.selectbox("Upgrade into", targets, key=f"tgt::{domain}/{technique}")
                     sid = recs[0]["id"]
-                    if st.button("Upgrade (use newest)", key=f"up::{domain}/{technique}"):
+                    # Upgrade mutates an existing skill in place, so preview first:
+                    # build the merged skill, show a diff, and apply only on confirm.
+                    if st.button("Preview upgrade", key=f"up::{domain}/{technique}"):
                         from scilink.agents.exp_agents.instruct import (
                             KNOWLEDGE_TO_SKILL_INSTRUCTIONS, SKILL_UPDATE_INSTRUCTIONS)
                         td, tn = tgt.split("/", 1)
-                        res = _staging.upgrade_skill_from_staged(
+                        prop = _staging.propose_skill_upgrade(
                             domain, [sid], target_domain=td, target_name=tn,
                             llm_call=_llm_call,
                             fresh_template=KNOWLEDGE_TO_SKILL_INSTRUCTIONS,
                             update_template=SKILL_UPDATE_INSTRUCTIONS)
-                        st.success(f"Upgraded {tgt} ({res.get('method')}).")
+                        if prop.get("status") == "success":
+                            st.session_state[prop_key] = prop
+                        else:
+                            st.error(prop.get("message", "Could not build upgrade."))
                         st.rerun()
                 else:
                     st.caption("No existing skills in this domain to upgrade into.")
@@ -226,6 +232,38 @@ def _render_staged_section() -> None:
                         consolidation_template=T2_CONSOLIDATION_INSTRUCTIONS,
                         update_template=SKILL_UPDATE_INSTRUCTIONS)
                     st.success(f"Consolidated {res.get('n_examples')} → auto_{technique} (provisional).")
+                    st.rerun()
+
+            # Pending upgrade preview — review the merged content before applying.
+            prop = st.session_state.get(prop_key)
+            if prop:
+                import difflib
+                st.markdown(
+                    f"**Review upgrade → `{prop['target_domain']}/{prop['target_name']}`** "
+                    "— applies in place; the current version is backed up to `.md.bak`."
+                )
+                diff = "\n".join(difflib.unified_diff(
+                    prop["existing_content"].splitlines(),
+                    prop["proposed_content"].splitlines(),
+                    fromfile="current", tofile="after upgrade", lineterm=""))
+                st.code(diff or "(no textual change)", language="diff")
+                a1, a2, _ = st.columns([2, 2, 4])
+                if a1.button("Apply upgrade", key=f"upapply::{domain}/{technique}",
+                             type="primary"):
+                    res = _staging.apply_skill_upgrade(
+                        domain, prop["staged_ids"],
+                        target_domain=prop["target_domain"],
+                        target_name=prop["target_name"],
+                        proposed_content=prop["proposed_content"])
+                    st.session_state.pop(prop_key, None)
+                    if res.get("status") == "success":
+                        st.success(f"Upgraded {prop['target_domain']}/{prop['target_name']} "
+                                   f"(backup saved).")
+                    else:
+                        st.error(res.get("message", "Apply failed."))
+                    st.rerun()
+                if a2.button("Cancel", key=f"upcancel::{domain}/{technique}"):
+                    st.session_state.pop(prop_key, None)
                     st.rerun()
                 if not ready:
                     st.caption(f"Accumulating {len(recs)}/{need} examples before a new skill.")

--- a/scilink/ui/components/skills.py
+++ b/scilink/ui/components/skills.py
@@ -171,14 +171,22 @@ def _render_staged_section() -> None:
         with st.expander(f"`{domain}/{technique}` — {len(recs)} staged", expanded=False):
             for r in recs:
                 metric = r.get("r_squared") or r.get("quality_score")
-                st.caption(f"id={r['id']} · session={r.get('session','?')}"
-                           + (f" · metric={metric}" if metric is not None else ""))
+                meta_col, view_col = st.columns([3, 1])
+                meta_col.caption(
+                    f"id={r['id']} · session={r.get('session','?')}"
+                    + (f" · metric={metric}" if metric is not None else "")
+                )
+                with view_col.popover("View", use_container_width=True):
+                    _render_staged_record(r)
             if model is None:
                 st.info("Start a session to enable upgrade/consolidate (needs a model).")
                 continue
-            # candidate existing skills to upgrade into (same domain)
+            # candidate existing skills to upgrade into (same domain).
+            # Keep the action buttons in narrow columns + a trailing spacer so
+            # they land at a modest size (like the sidebar's Reset/Quit) rather
+            # than stretching across the full-width memory panel.
             targets = [f"{s['domain']}/{s['name']}" for s in _memory.list_memory(domain=domain)]
-            c1, c2 = st.columns(2)
+            c1, c2, _ = st.columns([2, 2, 4])
             with c1:
                 if targets:
                     tgt = st.selectbox("Upgrade into", targets, key=f"tgt::{domain}/{technique}")
@@ -197,7 +205,20 @@ def _render_staged_section() -> None:
                 else:
                     st.caption("No existing skills in this domain to upgrade into.")
             with c2:
-                if st.button("Consolidate → new skill", key=f"con::{domain}/{technique}"):
+                # New-skill consolidation accumulates first: only suggest it once
+                # enough examples of this technique are staged. Below the threshold
+                # the agent is still gathering evidence (one fit is too idiosyncratic
+                # to generalize into a standalone skill). Upgrading an existing skill
+                # is exempt — that's the upgrade@1 path on the left.
+                need = _staging.consolidate_min_n()
+                ready = len(recs) >= need
+                if st.button("Consolidate → new skill", key=f"con::{domain}/{technique}",
+                             disabled=not ready,
+                             help=(None if ready else
+                                   f"Accumulating {len(recs)}/{need} — consolidation into a "
+                                   f"new skill unlocks once {need} solutions of this technique "
+                                   f"are staged (set SCILINK_CONSOLIDATE_N to change; "
+                                   f"`scilink memory consolidate` can force it).")):
                     from scilink.agents.exp_agents.instruct import (
                         T2_CONSOLIDATION_INSTRUCTIONS, SKILL_UPDATE_INSTRUCTIONS)
                     res = _staging.consolidate_technique(
@@ -206,6 +227,26 @@ def _render_staged_section() -> None:
                         update_template=SKILL_UPDATE_INSTRUCTIONS)
                     st.success(f"Consolidated {res.get('n_examples')} → auto_{technique} (provisional).")
                     st.rerun()
+                if not ready:
+                    st.caption(f"Accumulating {len(recs)}/{need} examples before a new skill.")
+
+
+# Bookkeeping keys not worth showing in the per-record viewer.
+_STAGED_HIDDEN_KEYS = {"id", "domain", "technique", "session", "working_script", "script"}
+
+
+def _render_staged_record(r: dict) -> None:
+    """Show one staged T=2 solution's actual content (planned vs final model,
+    deviation, metric, and the working script) so it can be inspected before
+    upgrading/consolidating."""
+    for k, v in r.items():
+        if k in _STAGED_HIDDEN_KEYS or v in (None, "", [], {}):
+            continue
+        st.markdown(f"**{k.replace('_', ' ')}:** {v}")
+    script = (r.get("working_script") or r.get("script") or "").strip()
+    if script:
+        st.markdown("**working script:**")
+        st.code(script, language="python")
 
 
 def _render_memory_row(_memory, r, *, provisional: bool) -> None:
@@ -223,7 +264,7 @@ def _render_memory_row(_memory, r, *, provisional: bool) -> None:
         except Exception as e:
             st.warning(f"Could not render skill: {e}")
 
-        c1, c2 = st.columns(2)
+        c1, c2, _ = st.columns([2, 2, 4])
         if provisional:
             if c1.button("Promote", key=f"promote::{ref}", type="primary"):
                 _memory.promote_memory(r["domain"], r["name"])

--- a/scilink/ui/theme.py
+++ b/scilink/ui/theme.py
@@ -172,7 +172,8 @@ div:has(> [data-testid="stMarkdown"] .theme-toggle-anchor) + div button:hover {
     box-shadow: none !important;
 }
 /* File explorer tree buttons — soft gray, blue on selection */
-[data-testid="stExpander"] .stButton > button {
+[data-testid="stExpander"] .stButton > button,
+[data-testid="stExpander"] .stButton button {
     background-color: #2A3340;
     color: #B0BEC5;
     border: 1px solid #3A4556;
@@ -182,13 +183,15 @@ div:has(> [data-testid="stMarkdown"] .theme-toggle-anchor) + div button:hover {
     font-size: 0.85em;
     padding: 0.25rem 0.5rem;
 }
-[data-testid="stExpander"] .stButton > button:hover {
+[data-testid="stExpander"] .stButton > button:hover,
+[data-testid="stExpander"] .stButton button:hover {
     background-color: #344155;
     border-color: #5B8DEF;
     color: #E0E0E0;
     box-shadow: none;
 }
-[data-testid="stExpander"] .stButton > button[kind="primary"] {
+[data-testid="stExpander"] .stButton > button[kind="primary"],
+[data-testid="stExpander"] .stButton button[kind="primary"] {
     background-color: #1A3A5C;
     border-color: #5B8DEF;
     color: #82B1FF;
@@ -383,6 +386,27 @@ h2, h3 {
     background-color: #D32F2F !important;
     border-color: #D32F2F !important;
     color: #FFFFFF !important;
+}
+/* The big 58px steel-blue rule above is for the chat-tab action buttons.
+   Inside expanders (Skills / Persistent Memory panels) secondary buttons
+   should stay compact like the file-explorer ones — higher specificity +
+   !important to beat the rule above (light mode has no such override, which
+   is why it already looked right). */
+.stTabs [data-testid="stExpander"] .stButton > button[kind="secondary"] {
+    width: auto !important;
+    height: auto !important;
+    min-height: 0 !important;
+    font-size: 0.85em !important;
+    padding: 0.25rem 0.5rem !important;
+    border-radius: 4px !important;
+    background-color: #2A3340 !important;
+    color: #B0BEC5 !important;
+    border: 1px solid #3A4556 !important;
+}
+.stTabs [data-testid="stExpander"] .stButton > button[kind="secondary"]:hover {
+    background-color: #344155 !important;
+    border-color: #5B8DEF !important;
+    color: #E0E0E0 !important;
 }
 
 /* ── Live log viewer ────────────────────────────────── */
@@ -724,6 +748,42 @@ div:has(> [data-testid="stMarkdown"] .theme-toggle-anchor) + div button:hover {
     border-color: #5B8DEF;
     color: #1565C0;
 }
+/* Popover triggers (e.g. the staged-solution "View" button) are NOT .stButton,
+   so the rule above misses them and they fall through to the launch-time dark
+   native theme. Style them to match the compact light expander buttons. */
+[data-testid="stExpander"] [data-testid="stPopover"] button {
+    background-color: #EEEEEE !important;
+    color: #212121 !important;
+    border: 1px solid #E0E0E0 !important;
+    font-weight: 400;
+    letter-spacing: 0;
+    font-size: 0.85em;
+    padding: 0.25rem 0.5rem;
+}
+[data-testid="stExpander"] [data-testid="stPopover"] button:hover {
+    background-color: #E3F2FD !important;
+    border-color: #5B8DEF !important;
+    color: #212121 !important;
+    box-shadow: none !important;
+}
+/* The popover panel is portaled to the document root (not inside the expander),
+   so style it globally for light mode. baseweb gives the body (and a nested
+   content wrapper) a dark inline background, so whiten the body AND its block
+   containers — otherwise the dark markdown text below sits on a dark wrapper and
+   is barely visible. The code block keeps its own dark bg via its own !important. */
+[data-testid="stPopoverBody"],
+[data-testid="stPopoverBody"] [data-testid="stVerticalBlock"],
+[data-testid="stPopoverBody"] [data-testid="stVerticalBlockBorderWrapper"],
+[data-testid="stPopoverBody"] [data-testid="stElementContainer"] {
+    background-color: #FFFFFF !important;
+}
+[data-testid="stPopoverBody"] {
+    border: 1px solid #E0E0E0 !important;
+}
+[data-testid="stPopoverBody"] [data-testid="stMarkdown"],
+[data-testid="stPopoverBody"] [data-testid="stMarkdown"] * {
+    color: #212121 !important;
+}
 
 /* ── Success-style button ──────────────────────────── */
 .success-btn > button {
@@ -945,20 +1005,25 @@ section[data-testid="stSidebar"] [data-testid="stExpander"] [data-testid="stExpa
     border-radius: 4px;
     background-color: #1E1E1E !important;
 }
+/* Keep the dark code-block background, but DON'T force a single color on
+   every span — that would flatten Prism's syntax highlighting to one gray.
+   Set a base color only for un-tokenized text (code/pre); token spans keep
+   their own colors (the native theme is dark, so they suit #1E1E1E). */
 .stCodeBlock code,
 .stCodeBlock pre,
 [data-testid="stCode"] code,
-[data-testid="stCode"] pre,
+[data-testid="stCode"] pre {
+    color: #E0E0E0 !important;
+    background-color: #1E1E1E !important;
+}
 .stCodeBlock *,
 [data-testid="stCode"] * {
-    color: #E0E0E0 !important;
     background-color: #1E1E1E !important;
 }
 .stCodeBlock:hover,
 .stCodeBlock:hover *,
 [data-testid="stCode"]:hover,
 [data-testid="stCode"]:hover * {
-    color: #E0E0E0 !important;
     background-color: #1E1E1E !important;
 }
 


### PR DESCRIPTION
## Summary (for scientists)

When SciLink solves a hard fit from scratch (a T=2 "hot-annealing" run), it now
**stages** that solution as raw material the agent can later turn into a reusable
skill. This PR improves how you *review* those staged solutions and decides what
becomes a skill — in the UI, the `scilink memory` CLI, and the meta-agent.

Two behavioral changes you'll notice:

- **It accumulates before suggesting a brand-new skill.** One hard fit is usually
  too specific to generalize, so creating a *new* skill now waits until a few
  solutions of the same technique have piled up (default 3). Until then the UI
  shows "accumulating 1/3". *Enriching an existing skill* from a single solution is
  still offered immediately — that's the safe, in-place case.
- **You can look before you leap.** Each staged solution gets a **View** button
  showing what the agent actually did (planned vs. final model, where it deviated,
  R², and the working script) so you can judge it before upgrading or consolidating.

Plus theme fixes so these controls render correctly in both light and dark mode
(buttons were oversized/dark; code listings lost syntax highlighting in light mode).

## Technical details

Branches off `main` after #274 (feature) and #275 (robustness) merged.

### Accumulate-before-consolidate (the substantive change)
- New shared `_staging.consolidate_min_n()` (`$SCILINK_CONSOLIDATE_N`, default 3) —
  single source of truth for the readiness threshold. The plan specified this but it
  had only ever existed as a private copy in the CLI; the UI offered consolidation at
  N=1.
- `ui/components/skills.py`: "Consolidate → new skill" is `disabled` until
  `len(recs) >= consolidate_min_n()`, with an "accumulating N/3" caption + tooltip.
  Upgrade@1 (merge into an existing skill) is intentionally exempt.
- `cli/memory.py`: `_consolidate_n()` delegates to the shared helper; `staged`
  prints per-technique `accumulating N/3` vs `ready to consolidate`, and the footer
  only suggests `consolidate` when something is ready.
- `meta_orchestrator_tools.py`: `list_staged` returns `consolidate_threshold` and a
  per-technique `ready_to_consolidate` flag; tool description tells the router to
  prefer `upgrade` and not `consolidate` a technique until it's ready.

### UI: inspect staged solutions
- `_render_staged_record()` + a per-row `st.popover("View")` rendering the staged
  record's fields (bookkeeping keys hidden) and the working script as a code block.
- Compact button sizing (dropped `use_container_width` on the action buttons; they
  hug their text inside the expander style).

### Theme (`ui/theme.py`)
- Dark mode: `.stTabs .stButton > button[kind="secondary"]` (the 58px steel-blue
  chat-tab action-button rule) was bleeding into the Skills/Memory expanders. Added a
  higher-specificity override that keeps secondary buttons inside expanders compact.
  Light mode never had that rule, which is why it already looked right.
- Light mode: the `.stCodeBlock * { color: … !important }` wildcard flattened Prism
  token colors to one gray — replaced with a base-only color (keeps token colors;
  plain text stays legible on the dark code background). Popover trigger
  (`stPopover`) and panel (`stPopoverBody` + nested block wrappers) are now styled
  for light mode (were dark/illegible because the app launches with a dark native
  Streamlit theme).

### Validation
- Offline: 33/33 (`tests/test_persistent_memory.py`, local — not in diff, per prior PRs).
- Live (Bedrock `opus-4-8`): audited technique-label reuse-or-create, threshold
  gating (default/override/garbage), upgrade@1 with no script bloat leaked into the
  skill, missing-target guard (errors + preserves staged record), consolidate
  N→new provisional skill (n_examples, loader-discoverable, no leak),
  provisional→promote, path-traversal containment, and the CLI
  `staged`/`prune-staged --yes`/`consolidate` (live model construction) end-to-end —
  all green.

### Notes
- Theme/`_staging` edits are imported modules; a Streamlit **restart** (not just an
  R-refresh) is needed to pick them up — a hot-refresh hit a stale-module
  `AttributeError` during development.
