### PR TITLE
Engine-neutral simulation architecture (critics + scale-agnostic pipeline + skill-bundle tools)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ this is a settled architectural commitment, not a refactoring waypoint:
 |---|---|---|
 | `analyze` | `AnalysisOrchestratorAgent` | Experimental data analysis (microscopy, spectroscopy, …) |
 | `plan` | `PlanningOrchestratorAgent` | Experimental campaign design |
-| `simulate` | `SimulationOrchestratorAgent` | Computational simulations (DFT today, LAMMPS later) |
+| `simulate` | `SimulationOrchestratorAgent` | Computational simulation (DFT, classical MD, MLIP-driven MD) |
 
 Anything in scientific workflow falls under one of these three. There will
 **not** be a fourth mode. Future capability growth happens *inside* one of
@@ -164,7 +164,7 @@ maintenance pain. We have not hit it.
 When building `SimulationOrchestratorAgent`, copy the structure of
 `AnalysisOrchestratorAgent`. Don't refactor the other two.
 
-## What the simulate orchestrator looks like
+## How the simulate orchestrator works
 
 Structure-centric, iterative, two-surface. **Different from analyze mode**
 in three ways: no data file required to start, structure-centric
@@ -346,6 +346,50 @@ When the simulate orchestrator ships, **these stay**. Analyze mode keeps
 the one-shot pipeline tool because that's the right shape for "I'm done
 analyzing, prepare a calc". Simulate mode adds *granular* alternatives
 for iterative work. Don't replace `run_dft_workflow`; add alongside.
+
+## Self-refinement is one shape
+
+Every simulation agent fits the same loop:
+
+1. **Generate** — structure + inputs. One-shot. Pre-run validation
+   (`StructureValidatorAgent`, `IncarValidatorAgent`) lives inside
+   this stage as part of generation, not as a separate pre-run phase.
+2. **Run** — the engine (VASP, LAMMPS, MD via `DeployedPotential`).
+   For MD-shaped runs the engine sweeps multiple phases
+   (optim → equilib → production) within this single stage.
+3. **Branch on outcome**:
+   - **Engine error** → debugger (`VaspUpdater` / `LAMMPSUpdater`)
+     parses the log, proposes corrected inputs, loops back to **Run**.
+   - **Phase success** → quality check fires *per phase*, not just at
+     the end. Pass → next phase or done. Questionable → refine and
+     loop back to **Run**.
+
+Both feedback paths terminate at **Run** with updated inputs — the
+iteration is around Run, not around Generate. The shape is
+scale-agnostic: DFT, classical MD, and MLIP-driven MD instantiate it
+with different agents in each slot. When adding a new simulation
+agent, fit it into this skeleton rather than reinventing the loop.
+
+## Engine-neutral contracts
+
+Some agents communicate through small, engine-neutral descriptors so
+adding a new backend is one skill bundle rather than N×M integrations.
+
+The canonical example today is `DeployedPotential` (in
+`scilink/agents/sim_agents/_potential.py`): `MLIPAgent` emits it,
+`MDSimulationAgent` consumes it. The descriptor carries `backend`,
+`model_name`, `model_file`, `elements`, and an `ASECalculatorSpec`
+(three strings: import line, construct expression, device env var).
+The MD agent fills its ASE calculator from those strings and never
+imports MLIP code itself. Engine-specific bindings (LAMMPS
+`pair_style`, GROMACS kernel, …) live with the engine in its skill
+bundle.
+
+The payoff is N+M wiring instead of N×M: one new MLIP backend means
+one new skill bundle, not one integration per MD engine. The same
+pattern should apply to any future producer→consumer agent boundary
+that crosses scale or engine — design the contract first, then add
+producer and consumer behind it.
 
 ## Skill subsystem
 

--- a/scilink/agents/lit_agents/literature_agent.py
+++ b/scilink/agents/lit_agents/literature_agent.py
@@ -139,43 +139,75 @@ class IncarLiteratureAgent:
         self.max_wait_time = max_wait_time
         self.logger = logging.getLogger(__name__)
 
-    def validate_incar(self, incar_content: str, system_description: str) -> dict:
-        """Validate INCAR parameters against literature."""
-        
-        # Clean system description - remove additional instructions
+    def validate_inputs(self, input_files_text: str, system_description: str,
+                        engine_label: str = "DFT") -> dict:
+        """Validate engine input parameters against literature.
+
+        Engine-neutral entry point: ``engine_label`` names the engine in
+        the query (e.g. "VASP INCAR", "Quantum ESPRESSO", "LAMMPS") so the
+        same literature mechanism grounds parameter review for any engine.
+
+        Args:
+            input_files_text: The input file contents to review.
+            system_description: What system the inputs are for.
+            engine_label: Human-readable engine name for the query.
+
+        Returns:
+            ``{status, response, task_id}`` on success, or an error /
+            timeout status dict.
+        """
         clean_description = self._clean_system_description(system_description)
-        
-        query = f"""Are these VASP INCAR parameters appropriate for {clean_description}?
+        query = (
+            f"Are these {engine_label} input parameters appropriate for "
+            f"{clean_description}?\n\n{input_files_text}"
+        )
+        return self._run_literature_query(query)
 
-{incar_content}"""
+    def validate_incar(self, incar_content: str, system_description: str) -> dict:
+        """Validate VASP INCAR parameters against literature.
 
+        Thin VASP-specific wrapper over :meth:`validate_inputs`.
+        """
+        return self.validate_inputs(
+            input_files_text=incar_content,
+            system_description=system_description,
+            engine_label="VASP INCAR",
+        )
+
+    def _run_literature_query(self, query: str) -> dict:
+        """Submit a literature query to CROW and poll until it resolves.
+
+        Args:
+            query: The fully-built natural-language query.
+
+        Returns:
+            ``{status, response, task_id}`` on success; an error or
+            timeout status dict otherwise.
+        """
         try:
-            # Submit to CROW
             task_data = {"name": JobNames.LITERATURE, "query": query}
             task_id = self.client.create_task(task_data)
-            
-            # Wait for completion
+
             import time
             start_time = time.time()
-            
+
             while time.time() - start_time < self.max_wait_time:
                 task_status = self.client.get_task(task_id)
-                
+
                 if task_status.status == "success":
-                    # Clean response to remove repeated question
                     clean_response = self._clean_response(task_status.formatted_answer, query)
                     return {
-                        "status": "success", 
+                        "status": "success",
                         "response": clean_response,
-                        "task_id": task_id
+                        "task_id": task_id,
                     }
                 elif task_status.status in ["FAILED", "ERROR", "error"]:
                     return {"status": "error", "message": f"CROW failed: {task_status.status}"}
-                
+
                 sleep(10)
-            
+
             return {"status": "timeout", "message": f"Timed out after {self.max_wait_time}s"}
-            
+
         except Exception as e:
             return {"status": "error", "message": str(e)}
 

--- a/scilink/agents/sim_agents/critics.py
+++ b/scilink/agents/sim_agents/critics.py
@@ -1,0 +1,676 @@
+"""Engine-neutral critic agents for simulation work.
+
+This module provides two foundation agents that review simulation inputs
+and outputs without engine-specific code. Engine knowledge (VASP INCAR
+conventions, LAMMPS pair_style rules, etc.) is supplied at call time by
+the active skill bundle's markdown sections, so adding support for a new
+engine requires only a new skill bundle, not changes here.
+
+Public agents:
+
+    InputValidator
+        Pre-run reviewer. Given proposed input files and a system
+        description, returns a structured report of suggested adjustments.
+        Reads the active skill's ``validation`` section.
+
+    RunCritic
+        Post-run reviewer. Given a finished run directory and the user's
+        research goal, returns a verdict on the result and (when relevant)
+        a set of proposed input patches. Handles both failed and successful
+        runs in one pass. Reads the active skill's ``interpretation``
+        section.
+
+The agents share a small base, :class:`_CriticBase`, that handles LLM
+client construction (proxy and public paths), skill section loading,
+and tolerant JSON parsing.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from ...auth import (
+    get_internal_proxy_key,
+    require_vendor_credentials,
+)
+from ...skills.loader import list_skills, load_skill
+from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
+from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
+from ._deprecation import normalize_params
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Shared base
+# ──────────────────────────────────────────────────────────────────────────
+
+class _CriticBase:
+    """Base class providing LLM client construction and skill access.
+
+    Subclasses declare two class attributes:
+
+        SKILL_SECTION
+            The markdown section name to load from the active skill on
+            each call (e.g. ``"validation"``, ``"interpretation"``).
+
+        BASELINE_PROMPT_TEMPLATE
+            The engine-neutral prompt template, with named placeholders
+            that the subclass's public method fills in.
+
+    The skill domain (e.g. ``"periodic_dft"``, ``"molecular_dynamics"``)
+    is a call-time argument rather than a class attribute, so one instance
+    can serve calls against different engine families in the same session.
+    """
+
+    SKILL_SECTION: str = ""
+    BASELINE_PROMPT_TEMPLATE: str = ""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model_name: str = "claude-opus-4-6",
+        base_url: Optional[str] = None,
+        google_api_key: Optional[str] = None,
+        local_model: Optional[str] = None,
+    ):
+        """Construct the critic agent and its underlying LLM client.
+
+        Args:
+            api_key: API key for the LLM provider. When ``base_url`` is
+                set, this is the internal-proxy key (or read from
+                ``SCILINK_API_KEY``). When ``base_url`` is unset, the
+                key is forwarded to LiteLLM, which falls back to the
+                vendor's conventional environment variable
+                (``ANTHROPIC_API_KEY`` etc.) when ``api_key`` is None.
+            model_name: Model identifier, in the form expected by the
+                resolved provider (e.g. ``"claude-opus-4-6"``).
+            base_url: Base URL for an OpenAI-compatible internal proxy.
+                When provided, requests are routed through the proxy
+                client; when ``None``, requests go through LiteLLM.
+            google_api_key: Deprecated. Use ``api_key`` instead.
+            local_model: Deprecated. Use ``base_url`` instead.
+
+        Raises:
+            ValueError: If ``base_url`` is set and no API key can be
+                resolved from arguments or environment.
+        """
+        self.logger = logging.getLogger(
+            f"{__name__}.{self.__class__.__name__}"
+        )
+
+        api_key, base_url = normalize_params(
+            api_key=api_key,
+            google_api_key=google_api_key,
+            base_url=base_url,
+            local_model=local_model,
+            source=self.__class__.__name__,
+        )
+
+        if base_url:
+            if api_key is None:
+                api_key = get_internal_proxy_key()
+            if not api_key:
+                raise ValueError(
+                    "API key required for internal proxy. Set "
+                    "SCILINK_API_KEY in the environment or pass api_key."
+                )
+            self.logger.info(f"Using internal proxy: {base_url}")
+            self.model = OpenAIAsGenerativeModel(
+                model=model_name, api_key=api_key, base_url=base_url
+            )
+        else:
+            if api_key is None:
+                require_vendor_credentials(model_name)
+            self.logger.info(f"Using LiteLLM: {model_name}")
+            self.model = LiteLLMGenerativeModel(
+                model=model_name, api_key=api_key
+            )
+
+        self.model_name = model_name
+        self.api_key = api_key
+        self.base_url = base_url
+
+    # ── skill access ──────────────────────────────────────────────────
+
+    def _load_skill_section(
+        self,
+        skill: Optional[str],
+        domain: str,
+    ) -> str:
+        """Load a skill bundle and return its ``SKILL_SECTION`` content.
+
+        Args:
+            skill: Skill bundle name within ``domain``, or ``None``.
+            domain: Skill domain subdirectory the bundle lives under.
+
+        Returns:
+            The section content prefixed by a labelled header, or an
+            empty string if no skill was requested, the bundle is not
+            found, or the section is empty.
+        """
+        if not skill:
+            return ""
+        try:
+            parsed = load_skill(skill, domain=domain)
+        except FileNotFoundError:
+            available = list_skills(domain=domain)
+            self.logger.warning(
+                f"Skill '{skill}' not found in '{domain}'. "
+                f"Available: {available}. Falling back to baseline."
+            )
+            return ""
+        section = parsed.get(self.SKILL_SECTION, "") or ""
+        skill_name = parsed.get("name", skill)
+        if not section.strip():
+            self.logger.info(
+                f"Skill '{skill_name}' has no '{self.SKILL_SECTION}' "
+                f"section; using baseline only."
+            )
+            return ""
+        return (
+            f"=== Engine knowledge from skill '{skill_name}' "
+            f"({self.SKILL_SECTION}) ===\n{section}"
+        )
+
+    # ── LLM helpers ───────────────────────────────────────────────────
+
+    def _generate_json(self, prompt: str) -> Dict[str, Any]:
+        """Call the LLM requesting JSON output and parse the response.
+
+        Tolerates LLM responses that wrap JSON in code fences or
+        surrounding prose by falling back to a brace-balanced extraction.
+
+        Args:
+            prompt: The complete prompt to send to the model.
+
+        Returns:
+            The parsed JSON object, or an error dict with
+            ``status="error"`` and the raw response when parsing fails.
+        """
+        import re
+        response = self.model.generate_content(
+            prompt,
+            generation_config={"response_mime_type": "application/json"},
+        )
+        text = response.text
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            pass
+        match = re.search(r"\{.*\}", text, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group(0))
+            except json.JSONDecodeError:
+                pass
+        self.logger.error(
+            f"Could not parse LLM response as JSON. "
+            f"First 400 chars: {text[:400]!r}"
+        )
+        return {
+            "status": "error",
+            "error": "Could not parse LLM response as JSON.",
+            "raw_response": text[:2000],
+        }
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────
+
+def _format_input_files(input_files: Dict[str, str]) -> str:
+    """Render an input-files mapping as fenced markdown sections.
+
+    Args:
+        input_files: Mapping of filename to file content.
+
+    Returns:
+        A single string with each file rendered under a ``=== name ===``
+        header. Individual file contents are truncated at 8000 characters
+        with a trailing ``[truncated]`` marker.
+    """
+    chunks = []
+    for name, content in input_files.items():
+        body = (content or "").rstrip()
+        if len(body) > 8000:
+            body = body[:8000] + "\n... [truncated]"
+        chunks.append(f"=== {name} ===\n{body}")
+    return "\n\n".join(chunks)
+
+
+_SNAPSHOT_TOOL_NAME = "snapshot_run"
+_SYNTAX_TOOL_NAME = "check_input_syntax"
+
+
+def _run_deterministic_syntax_check(
+    input_files: Dict[str, str],
+    skill: Optional[str],
+) -> List[Dict[str, Any]]:
+    """Run the active skill's deterministic pre-run syntax check, if any.
+
+    Looks up a ``check_input_syntax`` callable in the active skill bundle
+    and invokes it on the input files. The engine's tool selects whichever
+    file it knows how to check and returns a list of issue dicts.
+
+    Args:
+        input_files: Mapping of input filename to file contents.
+        skill: Name of the active skill bundle, or ``None``.
+
+    Returns:
+        The issue list from the engine's syntax check, or an empty list
+        when no skill is active or the active skill registers no
+        ``check_input_syntax`` tool. Never raises — a missing tool means
+        the engine offers no deterministic syntax pass.
+    """
+    if not skill:
+        return []
+    from ...skills._shared._registry import get_tool_function
+    try:
+        checker = get_tool_function(
+            _SYNTAX_TOOL_NAME, active_skills=[skill]
+        )
+    except LookupError:
+        return []
+    try:
+        result = checker(input_files=input_files)
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            f"Deterministic syntax check raised for skill '{skill}': {e}"
+        )
+        return []
+    return result if isinstance(result, list) else []
+
+
+def _format_syntax_issues(issues: List[Dict[str, Any]]) -> str:
+    """Render deterministic syntax issues as a prompt block.
+
+    Args:
+        issues: Issue dicts from a ``check_input_syntax`` call.
+
+    Returns:
+        A labelled markdown block listing each issue, or an empty string
+        when there are no issues (so callers can concatenate freely).
+    """
+    if not issues:
+        return ""
+    lines = [
+        "=== Deterministic syntax check (authoritative — already run) ===",
+        "These tag-level issues were found by an engine-native syntax "
+        "checker, not by you. Treat them as ground truth and fold them "
+        "into your assessment; do not re-litigate tag spellings.",
+    ]
+    for it in issues:
+        tag = it.get("tag")
+        suggested = it.get("suggested")
+        confidence = it.get("confidence", "")
+        desc = it.get("description", "")
+        lines.append(
+            f"- tag={tag!r} suggested={suggested!r} "
+            f"confidence={confidence}: {desc}"
+        )
+    return "\n".join(lines)
+
+
+def _snapshot_run_outputs(output_dir: str, skill: Optional[str]) -> Dict[str, Any]:
+    """Parse a finished run's output files into a structured snapshot.
+
+    Looks up a ``snapshot_run`` callable in the active skill bundle via
+    :func:`scilink.skills._shared._registry.get_tool_function`. The
+    callable lives alongside its skill markdown (e.g.
+    ``scilink/skills/periodic_dft/vasp/vasp_output.py``) and owns its own
+    output shape; this function delegates without inspecting the result.
+
+    Args:
+        output_dir: Path to the directory containing run output files.
+        skill: Name of the active skill bundle whose parser should be
+            invoked.
+
+    Returns:
+        The parser's structured snapshot. Returns a dict with a
+        ``"note"`` field when no skill is active or the active skill
+        does not register a ``snapshot_run`` callable, so callers can
+        hand the snapshot to the LLM uniformly without branching on
+        availability.
+    """
+    if not skill:
+        return {
+            "note": (
+                "No active skill — output parsing is dispatched through "
+                "the skill bundle's snapshot_run tool. Activate a skill "
+                "before calling assess()."
+            ),
+        }
+    from ...skills._shared._registry import get_tool_function
+    try:
+        parser = get_tool_function(
+            _SNAPSHOT_TOOL_NAME, active_skills=[skill]
+        )
+    except LookupError as e:
+        return {
+            "note": (
+                f"Skill '{skill}' does not expose a '{_SNAPSHOT_TOOL_NAME}' "
+                f"tool; the run snapshot is unavailable. ({e})"
+            ),
+        }
+    return parser(output_dir)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# InputValidator
+# ──────────────────────────────────────────────────────────────────────────
+
+_INPUT_VALIDATOR_PROMPT = """\
+You are a simulation input reviewer. Identify potential issues in the
+proposed input files BEFORE the user commits compute resources to running
+the calculation. Be concrete: flag what to change, why, and how serious it
+is.
+
+{skill_context}
+
+{syntax_block}
+
+=== Proposed input files ===
+{input_files}
+
+=== System description (what the user is trying to compute) ===
+{system_description}
+
+Return a JSON object with these fields:
+  status              "success" | "error"
+  validation_status   "passes" | "needs_revision" | "fails"
+  overall_assessment  2-3 sentence prose summary
+  suggested_adjustments  list of objects, each:
+      {{ "file": str,           // which input file
+         "key": str,            // parameter / tag / line identifier
+         "current": str,        // current value (or "missing")
+         "suggested": str,      // proposed value
+         "severity": "info" | "warning" | "error",
+         "reason": str }}       // 1-2 sentences
+  review_basis        prose: which engine conventions, system specifics,
+                      or general best practice drove your call
+
+If the inputs look correct, return validation_status="passes" with an
+empty suggested_adjustments list — do not invent issues.
+"""
+
+
+class InputValidator(_CriticBase):
+    """Pre-run reviewer for simulation input files.
+
+    Reviews proposed input files against engine conventions and returns
+    a structured report of suggested adjustments before the user submits
+    the calculation. The engine-neutral baseline prompt frames the
+    reasoning; engine-specific conventions are supplied by the active
+    skill's ``validation`` section.
+
+    Example:
+        >>> validator = InputValidator(api_key=key, model_name=model)
+        >>> result = validator.validate(
+        ...     input_files={"INCAR": incar_text, "KPOINTS": kp_text},
+        ...     system_description="Fe BCC, magnetic ground state at 0 K",
+        ...     skill="vasp",
+        ...     domain="periodic_dft",
+        ... )
+        >>> result["validation_status"]
+        'needs_revision'
+    """
+
+    SKILL_SECTION = "validation"
+    BASELINE_PROMPT_TEMPLATE = _INPUT_VALIDATOR_PROMPT
+
+    def validate(
+        self,
+        input_files: Dict[str, str],
+        system_description: str,
+        skill: Optional[str] = None,
+        domain: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Review proposed input files and return a structured report.
+
+        Args:
+            input_files: Mapping of input filename to file contents.
+                Filenames are engine-defined (e.g. ``INCAR`` and
+                ``KPOINTS`` for VASP, ``input.lmp`` for LAMMPS). An
+                empty mapping returns an error report.
+            system_description: A natural-language description of the
+                system being computed and the scientific objective, used
+                to judge whether parameter choices are appropriate.
+            skill: Name of the skill bundle within ``domain`` whose
+                ``validation`` section should be loaded. When ``None``,
+                the baseline prompt runs without engine-specific context.
+            domain: Skill subdirectory the bundle lives under, e.g.
+                ``"periodic_dft"`` or ``"molecular_dynamics"``. Required
+                when ``skill`` is provided; ignored when ``skill`` is
+                ``None``.
+
+        Returns:
+            A report dict with fields:
+
+                status              ``"success"`` or ``"error"``
+                validation_status   ``"passes"``, ``"needs_revision"``,
+                                    or ``"fails"``
+                overall_assessment  Prose summary
+                suggested_adjustments
+                                    List of adjustment dicts; each has
+                                    ``file``, ``key``, ``current``,
+                                    ``suggested``, ``severity``, ``reason``
+                review_basis        Prose explanation of what guided
+                                    the call
+
+        Raises:
+            ValueError: If ``skill`` is provided without ``domain``.
+        """
+        if not input_files:
+            return {
+                "status": "error",
+                "error": "input_files is empty — nothing to validate.",
+            }
+        if skill and not domain:
+            raise ValueError(
+                "domain is required when skill is provided. "
+                "Pass the skill subdirectory (e.g. 'periodic_dft' or "
+                "'molecular_dynamics') alongside the skill name."
+            )
+
+        skill_context = self._load_skill_section(skill, domain or "")
+
+        # Run the engine's deterministic syntax check first and pass its
+        # findings to the LLM as authoritative grounding, so the model
+        # reasons about physics rather than re-checking tag spellings.
+        syntax_issues = _run_deterministic_syntax_check(input_files, skill)
+
+        prompt = self.BASELINE_PROMPT_TEMPLATE.format(
+            skill_context=skill_context or "(no engine skill loaded)",
+            syntax_block=_format_syntax_issues(syntax_issues),
+            input_files=_format_input_files(input_files),
+            system_description=system_description,
+        )
+        report = self._generate_json(prompt)
+        report.setdefault("status", "success")
+        # Surface the deterministic findings on the report regardless of
+        # what the LLM did with them, so callers have the ground truth.
+        report["syntax_check"] = syntax_issues
+        return report
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# RunCritic
+# ──────────────────────────────────────────────────────────────────────────
+
+_RUN_CRITIC_PROMPT = """\
+You are a post-run simulation critic. The user has finished a calculation
+and needs an assessment: did the run produce what they wanted, and if not,
+what should they change? Handle both cases — a failed run (propose fixes)
+and a successful run (give a verdict and sanity-check the physics).
+
+{skill_context}
+
+=== Output directory ===
+{output_dir}
+
+=== Output snapshot (parsed from the run directory) ===
+{output_snapshot}
+
+=== Research goal (what the user was trying to compute) ===
+{research_goal}
+
+{fixes_directive}
+
+Return a JSON object with these fields:
+  status              "success" | "error"
+  run_status          "succeeded" | "failed" | "incomplete"
+  verdict             "good" | "warning" | "poor" | "needs_fixes"
+                      good        — converged, physically sensible
+                      warning     — converged but with concerns
+                      poor        — converged but result is suspect or wrong
+                      needs_fixes — did not converge or failed to run
+  reasoning           prose summary (3-6 sentences)
+  suggested_fixes     {{ "filename": "patched_content", ... }} | null
+                      Provide a non-null dict only when the verdict is
+                      "poor" or "needs_fixes" OR run_status is "failed".
+                      Otherwise return null.
+  recommendations     list of short strings — next steps the user should
+                      consider (rerun with X, gather more data, etc.)
+  diagnostic_notes    optional prose — specific log lines, energies,
+                      forces, or convergence trends that informed the verdict
+"""
+
+
+class RunCritic(_CriticBase):
+    """Post-run reviewer for finished simulation calculations.
+
+    Inspects a finished run's output directory and returns a verdict
+    on the result. When the run failed or the result is unsatisfactory,
+    proposes patched input files that the user can resubmit. A single
+    call covers both the convergence / runtime-error question and the
+    physical-quality question.
+
+    Engine-specific output parsers and error patterns are supplied by
+    the active skill's ``interpretation`` section and the dispatched
+    snapshot reader in :func:`_snapshot_run_outputs`.
+
+    Example:
+        >>> critic = RunCritic(api_key=key, model_name=model)
+        >>> result = critic.assess(
+        ...     output_dir="/path/to/run",
+        ...     research_goal="Bulk Si lattice parameter from relaxation",
+        ...     skill="vasp",
+        ...     domain="periodic_dft",
+        ... )
+        >>> result["verdict"]
+        'good'
+    """
+
+    SKILL_SECTION = "interpretation"
+    BASELINE_PROMPT_TEMPLATE = _RUN_CRITIC_PROMPT
+
+    def assess(
+        self,
+        output_dir: str,
+        research_goal: str,
+        skill: Optional[str] = None,
+        domain: Optional[str] = None,
+        fixes_mode: str = "auto",
+    ) -> Dict[str, Any]:
+        """Assess a finished run and return a verdict report.
+
+        Args:
+            output_dir: Path to the directory containing the finished
+                run's output files. Contents are engine-specific
+                (e.g. ``vasprun.xml``, ``OUTCAR`` for VASP;
+                ``log.lammps`` for LAMMPS).
+            research_goal: A natural-language description of what the
+                user was trying to compute. Drives whether the result
+                is sufficient for the intent.
+            skill: Name of the skill bundle within ``domain`` whose
+                ``interpretation`` section should be loaded. When
+                ``None``, the baseline prompt runs without
+                engine-specific context.
+            domain: Skill subdirectory the bundle lives under, e.g.
+                ``"periodic_dft"`` or ``"molecular_dynamics"``. Required
+                when ``skill`` is provided; ignored when ``skill`` is
+                ``None``. Also used to dispatch the output snapshot
+                parser.
+            fixes_mode: Controls when ``suggested_fixes`` may be
+                populated:
+
+                    ``"auto"`` (default)
+                        Propose fixes only when ``run_status`` is
+                        ``"failed"`` or ``verdict`` is ``"poor"`` /
+                        ``"needs_fixes"``.
+                    ``"always"``
+                        Propose fixes whenever the verdict is below
+                        ``"good"``.
+                    ``"skip"``
+                        Never propose fixes; ``suggested_fixes`` is
+                        forced to ``None`` regardless of verdict.
+
+        Returns:
+            A report dict with fields:
+
+                status              ``"success"`` or ``"error"``
+                run_status          ``"succeeded"``, ``"failed"``, or
+                                    ``"incomplete"``
+                verdict             ``"good"``, ``"warning"``, ``"poor"``,
+                                    or ``"needs_fixes"``
+                reasoning           Prose summary
+                suggested_fixes     Mapping of filename to patched
+                                    content, or ``None``
+                recommendations     List of next-step strings
+                diagnostic_notes    Optional prose on specific signals
+
+        Raises:
+            ValueError: If ``skill`` is provided without ``domain``.
+
+        Notes:
+            Missing output directories and parse failures surface as
+            ``status="error"`` entries in the returned report rather
+            than raised exceptions.
+        """
+        if skill and not domain:
+            raise ValueError(
+                "domain is required when skill is provided. "
+                "Pass the skill subdirectory (e.g. 'periodic_dft' or "
+                "'molecular_dynamics') alongside the skill name."
+            )
+        out_path = Path(output_dir)
+        if not out_path.exists():
+            return {
+                "status": "error",
+                "error": f"output_dir does not exist: {output_dir}",
+            }
+
+        snapshot = _snapshot_run_outputs(str(out_path), skill)
+        skill_context = self._load_skill_section(skill, domain or "")
+
+        fixes_directive = {
+            "auto": (
+                "Propose fixes only when run_status is 'failed' or verdict "
+                "is 'poor' or 'needs_fixes'."
+            ),
+            "always": (
+                "Propose fixes whenever the verdict is below 'good'."
+            ),
+            "skip": (
+                "Do NOT propose fixes — set suggested_fixes to null "
+                "regardless of verdict."
+            ),
+        }.get(
+            fixes_mode,
+            "Propose fixes only when run_status is 'failed' or verdict "
+            "is 'poor' or 'needs_fixes'.",
+        )
+
+        prompt = self.BASELINE_PROMPT_TEMPLATE.format(
+            skill_context=skill_context or "(no engine skill loaded)",
+            output_dir=str(out_path),
+            output_snapshot=json.dumps(snapshot, indent=2, default=str)[:12000],
+            research_goal=research_goal,
+            fixes_directive=fixes_directive,
+        )
+        report = self._generate_json(prompt)
+        report.setdefault("status", "success")
+        if fixes_mode == "skip":
+            report["suggested_fixes"] = None
+        return report

--- a/scilink/agents/sim_agents/critics.py
+++ b/scilink/agents/sim_agents/critics.py
@@ -71,6 +71,7 @@ class _CriticBase:
         api_key: Optional[str] = None,
         model_name: str = "claude-opus-4-6",
         base_url: Optional[str] = None,
+        futurehouse_api_key: Optional[str] = None,
         google_api_key: Optional[str] = None,
         local_model: Optional[str] = None,
     ):
@@ -88,6 +89,11 @@ class _CriticBase:
             base_url: Base URL for an OpenAI-compatible internal proxy.
                 When provided, requests are routed through the proxy
                 client; when ``None``, requests go through LiteLLM.
+            futurehouse_api_key: Optional FutureHouse (Edison) API key
+                enabling literature-grounded review. Falls back to the
+                ``FUTUREHOUSE_API_KEY`` environment variable. When no key
+                is available, literature grounding is skipped and the
+                critic runs on baseline guidance and engine tools only.
             google_api_key: Deprecated. Use ``api_key`` instead.
             local_model: Deprecated. Use ``base_url`` instead.
 
