### PR TITLE
Meta agent: parallel multi-dataset fan-out (gate + full-mesh + fusion)

### DIFF
--- a/FANOUT_TEST_FINDINGS.md
+++ b/FANOUT_TEST_FINDINGS.md
@@ -29,6 +29,21 @@ bugs found, and what was fixed vs. flagged.
   agents' own QC correctly rejected degenerate fits on the synthetic cube. A
   clean re-run with proper energy metadata confirms the EELS branch. ✅
 
+### 3-WAY end-to-end (image + datacube + spectrum, one sample) ✅
+HAADF→`ImageAnalysisAgent`, EELS cube→`HyperspectralAnalysisAgent`,
+XPS→`CurveFittingAgent` — **three different agents concurrently**, all 3
+produced output. Gate complementary 0.90 over a set with TWO join axes
+(spatial HAADF↔EELS + chemical-state ↔XPS). Fusion found the real correlation
+(bright HAADF domains = Ti⁴⁺ TiO₂ domains, ~45/55% spatial coincidence) **and
+explicitly flagged the unresolved dark phase** — honest demarcation on a
+3-dataset synthesis.
+
+### DSC + TGA end-to-end (same-modality, two CurveFitting branches) ✅
+Fusion reconciled events point-for-point on the shared temperature axis:
+dehydration (DSC endotherm + coincident TGA mass loss) vs a mass-neutral
+crystallization exotherm (DSC-only) — the planted physics — and flagged a
+DSC-vs-TGA quantitative discrepancy, prioritizing the direct mass measurement.
+
 ### Stress battery — data-type breadth (gate, one LLM call each) — 6/6 graded
 | Scenario | Verdict | Note |
 |---|---|---|

--- a/FANOUT_TEST_FINDINGS.md
+++ b/FANOUT_TEST_FINDINGS.md
@@ -29,6 +29,19 @@ bugs found, and what was fixed vs. flagged.
   agents' own QC correctly rejected degenerate fits on the synthetic cube. A
   clean re-run with proper energy metadata confirms the EELS branch. ✅
 
+### Stress battery — data-type breadth (gate, one LLM call each) — 6/6 graded
+| Scenario | Verdict | Note |
+|---|---|---|
+| **DSC + TGA** (thermal, shared T axis) | complementary 0.92 | join = "temperature at 10°C/min" ✅ |
+| **Raman + FTIR** (same calcite) | complementary 0.86 | join = vibrational wavenumber ✅ |
+| **PL + UV-Vis** (same QDs) | complementary 0.90 | join = wavelength / one band gap ✅ |
+| **image + results-table** (mis-routed) | unrelated 0.85 | correctly rejected planning data ✅ |
+| **Raman(polymer) + DSC(metal)** | unrelated 0.95 | different systems ✅ |
+| **two FTIR, same sample** | redundant 0.95 | replicate, clustered ✅ |
+| _observational:_ before/after SEM (temporal) | complementary 0.78 | **does NOT flag directionality** — see below |
+| _observational:_ survey + detail (diff mag) | uncertain 0.60, declined | conservative: same modality, no pixel co-registration |
+| _observational:_ two XPS, different regions | complementary 0.70 | correctly distinguished spatial heterogeneity from a replicate |
+
 ### Offline robustness (24/24 checks, deterministic)
 branch-error handling, empty-but-successful flagging, fuse edge cases
 (<2 / nonexistent / good indices), N=4 concurrency + ledger integrity,
