### PR TITLE
Staged + parallel MD campaigns (sequential multi-phase + parameter sweeps)

### DIFF
--- a/scilink/agents/sim_agents/lammps_orchestrator.py
+++ b/scilink/agents/sim_agents/lammps_orchestrator.py
@@ -183,9 +183,9 @@ class LAMMPSOrchestrator:
             self.logger.error(f"Failed to generate simulation: {e}")
             return self._failed_result(f"Simulation generation failed: {e}")
         
-        stages = sim_info.get("stages", [])
         stage_scripts = sim_info.get("staged_scripts", {})
-        
+        stages = list(stage_scripts.keys())
+
         if not stages or not stage_scripts:
             # Fallback to single script
             self.logger.warning("No staged scripts generated, using single script")

--- a/scilink/agents/sim_agents/md_simulation_agent.py
+++ b/scilink/agents/sim_agents/md_simulation_agent.py
@@ -182,6 +182,11 @@ class MDSimulationAgent(SimulationAgent):
             f"{planning}\n\n"
             "Use the tables above to select the correct unit system, timestep, and\n"
             "damping constants for this system type.\n\n"
+            "If the goal calls for a parameter sweep — several independent runs that\n"
+            "vary one quantity (e.g. a set of temperatures, pressures, strain rates,\n"
+            "or restraint positions) — set requires_multiple_simulations true, set\n"
+            "variable_parameter to that quantity's name, and set variable_values to\n"
+            "the list of values. Otherwise leave them false/null.\n\n"
             "Return JSON:\n"
             "{\n"
             '    "simulation_technique": "standard_md",\n'
@@ -193,6 +198,8 @@ class MDSimulationAgent(SimulationAgent):
             '    "production_time": 1.5,\n'
             '    "requires_multiple_simulations": false,\n'
             '    "number_of_simulations": 1,\n'
+            '    "variable_parameter": null,\n'
+            '    "variable_values": null,\n'
             '    "required_outputs": ["energy", "trajectory"],\n'
             '    "methodology_description": "brief explanation"\n'
             "}"
@@ -212,6 +219,8 @@ class MDSimulationAgent(SimulationAgent):
         params.setdefault("production_time", 1.5)
         params.setdefault("requires_multiple_simulations", False)
         params.setdefault("number_of_simulations", 1)
+        params.setdefault("variable_parameter", None)
+        params.setdefault("variable_values", None)
         params.setdefault("required_outputs", ["energy", "trajectory"])
 
         for k, v in kwargs.items():

--- a/scilink/agents/sim_agents/md_simulation_agent.py
+++ b/scilink/agents/sim_agents/md_simulation_agent.py
@@ -21,6 +21,39 @@ except ImportError:
     pass
 
 
