### PR TITLE
Plan mode: advisory physics/consistency critic (caveats) + domain-neutral planning

### DIFF
--- a/scilink/agents/planning_agents/html_generator.py
+++ b/scilink/agents/planning_agents/html_generator.py
@@ -4,6 +4,8 @@ import re
 from datetime import datetime
 from typing import Dict, Any, List
 
+from .user_interface import format_caveats
+
 class HTMLReportGenerator:
     def __init__(self, agent_state: Dict[str, Any]):
         self.state = agent_state
@@ -281,6 +283,16 @@ class HTMLReportGenerator:
                 content_html = self._render_tea(plan)
             else:
                 content_html = "".join(self._render_experiment(exp, x+1) for x, exp in enumerate(plan.get('proposed_experiments', [])))
+                # Advisory critic caveats (same source as the CLI summary / warnings)
+                caveat_lines = format_caveats(plan.get('critic_findings'))
+                if caveat_lines:
+                    items = "".join(f"<li>{html.escape(c)}</li>" for c in caveat_lines)
+                    content_html += (
+                        '<div class="caveats" style="margin-top:18px;padding:14px 16px;'
+                        'background:#fef3c7;border-left:4px solid #f59e0b;border-radius:6px;">'
+                        '<strong style="color:#b45309">⚠️ Caveats &amp; Potential Limitations</strong>'
+                        f'<ul style="margin:8px 0 0;color:#92400e">{items}</ul></div>'
+                    )
 
             html_content += f"""
             <div class="card">

--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -110,7 +110,7 @@ You MUST respond with a single JSON object containing a key "proposed_experiment
 - "hypothesis": (String) A clear, single-sentence, testable hypothesis.
 - "experiment_name": (String) A short, descriptive name for the experiment.
 - "experimental_steps": (List of Strings) A numbered or bulleted list of concrete steps to perform the experiment. Must be self-contained, i.e. fully understandable by a human WITHOUT referencing external code or files or other sections of the JSON file.
-- "required_equipment": (List of Strings) A list of common lab equipment.
+- "required_equipment": (List of Strings) Key resources, instruments, or techniques required (e.g. lab equipment/instruments, or computational resources/software).
 - "optimization_params": (Optional List) If the experiment requires optimization, provide one entry per parameter. Each entry is one of:
 
     **Continuous parameter** (real-valued knob):

--- a/scilink/agents/planning_agents/planning_agent.py
+++ b/scilink/agents/planning_agents/planning_agent.py
@@ -39,7 +39,8 @@ from .planning_rag import (
     perform_code_rag,
     refine_plan_with_feedback,
     refine_code_with_feedback,
-    verify_plan_relevance
+    verify_plan_relevance,
+    critique_plan
 )
 
 from ...skills.loader import load_skill
@@ -530,7 +531,7 @@ class PlanningAgent(BaseAgent):
 
         # RAG for science plan
         print(f"\n--- Generating Experimental Strategy ---")
-        res = perform_science_rag(
+        res, author_context = perform_science_rag(
             objective=objective,
             instructions=HYPOTHESIS_GENERATION_INSTRUCTIONS,
             task_name="Experimental Plan",
@@ -542,7 +543,8 @@ class PlanningAgent(BaseAgent):
             image_descriptions=image_descriptions,
             additional_context=ctx_string,
             external_context=external_context,
-            skill_context=skill_planning_context
+            skill_context=skill_planning_context,
+            return_context=True
         )
 
         if external_context:
@@ -566,10 +568,11 @@ class PlanningAgent(BaseAgent):
         self.state["plan_history"].append(res.copy())
         self.state["current_plan"] = res
         
-        # Self-correction
+        # 1) Objective-conformance check (enforcing). A non-conforming plan is
+        # automatically adjusted — the proven self-correction loop, unchanged.
         if not res.get("error"):
             is_relevant, critique = verify_plan_relevance(objective, res, self.model, self.generation_config)
-            
+
             if not is_relevant:
                 print(f"\n🔄 Self-correction triggered: {critique}")
                 res = refine_plan_with_feedback(
@@ -592,6 +595,46 @@ class PlanningAgent(BaseAgent):
                     result=res,
                     rationale=f"Auto-corrected due to: {critique}"
                 )
+
+        # 2) Advisory critic (separate call, AFTER conformance + any adjustment).
+        # Checks PHYSICAL REALISM and INTERNAL CONSISTENCY of the final plan and
+        # records caveats — it NEVER rewrites the plan. Findings surface as
+        # "Caveats & Potential Limitations" for the human (CO_PILOT / AUTOPILOT)
+        # at the feedback prompt, or as run_task `warnings` (AUTONOMOUS / meta).
+        # Auto-applying critic findings was shown to rescope plans unreliably, so
+        # acting on them is left to an explicit human/consumer decision.
+        if not res.get("error"):
+            verdict = critique_plan(
+                objective, res, self.model, self.generation_config,
+                retrieved_context=author_context.get("retrieved_context"),
+                primary_data=author_context.get("primary_data"),
+                images=all_image_paths or None,
+                image_descriptions=image_descriptions,
+                additional_context=ctx_string,
+                skill_context=skill_planning_context,
+            )
+            findings = verdict.get("findings", [])
+            if findings:
+                # Order critical-first so the caveats list and warnings lead with
+                # the most material concerns. Record on the plan (no rewrite).
+                _order = {"critical": 0, "minor": 1}
+                findings = sorted(findings, key=lambda f: _order.get(f.get("severity"), 1))
+                res["critic_findings"] = findings
+                self.state["current_plan"] = res
+                # Stamp onto the latest history snapshot too so the HTML report
+                # (which renders plan_history, not current_plan) shows the caveats.
+                if self.state.get("plan_history"):
+                    self.state["plan_history"][-1]["critic_findings"] = findings
+                n_crit = sum(1 for f in findings if f.get("severity") == "critical")
+                print(f"\n⚠️  Critic noted {len(findings)} caveat(s)"
+                      f"{f' ({n_crit} significant)' if n_crit else ''} "
+                      "— recorded under Caveats & Potential Limitations (plan unchanged).")
+                self._log_action(
+                    action="critic_review",
+                    input_ctx={"findings": findings},
+                    result=res,
+                    rationale="Advisory caveats recorded; plan not modified."
+                )
         
         # Human feedback on strategy
         human_feedback = None
@@ -600,6 +643,12 @@ class PlanningAgent(BaseAgent):
             human_feedback = get_user_feedback()
             
             if human_feedback:
+                # Snapshot the pre-refinement plan + its caveats. The re-critique
+                # below gets the full before/criticism/request/after picture and
+                # reasons about the revised plan itself — the human may address the
+                # caveats, change something unrelated, or override the critic.
+                prior_plan = res.copy()
+                prior_findings = res.get("critic_findings")
                 print(f"\n📝 Refining plan...")
                 self.state["human_feedback_history"].append({"phase": "science", "feedback": human_feedback})
                 refined = refine_plan_with_feedback(
@@ -618,6 +667,30 @@ class PlanningAgent(BaseAgent):
                     res = refined
                     res["iteration"] = current_iter
                     res["stage"] = "Human Refined (Science)"
+
+                    # Re-critique the refined plan so the caveats describe the
+                    # CURRENT plan, not the pre-refinement one. Pass prior_findings
+                    # so it acts as a resolution check (confirm fixes, drop resolved
+                    # ones, flag anything new) rather than re-deriving blindly.
+                    res.pop("critic_findings", None)  # discard any echoed-stale caveats
+                    verdict = critique_plan(
+                        objective, res, self.model, self.generation_config,
+                        retrieved_context=author_context.get("retrieved_context"),
+                        primary_data=author_context.get("primary_data"),
+                        images=all_image_paths or None,
+                        image_descriptions=image_descriptions,
+                        additional_context=ctx_string,
+                        skill_context=skill_planning_context,
+                        prior_plan=prior_plan,
+                        prior_findings=prior_findings,
+                        human_feedback=human_feedback,
+                    )
+                    fresh = verdict.get("findings", [])
+                    if fresh:
+                        _order = {"critical": 0, "minor": 1}
+                        fresh = sorted(fresh, key=lambda f: _order.get(f.get("severity"), 1))
+                        res["critic_findings"] = fresh
+
                     self.state["plan_history"].append(res.copy())
                     self.state["current_plan"] = res
                     display_plan_summary(res)

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -12,6 +12,7 @@ from ...auth import get_internal_proxy_key
 from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
 from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
 from .planning_agent import PlanningAgent
+from .user_interface import format_caveats
 from .scalarizer_agent import ScalarizerAgent
 from .bo_agent import BOAgent
 from .orchestrator_tools import OrchestratorTools
@@ -1377,6 +1378,13 @@ class PlanningOrchestratorAgent:
         warnings: List[str] = []
         if status == "success" and not files_produced:
             warnings.append("Task completed but produced no campaign artifacts.")
+
+        # Surface the advisory critic's caveats so a headless / meta consumer
+        # sees them even though no human reviewed them in-session. The plan is
+        # not modified — these are limitations for the caller to weigh.
+        _plan = (self.planner.state or {}).get("current_plan") or {}
+        for _c in format_caveats(_plan.get("critic_findings")):
+            warnings.append(f"Plan caveat — {_c}")
 
         result = {
             "status": status,

--- a/scilink/agents/planning_agents/planning_rag.py
+++ b/scilink/agents/planning_agents/planning_rag.py
@@ -3,6 +3,11 @@ import logging
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Tuple
 
+try:
+    from PIL import Image as _PIL_Image
+except Exception:  # Pillow optional — critic degrades to text-only evidence
+    _PIL_Image = None
+
 from scilink.parsers import parse_adaptive_excel
 from scilink.knowledge import run_rag, parse_json_from_response
 from .instruct import (
@@ -13,20 +18,26 @@ from .instruct import (
 )
 
 
-def verify_plan_relevance(objective: str, 
-                          result: Dict[str, Any], 
-                          model: Any, 
-                          generation_config: Any) -> Tuple[bool, str]: 
+def verify_plan_relevance(objective: str,
+                          result: Dict[str, Any],
+                          model: Any,
+                          generation_config: Any) -> Tuple[bool, str]:
     """