@@ -59,6 +72,26 @@ single-branch rejection, gate fail-closed, soft/hard size caps.
    axis assumptions and thus wrong analysis. Fixed: `_mesh_task` now forwards
    the primary's metadata — a `.json` path → instructs the child to
    `load_metadata` on it (don't synthesize); inline text → embedded directly.
+7. **Fusion template generalized (motivated by the stress tests).**
+   `HOLISTIC_EXPERIMENTAL_SYNTHESIS_INSTRUCTIONS` (its ONLY consumer is
+   fan-out) was entirely "local-atomic vs bulk-crystal" framed — wrong for the
+   thermal/vibrational/electronic pairs fan-out now fuses. Rewrote it to
+   reconcile on *whatever* the datasets share (co-registered spatial / shared
+   parameter axis / length-scale / complementary observables), folded the
+   anti-spurious-correlation principle INTO the template (was a separate
+   `fanout.py` guard, now removed), and added "claims must depend on >1
+   dataset." Zero blast radius (no other caller).
+
+## Design boundary surfaced by the stress tests (not a bug — deferred work)
+**Temporal before/after is treated as `complementary` (0.78) with no
+directionality flag.** Full-mesh would then let the "after" dataset inform the
+"before" branch's analysis — temporal leakage (anachronism). This is the
+Bucket-2 directional case from the design discussion: the gate sees "same
+region across a time/condition" as a valid join but doesn't mark the influence
+as one-way. Low severity today (the aux is an *optional* operand the agent may
+ignore), but it's the first concrete case justifying the deferred per-branch
+`auxiliary_from` (directed companions) extension. If time-series workflows are
+in scope, wire directed aux there first.
 
 ## Bugs found — PRE-EXISTING in the shared curve/image stack (NOT fan-out; flagged for your nod)
 

--- a/FANOUT_TEST_FINDINGS.md
+++ b/FANOUT_TEST_FINDINGS.md
@@ -1,0 +1,141 @@
+# Meta fan-out — live testing findings (branch `feature-meta-fanout`)
+
+Autonomous test/fix session on Bedrock opus-4-8. Summary of what was validated,
+bugs found, and what was fixed vs. flagged.
+
+## Validated (live, real LLM + real codegen)
+
+### Complementarity gate — battery (one LLM call each)
+| Scenario | Verdict | Outcome |
+|---|---|---|
+| Image + co-registered EELS map (same region) | complementary 0.93 | run ✅ |
+| STEM image + XRD of a different material | unrelated 0.95 | decline ✅ |
+| **Cross-modal: BSE image + XPS, same coupon** | complementary 0.83–0.86 | run ✅ |
+| **Cross-modal: Ti image + Si Raman** | unrelated 0.96 | decline ✅ |
+| **Redundant: two XPS of the same coupon** | redundant 0.95 (clustered) | decline ✅ |
+| **3-way: image + XPS + unrelated Raman** | partially_complementary | prune Raman, run image+XPS ✅ |
+| **Image + hyperspectral EELS datacube (co-registered)** | complementary 0.97 | run ✅ (join: pixel co-registration on 32×32 R1 grid) |
+
+### End-to-end (parallel branches + cross-modal fusion)
+- **Cross-modal image + XPS:** BSE→`ImageAnalysisAgent` (63%/37% two-phase),
+  XPS→`CurveFittingAgent` (Ti⁰/TiO₂ doublets). Fusion found the *real*
+  two-component agreement across modalities **and** correctly refused to
+  over-assign Z→phase without EDS. Honest, non-fabricated synthesis. ✅
+- **Image + hyperspectral datacube:** gate complementary 0.97 (pixel
+  co-registration); HAADF→`ImageAnalysisAgent`, EELS cube→`HyperspectralAnalysisAgent`
+  (correct heterogeneous routing); both branches produced output, fusion
+  succeeded. The run was noisy (see Bug C + the EELS metadata note) but the
+  fan-out orchestration was resilient: branches retried and recovered, and the
+  agents' own QC correctly rejected degenerate fits on the synthetic cube. A
+  clean re-run with proper energy metadata confirms the EELS branch. ✅
+
+### Offline robustness (24/24 checks, deterministic)
+branch-error handling, empty-but-successful flagging, fuse edge cases
+(<2 / nonexistent / good indices), N=4 concurrency + ledger integrity,
+single-branch rejection, gate fail-closed, soft/hard size caps.
+
+## Bugs found & FIXED (in the fan-out feature — mine)
+1. **Gate empty completions** — meta chat model carried delegation tool
+   schemas → structured prompt returned an attempted tool-call w/ empty text.
+   Fixed: dedicated tool-free `_structured_model` + retry-on-empty.
+2. **Gate under-credited bulk-vs-local reconciliation** — image+spectrum
+   (non-pixel-co-registered) flip-flopped complementary↔uncertain. Fixed the
+   rubric to credit "spatially-resolved vs bulk/area-averaged of the SAME
+   sample" as a valid join (the canonical multimodal case the fusion template
+   targets). Stabilized to 5/5 complementary.
+3. **Empty/errored branches waved through** — `run_fanout` now flags any
+   branch with no usable output (errored OR empty-success), warns, and does
+   not recommend fusing them.
+4. **`_mesh_task` primary ambiguity** — now states the PRIMARY path explicitly
+   so a child can't analyze a companion as the primary on near-identical data.
+5. **Negative-verdict guard** — an `unrelated`/`redundant` verdict can never
+   carry a runnable `fanout_set`, even if the model inconsistently lists one.
+6. **(MOST IMPORTANT) Branch metadata was never forwarded to the analysis
+   child.** `metadata` in a branch spec fed only the gate; `_mesh_task`/
+   `_run_one_branch` never passed it on, so every branch SYNTHESIZED metadata
+   from the task prose ("I created XPS metadata… none was provided") — losing
+   technique-specific fields (e.g. the EELS `energy_range` → repeated
+   `missing physical range` errors). On real data this risks wrong technique/
+   axis assumptions and thus wrong analysis. Fixed: `_mesh_task` now forwards
+   the primary's metadata — a `.json` path → instructs the child to
+   `load_metadata` on it (don't synthesize); inline text → embedded directly.
+
+## Bugs found — PRE-EXISTING in the shared curve/image stack (NOT fan-out; flagged for your nod)
+
+These surfaced when the hard XPS fit hit a synthesis-JSON-parse failure. The
+fan-out is resilient to them (the branch caught the error, retried, produced a
+`_002` result, fusion succeeded), but they are real and worth fixing. They live
+in sensitive shared agent code, so I did NOT change them — patches ready below.
+
+### Bug A — `_salvage_synthesis_fields` AttributeError on the salvage path
+- **Where:** `controllers/curve_fitting_controllers.py:6565,6734` and
+  `controllers/image_analysis_controllers.py:6642,6821` call
+  `self._salvage_synthesis_fields(response)`.
+- **Root cause:** that method lives on `BaseAnalysisAgent` (`base_agent.py:149`),
+  but `UnifiedCurveSynthesisController` (6347) / `UnifiedImageSynthesisController`
+  (6452) are standalone classes that don't inherit it → `AttributeError:
+  '…Controller' object has no attribute '_salvage_synthesis_fields'`.
+- **Trigger:** only when the synthesis JSON fails strict parsing (long
+  `detailed_analysis` with an unescaped quote/newline) — exactly the case the
+  salvage path exists for, so the safety net itself crashes.
+- **Proposed fix:** have the controllers call the shared util directly (which
+  `base_agent` already wraps):
+  ```python
+  from ...utils.synthesis_parse import salvage_synthesis_fields
+  raw = response.text if hasattr(response, "text") else str(response)
+  salvaged = salvage_synthesis_fields(raw)
+  ```
+  (or give the controller a `_salvage_synthesis_fields` helper mirroring the
+  base agent's extract-text-then-salvage). Apply at all four call sites.
+
+### Bug B — `NoneType` not subscriptable in `run_analysis`
+- **Where:** `analysis_orchestrator_tools.py:2686`
+  `"detailed_analysis": result.get("detailed_analysis", "")[:2000]`.
+- **Root cause:** when synthesis fails (Bug A), `result["detailed_analysis"]`
+  is present but `None`; `.get(key, "")` returns `None` (key exists) → `None[:2000]`.
+- **Proposed fix:** `(result.get("detailed_analysis") or "")[:2000]` and guard
+  `scientific_claims` similarly. Defensive; safe across all analysis paths.
+
+Note: Bug A → synthesis returns None → Bug B crash → caught by `run_analysis`'s
+outer try → agent retries (the `_002` run). So the loop recovers, at the cost of
+a wasted attempt + error-level logs.
+
+### Bug C — no image-dimension cap → API rejects >8000 px images (NEW, shared infra)
+- **Where:** `wrappers/litellm_wrapper.py:415-434` (`_convert_parts`) encodes both
+  PIL images and `{mime_type,data}` byte dicts to base64 with **no dimension
+  guard**.
+- **Symptom (seen live, 8×):** `BedrockException … image dimensions exceed max
+  allowed size: 8000 pixels` on the image-synthesis montage → synthesis returns
+  `None` → Bug B. The model APIs (Bedrock AND direct Anthropic) hard-cap at
+  8000 px per dimension; a tall multi-panel synthesis figure (best-of-N
+  candidates stacked) exceeds it.
+- **Impact:** affects ANY image-analysis run with large composite figures, not
+  just fan-out — likely common on Bedrock.
+- **Proposed fix (central, provider-agnostic):** downscale any encoded image
+  whose largest dimension > ~7990 px before base64, in both image branches of
+  `_convert_parts`:
+  ```python
+  _MAX_IMAGE_DIM = 7990
+  def _cap(raw: bytes) -> bytes:
+      im = Image.open(io.BytesIO(raw))
+      if max(im.size) > _MAX_IMAGE_DIM:
+          im.thumbnail((_MAX_IMAGE_DIM, _MAX_IMAGE_DIM))
+          out = io.BytesIO(); im.save(out, format="PNG"); return out.getvalue()
+      return raw
+  ```
+  (PIL path: thumbnail before save; dict path: decode→cap→re-encode only for
+  image mime types.) High blast radius (every image to every model) — verify
+  small images are byte-unchanged; hence flagged, not applied.
+
+## Known characteristics (not bugs)
+- The gate needs metadata to confidently call "complementary" — with bare
+  array probes and no metadata it conservatively returns `uncertain` (correct:
+  shape alone can't establish same-sample/join-axis). Fan-out effectively
+  expects per-dataset metadata, which the meta already gathers before delegating.
+- Synthetic test fixtures get flagged as non-physical by the analysis agents'
+  own data-validity gates — agent honesty, not a fan-out issue. Tests use
+  realistic fixtures (smoothed random fields, XPS doublets, EELS datacubes).
+- The EELS hyperspectral skill *requires* a numeric energy axis
+  (`energy_range`/`axis_spec.axis_2` with start/end) and raises `ValueError`
+  without it — correct strictness, but a fan-out caller must ensure the
+  datacube branch's metadata carries it (the meta gathers metadata pre-delegation).

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2094,6 +2094,7 @@ class AnalysisOrchestratorTools:
             literature_file: str = None,
             r2_threshold: float = None,
             max_verification_iterations: int = None,
+            starting_annealing_level: int = None,
             n_candidates: int = None,
         ) -> str:
             """
@@ -2637,6 +2638,21 @@ class AnalysisOrchestratorTools:
                             f"   max_verification_iterations={max_verification_iterations} ignored: "
                             f"{self.AGENT_NAMES.get(agent_id, 'agent')} has no verification loop."
                         )
+                if starting_annealing_level is not None:
+                    # Annealing-schedule override for a RE-RUN: start the
+                    # constraint-relaxation schedule higher (e.g. hot) so the
+                    # agent does not repeat early stages a prior run already
+                    # found inadequate. Default/first run is None -> unchanged
+                    # (schedule starts frozen at T=0). Only forward to agents
+                    # whose analyze() accepts it (CurveFitting, Image).
+                    import inspect as _inspect
+                    if "starting_annealing_level" in _inspect.signature(agent.analyze).parameters:
+                        analyze_kwargs["starting_annealing_level"] = int(starting_annealing_level)
+                    else:
+                        self.logger.info(
+                            f"   starting_annealing_level={starting_annealing_level} ignored: "
+                            f"{self.AGENT_NAMES.get(agent_id, 'agent')} has no annealing schedule."
+                        )
                 # Best-of-N: deterministic per-agent default (image=3, others 1)
                 # unless explicitly requested; forwarded only to agents whose
                 # analyze() accepts it.
@@ -2997,6 +3013,25 @@ class AnalysisOrchestratorTools:
                         "post-experiment analysis → leave unset (defaults to 7). "
                         "Often paired with r2_threshold (e.g. 'use R²=0.98 and a "
                         "single verification step')."
+                    )
+                },
+                "starting_annealing_level": {
+                    "type": "integer",
+                    "description": (
+                        "CurveFitting and Image analysis agents. The constraint-"
+                        "annealing schedule normally starts FROZEN (skill rules "
+                        "and model locked) and only relaxes toward full freedom "
+                        "across verification iterations. Set this to start the "
+                        "schedule HIGHER on a RE-RUN, so the agent does not waste "
+                        "iterations repeating early constraint stages that a prior "
+                        "run already showed to be inadequate. Levels: 0 = frozen "
+                        "(default / first run — ALWAYS leave UNSET on a first "
+                        "analysis), 1 = warm (constraints loosened), 2 = hot (full "
+                        "freedom, fresh generation from scratch). Set it ONLY when "
+                        "the user is re-running after an unsatisfactory fit and "
+                        "wants to skip the early restrictive stages (e.g. 'this "
+                        "didn't work — try again without the earlier constraints' "
+                        "→ 2). Leave UNSET otherwise."
                     )
                 },
                 "n_candidates": {

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2181,10 +2181,28 @@ class AnalysisOrchestratorTools:
                 if has_sidecars:
                     self.orch.current_metadata = {}
                 else:
-                    return json.dumps({
-                        "status": "error",
-                        "message": "No metadata available. Use load_metadata or convert_metadata first."
-                    })
+                    # Single-file backstop: if a stem-matched sidecar JSON sits
+                    # next to the data file (foo.npy -> foo.json), auto-load it
+                    # instead of erroring. This ONLY runs when no metadata was
+                    # loaded (so it can never override an explicit load); it
+                    # converts a hard error into a usable run and makes metadata
+                    # forwarding deterministic for the meta fan-out path.
+                    if data_p.is_file():
+                        sidecar = data_p.with_suffix(".json")
+                        if sidecar.exists():
+                            try:
+                                with open(sidecar) as _fh:
+                                    _md = json.load(_fh)
+                                if isinstance(_md, dict) and _md:
+                                    self.orch.current_metadata = _md
+                                    print(f"  📎 Auto-loaded sidecar metadata: {sidecar.name}")
+                            except Exception:  # noqa: BLE001 - bad sidecar -> fall through to error
+                                pass
+                    if self.orch.current_metadata is None:
+                        return json.dumps({
+                            "status": "error",
+                            "message": "No metadata available. Use load_metadata or convert_metadata first."
+                        })
             
             try:
                 # === Handle directory input - filter out metadata files ===
@@ -2683,8 +2701,8 @@ class AnalysisOrchestratorTools:
                         "analysis_id": analysis_id,
                         "agent_used": self.AGENT_NAMES.get(agent_id),
                         "output_directory": str(analysis_output_dir),
-                        "detailed_analysis": result.get("detailed_analysis", "")[:2000],
-                        "claims_count": len(result.get("scientific_claims", [])),
+                        "detailed_analysis": (result.get("detailed_analysis") or "")[:2000],
+                        "claims_count": len(result.get("scientific_claims") or []),
                         "full_result_available": True,
                         "note": f"All outputs saved to: {analysis_output_dir}",
                         "next_steps": "Use assess_novelty to check literature for these claims, or get_recommendations for follow-up experiments.",

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -38,6 +38,7 @@ from .._locked_exec import (
     atomic_np_save,
 )
 from ....utils.codegen_parse import parse_codegen_response
+from ....utils.synthesis_parse import salvage_synthesis_from_response
 
 # Canonical fitted-curve output the fit script saves alongside visualization.png.
 # Best-effort: when present it powers controller-side residual diagnostics; when
@@ -6562,7 +6563,7 @@ same trend.
             result_json, error_dict = self._parse(response)
 
             if error_dict:
-                salvaged = self._salvage_synthesis_fields(response)
+                salvaged = salvage_synthesis_from_response(response)
                 if salvaged:
                     self.logger.warning("Synthesis JSON parse failed; salvaged detailed_analysis from raw text.")
                     state["synthesis_result"] = salvaged
@@ -6731,7 +6732,7 @@ same trend.
             result_json, error_dict = self._parse(response)
 
             if error_dict:
-                salvaged = self._salvage_synthesis_fields(response)
+                salvaged = salvage_synthesis_from_response(response)
                 if salvaged:
                     self.logger.warning("Series synthesis JSON parse failed; salvaged detailed_analysis from raw text.")
                     state["synthesis_result"] = salvaged

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -3587,8 +3587,13 @@ Return JSON with:
                 f"from the prior run."
             )
 
-        # --- Initial fit (skills mandatory at T=0) ---
-        state["_annealing_level"] = 0
+        # --- Initial fit (annealing schedule starts here; default T=0) ---
+        # A re-run may start the schedule HIGHER (e.g. hot) via
+        # `_starting_annealing_level`, so it does not repeat early constraint
+        # stages a prior run already found inadequate. Default 0 = unchanged.
+        _start_level = max(0, min(int(state.get("_starting_annealing_level") or 0),
+                                  len(self._CONSTRAINT_ANNEALING_SCHEDULE) - 1))
+        state["_annealing_level"] = _start_level
         initial_model = state.get('locked_fitting_config', {}).get('physical_model') or 'Initial model'
         self.logger.info(f"   Attempt 1: {str(initial_model)[:80]}...")
 
@@ -3648,7 +3653,7 @@ Return JSON with:
                     #       the minimum allowed level — guarantees we hit the
                     #       hot level by the end of the budget regardless of
                     #       what the rate/patience say.
-                    _annealing_level = 0
+                    _annealing_level = _start_level
                     # Annealing level at which the PREVIOUS refit actually ran.
                     # Used to detect the escalation INTO the hot level (see the
                     # fresh-generation trigger below). Must track the prior
@@ -3657,7 +3662,10 @@ Return JSON with:
                     # an iteration, so a start-of-iteration snapshot already
                     # equals the (escalated) current level and never registers a
                     # transition. Mirrors image_analysis's _previous_annealing_level.
-                    _previous_annealing_level = 0
+                    # max(start-1,0): starting AT hot still registers the
+                    # transition into hot (fires fresh generation); start at 0
+                    # restores the original `= 0`.
+                    _previous_annealing_level = max(_start_level - 1, 0)
                     _prev_best_r2 = best_r2
                     _n_anneal_levels = len(self._CONSTRAINT_ANNEALING_SCHEDULE)
                     _PATIENCE = 2

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -3276,8 +3276,13 @@ Return JSON with:
                 f"differ from the prior run."
             )
 
-        # --- Initial analysis (skills at T=0 — guidance) ---
-        state["_annealing_level"] = 0
+        # --- Initial analysis (annealing schedule starts here; default T=0) ---
+        # A re-run may start the schedule HIGHER (e.g. hot) via
+        # `_starting_annealing_level`, so it does not repeat early constraint
+        # stages a prior run already found inadequate. Default 0 = unchanged.
+        _start_level = max(0, min(int(state.get("_starting_annealing_level") or 0),
+                                  len(self._CONSTRAINT_ANNEALING_SCHEDULE) - 1))
+        state["_annealing_level"] = _start_level
 
         # --- Initial analysis ---
         initial_pipeline = state.get(
@@ -3323,8 +3328,10 @@ Return JSON with:
                     # Unlike curve fitting (deterministic R²), quality_score is
                     # LLM-assigned and noisy, so we use a patience counter
                     # instead of a rate-based formula.
-                    _annealing_level = 0
-                    _previous_annealing_level = 0
+                    _annealing_level = _start_level
+                    # max(start-1,0): starting AT hot still registers the
+                    # transition into hot; start at 0 restores the original `= 0`.
+                    _previous_annealing_level = max(_start_level - 1, 0)
                     _stall_count = 0
                     _PATIENCE = 2
                     _prev_best_score = best_score

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -39,6 +39,7 @@ from .._locked_exec import (
     DATA_NAME, VIZ_NAME, CANDIDATES_DIR_NAME, atomic_np_save,
 )
 from ....utils.codegen_parse import parse_codegen_response
+from ....utils.synthesis_parse import salvage_synthesis_from_response
 
 
 # Anthropic's API rejects images over 5 MB. Cap below that with headroom
@@ -6639,7 +6640,7 @@ Return JSON with:
             result_json, error_dict = self._parse(response)
 
             if error_dict:
-                salvaged = self._salvage_synthesis_fields(response)
+                salvaged = salvage_synthesis_from_response(response)
                 if salvaged:
                     self.logger.warning("Synthesis JSON parse failed; salvaged detailed_analysis from raw text.")
                     state["synthesis_result"] = salvaged
@@ -6818,7 +6819,7 @@ Return JSON with:
             result_json, error_dict = self._parse(response)
 
             if error_dict:
-                salvaged = self._salvage_synthesis_fields(response)
+                salvaged = salvage_synthesis_from_response(response)
                 if salvaged:
                     self.logger.warning("Series synthesis JSON parse failed; salvaged detailed_analysis from raw text.")
                     state["synthesis_result"] = salvaged

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -307,6 +307,11 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         max_model_retries: Optional[int] = None,
         outlier_sigma: Optional[float] = None,
         max_verification_iterations: Optional[int] = None,
+        # Annealing schedule start level for THIS run (None/0 = current
+        # behavior: start frozen at T=0 and escalate adaptively). A re-run may
+        # start higher (e.g. hot) so it does not re-obey early constraint stages
+        # a prior run already found inadequate.
+        starting_annealing_level: Optional[int] = None,
         quality_gate: "QualityGate | dict | None" = None,
         # Number of independent anchor-fit attempts run in parallel; an LLM
         # judge compares finished fits (R² + fit plots) and locks the winner.
@@ -687,6 +692,8 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "analysis_hints": hints,
             "analysis_objective": objective,
             "task_mode": effective_task_mode,
+            # Annealing schedule start level (None/0 = start frozen at T=0).
+            "_starting_annealing_level": starting_annealing_level,
 
             # Auxiliary reference data
             **aux_state,

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -255,6 +255,11 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # Escalation mode: attempt 0 runs alone and is fast-accepted when
         # strong; the remaining n_candidates-1 launch only when it is weak.
         candidate_escalation: bool = False,
+        # Annealing schedule start level for THIS run (None/0 = current
+        # behavior: start frozen at T=0 and escalate adaptively). A re-run may
+        # start higher (e.g. hot) so it does not re-obey early constraint stages
+        # a prior run already found inadequate.
+        starting_annealing_level: Optional[int] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """
@@ -451,6 +456,8 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "series_metadata": series_metadata or {},
             "analysis_hints": hints,
             "analysis_objective": objective,
+            # Annealing schedule start level (None/0 = start frozen at T=0).
+            "_starting_annealing_level": starting_annealing_level,
             # Auxiliary reference data
             **aux_state,
             # Domain skill

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -1123,6 +1123,8 @@ Follow these steps:
 
 3.  **Generate synthesized claims** that genuinely depend on MORE THAN ONE dataset. Do not relabel a single-dataset finding as a synthesis.
 
+4.  **List the caveats** — the limitations a reader must keep in mind when trusting this synthesis. Be specific and honest: what is INFERRED vs directly MEASURED (e.g. a correlation read from area fractions rather than pixel-level co-registration); what could NOT be established from the data; technique limitations that bound the conclusions (surface- vs bulk-sensitivity, Z-contrast insensitivity to oxidation state, area-averaging); and any assumptions made (e.g. that the datasets share a region without an explicit registration marker). If there are essentially no caveats, return an empty list.
+
 You MUST respond in a valid JSON format with the following keys:
 {
     "detailed_analysis": "<reconciled narrative across the datasets; state explicitly where they correlate and where they do not>",
@@ -1133,7 +1135,8 @@ You MUST respond in a valid JSON format with the following keys:
             "has_anyone_question": "<A question for a literature search, formatted as 'Has anyone observed...'>",
             "keywords": ["<keyword1>", "<keyword2>"]
         }
-    ]
+    ],
+    "caveats": ["<a specific limitation/assumption a reader must keep in mind>", "..."]
 }
 """
 

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -1109,26 +1109,26 @@ You MUST respond with a valid JSON object containing a single key:
 
 
 HOLISTIC_EXPERIMENTAL_SYNTHESIS_INSTRUCTIONS = """
-You are an expert materials scientist tasked with synthesizing findings from a multi-modal characterization of a single sample. You have been provided with analyses from different experimental techniques, which may provide information at different length scales (e.g., local atomic structure vs. bulk crystal phase).
+You are an expert scientist synthesizing findings from several complementary measurements of ONE system. The datasets have already been confirmed to share a subject and a join axis; each was analyzed independently. Your task is to reconcile them into a single interpretation consistent with ALL the evidence — or to state clearly where they do NOT constrain one another.
 
-Your primary task is to build a single, cohesive scientific narrative that is consistent with ALL the provided experimental evidence.
+Follow these steps:
 
-To do this, follow these steps:
+1.  **Identify how the datasets join, and reconcile them on that basis.** The right reconciliation depends on what they share:
+    * **Co-registered spatial data** (e.g. an image + a spectral map or datacube of the same region): look for direct SPATIAL correlations — does a structural domain coincide with a distinct chemical/spectral signature on the same pixels?
+    * **A shared parameter axis** (temperature, energy, time, wavelength, composition): look for COINCIDENCES on that axis — e.g. a DSC thermal event at the same temperature as a TGA mass-loss step (a decomposition/dehydration) versus a mass-neutral event (a solid-state phase transition); an absorption edge and a photoluminescence peak consistent with a single band gap.
+    * **Different length scales** (a local probe + a bulk-average technique): reconcile the local observations with the bulk averages — do the phases, composition, or defects seen locally explain the bulk signal (e.g. XRD phases vs. TEM structure, XPS vs. EDX composition, local strain vs. peak broadening)?
+    * **Complementary observables of the same sample** (e.g. Raman vs. IR selection rules): check MUTUAL CONSISTENCY — do they point to the same phase / composition / structure?
 
-1.  **First, consider the nature of each analysis provided:**
-    * For **spatially-resolved techniques** (e.g., Microscopy, SEM, TEM, EELS/EDX mapping): Look for direct **spatial correlations**. Does a structural feature seen in an image correspond to a unique signature in a spectral map?
-    * For **bulk-average techniques** (e.g., XRD, DSC, XPS): **Reconcile** these average properties with the local observations. For example, do the phases identified by XRD match the crystal structure seen in TEM? Can local defects or strain observed in microscopy explain peak broadening in the XRD pattern? Is the bulk elemental composition from XPS consistent with the local composition from EDX?
+2.  **Formulate the reconciled narrative ('detailed_analysis').** Build a coherent account supported by the COMBINED evidence. CRITICAL — the evidence is the final authority: assert a cross-dataset correlation, coincidence, or causal link ONLY where the provided findings actually support it. If the datasets do not correlate or constrain one another, say so plainly — "the techniques are mutually consistent but capture independent aspects" or "no significant cross-dataset correlation was found" is a valid and valuable conclusion. NEVER invent a correlation or a shared feature to force a unified story; a manufactured correlation is worse than reporting its absence.
 
-2.  **Formulate a Unified Narrative**: Based on this correlated and reconciled understanding, write a comprehensive 'detailed_analysis'. This narrative should explain how the local, atomic-scale features give rise to the observed bulk properties, or vice-versa.
-
-3.  **Generate Synthesized Claims**: From your unified narrative, generate a list of high-level 'scientific_claims' that are supported by the combined evidence from all techniques.
+3.  **Generate synthesized claims** that genuinely depend on MORE THAN ONE dataset. Do not relabel a single-dataset finding as a synthesis.
 
 You MUST respond in a valid JSON format with the following keys:
 {
-    "detailed_analysis": "<Your comprehensive, synthesized scientific narrative that reconciles local and bulk findings>",
+    "detailed_analysis": "<reconciled narrative across the datasets; state explicitly where they correlate and where they do not>",
     "scientific_claims": [
         {
-            "claim": "<A high-level scientific claim based on the combined data>",
+            "claim": "<A high-level scientific claim supported by the COMBINED evidence>",
             "scientific_impact": "<The potential impact of this claim>",
             "has_anyone_question": "<A question for a literature search, formatted as 'Has anyone observed...'>",
             "keywords": ["<keyword1>", "<keyword2>"]

--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -32,6 +32,7 @@ import json
 import logging
 import re
 import sys
+import time
 from concurrent.futures import ThreadPoolExecutor, wait
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -42,7 +43,8 @@ logger = logging.getLogger("meta_agent.fanout")
 # not the raw input: the gate prunes first, so a 6-upload request with one
 # complementary pair runs a 2-way mesh, not a 6-way one.
 FANOUT_MAX_WORKERS = 4          # peak concurrent branches (rate-limit ceiling)
-_FANOUT_HEARTBEAT_S = 20        # how often to print a "still running" heartbeat
+_FANOUT_POLL_S = 5              # how often to check for finished branches
+_FANOUT_HEARTBEAT_S = 60        # min gap between "still running" ticks
 FANOUT_SOFT_CAP = 5             # warn / confirm beyond this many fused branches
 FANOUT_HARD_CAP = 8             # refuse beyond this — cost/quality cliff
 # In AUTONOMOUS mode there is no human to confirm, so the verdict IS the gate:
@@ -532,18 +534,29 @@ def run_fanout(orch, branches: List[dict]) -> str:
         # Wait with a periodic heartbeat so the user can see the parallel run is
         # alive (a slow branch can otherwise look like a hang). Each branch is
         # announced as it finishes; the rest get a "still running" tick.
+        # Plain text only — the branch child orchestrators stream their own
+        # progress to the same stdout from worker threads, and this output is
+        # often captured (UI / log) where ANSI escapes and \r are not honored.
+        # So no in-place rewrite: poll often (prompt completion announcements)
+        # but print a "still running" tick at most once per _FANOUT_HEARTBEAT_S,
+        # and treat a completion as its own liveness signal (resets the timer).
         pending = set(fut_label)
-        waited = 0
+        start = time.monotonic()
+        since_tick = 0.0
         while pending:
-            done, pending = wait(pending, timeout=_FANOUT_HEARTBEAT_S)
+            t0 = time.monotonic()
+            done, pending = wait(pending, timeout=_FANOUT_POLL_S)
+            since_tick += time.monotonic() - t0
             for f in done:
                 f.result()  # _run_one_branch never raises; just surfaces oddities
                 print(f"  ✅ analysis branch finished: {fut_label[f]}  "
                       f"({n_total - len(pending)}/{n_total} done)")
-            if pending:
-                waited += _FANOUT_HEARTBEAT_S
+                since_tick = 0.0  # a completion already shows the run is alive
+            if pending and since_tick >= _FANOUT_HEARTBEAT_S:
+                since_tick = 0.0
+                elapsed = int(time.monotonic() - start)
                 print(f"  ⏳ {len(pending)} of {n_total} parallel analyses still "
-                      f"running ... (~{waited}s elapsed)")
+                      f"running ... (~{elapsed}s elapsed)")
 
     def _productive(e):
         # A branch that reports success but yields neither findings nor files

--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -32,7 +32,7 @@ import json
 import logging
 import re
 import sys
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, wait
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -42,6 +42,7 @@ logger = logging.getLogger("meta_agent.fanout")
 # not the raw input: the gate prunes first, so a 6-upload request with one
 # complementary pair runs a 2-way mesh, not a 6-way one.
 FANOUT_MAX_WORKERS = 4          # peak concurrent branches (rate-limit ceiling)
+_FANOUT_HEARTBEAT_S = 20        # how often to print a "still running" heartbeat
 FANOUT_SOFT_CAP = 5             # warn / confirm beyond this many fused branches
 FANOUT_HARD_CAP = 8             # refuse beyond this — cost/quality cliff
 # In AUTONOMOUS mode there is no human to confirm, so the verdict IS the gate:
@@ -515,14 +516,28 @@ def run_fanout(orch, branches: List[dict]) -> str:
                 for j in range(len(run_branches)) if j != i]
 
     max_workers = min(len(run_branches), FANOUT_MAX_WORKERS)
+    n_total = len(run_branches)
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        futures = [
-            pool.submit(_run_one_branch, orch, run_branches[i],
-                        _companions_for(i), entries[i])
-            for i in range(len(run_branches))
-        ]
-        for f in futures:
-            f.result()  # _run_one_branch never raises; this just joins
+        fut_label = {}
+        for i in range(n_total):
+            fut = pool.submit(_run_one_branch, orch, run_branches[i],
+                              _companions_for(i), entries[i])
+            fut_label[fut] = run_branches[i]["label"]
+        # Wait with a periodic heartbeat so the user can see the parallel run is
+        # alive (a slow branch can otherwise look like a hang). Each branch is
+        # announced as it finishes; the rest get a "still running" tick.
+        pending = set(fut_label)
+        waited = 0
+        while pending:
+            done, pending = wait(pending, timeout=_FANOUT_HEARTBEAT_S)
+            for f in done:
+                f.result()  # _run_one_branch never raises; just surfaces oddities
+                print(f"  ✅ analysis branch finished: {fut_label[f]}  "
+                      f"({n_total - len(pending)}/{n_total} done)")
+            if pending:
+                waited += _FANOUT_HEARTBEAT_S
+                print(f"  ⏳ {len(pending)} of {n_total} parallel analyses still "
+                      f"running ... (~{waited}s elapsed)")
 
     def _productive(e):
         # A branch that reports success but yields neither findings nor files

--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -672,8 +672,9 @@ def _write_fusion_html(out_dir: Path, fused: dict, figures: list) -> Optional[Pa
                       if fused.get("focus") else "")
         doc = f"""<!doctype html><html><head><meta charset="utf-8">
 <title>Cross-dataset fusion</title><style>
+ html{{background:#ffffff}}
  body{{font-family:-apple-system,Segoe UI,Roboto,sans-serif;max-width:920px;
-   margin:24px auto;padding:0 18px;color:#1b1b1b;line-height:1.6}}
+   margin:0 auto;padding:24px 18px;color:#1b1b1b;background:#ffffff;line-height:1.6}}
  h1{{font-size:1.5em}} h2{{margin-top:1.4em;border-bottom:1px solid #e3e3e3;padding-bottom:4px}}
  .narr{{white-space:pre-wrap;background:#fafafa;border:1px solid #eee;border-radius:8px;padding:14px 16px}}
  .imp{{color:#555;font-size:.9em;margin:2px 0 10px}}

--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -27,6 +27,7 @@ The logic lives here as free functions taking the orchestrator instance; thin
 sibling helper to the orchestrator.
 """
 
+import io
 import json
 import logging
 import re
@@ -149,18 +150,23 @@ def _parse_json_block(text: str) -> Optional[dict]:
             return None
 
 
-def _llm_json(orch, prompt: str) -> Optional[dict]:
+def _llm_json(orch, prompt: str, extra_parts=None) -> Optional[dict]:
     """LLM call returning parsed JSON, or None after retries.
 
     Retries on an empty completion or an unparseable body — Bedrock
     intermittently returns an empty content block, and silently fail-closing
     the gate on that transient would wrongly decline a complementary set.
     Only a persistent failure returns None (which callers fail closed on).
+
+    ``extra_parts`` is an optional list of additional prompt parts (label
+    strings and/or ``{mime_type, data}`` image dicts) appended after the prompt
+    — used to attach per-dataset figures to the (multimodal) fusion call.
     """
     model = _structured_model(orch)
+    contents = [prompt] + list(extra_parts or [])
     for attempt in range(_LLM_JSON_ATTEMPTS):
         try:
-            resp = model.generate_content(contents=[prompt])
+            resp = model.generate_content(contents=contents)
             text = resp.text if hasattr(resp, "text") else str(resp)
         except Exception as e:  # noqa: BLE001
             logger.warning(f"complementarity/fusion LLM call failed "
@@ -571,6 +577,96 @@ def run_fanout(orch, branches: List[dict]) -> str:
 # Fusion
 # ======================================================================
 
+_FIGURE_EXTS = {".png", ".jpg", ".jpeg", ".tif", ".tiff"}
+_FUSION_FIG_MAX_DIM = 1536   # enough to read spatial structure; keeps payload small
+
+
+def _branch_key_figure(entry: dict) -> Optional[str]:
+    """Pick one representative figure from a branch's produced files.
+
+    Prefers known representative names (segmentation overlay, NMF/PCA summary
+    grid, fit-review plot); falls back to the first image. Returns a path or None.
+    """
+    imgs = [str(f) for f in (entry.get("files_produced") or [])
+            if Path(str(f)).suffix.lower() in _FIGURE_EXTS and Path(str(f)).exists()]
+    if not imgs:
+        return None
+    for pat in ("summary_grid", "visualization", "overlay", "review", "fit", "map"):
+        for f in imgs:
+            if pat in Path(f).name.lower():
+                return f
+    return imgs[0]
+
+
+def _load_figure_part(path: str) -> Optional[dict]:
+    """Load an image, downscale for the fusion call, return a {mime_type,data} part."""
+    try:
+        from PIL import Image
+        im = Image.open(path)
+        if im.mode not in ("RGB", "L"):
+            im = im.convert("RGB")
+        if max(im.size) > _FUSION_FIG_MAX_DIM:
+            im.thumbnail((_FUSION_FIG_MAX_DIM, _FUSION_FIG_MAX_DIM))
+        buf = io.BytesIO()
+        im.save(buf, format="PNG")
+        return {"mime_type": "image/png", "data": buf.getvalue()}
+    except Exception:  # noqa: BLE001 - a bad figure must not break fusion
+        return None
+
+
+def _write_fusion_html(out_dir: Path, fused: dict, figures: list) -> Optional[Path]:
+    """Write a self-contained HTML fusion report (narrative + claims + the
+    per-dataset figures inline as base64). ``figures`` is a list of
+    ``(label, png_bytes)``. Returns the path, or None on failure."""
+    import html as _html
+    import base64
+    try:
+        claims_html = "".join(
+            f"<li><b>{_html.escape(str(c.get('claim', '')))}</b>"
+            f"<div class='imp'>{_html.escape(str(c.get('scientific_impact', '')))}</div></li>"
+            for c in (fused.get("scientific_claims") or []) if isinstance(c, dict)
+        ) or "<li>(none)</li>"
+        caveats = [str(c) for c in (fused.get("caveats") or []) if str(c).strip()]
+        caveats_html = (
+            "<h2>Caveats &amp; limitations</h2><ul class='cav'>"
+            + "".join(f"<li>{_html.escape(c)}</li>" for c in caveats) + "</ul>"
+        ) if caveats else ""
+        figs_html = "".join(
+            f"<div class='fig'><h3>{_html.escape(str(lbl))}</h3>"
+            f"<img src='data:image/png;base64,{base64.b64encode(b).decode()}'></div>"
+            for lbl, b in figures
+        ) or "<p>(no figures available)</p>"
+        focus_html = (f"<p><b>Focus:</b> {_html.escape(str(fused.get('focus')))}</p>"
+                      if fused.get("focus") else "")
+        doc = f"""<!doctype html><html><head><meta charset="utf-8">
+<title>Cross-dataset fusion</title><style>
+ body{{font-family:-apple-system,Segoe UI,Roboto,sans-serif;max-width:920px;
+   margin:24px auto;padding:0 18px;color:#1b1b1b;line-height:1.6}}
+ h1{{font-size:1.5em}} h2{{margin-top:1.4em;border-bottom:1px solid #e3e3e3;padding-bottom:4px}}
+ .narr{{white-space:pre-wrap;background:#fafafa;border:1px solid #eee;border-radius:8px;padding:14px 16px}}
+ .imp{{color:#555;font-size:.9em;margin:2px 0 10px}}
+ .fig{{margin:14px 0}} .fig img{{max-width:100%;border:1px solid #ddd;border-radius:8px}}
+ ol{{padding-left:20px}} li{{margin-bottom:6px}}
+ .cav{{background:#fff8f0;border:1px solid #f0e0c8;border-radius:8px;padding:10px 16px 10px 32px}}
+ .cav li{{color:#6b4e1a}}
+</style></head><body>
+<h1>🔀 Cross-dataset fusion</h1>
+<p><b>Datasets:</b> {_html.escape(", ".join(str(l) for l in (fused.get("labels") or [])))}</p>
+{focus_html}
+<h2>Reconciled interpretation</h2>
+<div class="narr">{_html.escape(str(fused.get("detailed_analysis", "")))}</div>
+<h2>Synthesized claims</h2><ol>{claims_html}</ol>
+{caveats_html}
+<h2>Source figures (one per dataset)</h2>{figs_html}
+</body></html>"""
+        path = out_dir / "fusion_report.html"
+        path.write_text(doc, encoding="utf-8")
+        return path
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"could not write fusion HTML report: {e}")
+        return None
+
+
 def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> str:
     """Reconcile finished branch findings into one cross-dataset narrative.
 
@@ -609,14 +705,37 @@ def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> s
             f"Key findings:\n{findings_str}"
         )
 
+    # One representative figure per branch — attached to the (multimodal) fusion
+    # call so spatial correlations can be verified from the actual plots, not
+    # only the text. Also embedded in the HTML report. Best-effort: a missing or
+    # bad figure just drops that branch's image.
+    figures = []          # (label, png_bytes) for the HTML report
+    image_parts = []      # interleaved label-strings + image dicts for the LLM
+    for e in ok:
+        fpath = _branch_key_figure(e)
+        part = _load_figure_part(fpath) if fpath else None
+        if part:
+            label = e.get("label") or f"delegation {e['index']}"
+            figures.append((label, part["data"]))
+            image_parts.append(f"\n[Figure — {label}]:")
+            image_parts.append(part)
+
     prompt = (
         HOLISTIC_EXPERIMENTAL_SYNTHESIS_INSTRUCTIONS
         + (f"\n\nFUSION FOCUS (weight your synthesis toward this): {focus}\n"
            if focus else "")
+        + ("\n\nFIGURES: one representative figure per dataset is attached after "
+           "this text, labeled by dataset. Use them to verify spatial/visual "
+           "correlations DIRECTLY rather than relying on the text descriptions "
+           "alone.\n" if image_parts else "")
         + "\n\n--- PER-DATASET FINDINGS TO RECONCILE ---\n\n"
         + "\n\n".join(blocks)
     )
-    parsed = _llm_json(orch, prompt)
+    parsed = _llm_json(orch, prompt, extra_parts=image_parts or None)
+    if parsed is None and image_parts:
+        # Multimodal call failed — fall back to a text-only fusion.
+        logger.warning("fusion with figures failed; retrying text-only")
+        parsed = _llm_json(orch, prompt)
     if not parsed or "detailed_analysis" not in parsed:
         return json.dumps({"status": "error",
                            "message": "Fusion synthesis did not return a usable result."})
@@ -634,12 +753,17 @@ def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> s
         "focus": focus,
         "detailed_analysis": parsed.get("detailed_analysis", ""),
         "scientific_claims": parsed.get("scientific_claims", []),
+        "caveats": parsed.get("caveats", []),
     }
     try:
         with open(report_path, "w") as fh:
             json.dump(fused, fh, indent=2, default=str)
     except Exception as e:  # noqa: BLE001
         logger.warning(f"could not write fusion report: {e}")
+
+    # Human-facing HTML report: narrative + claims + the per-dataset figures.
+    html_path = _write_fusion_html(out_dir, fused, figures)
+    produced = [str(report_path)] + ([str(html_path)] if html_path else [])
 
     with orch._fanout_lock:
         orch._delegation_ledger.append({
@@ -653,7 +777,7 @@ def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> s
             "summary": parsed.get("detailed_analysis", ""),
             "key_findings": [c.get("claim", "") for c in parsed.get("scientific_claims", [])
                              if isinstance(c, dict)],
-            "files_produced": [str(report_path)],
+            "files_produced": produced,
             "warnings": [],
             "error": None,
         })
@@ -661,7 +785,10 @@ def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> s
     return json.dumps({
         "status": "success",
         "fused_from": [e["index"] for e in ok],
+        "figures_used": len(figures),
         "detailed_analysis": parsed.get("detailed_analysis", ""),
         "scientific_claims": parsed.get("scientific_claims", []),
+        "caveats": parsed.get("caveats", []),
         "report_path": str(report_path),
+        "report_html_path": str(html_path) if html_path else None,
     }, indent=2, default=str)

--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -512,6 +512,10 @@ def run_fanout(orch, branches: List[dict]) -> str:
                 "analysis", _mesh_task(b, []), b.get("context"), None, b["label"])
             entry["parallel_group"] = group_id
             entry["fanout"] = True
+            # Carry the input path/metadata so a later fuse_delegations can
+            # recognize this set as already gated (or re-gate a mixed set).
+            entry["data_path"] = b.get("data_path")
+            entry["metadata"] = b.get("metadata")
             entries.append(entry)
 
     # --- run concurrently; each branch sees all others (full mesh) ---
@@ -784,6 +788,39 @@ def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> s
                         f"Got {len(ok)} usable of {len(idxs)} requested."),
         })
 
+    # Honesty guard (review #293): fusion has no complementarity gate of its
+    # own — only run_fanout gates before launching branches. Branches of a
+    # single fan-out group were verified complementary at launch; ANY other
+    # fused set (notably two direct delegate_to_analysis runs on unrelated
+    # data) was NOT, and could manufacture a spurious "they agree" conclusion.
+    # Recognize already-gated sets; for the rest, re-run the gate when dataset
+    # paths are available, else mark the fusion ungated so the synthesis prompt
+    # and the report state it explicitly. We never hard-refuse (a caller may
+    # deliberately want a caveated comparison) — we just refuse to do it
+    # silently.
+    _groups = {e.get("parallel_group") for e in ok}
+    gated = (all(e.get("fanout") for e in ok)
+             and len(_groups) == 1 and None not in _groups)
+    ungated_warning = None
+    if not gated:
+        _paths = [e.get("data_path") for e in ok]
+        if all(_paths) and len(set(_paths)) >= 2:
+            _verdict = assess_complementarity(
+                orch, [{"path": e.get("data_path"), "metadata": e.get("metadata")}
+                       for e in ok])
+            _v = (_verdict.get("verdict") or "").lower()
+            gated = _v == "complementary"
+            if not gated:
+                ungated_warning = (
+                    f"These datasets were assessed NOT complementary (verdict: {_v}; "
+                    f"{_verdict.get('rationale') or 'no shared system/join axis'}). "
+                    "Any apparent agreement across them is likely spurious.")
+        else:
+            ungated_warning = (
+                "This fusion was NOT complementarity-gated and the datasets could "
+                "not be verified as measuring the same system. Treat any "
+                "cross-dataset agreement as unverified and possibly spurious.")
+
     blocks = []
     for e in ok:
         findings = e.get("key_findings") or []
@@ -812,6 +849,11 @@ def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> s
 
     prompt = (
         HOLISTIC_EXPERIMENTAL_SYNTHESIS_INSTRUCTIONS
+        + (f"\n\n⚠️ UNGATED FUSION — {ungated_warning} Do NOT claim the datasets "
+           "agree or correlate unless the evidence is overwhelming and explicit; "
+           "default to reporting them as independent observations and say plainly "
+           "that complementarity was not verified.\n"
+           if ungated_warning else "")
         + (f"\n\nFUSION FOCUS (weight your synthesis toward this): {focus}\n"
            if focus else "")
         + ("\n\nFIGURES: one representative figure per dataset is attached after "
@@ -860,9 +902,14 @@ def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> s
         "fused_from": [e["index"] for e in ok],
         "labels": [e.get("label") for e in ok],
         "focus": focus,
-        "detailed_analysis": parsed.get("detailed_analysis", ""),
+        "complementarity_gated": gated,
+        "complementarity_warning": ungated_warning,
+        "detailed_analysis": (
+            (f"⚠️ UNGATED FUSION — {ungated_warning}\n\n" if ungated_warning else "")
+            + parsed.get("detailed_analysis", "")),
         "scientific_claims": parsed.get("scientific_claims", []),
-        "caveats": parsed.get("caveats", []),
+        "caveats": (([ungated_warning] if ungated_warning else [])
+                    + (parsed.get("caveats", []) or [])),
         "novelty": novelty,
     }
     try:
@@ -884,21 +931,23 @@ def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> s
             "label": "cross-dataset fusion",
             "context_from": [e["index"] for e in ok],
             "status": "success",
-            "summary": parsed.get("detailed_analysis", ""),
+            "summary": fused["detailed_analysis"],
             "key_findings": [c.get("claim", "") for c in parsed.get("scientific_claims", [])
                              if isinstance(c, dict)],
             "files_produced": produced,
-            "warnings": [],
+            "warnings": ([ungated_warning] if ungated_warning else []),
             "error": None,
         })
 
     return json.dumps({
         "status": "success",
         "fused_from": [e["index"] for e in ok],
+        "complementarity_gated": gated,
+        "complementarity_warning": ungated_warning,
         "figures_used": len(figures),
-        "detailed_analysis": parsed.get("detailed_analysis", ""),
-        "scientific_claims": parsed.get("scientific_claims", []),
-        "caveats": parsed.get("caveats", []),
+        "detailed_analysis": fused["detailed_analysis"],
+        "scientific_claims": fused["scientific_claims"],
+        "caveats": fused["caveats"],
         "novelty": novelty,
         "report_path": str(report_path),
         "report_html_path": str(html_path) if html_path else None,

--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -1,0 +1,677 @@
+"""Parallel multi-dataset analysis (fan-out) + complementarity gating + fusion.
+
+See CLAUDE.md "The meta agent". This is the meta's **fan-out primitive**: run
+several analysis branches concurrently over GENUINELY COMPLEMENTARY datasets —
+each branch sees the others as full-mesh auxiliary operands — then fuse their
+findings into one cross-dataset narrative.
+
+Two guards bracket the fan-out, because the failure mode here is not a crash
+but a *plausible fabrication*:
+
+1. **Entry gate (complementarity).** Before any branch launches, the datasets
+   are assessed and PARTITIONED. The fan-out runs only over the complementary
+   subset that shares a join axis; redundant duplicates and unrelated outliers
+   are pruned out. Forcing the fusion template over unrelated data would
+   manufacture a correlation that isn't there — the gate is what prevents that.
+2. **Exit guard (anti-spurious-fusion).** Even on a clean gate, the fusion
+   prompt states that "no correlation found" is a valid, valuable conclusion,
+   so the synthesis reconciles the evidence rather than inventing a link.
+
+Branches run AUTONOMOUS regardless of the meta's mode: concurrent `input()`
+human-feedback prompts cannot interleave across threads, so a parallel branch
+cannot pause for approval. The single up-front user confirmation (AUTOPILOT)
+compensates for the per-branch approval the user would otherwise get.
+
+The logic lives here as free functions taking the orchestrator instance; thin
+``MetaOrchestratorAgent`` methods wrap them, matching how ``telemetry.py`` is a
+sibling helper to the orchestrator.
+"""
+
+import json
+import logging
+import re
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("meta_agent.fanout")
+
+# Concurrency + sizing. The complementary SET (post-gate) is what these bound,
+# not the raw input: the gate prunes first, so a 6-upload request with one
+# complementary pair runs a 2-way mesh, not a 6-way one.
+FANOUT_MAX_WORKERS = 4          # peak concurrent branches (rate-limit ceiling)
+FANOUT_SOFT_CAP = 5             # warn / confirm beyond this many fused branches
+FANOUT_HARD_CAP = 8             # refuse beyond this — cost/quality cliff
+# In AUTONOMOUS mode there is no human to confirm, so the verdict IS the gate:
+# proceed only on a confident 'complementary' read.
+AUTONOMOUS_CONFIDENCE_THRESHOLD = 0.6
+
+
+# ======================================================================
+# Complementarity gate
+# ======================================================================
+
+COMPLEMENTARITY_ASSESSMENT_INSTRUCTIONS = """You are a measurement scientist deciding whether several datasets are \
+GENUINELY COMPLEMENTARY — i.e. whether fusing their analyses into one \
+cross-dataset narrative is scientifically meaningful, or would instead \
+manufacture a correlation that the data do not support.
+
+Datasets are complementary only when ALL THREE hold:
+1. SAME SUBJECT — they measure the same physical system / sample / region.
+2. NON-REDUNDANT — they carry different information (different modality, \
+observable, or condition); two measurements of the same thing the same way \
+are redundant, not complementary.
+3. JOINABLE — a concrete axis exists to reconcile them ON: spatial \
+co-registration, a shared energy/time/parameter axis, or a shared \
+sample/condition. A join does NOT require pixel-level co-registration: \
+reconciling one modality's spatially-resolved or local measurement against \
+another's bulk / area-averaged measurement of the SAME sample (e.g. microscopy \
+phase fractions vs XPS/XRD/EDX composition) is itself a valid join — this \
+bulk-vs-local reconciliation is a canonical multimodal case, not a \
+manufactured correlation. Without any join there is nothing to fuse.
+
+Partition the datasets accordingly. Put into `fanout_set` ONLY a subset that \
+is mutually complementary on all three criteria and shares ONE join axis \
+(>= 2 members to be worth running in parallel). Cluster exact-duplicate / \
+same-information datasets in `redundant_clusters`. List datasets that belong \
+to a different system or have no join axis in `unrelated`.
+
+Be conservative: if you are not confident the datasets share a system and a \
+join axis, prefer `uncertain` over `complementary`. A wrong `complementary` \
+call produces a fabricated cross-dataset claim, which is worse than declining.
+
+Respond in valid JSON with EXACTLY these keys:
+{
+  "verdict": "complementary" | "partially_complementary" | "redundant" | "unrelated" | "uncertain",
+  "confidence": <float 0..1>,
+  "rationale": "<one or two sentences: what the datasets are and why this verdict>",
+  "join_axis": "<the shared axis the fanout_set reconciles on, or null>",
+  "fanout_set": ["<path>", ...],
+  "redundant_clusters": [["<path>", "<path>"], ...],
+  "unrelated": ["<path>", ...],
+  "excluded_notes": "<why anything was left out of fanout_set, or empty>"
+}
+"""
+
+_ANTI_SPURIOUS_FUSION_GUARD = """
+IMPORTANT — do not manufacture correlations. These datasets were screened as \
+plausibly complementary, but the evidence is the final authority. If the \
+findings do NOT actually correlate or reconcile, say so plainly: "no \
+significant cross-dataset correlation found" is a valid and valuable \
+conclusion. Assert a correlation ONLY where the provided findings support it; \
+never invent one to satisfy the synthesis.
+"""
+
+
+def _slug(text: str, maxlen: int = 32) -> str:
+    """Filesystem-safe short slug from a label."""
+    s = re.sub(r"[^a-zA-Z0-9]+", "_", (text or "").strip().lower()).strip("_")
+    return (s[:maxlen] or "branch")
+
+
+_LLM_JSON_ATTEMPTS = 3
+
+
+def _structured_model(orch):
+    """A TOOL-FREE generative model for the gate/fusion JSON calls.
+
+    The meta's chat model is built WITH the delegation tool schemas, so a
+    structured-output prompt about datasets intermittently comes back as an
+    attempted tool-call with empty text instead of the JSON we asked for.
+    A dedicated tool-less model (same provider routing / credentials) removes
+    that failure mode. Cached on the orchestrator.
+    """
+    m = getattr(orch, "_fanout_structured_model", None)
+    if m is not None:
+        return m
+    if orch.base_url:
+        from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
+        m = OpenAIAsGenerativeModel(
+            model=orch.model_name, api_key=orch.api_key, base_url=orch.base_url)
+    else:
+        from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
+        m = LiteLLMGenerativeModel(
+            model=orch.model_name, api_key=orch.api_key,
+            system_instruction="You output only valid JSON exactly as instructed.",
+            tools=None)
+    orch._fanout_structured_model = m
+    return m
+
+
+def _parse_json_block(text: str) -> Optional[dict]:
+    """Parse a JSON object from raw model text — tolerant of ```json fences and
+    surrounding prose (falls back to the first balanced ``{...}``)."""
+    if not text:
+        return None
+    fenced = re.search(r"```(?:json)?\s*(.*?)```", text, re.DOTALL)
+    candidate = fenced.group(1) if fenced else text
+    try:
+        return json.loads(candidate)
+    except Exception:  # noqa: BLE001 - fall back to first balanced {...}
+        m = re.search(r"\{.*\}", candidate, re.DOTALL)
+        if not m:
+            return None
+        try:
+            return json.loads(m.group(0))
+        except Exception:  # noqa: BLE001
+            return None
+
+
+def _llm_json(orch, prompt: str) -> Optional[dict]:
+    """LLM call returning parsed JSON, or None after retries.
+
+    Retries on an empty completion or an unparseable body — Bedrock
+    intermittently returns an empty content block, and silently fail-closing
+    the gate on that transient would wrongly decline a complementary set.
+    Only a persistent failure returns None (which callers fail closed on).
+    """
+    model = _structured_model(orch)
+    for attempt in range(_LLM_JSON_ATTEMPTS):
+        try:
+            resp = model.generate_content(contents=[prompt])
+            text = resp.text if hasattr(resp, "text") else str(resp)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"complementarity/fusion LLM call failed "
+                           f"(attempt {attempt + 1}): {e}")
+            continue
+        parsed = _parse_json_block(text)
+        if parsed is not None:
+            return parsed
+        logger.warning("complementarity/fusion LLM returned "
+                       f"{'empty' if not text else 'unparseable'} response "
+                       f"(attempt {attempt + 1}/{_LLM_JSON_ATTEMPTS}); retrying")
+    return None
+
+
+def _dataset_descriptor(path: str, role: Optional[str],
+                        metadata: Optional[str]) -> dict:
+    """Lightweight, router-tier descriptor of one dataset for the gate.
+
+    Reuses the meta's content probe (shape/dtype, table columns, document /
+    image dims) — the same evidence the meta routes on — plus any user-stated
+    role and metadata. Deliberately does NOT load full arrays: the gate is a
+    judgement over descriptors, consistent with the meta being a router.
+    """
+    from .meta_orchestrator_tools import _probe_file
+
+    p = Path(path)
+    desc: Dict[str, Any] = {"path": str(path)}
+    if not p.exists():
+        desc["note"] = "file not found"
+        return desc
+    try:
+        desc["probe"] = _probe_file(p)
+    except Exception as e:  # noqa: BLE001 - probe must not break the gate
+        desc["note"] = f"probe failed: {e}"
+    if role:
+        desc["stated_role"] = role
+    if metadata:
+        mp = Path(metadata)
+        if mp.exists() and mp.suffix.lower() == ".json":
+            try:
+                with open(mp, "r", errors="replace") as fh:
+                    desc["metadata"] = json.load(fh)
+            except Exception:  # noqa: BLE001
+                desc["metadata"] = str(metadata)
+        else:
+            desc["metadata"] = str(metadata)
+    return desc
+
+
+def assess_complementarity(orch, datasets: List[dict]) -> dict:
+    """Partition datasets into complementary / redundant / unrelated.
+
+    `datasets` is a list of ``{"path", "role"?, "metadata"?}``. Returns the
+    verdict dict (see COMPLEMENTARITY_ASSESSMENT_INSTRUCTIONS). Cached on the
+    orchestrator by the frozenset of paths so the standalone tool and the
+    internal gate in run_fanout don't double-spend the LLM call.
+    """
+    paths = [d.get("path") for d in datasets if d.get("path")]
+    if len(paths) < 2:
+        return {"verdict": "uncertain", "confidence": 0.0,
+                "rationale": "Need at least two datasets to assess complementarity.",
+                "join_axis": None, "fanout_set": [], "redundant_clusters": [],
+                "unrelated": list(paths), "excluded_notes": ""}
+
+    key = frozenset(paths)
+    cached = orch._complementarity_cache.get(key)
+    if cached is not None:
+        return cached
+
+    descriptors = [
+        _dataset_descriptor(d["path"], d.get("role"), d.get("metadata"))
+        for d in datasets if d.get("path")
+    ]
+    prompt = (
+        COMPLEMENTARITY_ASSESSMENT_INSTRUCTIONS
+        + "\n\n--- DATASETS ---\n"
+        + json.dumps(descriptors, indent=2, default=str)
+    )
+    verdict = _llm_json(orch, prompt)
+    if not verdict or "verdict" not in verdict:
+        # Fail closed: an unparseable assessment must not green-light a fusion.
+        verdict = {
+            "verdict": "uncertain", "confidence": 0.0,
+            "rationale": "Complementarity assessment did not return a usable verdict.",
+            "join_axis": None, "fanout_set": [], "redundant_clusters": [],
+            "unrelated": list(paths), "excluded_notes": "",
+        }
+    # Constrain the model's fanout_set to the actually-requested paths.
+    requested = set(paths)
+    verdict["fanout_set"] = [p for p in (verdict.get("fanout_set") or [])
+                             if p in requested]
+    # Defensive: a clearly-negative verdict must never carry a runnable set,
+    # even if the model inconsistently populated one — it means "do not fuse".
+    if (verdict.get("verdict") or "").lower() in ("unrelated", "redundant"):
+        verdict["fanout_set"] = []
+    orch._complementarity_cache[key] = verdict
+    return verdict
+
+
+# ======================================================================
+# Confirmation
+# ======================================================================
+
+def _confirm_fanout(orch, verdict: dict, fanout_set: List[str],
+                    branches_by_path: Dict[str, dict]) -> tuple:
+    """Decide whether to fire the fan-out. Returns (proceed: bool, reason: str).
+
+    AUTOPILOT (human attached): show the verdict + the exact plan and ask the
+    user to confirm. AUTONOMOUS (no human): the verdict is the gate — proceed
+    only on a confident 'complementary' read within the soft cap.
+    """
+    n = len(fanout_set)
+    n_aux = n * (n - 1)  # full-mesh: each branch sees the other n-1
+
+    if n > FANOUT_HARD_CAP:
+        return False, (f"Complementary set has {n} datasets (> hard cap "
+                       f"{FANOUT_HARD_CAP}); refuse to fan out. Run them in "
+                       "smaller complementary groups.")
+
+    if not orch._enable_human_feedback:
+        # AUTONOMOUS: verdict-gated, conservative.
+        v = (verdict.get("verdict") or "").lower()
+        conf = float(verdict.get("confidence") or 0.0)
+        if v != "complementary" or conf < AUTONOMOUS_CONFIDENCE_THRESHOLD:
+            return False, (f"Autonomous mode declines fan-out: verdict='{v}' "
+                           f"confidence={conf:.2f} (needs 'complementary' >= "
+                           f"{AUTONOMOUS_CONFIDENCE_THRESHOLD}). "
+                           f"{verdict.get('rationale', '')}")
+        if n > FANOUT_SOFT_CAP:
+            return False, (f"Autonomous mode declines a {n}-way mesh (> soft cap "
+                           f"{FANOUT_SOFT_CAP}); too expensive to fire unattended.")
+        return True, "autonomous: confident complementary verdict"
+
+    # AUTOPILOT: informed human confirmation.
+    lines = [
+        "",
+        "=" * 78,
+        "🔀 PARALLEL MULTI-DATASET ANALYSIS — confirm before launching",
+        "=" * 78,
+        f"  Complementarity verdict : {verdict.get('verdict')} "
+        f"(confidence {verdict.get('confidence')})",
+        f"  Join axis               : {verdict.get('join_axis')}",
+        f"  Rationale               : {verdict.get('rationale')}",
+        "",
+        f"  Will run {n} branches concurrently, full-mesh "
+        f"(~{n_aux} auxiliary loads):",
+    ]
+    for path in fanout_set:
+        b = branches_by_path.get(path, {})
+        lines.append(f"    • {b.get('label') or _slug(Path(path).name)}  ({Path(path).name})")
+    if verdict.get("redundant_clusters"):
+        lines.append(f"  Pruned as redundant     : {verdict['redundant_clusters']}")
+    if verdict.get("unrelated"):
+        lines.append(f"  Pruned as unrelated     : {verdict['unrelated']}")
+    if n > FANOUT_SOFT_CAP:
+        lines.append(f"  ⚠️  {n}-way mesh exceeds the soft cap ({FANOUT_SOFT_CAP}) "
+                     "— this is expensive.")
+    lines.append("  Branches run AUTONOMOUSLY (no per-branch approval pauses).")
+    lines.append("=" * 78)
+    print("\n".join(lines))
+
+    try:
+        ans = input("\n🤔 Launch this parallel analysis? [y/N]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        # No usable input channel in a mode that expects one → do not fire an
+        # expensive parallel op on a guess.
+        return False, "no confirmation received (declined)"
+    if ans in ("y", "yes"):
+        return True, "user confirmed"
+    return False, "user declined"
+
+
+# ======================================================================
+# Branch execution
+# ======================================================================
+
+def _make_ephemeral_analysis_child(orch, base_dir: Path):
+    """Build an isolated, one-shot analysis orchestrator for one branch.
+
+    NOT registered in ``orch._children`` — these are ephemeral fan-out workers,
+    not the persistent singleton, so they share no mutable state across threads
+    and are never restored. Resting mode AUTONOMOUS; run_task pins it per call.
+    """
+    from ..exp_agents.analysis_orchestrator import (
+        AnalysisOrchestratorAgent, AnalysisMode,
+    )
+    base_dir.mkdir(parents=True, exist_ok=True)
+    child = AnalysisOrchestratorAgent(
+        base_dir=str(base_dir),
+        api_key=orch.api_key,
+        model_name=orch.model_name,
+        base_url=orch.base_url,
+        embedding_model=orch.embedding_model,
+        embedding_api_key=orch.embedding_api_key,
+        futurehouse_api_key=orch.futurehouse_api_key,
+        restore_checkpoint=False,
+        analysis_mode=AnalysisMode.AUTONOMOUS,
+    )
+    child._agent_label = "Analysis branch"
+    # Share skills / custom tools / MCP servers registered on the meta.
+    orch._propagate_extensions_to_child(child)
+    return child
+
+
+def _mesh_task(branch: dict, companions: List[dict]) -> str:
+    """Compose a branch's self-contained task with its full-mesh companions.
+
+    Companions are named as auxiliary datasets with distinct labels so the
+    specialist passes them through ``run_analysis``'s ``auxiliary_data`` /
+    ``auxiliary_label`` — the existing operand path — and the codegen may use
+    a shape-aligned companion numerically (correlate / mask / normalize).
+    """
+    task = branch["task"].rstrip()
+    block = []
+    if companions:
+        block += ["", "",
+                  f"PRIMARY dataset for THIS analysis: {branch['data_path']} — pass "
+                  "it as run_analysis's `data_path`. The companion(s) below are "
+                  "AUXILIARY ONLY; do NOT analyze a companion as the primary."]
+    # Forward the caller-supplied metadata so the branch USES it rather than
+    # synthesizing metadata from the task prose (which loses technique-specific
+    # fields the downstream skill needs, e.g. the EELS energy axis).
+    meta = branch.get("metadata")
+    if meta:
+        mp = Path(str(meta))
+        if mp.exists() and mp.suffix.lower() == ".json":
+            block += ["", f"Metadata for the primary dataset is at {mp} — call "
+                          "`load_metadata` on this path before `run_analysis`; do "
+                          "NOT synthesize metadata when this file is provided."]
+        else:
+            block += ["", f"Metadata for the primary dataset: {meta}"]
+    if companions:
+        block += ["",
+                  "COMPANION DATASETS (complementary measurements of the SAME "
+                  "system — pass each as auxiliary_data with the given label so your "
+                  "generated code may correlate/mask/normalize against it where the "
+                  "method benefits; they are optional operands, never required):"]
+        for c in companions:
+            block.append(f"  - auxiliary_data: {c['data_path']}  "
+                         f"(auxiliary_label: '{c['label']}')")
+    if not block:
+        return task
+    return task + "\n".join(block)
+
+
+def _run_one_branch(orch, branch: dict, companions: List[dict],
+                    entry: dict) -> None:
+    """Execute a single fan-out branch into its preallocated ledger slot.
+
+    Each worker touches ONLY its own ``entry`` dict, so there is no shared
+    mutation across threads. Never raises — failures are captured into the
+    ledger slot like ``_delegate`` does.
+    """
+    index = entry["index"]
+    slug = _slug(branch.get("label") or Path(branch["data_path"]).stem)
+    base_dir = orch.fanout_dir / f"{index:02d}_{slug}"
+    try:
+        from ..exp_agents.analysis_orchestrator import AnalysisMode
+        child = _make_ephemeral_analysis_child(orch, base_dir)
+        result = child.run_task(
+            _mesh_task(branch, companions),
+            context=branch.get("context"),
+            autonomy=AnalysisMode.AUTONOMOUS,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.exception(f"fan-out branch {index} failed: {e}")
+        result = {"status": "error", "error": str(e), "summary": "",
+                  "key_findings": [], "files_produced": [],
+                  "suggested_followups": [], "warnings": []}
+    orch._close_delegation(entry, result)
+
+
+def run_fanout(orch, branches: List[dict]) -> str:
+    """Gate → confirm → run branches concurrently (full-mesh aux). Returns JSON.
+
+    `branches` is a list of ``{"data_path", "task", "label", "metadata"?,
+    "context"?}``. The complementarity gate prunes to the complementary subset;
+    only that subset runs, each branch seeing the others as auxiliary operands.
+    """
+    # --- normalize input ---
+    norm: List[dict] = []
+    for b in (branches or []):
+        if not isinstance(b, dict):
+            continue
+        dp, task = b.get("data_path"), b.get("task")
+        if not dp or not task:
+            continue
+        norm.append({
+            "data_path": dp, "task": task,
+            "label": (b.get("label") or Path(dp).stem),
+            "metadata": b.get("metadata"), "context": b.get("context"),
+        })
+    if len(norm) < 2:
+        return json.dumps({"status": "error",
+                           "message": "Fan-out needs at least two branches, each "
+                                      "with a data_path and a task."})
+
+    by_path = {b["data_path"]: b for b in norm}
+
+    # --- entry gate (reuses cached verdict if assess_complementarity ran) ---
+    datasets = [{"path": b["data_path"], "metadata": b.get("metadata")}
+                for b in norm]
+    verdict = assess_complementarity(orch, datasets)
+    fanout_set = [p for p in (verdict.get("fanout_set") or []) if p in by_path]
+
+    if len(fanout_set) < 2:
+        return json.dumps({
+            "status": "declined",
+            "reason": "not_complementary",
+            "verdict": verdict,
+            "message": (
+                "The datasets are not genuinely complementary (no 2+ that share "
+                "a system and a join axis), so a parallel cross-analysis with "
+                "fusion was NOT run. Consider analyzing them independently via "
+                "delegate_to_analysis, or one with the other as a plain "
+                "auxiliary. See the verdict for redundant/unrelated groupings."
+            ),
+        }, indent=2, default=str)
+
+    # --- confirmation ---
+    proceed, reason = _confirm_fanout(orch, verdict, fanout_set, by_path)
+    if not proceed:
+        return json.dumps({"status": "declined", "reason": reason,
+                           "verdict": verdict,
+                           "fanout_set": fanout_set}, indent=2, default=str)
+
+    # --- preallocate ledger slots (sequential, under lock — no concurrent append) ---
+    run_branches = [by_path[p] for p in fanout_set]
+    with orch._fanout_lock:
+        entries = []
+        group_id = f"fanout_{len(orch._delegation_ledger) + 1}"
+        for b in run_branches:
+            entry = orch._open_delegation(
+                "analysis", _mesh_task(b, []), b.get("context"), None, b["label"])
+            entry["parallel_group"] = group_id
+            entry["fanout"] = True
+            entries.append(entry)
+
+    # --- run concurrently; each branch sees all others (full mesh) ---
+    print(f"  🔀 Launching {len(run_branches)} parallel analysis branches "
+          f"(group {group_id}, full-mesh aux)...")
+
+    def _companions_for(i):
+        return [{"data_path": run_branches[j]["data_path"],
+                 "label": f"companion_{_slug(run_branches[j]['label'])}"}
+                for j in range(len(run_branches)) if j != i]
+
+    max_workers = min(len(run_branches), FANOUT_MAX_WORKERS)
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = [
+            pool.submit(_run_one_branch, orch, run_branches[i],
+                        _companions_for(i), entries[i])
+            for i in range(len(run_branches))
+        ]
+        for f in futures:
+            f.result()  # _run_one_branch never raises; this just joins
+
+    def _productive(e):
+        # A branch that reports success but yields neither findings nor files
+        # did no usable work (e.g. codegen aborted with no sandbox). Mirrors the
+        # 'empty_but_successful' guard in _summarize_delegation_result.
+        return (e.get("status") == "success"
+                and (bool(e.get("key_findings")) or bool(e.get("files_produced"))))
+
+    results = [{
+        "delegation_index": e["index"],
+        "label": e["label"],
+        "status": e.get("status"),
+        "produced_output": _productive(e),
+        "key_findings": e.get("key_findings", []),
+        "files_produced": e.get("files_produced", []),
+    } for e in entries]
+    productive = [r for r in results if r["produced_output"]]
+    # A branch is "degraded" if it produced no usable output — whether it
+    # hard-errored or reported success with empty findings/files (e.g. codegen
+    # could not run). Either way the meta must not treat it as a completed
+    # analysis or fuse it.
+    degraded = [r for r in results if not r["produced_output"]]
+
+    out = {
+        "status": "success",
+        "parallel_group": group_id,
+        "join_axis": verdict.get("join_axis"),
+        "branches_run": len(results),
+        "branches_with_output": len(productive),
+        "results": results,
+        "next_step": (
+            "Call fuse_delegations with delegation_indices="
+            f"{[r['delegation_index'] for r in productive]} to reconcile these "
+            "complementary findings into one cross-dataset interpretation."
+            if len(productive) >= 2 else
+            "Fewer than two branches produced usable output — report what ran "
+            "to the user; do NOT fuse empty branches into a synthesis."
+        ),
+    }
+    if degraded:
+        n_err = sum(1 for r in degraded if r["status"] != "success")
+        out["warning"] = (
+            f"{len(degraded)} branch(es) produced no usable output "
+            f"({n_err} errored, {len(degraded) - n_err} succeeded-but-empty, "
+            "e.g. analysis code could not execute). Do not treat these as "
+            "completed analyses or fuse them; report the gap to the user."
+        )
+    return json.dumps(out, indent=2, default=str)
+
+
+# ======================================================================
+# Fusion
+# ======================================================================
+
+def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> str:
+    """Reconcile finished branch findings into one cross-dataset narrative.
+
+    Reuses the HOLISTIC multi-modal synthesis template with the
+    anti-spurious-correlation guard so "no correlation found" is a valid
+    outcome. Reads each branch's findings from its ledger entry (summary +
+    key_findings). Records itself as a ``mode="fusion"`` ledger entry.
+    """
+    from ..exp_agents.instruct import HOLISTIC_EXPERIMENTAL_SYNTHESIS_INSTRUCTIONS
+
+    ledger = orch._delegation_ledger
+    by_index = {e["index"]: e for e in ledger}
+    try:
+        idxs = sorted({int(i) for i in (indices or [])})
+    except (TypeError, ValueError):
+        return json.dumps({"status": "error",
+                           "message": "delegation_indices must be integers."})
+    entries = [by_index[i] for i in idxs if i in by_index]
+    ok = [e for e in entries if e.get("status") == "success"
+          and (e.get("key_findings") or (e.get("summary") or "").strip())]
+    if len(ok) < 2:
+        return json.dumps({
+            "status": "error",
+            "message": ("Need >= 2 successful delegations with findings to fuse. "
+                        f"Got {len(ok)} usable of {len(idxs)} requested."),
+        })
+
+    blocks = []
+    for e in ok:
+        findings = e.get("key_findings") or []
+        findings_str = "\n".join(f"- {k}" for k in findings) if findings else "- (none)"
+        blocks.append(
+            f"### Dataset: {e.get('label') or ('delegation ' + str(e['index']))} "
+            f"(delegation #{e['index']})\n"
+            f"Summary:\n{e.get('summary', '') or '(none)'}\n\n"
+            f"Key findings:\n{findings_str}"
+        )
+
+    prompt = (
+        HOLISTIC_EXPERIMENTAL_SYNTHESIS_INSTRUCTIONS
+        + _ANTI_SPURIOUS_FUSION_GUARD
+        + (f"\n\nFUSION FOCUS (weight your synthesis toward this): {focus}\n"
+           if focus else "")
+        + "\n\n--- PER-DATASET FINDINGS TO RECONCILE ---\n\n"
+        + "\n\n".join(blocks)
+    )
+    parsed = _llm_json(orch, prompt)
+    if not parsed or "detailed_analysis" not in parsed:
+        return json.dumps({"status": "error",
+                           "message": "Fusion synthesis did not return a usable result."})
+
+    # Persist the fused report + record a fusion ledger entry.
+    from datetime import datetime
+    with orch._fanout_lock:
+        fusion_n = sum(1 for e in ledger if e.get("mode") == "fusion") + 1
+    out_dir = orch.fusion_dir / f"{fusion_n:02d}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    report_path = out_dir / "fusion_report.json"
+    fused = {
+        "fused_from": [e["index"] for e in ok],
+        "labels": [e.get("label") for e in ok],
+        "focus": focus,
+        "detailed_analysis": parsed.get("detailed_analysis", ""),
+        "scientific_claims": parsed.get("scientific_claims", []),
+    }
+    try:
+        with open(report_path, "w") as fh:
+            json.dump(fused, fh, indent=2, default=str)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"could not write fusion report: {e}")
+
+    with orch._fanout_lock:
+        orch._delegation_ledger.append({
+            "index": len(orch._delegation_ledger) + 1,
+            "timestamp": datetime.now().isoformat(),
+            "mode": "fusion",
+            "task": f"Fuse delegations {[e['index'] for e in ok]}",
+            "label": "cross-dataset fusion",
+            "context_from": [e["index"] for e in ok],
+            "status": "success",
+            "summary": parsed.get("detailed_analysis", ""),
+            "key_findings": [c.get("claim", "") for c in parsed.get("scientific_claims", [])
+                             if isinstance(c, dict)],
+            "files_produced": [str(report_path)],
+            "warnings": [],
+            "error": None,
+        })
+
+    return json.dumps({
+        "status": "success",
+        "fused_from": [e["index"] for e in ok],
+        "detailed_analysis": parsed.get("detailed_analysis", ""),
+        "scientific_claims": parsed.get("scientific_claims", []),
+        "report_path": str(report_path),
+    }, indent=2, default=str)

--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -94,15 +94,6 @@ Respond in valid JSON with EXACTLY these keys:
 }
 """
 
