### PR TITLE
ClusterExecutor: run refinement-loop phases on an HPC scheduler

### DIFF
--- a/scilink/agents/sim_agents/cluster_executor.py
+++ b/scilink/agents/sim_agents/cluster_executor.py
@@ -1,0 +1,206 @@
+"""Run refinement-loop phases on an HPC scheduler.
+
+``ClusterExecutor`` is the cluster counterpart to ``LocalExecutor``: it
+satisfies the same :class:`~scilink.agents.sim_agents.refinement.Executor`
+contract, so the refinement loop drives it without knowing a run happens on a
+remote scheduler rather than a local subprocess. A ``run`` uploads the phase's
+input files, submits a batch job, polls until the job reaches a terminal state,
+downloads the outputs back into the local ``run_dir``, and persists the same
+engine-neutral ``stdout`` / ``stderr`` / ``returncode`` files the local executor
+writes — so the post-run critic's snapshot is identical regardless of executor.
+
+This lives with the loop (not in ``scilink.hpc``) because it implements the
+loop's ``Executor`` contract; ``scilink.hpc`` stays self-contained and is
+imported lazily, so importing the loop does not pull in paramiko.
+
+v1 runs one job per ``run`` call and blocks until it finishes. The refinement
+loop calls ``run`` serially per phase (and per fan-out member), so a campaign's
+parallel members are submitted one after another. Concurrent submission across
+members is a future extension (a batch ``run_many`` seam) and does not change
+this contract.
+"""
+from __future__ import annotations
+
+import logging
+import stat as _stat
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from .refinement import Executor, LocalExecutor
+
+if TYPE_CHECKING:
+    from scilink.hpc.connection import HPCConnection
+    from scilink.hpc.scheduler import Scheduler
+
+logger = logging.getLogger(__name__)
+
+# Reuse the local executor's engine-neutral output filenames so a cluster run's
+# snapshot is byte-for-byte the same shape the critic already reads.
+_STDOUT = LocalExecutor.STDOUT_FILE
+_STDERR = LocalExecutor.STDERR_FILE
+_RC = LocalExecutor.RETURNCODE_FILE
+
+
+class ClusterExecutor(Executor):
+    """Execute inputs as a scheduler batch job on a remote host.
+
+    Attributes:
+        conn: A connected (or connectable) ``HPCConnection``.
+        remote_root: Base remote directory under which per-run directories are
+            created. Defaults to the remote home directory.
+        resources: Engine-neutral resource request for the batch directives
+            (partition, nodes, ntasks, time, account, gres, extra_directives).
+        setup: Shell lines run before the command (module loads, env setup).
+        poll_interval: Seconds between job-status polls.
+        timeout: Overall wall-clock cap (seconds) before the job is cancelled.
+    """
+
+    def __init__(
+        self,
+        connection: "HPCConnection",
+        *,
+        scheduler: "Scheduler | None" = None,
+        remote_root: Optional[str] = None,
+        resources: Optional[dict] = None,
+        setup: Optional[List[str]] = None,
+        poll_interval: int = 30,
+        timeout: int = 86400,
+        job_script_name: str = "scilink_job.sh",
+    ):
+        self.conn = connection
+        self._scheduler = scheduler
+        self.remote_root = remote_root
+        self.resources = resources or {}
+        self.setup = setup or []
+        self.poll_interval = poll_interval
+        self.timeout = timeout
+        self.job_script_name = job_script_name
+
+    # ── internals ─────────────────────────────────────────────
+
+    def _ensure_connected(self) -> None:
+        if not self.conn.is_connected:
+            self.conn.connect()
+
+    def _resolve_scheduler(self) -> "Scheduler":
+        if self._scheduler is None:
+            from scilink.hpc import detect_scheduler
+            self._scheduler = detect_scheduler(self.conn)
+            if self._scheduler is None:
+                raise RuntimeError(
+                    "No supported scheduler (SLURM/PBS/LSF) detected on the "
+                    "remote host."
+                )
+        return self._scheduler
+
+    def _remote_dir_for(self, run_dir: str) -> str:
+        base = (self.remote_root or self.conn.home_dir()).rstrip("/")
+        return f"{base}/{Path(run_dir).name}"
+
+    def _download_outputs(self, remote_dir: str, local: Path) -> None:
+        """Download every regular file in the remote run dir to ``local``.
+
+        Subdirectories are skipped — a phase's run directory is flat (the loop
+        gives each phase / fan-out member its own directory).
+        """
+        try:
+            entries = self.conn.listdir(remote_dir)
+        except Exception as exc:  # noqa: BLE001 — best-effort retrieval
+            logger.warning("ClusterExecutor: could not list %s: %s", remote_dir, exc)
+            return
+        for attr in entries:
+            name = attr.filename
+            if name in (".", ".."):
+                continue
+            if _stat.S_ISDIR(attr.st_mode):
+                continue
+            try:
+                self.conn.download(f"{remote_dir}/{name}", str(local / name))
+            except Exception as exc:  # noqa: BLE001 — one bad file shouldn't abort
+                logger.warning("ClusterExecutor: could not download %s: %s", name, exc)
+
+    # ── Executor contract ─────────────────────────────────────
+
+    def run(
+        self, input_files: Dict[str, str], run_command: str, run_dir: str
+    ) -> Dict[str, Any]:
+        from scilink.hpc.batch import build_batch_script
+
+        run_path = Path(run_dir)
+        run_path.mkdir(parents=True, exist_ok=True)
+
+        # Materialize inputs locally too — gives the local snapshot the inputs
+        # and serves as the upload source.
+        for name, contents in (input_files or {}).items():
+            (run_path / name).write_text(contents)
+
+        self._ensure_connected()
+        sched = self._resolve_scheduler()
+        remote_dir = self._remote_dir_for(run_dir)
+        self.conn.mkdir_p(remote_dir)
+
+        for name in (input_files or {}):
+            self.conn.upload(str(run_path / name), f"{remote_dir}/{name}")
+
+        script = build_batch_script(
+            sched, run_command,
+            resources=self.resources, setup=self.setup,
+            stdout_file=_STDOUT, stderr_file=_STDERR, rc_file=_RC,
+        )
+        (run_path / self.job_script_name).write_text(script)
+        self.conn.upload(
+            str(run_path / self.job_script_name),
+            f"{remote_dir}/{self.job_script_name}",
+        )
+
+        try:
+            job_id = sched.submit(self.job_script_name, work_dir=remote_dir)
+        except Exception as exc:  # noqa: BLE001 — surface as an executor error
+            (run_path / _STDERR).write_text(f"Job submission failed: {exc}")
+            (run_path / _RC).write_text("submit_error")
+            return {
+                "status": "error", "output_dir": str(run_path),
+                "returncode": None, "error": f"Job submission failed: {exc}",
+            }
+        logger.info("ClusterExecutor: submitted job %s in %s", job_id, remote_dir)
+
+        elapsed = 0
+        while True:
+            job = sched.status(job_id)
+            if job.status.is_terminal:
+                break
+            if elapsed >= self.timeout:
+                sched.cancel(job_id)
+                self._download_outputs(remote_dir, run_path)
+                (run_path / _STDERR).write_text(
+                    f"Job {job_id} exceeded {self.timeout}s wall-clock; cancelled."
+                )
+                (run_path / _RC).write_text("timeout")
+                return {
+                    "status": "error", "output_dir": str(run_path),
+                    "returncode": None,
+                    "error": f"Job timed out after {self.timeout}s",
+                }
+            time.sleep(self.poll_interval)
+            elapsed += self.poll_interval
+
+        self._download_outputs(remote_dir, run_path)
+
+        # Prefer the returncode the wrapper recorded; fall back to the
+        # scheduler's reported exit code.
+        returncode: Optional[int] = None
+        rc_path = run_path / _RC
+        if rc_path.exists():
+            try:
+                returncode = int(rc_path.read_text().strip())
+            except (ValueError, OSError):
+                returncode = None
+        if returncode is None:
+            returncode = job.exit_code
+
+        return {
+            "status": "completed",
+            "output_dir": str(run_path),
+            "returncode": returncode,
+        }

