### PR TITLE
Anneal the whole skill with temperature + harden XPS skill

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -656,6 +656,7 @@ class AnalysisOrchestratorAgent:
         self._discover_plugin_agents()
 
         # Initialize tools registry (reads agent registry via _sync_from_registry)
+        print("🤖 Agent: Hiring sub-agents...")
         self.tools = AnalysisOrchestratorTools(self)
 
         # Get appropriate system prompt (agent list built from registry)
@@ -667,7 +668,7 @@ class AnalysisOrchestratorAgent:
         
         # Initialize LLM
         if base_url:
-            logging.info(f"🏛️ Orchestrator using internal proxy: {base_url}")
+            logging.debug(f"🏛️ Orchestrator using internal proxy: {base_url}")
             self.model = OpenAIAsGenerativeModel(
                 model=model_name,
                 api_key=api_key,
@@ -676,7 +677,7 @@ class AnalysisOrchestratorAgent:
             self.use_openai = True
             self.tools_for_model = self.tools.openai_schemas
         else:
-            logging.info(f"🌐 Orchestrator using LiteLLM: {model_name}")
+            logging.debug(f"🌐 Orchestrator using LiteLLM: {model_name}")
             self.model = LiteLLMGenerativeModel(
                 model=model_name,
                 api_key=api_key,

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -524,11 +524,56 @@ def _append_fit_domain_guidance(prompt: list, state: dict) -> None:
     )
 
 
+# Domain-skill strictness by annealing temperature — the whole skill relaxes
+# uniformly as the fit "heats up": mandatory (T=0) → guidance (T=1) →
+# reference/overridable (T=2), at EVERY stage (planning, interpretation,
+# conformance; codegen/verification anneal via the class
+# _SKILL_STRICTNESS_SCHEDULE). Physics grounding is the baseline's job, not a
+# non-anneable skill rule. Each frame is
+# (skill_header_label, intro_text, validation_header_label); frame 0 reproduces
+# the original mandatory wording verbatim so a first run (T=0) is unchanged.
+_SKILL_STRICTNESS_FRAMES = (
+    ("MANDATORY Domain Skill Rules",
+     "The following rules are MANDATORY. Your analysis plan and implementation "
+     "MUST conform to these domain-specific requirements. These rules encode "
+     "validated domain expertise and take precedence over general-purpose defaults. "
+     "Do NOT substitute your own preferences where these rules specify a method, "
+     "treatment, or constraint.",
+     "MANDATORY Domain Validation Rules"),
+    ("Domain Skill Guidance",
+     "Follow these domain rules unless the data clearly requires a different "
+     "approach. If you deviate from a rule, explain why.",
+     "Domain Validation Guidance"),
+    ("Domain Skill Reference",
+     "Use these domain rules as context. Override any rule where the data "
+     "warrants it, justifying the deviation from what you observe. Physical "
+     "soundness of the result — not rule-adherence — is the standard here.",
+     "Domain Validation Reference"),
+)
+
+
+def _skill_annealing_level(state: dict) -> int:
+    """Effective skill-strictness temperature for skill injection.
+
+    The fit loop seeds ``_annealing_level`` as it escalates; planning runs
+    before that and interpretation after, so fall back to the run's starting
+    level (``_starting_annealing_level``) when ``_annealing_level`` is unset.
+    A re-run launched hot therefore re-plans with the skill already relaxed.
+    """
+    level = state.get("_annealing_level")
+    if level is None:
+        level = state.get("_starting_annealing_level") or 0
+    return max(0, min(int(level), len(_SKILL_STRICTNESS_FRAMES) - 1))
+
+
 def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
     """Append domain skill knowledge to an LLM prompt for the given stage.
 
-    With multiple skills loaded, each skill's section is appended in order
-    (most-relevant first) so the LLM can attribute guidance to its source.
+    The skill's binding strength tracks the annealing temperature (see
+    ``_SKILL_STRICTNESS_FRAMES``): mandatory when frozen (T=0), overridable
+    when hot (T=2). With multiple skills loaded, each skill's section is
+    appended in order (most-relevant first) so the LLM can attribute guidance
+    to its source.
 
     Args:
         prompt: Mutable list of prompt parts to extend.
@@ -542,6 +587,9 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
     if not skills:
         return
 
+    skill_label, intro_text, validation_label = _SKILL_STRICTNESS_FRAMES[
+        _skill_annealing_level(state)
+    ]
     intro_appended = False
     for sections in skills:
         if not sections:
@@ -551,15 +599,9 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
             continue
         skill_name = sections.get("name", "domain skill")
 
-        prompt.append(f"\n## MANDATORY Domain Skill Rules: {skill_name} ({stage})")
+        prompt.append(f"\n## {skill_label}: {skill_name} ({stage})")
         if not intro_appended:
-            prompt.append(
-                "The following rules are MANDATORY. Your analysis plan and implementation "
-                "MUST conform to these domain-specific requirements. These rules encode "
-                "validated domain expertise and take precedence over general-purpose defaults. "
-                "Do NOT substitute your own preferences where these rules specify a method, "
-                "treatment, or constraint."
-            )
+            prompt.append(intro_text)
             intro_appended = True
         prompt.append(content)
 
@@ -568,7 +610,7 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
         if stage in ("planning", "interpretation"):
             validation = sections.get("validation", "")
             if validation:
-                prompt.append(f"\n## MANDATORY Domain Validation Rules ({skill_name})")
+                prompt.append(f"\n## {validation_label} ({skill_name})")
                 prompt.append(validation)
 
 
@@ -2566,8 +2608,14 @@ Your guidance: '''
                 if content:
                     rules_parts.append(f"### {stage.title()} rules\n{content}")
             if rules_parts:
+                # Conformance checks the script against the (evolving) locked
+                # plan; the skill framing here anneals with temperature too, so
+                # a justified T=2 deviation from the skill is not re-flagged as
+                # mandatory non-conformance.
+                _skill_label = _SKILL_STRICTNESS_FRAMES[
+                    _skill_annealing_level(state)][0]
                 skill_rules_text = (
-                    f"\n**MANDATORY Domain Skill Rules ({skill_name}):**\n"
+                    f"\n**{_skill_label} ({skill_name}):**\n"
                     + "\n".join(rules_parts)
                     + "\n"
                 )
@@ -3009,8 +3057,10 @@ Remember: Rejecting a good fit (R² > {accept_threshold:.2f}) to chase marginal 
         "original plan based on what you observe in the data and residuals.\n",
     )
 
-    # Same annealing applied to domain skill strictness during fitting.
-    # Planning and interpretation stages always keep skills mandatory.
+    # Domain skill strictness during codegen/verification. Planning,
+    # interpretation, and conformance anneal the same way via the module-level
+    # _SKILL_STRICTNESS_FRAMES — the whole skill relaxes uniformly with
+    # temperature; physics grounding is the baseline's responsibility.
     _SKILL_STRICTNESS_SCHEDULE = (
         # T=0: mandatory
         "## MANDATORY Domain Skill Rules ({name})\n"

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -346,11 +346,49 @@ def _active_skill_names(state: dict) -> list[str]:
     return [legacy] if legacy else []
 
 
+# Domain-skill strictness by annealing temperature — the whole skill relaxes
+# uniformly as the analysis "heats up", at EVERY stage (planning, interpretation;
+# codegen/verification anneal via the class _SKILL_STRICTNESS_SCHEDULE). Image
+# skills are advisory by design (composable, not authoritative like curve
+# fitting's), so even T=0 is "expertise to inform", softening to "context" at
+# T=2. Each frame is (skill_header_label, intro_text, validation_header_label);
+# frame 0 reproduces the original wording verbatim so a first run is unchanged.
+_SKILL_STRICTNESS_FRAMES = (
+    ("Domain Expertise",
+     "The following guidance is from validated domain expertise. "
+     "Use it to inform your approach.",
+     "Domain Validation Guidance"),
+    ("Domain Expertise (reference)",
+     "Use this validated domain expertise as reference. If the data clearly "
+     "requires a different approach, deviate and explain why.",
+     "Domain Validation Reference"),
+    ("Domain Expertise (context)",
+     "Use this domain expertise as background context. Override any guidance "
+     "where the data warrants it — explain the deviation.",
+     "Domain Validation Context"),
+)
+
+
+def _skill_annealing_level(state: dict) -> int:
+    """Effective skill-strictness temperature for skill injection.
+
+    The analysis loop seeds ``_annealing_level`` as it escalates; planning runs
+    before that and interpretation after, so fall back to the run's starting
+    level (``_starting_annealing_level``) when ``_annealing_level`` is unset.
+    A re-run launched hot therefore re-plans with the skill already relaxed.
+    """
+    level = state.get("_annealing_level")
+    if level is None:
+        level = state.get("_starting_annealing_level") or 0
+    return max(0, min(int(level), len(_SKILL_STRICTNESS_FRAMES) - 1))
+
+
 def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
     """Append domain skill knowledge to an LLM prompt for the given stage.
 
-    With multiple skills loaded, sections from each are appended in order
-    so the LLM can attribute guidance to its source.
+    The skill's binding strength tracks the annealing temperature (see
+    ``_SKILL_STRICTNESS_FRAMES``). With multiple skills loaded, sections from
+    each are appended in order so the LLM can attribute guidance to its source.
 
     Args:
         prompt: Mutable list of prompt parts to extend.
