### PR TITLE
Agent-side multi-skill auto-selection (#256)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -460,6 +460,17 @@ by construction — they compose via the prose / code-in-markdown rungs, not
 `TOOL_SPEC`. So code-in-markdown is the highest reliability rung a custom
 skill can reach without a package contribution.
 
+A user-registered custom skill (UI uploader / `--skills` → `register_skill`,
+held in the orchestrator's `_custom_skills` as `{name: path}`) is still
+**auto-selectable by the agent**: `run_analysis` forwards `_custom_skills`
+to `analyze(custom_skills=…)`, and `build_skill_catalog` folds them into the
+per-domain catalog (skipping a custom skill that explicitly declares a
+*different* analysis modality), so the agent's selector treats them like
+built-ins. A selected custom name is resolved back to its path before
+loading (customs aren't on the loader's search roots). This means the
+orchestrator does NOT need to pass an uploaded skill authoritatively just to
+make it usable — it pre-loads `skill` only for an explicit user request.
+
 **Multi-skill composition.** When several skills are co-active, each may
 own a different pipeline stage (e.g. one skill's preprocessing recipe and
 another's analysis recipe), so codegen injects the `implementation`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,6 +429,82 @@ Domain scientists who write markdown only can ship a skill as a single
 `<name>.md` and never touch Python; the engineer-maintained helpers
 co-locate as siblings.
 
+This yields a three-rung reliability ladder for a skill's
+`implementation` recipe — prose → code-in-markdown → `TOOL_SPEC` helper:
+
+- **Prose recipe.** Narrative guidance; the codegen LLM improvises the
+  code. Lowest fidelity, zero packaging.
+- **Code-in-markdown.** A concrete snippet in the `implementation`
+  section, injected verbatim into the codegen prompt as the recipe to
+  follow; the LLM transcribes/adapts it into the generated script (it is
+  *not* imported or run directly). **Use when** you want to pin the exact
+  algorithm / params / library (much stronger than prose), the op is
+  short-to-medium, and you're fine with the LLM adapting it to the data.
+  This is the right default for most scientist-authored skills —
+  concrete, no Python packaging, composes automatically. The agent's
+  verification loop (sandbox run + compile-check + quality gate)
+  backstops transcription errors, so a mangled snippet is corrected, not
+  silently wrong.
+- **`TOOL_SPEC` helper.** A sibling `.py` callable surfaced in the
+  codegen tool inventory and *called* by the generated script (byte-exact,
+  deterministic, testable, reusable). **Promote to this when** the code
+  must run verbatim/deterministically, it's long or numerically
+  sensitive, or it's a reusable stage you want tested and called
+  identically every time (and you can contribute it to the package).
+
+Note the packaging boundary: `TOOL_SPEC` tools are discovered only from
+skills *inside the installed package* (`_registry` walks `_SKILLS_DIR`
+and imports them as `scilink.skills.…` modules). Skills added via the UI
+uploader or dropped in the persistent `~/.scilink` store are markdown-only
+by construction — they compose via the prose / code-in-markdown rungs, not
+`TOOL_SPEC`. So code-in-markdown is the highest reliability rung a custom
+skill can reach without a package contribution.
+
+**Multi-skill composition.** When several skills are co-active, each may
+own a different pipeline stage (e.g. one skill's preprocessing recipe and
+another's analysis recipe), so codegen injects the `implementation`
+sections of *all* co-active skills — labeled per skill, applied in the
+plan's order — rather than only the top-ranked one. The technique-aware
+selector keeps co-activation conservative (complementary skills only), so
+this composes stages rather than fusing competing recipes. Authors should
+write each `implementation` section as self-contained for *its* stage,
+not assuming it is the only active skill.
+
+**Selection policy differs by how authoritative a domain's skills are**
+(an `exclusive` flag on `_shared/_skill_selector.select_relevant_skills`):
+
+- **Curve fitting is *exclusive*.** Its skills encode AUTHORITATIVE,
+  mutually-exclusive *technique* rules (injected as "MANDATORY Domain
+  Skill Rules") — a 1D spectrum is XPS *or* EPR, never a blend, and two
+  technique skills would inject contradictory mandates. The agent-side
+  selector therefore picks the single best technique match (or none); the
+  result is capped to one.
+- **Image / hyperspectral are *composable*.** Their skills are advisory
+  ("Domain Expertise … use it to inform your approach") and often map to
+  distinct pipeline stages (flatten → segment), so multiple may load.
+
+The orchestrator can still pass an explicit multi-skill list to any agent;
+the `exclusive` policy governs only the agent's *own* auto-selection.
+
+**Authoritative `skill` vs non-binding `skill_hint`.** The orchestrator
+defers skill choice to the agents by default, but can influence it two ways
+via `run_analysis`:
+
+- `skill` (authoritative) — for an *explicit user request* or a custom
+  skill. Pre-loaded into `skills_loaded`; the agent's auto-selector is
+  skipped (its skip guard checks `skills_loaded`/`skill_sections`). Honored
+  as-is.
+- `skill_hint` (non-binding) — for the orchestrator's *own* autonomous guess
+  (from the `preview_image`/conversation context the agent can't see). NOT
+  pre-loaded; passed into the agent's selector as a prior. The agent
+  inspects the data and decides — confirm, augment, or override. **The agent
+  has final authority.** Forwarded only to agents whose `analyze()` accepts
+  it (signature-introspection, like `max_verification_iterations`).
+
+This resolves the preemption risk: an autonomous orchestrator guess no
+longer suppresses the agent's richer, data-level (and possibly multi-skill)
+selection, while a genuine user request still binds.
+
 ### Comparison with Anthropic Skills
 
 |  | Anthropic | SciLink |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,6 +497,26 @@ not assuming it is the only active skill.
 The orchestrator can still pass an explicit multi-skill list to any agent;
 the `exclusive` policy governs only the agent's *own* auto-selection.
 
+**The agent-side selectors share one brain but differ in the signal they
+feed it.** All three call `select_relevant_skills` and route through
+`_load_skills_to_state`, but the *context* each supplies differs in
+richness:
+
+- **Image** — the actual pixels (scout montage / image bytes) + metadata;
+  runs as a pipeline controller (`SkillSuggestionController`).
+- **Curve** — metadata + data statistics + the rendered plot; pipeline
+  controller (`CurveFittingSkillSuggestionController`).
+- **Hyperspectral** — **metadata only** (`_auto_select_skills` in
+  `analyze()`, not a controller; it does *not* inspect the datacube).
+
+So hyperspectral is the weakest selection path and partly redundant with
+the orchestrator (no signal the orchestrator lacks) — moot today with a
+single `eels` skill, but when a second hyperspectral skill lands the fix is
+to give its selector a real data signal (e.g. the datacube's mean
+spectrum), making it data-aware like image/curve. The non-redundancy rule:
+an agent-side selector earns its keep only where it reads data the
+orchestrator can't.
+
 **Authoritative `skill` vs non-binding `skill_hint`.** The orchestrator
 defers skill choice to the agents by default, but can influence it two ways
 via `run_analysis`:

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -269,11 +269,20 @@ examine_data returns data_type:
 2. `load_metadata` (can pass directory path) or `convert_metadata`
 3. Decide agent (ask user if disambiguation_needed=true)
 4. `select_agent`
-5. `run_analysis`. **Skill selection is technique-gated:** only pass a `skill`
-   whose declared technique matches the data's measurement technique (each
-   skill names its technique in the `skill` parameter's `[technique: …]` tag).
-   If no skill's technique matches the data, pass NO skill — the agent's
-   baseline fits it correctly. Never fall back to the nearest-sounding skill.
+5. `run_analysis`. **Skill selection defaults to the agent.** Each analysis
+   agent inspects the actual data and auto-selects the relevant skill(s)
+   itself, from a richer signal than you have. Two ways to influence it:
+   - `skill` (AUTHORITATIVE) — use only when the user explicitly named a
+     skill/technique (now or earlier in the conversation) or a registered
+     custom skill applies. The agent honors it as-is and does not re-select.
+   - `skill_hint` (NON-BINDING) — use for your OWN guess that a skill may
+     apply when the user did not ask. The agent treats it as a prior and
+     decides from the data: it may confirm, add complementary skills, or
+     override. The agent has final authority.
+   Default to passing NEITHER and letting the agent select. When you pass
+   `skill`, technique-match it (`[technique: …]` tag), never the
+   nearest-sounding one; curve-fitting techniques are mutually exclusive, so
+   pass at most one.
 6. Present results
 7. For deeper follow-up analysis on images, call `run_analysis` again with
    `prior_analysis_paths` set to the prior `output_directory`; the agent will

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -81,11 +81,15 @@ def _build_skill_description(agent_registry: dict = None,
     import inspect
 
     parts = [
-        "Domain skill name or path to a custom .md skill file. May be a "
-        "single string or a list of strings to load multiple skills at once "
-        "(useful for cross-domain tasks). For ImageAnalysisAgent, omit this "
-        "unless the user explicitly requests a specific skill — the agent "
-        "inspects the actual image and auto-selects a skill if one is relevant."
+        "Domain skill name(s) or path to a custom .md skill file — a single "
+        "string or a list of strings (to load several at once). DEFAULT: omit "
+        "this. Every analysis agent inspects the actual data (image pixels, the "
+        "fitted curve, the spectrum-image metadata) and auto-selects the "
+        "relevant skill(s) itself, from a richer signal than you have here. "
+        "Pass a skill ONLY when (a) the user explicitly named a skill or "
+        "technique — in this request or earlier in the conversation — or "
+        "(b) a custom skill listed below applies; that is context the agents "
+        "cannot see. Otherwise leave it unset and let the agent select."
     ]
 
     # Discover which agents support skills from their analyze() signature.
@@ -150,11 +154,12 @@ def _build_skill_description(agent_registry: dict = None,
         parts.append(f"Custom skills: {sorted(custom_skills.keys())}.")
 
     parts.append(
-        "Only select a skill whose measurement technique matches the data's "
-        "technique — compare the data's technique (from the metadata) against "
-        "each skill's `[technique: …]` tag above. If none matches, omit `skill` "
-        "and let the agent's baseline handle it; do not substitute the "
-        "nearest-sounding skill."
+        "When you DO pass a skill (user-requested or custom), choose only one "
+        "whose measurement technique matches the data's technique — compare "
+        "against each skill's `[technique: …]` tag above; do not substitute the "
+        "nearest-sounding skill. Curve-fitting techniques are mutually "
+        "exclusive — pass at most one. If unsure, omit `skill` and let the "
+        "agent decide."
     )
 
     return " ".join(parts)
@@ -2030,6 +2035,7 @@ class AnalysisOrchestratorTools:
             auxiliary_data = None,  # str | list[str] | None (#226 multi-aux)
             auxiliary_label = None,  # str | list[str] | None
             skill = None,  # str | list[str] | None (PR 3 multi-skill)
+            skill_hint = None,  # str | list[str] | None — non-binding suggestion
             series_metadata: str = None,
             task_mode: str = None,
             prior_analysis_paths: List[str] = None,
@@ -2506,6 +2512,14 @@ class AnalysisOrchestratorTools:
                         analyze_kwargs["skill"] = [_resolve_one(s) for s in skill]
                     else:
                         analyze_kwargs["skill"] = skill
+                if skill_hint is not None:
+                    # Non-binding suggestion: the agent's auto-selector uses it
+                    # as a prior but decides from the data (agent has final
+                    # authority). Only forward to agents whose analyze() accepts
+                    # it; others accept **kwargs and ignore it.
+                    import inspect as _inspect
+                    if "skill_hint" in _inspect.signature(agent.analyze).parameters:
+                        analyze_kwargs["skill_hint"] = skill_hint
                 if task_mode is not None:
                     # Currently consumed by CurveFittingAgent; other agents
                     # accept **kwargs and silently ignore unknown parameters,
@@ -2727,6 +2741,22 @@ class AnalysisOrchestratorTools:
                     "description": _build_skill_description(
                         getattr(self.orch, "_agent_registry", None),
                         getattr(self.orch, "_custom_skills", None),
+                    ),
+                },
+                "skill_hint": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {"type": "array", "items": {"type": "string"}},
+                    ],
+                    "description": (
+                        "Non-binding skill SUGGESTION — use this (instead of "
+                        "`skill`) for your OWN autonomous guess that a skill may "
+                        "apply, when the user did not explicitly request one. The "
+                        "agent inspects the actual data and decides: it may "
+                        "confirm your hint, add complementary skills, or override "
+                        "it. Use `skill` (authoritative) only for an explicit "
+                        "user request or a custom skill; use `skill_hint` for "
+                        "everything you infer yourself. Same name(s) as `skill`."
                     ),
                 },
                 "series_metadata": {

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -86,10 +86,12 @@ def _build_skill_description(agent_registry: dict = None,
         "this. Every analysis agent inspects the actual data (image pixels, the "
         "fitted curve, the spectrum-image metadata) and auto-selects the "
         "relevant skill(s) itself, from a richer signal than you have here. "
-        "Pass a skill ONLY when (a) the user explicitly named a skill or "
-        "technique — in this request or earlier in the conversation — or "
-        "(b) a custom skill listed below applies; that is context the agents "
-        "cannot see. Otherwise leave it unset and let the agent select."
+        "Pass a skill ONLY when the user explicitly named a skill or technique "
+        "— in this request or earlier in the conversation (this includes a "
+        "user asking to use a specific custom skill they uploaded). Custom "
+        "skills are auto-selected by the agent just like built-ins, so you do "
+        "NOT need to pass one merely because it was uploaded. Otherwise leave "
+        "it unset and let the agent select."
     ]
 
     # Discover which agents support skills from their analyze() signature.
@@ -2520,6 +2522,15 @@ class AnalysisOrchestratorTools:
                     import inspect as _inspect
                     if "skill_hint" in _inspect.signature(agent.analyze).parameters:
                         analyze_kwargs["skill_hint"] = skill_hint
+                # Make user-registered custom skills auto-selectable by the
+                # agent (not only passable as authoritative `skill`): forward
+                # the {name: path} registry so the agent-side selector folds
+                # them into its catalog (#256 fix #1).
+                _custom = getattr(self.orch, "_custom_skills", None)
+                if _custom:
+                    import inspect as _inspect
+                    if "custom_skills" in _inspect.signature(agent.analyze).parameters:
+                        analyze_kwargs["custom_skills"] = dict(_custom)
                 if task_mode is not None:
                     # Currently consumed by CurveFittingAgent; other agents
                     # accept **kwargs and silently ignore unknown parameters,

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -881,6 +881,7 @@ class CurveFittingSkillSuggestionController:
         # Curve-fitting skills are authoritative, mutually-exclusive techniques
         # (a 1D spectrum is XPS *or* EPR, never a blend) and inject MANDATORY
         # rules — so select at most one, the single best technique match.
+        custom_skills = state.get("custom_skills") or {}
         selected = select_relevant_skills(
             model=self.model,
             parse_fn=self._parse,
@@ -890,10 +891,13 @@ class CurveFittingSkillSuggestionController:
             safety_settings=self.safety_settings,
             exclusive=True,
             hint=state.get("skill_hint"),
+            custom_skills=custom_skills,
             logger=self.logger,
         )
         if selected:
-            state.update(self._load_skills(selected, domain=self.domain))
+            # Resolve selected custom-skill name(s) to their registered path(s).
+            resolved = [custom_skills.get(n, n) for n in selected]
+            state.update(self._load_skills(resolved, domain=self.domain))
 
         return state
 

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -521,37 +521,90 @@ def _append_fit_domain_guidance(prompt: list, state: dict) -> None:
 def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
     """Append domain skill knowledge to an LLM prompt for the given stage.
 
+    With multiple skills loaded, each skill's section is appended in order
+    (most-relevant first) so the LLM can attribute guidance to its source.
+
     Args:
         prompt: Mutable list of prompt parts to extend.
-        state: Pipeline state dict containing ``skill_sections`` and ``skill_name``.
+        state: Pipeline state dict containing ``skills_loaded`` (or the legacy
+            ``skill_sections`` / ``skill_name`` for single-skill state dicts).
         stage: One of ``"planning"``, ``"analysis"``, ``"interpretation"``, ``"validation"``.
     """
-    sections = state.get("skill_sections")
-    if not sections:
-        return
-
-    skill_name = state.get("skill_name", "domain skill")
-    content = sections.get(stage, "")
-    if not content:
-        return
-
-    prompt.append(f"\n## MANDATORY Domain Skill Rules: {skill_name} ({stage})")
-    prompt.append(
-        "The following rules are MANDATORY. Your analysis plan and implementation "
-        "MUST conform to these domain-specific requirements. These rules encode "
-        "validated domain expertise and take precedence over general-purpose defaults. "
-        "Do NOT substitute your own preferences where these rules specify a method, "
-        "treatment, or constraint."
+    skills = state.get("skills_loaded") or (
+        [state["skill_sections"]] if state.get("skill_sections") else []
     )
-    prompt.append(content)
+    if not skills:
+        return
 
-    # Include validation rules during planning and interpretation
-    # so the LLM knows quality criteria upfront
-    if stage in ("planning", "interpretation"):
-        validation = sections.get("validation", "")
-        if validation:
-            prompt.append(f"\n## MANDATORY Domain Validation Rules ({skill_name})")
-            prompt.append(validation)
+    intro_appended = False
+    for sections in skills:
+        if not sections:
+            continue
+        content = sections.get(stage, "")
+        if not content:
+            continue
+        skill_name = sections.get("name", "domain skill")
+
+        prompt.append(f"\n## MANDATORY Domain Skill Rules: {skill_name} ({stage})")
+        if not intro_appended:
+            prompt.append(
+                "The following rules are MANDATORY. Your analysis plan and implementation "
+                "MUST conform to these domain-specific requirements. These rules encode "
+                "validated domain expertise and take precedence over general-purpose defaults. "
+                "Do NOT substitute your own preferences where these rules specify a method, "
+                "treatment, or constraint."
+            )
+            intro_appended = True
+        prompt.append(content)
+
+        # Include validation rules during planning and interpretation
+        # so the LLM knows quality criteria upfront
+        if stage in ("planning", "interpretation"):
+            validation = sections.get("validation", "")
+            if validation:
+                prompt.append(f"\n## MANDATORY Domain Validation Rules ({skill_name})")
+                prompt.append(validation)
+
+
+def _collect_codegen_recipe(state: dict) -> list:
+    """Per-skill codegen recipes for every co-active skill that authored one.
+
+    Returns ``[(skill_name, recipe_text), …]`` in ranked order (most-relevant
+    first), preferring each skill's ``implementation`` section over its
+    ``analysis`` synonym. When several skills are active each may own a
+    different pipeline stage (e.g. preprocessing vs fitting), so all their
+    recipes are returned and the generated script applies each to its stage in
+    the plan's order — the top-ranked skill is NOT the sole recipe. Falls back
+    to the legacy singular ``skill_sections`` field.
+    """
+    skills = state.get("skills_loaded") or (
+        [state["skill_sections"]] if state.get("skill_sections") else []
+    )
+    recipes = []
+    for s in skills:
+        if not s:
+            continue
+        recipe = s.get("implementation") or s.get("analysis")
+        if recipe:
+            recipes.append((s.get("name", "skill"), recipe))
+    return recipes
+
+
+def _render_codegen_recipe(recipes: list) -> str:
+    """Render collected recipes into one codegen block.
+
+    Single skill: the recipe verbatim (unchanged from the pre-multi-skill
+    behavior). Multiple: a short composition note plus each recipe labeled by
+    skill, so the codegen LLM maps each recipe to its pipeline stage.
+    """
+    if len(recipes) == 1:
+        return recipes[0][1]
+    note = (
+        " Multiple skills are active; each recipe below may cover a different "
+        "stage of the analysis (e.g. preprocessing vs fitting). Apply each to "
+        "its stage in the plan's order and produce ONE script.\n\n"
+    )
+    return note + "\n\n".join(f"### Recipe — {n}\n{r}" for n, r in recipes)
 
 
 def _append_prior_knowledge_context(prompt: list, state: dict) -> None:
@@ -776,6 +829,71 @@ class AnalyzeDataController:
         except Exception as e:
             self.logger.error(f"❌ Data analysis failed: {e}", exc_info=True)
             state["error_dict"] = {"error": "Data analysis failed", "details": str(e)}
+
+        return state
+
+
+class CurveFittingSkillSuggestionController:
+    """Auto-suggest domain skill(s) when none were explicitly provided.
+
+    Runs after data analysis and before planning. Shows the LLM the curve's
+    metadata, summary statistics, and the raw-data plot alongside a catalog
+    of available curve-fitting skills, and asks which (if any) match the
+    measurement technique. No-op when a skill was already loaded (e.g. by the
+    orchestrator or user). Selection is conservative and technique-aware
+    (see issue #251); it may return zero, one, or several skills.
+    """
+
+    def __init__(self, model, logger, generation_config, safety_settings,
+                 parse_fn, load_skills_fn, domain="curve_fitting"):
+        self.model = model
+        self.logger = logger
+        self.generation_config = generation_config
+        self.safety_settings = safety_settings
+        self._parse = parse_fn
+        self._load_skills = load_skills_fn
+        self.domain = domain
+
+    def execute(self, state: dict) -> dict:
+        if (state.get("error_dict") or state.get("skills_loaded")
+                or state.get("skill_sections")):
+            return state
+
+        from ....skills._shared._skill_selector import select_relevant_skills
+
+        context_parts = []
+        sysinfo = state.get("system_info")
+        if isinstance(sysinfo, dict) and sysinfo:
+            context_parts.append(f"Metadata: {str(sysinfo)[:1500]}")
+        elif isinstance(sysinfo, str) and sysinfo.strip():
+            context_parts.append(f"Metadata: {sysinfo.strip()[:1500]}")
+        stats = state.get("data_statistics")
+        if stats:
+            context_parts.append(f"Data statistics: {stats}")
+        plot_bytes = state.get("original_plot_bytes")
+        if plot_bytes:
+            context_parts.append({"mime_type": "image/jpeg", "data": plot_bytes})
+        if not context_parts:
+            return state
+
+        self.logger.info("\n--- Skill Suggestion ---\n")
+
+        # Curve-fitting skills are authoritative, mutually-exclusive techniques
+        # (a 1D spectrum is XPS *or* EPR, never a blend) and inject MANDATORY
+        # rules — so select at most one, the single best technique match.
+        selected = select_relevant_skills(
+            model=self.model,
+            parse_fn=self._parse,
+            domain=self.domain,
+            context_parts=context_parts,
+            generation_config=self.generation_config,
+            safety_settings=self.safety_settings,
+            exclusive=True,
+            hint=state.get("skill_hint"),
+            logger=self.logger,
+        )
+        if selected:
+            state.update(self._load_skills(selected, domain=self.domain))
 
         return state
 
@@ -2219,18 +2337,17 @@ Your guidance: '''
         context_parts = []
         if state.get("literature_context"):
             context_parts.append(state["literature_context"])
-        skill_sections = state.get("skill_sections")
-        # Prefer the `implementation` section for codegen. CLAUDE.md: implementation
-        # is the going-forward name; the loader's analysis<->implementation synonym
-        # fold makes single-section skills populate both, while dual-section skills
-        # keep `implementation` as the runnable recipe (not `analysis`).
-        codegen_recipe = (skill_sections or {}).get("implementation") or (skill_sections or {}).get("analysis")
-        if codegen_recipe:
+        # Codegen recipe from ALL co-active skills (not just the top-ranked):
+        # with several skills active each may own a different pipeline stage,
+        # so none is dropped. Single-skill output is unchanged. Prefers each
+        # skill's `implementation` section over its `analysis` synonym.
+        recipes = _collect_codegen_recipe(state)
+        if recipes:
             level = state.get("_annealing_level", 0)
             preamble = self._SKILL_STRICTNESS_SCHEDULE[
                 min(level, len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
-            ].format(name=state.get("skill_name", "skill"))
-            context_parts.append(preamble + codegen_recipe)
+            ].format(name=", ".join(n for n, _ in recipes))
+            context_parts.append(preamble + _render_codegen_recipe(recipes))
         prior_runs = _prior_curve_fit_block(state)
         if prior_runs:
             context_parts.append(prior_runs)
@@ -2360,15 +2477,14 @@ Your guidance: '''
             error_message=error_msg,
             tool_inventory=_tool_inventory_text(state),
         )
-        skill_sections = state.get("skill_sections")
-        # Prefer `implementation` for codegen (see _generate_fitting_script).
-        codegen_recipe = (skill_sections or {}).get("implementation") or (skill_sections or {}).get("analysis")
-        if codegen_recipe:
+        # Codegen recipe from ALL co-active skills (see _generate_fitting_script).
+        recipes = _collect_codegen_recipe(state)
+        if recipes:
             level = state.get("_annealing_level", 0)
             preamble = self._SKILL_STRICTNESS_SCHEDULE[
                 min(level, len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
-            ].format(name=state.get("skill_name", "skill"))
-            prompt += "\n\n" + preamble + codegen_recipe
+            ].format(name=", ".join(n for n, _ in recipes))
+            prompt += "\n\n" + preamble + _render_codegen_recipe(recipes)
 
         response = self.model.generate_content(prompt)
         result, error = parse_codegen_response(response, field="script", logger=self.logger)

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -32,42 +32,53 @@ from ....utils.codegen_parse import parse_codegen_response
 
 
 def _render_skill_block(state: dict, stage: str) -> str:
-    """Render the active domain skill's block for ``stage`` as a single string.
+    """Render the active domain skill(s) block for ``stage`` as a single string.
 
-    Returns ``""`` when no skill is active or no content exists for the
-    requested stage. Use this from prompt builders that assemble a single
-    string (e.g. ``build_code_generation_prompt``); the list-mode wrapper
-    ``_append_skill_context`` below uses this internally.
+    With multiple skills loaded, each skill's block is rendered in order
+    (most-relevant first) — including at the ``implementation`` (codegen)
+    stage, where co-active skills may each own a different pipeline stage, so
+    none is dropped. Returns ``""`` when no skill is active or no content
+    exists for the requested stage. Use this from prompt builders that
+    assemble a single string (e.g. ``build_code_generation_prompt``); the
+    list-mode wrapper ``_append_skill_context`` below uses this internally.
     """
-    sections = state.get("skill_sections")
-    if not sections:
-        return ""
-    content = sections.get(stage, "")
-    if not content:
+    skills = state.get("skills_loaded") or (
+        [state["skill_sections"]] if state.get("skill_sections") else []
+    )
+    if not skills:
         return ""
 
-    skill_name = state.get("skill_name", "domain skill")
-    parts = [
-        f"\n## MANDATORY Domain Skill Rules: {skill_name} ({stage})",
-        (
-            "The following rules are MANDATORY. Your analysis plan and implementation "
-            "MUST conform to these domain-specific requirements. These rules encode "
-            "validated domain expertise and take precedence over general-purpose defaults. "
-            "Do NOT substitute your own preferences where these rules specify a method, "
-            "treatment, or constraint."
-        ),
-        content,
-    ]
+    parts: list = []
+    intro_appended = False
+    for sections in skills:
+        if not sections:
+            continue
+        content = sections.get(stage, "")
+        if not content:
+            continue
+        skill_name = sections.get("name", "domain skill")
 
-    # Include validation rules during planning, interpretation, and
-    # implementation so the LLM knows quality criteria upfront — at planning
-    # to shape the approach, at interpretation/implementation to shape the
-    # output and the generated code.
-    if stage in ("planning", "interpretation", "implementation"):
-        validation = sections.get("validation", "")
-        if validation:
-            parts.append(f"\n## MANDATORY Domain Validation Rules ({skill_name})")
-            parts.append(validation)
+        parts.append(f"\n## MANDATORY Domain Skill Rules: {skill_name} ({stage})")
+        if not intro_appended:
+            parts.append(
+                "The following rules are MANDATORY. Your analysis plan and implementation "
+                "MUST conform to these domain-specific requirements. These rules encode "
+                "validated domain expertise and take precedence over general-purpose defaults. "
+                "Do NOT substitute your own preferences where these rules specify a method, "
+                "treatment, or constraint."
+            )
+            intro_appended = True
+        parts.append(content)
+
+        # Include validation rules during planning, interpretation, and
+        # implementation so the LLM knows quality criteria upfront — at planning
+        # to shape the approach, at interpretation/implementation to shape the
+        # output and the generated code.
+        if stage in ("planning", "interpretation", "implementation"):
+            validation = sections.get("validation", "")
+            if validation:
+                parts.append(f"\n## MANDATORY Domain Validation Rules ({skill_name})")
+                parts.append(validation)
 
     return "\n".join(parts)
 

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -1039,6 +1039,7 @@ class SkillSuggestionController:
 
         self.logger.info("\n--- Skill Suggestion ---\n")
 
+        custom_skills = state.get("custom_skills") or {}
         selected = select_relevant_skills(
             model=self.model,
             parse_fn=self._parse,
@@ -1047,12 +1048,15 @@ class SkillSuggestionController:
             generation_config=self.generation_config,
             safety_settings=self.safety_settings,
             hint=state.get("skill_hint"),
+            custom_skills=custom_skills,
             logger=self.logger,
         )
         if selected:
-            # Route through the agent's loader so skills_loaded AND the legacy
-            # singular fields are populated consistently (top-ranked = first).
-            state.update(self._load_skills(selected, domain=self.domain))
+            # Resolve any selected custom-skill name to its registered path
+            # (customs aren't on the loader's search roots), then route through
+            # the agent's loader so skills_loaded + legacy fields stay consistent.
+            resolved = [custom_skills.get(n, n) for n in selected]
+            state.update(self._load_skills(resolved, domain=self.domain))
 
         return state
 

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -286,6 +286,46 @@ def _append_tool_inventory(
     prompt.append(format_library_inventory())
 
 
+def _collect_codegen_recipe(state: dict) -> list:
+    """Per-skill codegen recipes for every co-active skill that authored one.
+
+    Returns ``[(skill_name, recipe_text), …]`` in ranked order, preferring each
+    skill's ``implementation`` section over its ``analysis`` synonym. When
+    several skills are active each may own a different pipeline stage (e.g.
+    flattening vs segmentation), so all their recipes are returned — the
+    top-ranked skill is NOT the sole recipe. Falls back to the legacy singular
+    ``skill_sections`` field.
+    """
+    skills = state.get("skills_loaded") or (
+        [state["skill_sections"]] if state.get("skill_sections") else []
+    )
+    recipes = []
+    for s in skills:
+        if not s:
+            continue
+        recipe = s.get("implementation") or s.get("analysis")
+        if recipe:
+            recipes.append((s.get("name", "skill"), recipe))
+    return recipes
+
+
+def _render_codegen_recipe(recipes: list) -> str:
+    """Render collected recipes into one codegen block.
+
+    Single skill: the recipe verbatim (unchanged from pre-multi-skill
+    behavior). Multiple: a short composition note plus each recipe labeled by
+    skill, so the codegen LLM maps each recipe to its pipeline stage.
+    """
+    if len(recipes) == 1:
+        return recipes[0][1]
+    note = (
+        " Multiple skills are active; each recipe below may cover a different "
+        "stage of the analysis (e.g. flattening vs segmentation). Apply each to "
+        "its stage in the plan's order and produce ONE script.\n\n"
+    )
+    return note + "\n\n".join(f"### Recipe — {n}\n{r}" for n, r in recipes)
+
+
 def _active_skill_names(state: dict) -> list[str]:
     """Return names of all currently-loaded skills from a pipeline state dict.
 
@@ -966,66 +1006,53 @@ class SkillSuggestionController:
     """
 
     def __init__(self, model, logger, generation_config, safety_settings,
-                 parse_fn, domain="image_analysis"):
+                 parse_fn, load_skills_fn, domain="image_analysis"):
         self.model = model
         self.logger = logger
         self.generation_config = generation_config
         self.safety_settings = safety_settings
         self._parse = parse_fn
+        self._load_skills = load_skills_fn
         self.domain = domain
 
     def execute(self, state: dict) -> dict:
-        if state.get("error_dict") or state.get("skill_sections"):
+        # Skip when a skill was already provided (orchestrator/user) — check
+        # both the multi-skill list and the legacy singular field.
+        if (state.get("error_dict") or state.get("skills_loaded")
+                or state.get("skill_sections")):
             return state
 
-        from ....skills.loader import list_skills, load_skill
+        from ....skills._shared._skill_selector import select_relevant_skills
 
-        available = list_skills(domain=self.domain)
-        if not available:
-            return state
-
-        catalog, cache = [], {}
-        for name in available:
-            try:
-                parsed = load_skill(name, domain=self.domain)
-                cache[name] = parsed
-                catalog.append(f"- **{name}**: {parsed.get('overview', '').strip()}")
-            except Exception:
-                continue
-        if not catalog:
+        image_bytes = (state.get("scout_montage_bytes")
+                       or state.get("original_image_bytes"))
+        context_parts = []
+        sysinfo = state.get("system_info")
+        if isinstance(sysinfo, dict) and sysinfo:
+            context_parts.append(f"Metadata: {str(sysinfo)[:1500]}")
+        elif isinstance(sysinfo, str) and sysinfo.strip():
+            context_parts.append(f"Metadata: {sysinfo.strip()[:1500]}")
+        if image_bytes:
+            context_parts.append({"mime_type": "image/jpeg", "data": image_bytes})
+        if not context_parts:
             return state
 
         self.logger.info("\n--- Skill Suggestion ---\n")
 
-        prompt = [
-            "Based on the image(s) below, decide whether any of these "
-            "domain skills is relevant.\n\n## Available Skills\n"
-            + "\n".join(catalog),
-        ]
-        image_bytes = (state.get("scout_montage_bytes")
-                       or state.get("original_image_bytes"))
-        if image_bytes:
-            prompt.append({"mime_type": "image/jpeg", "data": image_bytes})
-        prompt.append(
-            'Respond with JSON: {"skill": "<name>"} if clearly relevant, '
-            'or {"skill": null} if none applies.'
+        selected = select_relevant_skills(
+            model=self.model,
+            parse_fn=self._parse,
+            domain=self.domain,
+            context_parts=context_parts,
+            generation_config=self.generation_config,
+            safety_settings=self.safety_settings,
+            hint=state.get("skill_hint"),
+            logger=self.logger,
         )
-
-        try:
-            resp = self.model.generate_content(
-                contents=prompt, generation_config=self.generation_config,
-                safety_settings=self.safety_settings,
-            )
-            result, _ = self._parse(resp)
-            suggested = (result or {}).get("skill")
-            if suggested and suggested in cache:
-                state["skill_name"] = cache[suggested]["name"]
-                state["skill_sections"] = cache[suggested]
-                print(f"  Auto-selected domain skill: {suggested}")
-            else:
-                self.logger.info("  No skill auto-selected")
-        except Exception as e:
-            self.logger.warning(f"  Skill suggestion failed: {e}")
+        if selected:
+            # Route through the agent's loader so skills_loaded AND the legacy
+            # singular fields are populated consistently (top-ranked = first).
+            state.update(self._load_skills(selected, domain=self.domain))
 
         return state
 
@@ -2025,18 +2052,17 @@ Your guidance: '''
         context_parts = []
         if state.get("literature_context"):
             context_parts.append(state["literature_context"])
-        skill_sections = state.get("skill_sections")
-        # Prefer the `implementation` section for codegen. CLAUDE.md: implementation
-        # is the going-forward name; the loader's analysis<->implementation synonym
-        # fold makes single-section skills populate both, while dual-section skills
-        # keep `implementation` as the runnable recipe (not `analysis`).
-        codegen_recipe = (skill_sections or {}).get("implementation") or (skill_sections or {}).get("analysis")
-        if codegen_recipe:
+        # Codegen recipe from ALL co-active skills (not just the top-ranked):
+        # with several skills active each may own a different pipeline stage
+        # (e.g. flattening vs segmentation), so none is dropped. Single-skill
+        # output is unchanged. Prefers `implementation` over `analysis`.
+        recipes = _collect_codegen_recipe(state)
+        if recipes:
             level = state.get("_annealing_level", 0)
             preamble = self._SKILL_STRICTNESS_SCHEDULE[
                 min(level, len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
-            ].format(name=state.get("skill_name", "skill"))
-            context_parts.append(preamble + codegen_recipe)
+            ].format(name=", ".join(n for n, _ in recipes))
+            context_parts.append(preamble + _render_codegen_recipe(recipes))
 
         # Add sub-agent preprocessing array paths
         for key in ("fft_preprocessing", "sam_preprocessing"):
@@ -2219,15 +2245,14 @@ Your guidance: '''
             error_message=error_msg,
             tool_inventory=format_tool_inventory("image_analysis", active_skills=active_skills),
         )
-        skill_sections = state.get("skill_sections")
-        # Prefer `implementation` for codegen (see the generate-script path).
-        codegen_recipe = (skill_sections or {}).get("implementation") or (skill_sections or {}).get("analysis")
-        if codegen_recipe:
+        # Codegen recipe from ALL co-active skills (see the generate-script path).
+        recipes = _collect_codegen_recipe(state)
+        if recipes:
             level = state.get("_annealing_level", 0)
             preamble = self._SKILL_STRICTNESS_SCHEDULE[
                 min(level, len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
-            ].format(name=state.get("skill_name", "skill"))
-            prompt += "\n\n" + preamble + codegen_recipe
+            ].format(name=", ".join(n for n, _ in recipes))
+            prompt += "\n\n" + preamble + _render_codegen_recipe(recipes)
 
         response = self.model.generate_content(prompt)
         result, error = parse_codegen_response(response, field="script", logger=self.logger)

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -288,6 +288,9 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # Non-binding skill suggestion from the orchestrator (the agent's
         # auto-selector treats it as a prior; agent has final authority).
         skill_hint: Optional[Union[str, List[str]]] = None,
+        # User-registered custom skills ({name: path}) — folded into the
+        # agent-side selector's catalog so an uploaded skill is auto-selectable.
+        custom_skills: Optional[Dict[str, str]] = None,
         # Prior knowledge from reference analyses
         prior_knowledge: Optional[List[Dict[str, Any]]] = None,
         # Prior curve-fit runs whose saved artifacts (fitting script, fit
@@ -681,6 +684,8 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             # Non-binding skill suggestion from the orchestrator (agent's
             # auto-selector uses it as a prior; agent has final authority).
             "skill_hint": skill_hint,
+            # User-registered custom skills ({name: path}) for the selector.
+            "custom_skills": custom_skills or {},
 
             # Prior knowledge from reference analyses
             "prior_knowledge": prior_knowledge or [],

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -285,6 +285,9 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         auxiliary_label: Optional[Union[str, List[str]]] = None,
         # Domain skill
         skill: Optional[str] = None,
+        # Non-binding skill suggestion from the orchestrator (the agent's
+        # auto-selector treats it as a prior; agent has final authority).
+        skill_hint: Optional[Union[str, List[str]]] = None,
         # Prior knowledge from reference analyses
         prior_knowledge: Optional[List[Dict[str, Any]]] = None,
         # Prior curve-fit runs whose saved artifacts (fitting script, fit
@@ -675,6 +678,9 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
 
             # Domain skill
             **skill_state,
+            # Non-binding skill suggestion from the orchestrator (agent's
+            # auto-selector uses it as a prior; agent has final authority).
+            "skill_hint": skill_hint,
 
             # Prior knowledge from reference analyses
             "prior_knowledge": prior_knowledge or [],
@@ -743,6 +749,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             outlier_sigma=effective_outlier_sigma,
             max_verification_iterations=effective_max_verification,
             parallel_workers=self.parallel_workers,
+            load_skills_fn=self._load_skills_to_state,
         )
         
         # Execute pipeline

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -181,6 +181,7 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         objective: str | None = None,
         hints: str | None = None,
         skill: str | None = None,
+        skill_hint: str | list[str] | None = None,
         prior_knowledge: list | None = None,
         auxiliary_data: str | list[str] | None = None,
         auxiliary_label: str | list[str] | None = None,
@@ -279,6 +280,16 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # — see PR 3 multi-skill support.
         skill_state = self._load_skills_to_state(skill, domain="hyperspectral")
 
+        # Auto-select skill(s) when none were explicitly provided, mirroring
+        # the image/curve agents. Conservative, technique-aware (issue #251);
+        # may pick zero, one, or several skills from the metadata.
+        if not skill_state.get("skills_loaded"):
+            selected = self._auto_select_skills(system_info, hint=skill_hint)
+            if selected:
+                skill_state = self._load_skills_to_state(
+                    selected, domain="hyperspectral"
+                )
+
         # Load auxiliary data if provided (one or several companion datasets).
         auxiliary_state = _empty_auxiliary_state()
         if auxiliary_data:
@@ -354,6 +365,34 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         self.logger.info(f"{'='*80}\n")
         
         return response
+
+    def _auto_select_skills(self, system_info, hint=None) -> list:
+        """Pick relevant hyperspectral skill(s) from the metadata.
+
+        Uses the shared technique-aware selector. ``hint`` is the orchestrator's
+        non-binding suggestion (the agent has final authority). Returns a
+        possibly-empty, ranked list of skill names; never raises.
+        """
+        from ...skills._shared._skill_selector import select_relevant_skills
+
+        context_parts = []
+        if isinstance(system_info, dict) and system_info:
+            context_parts.append(f"Metadata: {str(system_info)[:1500]}")
+        elif isinstance(system_info, str) and system_info.strip():
+            context_parts.append(f"Metadata: {system_info.strip()[:1500]}")
+        if not context_parts:
+            return []
+
+        return select_relevant_skills(
+            model=self.model,
+            parse_fn=self._parse_llm_response,
+            domain="hyperspectral",
+            context_parts=context_parts,
+            generation_config=self.generation_config,
+            safety_settings=self.safety_settings,
+            hint=hint,
+            logger=self.logger,
+        )
 
     # =========================================================================
     # BACKWARD COMPATIBLE METHODS

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -182,6 +182,7 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         hints: str | None = None,
         skill: str | None = None,
         skill_hint: str | list[str] | None = None,
+        custom_skills: dict | None = None,
         prior_knowledge: list | None = None,
         auxiliary_data: str | list[str] | None = None,
         auxiliary_label: str | list[str] | None = None,
@@ -284,10 +285,15 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # the image/curve agents. Conservative, technique-aware (issue #251);
         # may pick zero, one, or several skills from the metadata.
         if not skill_state.get("skills_loaded"):
-            selected = self._auto_select_skills(system_info, hint=skill_hint)
+            selected = self._auto_select_skills(
+                system_info, hint=skill_hint, custom_skills=custom_skills
+            )
             if selected:
+                # Resolve any selected custom-skill name to its registered path.
+                cs = custom_skills or {}
+                resolved = [cs.get(n, n) for n in selected]
                 skill_state = self._load_skills_to_state(
-                    selected, domain="hyperspectral"
+                    resolved, domain="hyperspectral"
                 )
 
         # Load auxiliary data if provided (one or several companion datasets).
@@ -366,11 +372,12 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         
         return response
 
-    def _auto_select_skills(self, system_info, hint=None) -> list:
+    def _auto_select_skills(self, system_info, hint=None, custom_skills=None) -> list:
         """Pick relevant hyperspectral skill(s) from the metadata.
 
         Uses the shared technique-aware selector. ``hint`` is the orchestrator's
-        non-binding suggestion (the agent has final authority). Returns a
+        non-binding suggestion (the agent has final authority). ``custom_skills``
+        ({name: path}) folds user-registered skills into the catalog. Returns a
         possibly-empty, ranked list of skill names; never raises.
         """
         from ...skills._shared._skill_selector import select_relevant_skills
@@ -391,6 +398,7 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             generation_config=self.generation_config,
             safety_settings=self.safety_settings,
             hint=hint,
+            custom_skills=custom_skills,
             logger=self.logger,
         )
 

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -236,6 +236,7 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         auxiliary_label: Optional[Union[str, List[str]]] = None,
         skill: Optional[str] = None,
         skill_hint: Optional[Union[str, List[str]]] = None,
+        custom_skills: Optional[Dict[str, str]] = None,
         prior_knowledge: Optional[List[Dict[str, Any]]] = None,
         prior_analysis_paths: Optional[List[str]] = None,
         # Opt-in: force verbatim reuse of the prior locked analysis script
@@ -433,6 +434,10 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             # Non-binding skill suggestion from the orchestrator (the agent's
             # auto-selector treats it as a prior; agent has final authority).
             "skill_hint": skill_hint,
+            # User-registered custom skills ({name: path}) — folded into the
+            # agent-side selector's catalog so an uploaded skill is
+            # auto-selectable, not only orchestrator-passable (#256 fix #1).
+            "custom_skills": custom_skills or {},
             # Prior knowledge
             "prior_knowledge": prior_knowledge or [],
             "prior_analysis_paths": prior_analysis_paths or [],

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -235,6 +235,7 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         auxiliary_data: Optional[Union[str, List[str]]] = None,
         auxiliary_label: Optional[Union[str, List[str]]] = None,
         skill: Optional[str] = None,
+        skill_hint: Optional[Union[str, List[str]]] = None,
         prior_knowledge: Optional[List[Dict[str, Any]]] = None,
         prior_analysis_paths: Optional[List[str]] = None,
         # Opt-in: force verbatim reuse of the prior locked analysis script
@@ -429,6 +430,9 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             **aux_state,
             # Domain skill
             **skill_state,
+            # Non-binding skill suggestion from the orchestrator (the agent's
+            # auto-selector treats it as a prior; agent has final authority).
+            "skill_hint": skill_hint,
             # Prior knowledge
             "prior_knowledge": prior_knowledge or [],
             "prior_analysis_paths": prior_analysis_paths or [],
@@ -483,6 +487,7 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             safety_settings=self.safety_settings,
             parse_fn=self._parse_llm_response,
             store_fn=self._store_analysis_images,
+            load_skills_fn=self._load_skills_to_state,
             image_to_bytes_fn=image_to_thumbnail_bytes,
             montage_fn=create_image_montage,
             executor=self.executor,
@@ -1084,6 +1089,7 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             safety_settings=self.safety_settings,
             parse_fn=self._parse_llm_response,
             store_fn=self._store_analysis_images,
+            load_skills_fn=self._load_skills_to_state,
             image_to_bytes_fn=image_to_thumbnail_bytes,
             montage_fn=create_image_montage,
             executor=self.executor,

--- a/scilink/agents/exp_agents/pipelines/curve_fitting_pipelines.py
+++ b/scilink/agents/exp_agents/pipelines/curve_fitting_pipelines.py
@@ -21,6 +21,7 @@ from typing import Callable, List, Any
 from ..controllers.curve_fitting_controllers import (
     # Original controllers
     AnalyzeDataController,
+    CurveFittingSkillSuggestionController,
     SeriesScoutController,
     LiteratureSearchController,
     GenerateCurveFittingReportController,
@@ -62,6 +63,7 @@ def create_unified_curve_fitting_pipeline(
     outlier_sigma: float = 2.0,
     max_verification_iterations: int = 7,
     parallel_workers: int | None = None,
+    load_skills_fn: Callable | None = None,
 ) -> List:
     """
     Factory function to create the unified curve fitting pipeline.
@@ -143,6 +145,22 @@ def create_unified_curve_fitting_pipeline(
             plot_fn=plot_fn,
         )
     )
+
+    # Step 1.7: Auto-suggest domain skill(s) if none were provided.
+    # Only wired when the agent supplies its skill loader (keeps the legacy
+    # backward-compat factory, which omits it, at the prior no-auto-select
+    # behavior).
+    if load_skills_fn is not None:
+        pipeline.append(
+            CurveFittingSkillSuggestionController(
+                model=model,
+                logger=logger,
+                generation_config=generation_config,
+                safety_settings=safety_settings,
+                parse_fn=parse_fn,
+                load_skills_fn=load_skills_fn,
+            )
+        )
 
     # Step 2: Human feedback refinement on fitting approach
     pipeline.append(

--- a/scilink/agents/exp_agents/pipelines/image_analysis_pipelines.py
+++ b/scilink/agents/exp_agents/pipelines/image_analysis_pipelines.py
@@ -52,6 +52,7 @@ def create_unified_image_analysis_pipeline(
     safety_settings,
     parse_fn: Callable,
     store_fn: Callable,
+    load_skills_fn: Callable,
     image_to_bytes_fn: Callable,
     montage_fn: Callable,
     executor: Any,
@@ -145,6 +146,7 @@ def create_unified_image_analysis_pipeline(
             generation_config=generation_config,
             safety_settings=safety_settings,
             parse_fn=parse_fn,
+            load_skills_fn=load_skills_fn,
         )
     )
 

--- a/scilink/skills/_shared/_skill_selector.py
+++ b/scilink/skills/_shared/_skill_selector.py
@@ -23,28 +23,33 @@ from __future__ import annotations
 from typing import Any, Callable, List, Optional
 
 
-def build_skill_catalog(domain: str, *, include_provisional: bool = False):
+def build_skill_catalog(domain: str, *, include_provisional: bool = False,
+                        custom_skills: Optional[dict] = None):
     """Build the selectable-skill catalog for ``domain``.
 
     Returns ``(catalog_lines, names)`` where ``catalog_lines`` is a list of
     human-/LLM-readable bullet strings and ``names`` is the set of valid skill
     names the selector is allowed to return. Mirrors the orchestrator's
     description convention (``analysis_orchestrator_tools._build_skill_description``).
+
+    ``custom_skills`` is an optional ``{name: path}`` map of user-registered
+    skills (UI upload / ``--skills``). They are folded into the catalog so the
+    agent-side selector can auto-select them like built-ins (issue #256 fix #1),
+    EXCEPT when a custom skill's frontmatter declares a *different* analysis
+    modality — that explicit cross-modality skill is skipped (mirrors the
+    loader's ``_MODALITY_DOMAINS`` guard). A custom skill with no declared
+    domain is included; the selector's technique/modality reasoning rejects it
+    if the data does not fit.
     """
-    from ..loader import list_skills, load_skill
+    from ..loader import list_skills, load_skill, _MODALITY_DOMAINS
 
     catalog: List[str] = []
     names: set[str] = set()
-    for name in list_skills(domain=domain):
-        try:
-            parsed = load_skill(name, domain=domain)
-        except Exception:
-            continue
+
+    def _entry(parsed, name):
         meta = parsed.get("meta") or {}
-        # Provisional skills stay loadable via an explicit skill= but are kept
-        # out of auto-routing until reviewed/promoted (see scilink memory).
         if meta.get("provisional") is True and not include_provisional:
-            continue
+            return False
         desc = meta.get("description")
         if not desc:
             desc = parsed.get("overview", "").split("\n")[0].strip()
@@ -58,6 +63,30 @@ def build_skill_catalog(domain: str, *, include_provisional: bool = False):
         body = f" — {desc}" if desc else ""
         catalog.append(f"- **{name}**{tech_tag}{body}")
         names.add(name)
+        return True
+
+    for name in list_skills(domain=domain):
+        try:
+            parsed = load_skill(name, domain=domain)
+        except Exception:
+            continue
+        _entry(parsed, name)
+
+    # User-registered custom skills (session-scoped) — fold them in so the
+    # agent can auto-select an uploaded skill, not just have the orchestrator
+    # pass it authoritatively.
+    for name, path in (custom_skills or {}).items():
+        if name in names:
+            continue
+        try:
+            parsed = load_skill(path, domain=domain)
+        except Exception:
+            continue
+        declared = (parsed.get("meta") or {}).get("domain")
+        if declared in _MODALITY_DOMAINS and declared != domain:
+            continue  # explicitly authored for a different modality
+        _entry(parsed, name)
+
     return catalog, names
 
 
@@ -100,6 +129,7 @@ def select_relevant_skills(
     max_skills: int = 3,
     exclusive: bool = False,
     hint: Any = None,
+    custom_skills: Optional[dict] = None,
     logger: Optional[Any] = None,
 ) -> List[str]:
     """Ask the model which domain skills (zero or more) fit the data.
@@ -120,12 +150,16 @@ def select_relevant_skills(
             (from conversation/preview context the data may not show). A
             NON-BINDING prior — the agent confirms from the data, augments, or
             overrides. The agent has final authority.
+        custom_skills: optional ``{name: path}`` of user-registered skills to
+            fold into the catalog so they are auto-selectable. A returned
+            custom name must be resolved to its path (via this same map) before
+            loading, since it is not on the loader's search roots.
 
     Returns:
         A ranked (most-relevant-first), de-duplicated list of valid skill
         names, possibly empty. Never raises — failures log and return ``[]``.
     """
-    catalog, valid = build_skill_catalog(domain)
+    catalog, valid = build_skill_catalog(domain, custom_skills=custom_skills)
     if not catalog:
         return []
 

--- a/scilink/skills/_shared/_skill_selector.py
+++ b/scilink/skills/_shared/_skill_selector.py
@@ -1,0 +1,198 @@
+"""Shared agent-side skill relevance selector.
+
+Lets the analysis foundation agents (image, curve-fitting, hyperspectral)
+auto-select **zero or more** relevant skills by inspecting the actual data,
+rather than relying solely on the orchestrator to pass a skill list.
+
+The agent supplies only its modality-specific context (image bytes, curve
+statistics, metadata); this module owns the catalog, the selection prompt,
+parsing, and validation. It mirrors the catalog convention used by the
+orchestrator's ``_build_skill_description`` — frontmatter ``description``
+(falling back to the overview's first line) plus a ``[technique: …]`` tag,
+with provisional (auto-distilled) skills excluded — so agent-side selection
+technique-matches the same way the orchestrator does (see issue #251).
+
+Selection is deliberately conservative: prefer zero or one skill unless
+multiple are *clearly* warranted. The result is ranked most-relevant-first,
+which downstream code relies on — the top-ranked skill drives single-recipe
+codegen while the full set enriches the prose context at each stage.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, List, Optional
+
+
+def build_skill_catalog(domain: str, *, include_provisional: bool = False):
+    """Build the selectable-skill catalog for ``domain``.
+
+    Returns ``(catalog_lines, names)`` where ``catalog_lines`` is a list of
+    human-/LLM-readable bullet strings and ``names`` is the set of valid skill
+    names the selector is allowed to return. Mirrors the orchestrator's
+    description convention (``analysis_orchestrator_tools._build_skill_description``).
+    """
+    from ..loader import list_skills, load_skill
+
+    catalog: List[str] = []
+    names: set[str] = set()
+    for name in list_skills(domain=domain):
+        try:
+            parsed = load_skill(name, domain=domain)
+        except Exception:
+            continue
+        meta = parsed.get("meta") or {}
+        # Provisional skills stay loadable via an explicit skill= but are kept
+        # out of auto-routing until reviewed/promoted (see scilink memory).
+        if meta.get("provisional") is True and not include_provisional:
+            continue
+        desc = meta.get("description")
+        if not desc:
+            desc = parsed.get("overview", "").split("\n")[0].strip()
+        desc = desc.rstrip(".;,") if desc else desc
+        techs = meta.get("technique")
+        if isinstance(techs, str):
+            techs = [techs]
+        tech_tag = (
+            f" [technique: {', '.join(map(str, techs))}]" if techs else ""
+        )
+        body = f" — {desc}" if desc else ""
+        catalog.append(f"- **{name}**{tech_tag}{body}")
+        names.add(name)
+    return catalog, names
+
+
+_SELECTION_GUIDANCE = (
+    "Select a skill only when its scope genuinely fits the data. When a skill "
+    "declares a `[technique: …]` tag, REQUIRE that the data's measurement "
+    "technique matches that tag — do NOT substitute the nearest-sounding "
+    "technique skill (e.g. an XRD skill for Raman data). When a skill has no "
+    "technique tag, match it on the data's imaging modality or the analysis "
+    "task it describes (e.g. a touching/overlapping-objects skill for an image "
+    "of densely packed grains). If nothing genuinely fits, return an empty "
+    "list and the agent's baseline expertise will handle it. Prefer zero or "
+    "one skill; return several ONLY when the data clearly spans complementary "
+    "skills that each contribute. Order the list most-relevant first."
+)
+
+# Exclusive policy — for agents (e.g. curve-fitting) whose skills encode
+# AUTHORITATIVE, mutually-exclusive technique rules. The data is produced by
+# one measurement technique, and two technique skills would inject
+# contradictory mandatory rules, so at most one may be selected.
+_EXCLUSIVE_GUIDANCE = (
+    "These skills encode authoritative, technique-specific rules and are "
+    "mutually exclusive — the data is produced by ONE measurement technique. "
+    "Select the SINGLE skill whose technique matches the data's technique "
+    "(compare against each skill's `[technique: …]` tag). If no skill's "
+    "technique matches, return an empty list and the agent's baseline handles "
+    "it — do NOT substitute the nearest-sounding skill, and never select more "
+    "than one."
+)
+
+
+def select_relevant_skills(
+    *,
+    model: Any,
+    parse_fn: Callable,
+    domain: str,
+    context_parts: List[Any],
+    generation_config: Any = None,
+    safety_settings: Any = None,
+    max_skills: int = 3,
+    exclusive: bool = False,
+    hint: Any = None,
+    logger: Optional[Any] = None,
+) -> List[str]:
+    """Ask the model which domain skills (zero or more) fit the data.
+
+    Args:
+        model: LLM client exposing ``generate_content(contents, ...)``.
+        parse_fn: the agent's response parser, returning ``(result_dict, _)``.
+        domain: skill domain to draw the catalog from.
+        context_parts: prompt parts describing the *actual* data — text
+            (stats, metadata) and/or vision dicts (``{"mime_type", "data"}``).
+        max_skills: hard cap on how many skills may be returned.
+        exclusive: when True, the skills are treated as authoritative and
+            mutually exclusive (curve-fitting techniques) — the prompt asks for
+            the single best technique match and the result is capped to one.
+            When False (default), multiple complementary skills may be
+            returned (image / hyperspectral stages compose).
+        hint: optional skill name(s) the orchestrator *suggests* may apply
+            (from conversation/preview context the data may not show). A
+            NON-BINDING prior — the agent confirms from the data, augments, or
+            overrides. The agent has final authority.
+
+    Returns:
+        A ranked (most-relevant-first), de-duplicated list of valid skill
+        names, possibly empty. Never raises — failures log and return ``[]``.
+    """
+    catalog, valid = build_skill_catalog(domain)
+    if not catalog:
+        return []
+
+    cap = 1 if exclusive else max_skills
+    guidance = _EXCLUSIVE_GUIDANCE if exclusive else _SELECTION_GUIDANCE
+    prompt: List[Any] = [
+        "Decide which (if any) of these domain skills are relevant to the "
+        "data described below.\n\n## Available Skills\n" + "\n".join(catalog),
+        "\n## Data / Context\n",
+    ]
+    prompt.extend(context_parts)
+
+    # Non-binding suggestion from the orchestrator (conversational/preview
+    # context the agent can't see). Only surface hints that name real skills;
+    # the agent still decides from the data above.
+    hint_names = [hint] if isinstance(hint, str) else list(hint or [])
+    hint_names = [h for h in hint_names if h in valid]
+    if hint_names:
+        prompt.append(
+            "\n## Orchestrator suggestion (non-binding)\n"
+            f"Based on the conversation/preview, these skills MAY apply: "
+            f"{', '.join(hint_names)}. Treat this only as a prior — confirm it "
+            "against the data above, add complementary skills if warranted, or "
+            "disregard it if the data does not support it. You decide."
+        )
+    prompt.append(
+        "\n" + guidance + "\n\n"
+        'Respond with JSON: {"skills": ["<name>", ...]} listing the relevant '
+        "skill names (an empty list if none apply)."
+    )
+
+    try:
+        resp = model.generate_content(
+            contents=prompt,
+            generation_config=generation_config,
+            safety_settings=safety_settings,
+        )
+        result, _ = parse_fn(resp)
+    except Exception as e:  # pragma: no cover - defensive
+        if logger:
+            logger.warning(f"  Skill selection failed: {e}")
+        return []
+
+    result = result or {}
+    # Accept the list contract, but tolerate a singular {"skill": "x"} reply.
+    raw = result.get("skills")
+    if raw is None:
+        one = result.get("skill")
+        raw = [one] if one else []
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, list):
+        return []
+
+    selected: List[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        name = item.strip() if isinstance(item, str) else None
+        if name and name in valid and name not in seen:
+            seen.add(name)
+            selected.append(name)
+        if len(selected) >= cap:
+            break
+
+    if logger:
+        if selected:
+            logger.info(f"  Auto-selected domain skill(s): {', '.join(selected)}")
+        else:
+            logger.info("  No skill auto-selected")
+    return selected

--- a/tests/test_multiskill_autoselect_live.py
+++ b/tests/test_multiskill_autoselect_live.py
@@ -1,0 +1,462 @@
+"""Comprehensive LIVE test suite for agent-side multi-skill auto-selection (#256).
+
+Validates, against a real LLM, the full feature set built on
+``feature-agent-multiskill-autoselect``:
+
+  * technique-aware single-select + the #251 no-substitution rule
+  * per-domain ``exclusive`` policy (curve = one technique; image/hsi compose)
+  * multi-skill composition (prose + codegen), end-to-end with execution
+  * ``skill_hint`` authority (orchestrator suggests, agent confirms/overrides/rejects)
+  * custom-skill visibility / auto-select (fix #1) + foreign-modality filtering
+  * orchestrator deferral vs explicit ``skill`` vs ``skill_hint``
+
+Uses REAL example data (grains image, EELS spectrum + datacube) and SYNTHETIC
+data (XPS/EPR/XRD/Raman/generic spectra; atomic-STEM / AFM-grain / control
+images) generated in-process.
+
+Run (Bedrock; agent/orchestrator tiers execute generated code):
+
+  UNSAFE_EXECUTION_OK=true \\
+  AWS_BEARER_TOKEN_BEDROCK=<key> AWS_REGION_NAME=us-east-1 \\
+    python tests/test_multiskill_autoselect_live.py --tier all --model bedrock/us.anthropic.claude-opus-4-8
+
+  --tier selector      fast, no code execution (default)
+  --tier agent         full analyze() runs (slow, executes code)
+  --tier orchestrator  orchestrator routing decisions (slow)
+  --tier all
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import re
+import sys
+import tempfile
+
+import numpy as np
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+EX = os.path.join(REPO, "examples")
+MODEL_DEFAULT = "bedrock/us.anthropic.claude-opus-4-8"
+
+# ───────────────────────────── result harness ─────────────────────────────
+_RESULTS = []  # (tier, label, status, detail)  status ∈ {PASS, FAIL, SOFT, INFO}
+
+
+def record(tier, label, status, detail=""):
+    _RESULTS.append((tier, label, status, detail))
+    mark = {"PASS": "✅", "FAIL": "❌", "SOFT": "🟡", "INFO": "ℹ️"}[status]
+    print(f"  {mark} [{tier}] {label}: {detail}")
+
+
+def check(tier, label, ok, got, *, soft=False):
+    record(tier, label, ("PASS" if ok else ("SOFT" if soft else "FAIL")),
+           f"got {got!r}")
+
+
+# ───────────────────────────── synthetic data ─────────────────────────────
+def synth_xps():
+    x = np.linspace(280, 295, 400)
+    bg = 0.4 * (x - 280) / 15
+    y = bg + 3.0 * np.exp(-0.5 * ((x - 284.8) / 0.5) ** 2) \
+          + 1.4 * np.exp(-0.5 * ((x - 286.3) / 0.7) ** 2)
+    y += 0.02 * np.random.RandomState(1).randn(x.size)
+    return x, y, {"technique": "XPS", "detail": "C 1s region", "x_units": "eV (binding energy)"}
+
+
+def synth_epr():
+    x = np.linspace(300, 360, 1024)  # mT
+    def deriv_gauss(c, w, A):
+        z = (x - c) / w
+        return A * (-z) * np.exp(-0.5 * z ** 2)
+    y = deriv_gauss(322, 1.2, 1.0) + deriv_gauss(345, 1.5, 0.8)  # axial-ish
+    y += 0.01 * np.random.RandomState(2).randn(x.size)
+    return x, y, {"technique": "EPR", "detail": "X-band CW first-derivative", "x_units": "mT"}
+
+
+def synth_xrd():
+    x = np.linspace(20, 80, 1200)  # 2theta
+    y = 0.05 * np.ones_like(x)
+    for c, A, w in [(28.4, 1.0, 0.15), (32.9, 0.6, 0.16), (47.2, 0.5, 0.2), (56.1, 0.4, 0.22)]:
+        y += A / (1 + ((x - c) / w) ** 2)
+    y += 0.01 * np.random.RandomState(3).randn(x.size)
+    return x, y, {"technique": "XRD", "detail": "powder diffraction", "x_units": "2theta deg"}
+
+
+def synth_raman():
+    x = np.linspace(100, 900, 700)  # cm^-1
+    y = 0.1 + 1.0 / (1 + ((x - 305) / 12) ** 2) + 0.7 / (1 + ((x - 515) / 18) ** 2) \
+          + 0.5 / (1 + ((x - 720) / 20) ** 2)
+    y += 0.01 * np.random.RandomState(4).randn(x.size)
+    return x, y, {"technique": "Raman", "detail": "BaTiO3 vibrational bands", "x_units": "cm^-1"}
+
+
+def synth_decay():
+    x = np.linspace(0, 10, 300)
+    y = 2.0 * np.exp(-x / 2.5) + 0.3 + 0.02 * np.random.RandomState(5).randn(x.size)
+    return x, y, {"technique": "generic sensor voltage vs time", "detail": "exponential decay, no spectroscopy"}
+
+
+def synth_atomic_image(n=256, spacing=16):
+    yy, xx = np.mgrid[0:n, 0:n]
+    img = np.zeros((n, n), float)
+    for cy in range(spacing // 2, n, spacing):
+        for cx in range(spacing // 2, n, spacing):
+            img += np.exp(-((xx - cx) ** 2 + (yy - cy) ** 2) / (2 * 3.0 ** 2))
+    img = (img / img.max() * 255).astype(np.uint8)
+    return img, {"microscopy_type": "STEM HAADF", "technique": "atomic-resolution Z-contrast",
+                 "detail": "zone-axis crystalline lattice, atomic columns"}
+
+
+def synth_afm_grains(n=512, n_seeds=45, seed=0):
+    rng = np.random.RandomState(seed)
+    pts = rng.rand(n_seeds, 2) * n
+    heights = rng.rand(n_seeds)
+    yy, xx = np.mgrid[0:n, 0:n]
+    d = (xx[..., None] - pts[:, 1]) ** 2 + (yy[..., None] - pts[:, 0]) ** 2
+    idx = d.argmin(-1)
+    img = heights[idx]
+    try:
+        from scipy.ndimage import gaussian_filter
+        img = gaussian_filter(img, 3)
+    except Exception:
+        pass
+    # dark grain boundaries where the nearest-seed label changes
+    b = np.zeros((n, n), bool)
+    b[:, 1:] |= idx[:, 1:] != idx[:, :-1]
+    b[1:, :] |= idx[1:, :] != idx[:-1, :]
+    img = (img - img.min()) / (np.ptp(img) + 1e-9)
+    img[b] = 0.0
+    img = (img * 255).astype(np.uint8)
+    return img, {"microscopy_type": "AFM", "technique": "topography (height)",
+                 "detail": "densely packed touching grains, intensity is height in nm",
+                 "x_units": "nm"}
+
+
+def synth_control_image(n=256):
+    yy, xx = np.mgrid[0:n, 0:n]
+    img = ((xx / n) * 255).astype(np.uint8)  # plain gradient
+    return img, {"detail": "featureless intensity gradient, no recognizable structure"}
+
+
+# ───────────────────────────── context builders ───────────────────────────
+def _plot_bytes(x, y):
+    fig, ax = plt.subplots(figsize=(5, 3))
+    ax.plot(x, y, lw=0.8)
+    buf = io.BytesIO()
+    fig.savefig(buf, format="jpeg", dpi=80, bbox_inches="tight")
+    plt.close(fig)
+    return buf.getvalue()
+
+
+def curve_ctx(x, y, meta):
+    stats = {"n_points": int(x.size),
+             "x_range": [float(x.min()), float(x.max())],
+             "y_range": [float(y.min()), float(y.max())]}
+    return [f"Metadata: {meta}", f"Data statistics: {stats}",
+            {"mime_type": "image/jpeg", "data": _plot_bytes(x, y)}]
+
+
+def image_ctx(img, meta):
+    from scilink.skills._shared.image_analysis_tools import image_to_thumbnail_bytes
+    return [f"Metadata: {meta}", {"mime_type": "image/jpeg", "data": image_to_thumbnail_bytes(img)}]
+
+
+def meta_ctx(meta):
+    return [f"Metadata: {meta}"]
+
+
+# ───────────────────────────── model + parse ──────────────────────────────
+def make_model(model_name):
+    from scilink.wrappers.litellm_wrapper import LiteLLMGenerativeModel
+    return LiteLLMGenerativeModel(model=model_name, api_key=None)
+
+
+def parse_fn(resp):
+    t = (getattr(resp, "text", "") or "").strip()
+    m = re.search(r"\{.*\}", t, re.DOTALL)
+    return (json.loads(m.group(0)) if m else {}), None
+
+
+# ════════════════════════════ TIER 1: selector ════════════════════════════
+def tier_selector(model_name):
+    from scilink.skills._shared._skill_selector import select_relevant_skills, build_skill_catalog
+    m = make_model(model_name)
+
+    def sel(domain, ctx, **kw):
+        return select_relevant_skills(model=m, parse_fn=parse_fn, domain=domain,
+                                      context_parts=ctx, **kw)
+
+    T = "selector"
+    print("\n── TIER 1: selector (technique-aware, exclusive, hint, custom) ──")
+
+    # catalog sanity
+    _, cf = build_skill_catalog("curve_fitting")
+    check(T, "catalog/curve has epr,xps,xrd", {"epr", "xps", "xrd_profile"} <= cf, sorted(cf))
+
+    # CURVE (exclusive) — synthetic spectra by technique
+    x, y, mta = synth_xps()
+    check(T, "curve XPS -> xps", sel("curve_fitting", curve_ctx(x, y, mta), exclusive=True) == ["xps"], "xps")
+    x, y, mta = synth_epr()
+    check(T, "curve EPR -> epr", sel("curve_fitting", curve_ctx(x, y, mta), exclusive=True) == ["epr"], "epr")
+    x, y, mta = synth_xrd()
+    check(T, "curve XRD -> xrd_profile", sel("curve_fitting", curve_ctx(x, y, mta), exclusive=True) == ["xrd_profile"], "xrd_profile")
+    x, y, mta = synth_raman()
+    r = sel("curve_fitting", curve_ctx(x, y, mta), exclusive=True)
+    check(T, "curve RAMAN -> [] (no substitution #251)", r == [], r)  # no raman skill; must NOT pick xrd/xps
+    x, y, mta = synth_decay()
+    r = sel("curve_fitting", curve_ctx(x, y, mta), exclusive=True)
+    check(T, "curve generic-decay -> []", r == [], r)
+
+    # IMAGE (composable)
+    img = np.load(os.path.join(EX, "polycrystalline_grains_demo/image.npy"))
+    meta = json.load(open(os.path.join(EX, "polycrystalline_grains_demo/image.json")))
+    r = sel("image_analysis", image_ctx(img, meta))
+    check(T, "image REAL grains -> overlapping_objects", "overlapping_objects" in r, r)
+    aimg, ameta = synth_atomic_image()
+    r = sel("image_analysis", image_ctx(aimg, ameta))
+    check(T, "image synth atomic-STEM -> atomic_stem", "atomic_stem" in r, r, soft=True)
+    gimg, gmeta = synth_afm_grains()
+    r = sel("image_analysis", image_ctx(gimg, gmeta))
+    check(T, "image synth AFM-grains -> overlapping_objects (+afm multi)", "overlapping_objects" in r, r, soft=True)
+    check(T, "image synth AFM-grains multi-skill fires", len(r) >= 2, r, soft=True)
+    cimg, cmeta = synth_control_image()
+    r = sel("image_analysis", image_ctx(cimg, cmeta))
+    check(T, "image control-gradient -> []", r == [], r, soft=True)
+
+    # HYPERSPECTRAL (metadata-only selector — weakest signal path; single skill)
+    em = json.load(open(os.path.join(EX, "eels_plasmons_demo/datacube.json")))
+    r = sel("hyperspectral", meta_ctx(em))
+    check(T, "hsi REAL EELS datacube -> eels", "eels" in r, r, soft=True)
+    em2 = json.load(open(os.path.join(EX, "eels_identification_demo/spectrum.json")))
+    r = sel("hyperspectral", meta_ctx(em2))
+    check(T, "hsi REAL EELS spectrum -> eels", "eels" in r, r)
+    r = sel("hyperspectral", meta_ctx({"technique": "optical photoluminescence, no EELS"}))
+    check(T, "hsi non-EELS -> []", r == [], r, soft=True)
+
+    # skill_hint authority
+    x, y, mta = synth_xps()
+    xps_ctx = curve_ctx(x, y, mta)
+    check(T, "hint confirm (xps/xps)", sel("curve_fitting", xps_ctx, exclusive=True, hint="xps") == ["xps"], "xps")
+    check(T, "hint OVERRIDE (epr hint, xps data)", sel("curve_fitting", xps_ctx, exclusive=True, hint="epr") == ["xps"], "xps")
+    x, y, mta = synth_decay()
+    check(T, "hint REJECT (xps hint, generic data)", sel("curve_fitting", curve_ctx(x, y, mta), exclusive=True, hint="xps") == [], "[]")
+    r = sel("image_analysis", image_ctx(img, meta), hint="atomic_stem")
+    check(T, "hint OVERRIDE image (atomic_stem hint, grains)", "overlapping_objects" in r and "atomic_stem" not in r, r, soft=True)
+
+    # custom skills (fix #1)
+    d = tempfile.mkdtemp()
+    raman_md = os.path.join(d, "raman_custom.md")
+    open(raman_md, "w").write(
+        "---\ndescription: Raman peak fitting (Lorentzian/Voigt bands, baseline)\n"
+        "technique: Raman, Raman spectroscopy\n---\n## overview\nRaman band fitting.\n"
+        "## planning\nFit bands with pseudo-Voigt; subtract polynomial baseline.\n")
+    foreign_md = os.path.join(d, "img_foreign.md")
+    open(foreign_md, "w").write("---\ndomain: image_analysis\n---\n## overview\nimage thing.\n")
+    CUST = {"raman_custom": raman_md, "img_foreign": foreign_md}
+
+    x, y, mta = synth_raman()
+    rctx = curve_ctx(x, y, mta)
+    check(T, "custom raman REGISTERED + Raman data -> raman_custom (fix #1)",
+          sel("curve_fitting", rctx, exclusive=True, custom_skills=CUST) == ["raman_custom"], "raman_custom")
+    check(T, "custom raman NOT registered + Raman -> [] (was the gap)",
+          sel("curve_fitting", rctx, exclusive=True) == [], "[]")
+    x, y, mta = synth_xps()
+    check(T, "custom raman registered + XPS data -> xps (ignore irrelevant custom)",
+          sel("curve_fitting", curve_ctx(x, y, mta), exclusive=True, custom_skills=CUST) == ["xps"], "xps")
+    _, names = build_skill_catalog("curve_fitting", custom_skills=CUST)
+    check(T, "custom foreign-modality filtered from catalog", "img_foreign" not in names and "raman_custom" in names, sorted(n for n in names if "custom" in n or "foreign" in n))
+
+
+# ════════════════════════════ TIER 2: agent e2e ═══════════════════════════
+def _write_dataset(dirpath, name, arr, meta):
+    os.makedirs(dirpath, exist_ok=True)
+    p = os.path.join(dirpath, name + ".npy")
+    np.save(p, arr)
+    json.dump(meta, open(os.path.join(dirpath, name + ".json"), "w"))
+    return p
+
+
+def tier_agent(model_name):
+    T = "agent-e2e"
+    print("\n── TIER 2: agent end-to-end (executes generated code) ──")
+    work = tempfile.mkdtemp(prefix="multiskill_e2e_")
+
+    # 2a. IMAGE two-skill composition on a SYNTHETIC AFM-grains image where BOTH
+    # skills genuinely apply: afm (flatten / physical-unit discipline) +
+    # overlapping_objects (segment touching grains). Saved as a file with a full
+    # AFM metadata sidecar so afm's physical-unit rule is satisfiable.
+    from scilink.agents.exp_agents.image_analysis_agent import ImageAnalysisAgent
+    gimg, _ = synth_afm_grains()
+    afm_meta = {
+        "microscopy_type": "AFM",
+        "technique": "topography (height channel)",
+        "data_range_minimum": 0.0,
+        "data_range_maximum": 45.0,
+        "data_range_units": "nm",
+        "spatial_info": {"field_of_view_x": 2.0, "field_of_view_y": 2.0,
+                         "field_of_view_units": "um"},
+        "detail": "densely packed touching grains; intensity is height in nm",
+    }
+    afm_path = _write_dataset(os.path.join(work, "afm_grains"), "afm_grains", gimg, afm_meta)
+    try:
+        agent = ImageAnalysisAgent(model_name=model_name, enable_human_feedback=False,
+                                   output_dir=os.path.join(work, "img_twoskill"),
+                                   max_verification_iterations=1)
+        res = agent.analyze(afm_path, system_info=afm_meta, skill=["afm", "overlapping_objects"])
+        check(T, "image two-skill (afm+overlapping) executes", res.get("status") == "success", res.get("status"))
+    except Exception as e:
+        record(T, "image two-skill (afm+overlapping)", "FAIL", f"{type(e).__name__}: {str(e)[:160]}")
+
+    img = np.load(os.path.join(EX, "polycrystalline_grains_demo/image.npy"))
+    meta = json.load(open(os.path.join(EX, "polycrystalline_grains_demo/image.json")))
+
+    # 2b. IMAGE auto-select (no skill) on grains -> overlapping_objects
+    try:
+        agent = ImageAnalysisAgent(model_name=model_name, enable_human_feedback=False,
+                                   output_dir=os.path.join(work, "img_auto"),
+                                   max_verification_iterations=1)
+        res = agent.analyze(img, system_info=meta)
+        check(T, "image auto-select executes", res.get("status") == "success", res.get("status"))
+    except Exception as e:
+        record(T, "image auto-select", "FAIL", f"{type(e).__name__}: {str(e)[:160]}")
+
+    # 2c. CURVE auto-select on synthetic XPS -> xps fit
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+    x, y, mta = synth_xps()
+    xps_path = _write_dataset(os.path.join(work, "xps_data"), "xps", np.vstack([x, y]), mta)
+    try:
+        agent = CurveFittingAgent(model_name=model_name, enable_human_feedback=False,
+                                  output_dir=os.path.join(work, "curve_auto"),
+                                  max_verification_iterations=1)
+        res = agent.analyze(xps_path, system_info=mta)
+        check(T, "curve auto-select (synth XPS) executes", res.get("status") == "success", res.get("status"))
+    except Exception as e:
+        record(T, "curve auto-select", "FAIL", f"{type(e).__name__}: {str(e)[:160]}")
+
+    # 2d. CUSTOM-skill end-to-end: register a raman skill, fit synth Raman
+    x, y, mta = synth_raman()
+    raman_path = _write_dataset(os.path.join(work, "raman_data"), "raman", np.vstack([x, y]), mta)
+    d = tempfile.mkdtemp()
+    raman_md = os.path.join(d, "raman_custom.md")
+    open(raman_md, "w").write(
+        "---\ndescription: Raman peak fitting (Lorentzian/pseudo-Voigt bands)\n"
+        "technique: Raman, Raman spectroscopy\n---\n## overview\nRaman band fitting.\n"
+        "## planning\nFit each band with a pseudo-Voigt on a polynomial baseline.\n"
+        "## implementation\nUse scipy.optimize.curve_fit with a sum of pseudo-Voigt "
+        "profiles plus a low-order polynomial baseline; report center, FWHM, amplitude.\n")
+    try:
+        agent = CurveFittingAgent(model_name=model_name, enable_human_feedback=False,
+                                  output_dir=os.path.join(work, "curve_custom"),
+                                  max_verification_iterations=1)
+        res = agent.analyze(raman_path, system_info=mta, custom_skills={"raman_custom": raman_md})
+        check(T, "custom raman skill drives a real fit (fix #1 e2e)", res.get("status") == "success", res.get("status"))
+    except Exception as e:
+        record(T, "custom raman e2e", "FAIL", f"{type(e).__name__}: {str(e)[:160]}")
+
+    print(f"  (e2e artifacts under {work})")
+
+
+# ════════════════════════════ TIER 3: orchestrator ════════════════════════
+def tier_orchestrator(model_name):
+    T = "orch"
+    print("\n── TIER 3: orchestrator routing (defer / skill / skill_hint) ──")
+    from scilink.agents.exp_agents.analysis_orchestrator import (
+        AnalysisOrchestratorAgent, AnalysisMode)
+
+    work = tempfile.mkdtemp(prefix="multiskill_orch_")
+    img = os.path.join(EX, "polycrystalline_grains_demo/image.npy")
+    x, y, mta = synth_xps()
+    # Explicit-technique copy (metadata declares XPS) for the "explicit" case.
+    xps_path = _write_dataset(os.path.join(work, "xps"), "xps", np.vstack([x, y]), mta)
+    # NEUTRAL-metadata copy (no declared technique) so the orchestrator has
+    # nothing to pick from and must DEFER to the agent (which sees the plot).
+    neutral_path = _write_dataset(os.path.join(work, "neutral"), "neutral",
+                                  np.vstack([x, y]),
+                                  {"detail": "1D spectrum; fit the peaks"})
+
+    class _Stop(Exception):
+        pass
+
+    def capture(message, turns=2):
+        agent = AnalysisOrchestratorAgent(base_dir=tempfile.mkdtemp(prefix="orch_"),
+                                          model_name=model_name,
+                                          analysis_mode=AnalysisMode.AUTONOMOUS)
+        cap = {"skill": "__nocall__", "hint": "__nocall__"}
+        real = agent.tools.execute_tool
+
+        def wrap(tool_name, **kw):
+            if tool_name == "run_analysis":
+                cap["skill"] = kw.get("skill", None)
+                cap["hint"] = kw.get("skill_hint", None)
+                raise _Stop()
+            return real(tool_name, **kw)
+        agent.tools.execute_tool = wrap
+        msg = message
+        for _ in range(turns):
+            try:
+                agent.chat(msg)
+            except _Stop:
+                break
+            except Exception as e:
+                record(T, f"chat ({message[:30]})", "INFO", f"{type(e).__name__}: {str(e)[:80]}")
+                break
+            msg = "Proceed with the analysis now. No literature search needed."
+        return cap
+
+    # image, no skill named -> defer (skill None) OR an autonomous pick (benign, has preview)
+    c = capture(f"Analyze this image and characterize the grains: {img}")
+    check(T, "image no-skill: defers (skill None) or autonomous-correct",
+          c["skill"] in (None, "overlapping_objects", ["overlapping_objects"]), c["skill"], soft=True)
+    # image, explicit skill -> passes it
+    c = capture(f"Analyze this image using the overlapping_objects skill: {img}")
+    check(T, "image explicit -> overlapping_objects",
+          c["skill"] == "overlapping_objects" or c["skill"] == ["overlapping_objects"], c["skill"])
+    # curve, no skill, NEUTRAL metadata -> defers (orchestrator has nothing to
+    # pick from; the agent's selector sees the plot and decides).
+    c = capture(f"Fit the peaks in this spectrum: {neutral_path}")
+    check(T, "curve no-skill (neutral meta) -> defers (None)", c["skill"] is None, c["skill"])
+    # curve, explicit technique -> passes xps
+    c = capture(f"This is an XPS spectrum (C 1s). Fit it: {xps_path}")
+    check(T, "curve explicit XPS -> xps",
+          c["skill"] == "xps" or c["skill"] == ["xps"], c["skill"])
+
+
+# ───────────────────────────── runner ─────────────────────────────────────
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tier", choices=["selector", "agent", "orchestrator", "all"], default="selector")
+    ap.add_argument("--model", default=MODEL_DEFAULT)
+    args = ap.parse_args()
+
+    print(f"=== MULTI-SKILL LIVE SUITE  model={args.model}  tier={args.tier} ===")
+    if args.tier in ("selector", "all"):
+        tier_selector(args.model)
+    if args.tier in ("agent", "all"):
+        tier_agent(args.model)
+    if args.tier in ("orchestrator", "all"):
+        tier_orchestrator(args.model)
+
+    # summary
+    n_pass = sum(1 for *_, s, _ in _RESULTS if s == "PASS")
+    n_fail = sum(1 for *_, s, _ in _RESULTS if s == "FAIL")
+    n_soft = sum(1 for *_, s, _ in _RESULTS if s == "SOFT")
+    print("\n" + "=" * 60)
+    print(f"SUMMARY: {n_pass} pass, {n_fail} FAIL, {n_soft} soft/stochastic")
+    if n_fail:
+        print("FAILURES:")
+        for tier, label, s, detail in _RESULTS:
+            if s == "FAIL":
+                print(f"  ❌ [{tier}] {label}: {detail}")
+    print("=" * 60)
+    sys.exit(1 if n_fail else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_skill_selector.py
+++ b/tests/test_skill_selector.py
@@ -1,0 +1,253 @@
+"""
+Tests for agent-side multi-skill auto-selection.
+
+Covers the shared relevance selector (`scilink.skills._shared._skill_selector`)
+and the multi-skill prompt rendering in the curve-fitting and hyperspectral
+controllers. The LLM call is mocked, so these are fully offline.
+"""
+
+import json
+
+import pytest
+
+from scilink.skills._shared._skill_selector import (
+    build_skill_catalog,
+    select_relevant_skills,
+)
+from scilink.agents.exp_agents.controllers import (
+    curve_fitting_controllers as cc,
+    hyperspectral_controllers as hc,
+    image_analysis_controllers as ic,
+)
+
+
+class _MockModel:
+    """Returns a fixed payload from generate_content."""
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def generate_content(self, contents, generation_config=None, safety_settings=None):
+        return self.payload
+
+
+def _parse(resp):
+    return json.loads(resp), None
+
+
+def _selector(payload, **kw):
+    return select_relevant_skills(
+        model=_MockModel(json.dumps(payload)),
+        parse_fn=_parse,
+        domain=kw.pop("domain", "curve_fitting"),
+        context_parts=["some data"],
+        **kw,
+    )
+
+
+class _RecordingModel:
+    """Captures the prompt `contents` passed to generate_content."""
+
+    def __init__(self, payload):
+        self.payload = payload
+        self.contents = None
+
+    def generate_content(self, contents, generation_config=None, safety_settings=None):
+        self.contents = contents
+        return self.payload
+
+
+def _prompt_text(model):
+    return "\n".join(p for p in model.contents if isinstance(p, str))
+
+
+class TestHintInjection:
+    def test_valid_hint_surfaces_as_suggestion(self):
+        m = _RecordingModel(json.dumps({"skills": []}))
+        select_relevant_skills(model=m, parse_fn=_parse, domain="curve_fitting",
+                               context_parts=["data"], hint="xps")
+        txt = _prompt_text(m)
+        assert "Orchestrator suggestion" in txt and "xps" in txt
+
+    def test_invalid_hint_is_dropped(self):
+        m = _RecordingModel(json.dumps({"skills": []}))
+        select_relevant_skills(model=m, parse_fn=_parse, domain="curve_fitting",
+                               context_parts=["data"], hint="does_not_exist")
+        assert "Orchestrator suggestion" not in _prompt_text(m)
+
+    def test_no_hint_no_suggestion_block(self):
+        m = _RecordingModel(json.dumps({"skills": []}))
+        select_relevant_skills(model=m, parse_fn=_parse, domain="curve_fitting",
+                               context_parts=["data"])
+        assert "Orchestrator suggestion" not in _prompt_text(m)
+
+
+class TestCatalog:
+    def test_curve_fitting_catalog_has_known_skills(self):
+        _, names = build_skill_catalog("curve_fitting")
+        assert {"epr", "xps", "xrd_profile"} <= names
+
+    def test_catalog_lines_carry_technique_tags(self):
+        lines, _ = build_skill_catalog("curve_fitting")
+        joined = "\n".join(lines)
+        assert "[technique:" in joined  # epr/xps/xrd_profile declare them
+
+
+class TestSelector:
+    def test_multiple_skills_selected_in_order(self):
+        assert _selector({"skills": ["xps", "epr"]}) == ["xps", "epr"]
+
+    def test_invalid_names_dropped(self):
+        assert _selector({"skills": ["xps", "does_not_exist"]}) == ["xps"]
+
+    def test_empty_when_none_apply(self):
+        assert _selector({"skills": []}) == []
+
+    def test_singular_reply_back_compat(self):
+        assert _selector({"skill": "xrd_profile"}) == ["xrd_profile"]
+
+    def test_string_reply_tolerated(self):
+        assert _selector({"skills": "xps"}) == ["xps"]
+
+    def test_max_skills_cap(self):
+        out = _selector({"skills": ["xps", "epr", "xrd_profile"]}, max_skills=2)
+        assert out == ["xps", "epr"]
+
+    def test_duplicates_deduped(self):
+        assert _selector({"skills": ["xps", "xps", "epr"]}) == ["xps", "epr"]
+
+    def test_exclusive_caps_to_single(self):
+        # Authoritative/mutually-exclusive domains (curve fitting) take at most
+        # one skill even if the model returns several.
+        assert _selector({"skills": ["xps", "epr"]}, exclusive=True) == ["xps"]
+
+    def test_non_exclusive_allows_multiple(self):
+        assert _selector({"skills": ["xps", "epr"]}) == ["xps", "epr"]
+
+    def test_hint_does_not_force_selection(self):
+        # Orchestrator hints 'epr' but the model (agent) chooses 'xps' from the
+        # data — the agent has final authority; the hint is non-binding.
+        assert _selector({"skills": ["xps"]}, hint="epr") == ["xps"]
+
+    def test_malformed_reply_returns_empty(self):
+        # parse_fn raises on non-JSON -> selector swallows and returns []
+        out = select_relevant_skills(
+            model=_MockModel("not json"),
+            parse_fn=_parse,
+            domain="curve_fitting",
+            context_parts=["x"],
+        )
+        assert out == []
+
+
+# Two loaded skills, most-relevant first.
+_TWO = {
+    "skills_loaded": [
+        {"name": "epr", "planning": "EPR planning rules", "validation": "EPR validation"},
+        {"name": "xps", "planning": "XPS planning rules"},
+    ]
+}
+# Legacy single-skill state (no skills_loaded).
+_LEGACY = {"skill_sections": {"name": "eels", "planning": "EELS rules"}, "skill_name": "eels"}
+
+
+class TestCurveMultiSkillRender:
+    def test_both_skills_and_validation_rendered(self):
+        prompt = []
+        cc._append_skill_context(prompt, _TWO, "planning")
+        joined = "\n".join(prompt)
+        assert "EPR planning rules" in joined
+        assert "XPS planning rules" in joined
+        assert "EPR validation" in joined
+
+    def test_legacy_single_skill_still_renders(self):
+        prompt = []
+        cc._append_skill_context(prompt, _LEGACY, "planning")
+        assert "EELS rules" in "\n".join(prompt)
+
+    def test_no_skill_is_noop(self):
+        prompt = []
+        cc._append_skill_context(prompt, {}, "planning")
+        assert prompt == []
+
+
+class TestHyperspectralMultiSkillRender:
+    def test_both_skills_rendered(self):
+        block = hc._render_skill_block(_TWO, "planning")
+        assert "EPR planning rules" in block and "XPS planning rules" in block
+
+    def test_legacy_single_skill_still_renders(self):
+        assert "EELS rules" in hc._render_skill_block(_LEGACY, "planning")
+
+    def test_no_skill_is_empty_string(self):
+        assert hc._render_skill_block({}, "planning") == ""
+
+    def test_codegen_renders_all_co_active_recipes(self):
+        # Co-active skills may each own a different stage — codegen must keep
+        # all their implementation recipes, not just the top-ranked one.
+        state = {
+            "skills_loaded": [
+                {"name": "eels", "implementation": "EELS recipe"},
+                {"name": "eds", "implementation": "EDS recipe"},
+            ]
+        }
+        block = hc._render_skill_block(state, "implementation")
+        assert "EELS recipe" in block and "EDS recipe" in block
+
+
+# Two skills where the TOP-ranked one carries NO implementation recipe — the
+# afm-first case: codegen must still surface the recipe-owner's recipe.
+_TOP_HAS_NO_RECIPE = {
+    "skills_loaded": [
+        {"name": "afm", "planning": "flatten guidance"},  # no implementation/analysis
+        {"name": "overlapping_objects", "analysis": "segmentation recipe"},
+    ]
+}
+
+
+class TestCodegenRecipeSourcing:
+    """fix #2 — codegen sources recipes from ALL co-active skills, not primary."""
+
+    def test_collects_all_recipe_bearing_skills_in_order(self):
+        state = {"skills_loaded": [
+            {"name": "epr", "implementation": "EPR recipe"},
+            {"name": "xps", "implementation": "XPS recipe"},
+        ]}
+        for mod in (cc, ic):
+            recipes = mod._collect_codegen_recipe(state)
+            assert [n for n, _ in recipes] == ["epr", "xps"]
+
+    def test_prose_only_skills_contribute_no_recipe(self):
+        # _TWO has planning/validation but no implementation -> no codegen recipe.
+        for mod in (cc, ic):
+            assert mod._collect_codegen_recipe(_TWO) == []
+
+    def test_top_skill_without_recipe_does_not_hide_owner(self):
+        # afm (top, no recipe) must NOT shadow overlapping_objects' recipe.
+        for mod in (cc, ic):
+            recipes = mod._collect_codegen_recipe(_TOP_HAS_NO_RECIPE)
+            assert recipes == [("overlapping_objects", "segmentation recipe")]
+
+    def test_single_skill_render_is_verbatim(self):
+        # Single-skill codegen output unchanged: just the recipe, no headers.
+        for mod in (cc, ic):
+            out = mod._render_codegen_recipe([("xps", "XPS recipe body")])
+            assert out == "XPS recipe body"
+
+    def test_multi_skill_render_labels_each(self):
+        for mod in (cc, ic):
+            out = mod._render_codegen_recipe(
+                [("afm", "flatten code"), ("overlapping_objects", "segment code")]
+            )
+            assert "### Recipe — afm" in out and "### Recipe — overlapping_objects" in out
+            assert "flatten code" in out and "segment code" in out
+            assert "plan's order" in out  # composition note present
+
+    def test_implementation_preferred_over_analysis(self):
+        state = {"skills_loaded": [{"name": "x", "implementation": "impl", "analysis": "anal"}]}
+        for mod in (cc, ic):
+            assert mod._collect_codegen_recipe(state) == [("x", "impl")]
+
+    def test_no_skill_is_empty(self):
+        for mod in (cc, ic):
+            assert mod._collect_codegen_recipe({}) == []

--- a/tests/test_skill_selector.py
+++ b/tests/test_skill_selector.py
@@ -82,6 +82,57 @@ class TestHintInjection:
         assert "Orchestrator suggestion" not in _prompt_text(m)
 
 
+def _write_custom_skill(tmp_path, name, *, technique=None, domain=None, body="Overview text."):
+    fm = []
+    if technique:
+        fm.append(f"technique: {technique}")
+    if domain:
+        fm.append(f"domain: {domain}")
+    front = ("---\n" + "\n".join(fm) + "\n---\n") if fm else ""
+    p = tmp_path / f"{name}.md"
+    p.write_text(f"{front}## overview\n{body}\n")
+    return str(p)
+
+
+class TestCustomSkills:
+    """#256 fix #1 — registered custom skills are visible to the agent selector."""
+
+    def test_custom_skill_folded_into_catalog(self, tmp_path):
+        path = _write_custom_skill(tmp_path, "myraman", technique="Raman")
+        cat, names = build_skill_catalog("curve_fitting", custom_skills={"myraman": path})
+        assert "myraman" in names
+        assert any("myraman" in line for line in cat)
+
+    def test_custom_skill_with_foreign_modality_is_skipped(self, tmp_path):
+        # A custom skill that explicitly declares a DIFFERENT modality domain
+        # must not leak into this agent's catalog.
+        path = _write_custom_skill(tmp_path, "imgthing", domain="image_analysis")
+        _, names = build_skill_catalog("curve_fitting", custom_skills={"imgthing": path})
+        assert "imgthing" not in names
+
+    def test_custom_skill_without_domain_is_included(self, tmp_path):
+        path = _write_custom_skill(tmp_path, "plainskill")
+        _, names = build_skill_catalog("curve_fitting", custom_skills={"plainskill": path})
+        assert "plainskill" in names
+
+    def test_selector_can_return_a_custom_skill(self, tmp_path):
+        path = _write_custom_skill(tmp_path, "myraman", technique="Raman")
+        out = select_relevant_skills(
+            model=_MockModel(json.dumps({"skills": ["myraman"]})),
+            parse_fn=_parse, domain="curve_fitting", context_parts=["Raman data"],
+            custom_skills={"myraman": path},
+        )
+        assert out == ["myraman"]
+
+    def test_custom_name_invalid_without_registration(self, tmp_path):
+        # Same name but NOT registered -> not in catalog -> dropped.
+        out = select_relevant_skills(
+            model=_MockModel(json.dumps({"skills": ["myraman"]})),
+            parse_fn=_parse, domain="curve_fitting", context_parts=["x"],
+        )
+        assert out == []
+
+
 class TestCatalog:
     def test_curve_fitting_catalog_has_known_skills(self):
         _, names = build_skill_catalog("curve_fitting")


### PR DESCRIPTION
## Summary

Today an analysis agent could only ever engage **one** domain skill, and only when the orchestrator picked it from metadata. This PR lets the three analysis foundation agents (image, curve-fitting, hyperspectral) **choose the right skill(s) by looking at the actual data** — and use **several complementary skills together** when a dataset genuinely needs them.

In practice:

- **The agent selects skills from the data it can see** — image pixels, the fitted curve, the spectrum metadata — instead of relying on the orchestrator's metadata-only guess.
- **Multiple complementary skills compose.** An AFM image of touching grains can use the AFM skill (flatten / physical-unit discipline) *and* the overlapping-objects skill (segment the grains) in one analysis — each contributing its stage to the generated script.
- **Curve fitting stays single-and-authoritative.** A 1-D spectrum is XPS *or* EPR *or* XRD, never a blend, so the agent picks the one matching technique (or none) and never substitutes a nearest-sounding skill.
- **Uploaded custom skills are auto-selected too.** A skill added via the UI or `--skills` is now picked up by the agent automatically when it fits the data — not only when you name it explicitly.
- **The orchestrator suggests, the agent decides.** The orchestrator can pass a non-binding hint, but the agent confirms it against the data, augments it, or overrides it. A skill you *explicitly* request is still honored exactly.

Validated end-to-end against a real model (Bedrock opus-4-8) on real and synthetic data, including full analysis runs that execute the generated code.

Implements #256. Advances #251 (technique-aware selection / no-substitution), minus the new Raman skill bundle that issue also requests.

---

## Technical details

### Shared selector — `scilink/skills/_shared/_skill_selector.py` (new)
- `build_skill_catalog(domain, *, include_provisional=False, custom_skills=None)` — mirrors the orchestrator's catalog convention (frontmatter `description` + `[technique: …]` tag, provisional excluded). Folds in `custom_skills` ({name: path}), skipping a custom skill whose frontmatter declares a *different* `_MODALITY_DOMAINS` domain.
- `select_relevant_skills(*, model, parse_fn, domain, context_parts, max_skills=3, exclusive=False, hint=None, custom_skills=None, logger=None)` — ranked, validated, possibly-empty list; never raises. `exclusive=True` → single best technique match, capped to 1 (`_EXCLUSIVE_GUIDANCE`). `hint` injects a non-binding "Orchestrator suggestion" block (filtered to valid names).

### Per-agent wiring (all route selection → `_load_skills_to_state`, `base_agent.py:549`, already list-capable)
- **Image** — rewrote `SkillSuggestionController` (`controllers/image_analysis_controllers.py`): fixed the bypass that hand-set the singular `skill_*` fields; now `select_relevant_skills(...)` → `skills_loaded`. `exclusive=False`.
- **Curve** — new `CurveFittingSkillSuggestionController` (pipeline step 1.7, gated on a `load_skills_fn` passed from the agent so the legacy factory is unchanged); `exclusive=True`.
- **Hyperspectral** — `_auto_select_skills()` in `analyze()` (metadata-only context — see Known limitations).

### Multi-skill prose + codegen composition
- Prose stages: curve `_append_skill_context` and hyperspectral `_render_skill_block` now iterate `skills_loaded` (image already did).
- Codegen recipe: `_collect_codegen_recipe(state)` / `_render_codegen_recipe(recipes)` source the `implementation`/`analysis` section from **all** co-active skills (labeled per skill, "apply each to its stage in the plan's order"), across the main + correction codegen sites in image (`:2014/2208` pre-edit) and curve (`:2294/2435` pre-edit). **Single-skill output is byte-identical.** This fixes a real silent-drop: the top-ranked skill can carry *no* recipe (e.g. `afm` authors only overview/planning/validation) while a lower-ranked skill owns it — the old `state["skill_sections"]`-only read returned empty.
- Ordering is plan-driven and LLM-mediated (the planning stage, now multi-skill, emits the ordered pipeline; codegen follows it). Not code-enforced.

### Orchestrator (`analysis_orchestrator.py`, `analysis_orchestrator_tools.py`)
- `run_analysis` gains `skill_hint` and forwards both `skill_hint` and the orchestrator's `_custom_skills` to `analyze(...)` via signature-introspection (same pattern as `max_verification_iterations`).
- Guidance (tool-param description + system prompt) generalized: **defer skill choice to the agent by default**; `skill` (authoritative) only on explicit user request / custom; `skill_hint` (non-binding) for the orchestrator's own guess; curve techniques are mutually exclusive (pass at most one).
- Precedence: an authoritative `skill` pre-loads `skills_loaded` → the agent's selector skip-guard short-circuits (honored as-is). A `skill_hint` does *not* pre-load → the selector runs with it as a prior. Custom-skill names selected by the agent are resolved back to paths before loading (customs aren't on the loader's search roots).

### Architecture notes
`CLAUDE.md` updated: three-rung reliability ladder (prose → code-in-markdown → `TOOL_SPEC`), multi-skill composition, per-domain `exclusive` policy, authoritative-`skill`-vs-`skill_hint`, and custom-skill auto-selectability.

### Tests
- `tests/test_skill_selector.py` — 35 offline unit tests (catalog, exclusive cap, hint injection/non-binding, multi-recipe sourcing incl. top-skill-without-recipe, custom-skill folding + foreign-modality filtering).
- `tests/test_multiskill_autoselect_live.py` (new) — comprehensive 3-tier live suite (selector / agent-e2e / orchestrator), real + synthetic data, argparse-selectable. Run: `UNSAFE_EXECUTION_OK=true AWS_BEARER_TOKEN_BEDROCK=… AWS_REGION_NAME=… python tests/test_multiskill_autoselect_live.py --tier all`.
- **Live (Bedrock opus-4-8):** selector 21 pass / 1 soft, agent-e2e 4/4 (two-skill composition, auto-select, custom-skill e2e fit), orchestrator 4/4 (defer / explicit / skill_hint). 0 hard failures.

### Known limitations / follow-ups
- **Hyperspectral selector is metadata-only** (no datacube inspection), so it's the weakest signal path and partly redundant with the orchestrator — the live suite's one soft result is the EELS *datacube* returning `[]` (the EELS *spectrum*, with an explicit technique tag, selects `eels`). Upgrade to read the mean spectrum when a second hyperspectral skill lands.
- **Custom skills remain markdown-only** — `TOOL_SPEC` tools are discovered only from skills inside the installed package (`_registry` walks `_SKILLS_DIR`). Out of scope here.
- The `#251` Raman curve-fitting skill bundle is not added in this PR.