-    Self-reflection step. Returns (True, "") if relevant, or (False, "Reason") if not.
-    
+    Objective-conformance check (the enforcing self-reflection step). Returns
+    (True, "") if the plan conforms, or (False, "Reason") if not — a False
+    triggers an automatic plan adjustment in the caller.
+
     Logic:
     1. Checks if the plan was generated via Fallback (General Knowledge).
     2. If Fallback: Verifies only scientific soundness (Relaxed).
     3. If Strict: Verifies document grounding and specific constraint adherence (Strict).
+
+    This is intentionally scoped to relevance / objective-conformance only.
+    Physical realism and internal consistency are handled separately and
+    advisorily by ``critique_plan`` (run after this check + any adjustment).
     """
     experiments = result.get("proposed_experiments", [])
-    if not experiments: 
+    if not experiments:
         return False, "No experiments generated."
 
     # 1. Detect Fallback Mode
@@ -44,12 +55,12 @@ def verify_plan_relevance(objective: str,
         name = exp.get('experiment_name', 'N/A')
         hyp = exp.get('hypothesis', 'N/A')
         justification = exp.get('justification', 'No justification provided.')
-        
+
         plan_summary_lines.append(f"Experiment {i+1}: {name}")
         plan_summary_lines.append(f"  Hypothesis: {hyp}")
-        plan_summary_lines.append(f"  Justification: {justification}") 
+        plan_summary_lines.append(f"  Justification: {justification}")
         plan_summary_lines.append("---")
-        
+
     plan_summary = "\n".join(plan_summary_lines)
 
     # 3. Construct Context-Aware Prompt
@@ -57,22 +68,22 @@ def verify_plan_relevance(objective: str,
         print("    - ℹ️  Verifying Fallback Plan (Relaxed Constraints)...")
         eval_prompt = f"""
         You are a scientific research evaluator.