@@ -97,6 +103,11 @@ class _CriticBase:
         """
         self.logger = logging.getLogger(
             f"{__name__}.{self.__class__.__name__}"
+        )
+
+        import os as _os
+        self.futurehouse_api_key = (
+            futurehouse_api_key or _os.environ.get("FUTUREHOUSE_API_KEY")
         )
 
         api_key, base_url = normalize_params(
@@ -370,6 +381,8 @@ is.
 
 {syntax_block}
 
+{literature_block}
+
 === Proposed input files ===
 {input_files}
 
@@ -418,6 +431,50 @@ class InputValidator(_CriticBase):
 
     SKILL_SECTION = "validation"
     BASELINE_PROMPT_TEMPLATE = _INPUT_VALIDATOR_PROMPT
+
+    def _literature_review(
+        self,
+        input_files: Dict[str, str],
+        system_description: str,
+        skill: Optional[str],
+    ) -> str:
+        """Return a literature-grounded review of the inputs, or ``""``.
+
+        Runs only when a FutureHouse key is configured. Builds an
+        engine-neutral query (the engine name is the active skill name)
+        and returns the literature answer text for folding into the
+        prompt and report. Failure-isolated: any error returns an empty
+        string so literature trouble never blocks the review.
+
+        Args:
+            input_files: Mapping of input filename to contents.
+            system_description: What the inputs are for.
+            skill: Active engine skill name, used as the engine label.
+
+        Returns:
+            The literature review text, or an empty string when no key is
+            configured or the search did not succeed.
+        """
+        if not self.futurehouse_api_key:
+            return ""
+        engine_label = (skill or "the engine").upper()
+        try:
+            from ..lit_agents.literature_agent import IncarLiteratureAgent
+            agent = IncarLiteratureAgent(api_key=self.futurehouse_api_key)
+            result = agent.validate_inputs(
+                input_files_text=_format_input_files(input_files),
+                system_description=system_description,
+                engine_label=engine_label,
+            )
+        except Exception as e:
+            self.logger.warning(f"Literature review skipped: {e}")
+            return ""
+        if result.get("status") != "success":
+            self.logger.info(
+                f"Literature review unavailable: {result.get('message', result.get('status'))}"
+            )
+            return ""
+        return (result.get("response") or "").strip()
 
     def validate(
         self,
@@ -480,17 +537,30 @@ class InputValidator(_CriticBase):
         # reasons about physics rather than re-checking tag spellings.
         syntax_issues = _run_deterministic_syntax_check(input_files, skill)
 
+        # Ground the review in literature when a FutureHouse key is
+        # configured; otherwise this is an empty string and the review
+        # proceeds on baseline guidance + the syntax check.
+        literature = self._literature_review(input_files, system_description, skill)
+        literature_block = (
+            f"=== Literature review (for grounding parameter choices) ===\n{literature}"
+            if literature else ""
+        )
+
         prompt = self.BASELINE_PROMPT_TEMPLATE.format(
             skill_context=skill_context or "(no engine skill loaded)",
             syntax_block=_format_syntax_issues(syntax_issues),
+            literature_block=literature_block,
             input_files=_format_input_files(input_files),
             system_description=system_description,
         )
         report = self._generate_json(prompt)
         report.setdefault("status", "success")
-        # Surface the deterministic findings on the report regardless of
-        # what the LLM did with them, so callers have the ground truth.
+        # Surface the deterministic findings + literature on the report
+        # regardless of what the LLM did with them, so callers have the
+        # ground truth and the source material.
         report["syntax_check"] = syntax_issues
+        if literature:
+            report["literature_review"] = literature
         return report
 
 

--- a/scilink/agents/sim_agents/dft_orchestrator.py
+++ b/scilink/agents/sim_agents/dft_orchestrator.py
@@ -1,34 +1,34 @@
 # scilink/agents/sim_agents/dft_orchestrator.py
+"""Deprecated DFT one-shot orchestrator — delegates to the scale-agnostic pipeline.
 
-import os
+``DFTOrchestrator`` predates the scale-agnostic
+:func:`scilink.agents.sim_agents.simulation_pipeline.run_complete_workflow`
+and is retained only as a thin back-compat shim. New code should call
+``run_complete_workflow`` directly with ``scale="periodic_dft"``.
+
+The pipeline routes input generation through ``PeriodicDFTAgent`` (engine
+selected by ``software``) and validates with the engine-neutral
+``InputValidator``, so this shim carries no VASP-specific result shaping —
+it returns the pipeline result unchanged.
+"""
+
 import logging
-import json
+import warnings
 from typing import Optional, Dict, Any
-from pathlib import Path
 
-from ase.io import read as ase_read
-
-from ...auth import get_api_key
 from ._deprecation import normalize_params
-from .structure_orchestrator import StructureOrchestrator
-from .val_agent import IncarValidatorAgent
-from .vasp_agent import VaspInputAgent
-from .vasp_updater import VaspUpdater
-# Atomate2Input is imported lazily in the "atomate2" branch so users picking
-# vasp_generator_method="llm" don't need pymatgen/atomate2 installed.
+from .simulation_pipeline import run_complete_workflow
+
+logger = logging.getLogger(__name__)
 
 
 class DFTOrchestrator:
-    """
-    Orchestrates a complete Density Functional Theory (DFT) input-generation pipeline.
+    """Back-compat shim over the scale-agnostic simulation pipeline.
 
-    Composes the sim-agents stack (StructureGenerator, StructureValidatorAgent,
-    VaspInputAgent / Atomate2Input, VaspUpdater, IncarValidatorAgent) to turn a
-    high-level natural-language request into a validated atomic structure plus a
-    complete set of VASP input files (POSCAR, INCAR, KPOINTS) ready for calculation.
-
-    Includes an iterative refinement loop where the validator provides feedback to
-    the structure generator, enabling self-correction. Does not run VASP itself.
+    Preserves the historical constructor and ``run_complete_workflow``
+    signature; forwards to
+    :func:`scilink.agents.sim_agents.simulation_pipeline.run_complete_workflow`
+    with ``scale="periodic_dft"`` and returns its result unchanged.
     """
 
     def __init__(self,
@@ -45,29 +45,12 @@ class DFTOrchestrator:
                  # Deprecated aliases
                  google_api_key: str = None,
                  local_model: str = None):
-        """
-        Initialize the DFT orchestrator and its constituent agents.
-
-        Args:
-            api_key: API key for the LLM provider. Auto-discovered from the
-                environment when both api_key and base_url are None.
-            base_url: Optional base URL for an OpenAI-compatible internal proxy.
-            futurehouse_api_key: FutureHouse API key for literature validation.
-                Auto-discovered when None.
-            mp_api_key: Materials Project API key for structure lookups.
-                Auto-discovered when None.
-            generator_model: Model name for structure / VASP-input generation.
-            validator_model: Model name for structure validation.
-            output_dir: Directory to save all generated files.
-            max_refinement_cycles: Maximum validator-guided correction cycles.
-            script_timeout: Timeout (seconds) for executing AI-generated ASE scripts.
-            vasp_generator_method: "atomate2" (rule-based, recommended for production)
-                or "llm" (AI-driven, more flexible but less predictable).
-            google_api_key: Deprecated, use api_key instead.
-            local_model: Deprecated, use base_url instead.
-        """
-
-        # Normalize deprecated parameters
+        warnings.warn(
+            "DFTOrchestrator is deprecated; call "
+            "scilink.agents.sim_agents.simulation_pipeline.run_complete_workflow"
+            "(scale='periodic_dft', ...) directly.",
+            DeprecationWarning, stacklevel=2,
+        )
         api_key, base_url = normalize_params(
             api_key=api_key,
             google_api_key=google_api_key,
@@ -75,389 +58,32 @@ class DFTOrchestrator:
             local_model=local_model,
             source="DFTOrchestrator",
         )
-
-        # Structure generation (Step 1) is delegated to a structure-class-aware,
-        # engine-agnostic StructureOrchestrator. It owns the structure
-        # generate → validate → refine loop, structure-class skill loading,
-        # API-key auto-discovery, and the shared run log. The DFT-specific agents
-        # below reuse its resolved credentials and run log.
-        self.structure = StructureOrchestrator(
-            api_key=api_key,
-            base_url=base_url,
-            mp_api_key=mp_api_key,
-            generator_model=generator_model,
-            validator_model=validator_model,
-            output_dir=output_dir,
-            max_refinement_cycles=max_refinement_cycles,
-            script_timeout=script_timeout,
-        )
-        api_key = self.api_key = self.structure.api_key
-        base_url = self.base_url = self.structure.base_url
-        self.logger = logging.getLogger(__name__)
-        self.log_capture = self.structure.log_capture
-
-        if futurehouse_api_key is None:
-            futurehouse_api_key = get_api_key('futurehouse')
+        self.api_key = api_key
+        self.base_url = base_url
         self.futurehouse_api_key = futurehouse_api_key
+        self.mp_api_key = mp_api_key
+        self.generator_model = generator_model
         self.output_dir = output_dir
         self.max_refinement_cycles = max_refinement_cycles
+        self.script_timeout = script_timeout
+        # Historical name for the input-generation method ("llm"/"atomate2").
         self.vasp_generator_method = vasp_generator_method
-
-        # Instantiate the correct VASP agent based on the chosen method.
-        if self.vasp_generator_method == "llm":
-            print("ℹ️  VASP Generator: 'llm' (default). Using AI to generate VASP inputs.")
-            self.vasp_agent = VaspInputAgent(
-                api_key=api_key,
-                base_url=base_url,
-                model_name=generator_model,
-            )
-        elif self.vasp_generator_method == "atomate2":
-            print("ℹ️  VASP Generator: 'atomate2'. Using pymatgen/atomate2 for reliable inputs.")
-            try:
-                from .atomate2_utils import Atomate2Input
-            except ImportError as e:
-                raise ImportError(
-                    "vasp_generator_method='atomate2' requires the [sim] extras "
-                    "(pymatgen, atomate2). Install with: pip install 'scilink[sim]'. "
-                    f"Original error: {e}"
-                )
-            self.vasp_agent = Atomate2Input()
-        else:
-            raise ValueError(f"Invalid vasp_generator_method: '{self.vasp_generator_method}'. "
-                             f"Choose 'llm' or 'atomate2'.")
-
-        # error_log based INCAR/KPOINTS refinement
-        self.vasp_error_updater = VaspUpdater(
-            api_key=api_key,
-            base_url=base_url,
-            model_name=generator_model,
-        )
-
-        if futurehouse_api_key:
-            self.incar_validator = IncarValidatorAgent(
-                api_key=api_key,
-                base_url=base_url,
-                futurehouse_api_key=futurehouse_api_key,
-            )
-        else:
-            self.incar_validator = None
-            print("ℹ️  Literature validation disabled (no FutureHouse API key)")
-
-        # Create output directory
-        os.makedirs(output_dir, exist_ok=True)
 
     def run_complete_workflow(self, user_request: str,
                               structure_class: str = "crystal") -> Dict[str, Any]:
-        """
-        Run the complete workflow from user request to final VASP inputs.
-
-        ``structure_class`` is forwarded to the StructureOrchestrator for Step 1
-        (structure generation); see ``StructureOrchestrator.build_structure``.
-        """
-        workflow_result = {
-            "user_request": user_request,
-            "steps_completed": [],
-            "final_status": "started"
-        }
-
-        print(f"\n🚀 DFT Workflow Starting")
-        print(f"{'='*60}")
-        print(f"📝 Request: {user_request}")
-        print(f"📁 Output:  {self.output_dir}/")
-        print(f"⚙️  VASP Input Method: '{self.vasp_generator_method}' is active.")
-        print(f"{'='*60}")
-
-        # Step 1: Structure Generation and Validation
-        print(f"\n🏗️  WORKFLOW STEP 1: Structure Generation & Validation")
-        print(f"{'─'*50}")
-
-        structure_result = self.structure.generate_and_validate(
-            user_request, structure_class=structure_class
+        """Run the periodic-DFT pipeline and return its result unchanged."""
+        return run_complete_workflow(
+            user_request,
+            scale="periodic_dft",
+            software="vasp",
+            method=self.vasp_generator_method,
+            structure_class=structure_class,
+            output_dir=self.output_dir,
+            api_key=self.api_key,
+            base_url=self.base_url,
+            model_name=self.generator_model,
+            futurehouse_api_key=self.futurehouse_api_key,
+            mp_api_key=self.mp_api_key,
+            max_refinement_cycles=self.max_refinement_cycles,
+            script_timeout=self.script_timeout,
         )
-        workflow_result["structure_generation"] = structure_result
-
-        if structure_result["status"] != "success":
-            print(f"❌ Structure generation failed: {structure_result.get('message', 'Unknown error')}")
-            workflow_result["final_status"] = "failed_structure_generation"
-            return workflow_result
-
-        workflow_result["steps_completed"].append("structure_generation")
-        structure_path = structure_result["final_structure_path"]
-
-        print(f"✅ Structure generated: {os.path.basename(structure_path)}")
-        if structure_result.get("warning"):
-            print(f"⚠️  {structure_result['warning']}")
-
-        # Step 2: VASP Input Generation
-        print(f"\n⚛️  WORKFLOW STEP 2: VASP Input Generation")
-        print(f"{'─'*50}")
-
-        vasp_result = self._generate_vasp_inputs(structure_path, user_request)
-        workflow_result["vasp_generation"] = vasp_result
-
-        if vasp_result["status"] != "success":
-            print(f"❌ VASP generation failed: {vasp_result.get('message', 'Unknown error')}")
-            workflow_result["final_status"] = "failed_vasp_generation"
-            return workflow_result
-
-        workflow_result["steps_completed"].append("vasp_generation")
-        print(f"✅ VASP inputs generated: INCAR, KPOINTS, POSCAR")
-        print(f"📋 Calculation type: {vasp_result.get('summary', 'N/A')}")
-
-        if self.incar_validator and self.vasp_generator_method == "llm":
-            print(f"\n📚  WORKFLOW STEP 3: Literature Validation")
-            print(f"{'─'*50}")
-
-            improvement_result = self._validate_and_improve_incar(
-                vasp_result, structure_path, user_request
-            )
-            workflow_result["incar_improvement"] = improvement_result
-            workflow_result["steps_completed"].append("incar_improvement")
-        else:
-            if self.vasp_generator_method == "atomate2":
-                msg = "Skipped, Atomate2 uses expert-defined parameters."
-            else:
-                msg = "Skipped, no FutureHouse API key."
-            print(f"\n📚  WORKFLOW STEP 3: Literature Validation")
-            print(f"{'─'*50}")
-            print(f"   {msg}")
-            workflow_result["incar_improvement"] = {"status": "skipped", "message": msg}
-
-        workflow_result["final_status"] = "success"
-        workflow_result["output_directory"] = self.output_dir
-
-        # Create final files manifest
-        final_manifest = self._create_final_files_manifest(workflow_result)
-        workflow_result["final_manifest"] = final_manifest
-
-        # Save complete log
-        self.structure._save_workflow_log()
-
-        # Final summary
-        self._print_final_summary(workflow_result)
-
-        return workflow_result
-
-    def refine_from_log(self, original_request: str, log_path: str) -> Dict[str, Any]:
-        """
-        Given a VASP stdout/stderr log file, iteratively refine INCAR/KPOINTS
-        in self.output_dir using VaspUpdater.
-        """
-        outdir    = Path(self.output_dir)
-        poscar_f  = outdir / "POSCAR"
-        incar_f   = outdir / "INCAR"
-        kpoints_f = outdir / "KPOINTS"
-
-        log_text = Path(log_path).read_text()
-        old_incar   = incar_f.read_text()
-        old_kpoints = kpoints_f.read_text()
-
-        plan = self.vasp_error_updater.refine_inputs(
-            poscar_path=str(poscar_f),
-            incar_path=str(incar_f),
-            kpoints_path=str(kpoints_f),
-            vasp_log=log_text,
-            original_request=original_request
-        )
-        print("Plan:", plan)
-
-        if plan.get("status") == "success":
-            # INCAR backup & overwrite
-            new_incar = plan.get("suggested_incar", "")
-            if new_incar and new_incar != old_incar:
-                ver = 0
-                while (incar_f.with_suffix(f"{incar_f.suffix}.v{ver}")).exists():
-                    ver += 1
-                incar_f.rename(incar_f.with_suffix(f"{incar_f.suffix}.v{ver}"))
-                incar_f.write_text(new_incar)
-                print(f"   • INCAR updated → backed up as INCAR{incar_f.suffix}.v{ver}")
-
-            # KPOINTS backup & overwrite
-            new_kp = plan.get("suggested_kpoints", "")
-            if new_kp and new_kp != old_kpoints:
-                ver = 0
-                while (kpoints_f.with_suffix(f"{kpoints_f.suffix}.v{ver}")).exists():
-                    ver += 1
-                kpoints_f.rename(kpoints_f.with_suffix(f"{kpoints_f.suffix}.v{ver}"))
-                kpoints_f.write_text(new_kp)
-                print(f"   • KPOINTS updated → backed up as KPOINTS{kpoints_f.suffix}.v{ver}")
-        else:
-            print("⚠️  Refinement failed:", plan.get("message"))
-
-        return {
-            "final_incar":   str(incar_f),
-            "final_kpoints": str(kpoints_f),
-            "status":        plan.get("status"),
-            "message":       plan.get("message", ""),
-            "explanation":    plan.get("explanation", {})
-        }
-
-    def _generate_vasp_inputs(self, structure_path: str, user_request: str) -> Dict[str, Any]:
-        """Generate VASP INCAR and KPOINTS files using the selected method."""
-        print(f"📝 Generating VASP input files using '{self.vasp_generator_method}' method...")
-
-        if self.vasp_generator_method == "llm":
-            vasp_result = self.vasp_agent.generate_vasp_inputs(
-                poscar_path=structure_path,
-                original_request=user_request
-            )
-            if vasp_result.get("status") == "success":
-                self.vasp_agent.save_inputs(vasp_result, self.output_dir)
-            return vasp_result
-
-        elif self.vasp_generator_method == "atomate2":
-            try:
-                structure_obj = ase_read(structure_path)
-                # The generate method now handles file writing internally
-                self.vasp_agent.generate(
-                    structure=structure_obj,
-                    output_dir=self.output_dir
-                )
-                return {
-                    "status": "success",
-                    "summary": "Standard relaxation set from atomate2/pymatgen",
-                    "incar": (Path(self.output_dir) / "INCAR").read_text()
-                }
-            except Exception as e:
-                self.logger.error(f"Atomate2 input generation failed: {e}", exc_info=True)
-                return {"status": "error", "message": f"Atomate2 generation failed: {e}"}
-
-        return {"status": "error", "message": "Invalid VASP generator method."}
-
-    def _validate_and_improve_incar(self, vasp_result: Dict[str, Any],
-                                    structure_path: str, user_request: str) -> Dict[str, Any]:
-        """Validate INCAR against literature and apply improvements."""
-
-        if self.vasp_generator_method != "llm":
-            msg = "Literature validation is only applicable for the 'llm' generator."
-            self.logger.info(msg)
-            return {"status": "skipped", "message": msg}
-
-        print(f"📖 Validating INCAR parameters against literature...")
-        validation_result = self.incar_validator.validate_and_improve_incar(
-            incar_content=vasp_result["incar"],
-            system_description=user_request
-        )
-        return validation_result
-
-    def _print_final_summary(self, workflow_result: Dict[str, Any]):
-        """Print a clean final summary."""
-        print(f"\n🎉 DFT Workflow Complete!")
-        print(f"{'='*60}")
-        status = workflow_result.get('final_status')
-        steps = workflow_result.get('steps_completed', [])
-        print(f"📋 Status: {status}")
-        print(f"✅ Steps: {' → '.join(steps)}")
-        print(f"📁 Output: {self.output_dir}/")
-
-        if "structure_generation" in workflow_result:
-            struct_result = workflow_result["structure_generation"]
-            if struct_result["status"] == "success":
-                cycles = struct_result.get('cycles_used', 1)
-                structure_file = os.path.basename(struct_result['final_structure_path'])
-                print(f"🏗️  Structure: {structure_file} (refined {cycles} cycle{'s' if cycles > 1 else ''})")
-
-        if "vasp_generation" in workflow_result:
-            vasp_result = workflow_result["vasp_generation"]
-            if vasp_result["status"] == "success":
-                calc_type = vasp_result.get('summary', 'DFT calculation')
-                print(f"⚛️  VASP: {calc_type}")
-
-        if "incar_improvement" in workflow_result:
-            imp_result = workflow_result["incar_improvement"]
-            if imp_result["status"] == "success":
-                if imp_result["validation_status"] == "needs_adjustment":
-                    adj_count = len(imp_result.get("suggested_adjustments", []))
-                    print(f"📚 Literature: {adj_count} parameter improvement{'s' if adj_count > 1 else ''} applied")
-                else:
-                    print(f"📚 Literature: Parameters validated, no changes needed")
-
-        print(f"\n📄 Ready for VASP:")
-        manifest = workflow_result.get("final_manifest", {})
-        if manifest.get("ready_for_vasp"):
-            files = manifest["final_files"]
-            structure_file = files.get('structure', 'POSCAR')
-            incar_file = files.get('incar', 'INCAR')
-            kpoints_file = files.get('kpoints', 'KPOINTS')
-            print(f"    • {structure_file}")
-            print(f"    • {incar_file}{' ⭐ (literature-optimized)' if manifest.get('literature_validated') else ''}")
-            print(f"    • {kpoints_file}")
-        print(f"{'='*60}")
-
-    def get_summary(self, workflow_result: Dict[str, Any]) -> str:
-        """Get a human-readable summary of the workflow results."""
-        summary = f"DFT Workflow Summary\n{'='*20}\n"
-        summary += f"Request: {workflow_result['user_request']}\n"
-        summary += f"Status: {workflow_result['final_status']}\n"
-        summary += f"Steps completed: {', '.join(workflow_result['steps_completed'])}\n"
-        summary += f"Output directory: {workflow_result.get('output_dir', 'N/A')}\n\n"
-        if "structure_generation" in workflow_result:
-            struct_result = workflow_result["structure_generation"]
-            if struct_result["status"] == "success":
-                struct_file = os.path.basename(struct_result['final_structure_path'])
-                summary += f"✓ Final Structure: {struct_file}\n"
-                summary += f"  Refinement cycles: {struct_result['cycles_used']}\n"
-                summary += f"  Location: {workflow_result.get('output_dir', '.')}/\n"
-        if "vasp_generation" in workflow_result:
-            vasp_result = workflow_result["vasp_generation"]
-            if vasp_result["status"] == "success":
-                summary += f"✓ VASP Input Files:\n"
-                if ("incar_improvement" in workflow_result and
-                        workflow_result["incar_improvement"].get("improvement_application", {}).get("status") == "success"):
-                    summary += f"  - INCAR_improved (literature-validated) ⭐\n"
-                    summary += f"  - INCAR (original)\n"
-                else:
-                    summary += f"  - INCAR\n"
-                summary += f"  - KPOINTS\n"
-                summary += f"  Calculation: {vasp_result['summary']}\n"
-        if "incar_improvement" in workflow_result:
-            imp_result = workflow_result["incar_improvement"]
-            if imp_result["status"] == "success":
-                if imp_result["validation_status"] == "needs_adjustment":
-                    adj_count = len(imp_result.get("suggested_adjustments", []))
-                    summary += f"✓ Literature improvements: {adj_count} adjustments applied\n"
-                else:
-                    summary += f"✓ Literature validation: No improvements needed\n"
-        if "final_manifest" in workflow_result:
-            manifest = workflow_result["final_manifest"]
-            if manifest.get("ready_for_vasp"):
-                summary += f"\n📋 FINAL FILES FOR VASP:\n"
-                final_files = manifest["final_files"]
-                summary += f"  Structure: {final_files.get('structure', 'N/A')}\n"
-                summary += f"  INCAR: {final_files.get('incar', 'N/A')}\n"
-                summary += f"  KPOINTS: {final_files.get('kpoints', 'N/A')}\n"
-                summary += f"  Directory: {manifest['output_directory']}/\n"
-        return summary
-
-    def _create_final_files_manifest(self, workflow_result: Dict[str, Any]) -> Dict[str, str]:
-        """Create a JSON manifest of final files."""
-        manifest = {
-            "workflow_status": workflow_result["final_status"],
-            "user_request": workflow_result["user_request"],
-            "output_directory": self.output_dir,
-            "final_files": {},
-            "ready_for_vasp": False
-        }
-        if ("structure_generation" in workflow_result and
-                workflow_result["structure_generation"]["status"] == "success"):
-            structure_path = workflow_result["structure_generation"]["final_structure_path"]
-            manifest["final_files"]["structure"] = os.path.basename(structure_path)
-        if ("vasp_generation" in workflow_result and
-                workflow_result["vasp_generation"]["status"] == "success"):
-            if ("incar_improvement" in workflow_result and
-                    workflow_result["incar_improvement"].get("improvement_application", {}).get("status") == "success"):
-                manifest["final_files"]["incar"] = "INCAR_improved"
-                manifest["literature_validated"] = True
-            else:
-                manifest["final_files"]["incar"] = "INCAR"
-                manifest["literature_validated"] = False
-            manifest["final_files"]["kpoints"] = "KPOINTS"
-            if all(key in manifest["final_files"] for key in ["structure", "incar", "kpoints"]):
-                manifest["ready_for_vasp"] = True
-        try:
-            manifest_path = os.path.join(self.output_dir, "final_files_manifest.json")
-            with open(manifest_path, 'w') as f:
-                json.dump(manifest, f, indent=2)
-        except Exception as e:
-            self.logger.error(f"Failed to save manifest: {e}")
-        return manifest

--- a/scilink/agents/sim_agents/periodic_dft_agent.py
+++ b/scilink/agents/sim_agents/periodic_dft_agent.py
@@ -337,6 +337,35 @@ class PeriodicDFTAgent:
                 "raw_result": result,
             }
 
+        # ── pre-submit syntax pass ────────────────────────────────────
+        # Engine-native syntax check on whatever the engine considers its
+        # primary parameter file.  Lives behind a per-engine validator
+        # module — PeriodicDFTAgent itself doesn't know about pymatgen.
+        # See CLAUDE.md "Engine-neutral contracts".
+        if software == "vasp" and "INCAR" in result["input_files"]:
+            try:
+                from .vasp_input_validator import (
+                    check_incar_syntax, apply_incar_syntax_fixes,
+                )
+                incar_text = result["input_files"]["INCAR"]
+                issues = check_incar_syntax(incar_text)
+                if issues:
+                    fixed, applied = apply_incar_syntax_fixes(incar_text, issues)
+                    if applied:
+                        result["input_files"]["INCAR"] = fixed
+                        for a in applied:
+                            self.logger.info(
+                                "pre-submit syntax fix: %s → %s",
+                                a["renamed_from"], a["renamed_to"],
+                            )
+                    result["syntax_check"] = {
+                        "issues": issues,
+                        "applied_fixes": applied,
+                    }
+            except Exception as exc:
+                # Syntax check is advisory — never block generation on it.
+                self.logger.warning("INCAR syntax check failed: %s", exc)
+
         result["status"] = "success"
         result["software"] = software
         return result

--- a/scilink/agents/sim_agents/periodic_dft_agent.py
+++ b/scilink/agents/sim_agents/periodic_dft_agent.py
@@ -338,33 +338,46 @@ class PeriodicDFTAgent:
             }
 
         # ── pre-submit syntax pass ────────────────────────────────────
-        # Engine-native syntax check on whatever the engine considers its
-        # primary parameter file.  Lives behind a per-engine validator
-        # module — PeriodicDFTAgent itself doesn't know about pymatgen.
-        # See CLAUDE.md "Engine-neutral contracts".
-        if software == "vasp" and "INCAR" in result["input_files"]:
+        # Engine-neutral: ask the active engine's skill bundle for its
+        # syntax checker/fixer via the registry. The agent never names an
+        # engine or imports a bundle by path — an engine with no such
+        # tools simply skips this advisory pass. See CLAUDE.md
+        # "Engine-neutral contracts" and the skill-bundle callables pattern.
+        try:
+            from ...skills._shared._registry import get_tool_function
             try:
-                from .vasp_input_validator import (
-                    check_incar_syntax, apply_incar_syntax_fixes,
+                checker = get_tool_function(
+                    "check_input_syntax", active_skills=[software]
                 )
-                incar_text = result["input_files"]["INCAR"]
-                issues = check_incar_syntax(incar_text)
+            except LookupError:
+                checker = None
+            if checker is not None:
+                issues = checker(input_files=result["input_files"])
                 if issues:
-                    fixed, applied = apply_incar_syntax_fixes(incar_text, issues)
-                    if applied:
-                        result["input_files"]["INCAR"] = fixed
+                    applied: list = []
+                    try:
+                        fixer = get_tool_function(
+                            "apply_input_syntax_fixes", active_skills=[software]
+                        )
+                    except LookupError:
+                        fixer = None
+                    if fixer is not None:
+                        fixed_files, applied = fixer(
+                            input_files=result["input_files"], issues=issues
+                        )
+                        result["input_files"] = fixed_files
                         for a in applied:
                             self.logger.info(
                                 "pre-submit syntax fix: %s → %s",
-                                a["renamed_from"], a["renamed_to"],
+                                a.get("renamed_from"), a.get("renamed_to"),
                             )
                     result["syntax_check"] = {
                         "issues": issues,
                         "applied_fixes": applied,
                     }
-            except Exception as exc:
-                # Syntax check is advisory — never block generation on it.
-                self.logger.warning("INCAR syntax check failed: %s", exc)
+        except Exception as exc:
+            # Syntax check is advisory — never block generation on it.
+            self.logger.warning("input syntax check failed: %s", exc)
 
         result["status"] = "success"
         result["software"] = software

--- a/scilink/agents/sim_agents/post_run_analysis.py
+++ b/scilink/agents/sim_agents/post_run_analysis.py
@@ -1,10 +1,20 @@
 """
+BENCHMARK BASELINE — legacy VASP output parser.
+
+Retained as a support module for the baseline ``VaspQualityAgent`` in the
+old-vs-new critic benchmark; NOT on the live path. The live post-run
+snapshot lives in the VASP skill bundle as ``snapshot_run``
+(``scilink.skills.periodic_dft.vasp.vasp_output``), discovered via the
+skill registry. The two share the same parsing logic by design (the bundle
+version is the relocation); this copy stays to keep the baseline agent
+self-contained.
+
 Post-run VASP output analysis.
 
 Reads OUTCAR / vasprun.xml from a completed (or failed) VASP run and
-produces a structured summary the simulate orchestrator can hand back
-to the user. This is the part of the orchestrator that closes the loop
-after the user runs VASP elsewhere — analyze mode never does this.
+produces a structured summary. Originally the simulate orchestrator's
+post-run close-the-loop step; that role is now the engine-neutral
+``RunCritic`` + the skill-bundle ``snapshot_run`` tool.
 
 Designed to be defensive: VASP runs fail in many ways and pymatgen's
 parser can raise on partial / corrupt outputs. Every code path returns

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -406,6 +406,33 @@ class SimulationOrchestratorAgent:
         logging.info(f"✅ SimulationOrchestratorAgent initialized. Session: {self.base_dir}")
 
     # ------------------------------------------------------------------
+    # Routing helpers
+    # ------------------------------------------------------------------
+
+    def active_skill_and_domain(self) -> tuple[Optional[str], Optional[str]]:
+        """Return ``(skill, domain)`` derived from the current routing decision.
+
+        Maps the router's ``(engine, scale)`` vocabulary onto the skill
+        infrastructure's ``(skill, domain)`` vocabulary so downstream tools
+        — in particular the engine-neutral critic agents — can derive their
+        ``skill=`` and ``domain=`` parameters from session state instead of
+        requiring the LLM to pass them on every call.
+
+        Returns:
+            ``(engine, scale)`` from ``routing_decision`` when it has been
+            populated by a successful ``route_simulation`` call. Returns
+            ``(None, None)`` when the orchestrator has not routed yet or
+            the prior routing call failed (the LLM should call
+            ``route_simulation`` before invoking tools that need this).
+        """
+        decision = self.routing_decision or {}
+        scale = decision.get("scale")
+        engine = decision.get("engine")
+        if not scale or not engine:
+            return None, None
+        return engine, scale
+
+    # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -1,14 +1,16 @@
 """
-Simulation Orchestrator Agent for VASP DFT input preparation.
+Simulation Orchestrator Agent for computational simulation.
 
-Coordinates structure generation, VASP input creation, and post-run analysis
-through tools wrapping the existing sim_agents stack (StructureGenerator,
-StructureValidatorAgent, VaspInputAgent, VaspUpdater, IncarValidatorAgent,
-DFTOrchestrator).
+Coordinates structure generation, input creation, validation, and post-run
+analysis through an engine-neutral tool surface: structure generation
+(StructureOrchestrator), the scale-agnostic simulation pipeline, and the
+engine-neutral critics (InputValidator / RunCritic), with engine specifics
+supplied by skill bundles. The routing decision selects scale + engine.
 
-Mirrors the shape of AnalysisOrchestratorAgent for consistent UX. VASP DFT
-only for now; LAMMPS support and HPC submission tools are follow-up work
-(see CLAUDE.md for the full sequencing plan).
+Mirrors the shape of AnalysisOrchestratorAgent for consistent UX. Periodic
+DFT (VASP, QE) is fully dispatched; MD and MLIP scales route and run the
+one-shot pipeline, with granular per-step tools as follow-up work (see
+CLAUDE.md for the full sequencing plan).
 
 The duplication with AnalysisOrchestratorAgent is intentional and acceptable
 at this development stage — see CLAUDE.md "Why no BaseChatOrchestrator

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -324,7 +324,7 @@ class SimulationOrchestratorAgent:
         self.structures_dir.mkdir(parents=True, exist_ok=True)
 
         # Session state — structure-centric (vs analysis-centric in analyze mode)
-        # generated_structures: list of {slug, poscar_path, description,
+        # generated_structures: list of {slug, structure_path, description,
         #     created_at, vasp_inputs_path?, vasp_output_dir?}
         self.generated_structures: List[Dict[str, Any]] = []
 
@@ -555,7 +555,7 @@ class SimulationOrchestratorAgent:
         files_produced: List[str] = []
         key_findings: List[str] = []
         for s in new_structures:
-            for key in ("poscar_path", "incar_path", "kpoints_path", "script_path"):
+            for key in ("structure_path", "incar_path", "kpoints_path", "script_path"):
                 p = s.get(key)
                 if p:
                     files_produced.append(p)
@@ -579,10 +579,10 @@ class SimulationOrchestratorAgent:
         # generate VASP inputs for it.
         suggested_followups: List[str] = []
         for s in new_structures:
-            if s.get("poscar_path") and not s.get("incar_path"):
+            if s.get("structure_path") and not s.get("incar_path"):
                 suggested_followups.append(
                     f"Generate VASP inputs for {s.get('slug')} "
-                    f"(POSCAR at {s.get('poscar_path')})."
+                    f"(POSCAR at {s.get('structure_path')})."
                 )
 
         result = {
@@ -596,7 +596,7 @@ class SimulationOrchestratorAgent:
                 {
                     "slug": s.get("slug"),
                     "description": s.get("description"),
-                    "poscar_path": s.get("poscar_path"),
+                    "structure_path": s.get("structure_path"),
                     "incar_path": s.get("incar_path"),
                     "kpoints_path": s.get("kpoints_path"),
                 } for s in new_structures

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -92,20 +92,26 @@ goal, the system, and what's actually available. Once a routing
 decision exists in the session, plan subsequent tool calls around
 that engine (don't re-route on every turn unless the user pivots).
 
+**Engine-neutral tool surface:**
+The granular tools are engine-neutral and take the engine from the active
+routing decision (or an explicit `software` argument): generate_structure,
+generate_dft_inputs, validate_inputs, apply_input_adjustments,
+analyze_output, and (when an HPC connection is active)
+submit_simulation_job / get_job_status / download_job_results. The engine's
+specifics come from its skill bundle, so the same tools serve any engine
+within a scale.
+
 **Dispatch maturity (as of this build):**
-- `periodic_dft` + `vasp` -> fully dispatched here: generate_structure,
-  generate_vasp_inputs, validate_incar, apply_incar_improvements,
-  submit_vasp_job (when HPC connection active), and the post-run
-  analysis chain are all available.
-- `molecular_dynamics` + `lammps` / `gromacs` / `openmm` -> routing
-  works; concrete dispatch tools are the next-step follow-up.
-  When the router picks one of these, tell the user the routing
-  matched and point them at `MDSimulationAgent` directly for now.
-- `machine_learning_potentials` + `mace` / others -> same situation.
-  Point at `MLIPAgent` directly until the dispatch tools land.
+- `periodic_dft` (`vasp`, `qe`) -> fully dispatched via the tools above.
+- `molecular_dynamics` (`lammps` / …) -> structure + the one-shot pipeline
+  work; the granular per-step generate tool is the next-step follow-up.
+  When the router picks one of these, you can still run the complete
+  workflow; point the user at `MDSimulationAgent` for granular control.
+- `machine_learning_potentials` (`mace` / …) -> point at `MLIPAgent`
+  directly until the dispatch tools land.
 
 **HPC integration:**
-When an HPC connection is active (`submit_vasp_job` is available), you
+When an HPC connection is active (`submit_simulation_job` is available), you
 can submit jobs to the cluster, monitor their status, download
 results, and generate a final report — all without leaving the
 session. Without an HPC connection, prep is local only; the user
@@ -555,8 +561,11 @@ class SimulationOrchestratorAgent:
         files_produced: List[str] = []
         key_findings: List[str] = []
         for s in new_structures:
-            for key in ("structure_path", "incar_path", "kpoints_path", "script_path"):
+            for key in ("structure_path", "script_path"):
                 p = s.get(key)
+                if p:
+                    files_produced.append(p)
+            for p in (s.get("input_files") or {}).values():
                 if p:
                     files_produced.append(p)
             val = s.get("validation") or {}
@@ -574,15 +583,14 @@ class SimulationOrchestratorAgent:
                     f"Structure {s.get('slug')} has unresolved validation issues."
                 )
 
-        # Heuristic: a "follow-up" is a structure that has a POSCAR but no
-        # INCAR/KPOINTS yet — natural next step for the caller is to
-        # generate VASP inputs for it.
+        # Heuristic: a "follow-up" is a structure that has been built but has
+        # no generated inputs yet — natural next step is to generate inputs.
         suggested_followups: List[str] = []
         for s in new_structures:
-            if s.get("structure_path") and not s.get("incar_path"):
+            if s.get("structure_path") and not s.get("input_files"):
                 suggested_followups.append(
-                    f"Generate VASP inputs for {s.get('slug')} "
-                    f"(POSCAR at {s.get('structure_path')})."
+                    f"Generate inputs for {s.get('slug')} "
+                    f"(structure at {s.get('structure_path')})."
                 )
 
         result = {
@@ -597,8 +605,7 @@ class SimulationOrchestratorAgent:
                     "slug": s.get("slug"),
                     "description": s.get("description"),
                     "structure_path": s.get("structure_path"),
-                    "incar_path": s.get("incar_path"),
-                    "kpoints_path": s.get("kpoints_path"),
+                    "input_files": s.get("input_files") or {},
                 } for s in new_structures
             ],
             "warnings": warnings,

--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -171,7 +171,7 @@ class SimulationOrchestratorTools:
                         "slug": s.get("slug"),
                         "description": s.get("description"),
                         "structure_path": s.get("structure_path"),
-                        "incar_path": s.get("incar_path"),
+                        "input_files": s.get("input_files") or {},
                     } for s in structures
                 ],
                 "default_calc_params": params,
@@ -399,9 +399,8 @@ class SimulationOrchestratorTools:
                 "script_content": result.get("final_script_content"),
                 "skill": skill,
                 "based_on_slug": based_on_slug,
-                "incar_path": None,
-                "kpoints_path": None,
-                "vasp_summary": None,
+                "input_files": {},
+                "summary": None,
                 "validation": val,
                 "created_at": datetime.now().isoformat(),
             }
@@ -425,7 +424,7 @@ class SimulationOrchestratorTools:
                 "refinement_cycles_used": result.get("cycles_used", 1),
                 "warning": result.get("warning"),
                 "next_steps": (
-                    "Generate VASP inputs with generate_vasp_inputs(...) "
+                    "Generate VASP inputs with generate_dft_inputs(...) "
                     "for the desired calculation type, or build a related "
                     "structure variant via another generate_structure call."
                     if not result.get("warning")
@@ -444,7 +443,7 @@ class SimulationOrchestratorTools:
                 "`run_analysis`: one tool call returns a structure that has "
                 "already been reviewed and improved if needed.\n\n"
                 "Returns POSCAR + the structure record's session slug. Does "
-                "NOT produce VASP inputs — call `generate_vasp_inputs` for "
+                "NOT produce VASP inputs — call `generate_dft_inputs` for "
                 "those, or `run_complete_dft_workflow` for the full pipeline "
                 "(structure + inputs together).\n\n"
                 "Set `skill='aimsgb'` for grain boundaries / bicrystals / "
@@ -620,121 +619,107 @@ class SimulationOrchestratorTools:
         # =====================================================================
         # 5. GENERATE VASP INPUTS
         # =====================================================================
-        def generate_vasp_inputs(structure_path: str, request: str,
-                                 method: str = "llm") -> str:
+        def generate_dft_inputs(structure_path: str, request: str,
+                                software: str = None, method: str = "llm") -> str:
             if not Path(structure_path).exists():
                 return json.dumps({
                     "status": "error",
-                    "message": f"POSCAR not found: {structure_path}",
+                    "message": f"Structure file not found: {structure_path}",
+                })
+
+            skill, domain = self._resolve_engine(software)
+            if not skill:
+                return json.dumps({
+                    "status": "error",
+                    "message": (
+                        "No engine selected. Call route_simulation first, or "
+                        "pass `software` explicitly (e.g. 'vasp')."
+                    ),
                 })
 
             structure_dir = Path(structure_path).parent
-
             try:
-                if method == "llm":
-                    from .vasp_agent import VaspInputAgent
-                    agent = VaspInputAgent(
-                        api_key=self.orch.api_key,
-                        base_url=self.orch.base_url,
-                        model_name=self.orch.model_name,
-                    )
-                    vasp_result = agent.generate_vasp_inputs(
-                        structure_path=structure_path,
-                        original_request=request,
-                    )
-                    if vasp_result.get("status") != "success":
-                        return json.dumps({
-                            "status": "error",
-                            "message": vasp_result.get("message") or "VASP input generation failed",
-                        })
-                    saved = agent.save_inputs(vasp_result, str(structure_dir))
-                    if "error" in saved:
-                        return json.dumps({"status": "error", "message": saved["error"]})
-                    summary = vasp_result.get("summary", "")
-
-                elif method == "atomate2":
-                    try:
-                        from .atomate2_utils import Atomate2Input
-                    except ImportError as e:
-                        return json.dumps({
-                            "status": "error",
-                            "message": (
-                                "method='atomate2' requires the [sim] extras "
-                                "(pymatgen, atomate2). Install with: "
-                                "pip install 'scilink[sim]'. "
-                                f"Original error: {e}"
-                            ),
-                        })
-                    from ase.io import read as ase_read
-                    structure_obj = ase_read(structure_path)
-                    Atomate2Input().generate(
-                        structure=structure_obj,
-                        output_dir=str(structure_dir),
-                    )
-                    summary = "Standard relaxation set from atomate2/pymatgen"
-
-                else:
-                    return json.dumps({
-                        "status": "error",
-                        "message": f"Invalid method '{method}'. Choose 'llm' or 'atomate2'.",
-                    })
-
+                from .simulation_pipeline import _generate_inputs
+                gen = _generate_inputs(
+                    scale=domain, software=skill, method=method,
+                    structure_file=structure_path, request=request,
+                    output_dir=str(structure_dir),
+                    api_key=self.orch.api_key, base_url=self.orch.base_url,
+                    model_name=self.orch.model_name,
+                )
             except Exception as e:
                 return json.dumps({
                     "status": "error",
-                    "message": f"VASP input generation failed: {e}",
+                    "message": f"DFT input generation failed: {e}",
                 })
 
-            incar_path = structure_dir / "INCAR"
-            kpoints_path = structure_dir / "KPOINTS"
+            if gen.get("status") not in (None, "success"):
+                return json.dumps({
+                    "status": "error",
+                    "message": gen.get("message") or "DFT input generation failed",
+                })
 
+            # Generic input-files record: filename -> path of the saved inputs.
+            file_paths = {
+                fn: str(structure_dir / fn)
+                for fn in (gen.get("input_files") or {})
+                if (structure_dir / fn).exists()
+            }
+            summary = gen.get("summary", "")
             record = self._find_structure_record(structure_path)
             if record is not None:
-                record["incar_path"] = str(incar_path)
-                record["kpoints_path"] = str(kpoints_path)
-                record["vasp_summary"] = summary
+                record["input_files"] = file_paths
+                record["summary"] = summary
 
             return json.dumps({
                 "status": "success",
-                "incar_path": str(incar_path),
-                "kpoints_path": str(kpoints_path),
+                "engine": skill,
+                "input_files": file_paths,
                 "summary": summary,
                 "method": method,
                 "structure_dir": str(structure_dir),
             })
 
         self._register_tool(
-            func=generate_vasp_inputs,
-            name="generate_vasp_inputs",
+            func=generate_dft_inputs,
+            name="generate_dft_inputs",
             description=(
-                "Generate VASP INCAR and KPOINTS files for a given structure "
-                "tailored to the scientific objective in `request`. Saves "
-                "INCAR + KPOINTS alongside the POSCAR. method='llm' (default) "
-                "uses an LLM to derive parameters; method='atomate2' uses "
-                "pymatgen/atomate2's MPRelaxSet (deterministic, requires the "
-                "[sim] extras)."
+                "Generate periodic-DFT input files for a structure, tailored "
+                "to the scientific objective in `request`, and save them "
+                "alongside the structure. Engine-neutral: `software` selects "
+                "the engine (e.g. 'vasp', 'qe'), defaulting to the routing "
+                "decision. method='llm' (default) derives parameters with an "
+                "LLM; a named method (e.g. 'atomate2' for VASP) uses a "
+                "deterministic generation backend from the engine's skill "
+                "bundle (requires the [sim] extras). Returns a generic "
+                "input_files map."
             ),
             parameters={
                 "structure_path": {
                     "type": "string",
-                    "description": "Absolute path to the POSCAR the inputs should match.",
+                    "description": "Absolute path to the structure the inputs should match.",
                 },
                 "request": {
                     "type": "string",
                     "description": (
-                        "Scientific objective / calculation type description "
+                        "Scientific objective / calculation type "
                         "(e.g., 'static SCF for band structure', "
-                        "'relaxation with vdW corrections for an interface'). "
-                        "Drives INCAR parameter choices."
+                        "'relaxation with vdW corrections'). Drives parameters."
+                    ),
+                },
+                "software": {
+                    "type": "string",
+                    "description": (
+                        "Optional engine override (e.g. 'vasp', 'qe'). "
+                        "Defaults to the engine chosen by route_simulation."
                     ),
                 },
                 "method": {
                     "type": "string",
-                    "enum": ["llm", "atomate2"],
                     "description": (
-                        "'llm' (default): AI-driven, more flexible. "
-                        "'atomate2': rule-based, deterministic, requires the "
-                        "[sim] extras."
+                        "'llm' (default): AI-driven generation. A named "
+                        "method (e.g. 'atomate2') uses a deterministic "
+                        "backend from the engine's skill bundle."
                     ),
                 },
             },
@@ -779,9 +764,17 @@ class SimulationOrchestratorTools:
             val_result = structure_gen.get("validation_result", {}) or {}
             outstanding_issues = val_result.get("all_identified_issues", []) or []
 
-            structure_path = workdir / "POSCAR"
-            incar_path = workdir / "INCAR"
-            kpoints_path = workdir / "KPOINTS"
+            # Engine-neutral: take the structure path from the result and
+            # build the input-files map from the generated inputs.
+            structure_path = Path(
+                structure_gen.get("final_structure_path") or (workdir / "POSCAR")
+            )
+            input_generation = result.get("input_generation", {}) or {}
+            input_files = {
+                fn: str(workdir / fn)
+                for fn in (input_generation.get("input_files") or {})
+                if (workdir / fn).exists()
+            }
 
             # Record in session state (only if structure exists)
             if structure_path.exists():
@@ -792,9 +785,8 @@ class SimulationOrchestratorTools:
                     "structure_path": str(structure_path),
                     "script_path": structure_gen.get("final_script_path"),
                     "script_content": None,  # not surfaced by run_complete_workflow
-                    "incar_path": str(incar_path) if incar_path.exists() else None,
-                    "kpoints_path": str(kpoints_path) if kpoints_path.exists() else None,
-                    "vasp_summary": result.get("vasp_generation", {}).get("summary"),
+                    "input_files": input_files,
+                    "summary": input_generation.get("summary"),
                     "validation": val_result,
                     "created_at": datetime.now().isoformat(),
                 }
@@ -822,7 +814,7 @@ class SimulationOrchestratorTools:
                 "without iterating on each step. For iterative work "
                 "(build → check → refine → inputs), use the granular tools "
                 "(generate_structure, validate_structure, refine_structure, "
-                "generate_vasp_inputs) instead."
+                "generate_dft_inputs) instead."
             ),
             parameters={
                 "description": {
@@ -913,31 +905,30 @@ class SimulationOrchestratorTools:
                     "message": result.get("message") or result.get("last_error") or "Refinement failed",
                 })
 
-            new_poscar = result["output_file"]
+            new_structure_path = result["output_file"]
             new_script_path = result["final_script_path"]
             new_script_content = result["final_script_content"]
-            n_atoms = self._count_atoms(new_poscar)
+            n_atoms = self._count_atoms(new_structure_path)
 
             # Update the record in place rather than appending — refinement
             # produces a successor of the same logical structure.
-            record["structure_path"] = new_poscar
+            record["structure_path"] = new_structure_path
             record["script_path"] = new_script_path
             record["script_content"] = new_script_content
             record["validation"] = None  # invalidate prior validation
-            record["incar_path"] = None  # invalidate prior inputs (geometry changed)
-            record["kpoints_path"] = None
-            record["vasp_summary"] = None
+            record["input_files"] = {}    # invalidate prior inputs (geometry changed)
+            record["summary"] = None
 
             return json.dumps({
                 "status": "success",
                 "slug": record["slug"],
-                "structure_path": new_poscar,
+                "structure_path": new_structure_path,
                 "script_path": new_script_path,
                 "n_atoms": n_atoms,
                 "next_steps": (
                     "Optionally call validate_structure again to confirm the "
                     "refinement addressed the prior issues; then proceed to "
-                    "generate_vasp_inputs."
+                    "generate_dft_inputs."
                 ),
             })
 
@@ -1118,19 +1109,15 @@ class SimulationOrchestratorTools:
         # =====================================================================
         # 7. APPLY INCAR IMPROVEMENTS
         # =====================================================================
-        def apply_incar_improvements(incar_path: str, structure_path: str,
-                                     original_request: str,
-                                     suggested_adjustments: list,
-                                     overall_assessment: str = "") -> str:
-            if not Path(incar_path).exists():
-                return json.dumps({
-                    "status": "error",
-                    "message": f"INCAR not found: {incar_path}",
-                })
+        def apply_input_adjustments(structure_path: str,
+                                    original_request: str,
+                                    suggested_adjustments: list,
+                                    software: str = None,
+                                    overall_assessment: str = "") -> str:
             if not Path(structure_path).exists():
                 return json.dumps({
                     "status": "error",
-                    "message": f"POSCAR not found: {structure_path}",
+                    "message": f"Structure file not found: {structure_path}",
                 })
             if not suggested_adjustments:
                 return json.dumps({
@@ -1138,9 +1125,42 @@ class SimulationOrchestratorTools:
                     "message": "No adjustments provided — nothing to apply.",
                 })
 
+            skill, domain = self._resolve_engine(software)
+            if not skill:
+                return json.dumps({
+                    "status": "error",
+                    "message": (
+                        "No engine selected. Call route_simulation first, or "
+                        "pass `software` explicitly (e.g. 'vasp')."
+                    ),
+                })
+
+            record = self._find_structure_record(structure_path)
+            original_inputs = self._record_input_files(record)
+            if not original_inputs:
+                return json.dumps({
+                    "status": "error",
+                    "message": (
+                        "No generated inputs to adjust. Run generate_dft_inputs "
+                        "(or generate_md_inputs) first."
+                    ),
+                })
+
+            # The engine-neutral apply lives on the periodic-DFT foundation
+            # agent (software-agnostic across vasp/qe). Other scales gain
+            # their own apply when their foundation agent implements it.
+            if domain != "periodic_dft":
+                return json.dumps({
+                    "status": "error",
+                    "message": (
+                        f"apply_input_adjustments is not yet available for "
+                        f"scale '{domain}'."
+                    ),
+                })
+
             try:
-                from .vasp_agent import VaspInputAgent
-                agent = VaspInputAgent(
+                from .periodic_dft_agent import PeriodicDFTAgent
+                agent = PeriodicDFTAgent(
                     api_key=self.orch.api_key,
                     base_url=self.orch.base_url,
                     model_name=self.orch.model_name,
@@ -1148,54 +1168,57 @@ class SimulationOrchestratorTools:
             except Exception as e:
                 return json.dumps({
                     "status": "error",
-                    "message": f"Failed to construct VaspInputAgent: {e}",
+                    "message": f"Failed to construct generator agent: {e}",
                 })
 
-            original_incar = Path(incar_path).read_text()
-            output_dir = str(Path(incar_path).parent)
-
+            output_dir = str(Path(structure_path).parent)
             result = agent.apply_improvements(
-                original_incar=original_incar,
+                original_inputs=original_inputs,
                 validation_result={
                     "validation_status": "needs_adjustment",
                     "suggested_adjustments": suggested_adjustments,
                     "overall_assessment": overall_assessment,
                 },
-                structure_path=structure_path,
-                original_request=original_request,
+                structure_file=structure_path,
+                request=original_request,
                 output_dir=output_dir,
+                software=skill,
             )
 
             if result.get("status") not in ("success", "no_changes"):
                 return json.dumps({
                     "status": "error",
-                    "message": result.get("message") or "Apply-improvements failed",
+                    "message": result.get("message") or "Apply-adjustments failed",
                 })
+
+            improved = result.get("improved_paths") or {}
+            if record is not None and improved:
+                record["input_files"] = dict(improved)
 
             return json.dumps({
                 "status": result.get("status"),
-                "improvements_applied": result.get("improvements_applied", False),
-                "adjustments_count": result.get("adjustments_count", 0),
-                "improved_incar_path": result.get("improved_incar_path"),
+                "engine": skill,
+                "improved_paths": improved,
             })
 
         self._register_tool(
-            func=apply_incar_improvements,
-            name="apply_incar_improvements",
+            func=apply_input_adjustments,
+            name="apply_input_adjustments",
             description=(
-                "Apply a list of literature-validated INCAR adjustments to an "
-                "existing INCAR, writing the result as INCAR_improved next to "
-                "the original. Pair with validate_incar — pass its "
+                "Apply a list of validated parameter adjustments to a "
+                "structure's generated inputs, writing improved files next to "
+                "the originals and updating the session record. Engine-neutral: "
+                "`software` selects the engine (defaults to the routing "
+                "decision). Pair with validate_inputs — pass its "
                 "suggested_adjustments through directly."
             ),
             parameters={
-                "incar_path": {
-                    "type": "string",
-                    "description": "Absolute path to the original INCAR.",
-                },
                 "structure_path": {
                     "type": "string",
-                    "description": "Absolute path to the POSCAR (provides system context).",
+                    "description": (
+                        "Absolute path to the structure whose generated inputs "
+                        "should be adjusted (provides system context)."
+                    ),
                 },
                 "original_request": {
                     "type": "string",
@@ -1205,17 +1228,23 @@ class SimulationOrchestratorTools:
                     "type": "array",
                     "items": {"type": "object"},
                     "description": (
-                        "List of adjustment dicts in the shape returned by "
-                        "validate_incar (each with parameter/current_value/"
-                        "suggested_value/reason)."
+                        "Adjustment dicts in the shape validate_inputs returns "
+                        "(each with file/key/current/suggested/reason)."
+                    ),
+                },
+                "software": {
+                    "type": "string",
+                    "description": (
+                        "Optional engine override (e.g. 'vasp', 'qe'). "
+                        "Defaults to the engine chosen by route_simulation."
                     ),
                 },
                 "overall_assessment": {
                     "type": "string",
-                    "description": "Brief literature-review summary (passed verbatim).",
+                    "description": "Brief validation summary (passed verbatim).",
                 },
             },
-            required=["incar_path", "structure_path", "original_request", "suggested_adjustments"],
+            required=["structure_path", "original_request", "suggested_adjustments"],
         )
 
         # =====================================================================
@@ -1232,8 +1261,7 @@ class SimulationOrchestratorTools:
                         "description": s.get("description"),
                         "structure_dir": s.get("structure_dir"),
                         "structure_path": s.get("structure_path"),
-                        "incar_path": s.get("incar_path"),
-                        "kpoints_path": s.get("kpoints_path"),
+                        "input_files": s.get("input_files") or {},
                         "has_validation": s.get("validation") is not None,
                         "created_at": s.get("created_at"),
                     } for s in structures
@@ -1342,15 +1370,15 @@ class SimulationOrchestratorTools:
         # =====================================================================
         # 12. SUBMIT VASP JOB
         # =====================================================================
-        def submit_vasp_job(
+        def submit_simulation_job(
             structure_slug: str,
             remote_dir: str,
-            job_name: str = "vasp",
+            run_command: str,
+            job_name: str = "sim",
             partition: str = "",
             n_nodes: int = 1,
             n_tasks: int = 16,
             time_limit: str = "04:00:00",
-            vasp_command: str = "srun vasp_std",
             modules: str = "",
             extra_directives: str = "",
         ) -> str:
@@ -1386,30 +1414,39 @@ class SimulationOrchestratorTools:
                     ),
                 })
 
-            poscar = record.get("structure_path")
-            incar = record.get("incar_path")
-            kpoints = record.get("kpoints_path")
-            missing = [
-                n for n, p in [("POSCAR", poscar), ("INCAR", incar), ("KPOINTS", kpoints)]
-                if not p or not Path(p).exists()
-            ]
-            if missing:
+            structure_file = record.get("structure_path")
+            input_files = record.get("input_files") or {}
+            if not structure_file or not Path(structure_file).exists():
                 return json.dumps({
                     "status": "error",
                     "message": (
-                        f"Missing local files before upload: {missing}. "
-                        "Run generate_vasp_inputs first."
+                        "No local structure file to upload. Run "
+                        "generate_structure first."
                     ),
+                })
+            if not input_files:
+                return json.dumps({
+                    "status": "error",
+                    "message": (
+                        "No generated input files to upload. Run "
+                        "generate_dft_inputs (or generate_md_inputs) first."
+                    ),
+                })
+            missing = [fn for fn, p in input_files.items()
+                       if not p or not Path(p).exists()]
+            if missing:
+                return json.dumps({
+                    "status": "error",
+                    "message": f"Missing local input files before upload: {missing}.",
                 })
 
             try:
                 conn.mkdir_p(remote_dir)
-                for local_path, remote_name in [
-                    (poscar, "POSCAR"),
-                    (incar, "INCAR"),
-                    (kpoints, "KPOINTS"),
-                ]:
-                    conn.upload(local_path, f"{remote_dir}/{remote_name}")
+                # Upload the structure under its own filename + every input file.
+                conn.upload(structure_file,
+                            f"{remote_dir}/{Path(structure_file).name}")
+                for fname, local_path in input_files.items():
+                    conn.upload(local_path, f"{remote_dir}/{fname}")
 
                 script_content = self._generate_job_script(
                     sched=sched,
@@ -1418,7 +1455,7 @@ class SimulationOrchestratorTools:
                     n_tasks=n_tasks,
                     time_limit=time_limit,
                     partition=partition,
-                    vasp_command=vasp_command,
+                    run_command=run_command,
                     modules=modules,
                     extra_directives=extra_directives,
                 )
@@ -1443,19 +1480,22 @@ class SimulationOrchestratorTools:
                 "next_steps": (
                     f"Monitor with get_job_status('{job_id}'). "
                     "When status is Completed, call "
-                    f"download_vasp_results('{job_id}') to retrieve outputs."
+                    f"download_job_results('{job_id}') to retrieve outputs."
                 ),
             })
 
         self._register_tool(
-            func=submit_vasp_job,
-            name="submit_vasp_job",
+            func=submit_simulation_job,
+            name="submit_simulation_job",
             description=(
-                "Upload VASP input files (POSCAR, INCAR, KPOINTS) to a remote "
+                "Upload a structure and its generated input files to a remote "
                 "HPC cluster and submit a job via the active scheduler "
-                "(SLURM / PBS / LSF). Requires hpc_connection and hpc_scheduler "
-                "to be set on the orchestrator. Call generate_vasp_inputs first "
-                "to ensure local inputs exist."
+                "(SLURM / PBS / LSF). Engine-neutral: uploads whatever inputs "
+                "were generated for the structure plus the structure file. "
+                "Requires hpc_connection and hpc_scheduler on the orchestrator, "
+                "and that inputs were generated first (generate_dft_inputs / "
+                "generate_md_inputs). The engine's run command is supplied "
+                "via `run_command`."
             ),
             parameters={
                 "structure_slug": {
@@ -1466,9 +1506,18 @@ class SimulationOrchestratorTools:
                     "type": "string",
                     "description": "Absolute remote path for the job working directory (e.g. /scratch/user/run1).",
                 },
+                "run_command": {
+                    "type": "string",
+                    "description": (
+                        "Full engine run command including MPI launcher, "
+                        "written verbatim into the job script (e.g. "
+                        "'srun vasp_std', 'mpirun -np 16 lmp -in run.lammps'). "
+                        "Engine-specific — there is no default."
+                    ),
+                },
                 "job_name": {
                     "type": "string",
-                    "description": "Scheduler job name (default: 'vasp').",
+                    "description": "Scheduler job name (default: 'sim').",
                 },
                 "partition": {
                     "type": "string",
@@ -1486,21 +1535,13 @@ class SimulationOrchestratorTools:
                     "type": "string",
                     "description": "Wall-time limit in HH:MM:SS (default: '04:00:00').",
                 },
-                "vasp_command": {
-                    "type": "string",
-                    "description": (
-                        "Full run command including MPI launcher "
-                        "(e.g. 'srun vasp_std', 'mpirun -np 16 vasp_std'). "
-                        "Written verbatim into the job script. Default: 'srun vasp_std'."
-                    ),
-                },
                 "modules": {
                     "type": "string",
                     "description": (
-                        "Shell commands to load the VASP environment, written "
-                        "verbatim into the job script "
-                        "(e.g. 'module load vasp/6.3.2 intel/2023'). Omit if "
-                        "the user's .bashrc already loads VASP."
+                        "Shell commands to load the engine environment, written "
+                        "verbatim into the job script (e.g. "
+                        "'module load vasp/6.3.2 intel/2023'). Omit if the "
+                        "user's .bashrc already loads it."
                     ),
                 },
                 "extra_directives": {
@@ -1512,7 +1553,7 @@ class SimulationOrchestratorTools:
                     ),
                 },
             },
