### PR TITLE
Persistent memory: feedback/error capture + opt-in on/off switch + plain-language UI

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1886,6 +1886,8 @@ class HumanFeedbackRefinementController:
                     state = self._get_human_feedback(state)
                     if state.pop("_refine_requested", False):
                         feedback = state.pop("_refine_feedback", "")
+                        if feedback:
+                            state.setdefault("human_feedback_log", []).append(str(feedback))
                         self.logger.info(f"  Refining with feedback: {feedback}")
                         print("\n🔄 Refining plan...\n")
                         state = self._refine_plan(state, feedback)
@@ -3271,6 +3273,11 @@ Return JSON with the refined fitting approach:
             return False
 
     def _refine_model_from_feedback(self, state: dict, feedback: str) -> dict:
+        # Persist the applied feedback so it survives to end-of-run (the staging
+        # hook distills human corrections into skills). Feedback is otherwise
+        # consumed transiently in-flight.
+        if feedback:
+            state.setdefault("human_feedback_log", []).append(str(feedback))
         config = state.get("locked_fitting_config", {})
         prompt = f"""Refine the fitting approach based on user feedback.
 

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -1673,6 +1673,8 @@ class ImagePlanningController:
                     state = self._get_human_feedback(state)
                     if state.pop("_refine_requested", False):
                         feedback = state.pop("_refine_feedback", "")
+                        if feedback:
+                            state.setdefault("human_feedback_log", []).append(str(feedback))
                         self.logger.info(f"  Refining with feedback: {feedback}")
                         print("\nRefining plan...\n")
                         state = self._refine_plan(state, feedback)
@@ -3499,6 +3501,7 @@ Return JSON with:
                         state, best_result, best_score
                     )
                     if user_feedback:
+                        state.setdefault("human_feedback_log", []).append(str(user_feedback))
                         best_result, best_score = self._apply_user_feedback(
                             state, user_feedback, best_result, best_score,
                             image_data, data_path, image_name,

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -790,6 +790,13 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         if staged:
             final_results["staged_solutions"] = staged
 
+        # Also stage human-feedback + resolved-error knowledge (the signals the
+        # old in-session distillation used), so they persist and flow through the
+        # same review/upgrade/consolidate path. Failure-isolated.
+        fb_staged = self._maybe_stage_feedback_errors(state, final_results)
+        if fb_staged:
+            final_results.setdefault("staged_solutions", []).extend(fb_staged)
+
         self.logger.info("")
         self.logger.info("✅ ANALYSIS COMPLETE")
         self.logger.info(f"   Results: {results_path}")
@@ -1143,6 +1150,51 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 f"`scilink memory staged` (upgrade an existing skill or consolidate)."
             )
         return staged
+
+    def _maybe_stage_feedback_errors(self, state: dict, final_results: dict) -> List[str]:
+        """Stage human-feedback + resolved-error knowledge for later distillation.
+
+        Complements the T=2 hook: captures the two signals the old in-session
+        distillation used (user feedback, recurring errors that were fixed) into
+        the same persistent staging buffer so they survive the session and flow
+        through the review-gated upgrade/consolidate path. Fully failure-isolated;
+        ``SCILINK_FEEDBACK_AUTODISTILL=0`` disables it.
+        """
+        flag = os.environ.get("SCILINK_FEEDBACK_AUTODISTILL", "").strip().lower()
+        if flag in ("0", "false", "off", "no"):
+            return []
+        try:
+            from .instruct import T2_TECHNIQUE_LABEL_INSTRUCTIONS
+            from scilink.skills._shared import _staging
+
+            def _llm_call(prompt: str) -> str:
+                response = self.model.generate_content(
+                    contents=[prompt],
+                    generation_config=self.generation_config,
+                    safety_settings=self.safety_settings,
+                )
+                return response.text if hasattr(response, "text") else str(response)
+
+            # Curve-fit feedback is captured durably in state["human_feedback_log"]
+            # (the controller persists it as it is applied — see
+            # curve_fitting_controllers); the top-level result does not carry it.
+            staged = _staging.stage_feedback_and_errors(
+                "curve_fitting",
+                results=state.get("series_results", []) or [],
+                feedback_texts=state.get("human_feedback_log") or [],
+                session=self.output_dir.name,
+                llm_call=_llm_call,
+                label_template=T2_TECHNIQUE_LABEL_INSTRUCTIONS,
+            )
+            if staged:
+                self.logger.info(
+                    f"   🧠 {len(staged)} feedback/error solution(s) staged; review "
+                    f"with `scilink memory staged`."
+                )
+            return staged
+        except Exception as e:
+            self.logger.warning(f"Feedback/error staging skipped: {e}")
+            return []
 
     def _compile_results(self, state: dict) -> Dict[str, Any]:
         """Compile results into a consistent output structure."""

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -1066,6 +1066,9 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         failure-isolated: any error is logged and swallowed so staging never
         affects the user's fit. ``SCILINK_T2_AUTODISTILL=0`` disables staging.
         """
+        from scilink.skills.loader import memory_enabled
+        if not memory_enabled():
+            return []
         flag = os.environ.get("SCILINK_T2_AUTODISTILL", "").strip().lower()
         if flag in ("0", "false", "off", "no"):
             return []