-_ANTI_SPURIOUS_FUSION_GUARD = """
-IMPORTANT — do not manufacture correlations. These datasets were screened as \
-plausibly complementary, but the evidence is the final authority. If the \
-findings do NOT actually correlate or reconcile, say so plainly: "no \
-significant cross-dataset correlation found" is a valid and valuable \
-conclusion. Assert a correlation ONLY where the provided findings support it; \
-never invent one to satisfy the synthesis.
-"""
-
 
 def _slug(text: str, maxlen: int = 32) -> str:
     """Filesystem-safe short slug from a label."""
@@ -620,7 +611,6 @@ def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> s
 
     prompt = (
         HOLISTIC_EXPERIMENTAL_SYNTHESIS_INSTRUCTIONS
-        + _ANTI_SPURIOUS_FUSION_GUARD
         + (f"\n\nFUSION FOCUS (weight your synthesis toward this): {focus}\n"
            if focus else "")
         + "\n\n--- PER-DATASET FINDINGS TO RECONCILE ---\n\n"

--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -381,7 +381,13 @@ def _mesh_task(branch: dict, companions: List[dict]) -> str:
     a shape-aligned companion numerically (correlate / mask / normalize).
     """
     task = branch["task"].rstrip()
-    block = []
+    # This is ONE branch of a joint multi-dataset analysis — novelty is assessed
+    # ONCE on the fused cross-dataset interpretation, not per branch.
+    block = ["", "",
+             "NOTE — this is ONE branch of a JOINT multi-dataset analysis: do NOT "
+             "run novelty / literature assessment (assess_novelty) on this branch's "
+             "findings. Novelty is evaluated once on the FUSED cross-dataset "
+             "interpretation afterward. Complete the analysis itself normally."]
     if companions:
         block += ["", "",
                   f"PRIMARY dataset for THIS analysis: {branch['data_path']} — pass "
@@ -636,11 +642,22 @@ def _write_fusion_html(out_dir: Path, fused: dict, figures: list) -> Optional[Pa
     import html as _html
     import base64
     try:
-        claims_html = "".join(
-            f"<li><b>{_html.escape(str(c.get('claim', '')))}</b>"
-            f"<div class='imp'>{_html.escape(str(c.get('scientific_impact', '')))}</div></li>"
-            for c in (fused.get("scientific_claims") or []) if isinstance(c, dict)
-        ) or "<li>(none)</li>"
+        def _claim_li(c):
+            score = c.get("novelty_score")
+            badge = (f" <span class='novbadge'>novelty {_html.escape(str(score))}/5</span>"
+                     if score not in (None, "") else "")
+            expl = c.get("novelty_explanation")
+            expl_html = (f"<div class='imp'><b>Novelty:</b> {_html.escape(str(expl))}</div>"
+                         if expl else "")
+            return (f"<li><b>{_html.escape(str(c.get('claim', '')))}</b>{badge}"
+                    f"<div class='imp'>{_html.escape(str(c.get('scientific_impact', '')))}</div>"
+                    f"{expl_html}</li>")
+        _claims = [c for c in (fused.get("scientific_claims") or []) if isinstance(c, dict)]
+        claims_html = "".join(_claim_li(c) for c in _claims) or "<li>(none)</li>"
+        _claims_hdr = ("Synthesized claims"
+                       + ("  <small>(with literature-novelty score per claim)</small>"
+                          if any(c.get("novelty_score") not in (None, "") for c in _claims)
+                          else ""))
         caveats = [str(c) for c in (fused.get("caveats") or []) if str(c).strip()]
         caveats_html = (
             "<h2>Caveats &amp; limitations</h2><ul class='cav'>"
@@ -664,13 +681,16 @@ def _write_fusion_html(out_dir: Path, fused: dict, figures: list) -> Optional[Pa
  ol{{padding-left:20px}} li{{margin-bottom:6px}}
  .cav{{background:#fff8f0;border:1px solid #f0e0c8;border-radius:8px;padding:10px 16px 10px 32px}}
  .cav li{{color:#6b4e1a}}
+ .novbadge{{background:#e7efff;color:#274690;border:1px solid #c7d6f5;border-radius:10px;
+   padding:1px 8px;font-size:.8em;font-weight:bold;white-space:nowrap}}
+ h2 small{{color:#888;font-weight:normal;font-size:.6em}}
 </style></head><body>
 <h1>🔀 Cross-dataset fusion</h1>
 <p><b>Datasets:</b> {_html.escape(", ".join(str(l) for l in (fused.get("labels") or [])))}</p>
 {focus_html}
 <h2>Reconciled interpretation</h2>
 <div class="narr">{_html.escape(str(fused.get("detailed_analysis", "")))}</div>
-<h2>Synthesized claims</h2><ol>{claims_html}</ol>
+<h2>{_claims_hdr}</h2><ol>{claims_html}</ol>
 {caveats_html}
 <h2>Source figures (one per dataset)</h2>{figs_html}
 </body></html>"""
@@ -680,6 +700,47 @@ def _write_fusion_html(out_dir: Path, fused: dict, figures: list) -> Optional[Pa
     except Exception as e:  # noqa: BLE001
         logger.warning(f"could not write fusion HTML report: {e}")
         return None
+
+
+def _assess_fusion_novelty(orch, claims: list):
+    """Literature-novelty scoring on the FUSED cross-dataset claims (the joint-
+    analysis equivalent of per-analysis `assess_novelty`). Reuses the same
+    OwlLiteratureAgent + NoveltyScorer path. Returns a list of scored entries,
+    or None when no literature backend (futurehouse_api_key) is configured or
+    nothing scored. Best-effort — never raises."""
+    key = getattr(orch, "futurehouse_api_key", None)
+    if not key or not claims:
+        return None
+    try:
+        from ..lit_agents import OwlLiteratureAgent, NoveltyScorer
+        owl = OwlLiteratureAgent(api_key=key, max_wait_time=600)
+        scorer = NoveltyScorer(api_key=orch.api_key, model_name=orch.model_name,
+                               base_url=orch.base_url)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"fusion novelty: could not init literature agents: {e}")
+        return None
+    scored = []
+    for i, c in enumerate(claims):
+        if not isinstance(c, dict):
+            continue
+        q = c.get("has_anyone_question")
+        if not q:
+            continue
+        try:
+            res = owl.query_literature(q)
+            if res.get("status") != "success":
+                continue
+            sc = scorer.score_novelty(q, res.get("formatted_answer", ""))
+            scored.append({
+                "claim": c.get("claim"),
+                "question": q,
+                "novelty_score": sc.get("novelty_score", 0),
+                "novelty_explanation": sc.get("explanation"),
+            })
+        except Exception as e:  # noqa: BLE001 - one bad claim must not break fusion
+            logger.warning(f"fusion novelty: claim {i + 1} failed: {e}")
+            continue
+    return scored or None
 
 
 def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> str:
@@ -755,6 +816,25 @@ def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> s
         return json.dumps({"status": "error",
                            "message": "Fusion synthesis did not return a usable result."})
 
+    # Joint-analysis novelty: assess the FUSED claims once (the branches were
+    # told to skip per-branch novelty). No-op without a literature backend.
+    fused_claims = parsed.get("scientific_claims") or []
+    novelty = None
+    if getattr(orch, "futurehouse_api_key", None) and fused_claims:
+        print(f"  🔍 Assessing novelty of {len(fused_claims)} fused "
+              "cross-dataset claim(s)...")
+        novelty = _assess_fusion_novelty(orch, fused_claims)
+        # Attach each score to ITS claim (matched by the literature question), so
+        # novelty enriches the claims inline rather than as a duplicate list.
+        if novelty:
+            _by_q = {n.get("question"): n for n in novelty if isinstance(n, dict)}
+            for c in fused_claims:
+                if isinstance(c, dict):
+                    _n = _by_q.get(c.get("has_anyone_question"))
+                    if _n:
+                        c["novelty_score"] = _n.get("novelty_score")
+                        c["novelty_explanation"] = _n.get("novelty_explanation")
+
     # Persist the fused report + record a fusion ledger entry.
     from datetime import datetime
     with orch._fanout_lock:
@@ -769,6 +849,7 @@ def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> s
         "detailed_analysis": parsed.get("detailed_analysis", ""),
         "scientific_claims": parsed.get("scientific_claims", []),
         "caveats": parsed.get("caveats", []),
+        "novelty": novelty,
     }
     try:
         with open(report_path, "w") as fh:
@@ -804,6 +885,7 @@ def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> s
         "detailed_analysis": parsed.get("detailed_analysis", ""),
         "scientific_claims": parsed.get("scientific_claims", []),
         "caveats": parsed.get("caveats", []),
+        "novelty": novelty,
         "report_path": str(report_path),
         "report_html_path": str(html_path) if html_path else None,
     }, indent=2, default=str)

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -17,6 +17,7 @@ this development stage — see CLAUDE.md "Why no BaseChatOrchestrator refactor".
 import json
 import logging
 import os
+import threading
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 from datetime import datetime
@@ -373,10 +374,21 @@ class MetaOrchestratorAgent:
         self.checkpoint_path = self.base_dir / "checkpoint.json"
         self.analysis_dir = self.base_dir / "analysis"
         self.planning_dir = self.base_dir / "planning"
+        # Fan-out workers (ephemeral, one isolated analysis session per branch)
+        # and fused cross-dataset reports live in their own sub-trees, distinct
+        # from the persistent analysis/ and planning/ children. See fanout.py.
+        self.fanout_dir = self.base_dir / "fanout"
+        self.fusion_dir = self.base_dir / "fusion"
 
         # Session state — kept shallow; children own their deep state.
         self._children: Dict[str, Any] = {}          # "analysis"/"planning" -> agent
         self._delegation_ledger: List[Dict[str, Any]] = []
