### PR TITLE
Condensed structure-gen: use available packing tools + harden numpy fallback

### DIFF
--- a/scilink/agents/sim_agents/structure_agent.py
+++ b/scilink/agents/sim_agents/structure_agent.py
@@ -16,7 +16,10 @@ from .instruct import (
     SCRIPT_CORRECTION_FROM_VALIDATION_TEMPLATE,
     MODIFICATION_PROMPT_TEMPLATE,
 )
-from .utils import save_generated_script, MaterialsProjectHelper, MP_SEARCH_TOOL_SCHEMA
+from .utils import (
+    save_generated_script, MaterialsProjectHelper, MP_SEARCH_TOOL_SCHEMA,
+    detect_structure_build_tools, format_available_tools_block,
+)
 from ...executors import ScriptExecutor, DEFAULT_TIMEOUT
 from ...utils.codegen_parse import parse_codegen_response
 
@@ -99,12 +102,21 @@ class StructureGenerator:
 
         self.mp_helper = MaterialsProjectHelper(api_key=mp_api_key)
 
+        # Probe optional structure-building libraries once, so every generation
+        # prompt can tell the LLM what is importable here. Without this signal
+        # the model guesses and tends to write dependency-free hand-rolled code
+        # even when a purpose-built tool (e.g. packmol) is installed.
+        self._available_tools = detect_structure_build_tools()
+        self._tools_block = format_available_tools_block(self._available_tools)
+
         # Initialization message
         print(f"🔧 Structure Generator Ready ({model_name})")
         if self.mp_helper.enabled:
             print(f"   🗃️  Materials Project: Connected")
         else:
             print(f"   🗃️  Materials Project: Not configured")
+        present = sorted(n for n, ok in self._available_tools.items() if ok)
+        print(f"   🧰 Build libraries: {', '.join(present) if present else 'ASE only'}")
 
     @staticmethod
     def _format_skill_block(skill_content: Optional[str]) -> str:
@@ -131,7 +143,7 @@ class StructureGenerator:
             description=description,
             tool_name="ASE",
         )
-        base_prompt = base_prompt + self._format_skill_block(skill_content)
+        base_prompt = base_prompt + self._format_skill_block(skill_content) + self._tools_block
 
         # Pre-resolve any named materials in the request to mp-ids via tool
         # calls, then inject the resolved facts as ground truth before the
@@ -154,7 +166,7 @@ class StructureGenerator:
             description=description,
             tool_name="ASE",
         )
-        base_prompt = base_prompt + self._format_skill_block(skill_content)
+        base_prompt = base_prompt + self._format_skill_block(skill_content) + self._tools_block
         return base_prompt + JSON_OUTPUT_INSTRUCTION
 
     def _build_correction_prompt(self, original_request: str, failed_script: str,
@@ -171,7 +183,7 @@ class StructureGenerator:
             error_message=error_message,
             tool_name="ASE",
         )
-        base_prompt = base_prompt + self._format_skill_block(skill_content)
+        base_prompt = base_prompt + self._format_skill_block(skill_content) + self._tools_block
         return base_prompt + JSON_OUTPUT_INSTRUCTION
 
     def _build_validation_correction_prompt(self, original_request: str,
@@ -211,7 +223,7 @@ class StructureGenerator:
             prior_attempts_summary=prior_block,
             tool_name="ASE",
         )
-        base_prompt = base_prompt + self._format_skill_block(skill_content)
+        base_prompt = base_prompt + self._format_skill_block(skill_content) + self._tools_block
 
         return base_prompt + JSON_OUTPUT_INSTRUCTION
 

--- a/scilink/agents/sim_agents/utils.py
+++ b/scilink/agents/sim_agents/utils.py
@@ -1,6 +1,8 @@
 import os
 import re
+import shutil
 import logging
+import importlib.util
 from typing import Optional, List, Dict
 
 import numpy as np
@@ -362,6 +364,52 @@ class MaterialsProjectHelper:
             )
             # Don't cache transient API/network errors — let the next call retry.
             return None