-        
+
         **CONTEXT:** The system failed to find specific documents for the User Objective in the Knowledge Base.
         Therefore, it generated a plan based on **General Scientific Knowledge**.
-        
+
         1. User Objective: "{objective}"
-        2. Proposed Plan (General Knowledge): 
+        2. Proposed Plan (General Knowledge):
         {plan_summary}
 
         **TASK:**
         Determine if the Proposed Plan makes scientific sense for the Objective, acknowledging that it CANNOT cite specific documents.
-        
+
         **CRITERIA FOR PASS:**
         - The plan addresses the objective using standard, correct scientific principles.
         - The logic is sound and actionable.
         - **DO NOT FAIL** the plan simply because it uses general knowledge or lacks specific context (this is expected in fallback mode).
-        
+
         **Output:**
         Respond with a single JSON object: {{ "is_relevant": boolean, "reason": "string explanation" }}
         """
@@ -80,20 +91,20 @@ def verify_plan_relevance(objective: str,
         print("    - ℹ️  Verifying Strict Plan (Document Constraints)...")
         eval_prompt = f"""
         You are a scientific research evaluator.
-        
+
         1. User Objective: "{objective}"
-        2. Proposed Plan: 
+        2. Proposed Plan:
         {plan_summary}
 
         **TASK:**
         Review the "Hypothesis" and "Justification" for each experiment.
         Determine if the Proposed Plan is directly relevant to the User Objective AND supported by the cited context.