+        # Complementarity verdicts cached by frozenset of dataset paths, so the
+        # standalone assess_complementarity tool and the internal gate in
+        # run_fanout share one LLM call. Serializes ledger preallocation and
+        # fusion-entry appends across fan-out worker threads.
+        self._complementarity_cache: Dict[frozenset, Dict[str, Any]] = {}
+        self._fanout_lock = threading.Lock()
         # Auto-generated specialist capability inventory — built once on the
         # first chat turn (children must exist to read their tool registries).
         self._capabilities_block: Optional[str] = None
@@ -1069,6 +1081,26 @@ class MetaOrchestratorAgent:
         if limit is not None and limit > 0:
             ledger = ledger[-limit:]
         return json.dumps(ledger, indent=2, default=str)
+
+    # =========================================================================
+    # Parallel multi-dataset analysis (fan-out) — see fanout.py
+    # =========================================================================
+
+    def _assess_complementarity(self, datasets: list) -> str:
+        """Partition datasets into complementary / redundant / unrelated."""
+        from .fanout import assess_complementarity
+        return json.dumps(assess_complementarity(self, datasets),
+                          indent=2, default=str)
+
+    def _run_fanout(self, branches: list) -> str:
+        """Gate, confirm, then run analysis branches concurrently (full mesh)."""
+        from .fanout import run_fanout
+        return run_fanout(self, branches)
+
+    def _fuse_delegations(self, indices: list, focus: Optional[str] = None) -> str:
+        """Reconcile finished complementary branch findings into one narrative."""
+        from .fanout import fuse_delegations
+        return fuse_delegations(self, indices, focus)
 
     # =========================================================================
     # Checkpoint / history

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -185,10 +185,25 @@ attempt to delegate simulation work.
   clear, ask the user before treating them as one. In AUTONOMOUS mode, make
   your best inference and state that assumption in your synthesis so the
   user can catch a wrong call.
-- For a confirmed shared system: analyze each modality with its proper
-  specialist agent, thread each result into the next delegation's `context`,
-  and end with ONE correlated interpretation across modalities — not N
-  separate reports.
+- For a confirmed shared system with TWO OR MORE datasets that each deserve
+  their own analysis, PREFER the parallel fan-out path over sequential
+  delegations: call `assess_complementarity` to confirm they are genuinely
+  complementary (same system, different information, a shared join axis), then
+  `delegate_to_analyses` to analyze them CONCURRENTLY — each branch routed to
+  its proper specialist and seeing the others as auxiliary — and finally
+  `fuse_delegations` to reconcile their findings into ONE correlated
+  interpretation. This both parallelizes the work and lets each analysis be
+  informed by the others.
+- Two cases do NOT take the fan-out path: (a) if `assess_complementarity` /
+  `delegate_to_analyses` DECLINES (the datasets are redundant or unrelated),
+  analyze them as independent `delegate_to_analysis` calls — do not force a
+  fused interpretation; (b) a pure REFERENCE / baseline / calibration dataset
+  (an I0, an empty-cell background, a dark frame) is an auxiliary, NOT its own
+  branch — pass it as a companion to a single `delegate_to_analysis` of the
+  measurement it calibrates, not as a fan-out branch.
+- Sequential `delegate_to_analysis` calls threaded through `context` remain the
+  fallback when fan-out is not appropriate; still end with ONE correlated
+  interpretation across modalities — not N separate reports.
 
 **THE DELEGATION CONTRACT:**
 - `delegate_to_analysis(task, context)` and `delegate_to_planning(task,

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -378,6 +378,136 @@ class MetaOrchestratorTools:
             required=["task", "label"],
         )
 
+        # -- assess_complementarity -----------------------------------------
+        def assess_complementarity(datasets: list) -> str:
+            print(f"  🔎 Assessing complementarity of {len(datasets or [])} dataset(s)...")
+            return self.orch._assess_complementarity(datasets)
+
+        self._register_tool(
+            func=assess_complementarity,
+            name="assess_complementarity",
+            description=(
+                "Judge whether two or more datasets are GENUINELY COMPLEMENTARY "
+                "— same physical system, different (non-redundant) information, "
+                "and a shared join axis to reconcile them on — and partition "
+                "them: a `fanout_set` worth analyzing together, `redundant_"
+                "clusters` (duplicates), and `unrelated` outliers. Call this "
+                "BEFORE proposing `delegate_to_analyses` so you can show the "
+                "user the verdict and discuss it. Read-only; does not run any "
+                "analysis. (The same gate also runs INSIDE delegate_to_analyses, "
+                "so a non-complementary set is refused even if you skip this.)"
+            ),
+            parameters={
+                "datasets": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string",
+                                     "description": "Absolute path to the dataset."},
+                            "role": {"type": "string",
+                                     "description": "Optional: what this dataset is / "
+                                                    "its stated relationship to the others."},
+                            "metadata": {"type": "string",
+                                         "description": "Optional: path to a metadata "
+                                                        "JSON, or an inline description."},
+                        },
+                        "required": ["path"],
+                    },
+                    "description": "The datasets to assess (>= 2).",
+                },
+            },
+            required=["datasets"],
+        )
+
+        # -- delegate_to_analyses (parallel fan-out, full-mesh aux) ----------
+        def delegate_to_analyses(branches: list) -> str:
+            print(f"  🔀 Parallel analysis over {len(branches or [])} dataset(s)...")
+            return self.orch._run_fanout(branches)
+
+        self._register_tool(
+            func=delegate_to_analyses,
+            name="delegate_to_analyses",
+            description=(
+                "Run SEVERAL analysis branches CONCURRENTLY over complementary "
+                "datasets, each branch seeing the others as auxiliary operands "
+                "(full mesh), then fuse with `fuse_delegations`. Use this — NOT "
+                "repeated `delegate_to_analysis` — when the user has 2+ datasets "
+                "that are complementary measurements of ONE system and you want "
+                "each analysis informed by the others plus a final cross-dataset "
+                "synthesis. A complementarity GATE runs first and PRUNES to the "
+                "genuinely-complementary subset: a redundant or unrelated set is "
+                "declined (analyze those independently instead). In AUTOPILOT the "
+                "user is asked to confirm before launching; branches always run "
+                "AUTONOMOUSLY (no per-branch approval pauses — concurrent prompts "
+                "can't interleave). Each branch's `task` must be a complete, "
+                "self-contained instruction with the absolute data path; the "
+                "companions are wired in automatically. Returns the per-branch "
+                "delegation_index list and the indices to pass to "
+                "`fuse_delegations`."
+            ),
+            parameters={
+                "branches": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "data_path": {"type": "string",
+                                          "description": "Absolute path to THIS branch's "
+                                                         "primary dataset."},
+                            "task": {"type": "string",
+                                     "description": "Complete, self-contained analysis "
+                                                    "instruction for this dataset."},
+                            "label": {"type": "string",
+                                      "description": "Short 2-5 word UI label (the data "
+                                                     "type, e.g. 'STEM image')."},
+                            "metadata": {"type": "string",
+                                         "description": "Optional: path to a metadata JSON "
+                                                        "or inline description (also feeds "
+                                                        "the complementarity gate)."},
+                        },
+                        "required": ["data_path", "task", "label"],
+                    },
+                    "description": "The analysis branches to run in parallel (>= 2).",
+                },
+            },
+            required=["branches"],
+        )
+
+        # -- fuse_delegations -----------------------------------------------
+        def fuse_delegations(delegation_indices: list, focus: str = None) -> str:
+            print(f"  🧬 Fusing delegations {delegation_indices}...")
+            return self.orch._fuse_delegations(delegation_indices, focus)
+
+        self._register_tool(
+            func=fuse_delegations,
+            name="fuse_delegations",
+            description=(
+                "Reconcile the findings of two or more COMPLETED analysis "
+                "delegations (typically the branches from `delegate_to_analyses`, "
+                "but any successful delegations work) into ONE cross-dataset "
+                "scientific narrative + synthesized claims, written to a fusion "
+                "report. Reconciles local vs bulk / multi-modal evidence. "
+                "Crucially, 'no significant correlation found' is a VALID result "
+                "— it will not manufacture a correlation the findings don't "
+                "support. Pass the `delegation_index` numbers to fuse; optional "
+                "`focus` weights the synthesis toward a specific question."
+            ),
+            parameters={
+                "delegation_indices": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "description": "delegation_index numbers of the completed "
+                                   "delegations to fuse (>= 2).",
+                },
+                "focus": {
+                    "type": "string",
+                    "description": "Optional question/aspect to weight the synthesis toward.",
+                },
+            },
+            required=["delegation_indices"],
+        )
+
         # -- delegate_to_simulation: DEFERRED lazy seam, intentionally NOT built
         #
         # v1 covers analysis + planning only. When simulation delegation is

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -486,12 +486,17 @@ class MetaOrchestratorTools:
                 "Reconcile the findings of two or more COMPLETED analysis "
                 "delegations (typically the branches from `delegate_to_analyses`, "
                 "but any successful delegations work) into ONE cross-dataset "
-                "scientific narrative + synthesized claims, written to a fusion "
-                "report. Reconciles local vs bulk / multi-modal evidence. "
-                "Crucially, 'no significant correlation found' is a VALID result "
-                "— it will not manufacture a correlation the findings don't "
-                "support. Pass the `delegation_index` numbers to fuse; optional "
-                "`focus` weights the synthesis toward a specific question."
+                "scientific narrative + synthesized claims. Reconciles spatial / "
+                "shared-axis / local-vs-bulk / complementary-observable evidence, "
+                "and ATTACHES one representative figure per dataset to the "
+                "(multimodal) synthesis so spatial correlations are verified from "
+                "the actual plots, not just the text. Writes BOTH a JSON and a "
+                "human-readable HTML fusion report (figures inline) — surface the "
+                "`report_html_path` to the user. Crucially, 'no significant "
+                "correlation found' is a VALID result — it will not manufacture a "
+                "correlation the findings don't support. Pass the "
+                "`delegation_index` numbers to fuse; optional `focus` weights the "
+                "synthesis toward a specific question."
             ),
             parameters={
                 "delegation_indices": {

--- a/scilink/ui/.streamlit/config.toml
+++ b/scilink/ui/.streamlit/config.toml
@@ -4,3 +4,14 @@ backgroundColor = "#252D38"
 secondaryBackgroundColor = "#1E2530"
 textColor = "#E0E0E0"
 font = "sans serif"
+
+[global]
+# Streamlit reference-caches any ForwardMsg >= minCachedMessageSize (default
+# 10 KB) by hash and evicts it after maxCachedMessageAge reruns (default 2).
+# Our injected theme CSS is ~17 KB (dark) / ~23 KB (light), so toggling
+# light<->dark re-references a CSS message that has already aged out of the
+# cache, and the client raises "Cached ForwardMsg MISS". Raising the threshold
+# above the blob makes the theme stylesheet always send in full (never
+# reference-cached), so the toggle is robust; genuinely huge payloads (>50 KB)
+# still get cached.
+minCachedMessageSize = 51200

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -697,6 +697,9 @@ else:
                 _ctx_tail = (req.context or "")[-1500:]
                 _prompt = req.prompt or ""
                 _is_keep_revert = "revert to original" in _ctx_tail.lower()
+                # Fan-out launch confirmation (meta parallel multi-dataset
+                # analysis) → dedicated Launch/Cancel buttons, not a text area.
+                _is_fanout_confirm = "parallel multi-dataset analysis" in _ctx_tail.lower()
                 if "Context" in _prompt or "MISSING METADATA" in _ctx_tail:
                     _input_label = "Describe your data (optional):"
                     _submit_label = "Submit description"
@@ -731,6 +734,26 @@ else:
                     with col_revert:
                         if st.button("Revert to original fit", type="primary", width="stretch"):
                             req.response = ""
+                            req.event.set()
+                            st.session_state.pop("_feedback_preview_images", None)
+                            st.session_state.pop("_code_review_files", None)
+                            st.rerun(scope="app")
+                # Fan-out launch confirmation: two clear buttons (Launch sends
+                # "y", Cancel sends "no" — matching _confirm_fanout's parsing),
+                # no text area (there is nothing to edit, only launch/abort).
+                elif _is_fanout_confirm:
+                    col_go, col_cancel = st.columns(2)
+                    with col_go:
+                        if st.button("🔀 Launch parallel analysis", type="primary",
+                                     width="stretch"):
+                            req.response = "y"
+                            req.event.set()
+                            st.session_state.pop("_feedback_preview_images", None)
+                            st.session_state.pop("_code_review_files", None)
+                            st.rerun(scope="app")
+                    with col_cancel:
+                        if st.button("Cancel", width="stretch"):
+                            req.response = "no"
                             req.event.set()
                             st.session_state.pop("_feedback_preview_images", None)
                             st.session_state.pop("_code_review_files", None)

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -85,8 +85,7 @@ def _render_fanout_confirm(ctx: str) -> None:
         st.markdown("**Branches** — run concurrently, each seeing the others "
                     "as auxiliary:\n" + "\n".join(f"- {b}" for b in branches))
     if rationale:
-        with st.expander("Why these are complementary"):
-            st.write(rationale)
+        st.markdown(f"**Why:** {rationale}")
     st.caption("Branches run autonomously — no per-branch approval pauses.")
 
 
@@ -770,6 +769,12 @@ else:
                 # "y", Cancel sends "no" — matching _confirm_fanout's parsing),
                 # no text area (there is nothing to edit, only launch/abort).
                 elif _is_fanout_confirm:
+                    # Anchor so theme.py can force Cancel/Launch to identical
+                    # box size (equal columns fix width; this fixes height too).
+                    st.markdown(
+                        '<span class="fanout-actions-anchor"></span>',
+                        unsafe_allow_html=True,
+                    )
                     col_cancel, col_go = st.columns(2)
                     with col_cancel:
                         if st.button("Cancel", type="secondary", width="stretch"):

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -64,6 +64,32 @@ def _escape_tildes(text: str) -> str:
     return "".join(parts)
 
 
+def _render_fanout_confirm(ctx: str) -> None:
+    """Clean confirmation panel for the meta fan-out launch — replaces the raw
+    monospace stdout dump with readable markdown (verdict, join axis, the
+    branch list; the long rationale tucked into an expander)."""
+    def _g(pat):
+        m = re.search(pat, ctx or "")
+        return re.sub(r"\s{2,}", " ", m.group(1).strip()) if m else None
+    verdict = _g(r"Complementarity verdict\s*:\s*(.+)")
+    join = _g(r"Join axis\s*:\s*(.+)")
+    rationale = _g(r"Rationale\s*:\s*(.+)")
+    branches = [re.sub(r"\s{2,}", " ", b.strip())
+                for b in re.findall(r"•\s*(.+)", ctx or "")]
+    st.markdown("#### 🔀 Launch parallel multi-dataset analysis?")
+    if verdict:
+        st.markdown(f"**Complementarity:** {verdict}")
+    if join:
+        st.markdown(f"**Join axis:** {join}")
+    if branches:
+        st.markdown("**Branches** — run concurrently, each seeing the others "
+                    "as auxiliary:\n" + "\n".join(f"- {b}" for b in branches))
+    if rationale:
+        with st.expander("Why these are complementary"):
+            st.write(rationale)
+    st.caption("Branches run autonomously — no per-branch approval pauses.")
+
+
 _LOGO_DIR = Path(__file__).resolve().parent / "assets"
 _LOGO_DARK = _LOGO_DIR / "scilink_logo_v3_dark.svg"
 _LOGO_LIGHT = _LOGO_DIR / "scilink_logo_v3_light.svg"
@@ -415,7 +441,7 @@ if not st.session_state.agent_initialized:
             with _col:
                 _btype = ("primary" if st.session_state.app_mode == _m["key"]
                           else "secondary")
-                if st.button(_m["label"], type=_btype, use_container_width=True,
+                if st.button(_m["label"], type=_btype, width="stretch",
                              key=f"mode_{_m['key']}"):
                     st.session_state.app_mode = _m["key"]
                     st.rerun()
@@ -638,10 +664,14 @@ else:
                             with st.expander(f"📄 {fname}", expanded=len(code_files) == 1):
                                 st.code(content, language="python")
     
-                if req.context:
+                _is_fanout_confirm = ("parallel multi-dataset analysis"
+                                      in (req.context or "").lower())
+                if _is_fanout_confirm:
+                    _render_fanout_confirm(req.context)
+                elif req.context:
                     import html as _html
                     import re
-    
+
                     display_ctx = req.context
                     lines = display_ctx.split("\n")
                     # Find the last separator block (===…) followed by a
@@ -697,9 +727,7 @@ else:
                 _ctx_tail = (req.context or "")[-1500:]
                 _prompt = req.prompt or ""
                 _is_keep_revert = "revert to original" in _ctx_tail.lower()
-                # Fan-out launch confirmation (meta parallel multi-dataset
-                # analysis) → dedicated Launch/Cancel buttons, not a text area.
-                _is_fanout_confirm = "parallel multi-dataset analysis" in _ctx_tail.lower()
+                # (_is_fanout_confirm computed above, before the context render)
                 if "Context" in _prompt or "MISSING METADATA" in _ctx_tail:
                     _input_label = "Describe your data (optional):"
                     _submit_label = "Submit description"
@@ -742,18 +770,18 @@ else:
                 # "y", Cancel sends "no" — matching _confirm_fanout's parsing),
                 # no text area (there is nothing to edit, only launch/abort).
                 elif _is_fanout_confirm:
-                    col_go, col_cancel = st.columns(2)
-                    with col_go:
-                        if st.button("🔀 Launch parallel analysis", type="primary",
-                                     width="stretch"):
-                            req.response = "y"
+                    col_cancel, col_go = st.columns(2)
+                    with col_cancel:
+                        if st.button("Cancel", type="secondary", width="stretch"):
+                            req.response = "no"
                             req.event.set()
                             st.session_state.pop("_feedback_preview_images", None)
                             st.session_state.pop("_code_review_files", None)
                             st.rerun(scope="app")
-                    with col_cancel:
-                        if st.button("Cancel", width="stretch"):
-                            req.response = "no"
+                    with col_go:
+                        if st.button("🔀 Launch parallel analysis", type="primary",
+                                     width="stretch"):
+                            req.response = "y"
                             req.event.set()
                             st.session_state.pop("_feedback_preview_images", None)
                             st.session_state.pop("_code_review_files", None)
@@ -1021,7 +1049,7 @@ else:
                     # rerun, which re-evaluates the rglob below and shows
                     # any newly-created files.
                     if st.button("🔄 Refresh", key="files_refresh_btn",
-                                 use_container_width=True,
+                                 width="stretch",
                                  help="Re-scan the session directory for new files."):
                         st.rerun()
     
@@ -1061,7 +1089,7 @@ else:
                                 if st.button(
                                     f"{icon}  {display_name}  ({size})",
                                     key=f"fbtn_{f.relative_to(session_path)}",
-                                    use_container_width=True,
+                                    width="stretch",
                                     type=btn_type,
                                     help=f.name,
                                 ):

--- a/scilink/ui/components/chat_uploads.py
+++ b/scilink/ui/components/chat_uploads.py
@@ -76,7 +76,7 @@ def _render_analyze_uploads(start_task_fn) -> None:
 
     # Show "Analyze" button once data is uploaded
     if st.session_state.uploaded_data_path:
-        if st.button("Analyze", type="primary", use_container_width=True):
+        if st.button("Analyze", type="primary", width="stretch"):
             data_path = st.session_state.uploaded_data_path
             meta_path = st.session_state.uploaded_metadata_path
             has_sidecars = st.session_state.get("uploaded_sidecar_metadata", False)
@@ -190,7 +190,7 @@ def _render_planning_uploads(start_task_fn) -> None:
     if st.button(
         "Start Planning",
         type="primary",
-        use_container_width=True,
+        width="stretch",
         disabled=not can_start,
     ):
         parts = []
@@ -352,7 +352,7 @@ def _render_meta_uploads(start_task_fn) -> None:
     if st.button(
         "Start",
         type="primary",
-        use_container_width=True,
+        width="stretch",
         disabled=not can_start,
     ):
         parts = []

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -137,7 +137,7 @@ def _render_hpc_connection() -> None:
             if st.button(
                 "Disconnect",
                 key="sidebar_hpc_disconnect",
-                use_container_width=True,
+                width="stretch",
             ):
                 conn.disconnect()
                 st.session_state.hpc_connection = None
@@ -202,7 +202,7 @@ def _render_hpc_connection() -> None:
         if st.button(
             "Connect",
             disabled=not (hostname and username),
-            use_container_width=True,
+            width="stretch",
             key="sidebar_hpc_connect",
         ):
             profile = HPCProfile(
@@ -433,7 +433,7 @@ def render_sidebar() -> None:
                     if st.button(
                         "Resume Session",
                         disabled=not consent,
-                        use_container_width=True,
+                        width="stretch",
                         key="resume_session_btn",
                     ):
                         _r_embed_preset = st.session_state.get("cfg_embedding_preset", "")
@@ -523,7 +523,7 @@ def render_sidebar() -> None:
 
         # ── Quit button (always visible at bottom) ────────────
         st.divider()
-        if st.button("Quit App", use_container_width=True):
+        if st.button("Quit App", width="stretch"):
             # Stop any running agent thread
             task = st.session_state.get("chat_task")
             if task and task.is_running:

--- a/scilink/ui/components/sim_workflow.py
+++ b/scilink/ui/components/sim_workflow.py
@@ -375,7 +375,7 @@ def _render_remote_file_picker(
                 key=f"_rfp_{key_prefix}_path_input",
                 label_visibility="collapsed",
             )
-            if st.form_submit_button("Go", use_container_width=True):
+            if st.form_submit_button("Go", width="stretch"):
                 if typed_path != st.session_state[PATH_KEY]:
                     st.session_state[PATH_KEY] = typed_path
                     st.rerun()
@@ -419,7 +419,7 @@ def _render_remote_file_picker(
                 if st.button(
                     f"📁 {name}/",
                     key=f"rfp_d_{key_prefix}_{cwd}_{name}",
-                    use_container_width=True,
+                    width="stretch",
                 ):
                     st.session_state[PATH_KEY] = full_path
                     st.rerun()
@@ -1001,7 +1001,7 @@ def _render_review_scripts() -> None:
 
     c_submit, c_back = st.columns(2)
     with c_back:
-        if st.button("← Back to configure", key="hpc_review_back", use_container_width=True):
+        if st.button("← Back to configure", key="hpc_review_back", width="stretch"):
             st.session_state.hpc_workflow_phase = "configure"
             st.rerun()
 
@@ -1010,7 +1010,7 @@ def _render_review_scripts() -> None:
             "🚀 Upload & Submit",
             type="primary",
             key="hpc_review_submit",
-            use_container_width=True,
+            width="stretch",
         ):
             conn = st.session_state.get("hpc_connection")
             sched = st.session_state.get("hpc_scheduler")
@@ -1209,7 +1209,7 @@ def _render_monitoring() -> None:
                 "📋 View Results",
                 type="primary",
                 key="mon_to_results",
-                use_container_width=True,
+                width="stretch",
             ):
                 st.session_state.hpc_workflow_phase = "results"
                 st.rerun()
@@ -1217,7 +1217,7 @@ def _render_monitoring() -> None:
             if st.button(
                 "🔄 New Simulation",
                 key="mon_new_sim",
-                use_container_width=True,
+                width="stretch",
             ):
                 st.session_state.hpc_workflow_phase = "configure"
                 st.rerun()
@@ -1396,12 +1396,12 @@ def _render_results() -> None:
     st.markdown("---")
     c1, c2 = st.columns(2)
     with c1:
-        if st.button("🔄 New Simulation", key="res_new", use_container_width=True):
+        if st.button("🔄 New Simulation", key="res_new", width="stretch"):
             _cleanup_monitoring_state()
             st.session_state.hpc_workflow_phase = "configure"
             st.rerun()
     with c2:
-        if st.button("📡 Back to Monitor", key="res_to_mon", use_container_width=True):
+        if st.button("📡 Back to Monitor", key="res_to_mon", width="stretch"):
             st.session_state.hpc_workflow_phase = "monitoring"
             st.rerun()
 

--- a/scilink/ui/components/simulations.py
+++ b/scilink/ui/components/simulations.py
@@ -285,7 +285,7 @@ def _render_dashboard() -> None:
             }
             for j in jobs
         ]
-        st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+        st.dataframe(pd.DataFrame(rows), width="stretch", hide_index=True)
 
     # ── Partitions ──
     with st.expander("Cluster partitions"):
@@ -294,7 +294,7 @@ def _render_dashboard() -> None:
             if parts:
                 import pandas as pd
                 st.dataframe(
-                    pd.DataFrame(parts), use_container_width=True, hide_index=True,
+                    pd.DataFrame(parts), width="stretch", hide_index=True,
                 )
             else:
                 st.caption("No partition info available.")
@@ -729,7 +729,7 @@ def _render_remote_files() -> None:
                 if st.button(
                     f"{icon} {name}/",
                     key=f"hpc_fd_{name}",
-                    use_container_width=True,
+                    width="stretch",
                 ):
                     st.session_state.hpc_remote_cwd = f"{cwd}/{name}"
                     st.rerun()

--- a/scilink/ui/components/skills.py
+++ b/scilink/ui/components/skills.py
@@ -96,7 +96,7 @@ def _render_available_skills(agent) -> None:
                 for name in names:
                     nc, vc = st.columns([3, 1])
                     nc.markdown(f"`{name}`")
-                    with vc.popover("view", use_container_width=True):
+                    with vc.popover("view", width="stretch"):
                         _render_skill_markdown(domain, name)
     else:
         st.caption("No built-in skills found.")
@@ -214,7 +214,7 @@ def _render_staged_section() -> None:
                     f"id={r['id']} · {prov} · session={r.get('session','?')}"
                     + (f" · {_staging.metric_label(r)}" if _staging.metric_label(r) else "")
                 )
