### PR TITLE
lammps skill: accept create_atoms as a system source in validate_script

### DIFF
--- a/scilink/skills/molecular_dynamics/lammps/lammps.py
+++ b/scilink/skills/molecular_dynamics/lammps/lammps.py
@@ -541,8 +541,13 @@ def validate_script(
         errors.append("Missing 'units' command")
     if "atom_style" not in commands_seen:
         errors.append("Missing 'atom_style' command")
-    if "read_data" not in commands_seen and "read_restart" not in commands_seen:
-        errors.append("Missing 'read_data' or 'read_restart'")
+    # A system can be brought in from a data/restart file or built in-deck with
+    # create_atoms (after create_box + lattice/region) — all three are valid.
+    if not commands_seen & {"read_data", "read_restart", "create_atoms"}:
+        errors.append(
+            "Missing system definition — need 'read_data', 'read_restart', "
+            "or 'create_atoms'"
+        )
     if not result["has_run"] and not result["has_minimize"]:
         errors.append("No 'run' or 'minimize' — script does nothing")
 

--- a/tests/test_lammps_skill/conftest.py
+++ b/tests/test_lammps_skill/conftest.py
@@ -512,6 +512,24 @@ run 1000
 """
 
 
+VALID_CREATE_ATOMS_SCRIPT = """\
+units lj
+atom_style atomic
+boundary p p p
+lattice fcc 0.8442
+region box block 0 10 0 10 0 10
+create_box 1 box
+create_atoms 1 box
+mass 1 1.0
+velocity all create 1.44 87287 loop geom
+pair_style lj/cut 2.5
+pair_coeff 1 1 1.0 1.0 2.5
+fix 1 all nve
+timestep 0.005
+run 250
+"""
+
+
 # ─── Pytest Fixtures ─────────────────────────────────────────────────
 
 @pytest.fixture
@@ -541,6 +559,7 @@ def fixtures_dir(tmp_path):
         "valid_bio.lammps": VALID_BIOMOLECULAR_SCRIPT,
         "valid_ionic.lammps": VALID_IONIC_SCRIPT,
         "valid_slab.lammps": VALID_SLAB_SCRIPT,
+        "valid_create_atoms.lammps": VALID_CREATE_ATOMS_SCRIPT,
     }
     for name, content in valid_scripts.items():
         (script_dir / name).write_text(content)

--- a/tests/test_lammps_skill/test_lammps_tools.py
+++ b/tests/test_lammps_skill/test_lammps_tools.py
@@ -270,6 +270,14 @@ class TestValidateScriptValid:
         assert r["valid"] is True, f"Unexpected errors: {r['errors']}"
         assert r["boundary"] == ["p", "p", "s"]
 
+    def test_valid_create_atoms(self, script_dir):
+        # A self-contained deck builds its system in-place with create_atoms
+        # (no read_data/read_restart) — a valid, common pattern that must pass.
+        r = lammps_tools.validate_script(str(script_dir / "valid_create_atoms.lammps"))
+        assert r["valid"] is True, f"Unexpected errors: {r['errors']}"
+        assert not any("read_data" in e or "system definition" in e
+                       for e in r["errors"])
+
 
 # =====================================================================
 # validate_script — error scripts caught


### PR DESCRIPTION
## Problem

`validate_script` in the LAMMPS skill requires `read_data` or `read_restart` and flags **"Missing 'read_data' or 'read_restart'"** otherwise. But a deck can equally define its system in-place with `create_atoms` (after `create_box` + `lattice`/`region`) — a valid and common LAMMPS pattern (e.g. a self-contained Lennard-Jones melt with no external data file). Such decks were marked invalid, which would false-fail a generated self-contained MD deck on the full-pipeline pre-run validation path.

## Fix

Accept `create_atoms` alongside `read_data` and `read_restart` as a system-definition source, and reword the error to name all three:

```python
if not commands_seen & {"read_data", "read_restart", "create_atoms"}:
    errors.append("Missing system definition — need 'read_data', "
                  "'read_restart', or 'create_atoms'")
```

The change is strictly more permissive — every previously-valid `read_data` deck still passes.

## Tests

Adds a self-contained `create_atoms` fixture (`VALID_CREATE_ATOMS_SCRIPT`) and a `validate_script` test that asserts it validates with no system-definition error. Full LAMMPS-skill suite: **84 passed**.

Surfaced while building the classical-MD tier of the simulation-agent refinement benchmark (self-contained LJ-melt cases).