+
+
+# Optional structure-building libraries the codegen LLM may reach for. Probed
+# at generation time so the prompt can tell the model what is actually
+# importable here instead of guessing — without an availability signal the model
+# defaults to dependency-free hand-rolled code even when a better purpose-built
+# tool is installed. This is a factual capability list; which tool to prefer for
+# a given task is the skill's domain guidance, stated there, not here.
+_OPTIONAL_BUILD_TOOLS = ("pymatgen", "rdkit", "openmm", "mbuild")
+
+
+def detect_structure_build_tools() -> Dict[str, bool]:
+    """Return {tool_name: importable} for optional structure-building libraries.
+
+    Fail-closed: a tool whose probe raises is reported unavailable. ``packmol``
+    requires both its pymatgen wrapper and the ``packmol`` executable on PATH —
+    the wrapper alone cannot pack a box.
+    """
+    available: Dict[str, bool] = {}
+    for name in _OPTIONAL_BUILD_TOOLS:
+        try:
+            available[name] = importlib.util.find_spec(name) is not None
+        except Exception:
+            available[name] = False
+    try:
+        wrapper = importlib.util.find_spec("pymatgen.io.packmol") is not None
+    except Exception:
+        wrapper = False
+    available["packmol"] = bool(wrapper and shutil.which("packmol"))
+    return available
+
+
+def format_available_tools_block(available: Dict[str, bool]) -> str:
+    """Render an availability dict into a prompt block, or '' if nothing is
+    available (in which case the prompt is left unchanged)."""
+    present = sorted(name for name, ok in available.items() if ok)
+    if not present:
+        return ""
+    return (
+        "\n\n## AVAILABLE LIBRARIES (importable in this environment):\n"
+        f"{', '.join(present)}\n"
+        "When one of these purpose-built libraries fits the task, prefer it "
+        "over a hand-rolled implementation — it handles edge cases that ad-hoc "
+        "code commonly gets wrong. Fall back to manual construction only when "
+        "no listed library covers the operation.\n"
+    )
 
 
 def save_generated_script(script_content: str, description: str, attempt: int, output_dir: str) -> str | None:

--- a/scilink/skills/structure_generation/condensed/condensed.md
+++ b/scilink/skills/structure_generation/condensed/condensed.md
@@ -46,7 +46,12 @@ Prefer whatever is installed (the generation loop will fall back if an import is
 - **mBuild (MoSDeF)** — programmatic construction of complex / multi-component / polymeric boxes
   (`mbuild.fill_box`).
 - **ASE / numpy fallback** — build each molecule once (ASE / RDKit), then insert copies at random
-  positions/orientations into the cell, rejecting placements closer than a minimum distance.
+  positions/orientations into the cell, rejecting placements closer than a minimum distance. The
+  rejection test must compare **every atom** of the trial molecule (hydrogens included) against
+  **every** already-placed atom under the minimum image — checking only heavy-atom or
+  molecular-centre distances lets light atoms of neighbouring molecules interpenetrate. Wrap each
+  molecule into the cell as a rigid unit (shift by one reference atom's image), never per-atom
+  (`positions % L` applied atom-by-atom splits a molecule across the boundary).
 - **Cell & PBC:** set an orthorhombic/cubic `cell` and `pbc=True` sized to the target density.
 - **Output:** write a periodic POSCAR, e.g.
   `ase.io.write("POSCAR", atoms, format="vasp", vasp5=True, direct=True)`, then print the exact

--- a/scilink/skills/structure_generation/condensed/condensed.md
+++ b/scilink/skills/structure_generation/condensed/condensed.md
@@ -35,12 +35,19 @@ rather than packed here. Pack explicitly here for generic liquids / solutions / 
 
 ## Implementation
 
-Prefer whatever is installed (the generation loop will fall back if an import is missing):
+Prefer whatever is installed (check the AVAILABLE LIBRARIES list in the prompt). For any
+**multi-component** box — solutions, ions in solvent, mixtures — strongly prefer a dedicated
+packing tool (Packmol, OpenMM, mBuild) over a hand-rolled placement loop: these enforce the
+minimum separation across **all** atom pairs, whereas ad-hoc loops routinely check only
+heavy-atom centres and let hydrogens of neighbouring molecules overlap. Reserve the ASE/numpy
+fallback for when no packing library is available.
 
-- **Packmol** — the de-facto packing tool. Drive it from Python via **pymatgen**
-  (`pymatgen.io.packmol.PackmolBoxGen`), which writes the Packmol input, runs it, and returns a
-  structure; or write a Packmol input file and call the `packmol` binary via `subprocess`
-  (place N copies per species with a `tolerance` ≈ 2.0 Å minimum separation).
+- **Packmol** — the de-facto packing tool, and the default choice for solvated / multi-component
+  boxes. Drive it from Python via **pymatgen** (`pymatgen.io.packmol.PackmolBoxGen`), which writes
+  the Packmol input, runs it, and returns a structure; or write a Packmol input file and call the
+  `packmol` binary via `subprocess` (place N copies per species with a `tolerance` ≈ 2.0 Å minimum
+  separation). Packmol checks every atom pair, so ions and solvent are packed without the
+  hydrogen-overlap clashes a manual loop produces.
 - **OpenMM `Modeller.addSolvent()`** (often with **PDBFixer**) — adds a water box + neutralizing
   ions in a few lines; convenient for solvating a solute.
 - **mBuild (MoSDeF)** — programmatic construction of complex / multi-component / polymeric boxes

--- a/tests/test_structure_build_tools.py
+++ b/tests/test_structure_build_tools.py
@@ -1,0 +1,87 @@
+"""Offline tests for the codegen environment-probe helpers.
+
+`detect_structure_build_tools` reports which optional structure-building
+libraries are importable so the generation prompt can tell the LLM what is
+available instead of guessing. No network, no real libraries required — the
+probe primitives (`importlib.util.find_spec`, `shutil.which`) are mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from scilink.agents.sim_agents.utils import (
+    detect_structure_build_tools,
+    format_available_tools_block,
+)
+
+
+# --- format_available_tools_block --------------------------------------------
+
+def test_format_block_empty_is_blank():
+    # Nothing available → no prompt block at all (prompt left unchanged).
+    assert format_available_tools_block({}) == ""
+    assert format_available_tools_block({"packmol": False, "rdkit": False}) == ""
+
+
+def test_format_block_lists_only_available_sorted():
+    block = format_available_tools_block(
+        {"packmol": True, "rdkit": False, "openmm": True, "mbuild": False}
+    )
+    assert "openmm, packmol" in block  # sorted, only the True ones
+    assert "rdkit" not in block
+    assert "mbuild" not in block
+
+
+def test_format_block_states_prefer_principle():
+    # The one load-bearing instruction: prefer a purpose-built lib over ad-hoc code.
+    block = format_available_tools_block({"packmol": True})
+    assert "prefer" in block.lower()
+    assert "AVAILABLE LIBRARIES" in block
+
+
+# --- detect_structure_build_tools --------------------------------------------
+
+def _fake_find_spec(present_modules):
+    def _spec(name):
+        return object() if name in present_modules else None
+    return _spec
+
+
+def test_detect_packmol_requires_wrapper_and_binary():
+    # Wrapper importable but binary missing → packmol unavailable.
+    with patch(
+        "scilink.agents.sim_agents.utils.importlib.util.find_spec",
+        _fake_find_spec({"pymatgen", "pymatgen.io.packmol"}),
+    ), patch("scilink.agents.sim_agents.utils.shutil.which", return_value=None):
+        avail = detect_structure_build_tools()
+    assert avail["pymatgen"] is True
+    assert avail["packmol"] is False  # wrapper present, binary absent
+
+
+def test_detect_packmol_available_when_both_present():
+    with patch(
+        "scilink.agents.sim_agents.utils.importlib.util.find_spec",
+        _fake_find_spec({"pymatgen", "pymatgen.io.packmol", "rdkit"}),
+    ), patch(
+        "scilink.agents.sim_agents.utils.shutil.which",
+        return_value="/usr/bin/packmol",
+    ):
+        avail = detect_structure_build_tools()
+    assert avail["packmol"] is True
+    assert avail["rdkit"] is True
+    assert avail["openmm"] is False
+    assert avail["mbuild"] is False
+
+
+def test_detect_fail_closed_on_probe_error():
+    # A probe that raises (e.g. broken parent package) → reported unavailable,
+    # never propagated.
+    def _boom(name):
+        raise ImportError("broken parent package")
+
+    with patch(
+        "scilink.agents.sim_agents.utils.importlib.util.find_spec", _boom
+    ), patch("scilink.agents.sim_agents.utils.shutil.which", return_value=None):
+        avail = detect_structure_build_tools()
+    assert all(v is False for v in avail.values())


### PR DESCRIPTION
## Summary

Fixes a systematic atom-clash in condensed-phase (solvated / multi-component) structure generation, surfaced by benchmarking the 1 M aqueous-NaCl case. The generated box reproducibly contained sub-0.3 Å contacts: the deterministic min-distance validity check flagged them on every run, while the LLM validator passed the structure each time.

Root cause was two-fold, and this PR addresses both layers:

1. **The codegen never knew packmol was installed.** The generation prompt anchors on ASE (*"use ASE as the primary library"*) and reported nothing about what else was importable, so the model defaulted to dependency-free hand-rolled code even though packmol was available. It wrote a manual placement loop whose overlap check compared only oxygen/ion centres — leaving hydrogens of neighbouring waters free to overlap.

2. **The fallback recipe under-specified the overlap test.** The condensed skill said only *"reject placements closer than a minimum distance"*, which is the ambiguity the model resolved the wrong way.

## Changes

- **Environment-aware codegen** (`structure_agent.py`, `utils.py`): probe a small set of optional structure-building libraries (`pymatgen`, `rdkit`, `openmm`, `mbuild`, `packmol`) once at generator construction and inject a factual `AVAILABLE LIBRARIES` block into every generation prompt, with one instruction — prefer a purpose-built library over hand-rolled code when one fits. The probe is fail-closed (a tool whose probe raises is reported unavailable); `packmol` requires both its pymatgen wrapper and the binary on PATH. The block is engine/class-neutral.
- **Condensed skill domain guidance** (`condensed/condensed.md`): state the packmol preference for multi-component boxes and *why* (it enforces the minimum separation across all atom pairs), and harden the numpy fallback recipe to require an all-atom overlap test and rigid-molecule wrapping — defense-in-depth for environments without packmol.
- **Tests** (`tests/test_structure_build_tools.py`): offline coverage of the probe (empty→blank block, sorted available-only listing, packmol needs both wrapper and binary, fail-closed on probe error).

## Verification

- New probe tests pass (6/6); existing structure tests pass (51) — no prompt-building regression.
- End-to-end on the benchmark: the aqueous-NaCl case score went 0.70 → 1.00. The generated script now uses `PackmolBoxGen(tolerance=2.0)` instead of a hand-rolled loop, and the packed box is clash-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)