-                with view_col.popover("View", use_container_width=True):
+                with view_col.popover("View", width="stretch"):
                     _render_staged_record(r)
             if model is None:
                 st.info("Start a session to enable upgrade/consolidate (needs a model).")

--- a/scilink/ui/components/telemetry.py
+++ b/scilink/ui/components/telemetry.py
@@ -146,7 +146,7 @@ def _ledger_table(delegations: list) -> None:
             "started": _short_time(d.get("timestamp")),
             "completed": _short_time(d.get("completed_at")),
         })
-    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+    st.dataframe(pd.DataFrame(rows), width="stretch", hide_index=True)
 
 
 # ── tool sequence ────────────────────────────────────────────────────
@@ -214,7 +214,7 @@ def _tool_sequence_section(sequence: dict) -> None:
             "output": _type_summary(c.get("result")),
             "status": c.get("status", "—"),
         } for i, c in enumerate(calls, 1)]
-        st.dataframe(pd.DataFrame(rows), use_container_width=True,
+        st.dataframe(pd.DataFrame(rows), width="stretch",
                      hide_index=True)
         src = entry.get("source")
         if src and Path(src).is_file():

--- a/scilink/ui/components/vasp_workflow.py
+++ b/scilink/ui/components/vasp_workflow.py
@@ -551,7 +551,7 @@ def _render_review_inputs() -> None:
         if st.button(
             "← Back to configure",
             key="vasp_review_back",
-            use_container_width=True,
+            width="stretch",
         ):
             st.session_state.hpc_workflow_phase = "configure"
             st.rerun()
@@ -561,7 +561,7 @@ def _render_review_inputs() -> None:
             "🚀 Upload & Submit",
             type="primary",
             key="vasp_review_submit",
-            use_container_width=True,
+            width="stretch",
         ):
             conn = st.session_state.get("hpc_connection")
             sched = st.session_state.get("hpc_scheduler")

--- a/scilink/ui/theme.py
+++ b/scilink/ui/theme.py
@@ -171,6 +171,25 @@ div:has(> [data-testid="stMarkdown"] .theme-toggle-anchor) + div button:hover {
     color: #E0E0E0 !important;
     box-shadow: none !important;
 }