-        
+
         **CRITERIA FOR FAIL:**
         - The plan ignores specific constraints in the objective (e.g., "Use X method" but the plan uses "Y").
         - The justification contradicts the hypothesis.
         - The plan is logically incoherent.
-        
+
         **Output:**
         Respond with a single JSON object: {{ "is_relevant": boolean, "reason": "string explanation" }}
         """
@@ -102,19 +113,202 @@ def verify_plan_relevance(objective: str,
     try:
         response = model.generate_content([eval_prompt], generation_config=generation_config)
         eval_result, _ = parse_json_from_response(response)
-        
+
         if eval_result and not eval_result.get("is_relevant"):
             reason = eval_result.get('reason', 'Unknown irrelevance.')
             print(f"    - ⚠️  Plan Verification Failed: {reason}")
             return False, reason
-            
+
         print(f"    - ✅ Plan Verification Passed.")
         return True, ""
-        
+
     except Exception as e:
         logging.error(f"Verification step failed: {e}")
         # Fail open: If the verifier crashes, we assume the plan is okay to avoid blocking the user.
         return True, ""
+
+
+def critique_plan(objective: str,
+                  result: Dict[str, Any],
+                  model: Any,
+                  generation_config: Any,
+                  retrieved_context: Optional[str] = None,
+                  primary_data: Optional[str] = None,
+                  images: Optional[List[Any]] = None,
+                  image_descriptions: Optional[List[str]] = None,
+                  additional_context: Optional[str] = None,
+                  skill_context: Optional[str] = None,
+                  prior_plan: Optional[Dict[str, Any]] = None,
+                  prior_findings: Optional[List[Dict[str, Any]]] = None,
+                  human_feedback: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Advisory critic for PHYSICAL REALISM and INTERNAL CONSISTENCY — a separate
+    LLM call run AFTER ``verify_plan_relevance`` (and any conformance-driven
+    adjustment), on the final plan. It NEVER rewrites the plan; it returns
+    caveats for a human / consumer to weigh.
+
+    Objective-relevance and document grounding are NOT re-litigated here — that
+    is ``verify_plan_relevance``'s enforcing job. This critic only flags physics
+    and consistency caveats.
+
+    Returns {"findings": [{"dimension","severity","experiment","issue"}, ...]}
+    with ``dimension`` in {physics, consistency}. Empty findings == clean. Fails
+    open ({"findings": []}) on error so a critic crash never blocks the user.
+
+    Optional evidence args mirror what the plan author saw, so the critic checks
+    against the same material rather than reasoning in a vacuum (the robustness
+    ingredient borrowed from the hyperspectral reviewer, which reads its plots):
+    ``retrieved_context``, ``primary_data``, ``images``/``image_descriptions``,
+    ``additional_context``, ``skill_context``. All optional.
+
+    Revision context (all optional, for re-critiquing a just-revised plan): pass
+    ``prior_plan`` (the version before the edit), ``prior_findings`` (the caveats
+    it carried), and ``human_feedback`` (what the human asked for). The critic is
+    handed the full picture and reasons about the CURRENT plan itself — the human
+    may have addressed the caveats, changed something unrelated, or deliberately
+    overridden the critic, so nothing is assumed: prior caveats that no longer
+    apply are dropped, ones that still apply are kept, and new issues introduced
+    by the revision are flagged.
+    """
+    experiments = result.get("proposed_experiments", [])
+    if not experiments:
+        return {"findings": []}
+
+    plan_summary = "\n".join(
+        f"Experiment {i+1}: {exp.get('experiment_name', 'N/A')}\n"
+        f"  Hypothesis: {exp.get('hypothesis', 'N/A')}\n"
+        f"  Justification: {exp.get('justification', 'No justification provided.')}\n---"
+        for i, exp in enumerate(experiments)
+    )
+
+    # --- Evidence: mirror what the plan author saw so checks are grounded. ---
+    evidence_parts = []
+    if primary_data:
+        evidence_parts.append(f"## 📊 Primary Experimental Data:\n{primary_data}")
+    if additional_context:
+        evidence_parts.append(f"## Additional Context:\n{additional_context}")
+    if retrieved_context:
+        evidence_parts.append(f"## Retrieved Context (KB + literature):\n{retrieved_context}")
+    if skill_context:
+        evidence_parts.append(skill_context)
+
+    loaded_images = []
+    if images and _PIL_Image:
+        for img in images:
+            if isinstance(img, str):
+                try:
+                    loaded_images.append(_PIL_Image.open(img))
+                except Exception as e:
+                    print(f"    - ⚠️ Critic could not load image {img}: {e}")
+            else:
+                loaded_images.append(img)  # assume already a PIL image
+    if loaded_images:
+        note = "## Provided Images: (See attached)"
+        if image_descriptions:
+            note += f"\n## Image Descriptions:\n{json.dumps(image_descriptions, indent=2)}"
+        evidence_parts.append(note)
+
+    if evidence_parts:
+        evidence_section = (
+            "\n────────────────────────────────────\n"
+            "EVIDENCE THE PLAN AUTHOR USED — anchor your physics checks to the\n"
+            "data values here:\n"
+            + "\n\n".join(evidence_parts) + "\n"
+        )
+    else:
+        evidence_section = ""
+
+    # Revision context: when the CURRENT plan is a revision, hand the critic the
+    # before/criticism/request/after picture and let it reason about the current
+    # plan — don't presume the human acted on the caveats (they may have changed
+    # something unrelated or overridden the critic entirely).
+    revision_parts = []
+    if prior_plan and prior_plan.get("proposed_experiments"):
+        prior_summary = "\n".join(
+            f"Experiment {i+1}: {e.get('experiment_name', 'N/A')}\n"
+            f"  Hypothesis: {e.get('hypothesis', 'N/A')}\n"
+            f"  Justification: {e.get('justification', 'No justification provided.')}\n---"
+            for i, e in enumerate(prior_plan.get("proposed_experiments", []))
+        )
+        revision_parts.append("PRIOR PLAN (before this revision):\n" + prior_summary)
+    if prior_findings:
+        pl = "\n".join(
+            f"  - [{f.get('dimension')}/{f.get('severity')}] {f.get('issue')}"
+            for f in prior_findings if f.get("issue")
+        )
+        if pl:
+            revision_parts.append("CAVEATS PREVIOUSLY RAISED on the prior plan:\n" + pl)
+    if human_feedback:
+        revision_parts.append(f'HUMAN REVISION REQUEST:\n"{human_feedback}"')
+
+    if revision_parts:
+        prior_section = (
+            "\n────────────────────────────────────\n"
+            "REVISION CONTEXT — the CURRENT plan above is a revision of an earlier one.\n"
+            "Using the prior plan, its caveats, and the human's request below, judge the\n"
+            "CURRENT plan:\n"
+            "  • a prior caveat the revision RESOLVED -> drop it.\n"
+            "  • a prior caveat that still applies and was left unaddressed -> report it.\n"
+            "  • a prior caveat the human EXPLICITLY ACCEPTED as a tradeoff -> RETAIN it\n"
+            "    but mark it accepted: phrase the issue as an accepted limitation and set\n"
+            "    its severity to 'minor' (documented for the record, not a blocker).\n"
+            "  • any NEW physics/consistency issue the revision introduced -> report it.\n\n"
+            + "\n\n".join(revision_parts) + "\n"
+        )
+    else:
+        prior_section = ""
+
+    eval_prompt = f"""
+You are reviewing an experimental plan for PHYSICAL REALISM and INTERNAL CONSISTENCY.
+A separate check has already confirmed the plan is relevant to the objective, so do
+NOT re-litigate objective-relevance or document grounding here.
+
+OBJECTIVE: "{objective}"
+
+PROPOSED PLAN:
+{plan_summary}
+{evidence_section}{prior_section}
+Assume the plan may be flawed and try to break it on two axes:
+  • physics — parameters or conditions that are physically impossible or implausible;
+              a technique that cannot measure the stated quantity or resolve the
+              claimed scale; violated conservation laws or instrument limits.
+  • consistency — a justification that contradicts its own hypothesis; steps that do
+              not actually test the stated hypothesis; equipment that does not match
+              the steps; two experiments that contradict each other.
+Report only a flaw you can name concretely. Do NOT invent problems to appear
+thorough; if an axis is clean, report nothing for it.
+
+SEVERITY:
+  • critical — would make the plan infeasible or scientifically wrong.
+  • minor    — worth noting, but the plan still stands.
+
+OUTPUT — a single JSON object:
+{{"findings": [
+   {{"dimension": "physics|consistency",
+     "severity": "critical|minor",
+     "experiment": "<experiment name or 'plan-wide'>",
+     "issue": "<one concrete sentence>"}}
+]}}
+If the plan is clean, return {{"findings": []}}.
+"""
+
+    try:
+        prompt_parts = [eval_prompt]
+        prompt_parts.extend(loaded_images)
+        response = model.generate_content(prompt_parts, generation_config=generation_config)
+        verdict, _ = parse_json_from_response(response)
+        findings = (verdict or {}).get("findings", []) or []
+        crit = [f for f in findings if f.get("severity") == "critical"]
+        if crit:
+            print(f"    - ⚠️  Critic noted {len(crit)} significant caveat(s).")
+        else:
+            print(f"    - ✅ Critic: {len(findings)} minor caveat(s).")
+        return {"findings": findings}
+
+    except Exception as e:
+        logging.error(f"Critic step failed: {e}")
+        # Fail open: if the critic crashes, assume the plan is okay to avoid blocking the user.
+        return {"findings": []}
 
 
 def perform_science_rag(objective: str,
@@ -128,13 +322,19 @@ def perform_science_rag(objective: str,
                         image_descriptions: Optional[List[str]] = None,
                         additional_context: Optional[str] = None,
                         external_context: Optional[str] = None,
-                        skill_context: Optional[str] = None) -> Dict[str, Any]:
+                        skill_context: Optional[str] = None,
+                        return_context: bool = False) -> Any:
     """
     Executes the Scientific/TEA RAG loop over the Docs KnowledgeBase.
 
     Thin planning-side wrapper over the shared ``scilink.knowledge.run_rag``
     engine: it resolves planning's primary-data Excel summary and selects the
     matching fallback instruction set, then delegates retrieval + generation.
+
+    When ``return_context`` is True, returns ``(result, author_context)`` where
+    ``author_context`` is ``{"retrieved_context", "primary_data"}`` — the
+    grounding evidence the generation saw, so a downstream critic can verify
+    against the same material. Default False preserves the result-only return.
     """
 
     # --- Resolve primary data (Excel) into a summary string ---