+def _assemble_fanout_stage(
+    members: List[Dict[str, str]],
+    entry_file: str,
+    shared_files: Dict[str, str],
+) -> List[Dict[str, Any]]:
+    """Assemble a one-stage fan-out campaign from expanded member scripts.
+
+    Each member becomes a self-contained run: the shared files (structure data,
+    force fields) plus its own substituted script under ``entry_file``. The
+    result is the engine-neutral ``stages`` structure ``_collect_stages``
+    consumes — pure and engine-agnostic, so it is unit-testable without an
+    agent, an LLM, or an engine.
+
+    Args:
+        members: ``{"name", "script"}`` dicts from ``expand_parameter_sweep``.
+        entry_file: Filename each member's script is written under.
+        shared_files: Files every member needs (filename → contents).
+
+    Returns:
+        A single-element list holding the production fan-out stage.
+    """
+    member_specs = []
+    for member in members:
+        input_files = dict(shared_files)
+        input_files[entry_file] = member["script"]
+        member_specs.append({
+            "name": member["name"],
+            "input_files": input_files,
+            "entry_file": entry_file,
+        })
+    return [{"name": "production", "parallel": True, "members": member_specs}]
+
+
 class MDSimulationAgent(SimulationAgent):
     """
     MD-specific simulation agent.
@@ -257,6 +290,16 @@ class MDSimulationAgent(SimulationAgent):
 
         script = self._clean_and_fix(script, plan)
 
+        # Parallel-sweep campaign: the script was authored with the sweep
+        # placeholder, so expand it into one independent run per value and
+        # return a normalized fan-out campaign instead of a single script.
+        sweep = self._sweep_spec(plan)
+        if sweep:
+            return self._finalize_campaign(
+                script, sweep, structure_file, force_field_files,
+                research_goal, system_description, system_info, plan,
+            )
+
         script_path = self.working_dir / "run.lammps"
         script_path.write_text(script)
 
@@ -489,13 +532,105 @@ class MDSimulationAgent(SimulationAgent):
         vals_str = ", ".join(str(v) for v in vals[:5])
         if len(vals) > 5:
             vals_str += f"... ({len(vals)} total)"
-        return (
-            "\n## Multi-Simulation\n"
+        block = (
+            "\n## Multi-Simulation (parallel sweep)\n"
             f"- Technique: {tech}\n"
             f"- Runs: {n}\n"
             f"- Variable: {var}\n"
             f"- Values: {vals_str}\n"
         )
+        # Author the sweep as ONE parameterized script: the swept quantity is
+        # marked with the engine's placeholder and expanded into one run per
+        # value downstream. The placeholder token belongs to the engine skill,
+        # so the prompt and the expander agree on it without the agent hardcoding
+        # a token.
+        placeholder = (getattr(self.tools_module, "SWEEP_PLACEHOLDER", None)
+                       if self.tools_module else None)
+        if placeholder and var:
+            block += (
+                f"- Write ONE script for the whole sweep: put the literal token "
+                f"{placeholder} everywhere the {var} value appears (e.g. in the "
+                f"velocity and fix commands), and use literal values for "
+                f"everything else. Each run is produced by substituting one "
+                f"value for {placeholder}.\n"
+            )
+        return block
+
+    # ================================================================
+    # PARALLEL-SWEEP CAMPAIGN
+    # ================================================================
+
+    def _sweep_spec(self, plan):
+        """Return ``{var_name, values}`` if the plan calls for a parallel sweep.
+
+        A sweep needs at least two values and an engine that knows how to expand
+        one (``expand_parameter_sweep``). Otherwise ``None`` — the caller emits
+        a single simulation.
+        """
+        if not (plan.get("requires_multiple_simulations")
+                and plan.get("number_of_simulations", 1) > 1):
+            return None
+        values = plan.get("variable_values") or []
+        if len(values) < 2:
+            return None
+        if not (self.tools_module
+                and hasattr(self.tools_module, "expand_parameter_sweep")):
+            return None
+        return {"var_name": plan.get("variable_parameter") or "parameter",
+                "values": values}
+
+    def _finalize_campaign(self, base_script, sweep, structure_file,
+                           force_field_files, goal, desc, info, plan):
+        """Expand a parameterized base script into a normalized fan-out campaign.
+
+        Each member is a self-contained run: the same structure data file and
+        force-field files plus its own substituted script, so members execute
+        independently in isolated directories. The expansion itself is the
+        engine skill's (``expand_parameter_sweep``); this method only assembles
+        the engine-neutral ``stages`` structure the refinement loop consumes.
+        """
+        entry = "run.lammps"
+        shared = self._campaign_shared_files(structure_file, force_field_files)
+        members = self.tools_module.expand_parameter_sweep(
+            base_script, sweep["var_name"], sweep["values"])
+        stages = _assemble_fanout_stage(members, entry, shared)
+
+        # Validate a representative member (the placeholder is already resolved).
+        rep_files = stages[0]["members"][0]["input_files"]
+        rep_path = self.working_dir / entry
+        rep_path.write_text(rep_files[entry])
+        validation = self._validate(str(rep_path), info, plan)
+        readme = self._generate_readme(goal, desc, info, plan, str(rep_path))
+
+        return {
+            "script_path": str(rep_path),
+            "readme_path": readme,
+            "data_path": structure_file,
+            "system_info": info,
+            "simulation_parameters": plan,
+            "validation": validation,
+            "skill_used": self.skill_name,
+            "stages": stages,
+            "input_files": rep_files,
+            "entry_file": entry,
+            "is_campaign": True,
+            "campaign_kind": "parameter_sweep",
+        }
+
+    def _campaign_shared_files(self, structure_file, force_field_files):
+        """Read the files every member needs (structure data + force fields)."""
+        shared = {}
+        try:
+            shared[Path(structure_file).name] = Path(structure_file).read_text(
+                errors="replace")
+        except OSError:
+            self.logger.warning("Could not read structure file for campaign")
+        for name, path in (force_field_files or {}).items():
+            try:
+                shared[name] = Path(path).read_text(errors="replace")
+            except OSError:
+                self.logger.warning("Could not read force-field file %s", path)
+        return shared
 
     # ================================================================
     # FORCE FIELD INTEGRATION

--- a/scilink/agents/sim_agents/md_simulation_agent.py
+++ b/scilink/agents/sim_agents/md_simulation_agent.py
@@ -548,11 +548,11 @@ class MDSimulationAgent(SimulationAgent):
                        if self.tools_module else None)
         if placeholder and var:
             block += (
-                f"- Write ONE script for the whole sweep: put the literal token "
-                f"{placeholder} everywhere the {var} value appears (e.g. in the "
-                f"velocity and fix commands), and use literal values for "
-                f"everything else. Each run is produced by substituting one "
-                f"value for {placeholder}.\n"
+                f"- Write ONE script for the whole sweep: use the literal token "
+                f"{placeholder} in place of every {var} value the script sets or "
+                f"references, and use literal values for everything else. Each "
+                f"run is produced by substituting one value for {placeholder}, so "
+                f"the placeholder must appear wherever a {var} value would.\n"
             )
         return block
 

--- a/scilink/agents/sim_agents/md_simulation_agent.py
+++ b/scilink/agents/sim_agents/md_simulation_agent.py
@@ -54,6 +54,41 @@ def _assemble_fanout_stage(
     return [{"name": "production", "parallel": True, "members": member_specs}]
 
 
+def _assemble_sequential_stages(
+    steps: List[Dict[str, str]],
+    shared_files: Dict[str, str],
+) -> List[Dict[str, Any]]:
+    """Assemble an ordered sequential campaign from staged step scripts.
+
+    Each step becomes one sequential stage. The stages share a run directory
+    (``_collect_stages`` does not isolate sequential steps), so a stage's
+    restart files are available to the next — the optimization → equilibration
+    → production chain. Every stage carries the shared files (structure data,
+    force fields) plus its own script under its ``entry_file``. The result is
+    the engine-neutral ``stages`` structure ``_collect_stages`` consumes — pure
+    and engine-agnostic, so it is unit-testable without an agent, an LLM, or an
+    engine.
+
+    Args:
+        steps: Ordered ``{"name", "entry_file", "script"}`` dicts, one per
+            phase, in execution order.
+        shared_files: Files every stage needs (filename → contents).
+
+    Returns:
+        A list of sequential stage specs in execution order.
+    """
+    specs = []
+    for step in steps:
+        input_files = dict(shared_files)
+        input_files[step["entry_file"]] = step["script"]
+        specs.append({
+            "name": step["name"],
+            "input_files": input_files,
+            "entry_file": step["entry_file"],
+        })
+    return specs
+
+
 class MDSimulationAgent(SimulationAgent):
     """
     MD-specific simulation agent.
@@ -707,19 +742,33 @@ class MDSimulationAgent(SimulationAgent):
             stages = {"production": full_script}
 
         stage_scripts = {}
+        steps = []
         for name, content in stages.items():
             if not isinstance(content, str):
                 continue
             content = self._clean_and_fix(content, plan)
-            path = self.working_dir / f"run_{name}.lammps"
+            entry = f"run_{name}.lammps"
+            path = self.working_dir / entry
             path.write_text(content)
             stage_scripts[name] = str(path)
+            steps.append({"name": name, "entry_file": entry, "script": content})
+
+        shared = self._campaign_shared_files(
+            structure_file, kw.get("force_field_files"))
+        stage_specs = _assemble_sequential_stages(steps, shared)
 
         result.update(
             staged_scripts=stage_scripts,
-            stages=list(stage_scripts.keys()),
+            stages=stage_specs,
             is_staged=True,
+            is_campaign=True,
+            campaign_kind="staged",
         )
+        # Representative phase for back-compat consumers that read a single
+        # input set (the pipeline's input_files normalization, etc.).
+        if stage_specs:
+            result["input_files"] = stage_specs[0]["input_files"]
+            result["entry_file"] = stage_specs[0]["entry_file"]
         return result
 
     # ================================================================

--- a/scilink/agents/sim_agents/refinement.py
+++ b/scilink/agents/sim_agents/refinement.py
@@ -98,6 +98,44 @@ class Phase:
     run_dir: str
 
 