--- a/scilink/agents/sim_agents/cluster_executor.py
+++ b/scilink/agents/sim_agents/cluster_executor.py
@@ -77,6 +77,53 @@ class ClusterExecutor(Executor):
         self.timeout = timeout
         self.job_script_name = job_script_name
 
+    @classmethod
+    def connect(
+        cls,
+        *,
+        hostname: str,
+        username: str,
+        password: str = "",
+        key_path: str = "",
+        key_passphrase: str = "",
+        auth_method: Optional[str] = None,
+        proxy_jump: str = "",
+        port: int = 22,
+        **executor_kwargs: Any,
+    ) -> "ClusterExecutor":
+        """Open an HPC connection and return a ready ``ClusterExecutor``.
+
+        Convenience constructor that assembles the ``HPCProfile`` /
+        ``HPCConnection``, opens the connection, and wraps it — so a caller
+        passes one call to ``run_complete_workflow(..., executor=...)`` instead
+        of hand-assembling the connection. ``auth_method`` defaults to
+        ``"password"`` when a password is given, else ``"key"``. Remaining
+        keyword arguments (``remote_root``, ``resources``, ``setup``,
+        ``poll_interval``, ``timeout``) are forwarded to the constructor.
+
+        Args:
+            hostname: SSH host of the cluster login node.
+            username: SSH username.
+            password: Password for password auth (omit for key auth).
+            key_path: Path to a private key for key auth.
+            key_passphrase: Passphrase for an encrypted key.
+            auth_method: ``"password"`` or ``"key"``; inferred when omitted.
+            proxy_jump: Optional ``user@bastion`` jump host.
+            port: SSH port.
+
+        Returns:
+            A connected ``ClusterExecutor``.
+        """
+        from scilink.hpc.connection import HPCConnection, HPCProfile
+        method = auth_method or ("password" if password else "key")
+        profile = HPCProfile(
+            name=hostname, hostname=hostname, username=username, port=port,
+            auth_method=method, key_path=key_path, proxy_jump=proxy_jump,
+        )
+        conn = HPCConnection(profile)
+        conn.connect(password=password, key_passphrase=key_passphrase)
+        return cls(conn, **executor_kwargs)
+
     # ── internals ─────────────────────────────────────────────
 
     def _ensure_connected(self) -> None:

--- a/scilink/agents/sim_agents/cluster_executor.py
+++ b/scilink/agents/sim_agents/cluster_executor.py
@@ -127,8 +127,20 @@ class ClusterExecutor(Executor):
     # ── internals ─────────────────────────────────────────────
 
     def _ensure_connected(self) -> None:
-        if not self.conn.is_connected:
+        if self.conn.is_connected:
+            return
+        # A key/agent session can re-establish from an arg-less connect(); a
+        # password session cannot (the password is intentionally not stored).
+        # Surface that as a clear error rather than a bare paramiko auth failure.
+        try:
             self.conn.connect()
+        except Exception as exc:  # noqa: BLE001 — re-raise with guidance
+            raise ConnectionError(
+                "HPC connection is down and could not be re-established "
+                "non-interactively (password sessions cannot self-recover). "
+                "Pass an already-connected HPCConnection, e.g. via "
+                "ClusterExecutor.connect(...)."
+            ) from exc
 
     def _resolve_scheduler(self) -> "Scheduler":
         if self._scheduler is None:

--- a/scilink/agents/sim_agents/simulation_pipeline.py
+++ b/scilink/agents/sim_agents/simulation_pipeline.py
@@ -185,9 +185,12 @@ def run_complete_workflow(
             inputs (skipped for non-LLM methods, which are expert-defined).
         executor: Optional execution backend. When provided, the workflow runs
             the generated inputs and refines them to convergence via the
-            engine-neutral refinement loop. When ``None`` (the default, used
-            for DFT), the workflow stops after generation + validation and the
-            user runs the calculation externally.
+            engine-neutral refinement loop. ``LocalExecutor`` runs a local
+            subprocess; ``ClusterExecutor`` (or ``ClusterExecutor.connect(...)``)
+            submits to an HPC scheduler — the loop drives either through the same
+            ``Executor`` contract. When ``None`` (the default, used for DFT), the
+            workflow stops after generation + validation and the user runs the
+            calculation externally.
         run_command: Command template the executor runs, with ``{script}``
             filled from each phase's entry file (e.g. ``"lmp -in {script}"``).
             User/config — required when ``executor`` is provided. The engine

--- a/scilink/hpc/batch.py
+++ b/scilink/hpc/batch.py
@@ -46,6 +46,12 @@ def build_batch_script(
     lines: List[str] = ["#!/bin/bash"]
     lines.extend(scheduler.batch_directives(resources or {}))
     lines.append("")
+    # Move to the submit directory before anything writes relative paths —
+    # a no-op for SLURM/LSF, a `cd $PBS_O_WORKDIR` for PBS/Torque.
+    prelude = scheduler.workdir_prelude()
+    if prelude:
+        lines.extend(prelude)
+        lines.append("")
     for line in setup or []:
         lines.append(line)
     if setup:

--- a/scilink/hpc/batch.py
+++ b/scilink/hpc/batch.py
@@ -1,0 +1,57 @@
+"""Build a scheduler batch script for a single run command.
+
+Engine-neutral and scheduler-neutral: the scheduler-specific directive lines
+come from ``scheduler.batch_directives(resources)``, so this module knows
+nothing about SLURM vs PBS vs LSF, and the run command and resources arrive as
+data. The wrapper captures stdout, stderr, and the exit code into fixed,
+engine-neutral filenames so a downstream consumer (e.g. the refinement loop's
+post-run critic) reads a run's outputs the same way no matter where it ran.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from scilink.hpc.scheduler import Scheduler
+
+
+def build_batch_script(
+    scheduler: "Scheduler",
+    run_command: str,
+    *,
+    resources: Optional[dict] = None,
+    setup: Optional[List[str]] = None,
+    stdout_file: str = "run_stdout.log",
+    stderr_file: str = "run_stderr.log",
+    rc_file: str = "run_returncode.txt",
+) -> str:
+    """Assemble a submit-ready batch script.
+
+    Args:
+        scheduler: The scheduler whose directive syntax to use; supplies the
+            ``#SBATCH`` / ``#PBS`` / ``#BSUB`` header from ``resources``.
+        run_command: The command to run in the job's working directory.
+        resources: Engine-neutral resource request forwarded to
+            ``scheduler.batch_directives`` (partition, nodes, time, …).
+        setup: Shell lines run before the command (e.g. ``module load`` lines,
+            ``conda activate``, env exports).
+        stdout_file, stderr_file, rc_file: Filenames the wrapper writes the
+            command's stdout, stderr, and exit code to, in the job's working
+            directory. Default to the engine-neutral names the local executor
+            uses, so the post-run snapshot is identical across executors.
+
+    Returns:
+        The batch script text (newline-terminated).
+    """
+    lines: List[str] = ["#!/bin/bash"]
+    lines.extend(scheduler.batch_directives(resources or {}))
+    lines.append("")
+    for line in setup or []:
+        lines.append(line)
+    if setup:
+        lines.append("")
+    # Capture stdout/stderr/returncode into fixed filenames so the post-run
+    # critic reads outputs identically regardless of where the run happened.
+    lines.append(f"{run_command} > {stdout_file} 2> {stderr_file}")
+    lines.append(f"echo $? > {rc_file}")
+    return "\n".join(lines) + "\n"

--- a/scilink/hpc/scheduler.py
+++ b/scilink/hpc/scheduler.py
@@ -91,6 +91,19 @@ class Scheduler(ABC):
     @abstractmethod
     def partitions(self) -> list[dict]: ...
 
+    @abstractmethod
+    def batch_directives(self, resources: dict) -> list[str]:
+        """Scheduler directive lines for a batch script.
+
+        Translates an engine-neutral ``resources`` dict into the scheduler's
+        own directive syntax (``#SBATCH`` / ``#PBS`` / ``#BSUB``). Recognized
+        keys (all optional): ``job_name``, ``partition``, ``nodes``,
+        ``ntasks``, ``time`` (HH:MM:SS), ``account``, ``gres``, and
+        ``extra_directives`` (a list of raw directive lines passed through
+        verbatim). Keeping this on the scheduler is what lets a new scheduler
+        be one subclass with zero changes elsewhere.
+        """
+
     def tail_output(
         self,
         job: HPCJob,
@@ -289,6 +302,23 @@ class SlurmScheduler(Scheduler):
             ))
         return parts
 
+    def batch_directives(self, resources: dict) -> list[str]:
+        r = resources or {}
+        d = [
+            f"#SBATCH --job-name={r.get('job_name', 'scilink')}",
+            f"#SBATCH --nodes={r.get('nodes', 1)}",
+            f"#SBATCH --ntasks={r.get('ntasks', 1)}",
+            f"#SBATCH --time={r.get('time', '01:00:00')}",
+        ]
+        if r.get("partition"):
+            d.append(f"#SBATCH --partition={r['partition']}")
+        if r.get("account"):
+            d.append(f"#SBATCH --account={r['account']}")
+        if r.get("gres"):
+            d.append(f"#SBATCH --gres={r['gres']}")
+        d.extend(r.get("extra_directives", []))
+        return d
+
 
 # ══════════════════════════════════════════════════════════════
 # PBS / Torque
@@ -373,6 +403,20 @@ class PBSScheduler(Scheduler):
             for line in out.strip().splitlines()[2:]
             if line.split()
         ]
+
+    def batch_directives(self, resources: dict) -> list[str]:
+        r = resources or {}
+        d = [
+            f"#PBS -N {r.get('job_name', 'scilink')}",
+            f"#PBS -l nodes={r.get('nodes', 1)}:ppn={r.get('ntasks', 1)}",
+            f"#PBS -l walltime={r.get('time', '01:00:00')}",
+        ]
+        if r.get("partition"):
+            d.append(f"#PBS -q {r['partition']}")
+        if r.get("account"):
+            d.append(f"#PBS -A {r['account']}")
+        d.extend(r.get("extra_directives", []))
+        return d
 
 
 # ══════════════════════════════════════════════════════════════
@@ -462,6 +506,21 @@ class LSFScheduler(Scheduler):
             for line in out.strip().splitlines()
             if line.strip()
         ]
+
+    def batch_directives(self, resources: dict) -> list[str]:
+        r = resources or {}
+        # LSF -W wants [hours:]minutes; callers targeting LSF pass that format.
+        d = [
+            f"#BSUB -J {r.get('job_name', 'scilink')}",
+            f"#BSUB -n {r.get('ntasks', 1)}",
+            f"#BSUB -W {r.get('time', '01:00')}",
+        ]
+        if r.get("partition"):
+            d.append(f"#BSUB -q {r['partition']}")
+        if r.get("account"):
+            d.append(f"#BSUB -P {r['account']}")
+        d.extend(r.get("extra_directives", []))
+        return d
 
 # ── helpers ───────────────────────────────────────────────────
 

--- a/scilink/hpc/scheduler.py
+++ b/scilink/hpc/scheduler.py
@@ -104,6 +104,17 @@ class Scheduler(ABC):
         be one subclass with zero changes elsewhere.
         """
 
+    def workdir_prelude(self) -> list[str]:
+        """Shell lines that move the job to its submit directory.
+
+        Schedulers differ on a job's starting directory: SLURM and LSF begin
+        in the submit directory, but PBS/Torque starts in ``$HOME``. A batch
+        script that writes relative output paths therefore needs a scheduler-
+        specific ``cd`` first. The default is empty (submit dir is already the
+        CWD); a scheduler that needs otherwise overrides this.
+        """
+        return []
+
     def tail_output(
         self,
         job: HPCJob,
@@ -417,6 +428,10 @@ class PBSScheduler(Scheduler):
             d.append(f"#PBS -A {r['account']}")
         d.extend(r.get("extra_directives", []))
         return d
+
+    def workdir_prelude(self) -> list[str]:
+        # PBS/Torque starts the job in $HOME, not the submit directory.
+        return ["cd $PBS_O_WORKDIR"]
 
 
 # ══════════════════════════════════════════════════════════════

--- a/tests/test_cluster_executor.py
+++ b/tests/test_cluster_executor.py
@@ -187,6 +187,51 @@ class TestClusterExecutorRun:
         assert sched.cancelled == ["12345"]
         assert (run_dir / _RC).read_text() == "timeout"
 
+    def test_connect_factory_builds_profile_and_connects(self, monkeypatch):
+        # The factory assembles the profile, opens the connection, and forwards
+        # executor kwargs — without any real SSH.
+        import scilink.hpc.connection as conn_mod
+        captured = {}
+
+        class FakeHPCConn:
+            def __init__(self, profile):
+                captured["profile"] = profile
+
+            def connect(self, password="", key_passphrase=""):
+                captured["password"] = password
+                captured["passphrase"] = key_passphrase
+
+        monkeypatch.setattr(conn_mod, "HPCConnection", FakeHPCConn)
+        ex = ClusterExecutor.connect(
+            hostname="deception.pnl.gov", username="alle927", password="secret",
+            resources={"account": "ACC"}, remote_root="/scratch",
+            poll_interval=5,
+        )
+        assert isinstance(ex, ClusterExecutor)
+        assert captured["profile"].hostname == "deception.pnl.gov"
+        assert captured["profile"].username == "alle927"
+        assert captured["profile"].auth_method == "password"  # inferred
+        assert captured["password"] == "secret"
+        assert ex.resources == {"account": "ACC"}
+        assert ex.remote_root == "/scratch"
+        assert ex.poll_interval == 5
+
+    def test_connect_factory_infers_key_auth_without_password(self, monkeypatch):
+        import scilink.hpc.connection as conn_mod
+        captured = {}
+
+        class FakeHPCConn:
+            def __init__(self, profile):
+                captured["profile"] = profile
+
+            def connect(self, password="", key_passphrase=""):
+                pass
+
+        monkeypatch.setattr(conn_mod, "HPCConnection", FakeHPCConn)
+        ClusterExecutor.connect(hostname="h", username="u", key_path="/k")
+        assert captured["profile"].auth_method == "key"
+        assert captured["profile"].key_path == "/k"
+
     def test_uploaded_script_has_directives_and_wrapper(self, tmp_path):
         conn = FakeConn()
         sched = FakeScheduler(conn)

--- a/tests/test_cluster_executor.py
+++ b/tests/test_cluster_executor.py
@@ -1,0 +1,262 @@
+"""Unit tests for ClusterExecutor and the scheduler batch builder.
+
+No real SSH, no paramiko, no cluster: a fake connection simulates a remote
+filesystem and a fake scheduler simulates submit/poll, so the upload → submit →
+poll → download → persist flow and the engine-neutral snapshot are verified
+offline.
+"""
+import stat
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scilink.agents.sim_agents.cluster_executor import (  # noqa: E402
+    ClusterExecutor, _RC, _STDOUT, _STDERR,
+)
+from scilink.hpc.batch import build_batch_script  # noqa: E402
+from scilink.hpc.scheduler import (  # noqa: E402
+    JobStatus, HPCJob, SlurmScheduler, PBSScheduler, LSFScheduler,
+)
+
+
+# ── test doubles ──────────────────────────────────────────────
+
+class FakeConn:
+    """In-memory stand-in for HPCConnection with a simulated remote FS."""
+
+    def __init__(self, connected=True):
+        self._connected = connected
+        self._remote: dict[str, str] = {}
+        self.uploads, self.downloads, self.mkdirs = [], [], []
+        self.connect_called = 0
+
+    @property
+    def is_connected(self):
+        return self._connected
+
+    def connect(self, *a, **k):
+        self.connect_called += 1
+        self._connected = True
+
+    def home_dir(self):
+        return "/remote/home"
+
+    def mkdir_p(self, path):
+        self.mkdirs.append(path)
+
+    def upload(self, local, remote):
+        self.uploads.append((local, remote))
+        self._remote[remote] = Path(local).read_text()
+
+    def download(self, remote, local):
+        self.downloads.append((remote, local))
+        Path(local).write_text(self._remote[remote])
+
+    def listdir(self, path):
+        prefix = path.rstrip("/") + "/"
+        out = []
+        for rp in self._remote:
+            rest = rp[len(prefix):] if rp.startswith(prefix) else None
+            if rest and "/" not in rest:
+                out.append(SimpleNamespace(
+                    filename=rest, st_mode=stat.S_IFREG | 0o644))
+        return out
+
+
+class FakeScheduler:
+    """Simulates submit + status; writes the wrapper's output files on submit."""
+
+    name = "FAKE"
+
+    def __init__(self, conn, *, terminal_after=1,
+                 final_status=JobStatus.COMPLETED, exit_code=0,
+                 rc_written="0", submit_raises=False):
+        self.conn = conn
+        self.terminal_after = terminal_after
+        self.final_status = final_status
+        self.exit_code = exit_code
+        self.rc_written = rc_written
+        self.submit_raises = submit_raises
+        self.submitted, self.cancelled = [], []
+        self._polls = 0
+
+    def batch_directives(self, resources):
+        return [f"#FAKE job={resources.get('job_name', 'scilink')}"]
+
+    def submit(self, script, work_dir=""):
+        if self.submit_raises:
+            raise RuntimeError("sbatch boom")
+        self.submitted.append((script, work_dir))
+        if self.rc_written is not None:
+            self.conn._remote[f"{work_dir}/{_RC}"] = self.rc_written
+            self.conn._remote[f"{work_dir}/{_STDOUT}"] = "thermo...\n"
+            self.conn._remote[f"{work_dir}/{_STDERR}"] = ""
+            self.conn._remote[f"{work_dir}/final.data"] = "RESULT"
+        return "12345"
+
+    def status(self, job_id):
+        self._polls += 1
+        st = (self.final_status if self._polls >= self.terminal_after
+              else JobStatus.RUNNING)
+        return HPCJob(job_id=job_id, status=st, exit_code=self.exit_code)
+
+    def cancel(self, job_id):
+        self.cancelled.append(job_id)
+        return True
+
+
+# ── ClusterExecutor.run ───────────────────────────────────────
+
+class TestClusterExecutorRun:
+    def test_full_flow_uploads_submits_polls_downloads(self, tmp_path):
+        conn = FakeConn()
+        sched = FakeScheduler(conn, terminal_after=2)
+        ex = ClusterExecutor(conn, scheduler=sched, remote_root="/scratch",
+                             resources={"partition": "normal"},
+                             poll_interval=0, timeout=100)
+        run_dir = tmp_path / "production"
+        result = ex.run({"in.lj": "SCRIPT"}, "lmp -in in.lj", str(run_dir))
+
+        assert result["status"] == "completed"
+        assert result["returncode"] == 0
+        assert result["output_dir"] == str(run_dir)
+        # Inputs materialized locally.
+        assert (run_dir / "in.lj").read_text() == "SCRIPT"
+        # Remote dir = remote_root / basename(run_dir); created and used.
+        assert "/scratch/production" in conn.mkdirs
+        # Inputs + job script uploaded.
+        uploaded = {r for _, r in conn.uploads}
+        assert "/scratch/production/in.lj" in uploaded
+        assert "/scratch/production/scilink_job.sh" in uploaded
+        # Submitted with the job script + remote work dir.
+        assert sched.submitted == [("scilink_job.sh", "/scratch/production")]
+        # Polled until terminal (terminal_after=2).
+        assert sched._polls == 2
+        # Outputs downloaded into the local run dir, including the rc file.
+        assert (run_dir / _RC).read_text() == "0"
+        assert (run_dir / "final.data").read_text() == "RESULT"
+
+    def test_remote_root_defaults_to_home(self, tmp_path):
+        conn = FakeConn()
+        sched = FakeScheduler(conn)
+        ex = ClusterExecutor(conn, scheduler=sched, poll_interval=0)
+        ex.run({"in.lj": "S"}, "lmp -in in.lj", str(tmp_path / "run"))
+        assert "/remote/home/run" in conn.mkdirs
+
+    def test_connects_if_not_connected(self, tmp_path):
+        conn = FakeConn(connected=False)
+        sched = FakeScheduler(conn)
+        ex = ClusterExecutor(conn, scheduler=sched, poll_interval=0)
+        ex.run({"in.lj": "S"}, "lmp -in in.lj", str(tmp_path / "run"))
+        assert conn.connect_called == 1
+
+    def test_returncode_falls_back_to_scheduler_exit_code(self, tmp_path):
+        # Wrapper wrote no rc file → use the scheduler's reported exit code.
+        conn = FakeConn()
+        sched = FakeScheduler(conn, rc_written=None,
+                              final_status=JobStatus.FAILED, exit_code=1)
+        ex = ClusterExecutor(conn, scheduler=sched, poll_interval=0)
+        result = ex.run({"in.lj": "S"}, "lmp -in in.lj", str(tmp_path / "run"))
+        assert result["status"] == "completed"   # ran to a terminal state
+        assert result["returncode"] == 1
+
+    def test_submit_failure_returns_error(self, tmp_path):
+        conn = FakeConn()
+        sched = FakeScheduler(conn, submit_raises=True)
+        ex = ClusterExecutor(conn, scheduler=sched, poll_interval=0)
+        run_dir = tmp_path / "run"
+        result = ex.run({"in.lj": "S"}, "lmp -in in.lj", str(run_dir))
+        assert result["status"] == "error"
+        assert result["returncode"] is None
+        assert (run_dir / _RC).read_text() == "submit_error"
+
+    def test_timeout_cancels_and_errors(self, tmp_path):
+        conn = FakeConn()
+        # Never reaches terminal within the budget.
+        sched = FakeScheduler(conn, terminal_after=9999)
+        ex = ClusterExecutor(conn, scheduler=sched, poll_interval=0, timeout=0)
+        run_dir = tmp_path / "run"
+        result = ex.run({"in.lj": "S"}, "lmp -in in.lj", str(run_dir))
+        assert result["status"] == "error"
+        assert "timed out" in result["error"]
+        assert sched.cancelled == ["12345"]
+        assert (run_dir / _RC).read_text() == "timeout"
+
+    def test_uploaded_script_has_directives_and_wrapper(self, tmp_path):
+        conn = FakeConn()
+        sched = FakeScheduler(conn)
+        ex = ClusterExecutor(conn, scheduler=sched, poll_interval=0,
+                             setup=["module load lammps"])
+        ex.run({"in.lj": "S"}, "lmp -in in.lj", str(tmp_path / "run"))
+        script = conn._remote["/remote/home/run/scilink_job.sh"]
+        assert script.startswith("#!/bin/bash")
+        assert "#FAKE job=scilink" in script
+        assert "module load lammps" in script
+        assert f"lmp -in in.lj > {_STDOUT} 2> {_STDERR}" in script
+        assert f"echo $? > {_RC}" in script
+
+
+# ── batch builder + scheduler directives ──────────────────────
+
+class TestBatchBuilder:
+    def test_slurm_directives(self):
+        sched = SlurmScheduler(conn=None)
+        d = sched.batch_directives({
+            "job_name": "md", "partition": "normal", "nodes": 2,
+            "ntasks": 8, "time": "00:30:00", "gres": "gpu:1",
+            "account": "proj", "extra_directives": ["#SBATCH --exclusive"],
+        })
+        assert "#SBATCH --job-name=md" in d
+        assert "#SBATCH --nodes=2" in d
+        assert "#SBATCH --ntasks=8" in d
+        assert "#SBATCH --time=00:30:00" in d
+        assert "#SBATCH --partition=normal" in d
+        assert "#SBATCH --gres=gpu:1" in d
+        assert "#SBATCH --account=proj" in d
+        assert "#SBATCH --exclusive" in d
+
+    def test_slurm_omits_optional_when_absent(self):
+        d = SlurmScheduler(conn=None).batch_directives({})
+        assert not any("partition" in line for line in d)
+        assert not any("gres" in line for line in d)
+
+    def test_pbs_directives(self):
+        d = PBSScheduler(conn=None).batch_directives(
+            {"job_name": "md", "nodes": 1, "ntasks": 4, "time": "01:00:00",
+             "partition": "batch"})
+        assert "#PBS -N md" in d
+        assert "#PBS -l nodes=1:ppn=4" in d
+        assert "#PBS -l walltime=01:00:00" in d
+        assert "#PBS -q batch" in d
+
+    def test_lsf_directives(self):
+        d = LSFScheduler(conn=None).batch_directives(
+            {"job_name": "md", "ntasks": 4, "time": "01:00", "partition": "q"})
+        assert "#BSUB -J md" in d
+        assert "#BSUB -n 4" in d
+        assert "#BSUB -W 01:00" in d
+        assert "#BSUB -q q" in d
+
+    def test_build_batch_script_assembles_header_setup_wrapper(self):
+        sched = SlurmScheduler(conn=None)
+        script = build_batch_script(
+            sched, "lmp -in in.lj",
+            resources={"partition": "normal", "time": "00:30:00"},
+            setup=["module load lammps", "conda activate md"],
+        )
+        lines = script.splitlines()
+        assert lines[0] == "#!/bin/bash"
+        assert "#SBATCH --partition=normal" in script
+        assert "module load lammps" in script
+        assert "conda activate md" in script
+        assert "lmp -in in.lj > run_stdout.log 2> run_stderr.log" in script
+        assert "echo $? > run_returncode.txt" in script
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_cluster_executor.py
+++ b/tests/test_cluster_executor.py
@@ -15,6 +15,10 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+# scilink.hpc.* imports paramiko (an optional dependency) via hpc/__init__, so
+# skip the whole module cleanly where it isn't installed rather than erroring.
+pytest.importorskip("paramiko")
+
 from scilink.agents.sim_agents.cluster_executor import (  # noqa: E402
     ClusterExecutor, _RC, _STDOUT, _STDERR,
 )
@@ -87,6 +91,9 @@ class FakeScheduler:
 
     def batch_directives(self, resources):
         return [f"#FAKE job={resources.get('job_name', 'scilink')}"]
+
+    def workdir_prelude(self):
+        return []
 
     def submit(self, script, work_dir=""):
         if self.submit_raises:
@@ -174,6 +181,20 @@ class TestClusterExecutorRun:
         assert result["status"] == "error"
         assert result["returncode"] is None
         assert (run_dir / _RC).read_text() == "submit_error"
+
+    def test_dead_session_that_cant_recover_raises_clear_error(self, tmp_path):
+        class DeadConn(FakeConn):
+            @property
+            def is_connected(self):
+                return False
+
+            def connect(self, *a, **k):
+                raise RuntimeError("password required")
+
+        ex = ClusterExecutor(DeadConn(), scheduler=FakeScheduler(FakeConn()),
+                             poll_interval=0)
+        with pytest.raises(ConnectionError, match="could not be re-established"):
+            ex.run({"in.lj": "S"}, "lmp -in in.lj", str(tmp_path / "run"))
 
     def test_timeout_cancels_and_errors(self, tmp_path):
         conn = FakeConn()
@@ -286,6 +307,19 @@ class TestBatchBuilder:
         assert "#BSUB -n 4" in d
         assert "#BSUB -W 01:00" in d
         assert "#BSUB -q q" in d
+
+    def test_pbs_prelude_cds_to_workdir_others_dont(self):
+        # PBS/Torque starts in $HOME → the wrapper must cd to the submit dir;
+        # SLURM/LSF start there already, so no cd.
+        assert PBSScheduler(conn=None).workdir_prelude() == ["cd $PBS_O_WORKDIR"]
+        assert SlurmScheduler(conn=None).workdir_prelude() == []
+        assert LSFScheduler(conn=None).workdir_prelude() == []
+        pbs = build_batch_script(PBSScheduler(conn=None), "nwchem in.nw")
+        slurm = build_batch_script(SlurmScheduler(conn=None), "nwchem in.nw")
+        assert "cd $PBS_O_WORKDIR" in pbs
+        # And it lands before the command, so relative output paths resolve.
+        assert pbs.index("cd $PBS_O_WORKDIR") < pbs.index("nwchem in.nw")
+        assert "$PBS_O_WORKDIR" not in slurm
 
     def test_build_batch_script_assembles_header_setup_wrapper(self):
         sched = SlurmScheduler(conn=None)


### PR DESCRIPTION
Adds `ClusterExecutor` — the HPC counterpart to `LocalExecutor` — so the engine-neutral refinement loop can run on a scheduler instead of a local subprocess, without the loop (or anything downstream) knowing the difference.

A `run()` does: upload the phase's input files → submit a batch job → poll to a terminal state → download the outputs into the local `run_dir` → persist the same engine-neutral `run_stdout.log` / `run_stderr.log` / `run_returncode.txt` files `LocalExecutor` writes. Because the outputs land in the local `run_dir`, the post-run `RunCritic` reads a cluster run's snapshot byte-for-byte the way it reads a local one — the executor swaps out, nothing else changes.

Design:
- **Same `Executor` contract** — `run_complete_workflow(..., executor=ClusterExecutor.connect(...))` works through the existing seam; no pipeline changes were needed.
- **Scheduler-neutral batch building** — a new `Scheduler.batch_directives(resources)` method translates an engine-neutral resource dict into `#SBATCH` / `#PBS` / `#BSUB` lines, and `scilink/hpc/batch.build_batch_script` wraps the command to capture its outputs. Adding a scheduler is one `Scheduler` subclass, nothing else.
- **Placement / layering** — `ClusterExecutor` lives with the loop in `sim_agents` (it implements the loop's contract), and imports the HPC backend lazily, so `scilink/hpc` stays self-contained and importing the loop doesn't pull in paramiko.
- **`ClusterExecutor.connect(...)`** — one-call factory that assembles the connection (inferring password vs key auth) and returns a ready executor.

Scope (v1): one job per `run()` call, blocking. The loop calls `run()` serially per phase and per fan-out member, so concurrent submission across members is a clean future seam (`run_many`), not a contract change.

Validation:
- 14 offline unit tests — a fake connection + scheduler exercise the full upload → submit → poll → download → persist flow, plus submit-failure, wall-clock-timeout (cancel), returncode fallback, the `connect` factory, and per-scheduler directives. No SSH, no paramiko, no cluster.
- Live on a real SLURM cluster (PNNL Deception): password-auth SSH → `sbatch` → poll the real queue to completion → outputs downloaded locally with `returncode 0`.