-            required=["structure_slug", "remote_dir"],
+            required=["structure_slug", "remote_dir", "run_command"],
         )
 
         # =====================================================================
@@ -1553,7 +1594,7 @@ class SimulationOrchestratorTools:
                 "exit_code": job.exit_code,
                 "node_list": job.node_list,
                 "next_steps": (
-                    f"download_vasp_results('{job_id}') to retrieve outputs."
+                    f"download_job_results('{job_id}') to retrieve outputs."
                     if job.status.is_terminal and job.status.value == "Completed"
                     else (
                         f"Call get_job_status('{job_id}') again to check progress."
@@ -1570,13 +1611,13 @@ class SimulationOrchestratorTools:
                 "Poll the HPC scheduler for the current status of a submitted "
                 "job. Returns job_status (Pending / Running / Completed / "
                 "Failed / Cancelled / Timeout), time used, and whether the "
-                "job has reached a terminal state. Use after submit_vasp_job "
+                "job has reached a terminal state. Use after submit_simulation_job "
                 "to check progress."
             ),
             parameters={
                 "job_id": {
                     "type": "string",
-                    "description": "Scheduler job ID returned by submit_vasp_job.",
+                    "description": "Scheduler job ID returned by submit_simulation_job.",
                 },
             },
             required=["job_id"],
@@ -1585,7 +1626,7 @@ class SimulationOrchestratorTools:
         # =====================================================================
         # 14. DOWNLOAD VASP RESULTS
         # =====================================================================
-        def download_vasp_results(job_id: str, local_dir: str = "") -> str:
+        def download_job_results(job_id: str, local_dir: str = "") -> str:
             conn = self.orch.hpc_connection
             if conn is None:
                 return json.dumps({
@@ -1604,7 +1645,7 @@ class SimulationOrchestratorTools:
                     "status": "error",
                     "message": (
                         f"No session record found for job_id='{job_id}'. "
-                        "Only jobs submitted via submit_vasp_job in this "
+                        "Only jobs submitted via submit_simulation_job in this "
                         "session can be downloaded automatically."
                     ),
                 })
@@ -1656,8 +1697,8 @@ class SimulationOrchestratorTools:
             })
 
         self._register_tool(
-            func=download_vasp_results,
-            name="download_vasp_results",
+            func=download_job_results,
+            name="download_job_results",
             description=(
                 "Download VASP output files (vasprun.xml, OUTCAR, CONTCAR, "
                 "OSZICAR, etc.) from the remote HPC directory to a local "
@@ -1668,7 +1709,7 @@ class SimulationOrchestratorTools:
             parameters={
                 "job_id": {
                     "type": "string",
-                    "description": "Scheduler job ID returned by submit_vasp_job.",
+                    "description": "Scheduler job ID returned by submit_simulation_job.",
                 },
                 "local_dir": {
                     "type": "string",
@@ -1747,14 +1788,13 @@ class SimulationOrchestratorTools:
                     for iss in issues:
                         lines.append(f"  - {iss}")
 
-            if record.get("incar_path") and Path(record["incar_path"]).exists():
-                lines += [
-                    "\n## VASP Inputs",
-                    f"- **INCAR:** `{record['incar_path']}`",
-                    f"- **KPOINTS:** `{record.get('kpoints_path', 'N/A')}`",
-                ]
-                if record.get("vasp_summary"):
-                    lines.append(f"- **Summary:** {record['vasp_summary']}")
+            input_files = record.get("input_files") or {}
+            if input_files:
+                lines.append("\n## Generated Inputs")
+                for fname, fpath in input_files.items():
+                    lines.append(f"- **{fname}:** `{fpath}`")
+                if record.get("summary"):
+                    lines.append(f"- **Summary:** {record['summary']}")
 
             if record.get("hpc_job_id"):
                 sched_name = (
@@ -1811,7 +1851,7 @@ class SimulationOrchestratorTools:
                 "workflow: structure description, validation outcome, VASP input "
                 "settings, HPC job info, and parsed results (energy, convergence, "
                 "error hints). Saves to <structure_dir>/final_report.md by default. "
-                "Call after download_vasp_results to include calculation outcomes."
+                "Call after download_job_results to include calculation outcomes."
             ),
             parameters={
                 "structure_slug": {
@@ -1976,11 +2016,11 @@ class SimulationOrchestratorTools:
         n_tasks: int,
         time_limit: str,
         partition: str,
-        vasp_command: str,
+        run_command: str,
         modules: str,
         extra_directives: str,
     ) -> str:
-        """Generate a scheduler job script for VASP."""
+        """Generate a scheduler job script for an arbitrary engine run command."""
         sname = getattr(sched, "name", "SLURM").upper()
         lines = ["#!/bin/bash"]
 
@@ -2026,7 +2066,7 @@ class SimulationOrchestratorTools:
         if modules:
             lines += ["", modules]
 
-        lines += ["", vasp_command, ""]
+        lines += ["", run_command, ""]
         return "\n".join(lines)
 
     # ------------------------------------------------------------------

--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -1254,150 +1254,89 @@ class SimulationOrchestratorTools:
         )
 
         # =====================================================================
-        # 8. ANALYZE VASP OUTPUT (post-run)
+        # 8. ANALYZE OUTPUT (engine-neutral, post-run)
         # =====================================================================
-        def analyze_vasp_output(output_dir: str) -> str:
-            from .post_run_analysis import analyze_run_directory
+        def analyze_output(output_dir: str, research_goal: str,
+                           software: str = None, fixes_mode: str = "auto") -> str:
+            skill, domain = self._resolve_engine(software)
+            if not skill:
+                return json.dumps({
+                    "status": "error",
+                    "message": (
+                        "No engine selected. Call route_simulation first, or "
+                        "pass `software` explicitly (e.g. 'vasp')."
+                    ),
+                })
 
-            summary = analyze_run_directory(output_dir)
-            # Trim verbose subdicts before sending back — keep it scannable
-            if isinstance(summary, dict):
-                vr = summary.get("vasprun") or {}
-                if "incar_snapshot" in vr and len(vr["incar_snapshot"]) > 30:
-                    vr["incar_snapshot"] = dict(list(vr["incar_snapshot"].items())[:30])
-                    vr["incar_snapshot_truncated"] = True
-            return json.dumps(summary)
+            try:
+                critic = self._get_run_critic()
+                report = critic.assess(
+                    output_dir=output_dir,
+                    research_goal=research_goal,
+                    skill=skill,
+                    domain=domain,
+                    fixes_mode=fixes_mode,
+                )
+            except Exception as e:
+                return json.dumps({
+                    "status": "error",
+                    "message": f"Run analysis failed: {e}",
+                })
+
+            report.setdefault("status", "success")
+            report["engine"] = skill
+            return json.dumps(report, default=str)
 
         self._register_tool(
-            func=analyze_vasp_output,
-            name="analyze_vasp_output",
+            func=analyze_output,
+            name="analyze_output",
             description=(
-                "Read VASP output files (vasprun.xml + OUTCAR + stdout/"
-                "stderr logs) from a completed or failed run and return a "
-                "structured summary: convergence status (converged / "
-                "not_converged / failed / unknown), final energy, ionic "
-                "step count, max force on last step, snapshot of effective "
-                "INCAR settings, and a list of human-readable hints for "
-                "any known VASP error patterns matched in the logs. Use "
-                "after the user runs VASP and points you at the run "
-                "directory."
+                "Post-run review of a finished calculation directory, "
+                "engine-neutral. Routes to the RunCritic, which reads the "
+                "engine's output files and the active skill's interpretation "
+                "guidance to return a verdict (good / warning / poor / "
+                "needs_fixes), the run status, reasoning, and — when the run "
+                "failed or the result is unsatisfactory — proposed patched "
+                "input files. Handles both failed and successful runs in one "
+                "call. The engine is taken from the active routing decision "
+                "unless `software` is given. Use after the user runs the "
+                "calculation and points you at the run directory."
             ),
             parameters={
                 "output_dir": {
                     "type": "string",
                     "description": (
-                        "Absolute path to the VASP run directory containing "
-                        "vasprun.xml / OUTCAR / log files."
+                        "Absolute path to the finished run's output "
+                        "directory (engine-specific contents, e.g. "
+                        "vasprun.xml / OUTCAR / logs for VASP)."
+                    ),
+                },
+                "research_goal": {
+                    "type": "string",
+                    "description": (
+                        "What the calculation was meant to compute — drives "
+                        "whether the result is sufficient for the intent and "
+                        "what fixes to suggest."
+                    ),
+                },
+                "software": {
+                    "type": "string",
+                    "description": (
+                        "Optional engine override (e.g. 'vasp'). Defaults to "
+                        "the engine chosen by route_simulation."
+                    ),
+                },
+                "fixes_mode": {
+                    "type": "string",
+                    "enum": ["auto", "always", "skip"],
+                    "description": (
+                        "When to propose patched inputs: 'auto' (default; "
+                        "only on failure or a poor verdict), 'always' "
+                        "(whenever below 'good'), or 'skip' (verdict only)."
                     ),
                 },
             },
-            required=["output_dir"],
-        )
-
-        # =====================================================================
-        # 9. SUGGEST INCAR FIXES (from VASP error log)
-        # =====================================================================
-        def suggest_incar_fixes(log_path: str, original_request: str) -> str:
-            from .vasp_updater import VaspUpdater
-
-            log_file = Path(log_path)
-            if not log_file.exists():
-                return json.dumps({
-                    "status": "error",
-                    "message": f"Log file not found: {log_path}",
-                })
-
-            run_dir = log_file.parent
-            poscar = run_dir / "POSCAR"
-            incar = run_dir / "INCAR"
-            kpoints = run_dir / "KPOINTS"
-            for required in [poscar, incar, kpoints]:
-                if not required.exists():
-                    return json.dumps({
-                        "status": "error",
-                        "message": (
-                            f"Expected {required.name} alongside the log at "
-                            f"{run_dir}, not found. suggest_incar_fixes "
-                            "needs the original POSCAR, INCAR, and KPOINTS "
-                            "in the same directory as the log."
-                        ),
-                    })
-
-            try:
-                updater = VaspUpdater(
-                    api_key=self.orch.api_key,
-                    base_url=self.orch.base_url,
-                    model_name=self.orch.model_name,
-                )
-            except Exception as e:
-                return json.dumps({
-                    "status": "error",
-                    "message": f"Failed to construct VaspUpdater: {e}",
-                })
-
-            log_text = log_file.read_text(errors="replace")
-            try:
-                plan = updater.refine_inputs(
-                    poscar_path=str(poscar),
-                    incar_path=str(incar),
-                    kpoints_path=str(kpoints),
-                    vasp_log=log_text,
-                    original_request=original_request,
-                )
-            except Exception as e:
-                return json.dumps({
-                    "status": "error",
-                    "message": f"VaspUpdater failed: {e}",
-                })
-
-            if plan.get("status") != "success":
-                return json.dumps({
-                    "status": "error",
-                    "message": plan.get("message") or "VaspUpdater did not produce a plan",
-                })
-
-            return json.dumps({
-                "status": "success",
-                "suggested_incar": plan.get("suggested_incar", ""),
-                "suggested_kpoints": plan.get("suggested_kpoints", ""),
-                "explanation": plan.get("explanation", ""),
-                "note": (
-                    "Suggestions returned as text; not applied to disk. "
-                    "If the user wants to use them, write them to disk "
-                    "manually or re-generate via generate_vasp_inputs with "
-                    "an updated request."
-                ),
-            })
-
-        self._register_tool(
-            func=suggest_incar_fixes,
-            name="suggest_incar_fixes",
-            description=(
-                "When a VASP run failed and the user has the log, ask the "
-                "VaspUpdater to read the log + the original INCAR/KPOINTS/"
-                "POSCAR and propose revised inputs that would address the "
-                "error. Returns suggested INCAR + KPOINTS as text plus an "
-                "explanation. Does NOT write to disk; the user decides "
-                "whether to apply the suggestions."
-            ),
-            parameters={
-                "log_path": {
-                    "type": "string",
-                    "description": (
-                        "Absolute path to the VASP stdout/stderr log file. "
-                        "POSCAR / INCAR / KPOINTS must live in the same "
-                        "directory."
-                    ),
-                },
-                "original_request": {
-                    "type": "string",
-                    "description": (
-                        "What the calculation was supposed to do — used as "
-                        "context for the fix suggestions."
-                    ),
-                },
-            },
-            required=["log_path", "original_request"],
+            required=["output_dir", "research_goal"],
         )
 
         # =====================================================================
@@ -1763,15 +1702,25 @@ class SimulationOrchestratorTools:
                     ),
                 })
 
-            # Run post-run analysis if results are available
-            vasp_analysis = None
+            # Run post-run analysis if results are available — engine-neutral
+            # via the active skill's snapshot_run tool. Only include the
+            # analysis section when the snapshot reflects a real run.
+            run_snapshot = None
             results_dir = record.get("hpc_results_dir") or record.get("structure_dir")
-            if results_dir and (Path(results_dir) / "vasprun.xml").exists():
+            skill, _domain = self._resolve_engine(None)
+            if results_dir and skill:
                 try:
-                    from .post_run_analysis import analyze_run_directory
-                    vasp_analysis = analyze_run_directory(results_dir)
+                    from ...skills._shared._registry import get_tool_function
+                    snap = get_tool_function("snapshot_run", active_skills=[skill])
+                    snapshot = snap(results_dir)
+                    if (snapshot.get("status") == "ok"
+                            and (snapshot.get("files_found")
+                                 or snapshot.get("convergence_status", "unknown") != "unknown")):
+                        run_snapshot = snapshot
+                except LookupError:
+                    run_snapshot = None
                 except Exception as e:
-                    vasp_analysis = {"error": str(e)}
+                    run_snapshot = {"error": str(e)}
 
             lines = [
                 "# VASP DFT Simulation Report",
@@ -1820,20 +1769,19 @@ class SimulationOrchestratorTools:
                     f"- **Local results:** `{record.get('hpc_results_dir', 'N/A')}`",
                 ]
 
-            if vasp_analysis:
+            if run_snapshot:
                 lines.append("\n## Calculation Results")
-                if "error" in vasp_analysis:
-                    lines.append(f"- **Parse error:** {vasp_analysis['error']}")
+                if "error" in run_snapshot:
+                    lines.append(f"- **Parse error:** {run_snapshot['error']}")
                 else:
-                    vr = vasp_analysis.get("vasprun") or {}
-                    oc = vasp_analysis.get("outcar") or {}
+                    vr = run_snapshot.get("vasprun") or {}
                     lines += [
-                        f"- **Convergence:** {vasp_analysis.get('convergence_status', 'unknown')}",
-                        f"- **Final energy:** {vr.get('final_energy_eV', 'N/A')} eV",
+                        f"- **Convergence:** {run_snapshot.get('convergence_status', 'unknown')}",
+                        f"- **Final energy:** {vr.get('final_energy', 'N/A')} eV",
                         f"- **Ionic steps:** {vr.get('n_ionic_steps', 'N/A')}",
-                        f"- **Max force (last step):** {oc.get('max_force_eV_per_A', 'N/A')} eV/Å",
+                        f"- **Max force (last step):** {vr.get('max_force_eV_per_A', 'N/A')} eV/Å",
                     ]
-                    hints = vasp_analysis.get("error_hints") or []
+                    hints = run_snapshot.get("log_error_hints") or []
                     if hints:
                         lines.append("- **Error hints:**")
                         for h in hints:

--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -170,7 +170,7 @@ class SimulationOrchestratorTools:
                     {
                         "slug": s.get("slug"),
                         "description": s.get("description"),
-                        "poscar_path": s.get("poscar_path"),
+                        "structure_path": s.get("structure_path"),
                         "incar_path": s.get("incar_path"),
                     } for s in structures
                 ],
@@ -394,7 +394,7 @@ class SimulationOrchestratorTools:
                 "slug": slug,
                 "description": description,
                 "structure_dir": str(workdir),
-                "poscar_path": result["final_structure_path"],
+                "structure_path": result["final_structure_path"],
                 "script_path": result["final_script_path"],
                 "script_content": result.get("final_script_content"),
                 "skill": skill,
@@ -411,9 +411,9 @@ class SimulationOrchestratorTools:
                 "status": "success",
                 "slug": slug,
                 "structure_dir": str(workdir),
-                "poscar_path": record["poscar_path"],
+                "structure_path": record["structure_path"],
                 "script_path": record["script_path"],
-                "n_atoms": self._count_atoms(record["poscar_path"]),
+                "n_atoms": self._count_atoms(record["structure_path"]),
                 "skill_used": skill,
                 "validation": {
                     "status": (val or {}).get("status"),
@@ -537,16 +537,16 @@ class SimulationOrchestratorTools:
         # =====================================================================
         # 2. VALIDATE STRUCTURE
         # =====================================================================
-        def validate_structure(poscar_path: str, original_request: str) -> str:
+        def validate_structure(structure_path: str, original_request: str) -> str:
             from .val_agent import StructureValidatorAgent
 
-            if not Path(poscar_path).exists():
+            if not Path(structure_path).exists():
                 return json.dumps({
                     "status": "error",
-                    "message": f"POSCAR not found: {poscar_path}",
+                    "message": f"POSCAR not found: {structure_path}",
                 })
 
-            script_content = self._find_script_content(poscar_path)
+            script_content = self._find_script_content(structure_path)
             if not script_content:
                 return json.dumps({
                     "status": "error",
@@ -570,13 +570,13 @@ class SimulationOrchestratorTools:
                 })
 
             val_result = validator.validate_structure_and_script(
-                structure_file_path=poscar_path,
+                structure_file_path=structure_path,
                 generating_script_content=script_content,
                 original_request=original_request,
             )
 
             # Attach to the matching session record (if any)
-            record = self._find_structure_record(poscar_path)
+            record = self._find_structure_record(structure_path)
             if record is not None:
                 record["validation"] = val_result
 
@@ -585,7 +585,7 @@ class SimulationOrchestratorTools:
                 "overall_assessment": val_result.get("overall_assessment", ""),
                 "all_identified_issues": val_result.get("all_identified_issues", []),
                 "script_modification_hints": val_result.get("script_modification_hints", []),
-                "poscar_path": poscar_path,
+                "structure_path": structure_path,
             })
 
         self._register_tool(
@@ -601,7 +601,7 @@ class SimulationOrchestratorTools:
                 "VASP inputs."
             ),
             parameters={
-                "poscar_path": {
+                "structure_path": {
                     "type": "string",
                     "description": "Absolute path to the POSCAR file to validate.",
                 },
@@ -614,21 +614,21 @@ class SimulationOrchestratorTools:
                     ),
                 },
             },
-            required=["poscar_path", "original_request"],
+            required=["structure_path", "original_request"],
         )
 
         # =====================================================================
         # 5. GENERATE VASP INPUTS
         # =====================================================================
-        def generate_vasp_inputs(poscar_path: str, request: str,
+        def generate_vasp_inputs(structure_path: str, request: str,
                                  method: str = "llm") -> str:
-            if not Path(poscar_path).exists():
+            if not Path(structure_path).exists():
                 return json.dumps({
                     "status": "error",
-                    "message": f"POSCAR not found: {poscar_path}",
+                    "message": f"POSCAR not found: {structure_path}",
                 })
 
-            structure_dir = Path(poscar_path).parent
+            structure_dir = Path(structure_path).parent
 
             try:
                 if method == "llm":
@@ -639,7 +639,7 @@ class SimulationOrchestratorTools:
                         model_name=self.orch.model_name,
                     )
                     vasp_result = agent.generate_vasp_inputs(
-                        poscar_path=poscar_path,
+                        structure_path=structure_path,
                         original_request=request,
                     )
                     if vasp_result.get("status") != "success":
@@ -666,7 +666,7 @@ class SimulationOrchestratorTools:
                             ),
                         })
                     from ase.io import read as ase_read
-                    structure_obj = ase_read(poscar_path)
+                    structure_obj = ase_read(structure_path)
                     Atomate2Input().generate(
                         structure=structure_obj,
                         output_dir=str(structure_dir),
@@ -688,7 +688,7 @@ class SimulationOrchestratorTools:
             incar_path = structure_dir / "INCAR"
             kpoints_path = structure_dir / "KPOINTS"
 
-            record = self._find_structure_record(poscar_path)
+            record = self._find_structure_record(structure_path)
             if record is not None:
                 record["incar_path"] = str(incar_path)
                 record["kpoints_path"] = str(kpoints_path)
@@ -715,7 +715,7 @@ class SimulationOrchestratorTools:
                 "[sim] extras)."
             ),
             parameters={
-                "poscar_path": {
+                "structure_path": {
                     "type": "string",
                     "description": "Absolute path to the POSCAR the inputs should match.",
                 },
@@ -738,7 +738,7 @@ class SimulationOrchestratorTools:
                     ),
                 },
             },
-            required=["poscar_path", "request"],
+            required=["structure_path", "request"],
         )
 
         # =====================================================================
@@ -779,17 +779,17 @@ class SimulationOrchestratorTools:
             val_result = structure_gen.get("validation_result", {}) or {}
             outstanding_issues = val_result.get("all_identified_issues", []) or []
 
-            poscar_path = workdir / "POSCAR"
+            structure_path = workdir / "POSCAR"
             incar_path = workdir / "INCAR"
             kpoints_path = workdir / "KPOINTS"
 
             # Record in session state (only if structure exists)
-            if poscar_path.exists():
+            if structure_path.exists():
                 record = {
                     "slug": slug,
                     "description": description,
                     "structure_dir": str(workdir),
-                    "poscar_path": str(poscar_path),
+                    "structure_path": str(structure_path),
                     "script_path": structure_gen.get("final_script_path"),
                     "script_content": None,  # not surfaced by run_complete_workflow
                     "incar_path": str(incar_path) if incar_path.exists() else None,
@@ -848,8 +848,8 @@ class SimulationOrchestratorTools:
         # =====================================================================
         # 3. REFINE STRUCTURE
         # =====================================================================
-        def refine_structure(poscar_path: str, original_request: str) -> str:
-            record = self._find_structure_record(poscar_path)
+        def refine_structure(structure_path: str, original_request: str) -> str:
+            record = self._find_structure_record(structure_path)
             if record is None:
                 return json.dumps({
                     "status": "error",
@@ -857,7 +857,7 @@ class SimulationOrchestratorTools:
                         "Refinement requires a structure that was generated "
                         "in this session (so the validator feedback and "
                         "prior script are available). No record found for: "
-                        f"{poscar_path}. Generate the structure first via "
+                        f"{structure_path}. Generate the structure first via "
                         "generate_structure, then validate, then refine."
                     ),
                 })
@@ -874,7 +874,7 @@ class SimulationOrchestratorTools:
                     ),
                 })
 
-            prior_script = record.get("script_content") or self._find_script_content(poscar_path)
+            prior_script = record.get("script_content") or self._find_script_content(structure_path)
             if not prior_script:
                 return json.dumps({
                     "status": "error",
@@ -920,7 +920,7 @@ class SimulationOrchestratorTools:
 
             # Update the record in place rather than appending — refinement
             # produces a successor of the same logical structure.
-            record["poscar_path"] = new_poscar
+            record["structure_path"] = new_poscar
             record["script_path"] = new_script_path
             record["script_content"] = new_script_content
             record["validation"] = None  # invalidate prior validation
@@ -931,7 +931,7 @@ class SimulationOrchestratorTools:
             return json.dumps({
                 "status": "success",
                 "slug": record["slug"],
-                "poscar_path": new_poscar,
+                "structure_path": new_poscar,
                 "script_path": new_script_path,
                 "n_atoms": n_atoms,
                 "next_steps": (
@@ -954,7 +954,7 @@ class SimulationOrchestratorTools:
                 "validated in this session — run validate_structure first."
             ),
             parameters={
-                "poscar_path": {
+                "structure_path": {
                     "type": "string",
                     "description": "Absolute path to the POSCAR to refine.",
                 },
@@ -967,23 +967,23 @@ class SimulationOrchestratorTools:
                     ),
                 },
             },
-            required=["poscar_path", "original_request"],
+            required=["structure_path", "original_request"],
         )
 
         # =====================================================================
         # 4. VIEW STRUCTURE
         # =====================================================================
-        def view_structure(poscar_path: str) -> str:
+        def view_structure(structure_path: str) -> str:
             from .utils import generate_structure_views
 
-            if not Path(poscar_path).exists():
+            if not Path(structure_path).exists():
                 return json.dumps({
                     "status": "error",
-                    "message": f"POSCAR not found: {poscar_path}",
+                    "message": f"POSCAR not found: {structure_path}",
                 })
 
             try:
-                image_paths = generate_structure_views(poscar_path)
+                image_paths = generate_structure_views(structure_path)
             except Exception as e:
                 return json.dumps({
                     "status": "error",
@@ -1021,18 +1021,18 @@ class SimulationOrchestratorTools:
                 "not to the model itself."
             ),
             parameters={
-                "poscar_path": {
+                "structure_path": {
                     "type": "string",
                     "description": "Absolute path to the POSCAR to render.",
                 },
             },
-            required=["poscar_path"],
+            required=["structure_path"],
         )
 
         # =====================================================================
         # 6. VALIDATE INPUTS (engine-neutral, pre-run)
         # =====================================================================
-        def validate_inputs(poscar_path: str, system_description: str,
+        def validate_inputs(structure_path: str, system_description: str,
                             software: str = None) -> str:
             skill, domain = self._resolve_engine(software)
             if not skill:
@@ -1044,7 +1044,7 @@ class SimulationOrchestratorTools:
                     ),
                 })
 
-            record = self._find_structure_record(poscar_path)
+            record = self._find_structure_record(structure_path)
             input_files = self._record_input_files(record)
             if not input_files:
                 return json.dumps({
@@ -1089,7 +1089,7 @@ class SimulationOrchestratorTools:
                 "generating inputs and before submitting a run."
             ),
             parameters={
-                "poscar_path": {
+                "structure_path": {
                     "type": "string",
                     "description": (
                         "Absolute path to the structure's POSCAR, used to "
@@ -1112,13 +1112,13 @@ class SimulationOrchestratorTools:
                     ),
                 },
             },
-            required=["poscar_path", "system_description"],
+            required=["structure_path", "system_description"],
         )
 
         # =====================================================================
         # 7. APPLY INCAR IMPROVEMENTS
         # =====================================================================
-        def apply_incar_improvements(incar_path: str, poscar_path: str,
+        def apply_incar_improvements(incar_path: str, structure_path: str,
                                      original_request: str,
                                      suggested_adjustments: list,
                                      overall_assessment: str = "") -> str:
@@ -1127,10 +1127,10 @@ class SimulationOrchestratorTools:
                     "status": "error",
                     "message": f"INCAR not found: {incar_path}",
                 })
-            if not Path(poscar_path).exists():
+            if not Path(structure_path).exists():
                 return json.dumps({
                     "status": "error",
-                    "message": f"POSCAR not found: {poscar_path}",
+                    "message": f"POSCAR not found: {structure_path}",
                 })
             if not suggested_adjustments:
                 return json.dumps({
@@ -1161,7 +1161,7 @@ class SimulationOrchestratorTools:
                     "suggested_adjustments": suggested_adjustments,
                     "overall_assessment": overall_assessment,
                 },
-                poscar_path=poscar_path,
+                structure_path=structure_path,
                 original_request=original_request,
                 output_dir=output_dir,
             )
@@ -1193,7 +1193,7 @@ class SimulationOrchestratorTools:
                     "type": "string",
                     "description": "Absolute path to the original INCAR.",
                 },
-                "poscar_path": {
+                "structure_path": {
                     "type": "string",
                     "description": "Absolute path to the POSCAR (provides system context).",
                 },
@@ -1215,7 +1215,7 @@ class SimulationOrchestratorTools:
                     "description": "Brief literature-review summary (passed verbatim).",
                 },
             },
-            required=["incar_path", "poscar_path", "original_request", "suggested_adjustments"],
+            required=["incar_path", "structure_path", "original_request", "suggested_adjustments"],
         )
 
         # =====================================================================
@@ -1231,7 +1231,7 @@ class SimulationOrchestratorTools:
                         "slug": s.get("slug"),
                         "description": s.get("description"),
                         "structure_dir": s.get("structure_dir"),
-                        "poscar_path": s.get("poscar_path"),
+                        "structure_path": s.get("structure_path"),
                         "incar_path": s.get("incar_path"),
                         "kpoints_path": s.get("kpoints_path"),
                         "has_validation": s.get("validation") is not None,
@@ -1386,7 +1386,7 @@ class SimulationOrchestratorTools:
                     ),
                 })
 
-            poscar = record.get("poscar_path")
+            poscar = record.get("structure_path")
             incar = record.get("incar_path")
             kpoints = record.get("kpoints_path")
             missing = [
@@ -1727,10 +1727,10 @@ class SimulationOrchestratorTools:
                 f"\n## Structure: {record.get('description', structure_slug)}",
                 f"- **Slug:** `{structure_slug}`",
                 f"- **Created:** {record.get('created_at', 'unknown')}",
-                f"- **POSCAR:** `{record.get('poscar_path', 'N/A')}`",
+                f"- **POSCAR:** `{record.get('structure_path', 'N/A')}`",
             ]
 
-            n_atoms = self._count_atoms(record.get("poscar_path", ""))
+            n_atoms = self._count_atoms(record.get("structure_path", ""))
             if n_atoms is not None:
                 lines.append(f"- **Atoms:** {n_atoms}")
 
@@ -1915,16 +1915,16 @@ class SimulationOrchestratorTools:
         return f"{safe}_{self.orch._structure_counter:03d}"
 
     @staticmethod
-    def _count_atoms(poscar_path: str) -> Optional[int]:
+    def _count_atoms(structure_path: str) -> Optional[int]:
         """Best-effort atom count via ASE; returns None on parse failure."""
         try:
             from ase.io import read as ase_read
-            atoms = ase_read(poscar_path)
+            atoms = ase_read(structure_path)
             return len(atoms)
         except Exception:
             return None
 
-    def _find_script_content(self, poscar_path: str) -> Optional[str]:
+    def _find_script_content(self, structure_path: str) -> Optional[str]:
         """Find the generating script for a POSCAR.
 
         First check the orchestrator's session records (cheap, exact). If
@@ -1933,11 +1933,11 @@ class SimulationOrchestratorTools:
         work even when the LLM passes around paths without going through
         the session record path.
         """
-        record = self._find_structure_record(poscar_path)
+        record = self._find_structure_record(structure_path)
         if record and record.get("script_content"):
             return record["script_content"]
 
