### PR TITLE
Planning: reliable saving of large files (chunked writes + fail-loud tool-argument parsing)

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -3041,9 +3041,13 @@ class OrchestratorTools:
             func=save_file,
             name="save_file",
             description=(
-                "Save text content (code, protocols, scripts, notes) to a file "
-                "in the session directory. Use this to persist generated code, "
-                "instrument protocols, or any text artifact."
+                "Save text content (protocols, notes, small scripts) to a file "
+                "in the session directory. Large content may not survive the "
+                "trip as a single tool-call argument — for anything long "
+                "(roughly >100 lines), save the first chunk with save_file and "
+                "the rest with append_file. For executable analysis/"
+                "optimization code, prefer generate_implementation_code, which "
+                "generates and persists the script itself."
             ),
             parameters={
                 "filename": {
@@ -3056,6 +3060,75 @@ class OrchestratorTools:
                 "content": {
                     "type": "string",
                     "description": "The text content to write to the file.",
+                },
+                "subfolder": {
+                    "type": "string",
+                    "description": (
+                        "Optional subfolder within the session directory, "
+                        "e.g. 'protocols' or 'scripts'. Created if it doesn't exist."
+                    ),
+                },
+            },
+            required=["filename", "content"],
+        )
+
+        # 9b. APPEND FILE
+        def append_file(filename: str, content: str, subfolder: str = ""):
+            """
+            Append text content to a file in the session directory (created
+            if it doesn't exist). Companion to save_file for chunked writes
+            of large content.
+            """
+            print(f"  ⚡ Tool: Appending to file '{filename}'...")
+
+            safe_name = Path(filename).name
+            if not safe_name:
+                return json.dumps({
+                    "status": "error",
+                    "message": "Invalid filename.",
+                })
+
+            target_dir = self.orch.base_dir
+            if subfolder:
+                safe_sub = Path(subfolder).name
+                target_dir = target_dir / safe_sub
+            target_dir.mkdir(parents=True, exist_ok=True)
+            dest = target_dir / safe_name
+
+            try:
+                with open(dest, "a", encoding="utf-8") as f:
+                    f.write(content)
+                print(f"    💾 Appended: {dest}")
+                return json.dumps({
+                    "status": "success",
+                    "path": str(dest),
+                    "size_bytes": dest.stat().st_size,
+                })
+            except Exception as e:
+                logging.error(f"append_file failed: {e}")
+                return json.dumps({
+                    "status": "error",
+                    "message": str(e),
+                })
+
+        self._register_tool(
+            func=append_file,
+            name="append_file",
+            description=(
+                "Append text content to a file in the session directory "
+                "(created if it doesn't exist). Use together with save_file "
+                "to write large files in chunks — save_file for the first "
+                "chunk, then append_file for each subsequent chunk — keeping "
+                "every chunk small enough to pass reliably as a tool argument."
+            ),
+            parameters={
+                "filename": {
+                    "type": "string",
+                    "description": "Name of the file to append to.",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The text content to append to the file.",
                 },
                 "subfolder": {
                     "type": "string",

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -497,6 +497,8 @@ Assume user runs agent from project directory. For example, when user says "file
 **MCP OUTPUT PERSISTENCE:**
 - When an MCP tool returns generated code, protocols, or other text artifacts, call `save_file`
   to persist the output BEFORE calling any other tool.
+- Write large artifacts in chunks (`save_file` for the first chunk, `append_file` for the rest);
+  a single oversized tool argument can be truncated and lost.
 
 **BEHAVIOR:**
 - Extract ALL paths mentioned by user (papers, data, code, reports)
@@ -1466,6 +1468,38 @@ class PlanningOrchestratorAgent:
         except Exception as e:
             logging.warning(f"Auto-checkpoint failed: {e}")
 
+    @staticmethod
+    def _parse_tool_args(tool_call, finish_reason=None):
+        """Parse a tool call's JSON arguments, failing loud on bad input.
+
+        Returns (args, None) on success, or (None, error_json) when the
+        arguments string is malformed or truncated. The error_json is handed
+        back to the model as the tool result so it can recover (#270) —
+        silently substituting ``args = {}`` surfaces as a raw TypeError from
+        the tool itself, which hides the real cause and sends the model into
+        an unrecoverable retry loop.
+        """
+        try:
+            return json.loads(tool_call.function.arguments), None
+        except json.JSONDecodeError:
+            if finish_reason == "length":
+                cause = ("the arguments JSON was truncated — the response "
+                         "hit the output-token limit")
+            else:
+                cause = ("the arguments string was not valid JSON — "
+                         "typically broken escaping of quotes/newlines "
+                         "inside a large string value")
+            return None, json.dumps({
+                "status": "error",
+                "message": (
+                    f"Tool call discarded: {cause}. The tool was NOT "
+                    "executed. Do not retry with one large argument. For "
+                    "large text content, write the file in chunks: "
+                    "save_file with the first chunk, then append_file for "
+                    "each remaining chunk."
+                ),
+            })
+
     def _handle_openai_chat(self, user_input: str) -> str:
         """Handle chat with OpenAI-compatible models with manual function calling loop."""
         from openai import OpenAI
@@ -1530,13 +1564,20 @@ class PlanningOrchestratorAgent:
 
             self._print_assistant_reasoning(message.content)
 
+            finish_reason = getattr(response.choices[0], "finish_reason", None)
+
             for tool_call in message.tool_calls:
                 func_name = tool_call.function.name
-                args = json.loads(tool_call.function.arguments)
+                args, args_error = self._parse_tool_args(tool_call, finish_reason)
 
                 print(f"  🔧 Calling tool: {func_name}")
 
-                result = self.tools.execute_tool(func_name, **args)
+                if args_error is not None:
+                    print("    ⚠️ Malformed/truncated tool arguments — "
+                          "returning recovery hint to the model")
+                    result = args_error
+                else:
+                    result = self.tools.execute_tool(func_name, **args)
 
                 self.messages.append({
                     "role": "tool",
@@ -1646,17 +1687,21 @@ class PlanningOrchestratorAgent:
 
             self._print_assistant_reasoning(content)
 
+            finish_reason = getattr(response.choices[0], "finish_reason", None)
+
             # Execute each tool call
             for tool_call in tool_calls:
                 func_name = tool_call.function.name
-                try:
-                    args = json.loads(tool_call.function.arguments)
-                except json.JSONDecodeError:
-                    args = {}
+                args, args_error = self._parse_tool_args(tool_call, finish_reason)
 
                 print(f"  🔧 Calling tool: {func_name}")
-                
-                result = self.tools.execute_tool(func_name, **args)
+
+                if args_error is not None:
+                    print("    ⚠️ Malformed/truncated tool arguments — "
+                          "returning recovery hint to the model")
+                    result = args_error
+                else:
+                    result = self.tools.execute_tool(func_name, **args)
                 
                 self.messages.append({
                     "role": "tool",

--- a/tests/test_save_file_chunking.py
+++ b/tests/test_save_file_chunking.py
@@ -1,0 +1,137 @@
+"""Tests for #270 — reliable persistence of large content from planning mode.
+
+Two halves:
+
+1. ``PlanningOrchestratorAgent._parse_tool_args`` — malformed/truncated
+   tool-call arguments must surface an actionable error the model can
+   recover from, never a silent ``args = {}`` + raw TypeError.
+2. ``append_file`` — the chunked-write companion to ``save_file`` so large
+   files never ride in a single JSON tool-call argument.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scilink.agents.planning_agents.orchestrator_tools import OrchestratorTools
+from scilink.agents.planning_agents.planning_orchestrator import (
+    PlanningOrchestratorAgent,
+)
+
+
+def _tool_call(arguments: str):
+    return SimpleNamespace(function=SimpleNamespace(name="save_file",
+                                                    arguments=arguments))
+
+
+# ---------------------------------------------------------------------------
+# _parse_tool_args
+# ---------------------------------------------------------------------------
+
+def test_valid_args_parse_cleanly():
+    args, err = PlanningOrchestratorAgent._parse_tool_args(
+        _tool_call('{"filename": "a.md", "content": "hello"}'))
+    assert err is None
+    assert args == {"filename": "a.md", "content": "hello"}
+
+
+def test_malformed_args_fail_loud_with_recovery_hint():
+    """Broken escaping must NOT become args={}; the error must name the
+    cause and point at the chunked-write path."""
+    bad = '{"filename": "a.md", "content": "it\'s \n broken'
+    args, err = PlanningOrchestratorAgent._parse_tool_args(_tool_call(bad))
+    assert args is None
+    payload = json.loads(err)
+    assert payload["status"] == "error"
+    assert "NOT executed" in payload["message"]
+    assert "append_file" in payload["message"]
+    assert "valid JSON" in payload["message"]
+
+
+def test_truncated_args_report_truncation():
+    """finish_reason == 'length' must be distinguished from bad escaping."""
+    truncated = '{"filename": "a.md", "content": "very long protoc'
+    args, err = PlanningOrchestratorAgent._parse_tool_args(
+        _tool_call(truncated), finish_reason="length")
+    assert args is None
+    payload = json.loads(err)
+    assert "truncated" in payload["message"]
+    assert "append_file" in payload["message"]
+
+
+# ---------------------------------------------------------------------------
+# append_file
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tools(tmp_path):
+    return OrchestratorTools(SimpleNamespace(base_dir=tmp_path))
+
+
+def test_append_file_registered(tools):
+    assert "append_file" in tools.functions_map
+    schema_names = [s["function"]["name"] for s in tools.openai_schemas]
+    assert "append_file" in schema_names
+
+
+def test_chunked_write_roundtrip(tools, tmp_path):
+    """save_file + N append_file calls reassemble a large, escape-hostile
+    artifact byte-for-byte."""
+    chunks = [
+        "# Protocol\n\nStep 1: mix 'A' with \"B\".\n",
+        "```python\nfor i in range(10):\n    print({'k': i})\n```\n",
+        "Final notes: 50 µL aliquots\n" * 50,
+    ]
+    r = json.loads(tools.execute_tool(
+        "save_file", filename="protocol.md", content=chunks[0]))
+    assert r["status"] == "success"
+    for chunk in chunks[1:]:
+        r = json.loads(tools.execute_tool(
+            "append_file", filename="protocol.md", content=chunk))
+        assert r["status"] == "success"
+    assert (tmp_path / "protocol.md").read_text() == "".join(chunks)
+
+
+def test_append_creates_missing_file(tools, tmp_path):
+    r = json.loads(tools.execute_tool(
+        "append_file", filename="fresh.txt", content="first"))
+    assert r["status"] == "success"
+    assert (tmp_path / "fresh.txt").read_text() == "first"
+
+
+def test_append_respects_subfolder_and_sanitizes(tools, tmp_path):
+    r = json.loads(tools.execute_tool(
+        "append_file", filename="../../escape.txt", content="x",
+        subfolder="protocols"))
+    assert r["status"] == "success"
+    # Path traversal stripped: lands inside the session dir, not outside.
+    assert (tmp_path / "protocols" / "escape.txt").read_text() == "x"
+    assert not (tmp_path.parent.parent / "escape.txt").exists()
+
+
+def test_append_rejects_empty_filename(tools):
+    r = json.loads(tools.execute_tool("append_file", filename="/", content="x"))
+    assert r["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Loop integration: a bad tool call must produce a tool-role recovery
+# message, not a TypeError from the tool.
+# ---------------------------------------------------------------------------
+
+def test_bad_args_never_reach_execute_tool(tmp_path):
+    """Simulate what the chat loops now do with a malformed call: the
+    recovery hint is returned and the tool function is never invoked."""
+    tools = OrchestratorTools(SimpleNamespace(base_dir=tmp_path))
+    args, err = PlanningOrchestratorAgent._parse_tool_args(
+        _tool_call('{"filename": "p.md", "content": "trunc'))
+    assert args is None and err is not None
+    # The old behavior (args={}) produced this unrecoverable TypeError:
+    old_result = tools.execute_tool("save_file")
+    assert "missing" in json.loads(old_result)["message"]
+    # The new behavior returns the actionable message instead.
+    assert "append_file" in json.loads(err)["message"]


### PR DESCRIPTION
## Summary

Closes #270.

When the planning assistant composes a large document — a full lab protocol, a long analysis script, a detailed report — and saves it to the session folder, the save could fail in a way the assistant couldn't recover from: it would keep retrying, get the same unhelpful error each time, and the document would never reach disk. This PR fixes that two ways:

1. **Large documents are now written in chunks.** A new `append_file` tool complements `save_file`, so the assistant writes the first portion and appends the rest — each piece small enough to transfer reliably. In live testing on Bedrock opus-4-8, the assistant adopted this unprompted and persisted a 21 KB / 485-line protocol (tables, quoted safety phrases, three embedded Python snippets) byte-for-byte intact, with all code blocks still valid, correctly indented Python.
2. **When a save does go wrong, the assistant now learns why.** Instead of a cryptic internal error, it receives a clear explanation ("your tool call was truncated/malformed — write the file in chunks") and recovers on its own.

No changes to analysis, simulation, or meta modes; no changes to any scientific logic.

---

## Technical details

*For AI review agents.*

**Root cause (#270).** `save_file(filename, content)` carries the entire artifact as a JSON-escaped tool-call argument. Large `content` breaks two independent ways: escaping corruption (quotes/newlines/braces) and output-budget truncation (`finish_reason == "length"`). Either way `json.loads(tool_call.function.arguments)` raises; the LiteLLM chat loop swallowed it into `args = {}` (`planning_orchestrator.py`, formerly `:1653-1655`), so `execute_tool` ran with no arguments and the model got back a raw `TypeError: save_file() missing 1 required positional argument: 'content'` — concealing the actual cause; observed live as an unrecoverable retry spiral on Bedrock opus-4-8. The OpenAI-compatible proxy loop (formerly `:1535`) had no guard at all, so a malformed argument string threw out of the chat turn entirely.

**Changes.**

- `planning_orchestrator.py` — new `PlanningOrchestratorAgent._parse_tool_args(tool_call, finish_reason=None) -> (args|None, error_json|None)` (static). Both chat loops (`_handle_openai_chat`, `_handle_litellm_chat`) now call it per tool call; on failure they skip execution and append the returned error JSON as the tool-role message. The message states the call was discarded, the tool was NOT executed, distinguishes truncation (`finish_reason == "length"`) from escaping breakage, and instructs chunked recovery via `save_file` + `append_file`. Protects every required-arg tool, not just `save_file`.
- `orchestrator_tools.py` — new `append_file(filename, content, subfolder="")` registered alongside `save_file` (section 9b): same `Path(...).name` traversal sanitization, `open(dest, "a", encoding="utf-8")`, creates the file if missing, returns `{status, path, size_bytes}`. `save_file`'s tool description now steers large content to chunking and generated implementation code to `generate_implementation_code` (which already persists scripts via the #240 compile-checked parser — issue Option 3, zero code needed). One-line chunking nudge added to the MCP-output-persistence block of the system prompt.
- `tests/test_save_file_chunking.py` — 9 offline tests (pytest): the three `_parse_tool_args` outcomes (valid / malformed-escaping / truncated-with-`finish_reason`); chunked roundtrip of an escape-hostile multi-part artifact reassembled byte-for-byte; append-creates-missing-file; subfolder + traversal sanitization (`../../escape.txt` lands inside the session dir); empty-filename rejection; and an old-vs-new seam test showing `execute_tool("save_file")` with empty args yields the legacy `TypeError` message while the new path returns the actionable recovery hint.

**Live validation (Bedrock `bedrock/us.anthropic.claude-opus-4-8`, AUTONOMOUS planning session).** Prompted for a ≥250-line protocol with three ```python blocks and quoted phrases, saved to the session dir. Model chunked unprompted (1 `save_file` + 4 `append_file`, chunk sizes 3978/4082/4540/3264/5105 B). Verified: concatenation of the five tool-call `content` arguments equals the on-disk file byte-for-byte; all three embedded Python blocks pass `ast.parse` with indentation intact (52/43/36 lines); every chunk junction falls on a clean line boundary (trailing `\n`); zero fail-loud recovery messages needed (prevention path); no literal `\n` escape artifacts.

**Known limits / scope.**
- Chunk-content fidelity (correct indentation/escaping within each small chunk, continuing exactly where the previous chunk ended) remains the model's responsibility; small chunks are the regime where this is reliable, and the offline seam tests lock the recovery path if it isn't.
- The same silent `args = {}` pattern exists in the analysis (`analysis_orchestrator.py:1603/:1735`), simulation (`simulation_orchestrator.py:857/:943`), and meta (`meta_orchestrator.py:1287/:1402`) chat loops. Deliberately out of scope here (per-issue scoping; those modes also lack `append_file`, so the recovery message needs a variant) — propagation is a natural follow-up.
- Issue Option 2 (extract artifacts from the assistant message body via a save-by-label contract) deferred per the issue's own recommendation.