@@ -1160,6 +1163,9 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         through the review-gated upgrade/consolidate path. Fully failure-isolated;
         ``SCILINK_FEEDBACK_AUTODISTILL=0`` disables it.
         """
+        from scilink.skills.loader import memory_enabled
+        if not memory_enabled():
+            return []
         flag = os.environ.get("SCILINK_FEEDBACK_AUTODISTILL", "").strip().lower()
         if flag in ("0", "false", "off", "no"):
             return []

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -600,6 +600,12 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         if staged:
             final_results["staged_solutions"] = staged
 
+        # Also stage human-feedback + resolved-error knowledge (persistent
+        # complement to the old in-session distillation). Failure-isolated.
+        fb_staged = self._maybe_stage_feedback_errors(tier1_state, final_results)
+        if fb_staged:
+            final_results.setdefault("staged_solutions", []).extend(fb_staged)
+
         # Save final merged results
         results_path = self.output_dir / "analysis_results.json"
         with open(results_path, "w") as f:
@@ -872,6 +878,50 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 f"`scilink memory staged`."
             )
         return staged
+
+    def _maybe_stage_feedback_errors(self, state: dict, final_results: dict) -> List[str]:
+        """Image-side mirror of the feedback/error staging hook (see the curve-
+        fitting agent). Persists human feedback + resolved-error lessons into the
+        same staging buffer. Failure-isolated; ``SCILINK_FEEDBACK_AUTODISTILL=0``
+        disables it."""
+        flag = os.environ.get("SCILINK_FEEDBACK_AUTODISTILL", "").strip().lower()
+        if flag in ("0", "false", "off", "no"):
+            return []
+        try:
+            from .instruct import T2_TECHNIQUE_LABEL_INSTRUCTIONS
+            from scilink.skills._shared import _staging
+
+            def _llm_call(prompt: str) -> str:
+                response = self.model.generate_content(
+                    contents=[prompt],
+                    generation_config=self.generation_config,
+                    safety_settings=self.safety_settings,
+                )
+                return response.text if hasattr(response, "text") else str(response)
+
+            # Image feedback is attached to the result by the feedback mixin
+            # (refined_result["human_feedback"]); also honor a state log if present.
+            hf = (final_results or {}).get("human_feedback")
+            fb_texts = list(state.get("human_feedback_log") or [])
+            if isinstance(hf, dict) and (hf.get("user_feedback") or "").strip():
+                fb_texts.append(hf["user_feedback"])
+            staged = _staging.stage_feedback_and_errors(
+                "image_analysis",
+                results=state.get("series_results", []) or [],
+                feedback_texts=fb_texts,
+                session=self.output_dir.name,
+                llm_call=_llm_call,
+                label_template=T2_TECHNIQUE_LABEL_INSTRUCTIONS,
+            )
+            if staged:
+                self.logger.info(
+                    f"   🧠 {len(staged)} feedback/error solution(s) staged; review "
+                    f"with `scilink memory staged`."
+                )
+            return staged
+        except Exception as e:
+            self.logger.warning(f"Feedback/error staging skipped: {e}")
+            return []
 
     def _evaluate_tier2_needed(
         self, tier1_results: dict, objective: Optional[str]

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -800,6 +800,9 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         Returns the list of staged solution ids. Fully failure-isolated.
         ``SCILINK_T2_AUTODISTILL=0`` disables staging.
         """
+        from scilink.skills.loader import memory_enabled
+        if not memory_enabled():
+            return []
         flag = os.environ.get("SCILINK_T2_AUTODISTILL", "").strip().lower()
         if flag in ("0", "false", "off", "no"):
             return []