@@ -366,6 +404,9 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
     if not skills:
         return
 
+    skill_label, intro_text, validation_label = _SKILL_STRICTNESS_FRAMES[
+        _skill_annealing_level(state)
+    ]
     intro_appended = False
     for sections in skills:
         if not sections:
@@ -374,12 +415,9 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
         if not content:
             continue
         skill_name = sections.get("name", "domain skill")
-        prompt.append(f"\n## Domain Expertise: {skill_name} ({stage})")
+        prompt.append(f"\n## {skill_label}: {skill_name} ({stage})")
         if not intro_appended:
-            prompt.append(
-                "The following guidance is from validated domain expertise. "
-                "Use it to inform your approach."
-            )
+            prompt.append(intro_text)
             intro_appended = True
         prompt.append(content)
 
@@ -387,7 +425,7 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
         if stage in ("planning", "interpretation"):
             validation = sections.get("validation", "")
             if validation:
-                prompt.append(f"\n## Domain Validation Guidance: {skill_name}")
+                prompt.append(f"\n## {validation_label}: {skill_name}")
                 prompt.append(validation)
 
 
@@ -1948,8 +1986,10 @@ class UnifiedImageProcessingController:
         "",
     )
 
-    # Same annealing applied to domain skill strictness during analysis.
-    # Planning and interpretation stages always keep skills at T=0 (guidance).
+    # Domain skill strictness during codegen/verification. Planning and
+    # interpretation anneal the same way via the module-level
+    # _SKILL_STRICTNESS_FRAMES — the whole skill relaxes uniformly with
+    # temperature; physics grounding is the baseline's responsibility.
     _SKILL_STRICTNESS_SCHEDULE = (
         # T=0: guidance (default for image analysis — softer than curve fitting's "mandatory")
         "## Domain Expertise Guidance ({name})\n"

--- a/scilink/agents/lit_agents/novelty_scorer.py
+++ b/scilink/agents/lit_agents/novelty_scorer.py
@@ -90,7 +90,7 @@ class NoveltyScorer:
                     "Set SCILINK_API_KEY environment variable or pass api_key parameter."
                 )
             