+@dataclass
+class Stage:
+    """One stage of a simulation campaign: a group of phases run together.
+
+    A campaign is an ordered list of stages. A stage is one of three shapes,
+    all engine-neutral — what a fan-out's members differ by (temperature,
+    restraint center, …) lives in each member's ``input_files``, authored by
+    the generator, never here:
+
+    * **sequential step** (``parallel=False``): its phases run in order and
+      chain through restart files (e.g. optimization → equilibration →
+      production). Typically one phase per stage.
+    * **parallel fan-out** (``parallel=True``): independent member phases that
+      differ only in their inputs — a temperature sweep, or the windows of an
+      umbrella-sampling run. Members are refined independently; one member's
+      failure does not abort its siblings.
+    * **combine** (``kind="combine"``): a single post-processing phase that
+      consumes a prior fan-out's outputs (e.g. assembling a free-energy
+      profile). Run once and judged, never iterated.
+
+    Attributes:
+        name: Short stage label for logging and the result record.
+        phases: The phases this stage runs.
+        parallel: Whether the phases are independent (fan-out) rather than a
+            chained sequence.
+        kind: ``"run"`` for a normal stage, ``"combine"`` for a run-once
+            post-processing stage.
+        min_success: For a fan-out, the minimum number of members that must
+            succeed for the stage to succeed. ``None`` requires all of them.
+    """
+
+    name: str
+    phases: List[Phase]
+    parallel: bool = False
+    kind: str = "run"
+    min_success: Optional[int] = None
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # Critic protocol (duck-typed against RunCritic.assess)
 # ──────────────────────────────────────────────────────────────────────────
@@ -468,6 +506,232 @@ def _stalled(ctx: RefinementContext) -> bool:
 # The loop
 # ──────────────────────────────────────────────────────────────────────────
 