@@ -884,6 +887,9 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         fitting agent). Persists human feedback + resolved-error lessons into the
         same staging buffer. Failure-isolated; ``SCILINK_FEEDBACK_AUTODISTILL=0``
         disables it."""
+        from scilink.skills.loader import memory_enabled
+        if not memory_enabled():
+            return []
         flag = os.environ.get("SCILINK_FEEDBACK_AUTODISTILL", "").strip().lower()
         if flag in ("0", "false", "off", "no"):
             return []

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2802,11 +2802,17 @@ Update an existing skill with new knowledge while preserving what is already cor
 1. Review the existing skill content carefully.
 2. Integrate the new findings into the appropriate section. Consolidate related guidance — \
    prefer merging into existing content over restating.
-3. Do NOT remove existing content unless the new knowledge explicitly contradicts it.
-4. When there is a conflict, prefer the newer knowledge but note the discrepancy briefly.
-5. If the new knowledge materially changes the skill's purpose, update the description; \
+3. The new knowledge may be a list of records, each with a `provenance`. Place each kind in \
+   the right section: `t2_solution` (working recipe, has `working_script_excerpt`) → \
+   overview/planning/analysis (generalize; never paste the script verbatim); `error_fix` \
+   (`error_lessons` error→fix pairs) → validation pitfalls/sanity-checks and analysis cautions; \
+   `user_correction` (`user_feedback`) → planning constraints/preferences and validation \
+   acceptance criteria (treat human corrections as high-priority ground truth).
+4. Do NOT remove existing content unless the new knowledge explicitly contradicts it.
+5. When there is a conflict, prefer the newer knowledge but note the discrepancy briefly.
+6. If the new knowledge materially changes the skill's purpose, update the description; \
    otherwise leave it intact.
-6. Keep prose tight. The skill is read into LLM context every time.
+7. Keep prose tight. The skill is read into LLM context every time.
 
 Return a JSON object with the SAME keys as the existing skill (description, overview, planning, \
 analysis, interpretation, validation) reflecting the merged skill content.
@@ -2885,9 +2891,16 @@ dataset's specific paths and magic numbers. Where the examples differ, note what
 when to choose each option (this is the value of having several examples). Explain why the \
 naive/default plan was insufficient.
 
-Each example includes a `working_script_excerpt` so you can extract the reusable procedure \
-from real code. Do NOT paste any script back verbatim — write a CONCISE, generalized recipe \
-(the skill is read into the prompt every run, so keep it tight; no one-off dataset code).
+Each record carries a `provenance` field — incorporate each kind into the right section:
+- `t2_solution`: a from-scratch working recipe (has a `working_script_excerpt`). Distill the \
+  generalized method into **overview/planning/analysis**. Do NOT paste the script back verbatim.
+- `error_fix`: errors that were hit and how they were resolved (`error_lessons`: error→fix \
+  pairs). Turn these into concrete pitfalls and sanity checks in **validation**, and cautions \
+  in **analysis** ("avoid X; if you see Y, do Z").
+- `user_correction`: a human's domain correction/preference (`user_feedback`). Treat this as \
+  high-priority ground truth — fold it into **planning** (constraints/preferences) and \
+  **validation** (acceptance criteria).
+Keep the skill CONCISE (it is read into the prompt every run); no one-off dataset code.
 
 Return a JSON object with exactly the following keys. Use markdown within values when helpful \
 (lists, inline code), but no section headings (`##`) or YAML frontmatter — the caller adds those.

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -475,7 +475,7 @@ class MetaOrchestratorTools:
                     {"technique": k, "n_staged": n, "ready_to_consolidate": n >= need}
                     for k, n in sorted(by_tech.items())
                 ]
-                print(f"  🧠 {len(rows)} staged T=2 solution(s) awaiting distillation "
+                print(f"  🧠 {len(rows)} staged solution(s) awaiting distillation "
                       f"({sum(1 for t in techniques if t['ready_to_consolidate'])} "
                       f"technique(s) ready to consolidate; threshold {need}).")
                 return json.dumps({"status": "success", "action": "list_staged",
@@ -542,7 +542,8 @@ class MetaOrchestratorTools:
             func=review_distilled_skills,
             name="review_distilled_skills",
             description=(
-                "Review and act on learned knowledge from hard (T=2 hot-annealing) "
+                "Review and act on learned knowledge from hard runs the agent solved "
+                "from scratch (constraint-annealing hot stage). "
                 "runs. Such runs STAGE a raw solution (delegate_to_analysis reports "
                 "`staged_solutions`); skills are produced from staged solutions two "
                 "ways, both review-gated: `upgrade` merges ONE staged solution into an "

--- a/scilink/cli/memory.py
+++ b/scilink/cli/memory.py
@@ -130,6 +130,7 @@ def _cmd_show(args) -> int:
 
 
 def _cmd_promote(args) -> int:
+    _warn_memory_off()
     domain, name = _split_ref(args.ref)
     try:
         res = promote_memory(domain, name, to_domain=args.to_domain)
@@ -159,6 +160,14 @@ def _cmd_prune(args) -> int:
 
 def _consolidate_n() -> int:
     return _staging.consolidate_min_n()
+
+def _warn_memory_off():
+    """Distilling/promoting while memory is off produces skills that won't load
+    into runs until it's enabled — warn so the action isn't silently inert."""
+    from scilink.skills import loader
+    if not loader.memory_enabled():
+        print("⚠️  Persistent memory is OFF — this won't affect runs until you "
+              "enable it (`scilink memory enable`).")
 
 
 def _cmd_staged(args) -> int:
@@ -202,6 +211,7 @@ def _cmd_staged(args) -> int:
 
 
 def _cmd_upgrade(args) -> int:
+    _warn_memory_off()
     import difflib
     from scilink.agents.exp_agents.instruct import (
         KNOWLEDGE_TO_SKILL_INSTRUCTIONS, SKILL_UPDATE_INSTRUCTIONS,
@@ -259,6 +269,7 @@ def _cmd_upgrade(args) -> int:
 
 
 def _cmd_consolidate(args) -> int:
+    _warn_memory_off()
     from scilink.agents.exp_agents.instruct import (
         T2_CONSOLIDATION_INSTRUCTIONS, SKILL_UPDATE_INSTRUCTIONS,
     )

--- a/scilink/cli/memory.py
+++ b/scilink/cli/memory.py
@@ -340,7 +340,7 @@ def main():
     p_prune.set_defaults(func=_cmd_prune)
 
     # --- staged T=2 solutions ---
-    p_staged = sub.add_parser("staged", help="List staged solutions (solved from scratch) by technique")
+    p_staged = sub.add_parser("staged", help="List staged knowledge (solved-from-scratch fits, feedback, error fixes) by technique")
     p_staged.add_argument("--domain", help="Restrict to one domain")
     p_staged.set_defaults(func=_cmd_staged)
 

--- a/scilink/cli/memory.py
+++ b/scilink/cli/memory.py
@@ -26,6 +26,7 @@ Staged T=2 solutions (distill_staging) subcommands:
 """
 
 import argparse
+import os
 import sys
 
 from scilink.skills._shared._memory import (
@@ -75,7 +76,29 @@ def _add_model_args(p):
                    help="API key (else taken from the conventional vendor env var)")
 
 
+def _cmd_memory_toggle(args) -> int:
+    """`scilink memory enable|disable|status` — the persistent-memory master switch."""
+    from scilink.skills import loader
+    if args.action == "status":
+        on = loader.memory_enabled()
+        env = os.environ.get("SCILINK_MEMORY", "").strip()
+        src = f"env SCILINK_MEMORY={env!r}" if env else f"config ({loader._config_path()})"
+        print(f"Persistent memory: {'ON' if on else 'OFF'}   [{src}]")
+        return 0
+    enabled = (args.action == "enable")
+    p = loader.set_memory_enabled(enabled)
+    print(f"Persistent memory {'ENABLED' if enabled else 'DISABLED'}  (saved to {p})")
+    print("  → staging + graduated-skill loading are now ACTIVE."
+          if enabled else
+          "  → inert: nothing is staged and graduated skills are not loaded into runs.")
+    if os.environ.get("SCILINK_MEMORY", "").strip():
+        print("  ⚠️  SCILINK_MEMORY env var is set and overrides this saved setting.")
+    return 0
+
+
 def _cmd_list(args) -> int:
+    from scilink.skills import loader
+    print(f"[persistent memory: {'ON' if loader.memory_enabled() else 'OFF — inert; `scilink memory enable` to use'}]\n")
     provisional = None
     if args.provisional_only:
         provisional = True
@@ -274,6 +297,13 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     sub = parser.add_subparsers(dest="action")
+
+    p_en = sub.add_parser("enable", help="Turn persistent memory ON (opt-in)")
+    p_en.set_defaults(func=_cmd_memory_toggle)
+    p_dis = sub.add_parser("disable", help="Turn persistent memory OFF (the default)")
+    p_dis.set_defaults(func=_cmd_memory_toggle)
+    p_status = sub.add_parser("status", help="Show whether persistent memory is on or off")
+    p_status.set_defaults(func=_cmd_memory_toggle)
 
     p_list = sub.add_parser("list", help="List persisted skills")
     p_list.add_argument("--domain", help="Restrict to one domain (e.g. curve_fitting)")

--- a/scilink/cli/memory.py
+++ b/scilink/cli/memory.py
@@ -186,10 +186,11 @@ def _cmd_staged(args) -> int:
             for r in recs:
                 metric = r.get("r_squared") or r.get("quality_score")
                 mtxt = f"  metric={metric}" if metric is not None else ""
-                prov = r.get("provenance", "t2_solution")
+                prov = _staging.PROVENANCE_LABELS.get(r.get("provenance", "t2_solution"),
+                                                      r.get("provenance", ""))
                 print(f"    · id={r['id']}  [{prov}]  session={r.get('session','?')}{mtxt}")
     if not total:
-        print("No staged T=2 solutions.")
+        print("No staged solutions.")
     else:
         # New-skill consolidation accumulates first (>= N of a technique). Upgrading an
         # existing skill from a single solution is always available.
@@ -328,7 +329,7 @@ def main():
     p_prune.set_defaults(func=_cmd_prune)
 
     # --- staged T=2 solutions ---
-    p_staged = sub.add_parser("staged", help="List staged raw T=2 solutions by technique")
+    p_staged = sub.add_parser("staged", help="List staged solutions (solved from scratch) by technique")
     p_staged.add_argument("--domain", help="Restrict to one domain")
     p_staged.set_defaults(func=_cmd_staged)
 

--- a/scilink/cli/memory.py
+++ b/scilink/cli/memory.py
@@ -110,7 +110,8 @@ def _cmd_list(args) -> int:
         return 0
     for r in rows:
         tag = "  [provisional]" if r["provisional"] else ""
-        r2 = f"  R²={r['r_squared']}" if r.get("r_squared") is not None else ""
+        _m = _staging.metric_label(r)
+        r2 = f"  {_m}" if _m else ""
         prov = f"  ({r['provenance']})" if r.get("provenance") else ""
         print(f"{r['domain']}/{r['name']}{tag}{r2}{prov}")
         if r.get("description"):
@@ -340,7 +341,7 @@ def main():
     p_prune.set_defaults(func=_cmd_prune)
 
     # --- staged T=2 solutions ---
-    p_staged = sub.add_parser("staged", help="List staged knowledge (solved-from-scratch fits, feedback, error fixes) by technique")
+    p_staged = sub.add_parser("staged", help="List staged knowledge (solved-from-scratch solutions, feedback, error fixes) by technique")
     p_staged.add_argument("--domain", help="Restrict to one domain")
     p_staged.set_defaults(func=_cmd_staged)
 

--- a/scilink/cli/memory.py
+++ b/scilink/cli/memory.py
@@ -163,7 +163,8 @@ def _cmd_staged(args) -> int:
             for r in recs:
                 metric = r.get("r_squared") or r.get("quality_score")
                 mtxt = f"  metric={metric}" if metric is not None else ""
-                print(f"    · id={r['id']}  session={r.get('session','?')}{mtxt}")
+                prov = r.get("provenance", "t2_solution")
+                print(f"    · id={r['id']}  [{prov}]  session={r.get('session','?')}{mtxt}")
     if not total:
         print("No staged T=2 solutions.")
     else:

--- a/scilink/skills/_shared/_staging.py
+++ b/scilink/skills/_shared/_staging.py
@@ -35,6 +35,15 @@ PROVENANCE_LABELS = {
 }
 
 
+def metric_label(rec: Dict[str, Any]) -> str:
+    """Agent-agnostic metric label for display: R² for fits, 'score' otherwise."""
+    if rec.get("r_squared") is not None:
+        return f"R² {rec['r_squared']}"
+    if rec.get("quality_score") is not None:
+        return f"score {rec['quality_score']}"
+    return ""
+
+
 def staging_dir() -> Path:
     """Root of the raw-solution staging buffer (honors ``$SCILINK_HOME``)."""
     return scilink_home() / "distill_staging"