-            self.logger.info(f"🏛️ NoveltyScorer using internal proxy: {base_url}")
+            self.logger.debug(f"🏛️ NoveltyScorer using internal proxy: {base_url}")
             self.model = OpenAIAsGenerativeModel(
                 model=model_name,
                 api_key=api_key,
@@ -104,7 +104,7 @@ class NoveltyScorer:
                     "Install with: pip install litellm"
                 )
             
-            self.logger.info(f"🌐 NoveltyScorer using LiteLLM: {model_name}")
+            self.logger.debug(f"🌐 NoveltyScorer using LiteLLM: {model_name}")
             self.model = LiteLLMGenerativeModel(
                 model=model_name,
                 api_key=api_key

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -443,14 +443,14 @@ class MetaOrchestratorAgent:
 
         # Initialize LLM (dual path, copied from AnalysisOrchestratorAgent).
         if base_url:
-            logging.info(f"🏛️ Meta orchestrator using internal proxy: {base_url}")
+            logging.debug(f"🏛️ Meta orchestrator using internal proxy: {base_url}")
             self.model = OpenAIAsGenerativeModel(
                 model=model_name, api_key=api_key, base_url=base_url
             )
             self.use_openai = True
             self.tools_for_model = self.tools.openai_schemas
         else:
-            logging.info(f"🌐 Meta orchestrator using LiteLLM: {model_name}")
+            logging.debug(f"🌐 Meta orchestrator using LiteLLM: {model_name}")
             self.model = LiteLLMGenerativeModel(
                 model=model_name,
                 api_key=api_key,

--- a/scilink/agents/planning_agents/bo_agent.py
+++ b/scilink/agents/planning_agents/bo_agent.py
@@ -197,7 +197,7 @@ class BOAgent(BaseAgent):
                     "Set SCILINK_API_KEY environment variable or pass api_key parameter."
                 )
             
-            logging.info(f"🏛️ BOAgent using internal proxy: {base_url}")
+            logging.debug(f"🏛️ BOAgent using internal proxy: {base_url}")
             self.model = OpenAIAsGenerativeModel(
                 model=model_name,
                 api_key=api_key,
@@ -205,7 +205,7 @@ class BOAgent(BaseAgent):
             )
         else:
             # PUBLIC LITELLM
-            logging.info(f"🌐 BOAgent using LiteLLM: {model_name}")
+            logging.debug(f"🌐 BOAgent using LiteLLM: {model_name}")
             self.model = LiteLLMGenerativeModel(
                 model=model_name,
                 api_key=api_key

--- a/scilink/agents/planning_agents/planning_agent.py
+++ b/scilink/agents/planning_agents/planning_agent.py
@@ -137,7 +137,7 @@ class PlanningAgent(BaseAgent):
                     "Using api_key for all requests."
                 )
             
-            logging.info(f"🏛️ PlanningAgent using internal proxy: {base_url}")
+            logging.debug(f"🏛️ PlanningAgent using internal proxy: {base_url}")
             self.model = OpenAIAsGenerativeModel(
                 model=model_name,
                 api_key=api_key,
@@ -148,7 +148,7 @@ class PlanningAgent(BaseAgent):
             
         else:
             # PUBLIC LITELLM - can use different keys per provider
-            logging.info(f"🌐 PlanningAgent using LiteLLM: {model_name}")
+            logging.debug(f"🌐 PlanningAgent using LiteLLM: {model_name}")
             self.model = LiteLLMGenerativeModel(
                 model=model_name,
                 api_key=api_key  # Can be None - LiteLLM reads env vars
@@ -267,7 +267,7 @@ class PlanningAgent(BaseAgent):
         
         if docs_loaded: print("    - ✅ Docs KB loaded.")
         if code_loaded: print("    - ✅ Code KB loaded.")
-        if not self._kb_is_built: print("    - ⚠️  No pre-built KBs found.")
+        if not self._kb_is_built: logging.debug("No pre-built KBs found.")
 
     def _initialize_state(self, objective: str, **kwargs) -> Dict[str, Any]:
         """Creates the foundational state dictionary for a new research task."""

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -755,7 +755,7 @@ class PlanningOrchestratorAgent:
         
         # --- LLM Initialization ---
         if base_url:
-            logging.info(f"🏛️ Orchestrator using internal proxy: {base_url}")
+            logging.debug(f"🏛️ Orchestrator using internal proxy: {base_url}")
             self.model = OpenAIAsGenerativeModel(
                 model=model_name,
                 api_key=api_key,
@@ -764,7 +764,7 @@ class PlanningOrchestratorAgent:
             self.use_openai = True
             self.tools_for_model = self.tools.openai_schemas
         else:
-            logging.info(f"🌐 Orchestrator using LiteLLM: {model_name}")
+            logging.debug(f"🌐 Orchestrator using LiteLLM: {model_name}")
             self.model = LiteLLMGenerativeModel(
                 model=model_name,
                 api_key=api_key,

--- a/scilink/agents/planning_agents/scalarizer_agent.py
+++ b/scilink/agents/planning_agents/scalarizer_agent.py
@@ -92,7 +92,7 @@ class ScalarizerAgent(BaseAgent):
                     "Set SCILINK_API_KEY environment variable or pass api_key parameter."
                 )
             
-            logging.info(f"🏛️ ScalarizerAgent using internal proxy: {base_url}")
+            logging.debug(f"🏛️ ScalarizerAgent using internal proxy: {base_url}")
             self.model = OpenAIAsGenerativeModel(
                 model=model_name,
                 api_key=api_key,
@@ -100,7 +100,7 @@ class ScalarizerAgent(BaseAgent):
             )
         else:
             # PUBLIC LITELLM
-            logging.info(f"🌐 ScalarizerAgent using LiteLLM: {model_name}")
+            logging.debug(f"🌐 ScalarizerAgent using LiteLLM: {model_name}")
             self.model = LiteLLMGenerativeModel(
                 model=model_name,
                 api_key=api_key

--- a/scilink/knowledge/knowledge_base.py
+++ b/scilink/knowledge/knowledge_base.py
@@ -57,14 +57,14 @@ class KnowledgeBase:
         
         # Initialize embedding client
         if base_url:
-            logging.info(f"🏛️ KnowledgeBase using internal proxy for embeddings")
+            logging.debug(f"🏛️ KnowledgeBase using internal proxy for embeddings")
             self.embedding_client = OpenAIAsEmbeddingModel(
                 model=embedding_model,
                 api_key=api_key,
                 base_url=base_url
             )
         elif use_litellm:
-            logging.info(f"🌐 KnowledgeBase using LiteLLM for embeddings: {embedding_model}")
+            logging.debug(f"🌐 KnowledgeBase using LiteLLM for embeddings: {embedding_model}")
             self.embedding_client = LiteLLMEmbeddingModel(
                 model=embedding_model,
                 api_key=api_key

--- a/scilink/skills/curve_fitting/xps/xps.md
+++ b/scilink/skills/curve_fitting/xps/xps.md
@@ -57,6 +57,22 @@ applied.
 3. Fit Voigt peaks to the background-subtracted data.
 4. Report R² on the FULL spectrum (background + peaks vs original data).
 
+**The inelastic background must be physically constrained, never free
+analytic terms.** Use a Shirley or Tougaard background — pre-subtracted (step 2,
+the default recipe here) or iterated jointly with the peaks (active Shirley, as
+CasaXPS does). Both are constrained: their shape is *determined by* the
+spectrum's inelastic tail, not freely optimized. What is NOT allowed is adding a
+*free-form analytic background* — an erf/sigmoid "inelastic shelf", a
+polynomial, an arbitrary spline — whose amplitude or shape are free model
+parameters. Those parameters trade intensity with the asymmetric metallic tail,
+inflating the higher-BE area and **biasing the chemical-state fraction** (e.g.
+metallic:oxide) even while *raising* R². A free background that climbs to match
+the high-BE plateau has absorbed peak intensity — a red flag. If a
+properly-backgrounded fit has poorer R² than a free-background fit, the
+properly-backgrounded one is usually the physically correct result: prefer
+fixing the background endpoints/model over switching to a free analytic
+background.
+
 **Complete XPS fitting template** — adapt this pattern for any XPS region:
 
 ```python
@@ -246,6 +262,22 @@ contamination.
 - Peak positions should match known chemical states within ±0.5 eV (after charge correction).
 - R² > 0.99 is expected for well-resolved XPS peaks; R² < 0.95 indicates a poor model.
 - Residuals should show no systematic structure (check for missed components or incorrect background).
+- **R² alone does NOT certify a chemical-state quantification.** When the fit's
+  purpose is a chemical-state fraction (e.g. metallic:oxide), a high R² can hide
+  a wrong area partition. Before accepting, also require: (a) the area ratio of
+  interest is *stable* — re-seeding amplitudes or perturbing the background
+  endpoints by a few percent must not swing it by more than ~10%; an unstable
+  ratio means the partition is ill-conditioned, not determined. (b) The residual
+  in the spin-orbit OVERLAP window (where one species' 2p1/2 sits under
+  another's 2p3/2 — e.g. ~458–461 eV for Ti 2p) has no dipolar/oscillatory
+  (sign-changing) structure; such structure signals intensity-sharing between
+  the overlapping doublets even at R² > 0.95. Reject the fit on these grounds
+  even when R² passes — do not let the R² threshold approve it.
+- **Background sanity:** the inelastic background must be Shirley or Tougaard
+  (pre-subtracted or active/iterated — both physically constrained). If the
+  reported model instead includes a FREE analytic background term — erf/sigmoid
+  "shelf", polynomial, or arbitrary spline with fitted parameters — the fit is
+  invalid regardless of R² (see analysis section).
 - If more than 5 components are needed in a single spectral region, verify physical justification.
 - Gaussian width should be consistent (within ±0.3 eV) across components in the same region.
 - **Differential charging:** On insulating samples, peaks may appear


### PR DESCRIPTION
> **Stacked on #293** (`feature-meta-fanout`). This PR's base is the fan-out branch, so its diff shows only the 2 commits below; GitHub will retarget it to `main` once the base PR merges. The annealing change depends on `starting_annealing_level`, which lands in the base PR.

## Summary (for scientists)

Two improvements to how the analysis agents use **domain skills** (the technique-specific expertise bundles, e.g. the XPS fitting skill), plus some CLI tidying.

**1. The whole skill now relaxes gradually as the fit "heats up."**

The agents already escalate a "temperature" when a fit is hard: at low temperature they stay strictly within the domain skill's recipe; at high temperature they're free to try a different model. Previously that relaxation only applied while *patching* a fit — the **planning** and **interpretation** steps always treated the skill as mandatory. That meant a re-run launched at high temperature couldn't actually **re-plan** freely; it kept re-deriving the same skill-bound plan it had already shown didn't work.

Now **one temperature governs the entire skill at every stage**: mandatory when frozen → guidance when warm → overridable reference when hot. Physical correctness is kept as the floor by the *baseline* verifier (a physically-implausible fit loses even at higher R², and a deterministic residual-structure check always runs) — **not** by forcing the skill to stay mandatory. So a hot re-run genuinely re-plans, while unphysical results are still caught.

**2. The XPS skill is hardened against a real failure mode.**

On a metal/oxide spectrum, the agent could get a *higher* R² by co-fitting a free-form background that quietly steals intensity from the metallic peak — biasing the metallic:oxide ratio while looking like a better fit. The skill now states the principle (use a physically-constrained Shirley/Tougaard background — pre-subtracted *or* active — never a free erf/polynomial term), and adds validation guidance that **R² alone doesn't certify a chemical-state quantification** (check the metallic:oxide ratio's stability and the spin-orbit overlap-region residual).

### Live validation (Bedrock opus-4-8)

Re-running the realistic Ti 2p test that previously failed:

| | Before | After |
|---|---|---|
| Background | free erf shelf (unphysical) | **constrained Shirley→Tougaard** |
| Converged at | hot (skill disregarded) | **warm (skill held as guidance)** |
| Oxide fraction (truth 40%) | wrong, via bad background | **39.4%** ✓ |
| R² | 0.982 (misleadingly high) | 0.965 (the honest one) |

The agent's generated script even implemented the new area-ratio stability check.

---

<details>
<summary><b>Technical details (for reviewers)</b></summary>

### Whole-skill temperature annealing (`3ed332c`)
Previously skill strictness annealed only in codegen/verification (the class `_SKILL_STRICTNESS_SCHEDULE`); `_append_skill_context` hardcoded `MANDATORY` for **planning** and **interpretation**, and curve's `_check_plan_conformance` re-asserted mandatory skill rules.

- New module-level **`_SKILL_STRICTNESS_FRAMES`** (both `curve_fitting_controllers.py` and `image_analysis_controllers.py`): a 3-tuple `(skill_header_label, intro_text, validation_header_label)`. **Frame 0 reproduces the prior hardcoded wording verbatim** — T=0 (first run) output is byte-identical (verified per agent).
- **`_skill_annealing_level(state)`** reads `_annealing_level`, **falling back to `_starting_annealing_level`** when unset — so a hot re-run re-plans with the skill already relaxed (planning runs before the fit loop seeds the level).
- `_append_skill_context` (planning + interpretation) and curve's `_check_plan_conformance` skill-rule framing now both pull from the frames at the current level. **Interpretation reads the final reached level** via the existing `state["_annealing_level"]` refinement-sync (`curve_fitting_controllers.py:3862`).
- Plan-conformance *logic* is unchanged — it still checks the script against the **evolving** `locked_fitting_config` (reassigned at every refinement, e.g. `:3859`), which is correct; only the skill-rule strictness wording anneals, so a justified T=2 deviation isn't re-flagged as mandatory non-conformance.
- Design rationale: physics grounding lives in the baseline (best-of-N physical-plausibility rubric `curve_fitting_controllers.py:~2239` + deterministic `residual_diagnostics`), not as a non-anneable skill invariant — so hot stays genuinely hot. Reverted an earlier xps.md "holds at every annealing level" line that contradicted this.

### XPS skill hardening (`scilink/skills/curve_fitting/xps/xps.md`, in `3ed332c`)
- `analysis`: principle-level rule — inelastic background must be physically constrained (Shirley/Tougaard, pre-subtracted or active); a *free analytic* background (erf/sigmoid/polynomial/spline) trades intensity with the metallic Doniach-Šunjić tail and biases the chemical-state fraction even while raising R². Permits active Shirley/Tougaard (does **not** ban co-determination — the original draft was over-absolute).
- `validation`: R² alone does not certify a chemical-state quantification — require area-ratio stability under re-seed/background perturbation, and no dipolar residual in the spin-orbit overlap window; reject on these grounds even when R² passes. Loader-verified: lands in `analysis`/`validation` (and folds to `implementation` for codegen), no off-vocab.

### CLI cosmetics (`434acef`)
- `🌐/🏛️ … using LiteLLM / internal proxy` init lines `logging.info`→`logging.debug` across meta/planning/analysis/lit/knowledge agents.
- `planning_agent.py` "No pre-built KBs found" print → `logging.debug`.
- `analysis_orchestrator.py`: `print("🤖 Agent: Hiring sub-agents...")` at tools setup, symmetric with planning.

</details>