+/* Fan-out confirm — force Cancel/Launch to IDENTICAL box size and shape.
+   Equal st.columns fixes width; the secondary (Cancel) and primary (Launch)
+   otherwise differ in height/box-model, so pin both to one height + padding. */
+div:has(> [data-testid="stMarkdown"] .fanout-actions-anchor) + div .stButton > button {
+    min-height: 2.75rem !important;
+    height: 2.75rem !important;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+}
+/* Cancel (secondary) gets a solid neutral fill so it reads as the SAME box as
+   the purple primary Launch — equal size AND equal shape, color = the only
+   difference (grey = abort, purple = go). */
+div:has(> [data-testid="stMarkdown"] .fanout-actions-anchor) + div .stButton > button[kind="secondary"] {
+    background-color: #3A4556 !important;
+    color: #C7D0DC !important;
+}
 /* File explorer tree buttons — soft gray, blue on selection */
 [data-testid="stExpander"] .stButton > button,
 [data-testid="stExpander"] .stButton button {

--- a/scilink/utils/synthesis_parse.py
+++ b/scilink/utils/synthesis_parse.py
@@ -82,3 +82,26 @@ def salvage_synthesis_fields(raw_text: str) -> Optional[dict]:
         if arr is not None:
             recovered[key] = arr
     return recovered
+
+
+def salvage_synthesis_from_response(response) -> Optional[dict]:
+    """Salvage synthesis fields directly from a raw model response object.
+
+    Extracts the text (``.text`` / ``.content`` / ``.choices[0].message.content``)
+    then delegates to :func:`salvage_synthesis_fields`. This mirrors
+    ``BaseAnalysisAgent._salvage_synthesis_fields`` for use by the standalone
+    synthesis CONTROLLERS, which do not inherit that method. Returns ``None`` on
+    any extraction failure or unrecoverable narrative.
+    """
+    try:
+        if hasattr(response, "text"):
+            raw = response.text
+        elif hasattr(response, "content"):
+            raw = response.content
+        elif getattr(response, "choices", None):
+            raw = response.choices[0].message.content
+        else:
+            raw = str(response)
+    except Exception:  # noqa: BLE001 - any odd response shape -> no salvage
+        return None
+    return salvage_synthesis_fields(raw or "")

--- a/scilink/wrappers/litellm_wrapper.py
+++ b/scilink/wrappers/litellm_wrapper.py
@@ -74,6 +74,33 @@ try:
 except ImportError:
     Image = None
 
+
+# Model image APIs (Bedrock, direct Anthropic) reject any image whose larger
+# dimension exceeds 8000 px. A tall multi-panel synthesis montage can exceed it
+# and the whole request fails. Downscale only such oversized images; everything
+# at or under the limit is returned BYTE-IDENTICAL so normal requests are
+# unchanged.
+_MAX_IMAGE_DIM = 8000
+
+
+def _cap_image_bytes(raw: bytes) -> bytes:
+    """Return ``raw`` unchanged unless it is an image larger than
+    ``_MAX_IMAGE_DIM`` on a side, in which case return a downscaled PNG. Any
+    failure (no PIL, non-image, undecodable) returns the input untouched."""
+    if not Image or not raw:
+        return raw
+    try:
+        im = Image.open(io.BytesIO(raw))
+        if max(im.size) <= _MAX_IMAGE_DIM:  # common case: identical passthrough
+            return raw
+        im = im.copy()
+        im.thumbnail((_MAX_IMAGE_DIM, _MAX_IMAGE_DIM))
+        out = io.BytesIO()
+        im.save(out, format="PNG")
+        return out.getvalue()
+    except Exception:  # noqa: BLE001 - never let capping break a request
+        return raw
+
 try:
     import litellm
     LITELLM_AVAILABLE = True
@@ -414,17 +441,24 @@ class LiteLLMGenerativeModel:
             
             elif Image and isinstance(part, Image.Image):
                 buf = io.BytesIO()
-                part.save(buf, format="PNG")
+                img = part
+                if max(part.size) > _MAX_IMAGE_DIM:   # downscale only if oversized
+                    img = part.copy()
+                    img.thumbnail((_MAX_IMAGE_DIM, _MAX_IMAGE_DIM))
+                img.save(buf, format="PNG")
                 b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
                 converted.append({
                     "type": "image_url",
                     "image_url": {"url": f"data:image/png;base64,{b64}"}
                 })
-            
+
             elif isinstance(part, dict):
                 if "mime_type" in part and "data" in part:
                     data = part["data"]
                     if isinstance(data, bytes):
+                        # Cap oversized image bytes (no-op / identical otherwise).
+                        if str(part.get("mime_type", "")).startswith("image/"):
+                            data = _cap_image_bytes(data)
                         b64 = base64.b64encode(data).decode("utf-8")
                     else:
                         b64 = data

--- a/tests/test_meta_fanout_3way_live.py
+++ b/tests/test_meta_fanout_3way_live.py
@@ -1,0 +1,106 @@
+"""Live test: 3-WAY fan-out over image + datacube + spectrum of one sample.
+
+The strongest heterogeneous-concurrency case: HAADF image ->ImageAnalysisAgent,
+EELS datacube ->HyperspectralAnalysisAgent, XPS spectrum ->CurveFittingAgent,
+all three concurrently, full-mesh aux, then a 3-dataset fusion.
+
+  export AWS_BEARER_TOKEN_BEDROCK=...  AWS_REGION_NAME=us-east-1
+  UNSAFE_EXECUTION_OK=true conda run -n scilink python tests/test_meta_fanout_3way_live.py --full
+"""
+import argparse, json, os, sys, tempfile
+import numpy as np
+
+MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+
+
+def make(d, n=32, nE=100):
+    from scipy.ndimage import gaussian_filter
+    r = np.random.RandomState(13)
+    field = gaussian_filter(r.randn(n, n), 3.0)
+    phase = (field > np.percentile(field, 45)).astype(np.float32)   # 1 = metal
+
+    haadf = gaussian_filter(0.62 * phase + 0.32 * (1 - phase) + r.normal(0, 0.03, (n, n)), 0.6).astype(np.float32)
+
+    E = np.arange(nE)
+    g = lambda c, w, a: a * np.exp(-0.5 * ((E - c) / w) ** 2)
+    s_metal, s_oxide = g(30, 4, 1.0) + g(48, 5, 0.4), g(34, 4, 1.0) + g(52, 5, 0.8)
+    cube = np.empty((n, n, nE), np.float32)
+    for j in range(n):
+        for i in range(n):
+            cube[j, i] = (s_metal if phase[j, i] > 0.5 else s_oxide) + 0.05 + r.normal(0, 0.02, nE)
+
+    be = np.linspace(450, 470, 400)
+    gx = lambda c, w, a: a * np.exp(-0.5 * ((be - c) / w) ** 2)
+    xps = (gx(454, 0.9, 0.62) + gx(460.1, 1.0, 0.3) + gx(458.6, 1.1, 0.38) + gx(464.4, 1.2, 0.18)
+           + 0.05 + r.normal(0, 0.012, be.size))
+
+    def save(name, arr, meta):
+        p = os.path.join(d, name + ".npy"); np.save(p, arr)
+        mp = os.path.join(d, name + ".json"); json.dump(meta, open(mp, "w"), indent=2)
+        return {"data_path": p, "metadata": mp}
+
+    img = save("haadf", haadf.astype(np.float32), {
+        "technique": "STEM-HAADF imaging", "sample": "TiOx thin film", "region_id": "R1",
+        "field_of_view_nm": 8.0, "pixels": f"{n}x{n}",
+        "description": f"Z-contrast image of region R1, pixel-aligned with the EELS datacube."})
+    cubep = save("eels", cube, {
+        "technique": "STEM-EELS spectrum image", "sample": "TiOx thin film", "region_id": "R1",
+        "field_of_view_nm": 8.0, "shape": f"{n}x{n}x{nE}",
+        "energy_range": {"start": 450.0, "end": 450.0 + nE, "units": "eV"},
+        "description": f"EELS datacube co-registered to the SAME {n}x{n} R1 grid as the HAADF."})
+    xpsp = save("xps", np.vstack([be, xps]).astype(np.float32).T, {
+        "technique": "XPS Ti 2p core level", "sample": "TiOx thin film",
+        "x_axis": "binding energy (eV)",
+        "description": "Bulk-averaged Ti 2p chemical state (metallic Ti + TiO2) of the SAME film."})
+    return img, cubep, xpsp
+
+
+def main():
+    ap = argparse.ArgumentParser(); ap.add_argument("--full", action="store_true")
+    args = ap.parse_args()
+    if not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
+        print("Set AWS_BEARER_TOKEN_BEDROCK (+ AWS_REGION_NAME)."); sys.exit(2)
+    from scilink.agents.meta_agent.meta_orchestrator import MetaOrchestratorAgent, MetaMode
+    d = tempfile.mkdtemp(prefix="fanout_3way_"); img, cube, xps = make(d)
+
+    with tempfile.TemporaryDirectory() as bd:
+        ag = MetaOrchestratorAgent(base_dir=bd, api_key=None, base_url=None,
+                                   model_name=MODEL, meta_mode=MetaMode.AUTONOMOUS)
+        print("### GATE: 3-way (HAADF image + EELS datacube + XPS spectrum) ###")
+        v = json.loads(ag._assess_complementarity([
+            {"path": img["data_path"], "metadata": img["metadata"]},
+            {"path": cube["data_path"], "metadata": cube["metadata"]},
+            {"path": xps["data_path"], "metadata": xps["metadata"]}]))
+        print(f"  verdict={v.get('verdict')} conf={v.get('confidence')} "
+              f"join={str(v.get('join_axis'))[:80]!r} fanout={len(v.get('fanout_set',[]))}")
+        gate_ok = v.get("verdict") in ("complementary", "partially_complementary") and len(v.get("fanout_set", [])) == 3
+        print(f"  gate -> {'PASS' if gate_ok else 'CHECK'}")
+
+        res = {"gate_3way": gate_ok}
+        if args.full:
+            ag._complementarity_cache.clear()
+            print("\n### FULL: 3-way delegate_to_analyses ###")
+            out = json.loads(ag._run_fanout([
+                {"data_path": img["data_path"], "metadata": img["metadata"], "label": "HAADF image",
+                 "task": f"Analyze the HAADF-STEM image at {img['data_path']}: segment the contrast phases and report area fractions."},
+                {"data_path": cube["data_path"], "metadata": cube["metadata"], "label": "EELS datacube",
+                 "task": f"Analyze the EELS datacube at {cube['data_path']}: decompose into spectral components and map them spatially."},
+                {"data_path": xps["data_path"], "metadata": xps["metadata"], "label": "XPS Ti2p",
+                 "task": f"Fit the XPS Ti 2p spectrum at {xps['data_path']}: identify metallic Ti vs TiO2 and report relative areas."},
+            ]))
+            print("FANOUT:", json.dumps(out, indent=2)[:1400])
+            res["branches_with_output"] = out.get("branches_with_output")
+            if out.get("status") == "success" and out.get("branches_with_output", 0) >= 2:
+                idxs = [r["delegation_index"] for r in out["results"] if r["produced_output"]]
+                fout = json.loads(ag._fuse_delegations(
+                    idxs, focus="Reconcile the HAADF structure, the EELS spatial chemistry, and the bulk XPS chemical state."))
+                print("FUSION:", json.dumps(fout, indent=2)[:1700])
+                res["full_3way"] = fout.get("status") == "success" and bool(fout.get("detailed_analysis"))
+            else:
+                res["full_3way"] = False
+        print("\nSUMMARY:", res)
+        sys.exit(0 if all(v for v in res.values() if isinstance(v, bool)) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_meta_fanout_hyperspectral_live.py
+++ b/tests/test_meta_fanout_hyperspectral_live.py
@@ -1,0 +1,131 @@
+"""Live test: meta fan-out over an IMAGE + a co-registered HYPERSPECTRAL
+datacube (Bedrock opus-4-8). The canonical STEM-HAADF + EELS-SI multimodal
+pair — genuine pixel co-registration, so the two branches route to different
+specialists (ImageAnalysisAgent vs HyperspectralAnalysisAgent).
+
+  export AWS_BEARER_TOKEN_BEDROCK=...  AWS_REGION_NAME=us-east-1
+  conda run -n scilink python tests/test_meta_fanout_hyperspectral_live.py          # gate only
+  UNSAFE_EXECUTION_OK=true conda run -n scilink python ... --full                    # + end-to-end
+"""
+import argparse
+import json
+import os
+import sys
+import tempfile
+
+import numpy as np
+
+MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+
+
+def _make_datasets(d, n=32, nE=100):
+    from scipy.ndimage import gaussian_filter
+    rng = np.random.RandomState(11)
+    # Two-phase spatial map (smoothed random field), shared by BOTH modalities.
+    field = gaussian_filter(rng.randn(n, n), sigma=3.0)
+    phase = (field > np.percentile(field, 45)).astype(np.float32)   # 1=metal
+
+    # Co-registered HAADF image: Z-contrast tracks the phase map.
+    haadf = (0.62 * phase + 0.32 * (1 - phase))
+    haadf = gaussian_filter(haadf + rng.normal(0, 0.03, haadf.shape), 0.6).astype(np.float32)
+
+    # EELS datacube: each pixel carries a spectrum set by its phase.
+    E = np.arange(nE)
+    def g(c, w, a):
+        return a * np.exp(-0.5 * ((E - c) / w) ** 2)
+    spec_metal = g(30, 4, 1.0) + g(48, 5, 0.4)            # metal L-edge
+    spec_oxide = g(34, 4, 1.0) + g(52, 5, 0.8)            # chemically shifted + higher white-line
+    cube = np.empty((n, n, nE), np.float32)
+    for j in range(n):
+        for i in range(n):
+            base = spec_metal if phase[j, i] > 0.5 else spec_oxide
+            cube[j, i] = base + 0.05 + rng.normal(0, 0.02, nE)
+    cube = cube.astype(np.float32)
+
+    def save(name, arr, meta):
+        p = os.path.join(d, f"{name}.npy"); np.save(p, arr)
+        mp = os.path.join(d, f"{name}.json"); json.dump(meta, open(mp, "w"), indent=2)
+        return p, mp
+
+    img = save("haadf_image", haadf, {
+        "technique": "STEM-HAADF imaging", "sample": "TiOx thin film",
+        "region_id": "R1", "field_of_view_nm": 8.0, "pixels": f"{n}x{n}",
+        "description": f"Z-contrast image of region R1, {n}x{n}, pixel-aligned "
+                       "with the EELS spectrum image below.",
+    })
+    cubep = save("eels_si", cube, {
+        "technique": "STEM-EELS spectrum image (SI)", "sample": "TiOx thin film",
+        "region_id": "R1", "field_of_view_nm": 8.0,
+        "shape": f"{n}x{n}x{nE}",
+        # EELS skill requires a numeric energy axis (start/end) for axis_2.
+        "energy_range": {"start": 450.0, "end": 450.0 + nE, "units": "eV"},
+        "energy_axis": "eV loss (Ti L-edge region)",
+        "description": f"EELS datacube co-registered to the SAME {n}x{n} region "
+                       "R1 grid as the HAADF image (one spectrum per pixel).",
+    })
+    return {"img": img, "cube": cubep}
+
+
+def _agent(base_dir):
+    from scilink.agents.meta_agent.meta_orchestrator import (
+        MetaOrchestratorAgent, MetaMode)
+    return MetaOrchestratorAgent(base_dir=base_dir, api_key=None, base_url=None,
+                                 model_name=MODEL, meta_mode=MetaMode.AUTONOMOUS)
+
+
+def test_gate(P, base_dir):
+    ag = _agent(base_dir)
+    img, imgm = P["img"]; cube, cubem = P["cube"]
+    v = json.loads(ag._assess_complementarity(
+        [{"path": img, "metadata": imgm}, {"path": cube, "metadata": cubem}]))
+    print("### GATE: HAADF image + co-registered EELS datacube")
+    print(f"  verdict={v.get('verdict')} conf={v.get('confidence')} join={v.get('join_axis')!r}")
+    print(f"  fanout_set={[os.path.basename(p) for p in v.get('fanout_set', [])]}")
+    ok = v.get("verdict") in ("complementary", "partially_complementary") and len(v.get("fanout_set", [])) == 2
+    print(f"  -> {'PASS' if ok else 'FAIL'}")
+    return ok
+
+
+def test_full(P, base_dir):
+    ag = _agent(base_dir)
+    img, imgm = P["img"]; cube, cubem = P["cube"]
+    print("### FULL: delegate_to_analyses(HAADF image + EELS datacube) ###")
+    out = json.loads(ag._run_fanout([
+        {"data_path": img, "metadata": imgm, "label": "HAADF image",
+         "task": f"Analyze the HAADF-STEM image at {img}: segment the two "
+                 "contrast phases and report their area fractions."},
+        {"data_path": cube, "metadata": cubem, "label": "EELS datacube",
+         "task": f"Analyze the EELS spectrum-image datacube at {cube}: decompose "
+                 "it into spectral components and map their spatial distribution."},
+    ]))
+    print("FANOUT:", json.dumps(out, indent=2)[:1400])
+    if out.get("status") != "success" or out.get("branches_with_output", 0) < 2:
+        print("FULL: branches did not both produce output"); return False
+    idxs = [r["delegation_index"] for r in out["results"] if r["produced_output"]]
+    fout = json.loads(ag._fuse_delegations(
+        idxs, focus="Do the HAADF contrast phases spatially coincide with the "
+                    "EELS spectral components, and what oxidation/phase picture results?"))
+    print("FUSION:", json.dumps(fout, indent=2)[:1700])
+    ok = fout.get("status") == "success" and bool(fout.get("detailed_analysis"))
+    print(f"FULL: fused={ok}")
+    return ok
+
+
+def main():
+    ap = argparse.ArgumentParser(); ap.add_argument("--full", action="store_true")
+    args = ap.parse_args()
+    if not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
+        print("Set AWS_BEARER_TOKEN_BEDROCK (+ AWS_REGION_NAME)."); sys.exit(2)
+    d = tempfile.mkdtemp(prefix="fanout_hs_"); P = _make_datasets(d)
+    res = {}
+    with tempfile.TemporaryDirectory() as bd:
+        res["gate"] = test_gate(P, os.path.join(bd, "g"))
+    if args.full:
+        with tempfile.TemporaryDirectory() as bd:
+            res["full"] = test_full(P, os.path.join(bd, "f"))
+    print("\nSUMMARY:", res)
+    sys.exit(0 if all(res.values()) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_meta_fanout_live.py
+++ b/tests/test_meta_fanout_live.py
@@ -1,0 +1,223 @@
+"""Live test for the meta-agent fan-out primitive (Bedrock opus-4-8).
+
+Exercises, against a real LLM:
+  - the complementarity GATE on same-modality and CROSS-MODALITY scenarios
+    (complementary / redundant / unrelated) — the core new judgment;
+  - optionally (--full) end-to-end delegate_to_analyses -> fuse_delegations,
+    including a CROSS-MODAL run (image + spectrum) that routes the two
+    branches to different specialist agents and fuses across modalities.
+
+Run (real code execution needs a sandbox; UNSAFE_EXECUTION_OK=true bypasses):
+  export AWS_BEARER_TOKEN_BEDROCK=...   AWS_REGION_NAME=us-east-1
+  conda run -n scilink python tests/test_meta_fanout_live.py            # gates only
+  UNSAFE_EXECUTION_OK=true conda run -n scilink python tests/test_meta_fanout_live.py --full
+"""
+import argparse
+import json
+import os
+import sys
+import tempfile
+
+import numpy as np
+
+MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+
+
+# ----------------------------------------------------------------------
+# Realistic fixtures (so the analysis agents' validity gates don't reject
+# them as synthetic test patterns).
+# ----------------------------------------------------------------------
+
+def _two_phase_image(rng, n=96, bright_frac=0.62):
+    """A natural-looking two-phase microstructure (smoothed random field
+    thresholded), NOT a periodic test pattern."""
+    from scipy.ndimage import gaussian_filter
+    field = gaussian_filter(rng.randn(n, n), sigma=4.0)
+    thr = np.percentile(field, 100 * (1 - bright_frac))
+    phase = (field > thr).astype(np.float32)          # 1 = bright (metal)
+    img = 0.66 * phase + 0.30 * (1 - phase)
+    img = gaussian_filter(img + rng.normal(0, 0.04, img.shape), 0.6)
+    return img.astype(np.float32), float(phase.mean())
+
+
+def _two_component_spectrum(rng, metal_area_frac=0.62):
+    """An XPS-like Ti 2p doublet: a metallic and an oxide component on a
+    sloped background with noise — exactly what curve fitting handles."""
+    x = np.linspace(450.0, 470.0, 450)               # binding energy (eV)
+
+    def g(a, c, w):
+        return a * np.exp(-0.5 * ((x - c) / w) ** 2)
+    # amplitudes chosen so metal:oxide AREA ~ metal_area_frac
+    metal = g(0.95, 454.0, 0.9) + g(0.48, 460.1, 1.0)   # 2p3/2 + 2p1/2
+    oxide = g(0.58, 458.6, 1.1) + g(0.29, 464.4, 1.2)
+    bg = 0.05 + 0.0015 * (x - 450.0)
+    y = metal + oxide + bg + rng.normal(0, 0.012, x.size)
+    return np.vstack([x, y]).T.astype(np.float32)
+
+
+def _save(d, name, arr, meta):
+    p = os.path.join(d, f"{name}.npy")
+    np.save(p, arr)
+    mp = os.path.join(d, f"{name}.json")
+    with open(mp, "w") as fh:
+        json.dump(meta, fh, indent=2)
+    return p, mp
+
+
+def _make_datasets(d):
+    rng = np.random.RandomState(7)
+    img, bf = _two_phase_image(rng)
+    spec = _two_component_spectrum(rng)
+    # An UNRELATED spectrum: a single sharp Raman line of a different material.
+    xr = np.linspace(100, 1200, 600)
+    raman = (np.exp(-0.5 * ((xr - 520) / 4) ** 2)
+             + 0.02 * rng.rand(xr.size))               # Si 520 cm^-1
+    raman_arr = np.vstack([xr, raman]).T.astype(np.float32)
+    # A REDUNDANT second XPS spectrum of the SAME sample (same technique).
+    spec2 = _two_component_spectrum(np.random.RandomState(8))
+
+    P = {}
+    P["img"] = _save(d, "bse_image", img, {
+        "technique": "BSE-SEM imaging", "sample": "oxidized Ti-6Al-4V coupon",
+        "region_id": "R1", "field_of_view_um": 5.0,
+        "description": f"Backscatter image of region R1; two-phase contrast "
+                       f"(bright metallic ~{bf:.0%}, dark oxide).",
+    })
+    P["spec"] = _save(d, "xps_ti2p", spec, {
+        "technique": "XPS Ti 2p core level", "sample": "oxidized Ti-6Al-4V coupon",
+        "region_id": "R1", "x_axis": "binding energy (eV)",
+        "description": "Ti 2p spectrum of the SAME coupon/region; metallic Ti "
+                       "+ TiO2 oxide components.",
+    })
+    P["raman_other"] = _save(d, "si_raman", raman_arr, {
+        "technique": "Raman spectroscopy", "sample": "silicon wafer (unrelated)",
+        "x_axis": "Raman shift (cm-1)",
+        "description": "Si 520 cm-1 line of an unrelated silicon reference.",
+    })
+    P["spec_dup"] = _save(d, "xps_ti2p_rep2", spec2, {
+        "technique": "XPS Ti 2p core level", "sample": "oxidized Ti-6Al-4V coupon",
+        "region_id": "R1", "x_axis": "binding energy (eV)",
+        "description": "Repeat XPS Ti 2p acquisition of the SAME coupon/region.",
+    })
+    return P
+
+
+def _new_agent(base_dir, mode):
+    from scilink.agents.meta_agent.meta_orchestrator import (
+        MetaOrchestratorAgent, MetaMode)
+    return MetaOrchestratorAgent(
+        base_dir=base_dir, api_key=None, base_url=None, model_name=MODEL,
+        meta_mode=MetaMode[mode])
+
+
+def _ds(P, *keys):
+    return [{"path": P[k][0], "metadata": P[k][1]} for k in keys]
+
+
+# ----------------------------------------------------------------------
+# Gate battery (cheap — one LLM call each)
+# ----------------------------------------------------------------------
+
+def test_gate(P, base_dir):
+    agent = _new_agent(base_dir, "AUTONOMOUS")
+    cases = [
+        # name, datasets, predicate(verdict)->ok, expectation
+        ("cross-modal complementary (image + XPS, same coupon)",
+         _ds(P, "img", "spec"),
+         lambda v: v["verdict"] == "complementary" and len(v["fanout_set"]) == 2,
+         "complementary, run both"),
+        ("cross-modal unrelated (image of Ti + Raman of Si)",
+         _ds(P, "img", "raman_other"),
+         lambda v: v["verdict"] in ("unrelated", "uncertain") and len(v["fanout_set"]) < 2,
+         "decline"),
+        ("redundant (two XPS Ti 2p of the same coupon)",
+         _ds(P, "spec", "spec_dup"),
+         lambda v: v["verdict"] in ("redundant", "uncertain") and len(v["fanout_set"]) < 2,
+         "decline (redundant)"),
+        ("3-way cross-modal (image + XPS same coupon + unrelated Si Raman)",
+         _ds(P, "img", "spec", "raman_other"),
+         lambda v: (len(v["fanout_set"]) == 2
+                    and P["raman_other"][0] not in v["fanout_set"]
+                    and P["img"][0] in v["fanout_set"]
+                    and P["spec"][0] in v["fanout_set"]),
+         "prune Si Raman, fan out image+XPS"),
+    ]
+    results = []
+    for name, datasets, ok_fn, expect in cases:
+        v = json.loads(agent._assess_complementarity(datasets))
+        agent._complementarity_cache.clear()  # independent judgments
+        try:
+            ok = bool(ok_fn(v))
+        except Exception:
+            ok = False
+        print(f"\n### GATE: {name}")
+        print(f"  expect: {expect}")
+        print(f"  verdict={v.get('verdict')} conf={v.get('confidence')} "
+              f"join={v.get('join_axis')!r}")
+        print(f"  fanout_set={[os.path.basename(p) for p in v.get('fanout_set', [])]} "
+              f"redundant={[[os.path.basename(p) for p in c] for c in v.get('redundant_clusters', [])]} "
+              f"unrelated={[os.path.basename(p) for p in v.get('unrelated', [])]}")
+        print(f"  -> {'PASS' if ok else 'FAIL'}")
+        results.append(ok)
+    passed = all(results)
+    print(f"\nGATE BATTERY: {sum(results)}/{len(results)} passed")
+    return passed
+
+
+# ----------------------------------------------------------------------
+# Full cross-modal end-to-end (slow — real codegen on two agents + fusion)
+# ----------------------------------------------------------------------
+
+def test_full_crossmodal(P, base_dir):
+    agent = _new_agent(base_dir, "AUTONOMOUS")
+    img, imgm = P["img"]; spec, specm = P["spec"]
+    print("\n### FULL CROSS-MODAL: delegate_to_analyses(image + XPS spectrum) ###")
+    out = json.loads(agent._run_fanout([
+        {"data_path": img, "metadata": imgm, "label": "BSE image",
+         "task": f"Analyze the BSE-SEM image at {img}: segment the phases and "
+                 "report the area fraction of each phase."},
+        {"data_path": spec, "metadata": specm, "label": "XPS Ti 2p",
+         "task": f"Fit the XPS Ti 2p spectrum at {spec}: identify the chemical "
+                 "components (metallic Ti vs TiO2) and report their relative areas."},
+    ]))
+    print("FANOUT:", json.dumps(out, indent=2)[:1400])
+    if out.get("status") != "success" or out.get("branches_with_output", 0) < 2:
+        print("FULL CROSS-MODAL: branches did not both produce output")
+        return False
+    idxs = [r["delegation_index"] for r in out["results"] if r["produced_output"]]
+    print("\n### FULL CROSS-MODAL: fuse_delegations ###")
+    fout = json.loads(agent._fuse_delegations(
+        idxs, focus="Do the two image phases correspond to the two XPS chemical "
+                    "components (metal vs oxide), and are the fractions consistent?"))
+    print("FUSION:", json.dumps(fout, indent=2)[:1800])
+    ok = fout.get("status") == "success" and bool(fout.get("detailed_analysis"))
+    print(f"\nFULL CROSS-MODAL: fused={ok}")
+    return ok
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--full", action="store_true",
+                    help="also run the end-to-end cross-modal fan-out + fuse (slow)")
+    args = ap.parse_args()
+    if not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
+        print("Set AWS_BEARER_TOKEN_BEDROCK (+ AWS_REGION_NAME).")
+        sys.exit(2)
+
+    d = tempfile.mkdtemp(prefix="fanout_live_")
+    P = _make_datasets(d)
+    results = {}
+    with tempfile.TemporaryDirectory() as bd:
+        results["gate_battery"] = test_gate(P, os.path.join(bd, "gate"))
+    if args.full:
+        with tempfile.TemporaryDirectory() as bd:
+            results["full_crossmodal"] = test_full_crossmodal(
+                P, os.path.join(bd, "xmodal"))
+
+    print("\n" + "=" * 60)
+    print("SUMMARY:", results)
+    sys.exit(0 if all(results.values()) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_meta_fanout_robustness.py
+++ b/tests/test_meta_fanout_robustness.py
@@ -72,7 +72,7 @@ def _verdict(paths, fanout_set):
 
 
 def _install_fake_gate(fanout_set):
-    def fake(orch, prompt):
+    def fake(orch, prompt, extra_parts=None):
         if "complementary measurements of ONE system" in prompt:   # HOLISTIC fusion prompt
             return {"detailed_analysis": "fused narrative",
                     "scientific_claims": [{"claim": "c", "keywords": ["k"]}]}

--- a/tests/test_meta_fanout_robustness.py
+++ b/tests/test_meta_fanout_robustness.py
@@ -1,0 +1,206 @@
+"""Offline robustness / edge-case tests for the meta fan-out primitive.
+
+No network — monkeypatches the gate LLM and the ephemeral child so the
+orchestration logic (branch errors, empty branches, fusion guards, concurrency,
+ledger integrity) is exercised deterministically and fast. Complements the
+live test (gate judgment + real codegen) in test_meta_fanout_live.py.
+
+  conda run -n scilink python tests/test_meta_fanout_robustness.py
+"""
+import json
+import os
+import tempfile
+import threading
+import time
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+
+import numpy as np
+import scilink.agents.meta_agent.fanout as fo
+from scilink.agents.meta_agent.meta_orchestrator import MetaOrchestratorAgent, MetaMode
+
+
+def _agent(mode="AUTONOMOUS"):
+    d = tempfile.mkdtemp()
+    A = os.path.join(d, "A.npy"); B = os.path.join(d, "B.npy"); C = os.path.join(d, "C.npy")
+    np.save(A, np.zeros((8, 8))); np.save(B, np.ones((8, 8))); np.save(C, np.full((8, 8), 2.0))
+    ag = MetaOrchestratorAgent(base_dir=d, api_key="sk-dummy",
+                               model_name="claude-opus-4-6", meta_mode=MetaMode[mode])
+    return ag, A, B, C
+
+
+# Behavior map: substring-in-task -> 'good' | 'empty' | 'error' | 'slow'
+BEHAVIORS = {}
+_ACTIVE = {"n": 0, "max": 0, "lock": threading.Lock()}
+
+
+def _install_fake_child():
+    def fake_child(orch, base_dir):
+        class C:
+            def run_task(self, task, context=None, autonomy=None):
+                with _ACTIVE["lock"]:
+                    _ACTIVE["n"] += 1
+                    _ACTIVE["max"] = max(_ACTIVE["max"], _ACTIVE["n"])
+                try:
+                    # Match behavior to the PRIMARY dataset only — full-mesh puts
+                    # every path in every task, so substring-match would alias.
+                    import re
+                    m = re.search(r"PRIMARY dataset for THIS analysis: (\S+)", task)
+                    primary = m.group(1) if m else None
+                    beh = (BEHAVIORS.get(primary, "good") if primary
+                           else next((v for k, v in BEHAVIORS.items() if k in task), "good"))
+                    if beh == "slow":
+                        time.sleep(0.3); beh = "good"
+                    if beh == "error":
+                        raise RuntimeError("synthetic branch failure")
+                    if beh == "empty":
+                        return {"status": "success", "summary": "blocked, no sandbox",
+                                "key_findings": [], "files_produced": []}
+                    return {"status": "success", "summary": f"ok",
+                            "key_findings": ["finding"], "files_produced": ["/x/v.png"]}
+                finally:
+                    with _ACTIVE["lock"]:
+                        _ACTIVE["n"] -= 1
+        return C()
+    fo._make_ephemeral_analysis_child = fake_child
+
+
+def _verdict(paths, fanout_set):
+    return {"verdict": "complementary", "confidence": 0.9, "rationale": "r",
+            "join_axis": "grid", "fanout_set": list(fanout_set),
+            "redundant_clusters": [], "unrelated": [], "excluded_notes": ""}
+
+
+def _install_fake_gate(fanout_set):
+    def fake(orch, prompt):
+        if "cohesive scientific narrative" in prompt:   # HOLISTIC fusion prompt
+            return {"detailed_analysis": "fused narrative",
+                    "scientific_claims": [{"claim": "c", "keywords": ["k"]}]}
+        return _verdict(None, fanout_set)
+    fo._llm_json = fake
+
+
+def _branches(*paths):
+    return [{"data_path": p, "task": f"Analyze {p}", "label": os.path.basename(p)}
+            for p in paths]
+
+
+results = {}
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+def main():
+    _install_fake_child()
+
+    # 1) One branch errors -> reported, not productive, no fuse recommended.
+    ag, A, B, C = _agent()
+    BEHAVIORS.clear(); BEHAVIORS[A] = "good"; BEHAVIORS[B] = "error"
+    _install_fake_gate([A, B]); ag._complementarity_cache.clear()
+    out = json.loads(ag._run_fanout(_branches(A, B)))
+    print("1) branch error:")
+    check("run still 'success' overall", out["status"] == "success")
+    check("branches_run == 2", out["branches_run"] == 2)
+    check("branches_with_output == 1", out["branches_with_output"] == 1)
+    errored = [r for r in out["results"] if r["status"] == "error"]
+    check("errored branch recorded with status=error", len(errored) == 1)
+    check("error: warning surfaced", "warning" in out)
+    check("error: next_step says do NOT fuse", "do NOT fuse" in out["next_step"])
+
+    # 2) One empty-but-successful branch -> flagged.
+    ag, A, B, C = _agent()
+    BEHAVIORS.clear(); BEHAVIORS[A] = "good"; BEHAVIORS[B] = "empty"
+    _install_fake_gate([A, B]); ag._complementarity_cache.clear()
+    out = json.loads(ag._run_fanout(_branches(A, B)))
+    print("2) empty-but-successful branch:")
+    check("empty: branches_with_output == 1", out["branches_with_output"] == 1)
+    check("empty: warning surfaced", "warning" in out)
+
+    # 3) Fuse edge cases.
+    ag, A, B, C = _agent()
+    BEHAVIORS.clear(); BEHAVIORS[A] = "good"; BEHAVIORS[B] = "good"
+    _install_fake_gate([A, B]); ag._complementarity_cache.clear()
+    out = json.loads(ag._run_fanout(_branches(A, B)))
+    good_idxs = [r["delegation_index"] for r in out["results"] if r["produced_output"]]
+    print("3) fuse edge cases:")
+    f1 = json.loads(ag._fuse_delegations(good_idxs[:1]))
+    check("fuse with <2 indices -> error", f1["status"] == "error")
+    f2 = json.loads(ag._fuse_delegations([999, 1000]))
+    check("fuse with nonexistent indices -> error", f2["status"] == "error")
+    f3 = json.loads(ag._fuse_delegations(good_idxs))
+    check("fuse with 2 good -> success", f3["status"] == "success")
+    check("fusion wrote a report file", os.path.exists(f3.get("report_path", "")))
+    check("fusion recorded as ledger entry mode=fusion",
+          any(e.get("mode") == "fusion" for e in ag._delegation_ledger))
+
+    # 4) Concurrency + ledger integrity at N=4 (slow children must overlap).
+    ag, A, B, C = _agent()
+    Dp = os.path.join(os.path.dirname(A), "D.npy"); np.save(Dp, np.full((8, 8), 3.0))
+    BEHAVIORS.clear()
+    for p in (A, B, C, Dp): BEHAVIORS[p] = "slow"
+    _install_fake_gate([A, B, C, Dp]); ag._complementarity_cache.clear()
+    _ACTIVE["max"] = 0
+    t0 = time.time()
+    out = json.loads(ag._run_fanout(_branches(A, B, C, Dp)))
+    dt = time.time() - t0
+    print("4) concurrency N=4:")
+    check("4 branches ran", out["branches_run"] == 4)
+    idxs = [r["delegation_index"] for r in out["results"]]
+    check("ledger indices unique", len(set(idxs)) == 4)
+    check("indices contiguous & ordered", idxs == sorted(idxs))
+    check("ran concurrently (>=2 overlap)", _ACTIVE["max"] >= 2)
+    check("wall-clock < serial (4x0.3=1.2s)", dt < 1.0)
+    grp = {e.get("parallel_group") for e in ag._delegation_ledger if e.get("fanout")}
+    check("all 4 share one parallel_group", len(grp) == 1)
+
+    # 5) Single-branch fan-out rejected.
+    ag, A, B, C = _agent()
+    _install_fake_gate([A]); ag._complementarity_cache.clear()
+    out = json.loads(ag._run_fanout(_branches(A)))
+    print("5) single branch:")
+    check("single branch -> error", out["status"] == "error")
+
+    # 6) Gate fail-closed on unparseable verdict.
+    ag, A, B, C = _agent()
+    fo._llm_json = lambda orch, prompt: None
+    ag._complementarity_cache.clear()
+    out = json.loads(ag._run_fanout(_branches(A, B)))
+    print("6) gate fail-closed:")
+    check("unparseable gate -> declined", out["status"] == "declined")
+
+    # 7) Size caps: many complementary datasets.
+    def _many(n):
+        ag, A, B, C = _agent()
+        d = os.path.dirname(A)
+        paths = [os.path.join(d, f"m{i}.npy") for i in range(n)]
+        for p in paths:
+            np.save(p, np.zeros((8, 8)))
+        BEHAVIORS.clear()
+        for p in paths: BEHAVIORS[p] = "good"
+        _install_fake_gate(paths); ag._complementarity_cache.clear()
+        return ag, paths
+    print("7) size caps (autonomous):")
+    ag, paths = _many(6)   # > SOFT_CAP (5)
+    out = json.loads(ag._run_fanout(_branches(*paths)))
+    check("6-way autonomous -> declined (soft cap)", out["status"] == "declined")
+    ag, paths = _many(9)   # > HARD_CAP (8)
+    out = json.loads(ag._run_fanout(_branches(*paths)))
+    check("9-way -> declined (hard cap)", out["status"] == "declined")
+    ag, paths = _many(3)   # within caps
+    out = json.loads(ag._run_fanout(_branches(*paths)))
+    check("3-way autonomous -> runs", out["status"] == "success" and out["branches_run"] == 3)
+
+    print("\n" + "=" * 50)
+    npass = sum(results.values())
+    print(f"ROBUSTNESS: {npass}/{len(results)} checks passed")
+    for k, v in results.items():
+        if not v:
+            print("  FAILED:", k)
+    raise SystemExit(0 if npass == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_meta_fanout_robustness.py
+++ b/tests/test_meta_fanout_robustness.py
@@ -73,7 +73,7 @@ def _verdict(paths, fanout_set):
 
 def _install_fake_gate(fanout_set):
     def fake(orch, prompt):
-        if "cohesive scientific narrative" in prompt:   # HOLISTIC fusion prompt
+        if "complementary measurements of ONE system" in prompt:   # HOLISTIC fusion prompt
             return {"detailed_analysis": "fused narrative",
                     "scientific_claims": [{"claim": "c", "keywords": ["k"]}]}
         return _verdict(None, fanout_set)

--- a/tests/test_meta_fanout_stress_live.py
+++ b/tests/test_meta_fanout_stress_live.py
@@ -1,0 +1,228 @@
+"""Live STRESS battery for the meta fan-out gate + a same-modality full run.
+
+Covers data-type variety the other live tests don't: same-modality
+spectroscopy pairs, thermal curves with a shared axis, temporal before/after
+(directionality probe), survey/detail, a mis-routed results table, two-region,
+plus unrelated/redundant sanity. Then a DSC+TGA end-to-end (two CurveFitting
+branches with a shared-temperature operand).
+
+  export AWS_BEARER_TOKEN_BEDROCK=...  AWS_REGION_NAME=us-east-1
+  conda run -n scilink python tests/test_meta_fanout_stress_live.py          # gate battery
+  UNSAFE_EXECUTION_OK=true conda run -n scilink python ... --full            # + DSC/TGA run
+"""
+import argparse, json, os, sys, tempfile
+import numpy as np
+
+MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+RNG = np.random.RandomState(3)
+
+
+# ---- 1D helpers ----
+def _g(x, c, w, a):       # gaussian
+    return a * np.exp(-0.5 * ((x - c) / w) ** 2)
+
+def _step(x, c, w, h):    # sigmoid mass-loss step (drops by h)
+    return -h / (1.0 + np.exp(-(x - c) / w))
+
+def _curve(x, y):
+    return np.vstack([x, y]).astype(np.float32).T
+
+
+def _save(d, name, arr, meta):
+    p = os.path.join(d, name + ".npy"); np.save(p, arr)
+    mp = os.path.join(d, name + ".json"); json.dump(meta, open(mp, "w"), indent=2)
+    return {"path": p, "metadata": mp}
+
+
+def _img_two_phase(n=64, frac=0.6, seed=0):
+    from scipy.ndimage import gaussian_filter
+    r = np.random.RandomState(seed)
+    f = gaussian_filter(r.randn(n, n), 3.0)
+    ph = (f > np.percentile(f, 100 * (1 - frac))).astype(np.float32)
+    return gaussian_filter(0.6 * ph + 0.3 * (1 - ph) + r.normal(0, 0.03, (n, n)), 0.6).astype(np.float32)
+
+
+def make_fixtures(d):
+    F = {}
+    # --- thermal: DSC + TGA on a shared temperature axis (30..600 C) ---
+    T = np.linspace(30, 600, 600)
+    tga = 100.0 + _step(T, 110, 12, 6) + _step(T, 410, 18, 40) + RNG.normal(0, 0.2, T.size)
+    dsc = (_g(T, 110, 12, -3.0)      # endotherm: dehydration (coincides w/ TGA step)
+           + _g(T, 250, 15, 2.0)     # exotherm: crystallization (NO mass change)
+           + _g(T, 410, 18, -5.0)    # endotherm: decomposition (coincides w/ TGA step)
+           + 0.01 * (T - 30) + RNG.normal(0, 0.05, T.size))
+    F["tga"] = _save(d, "tga_curve", _curve(T, tga), {
+        "technique": "Thermogravimetric analysis (TGA)", "sample": "hydrated metal carbonate",
+        "x_axis": "temperature (C)", "y_axis": "mass (%)", "heating_rate": "10 C/min",
+        "description": "Mass vs temperature; dehydration + decomposition steps."})
+    F["dsc"] = _save(d, "dsc_curve", _curve(T, dsc), {
+        "technique": "Differential scanning calorimetry (DSC)", "sample": "hydrated metal carbonate",
+        "x_axis": "temperature (C)", "y_axis": "heat flow (mW, endo down)", "heating_rate": "10 C/min",
+        "description": "Heat flow vs temperature on the SAME temperature axis as the TGA."})
+
+    # --- vibrational: Raman + FTIR of the same carbonate (different ranges) ---
+    xr = np.linspace(100, 1600, 700)
+    raman = _g(xr, 1086, 6, 1.0) + _g(xr, 712, 6, 0.3) + _g(xr, 1432, 9, 0.2) + 0.02 + RNG.normal(0, 0.01, xr.size)
+    xi = np.linspace(400, 2000, 800)
+    ftir = _g(xi, 1420, 30, 0.9) + _g(xi, 875, 12, 0.6) + _g(xi, 712, 10, 0.4) + 0.05 + RNG.normal(0, 0.01, xi.size)
+    F["raman"] = _save(d, "raman", _curve(xr, raman), {
+        "technique": "Raman spectroscopy", "sample": "calcite CaCO3",
+        "x_axis": "Raman shift (cm-1)", "description": "Raman-active CO3 modes."})
+    F["ftir"] = _save(d, "ftir", _curve(xi, ftir), {
+        "technique": "FTIR spectroscopy", "sample": "calcite CaCO3",
+        "x_axis": "wavenumber (cm-1)", "description": "IR-active CO3 modes of the SAME sample."})
+
+    # --- electronic: PL + UV-Vis of the same semiconductor ---
+    wl = np.linspace(350, 800, 600)
+    absorb = 1.0 / (1.0 + np.exp((wl - 520) / 8)) + 0.02 + RNG.normal(0, 0.01, wl.size)   # abs edge ~520nm
+    pl = _g(wl, 560, 18, 1.0) + 0.01 + RNG.normal(0, 0.01, wl.size)                       # emission ~560nm
+    F["uvvis"] = _save(d, "uvvis", _curve(wl, absorb), {
+        "technique": "UV-Vis absorption", "sample": "CdSe quantum dots",
+        "x_axis": "wavelength (nm)", "description": "Absorption edge."})
+    F["pl"] = _save(d, "pl", _curve(wl, pl), {
+        "technique": "Photoluminescence (PL)", "sample": "CdSe quantum dots",
+        "x_axis": "wavelength (nm)", "description": "Emission of the SAME quantum dots."})
+
+    # --- temporal before/after images (same region, two time points) ---
+    F["before"] = _save(d, "anneal_t0", _img_two_phase(frac=0.30, seed=1), {
+        "technique": "SEM imaging", "sample": "alloy coupon", "region_id": "R1",
+        "time_point": "t=0 (as-deposited)", "description": "Microstructure BEFORE annealing."})
+    F["after"] = _save(d, "anneal_t1", _img_two_phase(frac=0.55, seed=2), {
+        "technique": "SEM imaging", "sample": "alloy coupon", "region_id": "R1",
+        "time_point": "t=2h at 600C (annealed)", "description": "SAME region AFTER annealing."})
+
+    # --- survey + detail (same sample, different magnification) ---
+    F["survey"] = _save(d, "survey_lowmag", _img_two_phase(n=96, seed=3), {
+        "technique": "SEM imaging", "sample": "catalyst pellet", "magnification": "500x",
+        "field_of_view_um": 200.0, "description": "Wide overview."})
+    F["detail"] = _save(d, "detail_highmag", _img_two_phase(n=64, seed=4), {
+        "technique": "SEM imaging", "sample": "catalyst pellet", "magnification": "20000x",
+        "field_of_view_um": 5.0, "description": "High-mag detail of one region of the survey."})
+
+    # --- mis-routed: a RESULTS TABLE (planning data, not analysis) + an image ---
+    import csv
+    tbl = os.path.join(d, "results_table.csv")
+    with open(tbl, "w", newline="") as fh:
+        w = csv.writer(fh); w.writerow(["sample", "temp_C", "pressure_bar", "yield_pct"])
+        for i in range(12):
+            w.writerow([f"S{i}", 200 + 10 * i, 1 + 0.5 * i, round(40 + 3 * i + RNG.rand() * 5, 1)])
+    json.dump({"description": "process results table: rows=runs, cols=conditions+yield"},
+              open(os.path.join(d, "results_table.json"), "w"))
+    F["table"] = {"path": tbl, "metadata": os.path.join(d, "results_table.json")}
+    F["img_for_table"] = _save(d, "micro_img", _img_two_phase(seed=5), {
+        "technique": "optical microscopy", "sample": "catalyst pellet",
+        "description": "Micrograph (unrelated to the process table)."})
+
+    # --- two XPS from DIFFERENT regions of one sample (spatial heterogeneity) ---
+    be = np.linspace(450, 470, 400)
+    F["xps_core"] = _save(d, "xps_core", _curve(be, _g(be, 454, 0.9, 0.9) + _g(be, 458.6, 1.1, 0.3) + 0.05 + RNG.normal(0, 0.01, be.size)), {
+        "technique": "XPS Ti 2p", "sample": "oxidized coupon", "region_id": "core (metal-rich)",
+        "x_axis": "binding energy (eV)", "description": "Spot 1: mostly metallic Ti."})
+    F["xps_edge"] = _save(d, "xps_edge", _curve(be, _g(be, 454, 0.9, 0.3) + _g(be, 458.6, 1.1, 0.9) + 0.05 + RNG.normal(0, 0.01, be.size)), {
+        "technique": "XPS Ti 2p", "sample": "oxidized coupon", "region_id": "edge (oxide-rich)",
+        "x_axis": "binding energy (eV)", "description": "Spot 2 (different location): mostly TiO2."})
+
+    # --- unrelated sanity: Raman of polymer + DSC of a metal alloy ---
+    F["raman_poly"] = _save(d, "raman_polymer", _curve(xr, _g(xr, 1450, 10, 1.0) + 0.02 + RNG.normal(0, 0.01, xr.size)), {
+        "technique": "Raman spectroscopy", "sample": "polyethylene film", "x_axis": "Raman shift (cm-1)"})
+    # (DSC of metal alloy is F['dsc'] of a different sample) — reuse a fresh one:
+    F["dsc_metal"] = _save(d, "dsc_metal", _curve(T, _g(T, 480, 10, -4.0) + 0.01 * (T - 30) + RNG.normal(0, 0.05, T.size)), {
+        "technique": "DSC", "sample": "Al-Si casting alloy", "x_axis": "temperature (C)"})
+
+    # --- redundant sanity: two FTIR of the same sample, same technique ---
+    F["ftir_dup"] = _save(d, "ftir_rep2", _curve(xi, _g(xi, 1420, 30, 0.9) + _g(xi, 875, 12, 0.6) + _g(xi, 712, 10, 0.4) + 0.05 + RNG.normal(0, 0.01, xi.size)), {
+        "technique": "FTIR spectroscopy", "sample": "calcite CaCO3", "x_axis": "wavenumber (cm-1)",
+        "description": "Repeat FTIR acquisition of the same sample."})
+    return F
+
+
+def _agent(base_dir):
+    from scilink.agents.meta_agent.meta_orchestrator import MetaOrchestratorAgent, MetaMode
+    return MetaOrchestratorAgent(base_dir=base_dir, api_key=None, base_url=None,
+                                 model_name=MODEL, meta_mode=MetaMode.AUTONOMOUS)
+
+
+def _ds(F, *keys):
+    return [{"path": F[k]["path"], "metadata": F[k]["metadata"]} for k in keys]
+
+
+def gate_battery(F, base_dir):
+    ag = _agent(base_dir)
+    pos = lambda v: v["verdict"] in ("complementary", "partially_complementary") and len(v["fanout_set"]) >= 2
+    neg = lambda v: v["verdict"] in ("unrelated", "redundant", "uncertain") and len(v["fanout_set"]) < 2
+    obs = lambda v: True   # observational (genuinely ambiguous — record, don't grade)
+    cases = [
+        ("DSC + TGA (thermal, shared T axis)", _ds(F, "dsc", "tga"), pos, "complementary"),
+        ("Raman + FTIR (same calcite)", _ds(F, "raman", "ftir"), pos, "complementary"),
+        ("PL + UV-Vis (same QDs)", _ds(F, "pl", "uvvis"), pos, "complementary"),
+        ("before/after SEM (same region, temporal)", _ds(F, "before", "after"), obs, "observe: complementary? directional?"),
+        ("survey + detail (same sample, diff mag)", _ds(F, "survey", "detail"), obs, "observe"),
+        ("image + results-table (mis-routed)", _ds(F, "img_for_table", "table"), neg, "decline (table is planning data)"),
+        ("two XPS, different regions (spatial)", _ds(F, "xps_core", "xps_edge"), obs, "observe: complementary-spatial vs redundant"),
+        ("Raman(polymer) + DSC(metal) — UNRELATED", _ds(F, "raman_poly", "dsc_metal"), neg, "decline"),
+        ("two FTIR same sample — REDUNDANT", _ds(F, "ftir", "ftir_dup"), neg, "decline (redundant)"),
+    ]
+    results = {}
+    for name, datasets, pred, expect in cases:
+        v = json.loads(ag._assess_complementarity(datasets)); ag._complementarity_cache.clear()
+        ok = False
+        try: ok = bool(pred(v))
+        except Exception: ok = False
+        graded = pred is not obs
+        tag = ("PASS" if ok else "FAIL") if graded else "OBSERVE"
+        results[name] = (tag != "FAIL")
+        print(f"\n### {name}\n  expect: {expect}")
+        print(f"  -> verdict={v.get('verdict')} conf={v.get('confidence')} "
+              f"join={str(v.get('join_axis'))[:70]!r} fanout={len(v.get('fanout_set',[]))}")
+        if v.get("excluded_notes"): print(f"     notes: {str(v['excluded_notes'])[:160]}")
+        print(f"  [{tag}]")
+    graded = [k for k,(name) in zip(results, [c[2] for c in cases]) ]
+    npass = sum(1 for c in cases if c[2] is not obs and results[c[0]])
+    ngraded = sum(1 for c in cases if c[2] is not obs)
+    print(f"\nGATE BATTERY: {npass}/{ngraded} graded passed ({len(cases)-ngraded} observational)")
+    return npass == ngraded
+
+
+def dsc_tga_full(F, base_dir):
+    ag = _agent(base_dir)
+    dsc, tga = F["dsc"], F["tga"]
+    print("\n### FULL: DSC + TGA (two CurveFitting branches, shared T operand) ###")
+    out = json.loads(ag._run_fanout([
+        {"data_path": dsc["path"], "metadata": dsc["metadata"], "label": "DSC curve",
+         "task": f"Fit/characterize the DSC heat-flow curve at {dsc['path']}: identify thermal "
+                 "events (endo/exothermic) and their onset temperatures."},
+        {"data_path": tga["path"], "metadata": tga["metadata"], "label": "TGA curve",
+         "task": f"Characterize the TGA mass-loss curve at {tga['path']}: identify mass-loss steps, "
+                 "their onset temperatures and magnitudes."},
+    ]))
+    print("FANOUT:", json.dumps(out, indent=2)[:1200])
+    if out.get("status") != "success" or out.get("branches_with_output", 0) < 2:
+        print("DSC/TGA: branches did not both produce output"); return False
+    idxs = [r["delegation_index"] for r in out["results"] if r["produced_output"]]
+    fout = json.loads(ag._fuse_delegations(
+        idxs, focus="Which DSC events coincide with TGA mass loss (decomposition/dehydration) "
+                    "vs which are mass-neutral (phase transitions)?"))
+    print("FUSION:", json.dumps(fout, indent=2)[:1700])
+    ok = fout.get("status") == "success" and bool(fout.get("detailed_analysis"))
+    print(f"DSC/TGA: fused={ok}")
+    return ok
+
+
+def main():
+    ap = argparse.ArgumentParser(); ap.add_argument("--full", action="store_true")
+    args = ap.parse_args()
+    if not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
+        print("Set AWS_BEARER_TOKEN_BEDROCK (+ AWS_REGION_NAME)."); sys.exit(2)
+    d = tempfile.mkdtemp(prefix="fanout_stress_"); F = make_fixtures(d)
+    res = {}
+    with tempfile.TemporaryDirectory() as bd:
+        res["gate_battery"] = gate_battery(F, os.path.join(bd, "g"))
+    if args.full:
+        with tempfile.TemporaryDirectory() as bd:
+            res["dsc_tga_full"] = dsc_tga_full(F, os.path.join(bd, "f"))
+    print("\n" + "=" * 60); print("SUMMARY:", res)
+    sys.exit(0 if all(res.values()) else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary (for scientists)

This adds **parallel multi-dataset analysis** to the meta agent. When you give the assistant two or more complementary measurements of the *same* sample — e.g. a STEM image **and** an XPS spectrum, or DSC **and** TGA — it can now analyze them **at the same time, each informed by the others**, and then **fuse** the results into one cross-dataset interpretation.

How it behaves:

- **It only offers this when the datasets are genuinely complementary.** A complementarity gate checks that the inputs measure different-but-related aspects of one system (e.g. spatially-resolved morphology vs. bulk chemical state). If they're not complementary, it falls back to normal one-at-a-time analysis.
- **It asks before launching.** You get a clean confirmation panel (verdict, the shared "join axis", the branch list, a one-line rationale) and a Cancel / Launch choice.
- **Each analysis sees the others as auxiliary context** (full-mesh), so the XPS fit knows what the image found and vice-versa.
- **The branches run truly in parallel** (threads), with a "still running" heartbeat so a slow branch doesn't look like a hang.
- **The fused report** reconciles the datasets (e.g. "STEM oxide area = 40% and XPS Ti⁴⁺ = 38% agree"), is **honest about disagreements** (it will say a quantitative cross-check *cannot* be made if one fit didn't converge), carries a structured **caveats** section, embeds each branch's figure, and emits an **HTML report**. Literature **novelty is assessed once on the fused claims**, not per branch.

Also included: a `starting_annealing_level` control so a **re-run** of a curve/image fit can start from a higher "temperature" (skip the constraint stages a prior run already showed were inadequate), plus a batch of fan-out UI fixes surfaced during live testing.

Validated end-to-end on Bedrock opus-4-8 across image+spectrum, image+hyperspectral, DSC+TGA, and 3-way scenarios.

---

<details>
<summary><b>Technical details (for reviewers)</b></summary>

### Architecture
The fan-out is a **meta-agent primitive**, not a fourth mode. It lives in `scilink/agents/meta_agent/fanout.py` and is exposed through three tools on `MetaOrchestratorTools` (`assess_complementarity`, `run_fanout`, `fuse_delegations`). It consumes the mode orchestrators only through their duck-typed `run_task(task, context, autonomy)` contract — no base class.

- `assess_complementarity` / `run_fanout` — complementarity gate via a **tool-free** `_structured_model` (avoids empty completions on Bedrock when the chat model carries delegation tool schemas) + `_llm_json` with retry and multimodal `extra_parts`. Gate rubric credits *spatially-resolved-vs-bulk-of-same-sample* complementarity (criterion #3) — fixed an image+spectrum flip-flop.
- `run_fanout` — `ThreadPoolExecutor` over branches; each branch runs an ephemeral child analysis orchestrator at `AUTONOMOUS`. `_mesh_task` composes each branch's self-contained task with **full-mesh companions** passed via `run_analysis`'s `auxiliary_data`/`auxiliary_label`, forwards the primary's metadata (so branches don't synthesize it), and injects a per-branch NOTE suppressing per-branch novelty.
- `fuse_delegations` — drives `HOLISTIC_EXPERIMENTAL_SYNTHESIS_INSTRUCTIONS` (generalized for spatial / shared-axis / length-scale / complementary-observables joins, with an anti-spurious principle + `caveats` output field), feeds per-branch key figures to the multimodal fusion, writes `fusion_report.{json,html}`, and runs `_assess_fusion_novelty` once on the fused claims (inline `novelty_score` / `novelty_explanation` per claim, keyed on `has_anyone_question`; clean no-op without a FutureHouse backend).

### Heartbeat
Plain-text only (no `\r`/ANSI — branch children write to the same stdout from worker threads and output is often captured/ANSI-stripped). Polls every 5 s for prompt completion announcements; prints a "still running" tick at most every 60 s; a completion resets the tick timer. Elapsed via `time.monotonic()`.

### `starting_annealing_level` (curve + image)
`analyze(starting_annealing_level=None)` on `CurveFittingAgent` / `ImageAnalysisAgent`; controllers compute `_start_level = clamp(state["_starting_annealing_level"] or 0)` and seed the initial level, loop level, and `_previous_annealing_level = max(start-1, 0)` (so starting AT hot still fires fresh generation). `run_analysis` exposes it, forwarded via signature-introspection (like `max_verification_iterations`). **Default/None is byte-identical** to prior behavior `(0,0,0)`; verified.

### Shared-stack fixes (each a strict no-op on the success path)
`8a92dd3`: Bug A salvage `AttributeError`, Bug B `NoneType` subscript in `analysis_orchestrator_tools.py`, Bug C 8000px image cap, + sidecar metadata backstop.

### UI
`scilink/ui/app.py` `_render_fanout_confirm` (markdown panel; rationale inline, no expander); equal-size Cancel/Launch via a scoped `fanout-actions-anchor` + dark-CSS height pin in `theme.py`; `use_container_width`→`width="stretch"` across components; theme-toggle "Cached ForwardMsg MISS" fixed by raising `minCachedMessageSize` to 50 KB in `.streamlit/config.toml` (theme CSS is 17–23 KB, was being reference-cached and evicted); white background on the fusion HTML so it renders in dark hosts.

### Tests
`tests/test_meta_fanout_live.py`, `test_meta_fanout_robustness.py` (24/24 offline), `test_meta_fanout_hyperspectral_live.py`, `test_meta_fanout_3way_live.py`, `test_meta_fanout_stress_live.py`. `FANOUT_TEST_FINDINGS.md` records the validation log.

### Notes
- Targets the current `origin/main` (which already has #290/#291).
- Demo data (`fanout_demo_data/`) and figures are intentionally left untracked.

</details>