-        poscar_dir = Path(poscar_path).parent
+        poscar_dir = Path(structure_path).parent
         candidates = sorted(
             poscar_dir.glob("script_*.py"),
             key=lambda p: p.stat().st_mtime,
@@ -1950,12 +1950,12 @@ class SimulationOrchestratorTools:
         except Exception:
             return None
 
-    def _find_structure_record(self, poscar_path: str) -> Optional[Dict[str, Any]]:
+    def _find_structure_record(self, structure_path: str) -> Optional[Dict[str, Any]]:
         """Find the session record matching a POSCAR path, by string match."""
-        target = str(Path(poscar_path).resolve())
+        target = str(Path(structure_path).resolve())
         for record in self.orch.generated_structures or []:
             try:
-                if str(Path(record.get("poscar_path", "")).resolve()) == target:
+                if str(Path(record.get("structure_path", "")).resolve()) == target:
                     return record
             except Exception:
                 continue

--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -92,6 +92,8 @@ class SimulationOrchestratorTools:
         def session_status() -> str:
             structures = self.orch.generated_structures or []
             params = self.orch.default_calc_params or {}
+            engine, scale = self.orch.active_skill_and_domain()
+            routing = self.orch.routing_decision or {}
             return json.dumps({
                 "status": "ok",
                 "session_dir": str(self.orch.base_dir),
@@ -106,6 +108,12 @@ class SimulationOrchestratorTools:
                 ],
                 "default_calc_params": params,
                 "simulation_mode": self.orch.simulation_mode.value,
+                "routing": {
+                    "scale": scale,
+                    "engine": engine,
+                    "routed": bool(scale and engine),
+                    "reasoning": routing.get("reasoning"),
+                },
             })
 
         self._register_tool(
@@ -113,9 +121,11 @@ class SimulationOrchestratorTools:
             name="session_status",
             description=(
                 "Report the current simulation session state — structures "
-                "generated so far, sticky calculation parameters, output "
-                "directory. Free to call; useful when you need to remember "
-                "what's already been built before deciding the next step."
+                "generated so far, sticky calculation parameters, the "
+                "active routing decision (which scale and engine are in "
+                "use), and the output directory. Free to call; useful "
+                "when you need to remember what's already been built "
+                "before deciding the next step."
             ),
             parameters={},
             required=[],

--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -86,15 +86,30 @@ class SimulationOrchestratorTools:
     def _resolve_engine(self, software: Optional[str]) -> "tuple[Optional[str], Optional[str]]":
         """Resolve ``(skill, domain)`` for a critic call.
 
-        An explicit ``software`` argument names the engine skill directly
-        (domain inferred from the active routing decision when available,
-        else defaulted to periodic_dft). When ``software`` is omitted, both
-        are taken from the orchestrator's routing decision.
+        With an explicit ``software`` override, the scale (domain) is derived
+        from where that engine's skill bundle lives — not from routing or a
+        hardcoded default — so e.g. ``software="lammps"`` resolves to
+        ``("lammps", "molecular_dynamics")`` and ``software="vasp"`` to
+        ``("vasp", "periodic_dft")`` regardless of routing. The search is
+        scoped to the known simulation scales (the pipeline's scale
+        registry). When ``software`` is omitted, both come from the
+        orchestrator's routing decision.
         """
-        if software:
-            _engine, scale = self.orch.active_skill_and_domain()
-            return software, (scale or "periodic_dft")
-        return self.orch.active_skill_and_domain()
+        if not software:
+            return self.orch.active_skill_and_domain()
+
+        # Derive the scale from the engine's bundle location across the
+        # known simulation scales — no hardcoded engine→scale bias.
+        from ...skills.loader import list_all_skills
+        from .simulation_pipeline import _DEFAULT_ENGINE
+        all_skills = list_all_skills()
+        for scale in _DEFAULT_ENGINE:
+            if software in all_skills.get(scale, []):
+                return software, scale
+        # Unknown engine for the known scales: keep the name, take the scale
+        # from routing if any (still no hardcoded default).
+        _engine, routed_scale = self.orch.active_skill_and_domain()
+        return software, routed_scale
 
     def _get_input_validator(self):
         """Construct an InputValidator with the session's credentials.

--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -80,6 +80,74 @@ class SimulationOrchestratorTools:
         return so.structure_generator
 
     # ------------------------------------------------------------------
+    # Engine-neutral critic helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_engine(self, software: Optional[str]) -> "tuple[Optional[str], Optional[str]]":
+        """Resolve ``(skill, domain)`` for a critic call.
+
+        An explicit ``software`` argument names the engine skill directly
+        (domain inferred from the active routing decision when available,
+        else defaulted to periodic_dft). When ``software`` is omitted, both
+        are taken from the orchestrator's routing decision.
+        """
+        if software:
+            _engine, scale = self.orch.active_skill_and_domain()
+            return software, (scale or "periodic_dft")
+        return self.orch.active_skill_and_domain()
+
+    def _get_input_validator(self):
+        """Construct an InputValidator with the session's credentials.
+
+        Forwards the orchestrator's FutureHouse key so literature-grounded
+        review is available when one is configured (degrades gracefully
+        when absent)."""
+        from .critics import InputValidator
+        return InputValidator(
+            api_key=self.orch.api_key,
+            base_url=self.orch.base_url,
+            model_name=self.orch.model_name,
+            futurehouse_api_key=getattr(self.orch, "futurehouse_api_key", None),
+        )
+
+    def _get_run_critic(self):
+        """Construct a RunCritic with the session's LLM credentials."""
+        from .critics import RunCritic
+        return RunCritic(
+            api_key=self.orch.api_key,
+            base_url=self.orch.base_url,
+            model_name=self.orch.model_name,
+        )
+
+    def _record_input_files(self, record: Optional[Dict[str, Any]]) -> Dict[str, str]:
+        """Return ``{filename: contents}`` for a structure record's inputs.
+
+        Reads from the record's generic ``input_files`` map (filename →
+        path) when present, falling back to the legacy ``incar_path`` /
+        ``kpoints_path`` fields so records created before the generic map
+        still resolve. Missing or unreadable files are skipped.
+        """
+        if not record:
+            return {}
+        paths: Dict[str, str] = {}
+        generic = record.get("input_files")
+        if isinstance(generic, dict) and generic:
+            paths = dict(generic)
+        else:
+            for fname, key in (("INCAR", "incar_path"), ("KPOINTS", "kpoints_path")):
+                p = record.get(key)
+                if p:
+                    paths[fname] = p
+        contents: Dict[str, str] = {}
+        for fname, p in paths.items():
+            try:
+                if p and Path(p).exists():
+                    contents[fname] = Path(p).read_text()
+            except Exception:
+                continue
+        return contents
+
+    # ------------------------------------------------------------------
     # Tool registration
     # ------------------------------------------------------------------
 
@@ -962,88 +1030,89 @@ class SimulationOrchestratorTools:
         )
 
         # =====================================================================
-        # 6. VALIDATE INCAR (literature-grounded)
+        # 6. VALIDATE INPUTS (engine-neutral, pre-run)
         # =====================================================================
-        def validate_incar(incar_path: str, system_description: str) -> str:
-            if not Path(incar_path).exists():
+        def validate_inputs(poscar_path: str, system_description: str,
+                            software: str = None) -> str:
+            skill, domain = self._resolve_engine(software)
+            if not skill:
                 return json.dumps({
                     "status": "error",
-                    "message": f"INCAR not found: {incar_path}",
+                    "message": (
+                        "No engine selected. Call route_simulation first, or "
+                        "pass `software` explicitly (e.g. 'vasp')."
+                    ),
                 })
 
-            if not self.orch.futurehouse_api_key:
+            record = self._find_structure_record(poscar_path)
+            input_files = self._record_input_files(record)
+            if not input_files:
                 return json.dumps({
-                    "status": "skipped",
+                    "status": "error",
                     "message": (
-                        "Literature validation requires a FutureHouse API "
-                        "key. Set FUTUREHOUSE_API_KEY in the environment "
-                        "or pass futurehouse_api_key when constructing the "
-                        "orchestrator."
+                        "No input files found for this structure. Run "
+                        "generate_dft_inputs (or generate_md_inputs) first."
                     ),
                 })
 
             try:
-                from .val_agent import IncarValidatorAgent
-                validator = IncarValidatorAgent(
-                    api_key=self.orch.api_key,
-                    base_url=self.orch.base_url,
-                    model_name=self.orch.model_name,
-                    futurehouse_api_key=self.orch.futurehouse_api_key,
+                validator = self._get_input_validator()
+                report = validator.validate(
+                    input_files=input_files,
+                    system_description=system_description,
+                    skill=skill,
+                    domain=domain,
                 )
             except Exception as e:
                 return json.dumps({
                     "status": "error",
-                    "message": f"Failed to construct IncarValidatorAgent: {e}",
+                    "message": f"Input validation failed: {e}",
                 })
 
-            incar_content = Path(incar_path).read_text()
-            result = validator.validate_and_improve_incar(
-                incar_content=incar_content,
-                system_description=system_description,
-            )
-
-            if result.get("status") != "success":
-                return json.dumps({
-                    "status": "error",
-                    "message": result.get("message") or "Literature validation failed",
-                })
-
-            return json.dumps({
-                "status": "success",
-                "validation_status": result.get("validation_status"),
-                "overall_assessment": result.get("overall_assessment"),
-                "suggested_adjustments": result.get("suggested_adjustments", []),
-                "literature_review": result.get("literature_review", "")[:2000],
-                "incar_path": incar_path,
-            })
+            if record is not None:
+                record["input_validation"] = report
+            report.setdefault("status", "success")
+            report["engine"] = skill
+            return json.dumps(report, default=str)
 
         self._register_tool(
-            func=validate_incar,
-            name="validate_incar",
+            func=validate_inputs,
+            name="validate_inputs",
             description=(
-                "Run a literature-grounded review of an INCAR file: pulls "
-                "papers via FutureHouse, asks an LLM whether the chosen "
-                "parameters are consistent with established practice for "
-                "the system in question, returns suggested adjustments. "
-                "Returns 'skipped' status when no FutureHouse API key is "
-                "configured. Pair with apply_incar_improvements to write "
-                "the suggested INCAR to disk."
+                "Pre-run review of the generated input files for a structure, "
+                "engine-neutral. Routes to the InputValidator critic, which "
+                "combines the active engine skill's validation guidance, the "
+                "engine's deterministic syntax check, and — when a FutureHouse "
+                "key is configured — a literature-grounded review, returning "
+                "suggested adjustments. The engine is taken from the active "
+                "routing decision unless `software` is given. Use after "
+                "generating inputs and before submitting a run."
             ),
             parameters={
-                "incar_path": {
+                "poscar_path": {
                     "type": "string",
-                    "description": "Absolute path to the INCAR to validate.",
+                    "description": (
+                        "Absolute path to the structure's POSCAR, used to "
+                        "locate its generated input files in the session."
+                    ),
                 },
                 "system_description": {
                     "type": "string",
                     "description": (
-                        "What system the INCAR is for and what the calculation "
-                        "is supposed to compute (used as context for the "
-                        "literature review)."
+                        "What system the inputs are for and what the "
+                        "calculation should compute — context for judging "
+                        "whether the parameter choices are appropriate."
+                    ),
+                },
+                "software": {
+                    "type": "string",
+                    "description": (
+                        "Optional engine override (e.g. 'vasp'). Defaults to "
+                        "the engine chosen by route_simulation."
                     ),
                 },
             },
-            required=["incar_path", "system_description"],
+            required=["poscar_path", "system_description"],
         )
 
         # =====================================================================

--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -1764,11 +1764,11 @@ class SimulationOrchestratorTools:
                     run_snapshot = {"error": str(e)}
 
             lines = [
-                "# VASP DFT Simulation Report",
+                "# Simulation Report",
                 f"\n## Structure: {record.get('description', structure_slug)}",
                 f"- **Slug:** `{structure_slug}`",
                 f"- **Created:** {record.get('created_at', 'unknown')}",
-                f"- **POSCAR:** `{record.get('structure_path', 'N/A')}`",
+                f"- **Structure:** `{record.get('structure_path', 'N/A')}`",
             ]
 
             n_atoms = self._count_atoms(record.get("structure_path", ""))

--- a/scilink/agents/sim_agents/simulation_pipeline.py
+++ b/scilink/agents/sim_agents/simulation_pipeline.py
@@ -1,0 +1,281 @@
+"""Scale-agnostic deterministic simulation pipeline.
+
+A single one-shot pipeline that turns a natural-language request into a
+validated structure plus ready-to-run inputs, for any simulation scale.
+It replaces the per-scale orchestrator classes (the former
+``DFTOrchestrator`` and ``LAMMPSOrchestrator``), which are retained only
+as thin deprecated shims that delegate here.
+
+The pipeline is deterministic — it runs a fixed step sequence rather than
+letting an orchestration LLM choose steps — which is what makes its output
+reproducible for benchmarking. The chat / LLM-driven path lives on
+``SimulationOrchestratorAgent`` (``chat`` / ``run_task``); this is the
+headless sequence both that orchestrator and analyze-mode call.
+
+Steps:
+    1. Structure   — StructureOrchestrator (scale-agnostic) builds and
+                     validates the atomic structure.
+    2. Inputs      — the routed scale's foundation agent generates inputs,
+                     returning a normalized ``input_files`` map (engine
+                     selected by ``software``; an optional named ``method``
+                     selects a deterministic generation backend registered
+                     in the engine's skill bundle).
+    3. Validation  — InputValidator reviews the generated inputs (skill
+                     guidance + deterministic syntax check + literature
+                     grounding when a FutureHouse key is present).
+
+Adding a new scale (e.g. molecular DFT) is a new foundation agent plus a
+skill bundle and one dispatch branch in ``_generate_inputs`` — no new
+orchestrator class, and no hardcoded engine filenames anywhere.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# Default engine per scale, used when the caller does not name one. Each
+# scale's foundation agent resolves the engine to a skill bundle.
+_DEFAULT_ENGINE = {
+    "periodic_dft": "vasp",
+    "molecular_dynamics": "lammps",
+}
+
+
+def _generate_inputs(
+    *,
+    scale: str,
+    software: str,
+    method: str,
+    structure_file: str,
+    request: str,
+    output_dir: str,
+    api_key: Optional[str],
+    base_url: Optional[str],
+    model_name: str,
+) -> Dict[str, Any]:
+    """Generate inputs for ``scale``, returning a normalized result.
+
+    Every branch returns a result dict carrying an ``input_files`` mapping
+    (filename → contents), so downstream steps never guess engine
+    filenames. When ``method`` names a deterministic backend (anything
+    other than ``"llm"``), inputs come from a ``generate_inputs_<method>``
+    tool in the engine's skill bundle; otherwise the routed scale's
+    foundation agent produces them with its default LLM path.
+
+    Args:
+        scale: Simulation scale (e.g. ``"periodic_dft"``).
+        software: Engine name within the scale (e.g. ``"vasp"``).
+        method: ``"llm"`` for the agent's baseline generation, or a named
+            backend resolved from the skill bundle.
+        structure_file: Path to the built structure.
+        request: The scientific request driving parameter choices.
+        output_dir: Where inputs should be written.
+        api_key, base_url, model_name: LLM credentials forwarded to the
+            foundation agent.
+
+    Returns:
+        A dict with at least ``status`` and, on success, an ``input_files``
+        mapping (filename → contents).
+
+    Raises:
+        ValueError: If the scale is not supported by the pipeline.
+    """
+    # Named deterministic backend: a skill-bundle generation tool. The tool
+    # is responsible for returning a normalized input_files map.
+    if method and method != "llm":
+        from ...skills._shared._registry import get_tool_function
+        gen = get_tool_function(f"generate_inputs_{method}", active_skills=[software])
+        return gen(structure_file=structure_file, request=request,
+                   output_dir=output_dir)
+
+    if scale == "periodic_dft":
+        from .periodic_dft_agent import PeriodicDFTAgent
+        agent = PeriodicDFTAgent(
+            api_key=api_key, base_url=base_url, model_name=model_name,
+        )
+        result = agent.generate_inputs(
+            structure_file=structure_file, request=request, software=software,
+        )
+        # PeriodicDFTAgent already returns input_files as {filename: contents}.
+        if result.get("status") == "success":
+            agent.save_inputs(result, output_dir)
+        return result
+
+    if scale == "molecular_dynamics":
+        from .md_simulation_agent import MDSimulationAgent
+        agent = MDSimulationAgent(
+            working_dir=output_dir,
+            api_key=api_key, base_url=base_url, model_name=model_name,
+        )
+        result = agent.generate_simulation(
+            structure_file=structure_file, research_goal=request, runner=software,
+        )
+        # Normalize the MD agent's single script_path into the common
+        # input_files map so the pipeline stays engine-neutral downstream.
+        if "input_files" not in result:
+            script_path = result.get("script_path")
+            if script_path and Path(script_path).exists():
+                result["input_files"] = {
+                    Path(script_path).name: Path(script_path).read_text()
+                }
+        result.setdefault("status", "success")
+        return result
+
+    raise ValueError(
+        f"Unsupported simulation scale: {scale!r}. "
+        f"Supported: {sorted(_DEFAULT_ENGINE)}. Adding a scale means a new "
+        "foundation agent + skill bundle and one branch here."
+    )
+
+
+def run_complete_workflow(
+    user_request: str,
+    *,
+    scale: str = "periodic_dft",
+    software: Optional[str] = None,
+    method: str = "llm",
+    structure_class: str = "crystal",
+    output_dir: str = "simulation_workflow_output",
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    model_name: str = "claude-opus-4-6",
+    futurehouse_api_key: Optional[str] = None,
+    mp_api_key: Optional[str] = None,
+    max_refinement_cycles: int = 4,
+    script_timeout: int = 300,
+    validate: bool = True,
+) -> Dict[str, Any]:
+    """Run the full structure → inputs → validation pipeline for any scale.
+
+    Args:
+        user_request: Natural-language description of the calculation.
+        scale: Simulation scale (``"periodic_dft"``, ``"molecular_dynamics"``,
+            …). Selects the foundation agent.
+        software: Engine within the scale (e.g. ``"vasp"``, ``"lammps"``).
+            Defaults to the scale's conventional engine.
+        method: Input-generation backend. ``"llm"`` (default) uses the
+            foundation agent's generation; a named backend (e.g.
+            ``"atomate2"``) resolves to a skill-bundle generation tool.
+        structure_class: Structure-class hint forwarded to structure
+            generation.
+        output_dir: Directory for all generated files.
+        api_key, base_url, model_name: LLM credentials.
+        futurehouse_api_key: Optional FutureHouse key enabling
+            literature-grounded validation.
+        mp_api_key: Optional Materials Project key for structure lookups.
+        max_refinement_cycles: Structure validator-guided refinement cap.
+        script_timeout: Timeout for executing generated structure scripts.
+        validate: When True, run the pre-run InputValidator on the generated
+            inputs (skipped for non-LLM methods, which are expert-defined).
+
+    Returns:
+        A workflow-result dict with ``final_status``, ``scale``, ``engine``,
+        ``steps_completed``, ``output_directory``, and the per-step results
+        (``structure_generation``, ``input_generation``, ``input_validation``).
+    """
+    software = software or _DEFAULT_ENGINE.get(scale)
+    os.makedirs(output_dir, exist_ok=True)
+    result: Dict[str, Any] = {
+        "user_request": user_request,
+        "scale": scale,
+        "engine": software,
+        "steps_completed": [],
+        "final_status": "started",
+        "output_directory": output_dir,
+    }
+
+    # ── Step 1: structure generation + validation (scale-agnostic) ──
+    from .structure_orchestrator import StructureOrchestrator
+    structure = StructureOrchestrator(
+        api_key=api_key, base_url=base_url, mp_api_key=mp_api_key,
+        generator_model=model_name, validator_model=model_name,
+        output_dir=output_dir, max_refinement_cycles=max_refinement_cycles,
+        script_timeout=script_timeout,
+    )
+    # Reuse the structure orchestrator's resolved credentials downstream.
+    api_key = structure.api_key
+    base_url = structure.base_url
+
+    structure_result = structure.generate_and_validate(
+        user_request, structure_class=structure_class,
+    )
+    result["structure_generation"] = structure_result
+    if structure_result.get("status") != "success":
+        result["final_status"] = "failed_structure_generation"
+        return result
+    result["steps_completed"].append("structure_generation")
+    structure_path = structure_result["final_structure_path"]
+
+    # ── Step 2: input generation (routed to the scale's foundation agent) ──
+    try:
+        gen_result = _generate_inputs(
+            scale=scale, software=software, method=method,
+            structure_file=structure_path, request=user_request,
+            output_dir=output_dir, api_key=api_key, base_url=base_url,
+            model_name=model_name,
+        )
+    except Exception as e:
+        result["final_status"] = "failed_input_generation"
+        result["input_generation"] = {"status": "error", "message": str(e)}
+        return result
+    result["input_generation"] = gen_result
+    if gen_result.get("status") not in (None, "success"):
+        result["final_status"] = "failed_input_generation"
+        return result
+    result["steps_completed"].append("input_generation")
+
+    # ── Step 3: pre-run input validation (engine-neutral critic) ──
+    # Skipped for named (deterministic, expert-defined) backends and when
+    # the caller opts out.
+    if validate and method == "llm":
+        input_files = _collect_input_files(gen_result)
+        if input_files:
+            from .critics import InputValidator
+            validator = InputValidator(
+                api_key=api_key, base_url=base_url, model_name=model_name,
+                futurehouse_api_key=futurehouse_api_key,
+            )
+            result["input_validation"] = validator.validate(
+                input_files=input_files, system_description=user_request,
+                skill=software, domain=scale,
+            )
+            result["steps_completed"].append("input_validation")
+    else:
+        reason = ("non-LLM method uses expert-defined inputs"
+                  if method != "llm" else "validation disabled by caller")
+        result["input_validation"] = {"status": "skipped", "message": reason}
+
+    result["final_status"] = "success"
+    return result
+
+
+def _collect_input_files(gen_result: Dict[str, Any]) -> Dict[str, str]:
+    """Return ``{filename: contents}`` from a generation result.
+
+    Reads the normalized ``input_files`` map every ``_generate_inputs``
+    branch produces. Values may be inlined contents or paths; paths are
+    read so the InputValidator always receives contents. No engine-specific
+    filenames are assumed.
+    """
+    contents: Dict[str, str] = {}
+    files = gen_result.get("input_files")
+    if not isinstance(files, dict):
+        return contents
+    for name, val in files.items():
+        if not isinstance(val, str):
+            continue
+        try:
+            p = Path(val)
+            if p.exists():
+                contents[name] = p.read_text()
+                continue
+        except (OSError, ValueError):
+            pass
+        contents[name] = val
+    return contents

--- a/scilink/agents/sim_agents/val_agent.py
+++ b/scilink/agents/sim_agents/val_agent.py
@@ -56,8 +56,7 @@ from ...auth import (
 from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
 from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
 
-from .instruct import VALIDATOR_PROMPT_TEMPLATE, INCAR_VALIDATION_INSTRUCTIONS
-from ..lit_agents.literature_agent import IncarLiteratureAgent
+from .instruct import VALIDATOR_PROMPT_TEMPLATE
 from .utils import generate_structure_views
 from ._deprecation import normalize_params
 
@@ -485,153 +484,11 @@ class StructureValidatorAgent:
         return final_feedback
 
 
-class IncarValidatorAgent:
-    """Agent that validates and suggests improvements to VASP INCAR files using literature."""
-
-    def __init__(self, api_key: str = None, 
-                 model_name: str = "gemini-3.1-pro-preview", 
-                 base_url: Optional[str] = None,
-                 futurehouse_api_key: str = None, 
-                 max_wait_time: int = 500,
-                 # Legacy params
-                 local_model: str = None,
-                 google_api_key: str = None):
-        
-        self.logger = logging.getLogger(__name__)
-
-        api_key, base_url = normalize_params(
-            api_key=api_key,
-            google_api_key=google_api_key,
-            base_url=base_url,
-            local_model=local_model,
-            source="IncarValidatorAgent"
-        )
-        
-        if base_url:
-            if api_key is None:
-                api_key = get_internal_proxy_key()
-            self.model = OpenAIAsGenerativeModel(
-                model=model_name,
-                api_key=api_key,
-                base_url=base_url
-            )
-        else:
-            # Public / LiteLLM — delegate model→provider→env-var resolution
-            # to LiteLLM (works for any model LiteLLM supports; raises a
-            # message naming the missing vendor env var if not).
-            if api_key is None:
-                require_vendor_credentials(model_name)
-            self.model = LiteLLMGenerativeModel(
-                model=model_name,
-                api_key=api_key
-            )
-
-        self.generation_config = None
-
-        # Initialize literature agent
-        self.literature_agent = IncarLiteratureAgent(
-            api_key=futurehouse_api_key, 
-            max_wait_time=max_wait_time
-        )
-
-    def validate_and_improve_incar(self, incar_content: str, system_description: str) -> dict:
-        """Validate INCAR parameters and suggest improvements based on literature."""
-        
-        # Step 1: Get literature review
-        self.logger.info("Getting literature review of INCAR parameters...")
-        lit_result = self.literature_agent.validate_incar(incar_content, system_description)
-        
-        if lit_result["status"] != "success":
-            return {
-                "status": "error",
-                "message": f"Literature review failed: {lit_result.get('message')}",
-                "validation_status": "unknown"
-            }
-        
-        # Step 2: Analyze literature review and suggest improvements
-        self.logger.info("Analyzing literature review for potential improvements...")
-        
-        prompt = f"""{INCAR_VALIDATION_INSTRUCTIONS}
-
-## ORIGINAL INCAR:
-{incar_content}
-
-## SYSTEM DESCRIPTION:
-{system_description}
-
-## LITERATURE REVIEW:
-{lit_result['response']}
-
-Analyze the literature review and suggest specific parameter adjustments if needed."""
-
-        try:
-            response = self.model.generate_content(prompt, generation_config=self.generation_config)
-            result = json.loads(response.text)
-            
-            # Add literature review to result
-            result.update({
-                "status": "success",
-                "literature_review": lit_result['response'],
-                "literature_task_id": lit_result.get('task_id')
-            })
-            
-            return result
-            
-        except Exception as e:
-            self.logger.error(f"Error analyzing literature review: {e}")
-            return {
-                "status": "error", 
-                "message": f"Analysis failed: {str(e)}",
-                "literature_review": lit_result['response']
-            }
-
-    def save_validation_report(self, validation_result: dict, output_dir: str = ".") -> dict:
-        """Save validation report and revised INCAR if needed."""
-        if validation_result.get("status") != "success":
-            return {"error": "Validation was not successful"}
-        
-        os.makedirs(output_dir, exist_ok=True)
-        saved_files = {}
-        
-        try:
-            # Save validation report
-            report_path = os.path.join(output_dir, "incar_validation_report.json")
-            with open(report_path, 'w') as f:
-                json.dump(validation_result, f, indent=2, default=str)
-            saved_files["validation_report"] = report_path
-            
-            # Save revised INCAR if adjustments were made
-            if (validation_result.get("validation_status") == "needs_adjustment" and 
-                validation_result.get("revised_incar")):
-                
-                revised_path = os.path.join(output_dir, "INCAR_revised")
-                with open(revised_path, 'w') as f:
-                    f.write(validation_result["revised_incar"])
-                saved_files["revised_incar"] = revised_path
-                
-                # Also save adjustment summary
-                summary_path = os.path.join(output_dir, "incar_adjustments.txt")
-                with open(summary_path, 'w') as f:
-                    f.write("INCAR Parameter Adjustments\n")
-                    f.write("=" * 30 + "\n\n")
-                    f.write(f"Overall Assessment: {validation_result.get('overall_assessment', 'N/A')}\n\n")
-                    
-                    adjustments = validation_result.get("suggested_adjustments", [])
-                    if adjustments:
-                        f.write("Suggested Changes:\n")
-                        for adj in adjustments:
-                            f.write(f"\n• {adj.get('parameter')}:\n")
-                            f.write(f"  Current: {adj.get('current_value')}\n")
-                            f.write(f"  Suggested: {adj.get('suggested_value')}\n")
-                            f.write(f"  Reason: {adj.get('reason')}\n")
-                    else:
-                        f.write("No specific adjustments suggested.\n")
-                        
-                saved_files["adjustment_summary"] = summary_path
-            
-            self.logger.info(f"Validation report saved: {saved_files}")
-            return saved_files
-            
-        except Exception as e:
-            self.logger.error(f"Error saving validation files: {e}")
-            return {"error": f"Save failed: {str(e)}"}
+# IncarValidatorAgent moved to ``vasp_input_validator.py`` on 2026-05-17
+# as part of separating engine-neutral validators (structure) from
+# engine-specific ones (INCAR is VASP).  Re-exported here so existing
+# importers (``from .val_agent import IncarValidatorAgent``) keep
+# working; new code should import from ``vasp_input_validator`` directly.
+# See memory: project_engine_validator_generalize.md for the follow-up
+# PR that finishes the split (rename file, drop this shim).
+from .vasp_input_validator import IncarValidatorAgent  # noqa: F401

--- a/scilink/agents/sim_agents/vasp_input_validator.py
+++ b/scilink/agents/sim_agents/vasp_input_validator.py
@@ -39,10 +39,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-import re
-import warnings as _warnings
-from difflib import SequenceMatcher, get_close_matches
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from ...auth import (
     APIKeyNotFoundError, get_api_key, get_internal_proxy_key, infer_provider,
@@ -54,178 +51,14 @@ from ..lit_agents.literature_agent import IncarLiteratureAgent
 from ._deprecation import normalize_params
 from .instruct import INCAR_VALIDATION_INSTRUCTIONS
 
-
-# Tokens that show up inside legitimate INCAR *values* (e.g. ``LDAUL = 3
-# 3 -1``, ``LSORBIT = .TRUE.``) rather than as standalone tags.  Filtered
-# out of the difflib suggestion pool so we don't propose nonsense
-# renames.
-_VASP_SUGGESTION_BLOCKLIST = {"TRUE", "FALSE"}
-
-
-def _load_valid_vasp_tags() -> List[str]:
-    """Return the canonical VASP INCAR-tag list bundled with pymatgen.
-
-    Returns an empty list if pymatgen is unavailable or the bundled JSON
-    has moved — callers degrade gracefully (no rename suggestions).
-    """
-    try:
-        from pymatgen.io.vasp import inputs as _vasp_inputs
-    except Exception:
-        return []
-    tags_path = os.path.join(
-        os.path.dirname(_vasp_inputs.__file__), "incar_parameters.json"
-    )
-    if not os.path.exists(tags_path):
-        return []
-    try:
-        with open(tags_path) as f:
-            return list(json.load(f).keys())
-    except Exception:
-        return []
-
-
-def check_incar_syntax(incar_content: str) -> List[Dict[str, Any]]:
-    """Engine-native pre-run syntax check for a VASP INCAR.
-
-    Parameters
-    ----------
-    incar_content : str
-        Raw INCAR text (not a path).  Pass ``open(...).read()``.
-
-    Returns
-    -------
-    list of issue dicts (possibly empty).  Each dict carries:
-
-        severity    : "warning"
-        category    : "incar_tag"
-        tag         : the offending tag as written (str or None)
-        suggested   : closest valid VASP tag (str or None)
-        confidence  : "high" | "low"
-        description : human-readable summary
-        source      : "pymatgen Incar.check_params"
-
-    ``confidence="high"`` requires the top match to be ≥0.85 similar to
-    the bad tag AND clearly better than the runner-up (>0.05 margin).
-    The auto-fix path (``apply_incar_syntax_fixes``) only consumes
-    high-confidence entries; low-confidence entries are returned for the
-    LLM regenerator to consider as context.
-    """
-    try:
-        from pymatgen.io.vasp.inputs import Incar
-    except Exception:
-        return []
-
-    try:
-        if hasattr(Incar, "from_str"):
-            incar = Incar.from_str(incar_content)
-        else:
-            incar = Incar.from_string(incar_content)  # older pymatgen
-    except Exception:
-        # Malformed INCAR — let VASP itself complain.  Syntax pass is
-        # specifically for the "syntactically valid but contains a fake
-        # tag" failure mode.
-        return []
-
-    valid_tags = [
-        t for t in _load_valid_vasp_tags()
-        if t not in _VASP_SUGGESTION_BLOCKLIST
-    ]
-
-    issues: List[Dict[str, Any]] = []
-    with _warnings.catch_warnings(record=True) as caught:
-        _warnings.simplefilter("always")
-        try:
-            incar.check_params()
-        except Exception:
-            return []
-
-    for w in caught:
-        msg = str(w.message)
-        m = re.search(r"Cannot find\s+(\S+)", msg)
-        bad_tag = m.group(1).strip().strip(",.") if m else None
-
-        suggested: Optional[str] = None
-        confidence = "low"
-        if bad_tag and valid_tags:
-            matches = get_close_matches(
-                bad_tag.upper(), valid_tags, n=2, cutoff=0.7
-            )
-            if matches:
-                suggested = matches[0]
-                top_sim = SequenceMatcher(
-                    None, bad_tag.upper(), matches[0]
-                ).ratio()
-                runner_sim = (
-                    SequenceMatcher(None, bad_tag.upper(), matches[1]).ratio()
-                    if len(matches) > 1 else 0.0
-                )
-                if top_sim >= 0.85 and (top_sim - runner_sim) >= 0.05:
-                    confidence = "high"
-
-        issues.append({
-            "severity": "warning",
-            "category": "incar_tag",
-            "tag": bad_tag,
-            "suggested": suggested,
-            "confidence": confidence,
-            "description": (
-                f"INCAR tag '{bad_tag}' is not recognised by VASP. "
-                f"Closest match: {suggested}."
-                if bad_tag and suggested else msg
-            ),
-            "source": "pymatgen Incar.check_params",
-        })
-
-    return issues
-
-
-def apply_incar_syntax_fixes(
-    incar_content: str,
-    issues: Optional[List[Dict[str, Any]]] = None,
-) -> Tuple[str, List[Dict[str, Any]]]:
-    """Apply high-confidence tag renames in-place to an INCAR string.
-
-    Parameters
-    ----------
-    incar_content : str
-        Raw INCAR text.
-    issues : list, optional
-        Issues from a prior ``check_incar_syntax`` call.  If omitted,
-        the check is run inline.
-
-    Returns
-    -------
-    (fixed_content, applied) : tuple
-        ``fixed_content`` is the (possibly modified) INCAR text.
-        ``applied`` is the subset of issues whose rename actually fired,
-        each augmented with ``renamed_from`` / ``renamed_to`` keys.
-
-    Low-confidence issues are returned untouched; caller is expected to
-    forward them to the LLM regenerator as context.
-    """
-    if issues is None:
-        issues = check_incar_syntax(incar_content)
-
-    fixed = incar_content
-    applied: List[Dict[str, Any]] = []
-    for issue in issues:
-        if issue.get("category") != "incar_tag":
-            continue
-        if issue.get("confidence") != "high":
-            continue
-        bad = issue.get("tag")
-        good = issue.get("suggested")
-        if not bad or not good:
-            continue
-        # Only rename when ``bad`` is on the LHS of an assignment.  The
-        # word-boundary regex + line anchor avoids touching value tokens
-        # that happen to share the spelling.
-        pattern = re.compile(rf"(?im)^(\s*){re.escape(bad)}(\s*=)")
-        new_fixed, n = pattern.subn(rf"\1{good}\2", fixed)
-        if n > 0:
-            fixed = new_fixed
-            applied.append({**issue, "renamed_from": bad, "renamed_to": good})
-    return fixed, applied
+# The deterministic INCAR syntax helpers live in the VASP skill bundle
+# (scilink/skills/periodic_dft/vasp/vasp_syntax.py) — the single source of
+# truth, discovered via the skill registry. Re-exported here so existing
+# imports and IncarValidatorAgent.check_syntax keep resolving unchanged.
+from ...skills.periodic_dft.vasp.vasp_syntax import (  # noqa: F401
+    apply_incar_syntax_fixes,
+    check_incar_syntax,
+)
 
 
 class IncarValidatorAgent:

--- a/scilink/agents/sim_agents/vasp_input_validator.py
+++ b/scilink/agents/sim_agents/vasp_input_validator.py
@@ -1,0 +1,398 @@
+"""
+VASP-specific pre-run input validator.
+
+Two-layer pre-run validation for VASP INCAR files:
+
+  1. Engine-native syntax check  (``check_incar_syntax``)
+     Wraps pymatgen's ``Incar.check_params()`` to catch typoed /
+     non-conforming INCAR tags (e.g. ``ISPN = 2`` instead of ``ISPIN``).
+     No LLM call.  Returns structured issues with high/low-confidence
+     rename suggestions derived from difflib against the canonical
+     VASP tag list.
+
+  2. LLM / literature check       (``IncarValidatorAgent.validate_and_improve_incar``)
+     Asks a FutureHouse literature agent + an LLM to judge whether the
+     parameter choices are physically appropriate for the system.
+     Pre-existing behavior — moved here from val_agent.py as part of
+     the 2026-05-17 split.
+
+Why two layers:  VASP accepts unknown INCAR keys silently — it just
+emits a one-line OUTCAR warning and runs with that key ignored.  An
+``ISPN`` typo can therefore disable spin polarisation on Fe and produce
+a physics-wrong result that converges by every other metric.  The
+syntax layer catches this before submission; the LLM layer catches
+"valid tag, wrong value for this system".
+
+Engine-neutral consumers (orchestrators, benchmark harness, future
+meta-agent) call ``check_incar_syntax`` / ``apply_incar_syntax_fixes``
+and never import pymatgen directly.  pymatgen import is lazy so a
+machine without it returns an empty issue list rather than crashing.
+
+The shape ``check_syntax(content) -> List[issue]`` + optional
+``validate_and_improve()`` is the engine-neutral contract.  Future
+``lammps_input_validator.py`` and ``gromacs_input_validator.py``
+should mirror it; see CLAUDE.md "Engine-neutral contracts".
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import warnings as _warnings
+from difflib import SequenceMatcher, get_close_matches
+from typing import Any, Dict, List, Optional, Tuple
+
+from ...auth import (
+    APIKeyNotFoundError, get_api_key, get_internal_proxy_key, infer_provider,
+    require_vendor_credentials,
+)
+from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
+from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
+from ..lit_agents.literature_agent import IncarLiteratureAgent
+from ._deprecation import normalize_params
+from .instruct import INCAR_VALIDATION_INSTRUCTIONS
+
+
+# Tokens that show up inside legitimate INCAR *values* (e.g. ``LDAUL = 3
+# 3 -1``, ``LSORBIT = .TRUE.``) rather than as standalone tags.  Filtered
+# out of the difflib suggestion pool so we don't propose nonsense
+# renames.
+_VASP_SUGGESTION_BLOCKLIST = {"TRUE", "FALSE"}
+
+
+def _load_valid_vasp_tags() -> List[str]:
+    """Return the canonical VASP INCAR-tag list bundled with pymatgen.
+
+    Returns an empty list if pymatgen is unavailable or the bundled JSON
+    has moved — callers degrade gracefully (no rename suggestions).
+    """
+    try:
+        from pymatgen.io.vasp import inputs as _vasp_inputs
+    except Exception:
+        return []
+    tags_path = os.path.join(
+        os.path.dirname(_vasp_inputs.__file__), "incar_parameters.json"
+    )
+    if not os.path.exists(tags_path):
+        return []
+    try:
+        with open(tags_path) as f:
+            return list(json.load(f).keys())
+    except Exception:
+        return []
+
+
+def check_incar_syntax(incar_content: str) -> List[Dict[str, Any]]:
+    """Engine-native pre-run syntax check for a VASP INCAR.
+
+    Parameters
+    ----------
+    incar_content : str
+        Raw INCAR text (not a path).  Pass ``open(...).read()``.
+
+    Returns
+    -------
+    list of issue dicts (possibly empty).  Each dict carries:
+
+        severity    : "warning"
+        category    : "incar_tag"
+        tag         : the offending tag as written (str or None)
+        suggested   : closest valid VASP tag (str or None)
+        confidence  : "high" | "low"
+        description : human-readable summary
+        source      : "pymatgen Incar.check_params"
+
+    ``confidence="high"`` requires the top match to be ≥0.85 similar to
+    the bad tag AND clearly better than the runner-up (>0.05 margin).
+    The auto-fix path (``apply_incar_syntax_fixes``) only consumes
+    high-confidence entries; low-confidence entries are returned for the
+    LLM regenerator to consider as context.
+    """
+    try:
+        from pymatgen.io.vasp.inputs import Incar
+    except Exception:
+        return []
+
+    try:
+        if hasattr(Incar, "from_str"):
+            incar = Incar.from_str(incar_content)
+        else:
+            incar = Incar.from_string(incar_content)  # older pymatgen
+    except Exception:
+        # Malformed INCAR — let VASP itself complain.  Syntax pass is
+        # specifically for the "syntactically valid but contains a fake
+        # tag" failure mode.
+        return []
+
+    valid_tags = [
+        t for t in _load_valid_vasp_tags()
+        if t not in _VASP_SUGGESTION_BLOCKLIST
+    ]
+
+    issues: List[Dict[str, Any]] = []
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        try:
+            incar.check_params()
+        except Exception:
+            return []
+
+    for w in caught:
+        msg = str(w.message)
+        m = re.search(r"Cannot find\s+(\S+)", msg)
+        bad_tag = m.group(1).strip().strip(",.") if m else None
+
+        suggested: Optional[str] = None
+        confidence = "low"
+        if bad_tag and valid_tags:
+            matches = get_close_matches(
+                bad_tag.upper(), valid_tags, n=2, cutoff=0.7
+            )
+            if matches:
+                suggested = matches[0]
+                top_sim = SequenceMatcher(
+                    None, bad_tag.upper(), matches[0]
+                ).ratio()
+                runner_sim = (
+                    SequenceMatcher(None, bad_tag.upper(), matches[1]).ratio()
+                    if len(matches) > 1 else 0.0
+                )
+                if top_sim >= 0.85 and (top_sim - runner_sim) >= 0.05:
+                    confidence = "high"
+
+        issues.append({
+            "severity": "warning",
+            "category": "incar_tag",
+            "tag": bad_tag,
+            "suggested": suggested,
+            "confidence": confidence,
+            "description": (
+                f"INCAR tag '{bad_tag}' is not recognised by VASP. "
+                f"Closest match: {suggested}."
+                if bad_tag and suggested else msg
+            ),
+            "source": "pymatgen Incar.check_params",
+        })
+
+    return issues
+
+
+def apply_incar_syntax_fixes(
+    incar_content: str,
+    issues: Optional[List[Dict[str, Any]]] = None,
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """Apply high-confidence tag renames in-place to an INCAR string.
+
+    Parameters
+    ----------
+    incar_content : str
+        Raw INCAR text.
+    issues : list, optional
+        Issues from a prior ``check_incar_syntax`` call.  If omitted,
+        the check is run inline.
+
+    Returns
+    -------
+    (fixed_content, applied) : tuple
+        ``fixed_content`` is the (possibly modified) INCAR text.
+        ``applied`` is the subset of issues whose rename actually fired,
+        each augmented with ``renamed_from`` / ``renamed_to`` keys.
+
+    Low-confidence issues are returned untouched; caller is expected to
+    forward them to the LLM regenerator as context.
+    """
+    if issues is None:
+        issues = check_incar_syntax(incar_content)
+
+    fixed = incar_content
+    applied: List[Dict[str, Any]] = []
+    for issue in issues:
+        if issue.get("category") != "incar_tag":
+            continue
+        if issue.get("confidence") != "high":
+            continue
+        bad = issue.get("tag")
+        good = issue.get("suggested")
+        if not bad or not good:
+            continue
+        # Only rename when ``bad`` is on the LHS of an assignment.  The
+        # word-boundary regex + line anchor avoids touching value tokens
+        # that happen to share the spelling.
+        pattern = re.compile(rf"(?im)^(\s*){re.escape(bad)}(\s*=)")
+        new_fixed, n = pattern.subn(rf"\1{good}\2", fixed)
+        if n > 0:
+            fixed = new_fixed
+            applied.append({**issue, "renamed_from": bad, "renamed_to": good})
+    return fixed, applied
+
+
+class IncarValidatorAgent:
+    """Agent that validates and suggests improvements to VASP INCAR files.
+
+    Two surfaces:
+
+      * ``check_syntax(incar_content)`` — engine-native pymatgen check.
+        No LLM, no FutureHouse dependency.  Returns the same list shape
+        as the module-level ``check_incar_syntax`` and is provided as a
+        convenience so callers that already hold a validator instance
+        don't need a separate import.
+
+      * ``validate_and_improve_incar(incar_content, system_description)``
+        — LLM-driven literature review of parameter choices.  Requires
+        an LLM model + FutureHouse API key (existing pre-PR behavior).
+
+    The two surfaces are independent: a caller that only needs the
+    syntax pass can use the module function and skip the LLM init
+    entirely.
+    """
+
+    def __init__(self, api_key: str = None,
+                 model_name: str = "gemini-3.1-pro-preview",
+                 base_url: Optional[str] = None,
+                 futurehouse_api_key: str = None,
+                 max_wait_time: int = 500,
+                 # Legacy params
+                 local_model: str = None,
+                 google_api_key: str = None):
+
+        self.logger = logging.getLogger(__name__)
+
+        api_key, base_url = normalize_params(
+            api_key=api_key,
+            google_api_key=google_api_key,
+            base_url=base_url,
+            local_model=local_model,
+            source="IncarValidatorAgent"
+        )
+
+        if base_url:
+            if api_key is None:
+                api_key = get_internal_proxy_key()
+            self.model = OpenAIAsGenerativeModel(
+                model=model_name,
+                api_key=api_key,
+                base_url=base_url
+            )
+        else:
+            # Public / LiteLLM — delegate model→provider→env-var resolution
+            # to LiteLLM (works for any model LiteLLM supports; raises a
+            # message naming the missing vendor env var if not).
+            if api_key is None:
+                require_vendor_credentials(model_name)
+            self.model = LiteLLMGenerativeModel(
+                model=model_name,
+                api_key=api_key
+            )
+
+        self.generation_config = None
+
+        self.literature_agent = IncarLiteratureAgent(
+            api_key=futurehouse_api_key,
+            max_wait_time=max_wait_time
+        )
+
+    def check_syntax(self, incar_content: str) -> List[Dict[str, Any]]:
+        """Instance-method convenience wrapper around ``check_incar_syntax``."""
+        return check_incar_syntax(incar_content)
+
+    def validate_and_improve_incar(self, incar_content: str,
+                                   system_description: str) -> dict:
+        """Validate INCAR parameters and suggest improvements based on literature."""
+
+        self.logger.info("Getting literature review of INCAR parameters...")
+        lit_result = self.literature_agent.validate_incar(
+            incar_content, system_description
+        )
+
+        if lit_result["status"] != "success":
+            return {
+                "status": "error",
+                "message": f"Literature review failed: {lit_result.get('message')}",
+                "validation_status": "unknown"
+            }
+
+        self.logger.info("Analyzing literature review for potential improvements...")
+
+        prompt = f"""{INCAR_VALIDATION_INSTRUCTIONS}
+
+## ORIGINAL INCAR:
+{incar_content}
+
+## SYSTEM DESCRIPTION:
+{system_description}
+
+## LITERATURE REVIEW:
+{lit_result['response']}
+
+Analyze the literature review and suggest specific parameter adjustments if needed."""
+
+        try:
+            response = self.model.generate_content(
+                prompt, generation_config=self.generation_config
+            )
+            result = json.loads(response.text)
+            result.update({
+                "status": "success",
+                "literature_review": lit_result['response'],
+                "literature_task_id": lit_result.get('task_id')
+            })
+            return result
+
+        except Exception as e:
+            self.logger.error(f"Error analyzing literature review: {e}")
+            return {
+                "status": "error",
+                "message": f"Analysis failed: {str(e)}",
+                "literature_review": lit_result['response']
+            }
+
+    def save_validation_report(self, validation_result: dict,
+                               output_dir: str = ".") -> dict:
+        """Save validation report and revised INCAR if needed."""
+        if validation_result.get("status") != "success":
+            return {"error": "Validation was not successful"}
+
+        os.makedirs(output_dir, exist_ok=True)
+        saved_files = {}
+
+        try:
+            report_path = os.path.join(output_dir, "incar_validation_report.json")
+            with open(report_path, 'w') as f:
+                json.dump(validation_result, f, indent=2, default=str)
+            saved_files["validation_report"] = report_path
+
+            if (validation_result.get("validation_status") == "needs_adjustment" and
+                    validation_result.get("revised_incar")):
+
+                revised_path = os.path.join(output_dir, "INCAR_revised")
+                with open(revised_path, 'w') as f:
+                    f.write(validation_result["revised_incar"])
+                saved_files["revised_incar"] = revised_path
+
+                summary_path = os.path.join(output_dir, "incar_adjustments.txt")
+                with open(summary_path, 'w') as f:
+                    f.write("INCAR Parameter Adjustments\n")
+                    f.write("=" * 30 + "\n\n")
+                    f.write(f"Overall Assessment: {validation_result.get('overall_assessment', 'N/A')}\n\n")
+
+                    adjustments = validation_result.get("suggested_adjustments", [])
+                    if adjustments:
+                        f.write("Suggested Changes:\n")
+                        for adj in adjustments:
+                            f.write(f"\n• {adj.get('parameter')}:\n")
+                            f.write(f"  Current: {adj.get('current_value')}\n")
+                            f.write(f"  Suggested: {adj.get('suggested_value')}\n")
+                            f.write(f"  Reason: {adj.get('reason')}\n")
+                    else:
+                        f.write("No specific adjustments suggested.\n")
+
+                saved_files["adjustment_summary"] = summary_path
+
+            self.logger.info(f"Validation report saved: {saved_files}")
+            return saved_files
+
+        except Exception as e:
+            self.logger.error(f"Error saving validation files: {e}")
+            return {"error": f"Save failed: {str(e)}"}

--- a/scilink/agents/sim_agents/vasp_quality.py
+++ b/scilink/agents/sim_agents/vasp_quality.py
@@ -1,4 +1,12 @@
-"""Post-run quality / critic agent for VASP calculations.
+"""BENCHMARK BASELINE — legacy VASP-specific post-run quality critic.
+
+Retained only as a baseline for the old-vs-new critic comparison in the
+benchmark suite; NOT on the live path. The live post-run capability is the
+engine-neutral ``RunCritic`` (``scilink.agents.sim_agents.critics``).
+Nothing in the live orchestrator/pipeline imports this module — only the
+benchmark harness does.
+
+Post-run quality / critic agent for VASP calculations.
 
 Wraps `post_run_analysis.analyze_run_directory` (the deterministic
 data layer that parses vasprun.xml + logs) with an LLM layer that

--- a/scilink/agents/sim_agents/vasp_quality.py
+++ b/scilink/agents/sim_agents/vasp_quality.py
@@ -51,6 +51,30 @@ from .skill_graduation import (
 # Deterministic guardrails
 # ──────────────────────────────────────────────────────────────
 
+def _check_incar_tags(incar_path: str) -> List[Dict[str, Any]]:
+    """Post-run wrapper around the engine-native INCAR syntax check.
+
+    Reads the INCAR off disk and delegates to
+    ``vasp_input_validator.check_incar_syntax``.  The pre-run path
+    (PeriodicDFTAgent) usually catches typos before submission; this
+    post-run pass exists as a defense-in-depth check so that runs that
+    bypassed pre-validation (manual INCAR edits, externally-supplied
+    inputs) still get the warning.
+
+    Same return shape as ``check_incar_syntax`` — keeps the issue
+    contract consistent between Generate and Quality stages.
+    """
+    if not os.path.exists(incar_path):
+        return []
+    try:
+        with open(incar_path) as f:
+            content = f.read()
+    except Exception:
+        return []
+    from .vasp_input_validator import check_incar_syntax
+    return check_incar_syntax(content)
+
+
 def _deterministic_issues(facts: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Issues that should always be flagged based on the parsed facts.
 
@@ -280,6 +304,11 @@ class VaspQualityAgent:
         # Layer 1: deterministic facts + guardrails.
         facts = analyze_run_directory(output_dir)
         det_issues = _deterministic_issues(facts)
+        # Plus: scan the on-disk INCAR for typoed / unknown tags.
+        # Picks up things VASP silently ignores (e.g. ISPN-for-ISPIN).
+        det_issues.extend(
+            _check_incar_tags(os.path.join(output_dir, "INCAR"))
+        )
 
         # Skill convention text (validation section preferred).
         skill_text = self._load_skill_text(skill)

--- a/scilink/agents/sim_agents/vasp_updater.py
+++ b/scilink/agents/sim_agents/vasp_updater.py
@@ -1,4 +1,13 @@
 # scilink/agents/sim_agents/vasp_updater.py
+"""BENCHMARK BASELINE — legacy VASP-specific runtime updater.
+
+Retained only as a baseline for the old-vs-new critic comparison in the
+benchmark suite; NOT on the live path. The live runtime-fix capability is
+the engine-neutral ``RunCritic`` (``scilink.agents.sim_agents.critics``),
+which reads the engine skill's ``interpretation`` section. Nothing in the
+live orchestrator/pipeline imports this module — only the benchmark
+harness does.
+"""
 
 import re
 import logging

--- a/scilink/cli/simulate.py
+++ b/scilink/cli/simulate.py
@@ -402,7 +402,7 @@ planned follow-up work; see CLAUDE.md.
             print(f"\n🏗️  Structures generated this session: {len(structures)}")
             for s in structures:
                 print(f"  • {s.get('slug')}: {s.get('description')}")
-                print(f"      POSCAR: {s.get('poscar_path')}")
+                print(f"      POSCAR: {s.get('structure_path')}")
                 if s.get('incar_path'):
                     print(f"      INCAR/KPOINTS: ✓")
             return True

--- a/scilink/cli/simulate.py
+++ b/scilink/cli/simulate.py
@@ -402,9 +402,10 @@ planned follow-up work; see CLAUDE.md.
             print(f"\n🏗️  Structures generated this session: {len(structures)}")
             for s in structures:
                 print(f"  • {s.get('slug')}: {s.get('description')}")
-                print(f"      POSCAR: {s.get('structure_path')}")
-                if s.get('incar_path'):
-                    print(f"      INCAR/KPOINTS: ✓")
+                print(f"      structure: {s.get('structure_path')}")
+                files = s.get('input_files') or {}
+                if files:
+                    print(f"      inputs: {', '.join(sorted(files))}")
             return True
 
         if cmd == "/status":

--- a/scilink/skills/_shared/_registry.py
+++ b/scilink/skills/_shared/_registry.py
@@ -19,6 +19,7 @@ import importlib
 import logging
 import pkgutil
 from functools import lru_cache
+from typing import Any, Callable
 
 from ._spec import ToolSpec
 
@@ -176,3 +177,93 @@ def get_tools_for(agent: str, active_skills: list[str] | None = None) -> list[To
             if name in active_set:
                 visible.extend(specs)
     return visible
+
+
+@lru_cache(maxsize=None)
+def _per_skill_callables() -> dict[tuple[str, str], dict[str, Callable[..., Any]]]:
+    """Map ``(domain, skill_name)`` to ``{spec.name: callable}``.
+
+    Walks the same skill bundles as :func:`_per_skill_specs`. For each
+    discovered ``TOOL_SPEC``, looks up the matching callable in the
+    declaring module by name: a spec with ``name="snapshot_run"`` is
+    paired with a function named ``snapshot_run`` in the same module.
+    Specs whose corresponding function cannot be located are logged
+    and skipped.
+
+    Cached for the life of the process; the skill tree is static within
+    a run.
+    """
+    from scilink.skills.loader import list_all_skills, _SKILLS_DIR
+
+    result: dict[tuple[str, str], dict[str, Callable[..., Any]]] = {}
+    for domain, names in list_all_skills().items():
+        for name in names:
+            skill_dir = _SKILLS_DIR / domain / name
+            callables: dict[str, Callable[..., Any]] = {}
+            for py_file in sorted(skill_dir.glob("*.py")):
+                if py_file.stem.startswith("_"):
+                    continue
+                module_path = f"scilink.skills.{domain}.{name}.{py_file.stem}"
+                try:
+                    mod = importlib.import_module(module_path)
+                except Exception as exc:
+                    _logger.debug("Skipping %s: %s", module_path, exc)
+                    continue
+                for spec in _collect_specs_from_module(mod):
+                    fn = getattr(mod, spec.name, None)
+                    if callable(fn):
+                        callables[spec.name] = fn
+                    else:
+                        _logger.warning(
+                            "TOOL_SPEC '%s' declared in %s but no "
+                            "callable with that name found; skipping.",
+                            spec.name, module_path,
+                        )
+            if callables:
+                result[(domain, name)] = callables
+    return result
+
+
+def get_tool_function(
+    name: str,
+    active_skills: list[str] | None = None,
+) -> Callable[..., Any]:
+    """Resolve a tool name to its callable from the active skill bundles.
+
+    Looks up ``name`` in every skill bundle listed in ``active_skills``
+    and returns the first matching callable. Used by Python code that
+    needs to invoke a skill-registered tool directly (as opposed to
+    surfacing its spec to an LLM via :func:`get_tools_for`).
+
+    Args:
+        name: The ``TOOL_SPEC.name`` to resolve.
+        active_skills: Skill names whose bundles should be searched.
+            ``None`` or an empty list raises ``LookupError`` — at least
+            one skill must be specified.
+
+    Returns:
+        The callable registered for ``name`` in one of the active skill
+        bundles. The callable accepts whatever ``**kwargs`` its
+        ``TOOL_SPEC.parameters`` describe; callers may invoke it as
+        ``get_tool_function(name, active_skills=[...])(**kwargs)``.
+
+    Raises:
+        LookupError: If no matching callable is found in any active
+            skill bundle. The message names the searched skills so the
+            caller can verify the bundle declares the expected spec.
+    """
+    if not active_skills:
+        raise LookupError(
+            f"Cannot resolve tool {name!r}: no active skills supplied. "
+            "Pass active_skills=[<skill_name>, ...] to enable lookup."
+        )
+    active_set = set(active_skills)
+    for (_domain, skill_name), callables_map in _per_skill_callables().items():
+        if skill_name in active_set and name in callables_map:
+            return callables_map[name]
+    raise LookupError(
+        f"Tool {name!r} not found in any of the active skill bundles "
+        f"{sorted(active_set)!r}. Verify that the matching bundle "
+        f"declares a TOOL_SPEC with name={name!r} and that a callable "
+        "with the same name exists in the spec's declaring module."
+    )

--- a/scilink/skills/periodic_dft/vasp/vasp.md
+++ b/scilink/skills/periodic_dft/vasp/vasp.md
@@ -197,6 +197,24 @@ wrong magnetic ground states, and unreliable forces.
 
 ## validation
 
+**Pre-submit syntax check (engine-native, no LLM):**
+
+VASP accepts unknown INCAR keys silently — a one-letter typo such as
+`ISPN = 2` instead of `ISPIN = 2` disables spin polarisation and
+produces a physics-wrong result that converges by every other metric.
+Before submission, `PeriodicDFTAgent` runs the generated INCAR through
+`scilink.agents.sim_agents.vasp_input_validator.check_incar_syntax`
+(pymatgen's `Incar.check_params()`). High-confidence typos are
+auto-renamed to the closest valid tag; low-confidence matches are
+returned for downstream LLM review. The fix payload is recorded under
+`result["syntax_check"]` so the caller can log what was changed.
+
+This is the VASP instance of an engine-neutral contract:
+`<engine>_input_validator.check_syntax(content) -> List[issue]`. Don't
+add tag-spelling guidance to LLM prompts — the pymatgen check is the
+canonical authority, and the LLM should reason about physics, not
+syntax.
+
 **Quality checks for generated INCAR files:**
 
 - GGA tag MUST be present and match the intended functional. Its absence

--- a/scilink/skills/periodic_dft/vasp/vasp.md
+++ b/scilink/skills/periodic_dft/vasp/vasp.md
@@ -195,6 +195,53 @@ wrong magnetic ground states, and unreliable forces.
   NCORE = 1
   KPAR = 1
 
+## interpretation
+
+Read a finished run against the calculation's intent, not just its exit
+status — a run can exit cleanly and still be physically wrong.
+
+**Convergence has two levels.** Electronic convergence (SCF reaches EDIFF)
+must hold for any result; ionic convergence (forces below EDIFFG) must
+also hold for a relaxation. Electronic non-convergence is disqualifying —
+the energy is meaningless. Ionic non-convergence means the geometry is
+still moving, so the energy is an upper bound, not the minimum.
+
+**Distinguish "stopped" from "converged."** The most common false success
+is a run that hit a ceiling and reported its last value: if the final
+ionic step's SCF count sits at NELM, the SCF was truncated; if the ionic
+step count equals NSW with forces still above |EDIFFG|, the relaxation ran
+out of budget. Check forces against the intended threshold, not zero —
+energy plateaus well before forces do, so a small energy change does not
+imply a stationary point.
+
+**Sanity-check the physics, not only the numerics.** The hardest failure
+to catch is a converged run with the wrong setup: spin disabled on a
+magnetic system, smearing wrong for the system class (metallic smearing
+broadens an insulator's gap; tetrahedron smearing gives wrong relaxation
+forces), or a final magnetic moment far from chemical expectation. When
+the result contradicts what the system should physically do, distrust the
+inputs before trusting the number.
+
+**Error-pattern triage.** When a run fails, the log usually names the mode.
+Map the symptom to the smallest input change and resubmit one change at a
+time so the next failure stays diagnostic:
+
+- *No pseudopotential / wrong POTCAR directory* — `GGA` tag missing or
+  inconsistent with the potentials. Set `GGA = PE` (or the intended functional's tag).
+- *`ZBRENT: fatal error`* — ionic step too large. Reduce `POTIM` (~0.1),
+  switch to `IBRION = 1`, restart from CONTCAR.
+- *`Sub-Space-Matrix is not hermitian`* — minimization instability. Use `ALGO = Normal`.
+- *`BRMIX: very serious problems`* — charge mixing diverging. Reduce mixing
+  (`AMIX = 0.1`, `BMIX = 0.01`) and raise `NELM`.
+- *`ERROR RSPHER`* — real-space projection unstable. Set `LREAL = .FALSE.`.
+- *`EDDDAV did not converge` / `EDDRMM`* — Davidson struggling. Use `ALGO = All`, raise `NELM`.
+- *Highest band occupied / no empty bands* — too few bands. Increase `NBANDS` (~+50%).
+- *SCF not achieved within NELM* — raise `NELM`, switch to `ALGO = All`; if it
+  recurs, revisit smearing and mixing.
+
+Escalate (looser mixing, more bands, different algorithm) only when the
+first targeted fix does not resolve the named failure.
+
 ## validation
 
 **Pre-submit syntax check (engine-native, no LLM):**
@@ -238,12 +285,6 @@ syntax.
 - Check for contradictory settings: for example ISMEAR = -5 with NSW > 0,
   or ISIF = 3 with a slab geometry.
 
-**Common errors and their INCAR fixes:**
-
-- "No pseudopotential for X": Missing or wrong GGA tag. Fix: add GGA = PE.
-- "ZBRENT: fatal error": POTIM too large. Fix: reduce POTIM to 0.1, use IBRION = 1.
-- "Sub-Space-Matrix not hermitian": ALGO incompatibility. Fix: use ALGO = Normal.
-- "BRMIX: very serious problems": SCF not converging. Fix: add AMIX=0.1, BMIX=0.01.
-- "RSPHER": Real-space projection overlap. Fix: set LREAL = .FALSE.
-- "Highest band is occupied": Not enough bands. Fix: increase NBANDS.
-- "EDDDAV did not converge": Electronic convergence failure. Fix: ALGO = All, increase NELM.
+Post-run error diagnosis and the corresponding INCAR fixes live in the
+`interpretation` section — those apply after a run has failed, whereas
+the checks here apply to inputs before submission.

--- a/scilink/skills/periodic_dft/vasp/vasp_atomate2.py
+++ b/scilink/skills/periodic_dft/vasp/vasp_atomate2.py
@@ -1,0 +1,108 @@
+"""Rule-based VASP input generation via atomate2 / pymatgen.
+
+A deterministic generation backend for the ``vasp`` skill: it produces
+INCAR / KPOINTS / POSCAR from Materials-Project-standard input sets
+(atomate2's ``VaspInputGenerator``, falling back to ``MPRelaxSet``) rather
+than from an LLM. Selected through the pipeline's ``method='atomate2'``
+path and discovered via the skill registry as ``generate_inputs_atomate2``.
+
+This is the foundation-agent "optional code helper" pattern: the LLM path
+is the agent's baseline generation; named deterministic backends live in
+the engine's skill bundle as tools. Requires the ``[sim]`` extras
+(pymatgen + atomate2), imported lazily so the bundle stays discoverable
+without them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from ..._shared._spec import ToolSpec
+
+
+def generate_inputs_atomate2(
+    structure_file: str,
+    request: str = "",
+    output_dir: str = ".",
+) -> Dict[str, Any]:
+    """Generate VASP inputs from Materials-Project input sets.
+
+    Args:
+        structure_file: Path to the structure (read via ASE).
+        request: Scientific request. Accepted for interface parity with
+            the LLM generator; the rule-based set does not consume it.
+        output_dir: Directory to write INCAR / KPOINTS / POSCAR into.
+
+    Returns:
+        A dict with ``status`` and, on success, an ``input_files`` mapping
+        (filename → contents) plus a ``summary``. Returns an error dict
+        when the ``[sim]`` extras are missing or generation fails.
+    """
+    try:
+        from ....agents.sim_agents.atomate2_utils import Atomate2Input
+    except ImportError as e:
+        return {
+            "status": "error",
+            "message": (
+                "method='atomate2' requires the [sim] extras "
+                "(pymatgen, atomate2). Install with: pip install 'scilink[sim]'. "
+                f"Original error: {e}"
+            ),
+        }
+
+    try:
+        from ase.io import read as ase_read
+        structure = ase_read(structure_file)
+        Atomate2Input().generate(structure=structure, output_dir=output_dir)
+    except Exception as e:
+        return {"status": "error", "message": f"atomate2 generation failed: {e}"}
+
+    out = Path(output_dir)
+    input_files: Dict[str, str] = {}
+    for name in ("INCAR", "KPOINTS", "POSCAR"):
+        p = out / name
+        if p.exists():
+            input_files[name] = p.read_text()
+
+    if "INCAR" not in input_files:
+        return {
+            "status": "error",
+            "message": "atomate2 generation produced no INCAR.",
+        }
+
+    return {
+        "status": "success",
+        "input_files": input_files,
+        "summary": "Materials Project standard relaxation set (atomate2/pymatgen).",
+    }
+
+
+TOOL_SPEC = ToolSpec(
+    name="generate_inputs_atomate2",
+    description=(
+        "Deterministic VASP input generation from Materials-Project "
+        "standard input sets (atomate2 / pymatgen MPRelaxSet). The "
+        "rule-based alternative to LLM generation; returns a normalized "
+        "input_files map. Requires the [sim] extras."
+    ),
+    parameters={
+        "structure_file": {
+            "type": "string",
+            "description": "Path to the structure file (read via ASE).",
+        },
+        "request": {
+            "type": "string",
+            "description": "Scientific request (unused by the rule-based set).",
+        },
+        "output_dir": {
+            "type": "string",
+            "description": "Directory to write INCAR / KPOINTS / POSCAR into.",
+        },
+    },
+    required=["structure_file"],
+    signature="generate_inputs_atomate2(structure_file, request, output_dir) -> dict",
+    import_line="from scilink.skills.periodic_dft.vasp.vasp_atomate2 import generate_inputs_atomate2",
+    agents=["simulation"],
+    returns="dict with status, input_files (filename->contents), summary.",
+)

--- a/scilink/skills/periodic_dft/vasp/vasp_output.py
+++ b/scilink/skills/periodic_dft/vasp/vasp_output.py
@@ -1,0 +1,288 @@
+"""VASP output snapshot parser.
+
+Reads OUTCAR / vasprun.xml from a completed (or failed) VASP run and
+produces a structured summary that simulate-mode critics hand to the LLM
+when assessing the run. Discovered via the skill registry when the
+``vasp`` skill is active and called through
+:func:`scilink.skills._shared._registry.get_tool_function`.
+
+All code paths return a dict with a ``status`` key; failures are reported
+in the returned structure rather than raised, so callers can hand the
+result to the LLM uniformly.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ..._shared._spec import ToolSpec
+
+logger = logging.getLogger(__name__)
+
+
+# Common VASP error patterns surfaced via the stdout/stderr log so the
+# summary can flag known failure modes even when vasprun.xml is missing
+# or unparseable.
+_VASP_ERROR_HINTS = [
+    ("ZBRENT", "ionic optimization stuck — try IBRION=1 or tighten POTIM"),
+    ("NELM", "electronic SCF failed to converge — increase NELM, tighten EDIFF, try ALGO=All"),
+    ("VERY BAD NEWS", "fatal numerical failure — usually indicates a bad starting geometry or symmetry mismatch"),
+    ("Therefore set LREAL=.FALSE.", "real-space projection unstable — set LREAL=.FALSE."),
+    ("internal error in subroutine SGRCON", "symmetry detection failure — try ISYM=0 or perturb the structure slightly"),
+    ("inverse of rotation matrix", "symmetry / lattice issue — try ISYM=0"),
+    ("SBESSELITER", "SCF instability — try ALGO=Normal/All or smaller AMIX"),
+    ("EDDDAV: Call to ZHEGV failed", "Davidson algorithm failed — try ALGO=All or increase NBANDS"),
+    ("SGCC: nion", "ion mismatch between INCAR and POSCAR — check selective dynamics block"),
+    ("WARNING: stress tensor not correct", "stress incomplete — usually because ISIF or NSW is wrong for what you're computing"),
+]
+
+
+def _classify_log_errors(log_text: str) -> List[str]:
+    """Return human-readable hints matching known VASP error patterns.
+
+    Args:
+        log_text: Tail-read text of stdout / stderr / OUTCAR.
+
+    Returns:
+        List of ``"<pattern>: <hint>"`` strings for each pattern matched
+        case-insensitively in ``log_text``.
+    """
+    hits: List[str] = []
+    for pattern, hint in _VASP_ERROR_HINTS:
+        if pattern.lower() in log_text.lower():
+            hits.append(f"{pattern}: {hint}")
+    return hits
+
+
+def _read_first_existing(*paths: Path, max_chars: int = 80_000) -> Optional[str]:
+    """Read the first existing path, returning at most ``max_chars`` of its tail.
+
+    Used for stdout / stderr style logs where only the trailing region
+    typically contains the failure signature.
+
+    Args:
+        *paths: Candidate file paths, tried in order.
+        max_chars: Maximum number of characters to return; the tail of
+            the file is preferred when the file exceeds this size.
+
+    Returns:
+        The file's text (tail-trimmed) for the first readable path, or
+        ``None`` if none exist or all reads fail.
+    """
+    for p in paths:
+        if not p.exists() or not p.is_file():
+            continue
+        try:
+            text = p.read_text(errors="replace")
+        except Exception as e:
+            logger.warning(f"Could not read {p}: {e}")
+            continue
+        if len(text) > max_chars:
+            return text[-max_chars:]
+        return text
+    return None
+
+
+def _summarize_vasprun(vasprun_path: Path) -> Dict[str, Any]:
+    """Parse ``vasprun.xml`` and extract convergence + energetics.
+
+    Args:
+        vasprun_path: Path to a vasprun.xml file.
+
+    Returns:
+        A dict containing some subset of: ``converged_electronic``,
+        ``converged_ionic``, ``converged``, ``final_energy``,
+        ``n_ionic_steps``, ``n_electronic_steps_last_ionic``,
+        ``max_force_eV_per_A``, ``incar_snapshot``. On parse failure
+        returns ``{"error": "..."}``. Partial parse failures populate
+        the available fields and surface the missing ones under
+        per-field ``*_error`` keys.
+    """
+    try:
+        from pymatgen.io.vasp.outputs import Vasprun
+    except ImportError as e:
+        return {"error": f"pymatgen not available: {e}"}
+
+    try:
+        vr = Vasprun(
+            str(vasprun_path),
+            parse_dos=False,
+            parse_eigen=False,
+            parse_potcar_file=False,
+            exception_on_bad_xml=False,
+        )
+    except Exception as e:
+        return {"error": f"vasprun.xml parse failed: {e}"}
+
+    out: Dict[str, Any] = {}
+    try:
+        out["converged_electronic"] = bool(vr.converged_electronic)
+        out["converged_ionic"] = bool(vr.converged_ionic)
+        out["converged"] = bool(vr.converged)
+    except Exception as e:
+        out["convergence_check_error"] = str(e)
+
+    try:
+        out["final_energy"] = float(vr.final_energy)
+    except Exception:
+        out["final_energy"] = None
+
+    try:
+        out["n_ionic_steps"] = len(vr.ionic_steps)
+        if vr.ionic_steps:
+            last = vr.ionic_steps[-1]
+            scs = last.get("electronic_steps", []) if isinstance(last, dict) else []
+            out["n_electronic_steps_last_ionic"] = len(scs)
+        else:
+            out["n_electronic_steps_last_ionic"] = 0
+    except Exception as e:
+        out["ionic_step_error"] = str(e)
+
+    try:
+        if vr.ionic_steps:
+            forces = vr.ionic_steps[-1].get("forces")
+            if forces is not None:
+                import numpy as np
+                f = np.asarray(forces)
+                out["max_force_eV_per_A"] = float(np.linalg.norm(f, axis=1).max())
+    except Exception as e:
+        out["force_check_error"] = str(e)
+
+    try:
+        params = vr.incar.as_dict() if vr.incar else {}
+        keys = ["IBRION", "NSW", "ISIF", "EDIFF", "EDIFFG", "ENCUT",
+                "ISMEAR", "SIGMA", "ALGO", "PREC", "NELM", "ISYM",
+                "LREAL", "ISPIN"]
+        out["incar_snapshot"] = {k: params[k] for k in keys if k in params}
+    except Exception as e:
+        out["incar_snapshot_error"] = str(e)
+
+    return out
+
+
+def snapshot_run(output_dir: str) -> Dict[str, Any]:
+    """Summarize a VASP run directory into a structured snapshot.
+
+    Inspects the directory for ``vasprun.xml`` (preferred, structured
+    parse via pymatgen) and falls back to OUTCAR / OSZICAR / stdout /
+    stderr tail-matching for known VASP error patterns when the
+    structured output is missing or unparseable.
+
+    Args:
+        output_dir: Path to the directory containing the VASP run's
+            output files.
+
+    Returns:
+        A dict with fields:
+
+            status              ``"ok"`` or ``"error"``
+            output_directory    The directory inspected
+            files_found         List of recognized output files present
+            vasprun             Dict from :func:`_summarize_vasprun`
+                                when ``vasprun.xml`` was parseable;
+                                ``None`` otherwise
+            log_error_hints     List of ``"<pattern>: <hint>"`` strings
+                                matched in log files
+            convergence_status  One of ``"converged"``, ``"not_converged"``,
+                                ``"failed"``, ``"unknown"``
+            headline            One-sentence top-line assessment for
+                                quick LLM consumption
+    """
+    out_dir = Path(output_dir)
+    if not out_dir.exists():
+        return {"status": "error", "message": f"Directory not found: {output_dir}"}
+    if not out_dir.is_dir():
+        return {"status": "error", "message": f"Not a directory: {output_dir}"}
+
+    summary: Dict[str, Any] = {
+        "status": "ok",
+        "output_directory": str(out_dir),
+        "files_found": [],
+        "vasprun": None,
+        "log_error_hints": [],
+        "convergence_status": "unknown",
+    }
+
+    candidates = ["vasprun.xml", "OUTCAR", "OSZICAR", "CONTCAR",
+                  "vasp.out", "stdout", "stdout.log", "stderr",
+                  "stderr.log"]
+    for name in candidates:
+        if (out_dir / name).exists():
+            summary["files_found"].append(name)
+
+    vasprun_path = out_dir / "vasprun.xml"
+    if vasprun_path.exists():
+        vr_summary = _summarize_vasprun(vasprun_path)
+        summary["vasprun"] = vr_summary
+        if "error" not in vr_summary:
+            converged = vr_summary.get("converged")
+            if converged is True:
+                summary["convergence_status"] = "converged"
+            elif converged is False:
+                summary["convergence_status"] = "not_converged"
+
+    log_text = _read_first_existing(
+        out_dir / "vasp.out",
+        out_dir / "stdout",
+        out_dir / "stdout.log",
+        out_dir / "stderr",
+        out_dir / "stderr.log",
+        out_dir / "OUTCAR",
+    )
+    if log_text:
+        summary["log_error_hints"] = _classify_log_errors(log_text)
+        if summary["convergence_status"] == "unknown" and summary["log_error_hints"]:
+            summary["convergence_status"] = "failed"
+
+    if summary["convergence_status"] == "converged":
+        summary["headline"] = "Run converged successfully."
+    elif summary["convergence_status"] == "not_converged":
+        summary["headline"] = (
+            "Run did NOT reach convergence within the requested limits. "
+            "Check NELM/NSW and the convergence criteria; consider "
+            "tightening EDIFF / loosening EDIFFG, or trying ALGO=All."
+        )
+    elif summary["convergence_status"] == "failed":
+        summary["headline"] = (
+            "Run appears to have failed (errors found in the log). "
+            "See log_error_hints for known patterns."
+        )
+    else:
+        summary["headline"] = (
+            "Convergence status could not be determined from the available "
+            "outputs. The run may still be in progress, or critical files "
+            "(vasprun.xml, OUTCAR) may be missing."
+        )
+
+    return summary
+
+
+TOOL_SPEC = ToolSpec(
+    name="snapshot_run",
+    description=(
+        "Read a VASP run directory and return a structured snapshot of "
+        "convergence status, energetics, and any matched error patterns. "
+        "Discovered and dispatched when the ``vasp`` skill is active."
+    ),
+    parameters={
+        "output_dir": {
+            "type": "string",
+            "description": (
+                "Absolute path to the directory containing the VASP run's "
+                "output files (vasprun.xml, OUTCAR, OSZICAR, stdout, "
+                "stderr)."
+            ),
+        },
+    },
+    required=["output_dir"],
+    signature="snapshot_run(output_dir: str) -> dict",
+    import_line="from scilink.skills.periodic_dft.vasp.vasp_output import snapshot_run",
+    agents=["simulation"],
+    returns=(
+        "dict with status, files_found, vasprun (convergence + energetics), "
+        "log_error_hints (matched VASP failure patterns), "
+        "convergence_status, and a one-line headline."
+    ),
+)

--- a/scilink/skills/periodic_dft/vasp/vasp_syntax.py
+++ b/scilink/skills/periodic_dft/vasp/vasp_syntax.py
@@ -1,0 +1,366 @@
+"""VASP INCAR syntax validation.
+
+Deterministic, LLM-free checks for VASP INCAR files: detection of
+unrecognized tags (typically one-character typos such as ``ISPN`` for
+``ISPIN``) against pymatgen's canonical tag list, with closest-match
+suggestions and an in-place high-confidence auto-rename.
+
+VASP accepts unknown INCAR keys silently, so a typo like ``ISPN = 2``
+disables spin polarization and yields a physically wrong result that
+converges by every other metric. Catching this is a lookup problem with
+a definitive answer, so it stays deterministic rather than going to an
+LLM. Discovered via the skill registry when the ``vasp`` skill is active
+and called through
+:func:`scilink.skills._shared._registry.get_tool_function`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import warnings as _warnings
+from difflib import SequenceMatcher, get_close_matches
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..._shared._spec import ToolSpec
+
+
+# Tokens that appear inside legitimate INCAR values (e.g. ``LDAUL = 3 3
+# -1``, ``LSORBIT = .TRUE.``) rather than as standalone tags. Filtered out
+# of the suggestion pool so a value token is never proposed as a rename.
+_VASP_SUGGESTION_BLOCKLIST = {"TRUE", "FALSE"}
+
+
+def _load_valid_vasp_tags() -> List[str]:
+    """Return the canonical VASP INCAR-tag list bundled with pymatgen.
+
+    Returns:
+        The list of recognized INCAR tag names. Empty if pymatgen is
+        unavailable or the bundled tag JSON cannot be located, in which
+        case callers degrade gracefully (no rename suggestions).
+    """
+    try:
+        from pymatgen.io.vasp import inputs as _vasp_inputs
+    except Exception:
+        return []
+    tags_path = os.path.join(
+        os.path.dirname(_vasp_inputs.__file__), "incar_parameters.json"
+    )
+    if not os.path.exists(tags_path):
+        return []
+    try:
+        with open(tags_path) as f:
+            return list(json.load(f).keys())
+    except Exception:
+        return []
+
+
+def check_incar_syntax(incar_content: str) -> List[Dict[str, Any]]:
+    """Check a VASP INCAR for unrecognized tags via pymatgen.
+
+    Args:
+        incar_content: Raw INCAR text (not a path). Pass the file
+            contents, e.g. ``open(path).read()``.
+
+    Returns:
+        A list of issue dicts, one per unrecognized tag (possibly empty).
+        Each dict carries:
+
+            severity     ``"warning"``
+            category     ``"incar_tag"``
+            tag          The offending tag as written (str or None)
+            suggested    Closest valid VASP tag (str or None)
+            confidence   ``"high"`` or ``"low"``
+            description  Human-readable summary
+            source       ``"pymatgen Incar.check_params"``
+
+        ``confidence="high"`` requires the closest match to be at least
+        0.85 similar to the unrecognized tag and clearly better than the
+        runner-up (margin > 0.05). Only high-confidence entries are
+        consumed by :func:`apply_incar_syntax_fixes`; low-confidence
+        entries are returned as context for an LLM regenerator.
+    """
+    try:
+        from pymatgen.io.vasp.inputs import Incar
+    except Exception:
+        return []
+
+    try:
+        if hasattr(Incar, "from_str"):
+            incar = Incar.from_str(incar_content)
+        else:
+            incar = Incar.from_string(incar_content)  # older pymatgen
+    except Exception:
+        # Malformed INCAR — let VASP itself complain. This pass targets
+        # the "syntactically valid but contains a fake tag" failure mode.
+        return []
+
+    valid_tags = [
+        t for t in _load_valid_vasp_tags()
+        if t not in _VASP_SUGGESTION_BLOCKLIST
+    ]
+
+    issues: List[Dict[str, Any]] = []
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        try:
+            incar.check_params()
+        except Exception:
+            return []
+
+    for w in caught:
+        msg = str(w.message)
+        m = re.search(r"Cannot find\s+(\S+)", msg)
+        bad_tag = m.group(1).strip().strip(",.") if m else None
+
+        suggested: Optional[str] = None
+        confidence = "low"
+        if bad_tag and valid_tags:
+            matches = get_close_matches(
+                bad_tag.upper(), valid_tags, n=2, cutoff=0.7
+            )
+            if matches:
+                suggested = matches[0]
+                top_sim = SequenceMatcher(
+                    None, bad_tag.upper(), matches[0]
+                ).ratio()
+                runner_sim = (
+                    SequenceMatcher(None, bad_tag.upper(), matches[1]).ratio()
+                    if len(matches) > 1 else 0.0
+                )
+                if top_sim >= 0.85 and (top_sim - runner_sim) >= 0.05:
+                    confidence = "high"
+
+        issues.append({
+            "severity": "warning",
+            "category": "incar_tag",
+            "tag": bad_tag,
+            "suggested": suggested,
+            "confidence": confidence,
+            "description": (
+                f"INCAR tag '{bad_tag}' is not recognised by VASP. "
+                f"Closest match: {suggested}."
+                if bad_tag and suggested else msg
+            ),
+            "source": "pymatgen Incar.check_params",
+        })
+
+    return issues
+
+
+def apply_incar_syntax_fixes(
+    incar_content: str,
+    issues: Optional[List[Dict[str, Any]]] = None,
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """Apply high-confidence tag renames in place to an INCAR string.
+
+    Args:
+        incar_content: Raw INCAR text.
+        issues: Issues from a prior :func:`check_incar_syntax` call. When
+            omitted, the check is run inline.
+
+    Returns:
+        A ``(fixed_content, applied)`` tuple. ``fixed_content`` is the
+        possibly-modified INCAR text. ``applied`` is the subset of issues
+        whose rename actually fired, each augmented with ``renamed_from``
+        and ``renamed_to`` keys. Low-confidence issues are left untouched
+        for the caller to forward to an LLM regenerator.
+    """
+    if issues is None:
+        issues = check_incar_syntax(incar_content)
+
+    fixed = incar_content
+    applied: List[Dict[str, Any]] = []
+    for issue in issues:
+        if issue.get("category") != "incar_tag":
+            continue
+        if issue.get("confidence") != "high":
+            continue
+        bad = issue.get("tag")
+        good = issue.get("suggested")
+        if not bad or not good:
+            continue
+        # Only rename when ``bad`` is on the LHS of an assignment. The
+        # word-boundary regex + line anchor avoids touching value tokens
+        # that happen to share the spelling.
+        pattern = re.compile(rf"(?im)^(\s*){re.escape(bad)}(\s*=)")
+        new_fixed, n = pattern.subn(rf"\1{good}\2", fixed)
+        if n > 0:
+            fixed = new_fixed
+            applied.append({**issue, "renamed_from": bad, "renamed_to": good})
+    return fixed, applied
+
+
+def check_input_syntax(input_files: Dict[str, str]) -> List[Dict[str, Any]]:
+    """Engine-neutral pre-run syntax check entry point for VASP inputs.
+
+    This is the conventionally-named tool that an engine-neutral input
+    reviewer invokes (mirroring ``snapshot_run`` on the post-run side):
+    it accepts the full input-files mapping, selects the file this engine
+    knows how to check (the INCAR), and delegates to
+    :func:`check_incar_syntax`.
+
+    Args:
+        input_files: Mapping of input filename to file contents. The
+            entry whose name matches ``INCAR`` (case-insensitive) is
+            checked; other entries are ignored.
+
+    Returns:
+        The issue list from :func:`check_incar_syntax`, or an empty list
+        when no INCAR is present in ``input_files``.
+    """
+    for name, content in input_files.items():
+        if name.upper() == "INCAR" or name.upper().endswith("/INCAR"):
+            return check_incar_syntax(content or "")
+    return []
+
+
+def apply_input_syntax_fixes(
+    input_files: Dict[str, str],
+    issues: Optional[List[Dict[str, Any]]] = None,
+) -> Tuple[Dict[str, str], List[Dict[str, Any]]]:
+    """Engine-neutral pre-submit auto-fix entry point for VASP inputs.
+
+    The fix-side counterpart to :func:`check_input_syntax`: accepts the
+    full input-files mapping, applies high-confidence tag renames to the
+    file this engine knows how to fix (the INCAR), and returns the
+    updated mapping. The conventional auto-fix tool a generator invokes
+    to clean obvious typos before handing inputs off.
+
+    Args:
+        input_files: Mapping of input filename to file contents.
+        issues: Issues from a prior :func:`check_input_syntax` call. When
+            omitted, the check is run inline on the INCAR.
+
+    Returns:
+        A ``(fixed_files, applied)`` tuple. ``fixed_files`` is a shallow
+        copy of ``input_files`` with the INCAR entry replaced by its
+        fixed text (unchanged when no INCAR is present or no fix fires).
+        ``applied`` is the list of renames that fired, each with
+        ``renamed_from`` / ``renamed_to`` keys.
+    """
+    fixed_files = dict(input_files)
+    for name, content in input_files.items():
+        if name.upper() == "INCAR" or name.upper().endswith("/INCAR"):
+            fixed_text, applied = apply_incar_syntax_fixes(content or "", issues)
+            fixed_files[name] = fixed_text
+            return fixed_files, applied
+    return fixed_files, []
+
+
+TOOL_SPEC_INPUT_SYNTAX = ToolSpec(
+    name="check_input_syntax",
+    description=(
+        "Engine-neutral pre-run syntax check for VASP inputs: selects the "
+        "INCAR from the input-files mapping and deterministically flags "
+        "unrecognized tags. The conventional pre-run tool an input "
+        "reviewer invokes; no LLM call."
+    ),
+    parameters={
+        "input_files": {
+            "type": "object",
+            "description": (
+                "Mapping of input filename to contents; the INCAR entry "
+                "is selected and checked."
+            ),
+        },
+    },
+    required=["input_files"],
+    signature="check_input_syntax(input_files: dict) -> list[dict]",
+    import_line="from scilink.skills.periodic_dft.vasp.vasp_syntax import check_input_syntax",
+    agents=["simulation"],
+    returns="list of INCAR syntax issue dicts (empty when no INCAR present).",
+)
+
+TOOL_SPEC_CHECK = ToolSpec(
+    name="check_incar_syntax",
+    description=(
+        "Deterministically check a VASP INCAR for unrecognized tags "
+        "(typically typos) against pymatgen's canonical tag list. Returns "
+        "issue dicts with closest-match suggestions and a high/low "
+        "confidence rating. No LLM call."
+    ),
+    parameters={
+        "incar_content": {
+            "type": "string",
+            "description": "Raw INCAR text (file contents, not a path).",
+        },
+    },
+    required=["incar_content"],
+    signature="check_incar_syntax(incar_content: str) -> list[dict]",
+    import_line="from scilink.skills.periodic_dft.vasp.vasp_syntax import check_incar_syntax",
+    agents=["simulation"],
+    returns=(
+        "list of issue dicts: severity, category, tag, suggested, "
+        "confidence, description, source. Empty when no unrecognized tags."
+    ),
+)
+
+TOOL_SPEC_FIX = ToolSpec(
+    name="apply_incar_syntax_fixes",
+    description=(
+        "Apply high-confidence tag renames in place to a VASP INCAR "
+        "string (e.g. ISPN -> ISPIN). Low-confidence issues are left "
+        "untouched for LLM review. No LLM call."
+    ),
+    parameters={
+        "incar_content": {
+            "type": "string",
+            "description": "Raw INCAR text to fix.",
+        },
+        "issues": {
+            "type": "array",
+            "description": (
+                "Optional issues from a prior check_incar_syntax call. "
+                "When omitted, the check is run inline."
+            ),
+        },
+    },
+    required=["incar_content"],
+    signature=(
+        "apply_incar_syntax_fixes(incar_content: str, issues: list | None) "
+        "-> tuple[str, list[dict]]"
+    ),
+    import_line="from scilink.skills.periodic_dft.vasp.vasp_syntax import apply_incar_syntax_fixes",
+    agents=["simulation"],
+    returns="(fixed_incar_text, applied_renames) tuple.",
+)
+
+TOOL_SPEC_INPUT_FIX = ToolSpec(
+    name="apply_input_syntax_fixes",
+    description=(
+        "Engine-neutral pre-submit auto-fix for VASP inputs: applies "
+        "high-confidence tag renames to the INCAR in the input-files "
+        "mapping and returns the updated mapping. The conventional "
+        "auto-fix tool a generator invokes; no LLM call."
+    ),
+    parameters={
+        "input_files": {
+            "type": "object",
+            "description": "Mapping of input filename to contents.",
+        },
+        "issues": {
+            "type": "array",
+            "description": (
+                "Optional issues from a prior check_input_syntax call. "
+                "When omitted, the check is run inline."
+            ),
+        },
+    },
+    required=["input_files"],
+    signature=(
+        "apply_input_syntax_fixes(input_files: dict, issues: list | None) "
+        "-> tuple[dict, list[dict]]"
+    ),
+    import_line="from scilink.skills.periodic_dft.vasp.vasp_syntax import apply_input_syntax_fixes",
+    agents=["simulation"],
+    returns="(fixed_input_files, applied_renames) tuple.",
+)
+
+TOOL_SPECS = [
+    TOOL_SPEC_INPUT_SYNTAX,
+    TOOL_SPEC_INPUT_FIX,
+    TOOL_SPEC_CHECK,
+    TOOL_SPEC_FIX,
+]

--- a/scilink/ui/components/vasp_workflow.py
+++ b/scilink/ui/components/vasp_workflow.py
@@ -367,7 +367,7 @@ def _render_configure() -> None:
 
         # Stash files + draft SLURM script in session state.
         try:
-            poscar_text = Path(structure["poscar_path"]).read_text()
+            poscar_text = Path(structure["structure_path"]).read_text()
             incar_text = Path(structure["incar_path"]).read_text()
             kpoints_text = Path(structure["kpoints_path"]).read_text()
         except Exception as exc:
@@ -493,7 +493,7 @@ def _run_generation(
     # agent decided to refine; the wizard always uses the latest).
     candidate = new[-1]
     if not (
-        candidate.get("poscar_path")
+        candidate.get("structure_path")
         and candidate.get("incar_path")
         and candidate.get("kpoints_path")
     ):

--- a/scilink/ui/components/vasp_workflow.py
+++ b/scilink/ui/components/vasp_workflow.py
@@ -365,11 +365,15 @@ def _render_configure() -> None:
             )
             return
 
-        # Stash files + draft SLURM script in session state.
+        # Stash files + draft SLURM script in session state. The backend
+        # record stores a generic input_files map; this VASP wizard reads
+        # its engine's files (INCAR/KPOINTS) from it by name. (Engine-agnostic
+        # UI rework is a separate PR — see task list.)
         try:
+            files = structure.get("input_files") or {}
             poscar_text = Path(structure["structure_path"]).read_text()
-            incar_text = Path(structure["incar_path"]).read_text()
-            kpoints_text = Path(structure["kpoints_path"]).read_text()
+            incar_text = Path(files["INCAR"]).read_text() if files.get("INCAR") else ""
+            kpoints_text = Path(files["KPOINTS"]).read_text() if files.get("KPOINTS") else ""
         except Exception as exc:
             err_slot.error(f"Could not read generated files: {exc}")
             return
@@ -492,10 +496,11 @@ def _run_generation(
     # Use the most recent record (the call may have produced multiple if the
     # agent decided to refine; the wizard always uses the latest).
     candidate = new[-1]
+    files = candidate.get("input_files") or {}
     if not (
         candidate.get("structure_path")
-        and candidate.get("incar_path")
-        and candidate.get("kpoints_path")
+        and files.get("INCAR")
+        and files.get("KPOINTS")
     ):
         return None
     return candidate

--- a/tests/test_simulation_orchestrator.py
+++ b/tests/test_simulation_orchestrator.py
@@ -133,13 +133,24 @@ def test_2_tool_error_paths(model_name: str):
         ))
         assert r["status"] == "error" and "not found" in r["message"]
 
-        # generate_vasp_inputs with bad method
         fake = Path(td) / "POSCAR"
         fake.write_text("Si\n1.0\n3 0 0\n0 3 0\n0 0 3\nSi\n1\nDirect\n0 0 0\n")
+
+        # generate_dft_inputs with no engine selected (no routing, no software)
         r = json.loads(orch.tools.execute_tool(
-            "generate_vasp_inputs",
+            "generate_dft_inputs",
             structure_path=str(fake),
             request="test",
+        ))
+        assert r["status"] == "error" and "engine" in r["message"].lower()
+
+        # generate_dft_inputs with an explicit engine but an unknown method
+        # → the named-backend lookup misses in the skill bundle.
+        r = json.loads(orch.tools.execute_tool(
+            "generate_dft_inputs",
+            structure_path=str(fake),
+            request="test",
+            software="vasp",
             method="banana",
         ))
         assert r["status"] == "error" and "banana" in r["message"]
@@ -159,31 +170,30 @@ def test_2_tool_error_paths(model_name: str):
         ))
         assert r["status"] == "error"
 
-        # validate_incar without FH key returns 'skipped', not 'error'
-        fake_incar = Path(td) / "INCAR"
-        fake_incar.write_text("ENCUT = 400\n")
+        # validate_inputs with an engine but no generated inputs for the structure
         r = json.loads(orch.tools.execute_tool(
-            "validate_incar",
-            incar_path=str(fake_incar),
+            "validate_inputs",
+            structure_path=str(fake),
             system_description="test",
+            software="vasp",
         ))
-        assert r["status"] in ("skipped", "error")
+        assert r["status"] == "error" and "input files" in r["message"].lower()
 
-        # apply_incar_improvements with no adjustments
+        # apply_input_adjustments with no adjustments → no_changes (before engine work)
         r = json.loads(orch.tools.execute_tool(
-            "apply_incar_improvements",
-            incar_path=str(fake_incar),
+            "apply_input_adjustments",
             structure_path=str(fake),
             original_request="test",
             suggested_adjustments=[],
         ))
         assert r["status"] == "no_changes"
 
-        # suggest_incar_fixes on missing log
+        # analyze_output on a nonexistent run directory
         r = json.loads(orch.tools.execute_tool(
-            "suggest_incar_fixes",
-            log_path="/nope/log",
-            original_request="test",
+            "analyze_output",
+            output_dir="/nope/run",
+            research_goal="test",
+            software="vasp",
         ))
         assert r["status"] == "error"
 
@@ -195,12 +205,17 @@ def test_2_tool_error_paths(model_name: str):
 
 
 def test_3_post_run_analysis_synthetic(model_name: str):
-    """post_run_analysis works on synthetic log dirs without pymatgen-parseable files."""
-    from scilink.agents.sim_agents.post_run_analysis import analyze_run_directory
+    """The live VASP snapshot tool (skill bundle) handles synthetic run dirs.
+
+    Tests the engine-neutral live path: the vasp skill bundle's snapshot_run
+    tool, resolved via the registry (what RunCritic dispatches to).
+    """
+    from scilink.skills._shared._registry import get_tool_function
+    snapshot_run = get_tool_function("snapshot_run", active_skills=["vasp"])
 
     # Empty dir → status=ok, convergence=unknown
     with tempfile.TemporaryDirectory() as td:
-        r = analyze_run_directory(td)
+        r = snapshot_run(td)
         assert r["status"] == "ok"
         assert r["convergence_status"] == "unknown"
 
@@ -209,15 +224,15 @@ def test_3_post_run_analysis_synthetic(model_name: str):
         Path(td, "stdout").write_text(
             "running on 32 cores\nVERY BAD NEWS! internal error in subroutine SGRCON\n"
         )
-        r = analyze_run_directory(td)
+        r = snapshot_run(td)
         assert r["convergence_status"] == "failed"
         assert any("VERY BAD NEWS" in h for h in r["log_error_hints"])
 
     # Nonexistent dir → status=error
-    r = analyze_run_directory("/path/does/not/exist")
+    r = snapshot_run("/path/does/not/exist")
     assert r["status"] == "error"
 
-    print("   ✅ Post-run analysis: empty / failed / nonexistent dirs all handled")
+    print("   ✅ Live snapshot tool: empty / failed / nonexistent dirs all handled")
 
 
 def test_4_mode_switching(model_name: str):
@@ -251,8 +266,7 @@ def test_5_run_task_without_llm(model_name: str):
                 "slug": "fake_001",
                 "description": "test structure",
                 "structure_path": "/tmp/POSCAR",
-                "incar_path": None,
-                "kpoints_path": None,
+                "input_files": {},
                 "script_path": "/tmp/script.py",
                 "validation": {
                     "status": "needs_correction",
@@ -270,7 +284,7 @@ def test_5_run_task_without_llm(model_name: str):
         assert orch.simulation_mode == SimulationMode.CO_PILOT  # restored
         assert "/tmp/POSCAR" in result["files_produced"]
         assert any("Vacuum" in f for f in result["key_findings"])
-        assert any("VASP inputs" in f for f in result["suggested_followups"])
+        assert any("Generate inputs" in f for f in result["suggested_followups"])
         assert any("unresolved" in w for w in result["warnings"])
 
         # Error path: chat raises → mode still restored, status=error
@@ -320,9 +334,10 @@ def test_7_hpc_tools_no_connection(model_name: str):
         orch = _make_orch(model_name, td + "/sim")
 
         for tool, kwargs in [
-            ("submit_vasp_job",       {"structure_slug": "x", "remote_dir": "/tmp"}),
+            ("submit_simulation_job", {"structure_slug": "x", "remote_dir": "/tmp",
+                                       "run_command": "srun vasp_std"}),
             ("get_job_status",        {"job_id": "12345"}),
-            ("download_vasp_results", {"job_id": "12345"}),
+            ("download_job_results",  {"job_id": "12345"}),
             ("generate_final_report", {"structure_slug": "x"}),
         ]:
             r = json.loads(orch.tools.execute_tool(tool, **kwargs))
@@ -380,22 +395,22 @@ def test_8_hpc_tools_mock_connection(model_name: str):
             "description": "bulk silicon",
             "structure_dir": str(struct_dir),
             "structure_path": str(poscar),
-            "incar_path": str(incar),
-            "kpoints_path": str(kpoints),
+            "input_files": {"INCAR": str(incar), "KPOINTS": str(kpoints)},
             "hpc_job_id": None,
             "hpc_remote_dir": None,
             "hpc_results_dir": None,
             "validation": {"status": "success", "overall_assessment": "Looks good.",
                            "all_identified_issues": []},
-            "vasp_summary": "Static SCF, ENCUT=400",
+            "summary": "Static SCF, ENCUT=400",
             "created_at": datetime.now().isoformat(),
         })
 
-        # 1. submit_vasp_job
+        # 1. submit_simulation_job
         r = json.loads(orch.tools.execute_tool(
-            "submit_vasp_job",
+            "submit_simulation_job",
             structure_slug=slug,
             remote_dir="/scratch/test",
+            run_command="srun vasp_std",
             job_name="si_test",
             n_nodes=1,
             n_tasks=8,
@@ -405,7 +420,7 @@ def test_8_hpc_tools_mock_connection(model_name: str):
         assert r["job_id"] == "99999"
         mock_conn.upload.assert_called()
         mock_sched.submit.assert_called_once()
-        print("   ✅ submit_vasp_job: uploaded files, submitted job, got job_id=99999")
+        print("   ✅ submit_simulation_job: uploaded files, submitted job, got job_id=99999")
 
         # 2. get_job_status
         r = json.loads(orch.tools.execute_tool("get_job_status", job_id="99999"))
@@ -422,10 +437,10 @@ def test_8_hpc_tools_mock_connection(model_name: str):
                 Path(local).write_text(f"fake {fname} content")
         mock_conn.download = MagicMock(side_effect=fake_download)
 
-        r = json.loads(orch.tools.execute_tool("download_vasp_results", job_id="99999"))
+        r = json.loads(orch.tools.execute_tool("download_job_results", job_id="99999"))
         assert r["status"] == "success", f"download failed: {r}"
         assert "OUTCAR" in r["downloaded"] or "vasp.stdout" in r["downloaded"]
-        print(f"   ✅ download_vasp_results: got {r['downloaded']}")
+        print(f"   ✅ download_job_results: got {r['downloaded']}")
 
         # 4. generate_final_report
         r = json.loads(orch.tools.execute_tool(
@@ -436,7 +451,7 @@ def test_8_hpc_tools_mock_connection(model_name: str):
         report = r["report"]
         assert "bulk silicon" in report
         assert "99999" in report  # job ID in report
-        assert "VASP DFT Simulation Report" in report
+        assert "Simulation Report" in report
         print(f"   ✅ generate_final_report: written to {r['report_path']}")
 
     print("   ✅ Full offline HPC flow: submit → status → download → report")
@@ -457,7 +472,7 @@ def stress_1_generate_then_inputs(model_name: str):
     response = orch.chat(
         "Build a 2x2x1 supercell of bulk silicon (mp-149) and then generate "
         "static VASP inputs for a single-point calculation. Use the granular "
-        "tools (generate_structure, then generate_vasp_inputs)."
+        "tools (generate_structure, then generate_dft_inputs)."
     )
     print("   --- agent response (last 400 chars) ---")
     print("   " + response[-400:].replace("\n", "\n   "))
@@ -468,9 +483,10 @@ def stress_1_generate_then_inputs(model_name: str):
     assert Path(s["structure_path"]).exists(), f"POSCAR missing: {s['structure_path']}"
     print(f"   ✅ POSCAR produced: {s['structure_path']}")
 
-    if s.get("incar_path"):
-        assert Path(s["incar_path"]).exists()
-        print(f"   ✅ INCAR produced: {s['incar_path']}")
+    incar_path = (s.get("input_files") or {}).get("INCAR")
+    if incar_path:
+        assert Path(incar_path).exists()
+        print(f"   ✅ INCAR produced: {incar_path}")
     else:
         print("   ⚠️  Agent built the structure but didn't generate INCAR — "
               "may have stopped to ask. Acceptable for a stress test.")
@@ -496,7 +512,7 @@ def stress_2_post_run_analysis_failure(model_name: str):
     orch = _make_orch(model_name, str(workdir / "sim"), autonomy="autonomous")
     response = orch.chat(
         f"I ran VASP and the calculation failed. Output files are in "
-        f"{fake_run_dir}. Use analyze_vasp_output to read the run, summarize "
+        f"{fake_run_dir}. Use analyze_output to read the run, summarize "
         f"what happened, and recommend INCAR adjustments."
     )
     print("   --- agent response (last 600 chars) ---")
@@ -633,12 +649,11 @@ def stress_5_hpc_workflow_mocked(model_name: str):
         "description": "2x2x2 bulk silicon supercell",
         "structure_dir": str(struct_dir),
         "structure_path": str(poscar),
-        "incar_path": str(incar),
-        "kpoints_path": str(kpoints),
+        "input_files": {"INCAR": str(incar), "KPOINTS": str(kpoints)},
         "hpc_job_id": None,
         "hpc_remote_dir": None,
         "hpc_results_dir": None,
-        "vasp_summary": "Static SCF, ENCUT=520",
+        "summary": "Static SCF, ENCUT=520",
         "validation": {"status": "success", "overall_assessment": "Structure looks correct.",
                        "all_identified_issues": []},
         "created_at": datetime.now().isoformat(),
@@ -683,7 +698,7 @@ def e2e_1_run_task_minimal_structure(model_name: str):
     result = orch.run_task(
         "Build a 2x2x2 supercell of bulk silicon (mp-149, Fd-3m) and "
         "generate VASP inputs for a static SCF calculation. Use the "
-        "granular tools (generate_structure, then generate_vasp_inputs)."
+        "granular tools (generate_structure, then generate_dft_inputs)."
     )
 
     print(f"   status: {result['status']}")
@@ -778,12 +793,11 @@ def integration_1_hpc_slurm(model_name: str):
         "description": "bulk silicon integration test",
         "structure_dir": str(struct_dir),
         "structure_path": str(poscar),
-        "incar_path": str(incar),
-        "kpoints_path": str(kpoints),
+        "input_files": {"INCAR": str(incar), "KPOINTS": str(kpoints)},
         "hpc_job_id": None,
         "hpc_remote_dir": None,
         "hpc_results_dir": None,
-        "vasp_summary": "Static SCF, ENCUT=520",
+        "summary": "Static SCF, ENCUT=520",
         "validation": None,
         "created_at": datetime.now().isoformat(),
     })
@@ -798,14 +812,14 @@ def integration_1_hpc_slurm(model_name: str):
         "echo '  1 F= -.100E+03 E0= -.100E+03 d E =0.000' > OSZICAR"
     )
     r = json.loads(orch.tools.execute_tool(
-        "submit_vasp_job",
+        "submit_simulation_job",
         structure_slug=slug,
         remote_dir=remote_dir,
+        run_command=fake_vasp,
         job_name="scilink_test",
         n_nodes=1,
         n_tasks=1,
         time_limit="00:05:00",
-        vasp_command=fake_vasp,
     ))
     assert r["status"] == "success", f"submit failed: {r}"
     job_id = r["job_id"]
@@ -827,7 +841,7 @@ def integration_1_hpc_slurm(model_name: str):
     print(f"   ✅ Job {job_id} completed")
 
     # Download
-    r = json.loads(orch.tools.execute_tool("download_vasp_results", job_id=job_id))
+    r = json.loads(orch.tools.execute_tool("download_job_results", job_id=job_id))
     assert r["status"] == "success", f"download failed: {r}"
     assert r["downloaded"], "No files downloaded"
     print(f"   ✅ Downloaded: {r['downloaded']}")

--- a/tests/test_simulation_orchestrator.py
+++ b/tests/test_simulation_orchestrator.py
@@ -128,7 +128,7 @@ def test_2_tool_error_paths(model_name: str):
         # validate_structure on missing file
         r = json.loads(orch.tools.execute_tool(
             "validate_structure",
-            poscar_path="/nonexistent/POSCAR",
+            structure_path="/nonexistent/POSCAR",
             original_request="test",
         ))
         assert r["status"] == "error" and "not found" in r["message"]
@@ -138,7 +138,7 @@ def test_2_tool_error_paths(model_name: str):
         fake.write_text("Si\n1.0\n3 0 0\n0 3 0\n0 0 3\nSi\n1\nDirect\n0 0 0\n")
         r = json.loads(orch.tools.execute_tool(
             "generate_vasp_inputs",
-            poscar_path=str(fake),
+            structure_path=str(fake),
             request="test",
             method="banana",
         ))
@@ -147,7 +147,7 @@ def test_2_tool_error_paths(model_name: str):
         # refine_structure on a path with no session record
         r = json.loads(orch.tools.execute_tool(
             "refine_structure",
-            poscar_path=str(fake),
+            structure_path=str(fake),
             original_request="test",
         ))
         assert r["status"] == "error" and "No record found" in r["message"]
@@ -155,7 +155,7 @@ def test_2_tool_error_paths(model_name: str):
         # view_structure on missing file
         r = json.loads(orch.tools.execute_tool(
             "view_structure",
-            poscar_path="/nope/POSCAR",
+            structure_path="/nope/POSCAR",
         ))
         assert r["status"] == "error"
 
@@ -173,7 +173,7 @@ def test_2_tool_error_paths(model_name: str):
         r = json.loads(orch.tools.execute_tool(
             "apply_incar_improvements",
             incar_path=str(fake_incar),
-            poscar_path=str(fake),
+            structure_path=str(fake),
             original_request="test",
             suggested_adjustments=[],
         ))
@@ -250,7 +250,7 @@ def test_5_run_task_without_llm(model_name: str):
             orch.generated_structures.append({
                 "slug": "fake_001",
                 "description": "test structure",
-                "poscar_path": "/tmp/POSCAR",
+                "structure_path": "/tmp/POSCAR",
                 "incar_path": None,
                 "kpoints_path": None,
                 "script_path": "/tmp/script.py",
@@ -292,7 +292,7 @@ def test_6_session_persistence(model_name: str):
         orch.generated_structures.append({
             "slug": "persist_001",
             "description": "survival test",
-            "poscar_path": "/tmp/POSCAR",
+            "structure_path": "/tmp/POSCAR",
         })
         orch.default_calc_params = {"ENCUT": 520, "kpoint_density": 30}
         # Force a checkpoint write
@@ -379,7 +379,7 @@ def test_8_hpc_tools_mock_connection(model_name: str):
             "slug": slug,
             "description": "bulk silicon",
             "structure_dir": str(struct_dir),
-            "poscar_path": str(poscar),
+            "structure_path": str(poscar),
             "incar_path": str(incar),
             "kpoints_path": str(kpoints),
             "hpc_job_id": None,
@@ -465,8 +465,8 @@ def stress_1_generate_then_inputs(model_name: str):
     structures = orch.generated_structures
     assert structures, "Agent did not record any generated structures"
     s = structures[-1]
-    assert Path(s["poscar_path"]).exists(), f"POSCAR missing: {s['poscar_path']}"
-    print(f"   ✅ POSCAR produced: {s['poscar_path']}")
+    assert Path(s["structure_path"]).exists(), f"POSCAR missing: {s['structure_path']}"
+    print(f"   ✅ POSCAR produced: {s['structure_path']}")
 
     if s.get("incar_path"):
         assert Path(s["incar_path"]).exists()
@@ -569,7 +569,7 @@ def stress_4_aimsgb_skill_loaded(model_name: str):
     assert "GrainBoundary" in script_text, "Script should use GrainBoundary"
     assert "build_gb" in script_text, "Script should call .build_gb()"
 
-    poscar = Path(s["poscar_path"])
+    poscar = Path(s["structure_path"])
     assert poscar.exists(), f"POSCAR missing: {poscar}"
 
     from ase.io import read as ase_read
@@ -632,7 +632,7 @@ def stress_5_hpc_workflow_mocked(model_name: str):
         "slug": "si_bulk_001",
         "description": "2x2x2 bulk silicon supercell",
         "structure_dir": str(struct_dir),
-        "poscar_path": str(poscar),
+        "structure_path": str(poscar),
         "incar_path": str(incar),
         "kpoints_path": str(kpoints),
         "hpc_job_id": None,
@@ -694,8 +694,8 @@ def e2e_1_run_task_minimal_structure(model_name: str):
     assert result["status"] == "success", f"run_task failed: {result.get('error')}"
     assert result["structures"], "No structures recorded"
     s = result["structures"][0]
-    assert Path(s["poscar_path"]).exists(), "POSCAR not on disk"
-    print(f"   ✅ run_task produced a structure at {s['poscar_path']}")
+    assert Path(s["structure_path"]).exists(), "POSCAR not on disk"
+    print(f"   ✅ run_task produced a structure at {s['structure_path']}")
 
 
 # ---------------------------------------------------------------------------
@@ -777,7 +777,7 @@ def integration_1_hpc_slurm(model_name: str):
         "slug": slug,
         "description": "bulk silicon integration test",
         "structure_dir": str(struct_dir),
-        "poscar_path": str(poscar),
+        "structure_path": str(poscar),
         "incar_path": str(incar),
         "kpoints_path": str(kpoints),
         "hpc_job_id": None,

--- a/tests/test_simulation_orchestrator.py
+++ b/tests/test_simulation_orchestrator.py
@@ -89,21 +89,21 @@ def _make_orch(model_name: str, base_dir: str, autonomy: str = "co-pilot"):
 EXPECTED_TOOLS = {
     "session_status",
     "generate_structure",
+    "plan_structure",
     "validate_structure",
-    "generate_vasp_inputs",
+    "generate_dft_inputs",
     "run_complete_dft_workflow",
     "refine_structure",
     "view_structure",
-    "validate_incar",
-    "apply_incar_improvements",
+    "validate_inputs",
+    "apply_input_adjustments",
     "list_generated_structures",
-    "analyze_vasp_output",
-    "suggest_incar_fixes",
+    "analyze_output",
     "route_simulation",
     # HPC tools
-    "submit_vasp_job",
+    "submit_simulation_job",
     "get_job_status",
-    "download_vasp_results",
+    "download_job_results",
     "generate_final_report",
 }
 

--- a/tests/test_vasp_syntax.py
+++ b/tests/test_vasp_syntax.py
@@ -1,0 +1,139 @@
+"""Deterministic-layer tests for the VASP INCAR syntax tools.
+
+Covers the engine-native syntax check that lives in the VASP skill
+bundle (``scilink/skills/periodic_dft/vasp/vasp_syntax.py``): unrecognized
+tag detection, closest-match suggestions, high/low confidence rating,
+the in-place auto-rename, the engine-neutral ``check_input_syntax``
+entry point, and resolution through the skill registry. No LLM, no VASP
+run, no API key required.
+
+Requires pymatgen for the canonical tag list; tests that depend on it
+skip cleanly when it is unavailable.
+"""
+
+import pytest
+
+pytest.importorskip("pymatgen")
+
+from scilink.skills.periodic_dft.vasp.vasp_syntax import (
+    apply_incar_syntax_fixes,
+    apply_input_syntax_fixes,
+    check_incar_syntax,
+    check_input_syntax,
+)
+
+
+CLEAN_INCAR = "ISPIN = 2\nENCUT = 400\nGGA = PE\nISMEAR = 1\nSIGMA = 0.1\n"
+TYPO_INCAR = "ISPN = 2\nENCUT = 400\nGGA = PE\n"  # ISPN should be ISPIN
+
+
+# ── check_incar_syntax ────────────────────────────────────────
+
+class TestCheckIncarSyntax:
+    def test_clean_incar_has_no_issues(self):
+        assert check_incar_syntax(CLEAN_INCAR) == []
+
+    def test_typo_is_flagged_with_high_confidence_suggestion(self):
+        issues = check_incar_syntax(TYPO_INCAR)
+        assert len(issues) == 1
+        issue = issues[0]
+        assert issue["tag"] == "ISPN"
+        assert issue["suggested"] == "ISPIN"
+        assert issue["confidence"] == "high"
+        assert issue["category"] == "incar_tag"
+
+    def test_prose_without_assignments_returns_empty(self):
+        # No ``key = value`` lines means no tags to validate — the pass
+        # is specifically for valid-looking INCARs with a fake tag.
+        assert check_incar_syntax("just some notes\nnothing assigned here\n") == []
+
+    def test_empty_content_returns_empty(self):
+        assert check_incar_syntax("") == []
+
+
+# ── check_input_syntax (engine-neutral entry point) ───────────
+
+class TestCheckInputSyntax:
+    def test_selects_incar_from_mapping(self):
+        issues = check_input_syntax({"INCAR": TYPO_INCAR, "KPOINTS": "auto"})
+        assert len(issues) == 1
+        assert issues[0]["tag"] == "ISPN"
+
+    def test_no_incar_present_returns_empty(self):
+        assert check_input_syntax({"KPOINTS": "auto", "POSCAR": "..."}) == []
+
+    def test_clean_incar_in_mapping_returns_empty(self):
+        assert check_input_syntax({"INCAR": CLEAN_INCAR}) == []
+
+
+# ── apply_incar_syntax_fixes ──────────────────────────────────
+
+class TestApplyIncarSyntaxFixes:
+    def test_high_confidence_typo_is_renamed(self):
+        fixed, applied = apply_incar_syntax_fixes(TYPO_INCAR)
+        assert "ISPIN = 2" in fixed
+        assert "ISPN = 2" not in fixed
+        assert len(applied) == 1
+        assert applied[0]["renamed_from"] == "ISPN"
+        assert applied[0]["renamed_to"] == "ISPIN"
+
+    def test_clean_incar_is_unchanged(self):
+        fixed, applied = apply_incar_syntax_fixes(CLEAN_INCAR)
+        assert fixed == CLEAN_INCAR
+        assert applied == []
+
+    def test_value_tokens_are_not_renamed(self):
+        # A value token that happens to share a tag spelling must not be
+        # rewritten — only left-hand-side assignments are touched.
+        incar = "LDAUL = 3 3 -1\nISPIN = 2\n"
+        fixed, applied = apply_incar_syntax_fixes(incar)
+        assert fixed == incar
+        assert applied == []
+
+
+# ── apply_input_syntax_fixes (engine-neutral entry point) ─────
+
+class TestApplyInputSyntaxFixes:
+    def test_fixes_incar_in_mapping_and_preserves_others(self):
+        files = {"INCAR": TYPO_INCAR, "KPOINTS": "auto"}
+        fixed_files, applied = apply_input_syntax_fixes(files)
+        assert "ISPIN = 2" in fixed_files["INCAR"]
+        assert fixed_files["KPOINTS"] == "auto"
+        assert len(applied) == 1
+        # Original mapping is not mutated in place.
+        assert "ISPN = 2" in files["INCAR"]
+
+    def test_no_incar_present_returns_input_unchanged(self):
+        files = {"KPOINTS": "auto", "POSCAR": "..."}
+        fixed_files, applied = apply_input_syntax_fixes(files)
+        assert fixed_files == files
+        assert applied == []
+
+    def test_clean_incar_returns_unchanged(self):
+        files = {"INCAR": CLEAN_INCAR}
+        fixed_files, applied = apply_input_syntax_fixes(files)
+        assert fixed_files["INCAR"] == CLEAN_INCAR
+        assert applied == []
+
+
+# ── registry resolution ───────────────────────────────────────
+
+class TestRegistryResolution:
+    def test_check_input_syntax_resolves_via_registry(self):
+        from scilink.skills._shared._registry import get_tool_function
+        fn = get_tool_function("check_input_syntax", active_skills=["vasp"])
+        issues = fn(input_files={"INCAR": TYPO_INCAR})
+        assert len(issues) == 1
+        assert issues[0]["suggested"] == "ISPIN"
+
+    def test_unknown_skill_raises_lookup_error(self):
+        from scilink.skills._shared._registry import get_tool_function
+        with pytest.raises(LookupError):
+            get_tool_function("check_input_syntax", active_skills=["nonexistent_engine"])
+
+    def test_apply_input_syntax_fixes_resolves_via_registry(self):
+        from scilink.skills._shared._registry import get_tool_function
+        fn = get_tool_function("apply_input_syntax_fixes", active_skills=["vasp"])
+        fixed_files, applied = fn(input_files={"INCAR": TYPO_INCAR})
+        assert "ISPIN = 2" in fixed_files["INCAR"]
+        assert len(applied) == 1


### PR DESCRIPTION
# Engine-neutral simulation architecture (critics + scale-agnostic pipeline + skill-bundle tools)

## Summary

Refactors the simulation (`simulate`) side so the orchestrator, critics, and
tool surface are **engine-neutral**: engine-specific knowledge (VASP INCAR
conventions, syntax rules, output parsing, generation backends) lives in skill
bundles, and the shared code contains no hardcoded engine names, filenames, or
per-engine dispatch maps. Adding a new engine (QE) or scale (molecular DFT,
MD) becomes a new skill bundle and/or foundation agent — not edits to shared
code.

VASP is the worked example throughout; the next PR (LAMMPS as a second engine)
is intended as the extensibility proof — it should touch ~zero shared code.

## What's in it

**Engine-neutral critics** (`scilink/agents/sim_agents/critics.py`)
- `InputValidator` — pre-run review. Combines three grounding sources into one
  pass: the engine's deterministic syntax check, a literature-grounded review
  (when a FutureHouse key is configured), and the active skill's `validation`
  guidance + LLM judgment.
- `RunCritic` — post-run review. Reads a finished run directory and the skill's
  `interpretation` guidance; returns a verdict and, when warranted, proposed
  input patches. Handles failed and successful runs in one call.
- Both are skill-driven and contain no engine-specific code. They consolidate
  the prior VASP-only critic classes (`IncarValidatorAgent`, `VaspUpdater`,
  `VaspQualityAgent`).

**Skill-bundle tool resolution** (`scilink/skills/_shared/_registry.py`)
- New `get_tool_function(name, active_skills=[...])` resolves a `TOOL_SPEC`
  name to its callable from the active skill bundle — completing the TOOL_SPEC
  system (specs were discoverable but never resolved to callables). Engine
  helpers now live in their bundle and are reached via the registry, not
  central dispatch or by-path imports.
- VASP bundle gains: `vasp_output.py` (`snapshot_run`), `vasp_syntax.py`
  (`check_input_syntax` / `apply_input_syntax_fixes` + INCAR primitives),
  `vasp_atomate2.py` (`generate_inputs_atomate2`). VASP physics knowledge is
  authored as prose in `vasp.md`'s `validation` / `interpretation` sections.

**Scale-agnostic pipeline** (`scilink/agents/sim_agents/simulation_pipeline.py`)
- `run_complete_workflow(scale=, software=, method=)` — a deterministic
  structure → inputs → validation sequence for any scale, routing input
  generation to the scale's foundation agent and validating via the critics.
  Replaces the per-scale orchestrator classes. `DFTOrchestrator` is reduced to
  a thin deprecation shim that delegates here (`LAMMPSOrchestrator` gets the
  same treatment in the LAMMPS PR).

**Engine-neutral orchestrator tool surface**
(`simulation_orchestrator_tools.py`, `simulation_orchestrator.py`)
- Tools: `generate_dft_inputs(software=, method=)`, `validate_inputs`,
  `analyze_output`, `apply_input_adjustments`, `submit_simulation_job
  (run_command=)`, `download_job_results`, etc.
- Generic session record: `input_files: {filename: path}` instead of
  `incar_path` / `kpoints_path`; `structure_path` instead of `poscar_path`;
  `run_command` instead of a `vasp_std` default; generic report title.

## Notable decisions

- **Literature-grounded validation is preserved and generalized.** The
  FutureHouse CROW mechanism was already engine-neutral; only the query was
  VASP-shaped. It's now folded into `InputValidator` with an engine-neutral
  query, gated on a key, degrading gracefully when absent.
- **atomate2 is a generation *method*, not an engine** — it lives in the VASP
  bundle as a tool (`generate_inputs_atomate2`); `method='llm'` is the agent
  baseline, named methods are bundle tools.
- **The old VASP-specific critics are retained as a labeled benchmark
  baseline** (module-docstring banners; off the live path) for an old-vs-new
  critic comparison in the paper benchmarks — not deleted.

## Testing

- `tests/test_vasp_syntax.py` (new) — 14 deterministic tests (no LLM/API key)
  for the syntax tools + registry resolution.
- `tests/test_simulation_orchestrator.py` — targeted (no-LLM) suite updated to
  the new tool surface; all 8 pass, including the full mocked HPC flow.
- Construction + import checks across the orchestrator / pipeline / critics.

## Scope boundaries / follow-ups

- **Engine-agnostic UI** is a deliberate separate PR — this PR only updates the
  prototype UI/CLI *reads* to the new record shape so they don't break.
- **LAMMPS (second engine)** is the next PR, branched off this one.
- **Benchmark/eval harness** now lives in a dedicated repo
  (`SciLink-Benchmarks`), depending on SciLink as a pinned install — so this
  PR is library-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