+def _refine_phase(
+    phase: Phase,
+    executor: Executor,
+    run_critic: _RunCriticLike,
+    policy: RefinementPolicy,
+    ctx: RefinementContext,
+) -> Dict[str, Any]:
+    """Run one phase to convergence: run → assess → fix → re-run.
+
+    The per-phase primitive shared by sequential steps and fan-out members:
+    runs the executor, assesses the output, and — when the policy says to
+    refine — applies the critic's whole-file fixes and re-runs, up to the
+    context's cycle budget. The pre-run gate is *not* applied here; the caller
+    gates the campaign's first phase once. Appends one history entry per cycle.
+
+    Returns:
+        A phase record: ``phase``, ``status`` (``"success"``, ``"stopped"``,
+        ``"aborted"``, or ``"exhausted"``), ``cycles``, ``verdict``, and
+        ``run_status``.
+    """
+    inputs = phase.input_files
+    ctx.cycle = 0
+    last_verdict: Dict[str, Any] = {}
+    phase_status = "failed"
+
+    while ctx.cycle < ctx.max_cycles:
+        result = executor.run(inputs, phase.run_command, phase.run_dir)
+
+        if result.get("status") == "error":
+            # Could not launch — still assess (the critic reads the persisted
+            # stderr) so a fix can be proposed.
+            logger.warning(
+                "Executor could not launch phase %s: %s",
+                phase.name, result.get("error"),
+            )
+
+        verdict = run_critic.assess(
+            output_dir=result.get("output_dir", phase.run_dir),
+            research_goal=ctx.research_goal,
+            skill=ctx.skill,
+            domain=ctx.domain,
+        )
+        last_verdict = verdict
+        ctx.record(phase, result, verdict)
+
+        decision = policy.after_run(result, verdict, ctx)
+        if decision == CycleDecision.STOP:
+            phase_status = "success" if _is_acceptable(verdict) else "stopped"
+            break
+
+        fixes = verdict.get("suggested_fixes")
+        if not fixes:
+            phase_status = "success" if _is_acceptable(verdict) else "stopped"
+            break
+
+        approved = policy.approve_change(fixes, verdict, ctx)
+        if approved is None:
+            phase_status = "aborted"
+            break
+        inputs = approved
+        ctx.cycle += 1
+    else:
+        # Budget exhausted without an acceptable verdict.
+        phase_status = "exhausted"
+
+    return {
+        "phase": phase.name,
+        "status": phase_status,
+        "cycles": ctx.cycle + 1,
+        "verdict": last_verdict.get("verdict"),
+        "run_status": last_verdict.get("run_status"),
+    }
+
+
+def _run_once_phase(
+    phase: Phase,
+    executor: Executor,
+    run_critic: _RunCriticLike,
+    ctx: RefinementContext,
+) -> Dict[str, Any]:
+    """Run a phase exactly once and assess it, with no refine loop.
+
+    Used for a combine stage: it consumes a prior fan-out's outputs (e.g.
+    assembling a free-energy profile from umbrella windows), so re-running it
+    with a fix is not the right recovery — it is judged once, not iterated.
+    """
+    result = executor.run(phase.input_files, phase.run_command, phase.run_dir)
+    if result.get("status") == "error":
+        logger.warning(
+            "Executor could not launch combine phase %s: %s",
+            phase.name, result.get("error"),
+        )
+    verdict = run_critic.assess(
+        output_dir=result.get("output_dir", phase.run_dir),
+        research_goal=ctx.research_goal,
+        skill=ctx.skill,
+        domain=ctx.domain,
+    )
+    ctx.record(phase, result, verdict)
+    return {
+        "phase": phase.name,
+        "status": "success" if _is_acceptable(verdict) else "stopped",
+        "cycles": 1,
+        "verdict": verdict.get("verdict"),
+        "run_status": verdict.get("run_status"),
+    }
+
+
+def run_campaign(
+    stages: List[Stage],
+    executor: Executor,
+    run_critic: _RunCriticLike,
+    policy: RefinementPolicy,
+    ctx: RefinementContext,
+    pre_run_verdict: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Drive a staged MD campaign of sequential and parallel phases.
+
+    Generalizes the single-chain refinement loop to the shapes a real MD study
+    needs: sequential steps (optimization → equilibration → production, chained
+    through restart files), a parallel fan-out (independent runs differing only
+    in their inputs — a temperature sweep or umbrella-sampling windows), and an
+    optional combine step that post-processes a fan-out's outputs. Each phase
+    is still refined by the same run → assess → fix loop; fan-out members are
+    refined independently, so one member's failure does not abort its siblings.
+
+    Stages run in order; a stage that does not succeed stops the campaign
+    (later stages depend on its output). Whether a fan-out's members actually
+    run concurrently is the executor's concern — the campaign only expresses
+    that they are independent. The pre-run gate runs once on the first phase's
+    inputs, reusing ``pre_run_verdict`` so no second validation call is made.
+
+    Args:
+        stages: Ordered stages to execute.
+        executor: How to run a phase's inputs.
+        run_critic: Post-run critic exposing ``assess(...)``.
+        policy: Autonomy policy gating changes and continuation.
+        ctx: Shared refinement state (goal, routing, budget, history).
+        pre_run_verdict: Optional input-validator report for the pre-run gate.
+
+    Returns:
+        A dict with ``status`` (``"success"``, ``"aborted"``, or ``"failed"``),
+        ``stages`` (per-stage status + member records), ``phases`` (every phase
+        record, flattened in execution order — back-compatible with the
+        single-chain result), and the full ``history``.
+    """
+    runnable = [s for s in stages if s.phases]
+    if not runnable:
+        return {"status": "failed", "error": "no phases to run",
+                "stages": [], "phases": [], "history": ctx.history}
+
+    # ── Pre-run gate (1): accept the first phase's inputs before any run ──
+    first_phase = runnable[0].phases[0]
+    gated = policy.approve_change(first_phase.input_files, pre_run_verdict, ctx)
+    if gated is None:
+        return {"status": "aborted", "reason": "pre-run inputs rejected",
+                "stages": [], "phases": [], "history": ctx.history}
+    first_phase.input_files = gated
+
+    flat: List[Dict[str, Any]] = []
+    stage_records: List[Dict[str, Any]] = []
+    overall = "success"
+
+    for stage in runnable:
+        if stage.kind == "combine":
+            rec = _run_once_phase(stage.phases[0], executor, run_critic, ctx)
+            flat.append(rec)
+            status = "success" if rec["status"] == "success" else "failed"
+            stage_records.append({
+                "name": stage.name, "parallel": False, "kind": "combine",
+                "status": status, "members": [rec],
+            })
+
+        elif not stage.parallel:
+            members: List[Dict[str, Any]] = []
+            status = "success"
+            for ph in stage.phases:
+                rec = _refine_phase(ph, executor, run_critic, policy, ctx)
+                flat.append(rec)
+                members.append(rec)
+                if rec["status"] != "success":
+                    status = ("aborted" if rec["status"] == "aborted"
+                              else "failed")
+                    break
+            stage_records.append({
+                "name": stage.name, "parallel": False, "kind": "run",
+                "status": status, "members": members,
+            })
+
+        else:
+            # Fan-out: every member is refined independently. A failing member
+            # does not abort its siblings — collect them all, then judge the
+            # stage against its success quorum.
+            members = []
+            n_success = 0
+            any_aborted = False
+            for ph in stage.phases:
+                rec = _refine_phase(ph, executor, run_critic, policy, ctx)
+                flat.append(rec)
+                members.append(rec)
+                if rec["status"] == "success":
+                    n_success += 1
+                elif rec["status"] == "aborted":
+                    any_aborted = True
+            required = (stage.min_success if stage.min_success is not None
+                        else len(stage.phases))
+            if n_success >= required:
+                status = "success"
+            elif any_aborted and n_success == 0:
+                status = "aborted"
+            else:
+                status = "failed"
+            stage_records.append({
+                "name": stage.name, "parallel": True, "kind": "run",
+                "status": status, "members": members,
+                "n_success": n_success, "required": required,
+            })
+
+        if status != "success":
+            overall = "aborted" if status == "aborted" else "failed"
+            break
+
+    return {"status": overall, "stages": stage_records, "phases": flat,
+            "history": ctx.history}
+
+
 def run_refinement(
     phases: List[Phase],
     executor: Executor,
@@ -476,14 +740,12 @@ def run_refinement(
     ctx: RefinementContext,
     pre_run_verdict: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    """Drive a simulation to convergence: run → assess → fix → re-run.
+    """Drive a single sequential phase chain to convergence.
 
-    Iterates the phases in order; within each phase, runs the executor,
-    assesses the output with the critic, and — when the policy says to refine
-    — applies the critic's whole-file fixes and re-runs, up to the context's
-    cycle budget. The pre-run gate runs once on the first phase's inputs,
-    reusing ``pre_run_verdict`` (the input validator's report) so no second
-    validation call is made.
+    A thin wrapper over :func:`run_campaign` for the common single-chain case
+    (one phase for DFT, a restart-chained optimization → equilibration →
+    production for MD). Equivalent to one sequential stage; the result keeps
+    the same ``status`` / ``phases`` / ``history`` shape it has always had.
 
     Args:
         phases: Ordered phases to execute (one for DFT, several for staged MD).
@@ -494,92 +756,9 @@ def run_refinement(
         pre_run_verdict: Optional input-validator report for the pre-run gate.
 
     Returns:
-        A dict with ``status`` (``"success"``, ``"aborted"``, or
-        ``"failed"``), ``phases`` (per-phase final verdict + cycles), and the
-        full ``history``.
+        A dict with ``status``, ``phases`` (per-phase final verdict + cycles),
+        and the full ``history``.
     """
-    if not phases:
-        return {"status": "failed", "error": "no phases to run", "phases": [],
-                "history": ctx.history}
-
-    # ── Pre-run gate (1): accept the generated inputs before the first run ──
-    gated = policy.approve_change(phases[0].input_files, pre_run_verdict, ctx)
-    if gated is None:
-        return {"status": "aborted", "reason": "pre-run inputs rejected",
-                "phases": [], "history": ctx.history}
-    phases[0].input_files = gated
-
-    phase_results: List[Dict[str, Any]] = []
-
-    for phase in phases:
-        ctx.cycle = 0
-        inputs = phase.input_files
-        last_verdict: Dict[str, Any] = {}
-        phase_status = "failed"
-
-        while ctx.cycle < ctx.max_cycles:
-            result = executor.run(inputs, phase.run_command, phase.run_dir)
-
-            if result.get("status") == "error":
-                # Could not launch — still assess (the critic reads the
-                # persisted stderr) so a fix can be proposed, but treat a
-                # launch failure as a needs_fixes verdict if the critic errors.
-                logger.warning(
-                    "Executor could not launch phase %s: %s",
-                    phase.name, result.get("error"),
-                )
-
-            verdict = run_critic.assess(
-                output_dir=result.get("output_dir", phase.run_dir),
-                research_goal=ctx.research_goal,
-                skill=ctx.skill,
-                domain=ctx.domain,
-            )
-            last_verdict = verdict
-            ctx.record(phase, result, verdict)
-
-            decision = policy.after_run(result, verdict, ctx)
-            if decision == CycleDecision.STOP:
-                phase_status = "success" if _is_acceptable(verdict) else "stopped"
-                break
-
-            fixes = verdict.get("suggested_fixes")
-            if not fixes:
-                phase_status = "success" if _is_acceptable(verdict) else "stopped"
-                break
-
-            approved = policy.approve_change(fixes, verdict, ctx)
-            if approved is None:
-                phase_status = "aborted"
-                break
-            inputs = approved
-            ctx.cycle += 1
-        else:
-            # Budget exhausted without an acceptable verdict.
-            phase_status = "exhausted"
-
-        phase_results.append({
-            "phase": phase.name,
-            "status": phase_status,
-            "cycles": ctx.cycle + 1,
-            "verdict": last_verdict.get("verdict"),
-            "run_status": last_verdict.get("run_status"),
-        })
-
-        # A phase that did not reach an acceptable verdict stops the chain —
-        # later phases depend on this one's output (restart files). Only a
-        # phase that ended acceptable ("success") lets the run proceed; a
-        # "stopped" phase (refining halted below acceptable — a benign-but-poor
-        # result, or a stalled loop) is not a success and ends the run.
-        if phase_status != "success":
-            return {
-                "status": "aborted" if phase_status == "aborted" else "failed",
-                "phases": phase_results,
-                "history": ctx.history,
-            }
-
-    return {
-        "status": "success",
-        "phases": phase_results,
-        "history": ctx.history,
-    }
+    stage = Stage(name="run", phases=list(phases), parallel=False)
+    return run_campaign([stage], executor, run_critic, policy, ctx,
+                        pre_run_verdict)

--- a/scilink/agents/sim_agents/simulation_pipeline.py
+++ b/scilink/agents/sim_agents/simulation_pipeline.py
@@ -302,10 +302,10 @@ def run_complete_workflow(
         result["final_status"] = "success"
         return result
 
-    from .refinement import RefinementContext, policy_for, run_refinement
+    from .refinement import RefinementContext, policy_for, run_campaign
     from .critics import RunCritic
 
-    phases = _collect_phases(gen_result, output_dir, run_command)
+    stages = _collect_stages(gen_result, output_dir, run_command)
     ctx = RefinementContext(
         research_goal=user_request, scale=scale, engine=software,
         skill=software, domain=scale, autonomy=autonomy,
@@ -314,8 +314,8 @@ def run_complete_workflow(
     run_critic = RunCritic(
         api_key=api_key, base_url=base_url, model_name=model_name,
     )
-    refinement = run_refinement(
-        phases, executor, run_critic, policy_for(autonomy), ctx,
+    refinement = run_campaign(
+        stages, executor, run_critic, policy_for(autonomy), ctx,
         pre_run_verdict=result.get("input_validation"),
     )
     result["refinement"] = refinement
@@ -377,6 +377,87 @@ def _collect_phases(
             run_dir=str(run_dir),
         ))
     return phases
+
+
+def _collect_stages(
+    gen_result: Dict[str, Any], run_dir: str, run_command_template: str
+) -> list:
+    """Build refinement ``Stage`` objects from a generation result.
+
+    Reads only normalized, engine-neutral campaign fields. A generation result
+    may carry a ``stages`` list describing a staged/parallel campaign; each
+    entry is one of:
+
+    * a **sequential step** — ``{name, input_files, entry_file}``. Steps share
+      ``run_dir`` so restart files chain.
+    * a **parallel fan-out** — ``{name, parallel: true, members: [...],
+      min_success?}`` where each member is ``{name, input_files, entry_file}``.
+      Members run in their own ``run_dir/<stage>/<member>`` directory.
+    * a **combine** step — ``{name, kind: "combine", input_files, entry_file,
+      run_command?}`` in ``run_dir/<stage>``; ``run_command`` may override the
+      template (e.g. a Python post-processing script).
+
+    When no ``stages`` field is present, the legacy single-chain shape is read
+    via :func:`_collect_phases` and wrapped as one sequential stage, so older
+    generation results behave exactly as before.
+
+    Args:
+        gen_result: The input-generation result.
+        run_dir: Base directory the campaign executes in.
+        run_command_template: Command template with an optional ``{script}``
+            placeholder for a phase's entry file.
+
+    Returns:
+        A list of ``Stage`` objects in execution order.
+    """
+    import os
+
+    from .refinement import Phase, Stage
+
+    stages_spec = gen_result.get("stages")
+    if not stages_spec:
+        phases = _collect_phases(gen_result, run_dir, run_command_template)
+        return [Stage(name="run", phases=phases, parallel=False)]
+
+    def _command(entry: str, override) -> str:
+        template = override or run_command_template
+        if "{script}" in template:
+            return template.format(script=entry or "")
+        return template
+
+    def _phase(spec: Dict[str, Any], rdir: str) -> "Phase":
+        entry = spec.get("entry_file") or ""
+        return Phase(
+            name=spec.get("name", "run"),
+            input_files=spec.get("input_files") or {},
+            run_command=_command(entry, spec.get("run_command")),
+            run_dir=str(rdir),
+        )
+
+    stages = []
+    for spec in stages_spec:
+        name = spec.get("name", "run")
+        if spec.get("kind") == "combine":
+            stages.append(Stage(
+                name=name, kind="combine", parallel=False,
+                phases=[_phase(spec, os.path.join(str(run_dir), name))],
+            ))
+        elif spec.get("parallel") or spec.get("members"):
+            members = [
+                _phase(m, os.path.join(str(run_dir), name,
+                                       m.get("name", "member")))
+                for m in (spec.get("members") or [])
+            ]
+            stages.append(Stage(
+                name=name, parallel=True, phases=members,
+                min_success=spec.get("min_success"),
+            ))
+        else:
+            # Sequential step: share the base run_dir so restart files chain.
+            stages.append(Stage(
+                name=name, parallel=False, phases=[_phase(spec, run_dir)],
+            ))
+    return stages
 
 
 def _collect_input_files(gen_result: Dict[str, Any]) -> Dict[str, str]:

--- a/scilink/agents/sim_agents/simulation_pipeline.py
+++ b/scilink/agents/sim_agents/simulation_pipeline.py
@@ -59,6 +59,7 @@ def _generate_inputs(
     base_url: Optional[str],
     model_name: str,
     force_field_files: Optional[Dict[str, str]] = None,
+    staged: bool = False,
 ) -> Dict[str, Any]:
     """Generate inputs for ``scale``, returning a normalized result.
 
@@ -114,7 +115,13 @@ def _generate_inputs(
             working_dir=output_dir,
             api_key=api_key, base_url=base_url, model_name=model_name,
         )
-        result = agent.generate_simulation(
+        # Staged generation emits an optimization → equilibration → production
+        # chain as a normalized sequential campaign; one-shot generation emits a
+        # single phase (or a parallel sweep when the plan calls for one). Both
+        # return the same normalized result shape the pipeline consumes.
+        gen = (agent.generate_staged_simulation if staged
+               else agent.generate_simulation)
+        result = gen(
             structure_file=structure_file, research_goal=request, runner=software,
             force_field_files=force_field_files,
         )
@@ -160,6 +167,7 @@ def run_complete_workflow(
     max_run_cycles: int = 3,
     structure_file: Optional[str] = None,
     force_field_files: Optional[Dict[str, str]] = None,
+    staged: bool = False,
 ) -> Dict[str, Any]:
     """Run the full structure → inputs → validation pipeline for any scale.
 
@@ -201,6 +209,10 @@ def run_complete_workflow(
             input generation + (optional) execution.
         force_field_files: Optional mapping of force-field filename to contents,
             forwarded to MD input generation.
+        staged: When True, MD generation emits a multi-phase (optimization →
+            equilibration → production) sequential campaign instead of a single
+            run, so the refinement loop runs the per-phase loop over a restart-
+            chained sequence. MD only; ignored by other scales.
 
     Returns:
         A workflow-result dict with ``final_status``, ``scale``, ``engine``,
@@ -256,6 +268,7 @@ def run_complete_workflow(
             structure_file=structure_path, request=user_request,
             output_dir=output_dir, api_key=api_key, base_url=base_url,
             model_name=model_name, force_field_files=force_field_files,
+            staged=staged,
         )
     except Exception as e:
         result["final_status"] = "failed_input_generation"

--- a/scilink/skills/molecular_dynamics/lammps/lammps.py
+++ b/scilink/skills/molecular_dynamics/lammps/lammps.py
@@ -732,6 +732,54 @@ def substitute_variables(
     return script
 
 
+SWEEP_PLACEHOLDER = "__SWEEP__"
+
+
+def sweep_member_name(var_name: str, value: Any) -> str:
+    """Build a filesystem- and LAMMPS-safe member name for one sweep value.
+
+    Example: ``("temperature", 300)`` → ``"temperature_300"``. Used to name a
+    fan-out member's run directory and result record, so a temperature sweep or
+    umbrella window set is self-describing.
+    """
+    var = re.sub(r"[^A-Za-z0-9]+", "", str(var_name)) or "sweep"
+    val = re.sub(r"[^A-Za-z0-9.+-]+", "_", str(value)).strip("_") or "0"
+    return f"{var}_{val}"
+
+
+def expand_parameter_sweep(
+    base_script: str,
+    var_name: str,
+    values: List[Any],
+    placeholder: str = SWEEP_PLACEHOLDER,
+) -> List[Dict[str, str]]:
+    """Expand one parameterized base script into a fan-out of member scripts.
+
+    The base script carries ``placeholder`` everywhere the swept quantity
+    appears (e.g. a temperature in ``velocity create`` and ``fix nvt``, or a
+    restraint center in ``fix spring``); each member is produced by replacing
+    the placeholder with one value. This is the engine-idiomatic way to author
+    a temperature sweep or the windows of an umbrella-sampling run: write the
+    physics once, vary one number. Deterministic — no LLM call per member.
+
+    Args:
+        base_script: The parameterized script containing ``placeholder``.
+        var_name: Name of the swept quantity (used to name members).
+        values: The values to sweep over, one member each.
+        placeholder: Token in ``base_script`` to replace with each value.
+
+    Returns:
+        A list of ``{"name", "script"}`` dicts, one per value, in order.
+    """
+    members: List[Dict[str, str]] = []
+    for value in values:
+        members.append({
+            "name": sweep_member_name(var_name, value),
+            "script": base_script.replace(placeholder, str(value)),
+        })
+    return members
+
+
 # ─── Force Field Integration ─────────────────────────────────────────
 
 _FF_STYLE_COMMANDS = {

--- a/tests/test_refinement_loop.py
+++ b/tests/test_refinement_loop.py
@@ -22,6 +22,8 @@ from scilink.agents.sim_agents.refinement import (  # noqa: E402
     Executor,
     Phase,
     RefinementContext,
+    Stage,
+    run_campaign,
     run_refinement,
     policy_for,
 )
@@ -256,6 +258,101 @@ class TestPolicies:
         # Unknown label defaults to autonomous (safe for headless callers).
         assert isinstance(policy_for("nonsense"), AutonomousPolicy)
         assert isinstance(policy_for(""), AutonomousPolicy)
+
+
+class TestStages:
+    """Staged + parallel campaigns via run_campaign (Stage model)."""
+
+    def _member(self, name):
+        return Phase(name=name, input_files={"in.sim": "original"},
+                     run_command="true", run_dir=f"/tmp/rf_{name}")
+
+    def test_single_sequential_stage_matches_run_refinement(self):
+        # A campaign of one sequential stage behaves like the flat chain.
+        ex = FakeExecutor()
+        critic = ScriptedCritic([_good(), _needs_fixes({"in.sim": "f"}), _good()])
+        stages = [Stage(name="run",
+                        phases=[self._member("equil"), self._member("prod")])]
+        result = run_campaign(stages, ex, critic, AutonomousPolicy(), _ctx())
+        assert result["status"] == "success"
+        assert [p["phase"] for p in result["phases"]] == ["equil", "prod"]
+        assert len(result["stages"]) == 1
+
+    def test_fanout_members_are_independent(self):
+        # 3 independent members: A good, B needs a fix then good, C poor with no
+        # fix (stops). B's refinement and C's failure must not disturb A.
+        ex = FakeExecutor()
+        critic = ScriptedCritic([
+            _good(),                                # A: T300
+            _needs_fixes({"in.sim": "fixed"}), _good(),  # B: T400 (fix→good)
+            {"verdict": "poor", "run_status": "succeeded",
+             "suggested_fixes": None},              # C: T500 (stopped)
+        ])
+        fanout = Stage(name="tsweep", parallel=True, phases=[
+            self._member("T300"), self._member("T400"), self._member("T500")])
+        result = run_campaign([fanout], ex, critic, AutonomousPolicy(), _ctx())
+
+        # Every member ran in its own dir; the fan-out did not short-circuit.
+        assert {c["run_dir"] for c in ex.calls} == {
+            "/tmp/rf_T300", "/tmp/rf_T400", "/tmp/rf_T500"}
+        members = {m["phase"]: m for m in result["stages"][0]["members"]}
+        assert members["T300"]["status"] == "success"
+        assert members["T400"]["status"] == "success"   # recovered
+        assert members["T500"]["status"] == "stopped"
+        # All-required by default → one stopped member fails the stage.
+        assert result["stages"][0]["n_success"] == 2
+        assert result["status"] == "failed"
+
+    def test_fanout_min_success_quorum(self):
+        # Same 2-of-3, but a quorum of 2 lets the stage (and campaign) succeed.
+        ex = FakeExecutor()
+        critic = ScriptedCritic([
+            _good(), _good(),
+            {"verdict": "poor", "run_status": "succeeded", "suggested_fixes": None},
+        ])
+        fanout = Stage(name="tsweep", parallel=True, min_success=2, phases=[
+            self._member("T300"), self._member("T400"), self._member("T500")])
+        result = run_campaign([fanout], ex, critic, AutonomousPolicy(), _ctx())
+        assert result["stages"][0]["n_success"] == 2
+        assert result["status"] == "success"
+
+    def test_combine_runs_once_after_fanout(self):
+        # optim → fan-out(2, both good) → combine. Combine runs exactly once.
+        ex = FakeExecutor()
+        critic = ScriptedCritic([_good(), _good(), _good(), _good()])
+        stages = [
+            Stage(name="optim", phases=[self._member("optim")]),
+            Stage(name="windows", parallel=True,
+                  phases=[self._member("w0"), self._member("w1")]),
+            Stage(name="wham", kind="combine", phases=[self._member("wham")]),
+        ]
+        result = run_campaign(stages, ex, critic, AutonomousPolicy(), _ctx())
+        assert result["status"] == "success"
+        assert result["stages"][-1]["kind"] == "combine"
+        # Combine executed once, and last.
+        assert ex.calls[-1]["run_dir"] == "/tmp/rf_wham"
+        assert sum(c["run_dir"] == "/tmp/rf_wham" for c in ex.calls) == 1
+
+    def test_combine_skipped_when_fanout_fails(self):
+        # A failing fan-out stops the campaign before the combine stage runs.
+        ex = FakeExecutor()
+        critic = ScriptedCritic([
+            {"verdict": "poor", "run_status": "succeeded", "suggested_fixes": None},
+        ])
+        stages = [
+            Stage(name="windows", parallel=True, phases=[self._member("w0")]),
+            Stage(name="wham", kind="combine", phases=[self._member("wham")]),
+        ]
+        result = run_campaign(stages, ex, critic, AutonomousPolicy(), _ctx())
+        assert result["status"] == "failed"
+        # The combine never ran.
+        assert all(c["run_dir"] != "/tmp/rf_wham" for c in ex.calls)
+        assert [s["name"] for s in result["stages"]] == ["windows"]
+
+    def test_empty_campaign_fails_cleanly(self):
+        result = run_campaign([Stage(name="x", phases=[])], FakeExecutor(),
+                              ScriptedCritic([_good()]), AutonomousPolicy(), _ctx())
+        assert result["status"] == "failed"
 
 
 class TestCollectPhases:

--- a/tests/test_refinement_loop.py
+++ b/tests/test_refinement_loop.py
@@ -443,5 +443,71 @@ class TestCollectStages:
         assert combine.phases[0].run_command == "python wham.py"
 
 
+class TestSweepGeneration:
+    """Parallel-sweep generation: expansion + fan-out assembly (offline)."""
+
+    def test_expand_parameter_sweep_substitutes_placeholder(self):
+        from scilink.skills.molecular_dynamics.lammps.lammps import (
+            expand_parameter_sweep, SWEEP_PLACEHOLDER,
+        )
+        base = (f"velocity all create {SWEEP_PLACEHOLDER} 12345\n"
+                f"fix 1 all nvt temp {SWEEP_PLACEHOLDER} {SWEEP_PLACEHOLDER} 0.1\n")
+        members = expand_parameter_sweep(base, "temperature", [300, 400, 500])
+        assert [m["name"] for m in members] == [
+            "temperature_300", "temperature_400", "temperature_500"]
+        # The placeholder is gone and the value is substituted everywhere.
+        assert SWEEP_PLACEHOLDER not in members[1]["script"]
+        assert members[1]["script"].count("400") == 3
+        assert "300" not in members[1]["script"]
+
+    def test_sweep_member_name_is_safe(self):
+        from scilink.skills.molecular_dynamics.lammps.lammps import sweep_member_name
+        assert sweep_member_name("temperature", 300) == "temperature_300"
+        assert sweep_member_name("rest center", 1.5) == "restcenter_1.5"
+
+    def test_assemble_fanout_stage_makes_self_contained_members(self):
+        from scilink.agents.sim_agents.md_simulation_agent import (
+            _assemble_fanout_stage,
+        )
+        members = [{"name": "temperature_300", "script": "S300"},
+                   {"name": "temperature_400", "script": "S400"}]
+        shared = {"system.data": "DATA", "ff.params": "FF"}
+        stages = _assemble_fanout_stage(members, "run.lammps", shared)
+        assert len(stages) == 1
+        st = stages[0]
+        assert st["name"] == "production" and st["parallel"] is True
+        m0 = st["members"][0]
+        # Every member carries the shared files plus its own script.
+        assert m0["input_files"]["system.data"] == "DATA"
+        assert m0["input_files"]["ff.params"] == "FF"
+        assert m0["input_files"]["run.lammps"] == "S300"
+        assert m0["entry_file"] == "run.lammps"
+        # Members are independent: editing one's map must not touch the other's.
+        assert st["members"][1]["input_files"]["run.lammps"] == "S400"
+
+    def test_sweep_expansion_feeds_collect_stages(self):
+        # End-to-end of the deterministic half: expand → assemble → normalize
+        # into Stage objects with isolated run dirs (no agent, no LLM).
+        from scilink.skills.molecular_dynamics.lammps.lammps import (
+            expand_parameter_sweep, SWEEP_PLACEHOLDER,
+        )
+        from scilink.agents.sim_agents.md_simulation_agent import (
+            _assemble_fanout_stage,
+        )
+        from scilink.agents.sim_agents.simulation_pipeline import _collect_stages
+
+        base = f"fix 1 all nvt temp {SWEEP_PLACEHOLDER} {SWEEP_PLACEHOLDER} 0.1\n"
+        members = expand_parameter_sweep(base, "temperature", [300, 400])
+        stages_spec = _assemble_fanout_stage(
+            members, "run.lammps", {"system.data": "DATA"})
+        stages = _collect_stages({"stages": stages_spec}, "/tmp/base",
+                                 "lmp -in {script}")
+        assert len(stages) == 1 and stages[0].parallel is True
+        assert {p.run_dir for p in stages[0].phases} == {
+            "/tmp/base/production/temperature_300",
+            "/tmp/base/production/temperature_400"}
+        assert all(p.run_command == "lmp -in run.lammps" for p in stages[0].phases)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_refinement_loop.py
+++ b/tests/test_refinement_loop.py
@@ -388,5 +388,60 @@ class TestCollectPhases:
         assert _collect_phases(gr, "/tmp/y", "run_md.sh")[0].run_command == "run_md.sh"
 
 
+class TestCollectStages:
+    """Generation-result → Stage normalization (engine-neutral, offline)."""
+
+    def test_legacy_shape_wraps_as_one_sequential_stage(self):
+        from scilink.agents.sim_agents.simulation_pipeline import _collect_stages
+        gr = {"input_files": {"run.lammps": "x"}, "entry_file": "run.lammps"}
+        stages = _collect_stages(gr, "/tmp/base", "lmp -in {script}")
+        assert len(stages) == 1
+        assert stages[0].parallel is False and stages[0].kind == "run"
+        assert stages[0].phases[0].run_command == "lmp -in run.lammps"
+        assert stages[0].phases[0].run_dir == "/tmp/base"
+
+    def test_sequential_steps_share_base_run_dir(self):
+        from scilink.agents.sim_agents.simulation_pipeline import _collect_stages
+        gr = {"stages": [
+            {"name": "optim", "input_files": {"o.lmp": "a"}, "entry_file": "o.lmp"},
+            {"name": "prod", "input_files": {"p.lmp": "b"}, "entry_file": "p.lmp"},
+        ]}
+        stages = _collect_stages(gr, "/tmp/base", "lmp -in {script}")
+        assert [s.name for s in stages] == ["optim", "prod"]
+        # Sequential steps chain in the shared base dir.
+        assert all(s.phases[0].run_dir == "/tmp/base" for s in stages)
+
+    def test_fanout_members_get_isolated_run_dirs(self):
+        from scilink.agents.sim_agents.simulation_pipeline import _collect_stages
+        gr = {"stages": [
+            {"name": "tsweep", "parallel": True, "min_success": 2, "members": [
+                {"name": "T300", "input_files": {"p.lmp": "a"}, "entry_file": "p.lmp"},
+                {"name": "T400", "input_files": {"p.lmp": "b"}, "entry_file": "p.lmp"},
+            ]},
+        ]}
+        stages = _collect_stages(gr, "/tmp/base", "lmp -in {script}")
+        st = stages[0]
+        assert st.parallel is True and st.min_success == 2
+        assert {p.run_dir for p in st.phases} == {
+            "/tmp/base/tsweep/T300", "/tmp/base/tsweep/T400"}
+        assert all(p.run_command == "lmp -in p.lmp" for p in st.phases)
+
+    def test_combine_stage_dir_and_command_override(self):
+        from scilink.agents.sim_agents.simulation_pipeline import _collect_stages
+        gr = {"stages": [
+            {"name": "windows", "parallel": True, "members": [
+                {"name": "w0", "input_files": {"w.lmp": "a"}, "entry_file": "w.lmp"},
+            ]},
+            {"name": "wham", "kind": "combine", "entry_file": "wham.py",
+             "input_files": {"wham.py": "..."}, "run_command": "python {script}"},
+        ]}
+        stages = _collect_stages(gr, "/tmp/base", "lmp -in {script}")
+        combine = stages[-1]
+        assert combine.kind == "combine"
+        assert combine.phases[0].run_dir == "/tmp/base/wham"
+        # The combine declares its own interpreter, overriding the engine template.
+        assert combine.phases[0].run_command == "python wham.py"
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_refinement_loop.py
+++ b/tests/test_refinement_loop.py
@@ -509,5 +509,59 @@ class TestSweepGeneration:
         assert all(p.run_command == "lmp -in run.lammps" for p in stages[0].phases)
 
 
+class TestStagedGeneration:
+    """Sequential multi-phase generation: sequential stage assembly (offline)."""
+
+    def test_assemble_sequential_stages_makes_self_contained_stages(self):
+        from scilink.agents.sim_agents.md_simulation_agent import (
+            _assemble_sequential_stages,
+        )
+        steps = [
+            {"name": "equilibration", "entry_file": "run_equilibration.lammps",
+             "script": "EQUIL"},
+            {"name": "production", "entry_file": "run_production.lammps",
+             "script": "PROD"},
+        ]
+        shared = {"system.data": "DATA", "ff.params": "FF"}
+        specs = _assemble_sequential_stages(steps, shared)
+        assert [s["name"] for s in specs] == ["equilibration", "production"]
+        s0 = specs[0]
+        # Each stage carries the shared files plus its own script — and is a
+        # plain sequential step (no parallel / members).
+        assert s0["input_files"]["system.data"] == "DATA"
+        assert s0["input_files"]["ff.params"] == "FF"
+        assert s0["input_files"]["run_equilibration.lammps"] == "EQUIL"
+        assert s0["entry_file"] == "run_equilibration.lammps"
+        assert "parallel" not in s0 and "members" not in s0
+        # Stages are independent dicts; one stage's script doesn't leak into another.
+        assert specs[1]["input_files"]["run_production.lammps"] == "PROD"
+        assert "run_equilibration.lammps" not in specs[1]["input_files"]
+
+    def test_sequential_assembly_feeds_collect_stages(self):
+        # End-to-end of the deterministic half: assemble → normalize into
+        # sequential Stage objects sharing the base run dir (no agent, no LLM).
+        from scilink.agents.sim_agents.md_simulation_agent import (
+            _assemble_sequential_stages,
+        )
+        from scilink.agents.sim_agents.simulation_pipeline import _collect_stages
+
+        steps = [
+            {"name": "equilibration", "entry_file": "run_equilibration.lammps",
+             "script": "EQUIL"},
+            {"name": "production", "entry_file": "run_production.lammps",
+             "script": "PROD"},
+        ]
+        specs = _assemble_sequential_stages(steps, {"system.data": "DATA"})
+        stages = _collect_stages({"stages": specs}, "/tmp/base", "lmp -in {script}")
+        # Two sequential stages, one phase each, all sharing the base run dir so
+        # restart files chain optimization → equilibration → production.
+        assert len(stages) == 2
+        assert [st.name for st in stages] == ["equilibration", "production"]
+        assert all(st.parallel is False and len(st.phases) == 1 for st in stages)
+        assert {st.phases[0].run_dir for st in stages} == {"/tmp/base"}
+        assert stages[0].phases[0].run_command == "lmp -in run_equilibration.lammps"
+        assert stages[1].phases[0].run_command == "lmp -in run_production.lammps"
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Extends the engine-neutral refinement loop (#280) to run **multi-stage MD campaigns**, in both shapes:

- **Sequential multi-phase** — an optimization → equilibration → production chain runs as ordered stages sharing a run directory, so restart files chain and the per-phase refinement loop fires on each phase.
- **Parallel fan-out** — a parameter sweep (e.g. temperature) expands one parameterized script into N independent member runs in isolated directories, each refined independently; a failing member doesn't abort its siblings.

Both flow through one new `run_campaign` over a `Stage` model (sequential step | parallel fan-out | combine); `run_refinement` becomes a thin wrapper (a single sequential stage), so existing single-phase behavior is unchanged. What members differ by lives in their generated `input_files` — the loop stays engine-neutral (no engine names or filenames in shared code). The sweep placeholder and expander live in the LAMMPS skill bundle, so adding an engine is a bundle, not loop changes.

Generation: `MDSimulationAgent` auto-detects a sweep from the plan and emits a fan-out campaign; `generate_staged_simulation` emits a normalized sequential campaign (reachable via `run_complete_workflow(..., staged=True)`). The combine stage (run-once post-processing, e.g. WHAM) is already supported by the data model for a future umbrella-sampling skill.

Validation:
- 35 loop / stage / generation unit tests + the pipeline-integration suite green.
- Parallel sweep verified live end-to-end against real `lmp` (generation 8/8, execution 4/4), including on a PNNL HPC compute node via `LocalExecutor`.
- Sequential multi-phase verified live against real `lmp` (5/5): a 2-stage run where the production stage has only `read_restart` succeeds, proving restart genuinely chains through the shared run dir — and the per-phase refinement loop fired on the equilibration stage before it passed.
- The `LAMMPSOrchestrator` benchmark baseline is preserved.