@@ -161,7 +361,7 @@ def perform_science_rag(objective: str,
     elif instructions == TEA_INSTRUCTIONS:
         fallback_instructions = TEA_INSTRUCTIONS_FALLBACK
 
-    return run_rag(
+    rag_out = run_rag(
         query=objective,
         instructions=instructions,
         kb=kb_docs,
@@ -175,7 +375,14 @@ def perform_science_rag(objective: str,
         skill_context=skill_context,
         fallback_instructions=fallback_instructions,
         task_name=task_name,
+        return_context=return_context,
     )
+
+    if return_context:
+        result, retrieved_context = rag_out
+        return result, {"retrieved_context": retrieved_context,
+                        "primary_data": primary_data_str}
+    return rag_out
 
 
 def normalize_code(code: str) -> str:
@@ -361,8 +568,13 @@ def refine_plan_with_feedback(original_result: Dict[str, Any],
     """
     Refines the experimental plan based on user input or experimental results.
     Now supports injecting fresh RAG context relevant to the feedback/results.
+
+    Feedback here is authoritative (human review, experimental results, or a
+    discovered constraint) and is incorporated directly. The advisory critic does
+    NOT route through this function — its caveats are surfaced for a human /
+    consumer to weigh, not auto-applied.
     """
-    
+
     # Construct the context block if available
     context_block = ""
     if new_context:

--- a/scilink/agents/planning_agents/user_interface.py
+++ b/scilink/agents/planning_agents/user_interface.py
@@ -1,5 +1,24 @@
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 import re
+
+
+def format_caveats(findings: Optional[List[Dict[str, Any]]]) -> List[str]:
+    """Concise, advisory caveat lines from critic findings.
+
+    Assumes ``findings`` is already ordered critical-first (the agent sorts it).
+    Minor findings get a ``Minor:`` prefix; each line is ``[dimension] issue``.
+    Returns ``[]`` when there are no findings — the single source rendered by
+    both the console summary and ``run_task`` warnings.
+    """
+    lines: List[str] = []
+    for f in findings or []:
+        dim = f.get("dimension", "")
+        issue = (f.get("issue") or "").strip()
+        if not issue:
+            continue
+        prefix = "Minor: " if f.get("severity") == "minor" else ""
+        lines.append(f"{prefix}[{dim}] {issue}")
+    return lines
 
 
 def display_plan_summary(result: Dict[str, Any]) -> None:
@@ -78,6 +97,14 @@ def display_plan_summary(result: Dict[str, Any]) -> None:
             print("\n--- 💻 Implementation Code ---")
             print("  ℹ️  Plan includes implementation script.")
 
+    # --- Plan-level caveats (advisory; from the critic — the plan is unchanged) ---
+    caveats = format_caveats(result.get("critic_findings"))
+    if caveats:
+        print("\n" + "-"*80)
+        print("⚠️  Caveats & Potential Limitations")
+        for c in caveats:
+            print(f"  • {c}")
+
     print("\n" + "="*80)
 
 
@@ -90,9 +117,10 @@ def get_user_feedback() -> Optional[str]:
     
     print("📝 REQUESTING FEEDBACK")
     print("-" * 60)
-    print("Review the plan above.")
-    print("• To APPROVE: Press [ENTER] directly.")
-    print("• To REQUEST CHANGES: Type your feedback/instructions and press [ENTER].")
+    print("Review the plan and any caveats above.")
+    print("• To APPROVE as-is: Press [ENTER] directly.")
+    print("• To REVISE (e.g. address the caveats, or your own changes): "
+          "Type instructions and press [ENTER].")
     
     feedback = input("\n> Instruction: ").strip()
     

--- a/scilink/knowledge/rag_engine.py
+++ b/scilink/knowledge/rag_engine.py
@@ -171,7 +171,8 @@ def run_rag(query: str,
             primary_data_str: Optional[str] = None,
             skill_context: Optional[str] = None,
             fallback_instructions: Optional[str] = None,
-            task_name: str = "RAG") -> Dict[str, Any]:
+            task_name: str = "RAG",
+            return_context: bool = False) -> Any:
     """Generic RAG generation loop.
 
     Retrieves context for ``query`` from ``kb``, builds a multimodal prompt
@@ -195,9 +196,14 @@ def run_rag(query: str,
         fallback_instructions: Optional instructions used to retry once when
             strict generation reports insufficient context.
         task_name: Label used in progress logging.
+        return_context: When True, return ``(result, retrieved_context_str)``
+            so callers can reuse the exact grounding evidence the generation
+            saw (e.g. a downstream critic). Default False preserves the
+            original ``result``-only return for all existing callers.
 
     Returns:
-        The parsed JSON dict, or ``{"error": ...}`` on failure.
+        The parsed JSON dict (or ``{"error": ...}`` on failure). When
+        ``return_context`` is True, a ``(result, retrieved_context_str)`` tuple.
     """
     # --- 1. Retrieve context ---
     print(f"\n--- Retrieving Context for {task_name} ---")
@@ -211,6 +217,11 @@ def run_rag(query: str,
             retrieved_context_str += f"## 🌍 External Scientific Literature\n{external_context}\n\n"
         if rag_str:
             retrieved_context_str += f"## 📂 Retrieved Local Documents\n{rag_str}"
+
+    def _ret(payload):
+        # Honor the opt-in context return without disturbing the original
+        # result-only contract for callers that don't request it.
+        return (payload, retrieved_context_str) if return_context else payload
 
     # --- 2. Build multimodal prompt ---
     loaded_images = []
@@ -253,7 +264,7 @@ def run_rag(query: str,
         result, error_msg = parse_json_from_response(response)
 
         if error_msg:
-            return {"error": f"JSON Parsing Error: {error_msg}"}
+            return _ret({"error": f"JSON Parsing Error: {error_msg}"})
 
         # Check for insufficient-context signal
         needs_fallback = bool(
@@ -263,7 +274,7 @@ def run_rag(query: str,
         if needs_fallback:
             print(f"    - ⚠️ Strict generation failed: {result.get('error')}")
             if not fallback_instructions:
-                return result  # no fallback available
+                return _ret(result)  # no fallback available
 
             print("    - 🔄 Entering Fallback Mode (General Knowledge)...")
             prompt_parts[0] = fallback_instructions
@@ -272,11 +283,11 @@ def run_rag(query: str,
             )
             result, error_msg_fb = parse_json_from_response(fallback_response)
             if error_msg_fb:
-                return {"error": f"Fallback JSON Parsing Error: {error_msg_fb}"}
+                return _ret({"error": f"Fallback JSON Parsing Error: {error_msg_fb}"})
             print("    - ✅ Fallback generation successful.")
 
-        return result
+        return _ret(result)
 
     except Exception as e:
         logging.error(f"Error in run_rag: {e}")
-        return {"error": str(e)}
+        return _ret({"error": str(e)})


### PR DESCRIPTION
## Summary

SciLink's **planning mode** now does two things after it drafts a plan:

1. **The objective-conformance check is unchanged** — it still automatically corrects a plan that doesn't address the stated objective (the proven self-correction loop).
2. **A new, *separate* advisory review** checks the final plan for **physical realism and internal consistency**, grounded in the *actual data/evidence the plan was built from*, and surfaces a **"Caveats & Potential Limitations"** list. It **never rewrites the plan** — the human (or downstream consumer) decides what to act on. Caveats appear in the CLI summary, the HTML report (UI), and the structured `run_task` output.

When you ask the agent to **address the caveats** — or make any other change — it re-reviews the revised plan *aware of what was raised and what you asked*, so the caveats stay truthful: resolved ones drop, ones you **explicitly accept** are kept as minor "accepted" limitations, unaddressed ones persist, and new issues the revision introduces are flagged.

A one-line prompt fix also makes planning mode read cleanly for **computational/simulation campaigns**, not just wet-lab — so it already designs computational and combined experimental–theoretical campaigns out of the box.

**Why advisory, not auto-fixing:** live testing showed an auto-correcting critic rescoped plans unreliably (e.g. chasing an unmeasured target, 0/6 runs converging). So *detection* (reliably valuable) is separated from *correction* (which the human owns).

**Validated live** on real data (produced-water critical-material recovery; a DFT screening campaign). Representative caveats it produced: *"carbonate can't selectively precipitate Sr from a 15× Ca excess — CaCO₃ co-precipitates"* and *"PBE underestimates band gaps by 1–2 eV, so screening for a 1.5 eV PBE gap is wrong."*

---

## Technical details

**Architecture — two separate LLM calls in `generate_plan` (`planning_agent.py`):**

1. **`verify_plan_relevance`** (`planning_rag.py`) — the original *enforcing* objective-conformance check. Returns `(bool, str)`; a `False` auto-corrects via `refine_plan_with_feedback` → stage `Auto-Corrected`. **Reverted to `main`** (strict/fallback prompts byte-identical).
2. **`critique_plan`** (`planning_rag.py`, **new**) — *advisory* physics+consistency critic on the final plan. Evidence-fed (`retrieved_context`, `primary_data`, `images`/`image_descriptions`, `additional_context`, `skill_context`) so checks are anchored to real data. Revision-context params (`prior_plan`, `prior_findings`, `human_feedback`) turn a re-run into a resolution check. Returns `{"findings":[{dimension∈{physics,consistency}, severity, experiment, issue}]}`; fails open to `{"findings":[]}`. Records `critic_findings` (sorted critical-first); never rewrites.

**Plumbing:**
- `rag_engine.py` (`run_rag`) + `perform_science_rag`: opt-in `return_context` (default off; `_ret` helper) so the critic reuses the *exact* grounding evidence the generation saw. Only `generate_plan` opts in; the TEA caller and all others are unchanged.
- `generate_plan`: conformance + auto-correct, then a separate `critique_plan` on the final plan; on human refinement, re-critique with `prior_plan`/`prior_findings`/`human_feedback` and refresh caveats; `critic_findings` is stamped onto `plan_history[-1]` (the HTML report renders snapshots, not `current_plan`).
- `user_interface.py`: `format_caveats()` (single source) + a "Caveats & Potential Limitations" section in `display_plan_summary`.
- `html_generator.py`: caveats section in the HTML report.
- `planning_orchestrator.py`: caveats folded into `run_task` `warnings`.
- `instruct.py`: the fallback `required_equipment` blurb generalized from *"A list of common lab equipment"* → *"Key resources, instruments, or techniques (lab equipment/instruments, or computational resources/software)"* — the only wet-lab-binding phrase found in an audit of the planning prompts.

**Backward compatibility:** `verify_plan_relevance` and `refine_plan_with_feedback` prompts are **byte-identical to `main`** (an earlier auto-correcting `adjudicate` design was removed); `return_context` defaults off so existing callers are unaffected; `critic_findings` is an additive plan-dict field no consumer rejects.

**Design notes / known limits:**
- The critic shares the author's model (agreement-bias risk consciously accepted); evidence-grounding mitigated it in testing (it corrected a confidently-wrong physics finding). Tripwire: route the critic to a different model if such findings recur.
- Objective conformance is text-only (as on `main`); the critic does **not** backstop relevance — it stays in its physics/consistency lane.
- Validated with a frontier model; the `instruct.py` change is cheap insurance for weaker LiteLLM models.

**Validation:** offline (compile; `verify_plan_relevance`/`refine_plan_with_feedback` byte-identity vs `main`; critic contract + severity gating; advisory rendering; HTML caveats) and live on Bedrock opus-4-8 (two-call flow; address/accept/override re-critique behaviors; UI `plan.html` caveats; a computational DFT-screening campaign with correct expert caveats).