--- a/scilink/skills/_shared/_staging.py
+++ b/scilink/skills/_shared/_staging.py
@@ -214,6 +214,89 @@ def _record_for_prompt(rec: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # ──────────────────────────────────────────────────────────────
+# Feedback / error capture — the second staging source.
+#
+# Besides T=2 hot-annealing wins (``t2_solution`` provenance), the buffer also
+# captures the two signals the old in-session distillation used — human feedback
+# and recurring errors that were resolved during a run — so they persist across
+# sessions and flow through the same review/upgrade/consolidate path. These are
+# staged as records with provenance ``user_correction`` / ``error_fix``.
+# ──────────────────────────────────────────────────────────────
+
+def resolved_error_lessons(quality_history: Optional[Dict[str, Any]]) -> List[Dict[str, str]]:
+    """Extract ``{error, fix}`` lessons from a result's quality history.
+
+    Pulls script errors that were diagnosed/fixed (curve-fitting stores the fix
+    under ``diagnosis``, image analysis under ``fix``) and verification
+    iterations where a fix was applied to named issues. Unresolved errors (no
+    fix) are skipped — a lesson needs the resolution to be reusable.
+    """
+    qh = quality_history or {}
+    lessons: List[Dict[str, str]] = []
+    for se in qh.get("script_errors", []) or []:
+        err = (se.get("error") or "").strip()
+        fix = (se.get("fix") or se.get("diagnosis") or "").strip()
+        if err and fix:
+            lessons.append({"error": err[:400], "fix": fix[:400]})
+    for it in qh.get("verification_iterations", []) or []:
+        fix = (it.get("fix_applied") or "").strip()
+        issues = [x.get("problem", "") for x in (it.get("issues") or []) if x.get("problem")]
+        if fix and issues:
+            lessons.append({"error": "; ".join(issues)[:400], "fix": fix[:400]})
+    return lessons
+
+
+def stage_feedback_and_errors(
+    domain: str,
+    *,
+    results: List[Dict[str, Any]],
+    feedback_texts: Optional[List[str]] = None,
+    session: str,
+    llm_call: Callable[[str], str],
+    label_template: str,
+    root: Optional[Path] = None,
+) -> List[str]:
+    """Stage human-feedback + resolved-error knowledge from a finished run.
+
+    For each successful result that resolved errors along the way, stages an
+    ``error_fix`` record; if the run gathered any human feedback (``feedback_texts``),
+    stages one combined ``user_correction`` record. Each gets an LLM-assigned
+    technique label so it accumulates alongside (and consolidates with) T=2
+    solutions of the same technique. Returns the list of staged ids.
+    """
+    staged: List[str] = []
+    for r in results or []:
+        if not r.get("success"):
+            continue
+        lessons = resolved_error_lessons(r.get("quality_history"))
+        if not lessons:
+            continue
+        model = r.get("model_type") or r.get("analysis_type") or "model"
+        technique = assign_technique_label(
+            domain, model, "recurring errors resolved during the run",
+            llm_call, label_template, root=root)
+        rec: Dict[str, Any] = {"provenance": "error_fix", "model": model,
+                               "error_lessons": lessons, "session": session}
+        r2 = (r.get("fit_quality") or {}).get("r_squared")
+        if r2 is not None:
+            rec["r_squared"] = round(float(r2), 4)
+        staged.append(stage_solution(domain, technique, rec, root=root))
+
+    texts = [str(t).strip() for t in (feedback_texts or []) if str(t).strip()]
+    if texts:
+        fb = "\n".join(dict.fromkeys(texts))  # dedupe, preserve order
+        model = next((r.get("model_type") or r.get("analysis_type")
+                      for r in (results or []) if r.get("model_type") or r.get("analysis_type")), "model")
+        technique = assign_technique_label(
+            domain, model, "user correction / domain expertise",
+            llm_call, label_template, root=root)
+        staged.append(stage_solution(domain, technique, {
+            "provenance": "user_correction", "model": model,
+            "user_feedback": fb, "session": session}, root=root))
+    return staged
+
+
+# ──────────────────────────────────────────────────────────────
 # upgrade@1 — merge staged solution(s) into an EXISTING skill
 #
 # Upgrade mutates an existing (often already-active) skill in place, so it is

--- a/scilink/skills/_shared/_staging.py
+++ b/scilink/skills/_shared/_staging.py
@@ -26,6 +26,15 @@ from ..loader import scilink_home, load_skill, list_skills, graduated_skills_dir
 from ._graduation import graduate_to_skill_file, safe_path_component, warn_if_ephemeral_store
 
 
+# Friendly, jargon-free labels for record provenance (the stored values stay as
+# t2_solution/error_fix/user_correction; these are for user-facing display only).
+PROVENANCE_LABELS = {
+    "t2_solution": "solved from scratch",
+    "error_fix": "error fix",
+    "user_correction": "your feedback",
+}
+
+
 def staging_dir() -> Path:
     """Root of the raw-solution staging buffer (honors ``$SCILINK_HOME``)."""
     return scilink_home() / "distill_staging"

--- a/scilink/skills/loader.py
+++ b/scilink/skills/loader.py
@@ -21,6 +21,7 @@ skill. Sections whose heading isn't in the canonical vocabulary are preserved
 under the ``extras`` key (lowercased heading → body) and a warning is logged.
 """
 
+import json
 import logging
 import os
 import re
@@ -71,6 +72,56 @@ def graduated_skills_dir() -> Path:
     return scilink_home() / "graduated_skills"
 
 
+# ─── Persistent-memory master switch ───────────────────────────────
+# Persistent memory (auto-staging T=2/feedback/error knowledge AND loading the
+# graduated-skills store into runs) is OFF by default — opt-in. When off it is
+# fully inert: nothing is staged and the graduated store is not loaded, so runs
+# behave exactly as if the store did not exist. The review surfaces
+# (``scilink memory`` / UI panel) still work so a user can inspect/manage it.
+#
+# Resolution order: the ``SCILINK_MEMORY`` env var overrides (truthy → on,
+# falsy → off); otherwise the persisted setting in ``scilink_home()/config.json``;
+# otherwise the default (off).
+
+_TRUTHY = {"1", "true", "on", "yes"}
+_FALSY = {"0", "false", "off", "no"}
+
+
+def _config_path() -> Path:
+    return scilink_home() / "config.json"
+
+
+def _read_config() -> dict:
+    p = _config_path()
+    if p.exists():
+        try:
+            return json.loads(p.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def memory_enabled() -> bool:
+    """Whether persistent memory is active (default False — opt-in)."""
+    env = os.environ.get("SCILINK_MEMORY", "").strip().lower()
+    if env in _TRUTHY:
+        return True
+    if env in _FALSY:
+        return False
+    return bool(_read_config().get("memory_enabled", False))
+
+
+def set_memory_enabled(enabled: bool) -> Path:
+    """Persist the memory on/off setting to ``config.json``; return its path."""
+    home = scilink_home()
+    home.mkdir(parents=True, exist_ok=True)
+    cfg = _read_config()
+    cfg["memory_enabled"] = bool(enabled)
+    p = _config_path()
+    p.write_text(json.dumps(cfg, indent=2))
+    return p
+
+
 # ─── User-provided skill roots ─────────────────────────────────────
 # Users can add their own skill bundles without modifying SciLink source
 # by pointing the ``SCILINK_SKILLS_PATH`` env var at one (or several,
@@ -109,9 +160,12 @@ def _skill_roots() -> List[Path]:
                 _logger.warning(
                     "SCILINK_SKILLS_PATH entry not found or not a directory: %s", p
                 )
-    graduated = graduated_skills_dir()
-    if graduated.is_dir():
-        candidates.append(graduated.resolve())
+    # The persistent graduated store is only consulted when memory is enabled
+    # (opt-in). Off ⇒ the store is not loaded, so runs ignore promoted skills.
+    if memory_enabled():
+        graduated = graduated_skills_dir()
+        if graduated.is_dir():
+            candidates.append(graduated.resolve())
     candidates.append(_SKILLS_DIR)
 
     roots: List[Path] = []

--- a/scilink/ui/components/skills.py
+++ b/scilink/ui/components/skills.py
@@ -170,7 +170,7 @@ def _render_staged_section() -> None:
     mem_on = loader.memory_enabled()
 
     st.markdown("---")
-    st.markdown("**Staged solutions** (solved from scratch)")
+    st.markdown("**Staged knowledge** — solved-from-scratch fits, your feedback & error fixes")
     st.caption(
         "Hard problems the agent solved only after rebuilding its approach from "
         "scratch — plus your feedback and recurring error fixes. Upgrade an "

--- a/scilink/ui/components/skills.py
+++ b/scilink/ui/components/skills.py
@@ -166,6 +166,8 @@ def _render_staged_section() -> None:
     """Staged raw T=2 solutions — distill into skills (upgrade an existing skill,
     or consolidate N of a technique into a new one)."""
     from scilink.skills._shared import _staging, _memory
+    from scilink.skills import loader
+    mem_on = loader.memory_enabled()
 
     st.markdown("---")
     st.markdown("**Staged solutions** (solved from scratch)")
@@ -218,7 +220,11 @@ def _render_staged_section() -> None:
                     sid = recs[0]["id"]
                     # Upgrade mutates an existing skill in place, so preview first:
                     # build the merged skill, show a diff, and apply only on confirm.
-                    if st.button("Preview upgrade", key=f"up::{domain}/{technique}"):
+                    if st.button("Preview upgrade", key=f"up::{domain}/{technique}",
+                                 disabled=not mem_on,
+                                 help=(None if mem_on else
+                                       "Persistent memory is off — turn it on to distill "
+                                       "staged solutions into skills.")):
                         from scilink.agents.exp_agents.instruct import (
                             KNOWLEDGE_TO_SKILL_INSTRUCTIONS, SKILL_UPDATE_INSTRUCTIONS)
                         td, tn = tgt.split("/", 1)
@@ -242,13 +248,18 @@ def _render_staged_section() -> None:
                 # is exempt — that's the upgrade@1 path on the left.
                 need = _staging.consolidate_min_n()
                 ready = len(recs) >= need
+                if not mem_on:
+                    con_help = ("Persistent memory is off — turn it on to distill "
+                                "staged solutions into skills.")
+                elif not ready:
+                    con_help = (f"Accumulating {len(recs)}/{need} — consolidation into a "
+                                f"new skill unlocks once {need} solutions of this technique "
+                                f"are staged (set SCILINK_CONSOLIDATE_N to change; "
+                                f"`scilink memory consolidate` can force it).")
+                else:
+                    con_help = None
                 if st.button("Consolidate → new skill", key=f"con::{domain}/{technique}",
-                             disabled=not ready,
-                             help=(None if ready else
-                                   f"Accumulating {len(recs)}/{need} — consolidation into a "
-                                   f"new skill unlocks once {need} solutions of this technique "
-                                   f"are staged (set SCILINK_CONSOLIDATE_N to change; "
-                                   f"`scilink memory consolidate` can force it).")):
+                             disabled=(not ready) or (not mem_on), help=con_help):
                     from scilink.agents.exp_agents.instruct import (
                         T2_CONSOLIDATION_INSTRUCTIONS, SKILL_UPDATE_INSTRUCTIONS)
                     res = _staging.consolidate_technique(
@@ -326,9 +337,15 @@ def _render_memory_row(_memory, r, *, provisional: bool) -> None:
         except Exception as e:
             st.warning(f"Could not render skill: {e}")
 
+        from scilink.skills import loader
+        mem_on = loader.memory_enabled()
         c1, c2, _ = st.columns([2, 2, 4])
         if provisional:
-            if c1.button("Promote", key=f"promote::{ref}", type="primary"):
+            if c1.button("Promote", key=f"promote::{ref}", type="primary",
+                         disabled=not mem_on,
+                         help=(None if mem_on else
+                               "Persistent memory is off — promoted skills won't load "
+                               "until you turn it on.")):
                 _memory.promote_memory(r["domain"], r["name"])
                 st.success(f"Promoted {ref} — now auto-routable.")
                 st.rerun()

--- a/scilink/ui/components/skills.py
+++ b/scilink/ui/components/skills.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import os
 import streamlit as st
 
 from scilink.skills.loader import list_all_skills
@@ -109,6 +110,8 @@ def _render_memory_section() -> None:
     """
     from scilink.skills._shared import _memory
 
+    from scilink.skills import loader
+
     st.subheader("Persistent Memory")
     st.caption(
         "Graduated and auto-distilled skills stored under `~/.scilink` — they "
@@ -116,6 +119,24 @@ def _render_memory_section() -> None:
         "hard fits the agent had to solve from scratch — currently curve fitting) "
         "are held out of auto-routing until you promote them."
     )
+
+    # Master on/off switch (opt-in; off by default). When off, persistent memory
+    # is inert: nothing is staged and graduated skills are not loaded into runs.
+    cur = loader.memory_enabled()
+    new = st.toggle(
+        "Enable persistent memory", value=cur, key="mem_enabled_toggle",
+        help=("Off (default): inert — nothing is staged and graduated skills are "
+              "not loaded into runs. On: auto-staging + reuse of promoted skills."),
+    )
+    if new != cur:
+        loader.set_memory_enabled(new)
+        st.rerun()
+    if os.environ.get("SCILINK_MEMORY", "").strip():
+        st.caption("⚠️ `SCILINK_MEMORY` env var is set and overrides this toggle.")
+    if not new:
+        st.info("Persistent memory is **OFF** (inert). Turn it on to stage T=2 / "
+                "feedback / error knowledge and load promoted skills into runs. "
+                "Existing items below are kept and can still be reviewed.")
 
     try:
         rows = _memory.list_memory()

--- a/scilink/ui/components/skills.py
+++ b/scilink/ui/components/skills.py
@@ -116,7 +116,7 @@ def _render_memory_section() -> None:
     st.caption(
         "Graduated and auto-distilled skills stored under `~/.scilink` — they "
         "survive sessions and upgrades. Provisional skills (auto-distilled from "
-        "hard fits the agent had to solve from scratch — currently curve fitting) "
+        "hard problems the agent had to solve from scratch) "
         "are held out of auto-routing until you promote them."
     )
 
@@ -170,7 +170,7 @@ def _render_staged_section() -> None:
     mem_on = loader.memory_enabled()
 
     st.markdown("---")
-    st.markdown("**Staged knowledge** — solved-from-scratch fits, your feedback & error fixes")
+    st.markdown("**Staged knowledge** — solved-from-scratch solutions, your feedback & error fixes")
     st.caption(
         "Hard problems the agent solved only after rebuilding its approach from "
         "scratch — plus your feedback and recurring error fixes. Upgrade an "
@@ -200,7 +200,7 @@ def _render_staged_section() -> None:
                 meta_col, view_col = st.columns([3, 1])
                 meta_col.caption(
                     f"id={r['id']} · {prov} · session={r.get('session','?')}"
-                    + (f" · metric={metric}" if metric is not None else "")
+                    + (f" · {_staging.metric_label(r)}" if _staging.metric_label(r) else "")
                 )
                 with view_col.popover("View", use_container_width=True):
                     _render_staged_record(r)
@@ -323,9 +323,11 @@ def _render_staged_record(r: dict) -> None:
 
 
 def _render_memory_row(_memory, r, *, provisional: bool) -> None:
+    from scilink.skills._shared import _staging
     ref = f"{r['domain']}/{r['name']}"
     badge = "🟡 provisional" if provisional else "✅ promoted"
-    r2 = f" · R²={r['r_squared']}" if r.get("r_squared") is not None else ""
+    _m = _staging.metric_label(r)
+    r2 = f" · {_m}" if _m else ""
     with st.expander(f"{badge} · `{ref}`{r2}", expanded=False):
         if r.get("description"):
             st.markdown(f"_{r['description']}_")

--- a/scilink/ui/components/skills.py
+++ b/scilink/ui/components/skills.py
@@ -134,9 +134,10 @@ def _render_memory_section() -> None:
     if os.environ.get("SCILINK_MEMORY", "").strip():
         st.caption("⚠️ `SCILINK_MEMORY` env var is set and overrides this toggle.")
     if not new:
-        st.info("Persistent memory is **OFF** (inert). Turn it on to stage T=2 / "
-                "feedback / error knowledge and load promoted skills into runs. "
-                "Existing items below are kept and can still be reviewed.")
+        st.info("Persistent memory is **OFF** (inert). Turn it on to capture "
+                "hard-won solutions, your feedback, and error fixes — and to load "
+                "promoted skills into runs. Existing items below are kept and can "
+                "still be reviewed.")
 
     try:
         rows = _memory.list_memory()
@@ -167,11 +168,12 @@ def _render_staged_section() -> None:
     from scilink.skills._shared import _staging, _memory
 
     st.markdown("---")
-    st.markdown("**Staged T=2 solutions**")
+    st.markdown("**Staged solutions** (solved from scratch)")
     st.caption(
-        "Hard problems the agent solved from scratch (T=2). Upgrade an existing "
-        "skill from one, or consolidate several of the same technique into a new "
-        "skill. Both use the active session's model."
+        "Hard problems the agent solved only after rebuilding its approach from "
+        "scratch — plus your feedback and recurring error fixes. Upgrade an "
+        "existing skill from one, or consolidate several of the same technique "
+        "into a new skill. Both use the active session's model."
     )
 
     groups = {}
@@ -192,7 +194,7 @@ def _render_staged_section() -> None:
         with st.expander(f"`{domain}/{technique}` — {len(recs)} staged", expanded=False):
             for r in recs:
                 metric = r.get("r_squared") or r.get("quality_score")
-                prov = r.get("provenance", "t2_solution")
+                prov = _staging.PROVENANCE_LABELS.get(r.get("provenance", "t2_solution"), r.get("provenance", ""))
                 meta_col, view_col = st.columns([3, 1])
                 meta_col.caption(
                     f"id={r['id']} · {prov} · session={r.get('session','?')}"

--- a/scilink/ui/components/skills.py
+++ b/scilink/ui/components/skills.py
@@ -72,6 +72,15 @@ def _load_skill_file(agent, uploaded_file) -> None:
         st.error(f"Failed to register {uploaded_file.name}: {e}")
 
 
+def _render_skill_markdown(domain: str, name: str) -> None:
+    """Render a discoverable skill's markdown (built-in / user / graduated)."""
+    from scilink.skills.loader import _resolve_skill_path
+    try:
+        st.markdown(_resolve_skill_path(name, domain).read_text())
+    except Exception as e:
+        st.warning(f"Could not load skill: {e}")
+
+
 def _render_available_skills(agent) -> None:
     """Show built-in and custom skills."""
     st.subheader("Available Skills")
@@ -85,7 +94,10 @@ def _render_available_skills(agent) -> None:
             label = domain.replace("_", " ").title()
             with st.expander(f"{label} ({len(names)})", expanded=False):
                 for name in names:
-                    st.markdown(f"- `{name}`")
+                    nc, vc = st.columns([3, 1])
+                    nc.markdown(f"`{name}`")
+                    with vc.popover("view", use_container_width=True):
+                        _render_skill_markdown(domain, name)
     else:
         st.caption("No built-in skills found.")
 

--- a/scilink/ui/components/skills.py
+++ b/scilink/ui/components/skills.py
@@ -171,9 +171,10 @@ def _render_staged_section() -> None:
         with st.expander(f"`{domain}/{technique}` — {len(recs)} staged", expanded=False):
             for r in recs:
                 metric = r.get("r_squared") or r.get("quality_score")
+                prov = r.get("provenance", "t2_solution")
                 meta_col, view_col = st.columns([3, 1])
                 meta_col.caption(
-                    f"id={r['id']} · session={r.get('session','?')}"
+                    f"id={r['id']} · {prov} · session={r.get('session','?')}"
                     + (f" · metric={metric}" if metric is not None else "")
                 )
                 with view_col.popover("View", use_container_width=True):


### PR DESCRIPTION
## Summary (for scientists)

Two related improvements to SciLink's persistent memory, plus polish:

1. **Captures more of what you teach it.** Hard-won solutions the agent rebuilds
   from scratch were already saved; now your **mid-run feedback** and the
   **recurring errors it fixed** are saved too — into the same place, so they
   survive the session, pile up by technique, and can become skills through the
   normal review step (`scilink memory staged` → upgrade/consolidate).
2. **Memory is now opt-in (OFF by default).** A single toggle (UI + CLI) controls
   it. When off it is fully inert — nothing is saved and saved skills are not
   loaded into runs — so the default experience is unchanged unless you turn it on.

Plus: the UI/CLI no longer uses internal jargon ("T=2"), and you can't accidentally
build a do-nothing skill while memory is off.

## Technical details

**Feedback + error capture (complements the T=2 path)**
- `_staging.resolved_error_lessons()` extracts `{error, fix}` from `quality_history`
  (curve-fit `diagnosis` / image `fix` + verification fixes).
- `_staging.stage_feedback_and_errors()` stages `error_fix` and one combined
  `user_correction` per run, each LLM-labeled by technique (groups/consolidates
  with `t2_solution` records).
- `_maybe_stage_feedback_errors` hook on both agents (after the T=2 hook);
  failure-isolated; `SCILINK_FEEDBACK_AUTODISTILL=0` disables.
- **Feedback persistence fix:** both controllers captured feedback transiently
  (`state["_refine_feedback"]`, popped in-flight) so it never reached end-of-run;
  they now append applied feedback to `state["human_feedback_log"]`, which the
  hooks read. (Surfaced by real-run E2E — synthetic tests had masked it.)
- **Provenance-aware graduation:** consolidation/update templates place each record
  by provenance — t2_solution → overview/planning/analysis, error_fix →
  validation/analysis cautions, user_correction → planning/validation (high-priority).

**Master on/off switch (opt-in, OFF by default)**
- `loader.memory_enabled()` / `set_memory_enabled()`: `SCILINK_MEMORY` env override
  → persisted `~/.scilink/config.json` → default False.
- `loader._skill_roots()` only adds the graduated store when enabled; the four
  staging hooks no-op when disabled → fully inert when off.
- CLI `scilink memory enable | disable | status` (+ status shown in `list`); UI
  toggle in the Persistent Memory panel.
- **Behavior change:** promoted skills no longer auto-load until memory is on.

**Polish**
- User-facing "T=2" reworded to "solved from scratch"; provenance values shown via
  a friendly `PROVENANCE_LABELS` map ("solved from scratch" / "error fix" /
  "your feedback"). Internal names unchanged.
- Distill/promote actions are disabled (UI) / warned (CLI) while memory is off, so
  you can't build a skill the loader will ignore. Review (View) and Prune stay.

The old in-session distillation path (`synthesize_knowledge` → `graduate_to_skill`)
is left intact (to revisit separately).

### Validation
- Offline: `test_persistent_memory` 42/42 (autouse fixture enables memory for store/
  hook tests; `TestMemorySwitch` covers default-off, env-overrides-config,
  off-excludes-store/on-restores). 72/72 across graduation/loader/quality/vasp; 0
  regressions in the full non-live suite.
- Live (Bedrock opus-4-8, real example data): curve-fit staged
  t2_solution + error_fix + user_correction; image staged error_fix +
  user_correction; mixed-provenance records consolidated into one skill. CLI
  enable/disable/status + friendly labels + off-state guards verified.

Test module kept local (not in diff), consistent with prior PRs.
