### PR TITLE
Robust multi-column & instrument-export handling for curve fitting

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1953,6 +1953,13 @@ class HumanFeedbackRefinementController:
             f"Parameters: {', '.join(state.get('parameters_to_extract', []))}\n"
             f"Strategy: {state.get('fitting_strategy', 'N/A')}"
         )
+        # For >2-column inputs, show the currently selected columns so the
+        # feedback (e.g. "use the other columns") is anchored to what is wrong.
+        if state.get("column_info") and state.get("column_mapping"):
+            current_plan += (
+                f"\nColumn Mapping: {json.dumps(state['column_mapping'])}"
+                f" — {state.get('column_mapping_note', '')}"
+            )
 
         prompt = [
             self.instructions,
@@ -1964,6 +1971,7 @@ class HumanFeedbackRefinementController:
             f"\n## User Feedback\nAdjust the plan based on this feedback: \"{feedback}\"",
         ]
 
+        _append_column_structure(prompt, state)
         _append_objective_context(prompt, state)
         _append_fit_domain_guidance(prompt, state)
 
@@ -2006,6 +2014,21 @@ class HumanFeedbackRefinementController:
         state["parameters_to_extract"] = result.get("parameters_to_extract", state.get("parameters_to_extract", []))
         state["fitting_strategy"] = result.get("fitting_strategy", state.get("fitting_strategy"))
         state["literature_query"] = result.get("literature_query", state.get("literature_query"))
+
+        # Re-extract the column decision so a feedback-corrected X/Y choice is
+        # honored at lock time. Mirrors _plan_analysis; guarded so a refinement
+        # that omits column_mapping keeps the prior selection rather than nulling
+        # it (the locked fit reads state["column_mapping"] via _resolve_column_mapping).
+        if state.get("column_info"):
+            state["column_mapping"] = result.get("column_mapping", state.get("column_mapping"))
+            state["column_mapping_note"] = result.get(
+                "column_mapping_note", state.get("column_mapping_note", "")
+            )
+            if state.get("column_mapping"):
+                self.logger.info(
+                    f"  Column mapping (refined): {state['column_mapping']} "
+                    f"— {state['column_mapping_note']}"
+                )
 
         # Re-extract series plan (may have been updated or removed)
         self._extract_series_plan(state, result)

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -577,21 +577,32 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         else:
             try:
                 first_spectrum = load_curve_data(spectrum_paths[0], system_info=system_info)
-                first_spectrum_name = Path(spectrum_paths[0]).stem
-                # Capture the raw column structure for the planner (best-effort);
-                # the per-spectrum fit re-loads lazily with the locked mapping.
-                try:
-                    _raw0 = load_curve_data(spectrum_paths[0], auto_orient=False)
-                    column_info = describe_columns(
-                        _raw0, names=sniff_column_names(spectrum_paths[0]))
-                except Exception:
-                    column_info = None
             except Exception as e:
-                return {
-                    "status": "error",
-                    "error": {"error": "Failed to load spectrum", "details": str(e)},
-                    "output_directory": str(self.output_dir)
-                }
+                # Deterministic load failed — e.g. a metadata block above a plain
+                # (non-#) header that np.loadtxt's fixed skiprows attempts can't
+                # skip. Rather than grow the deterministic attempt-ladder for every
+                # format, let the LLM normalizer split metadata from the numeric
+                # table into a clean file, then retry. LLM proposes the parse, the
+                # round-trip check verifies it (lossless); on any failure we keep
+                # the original error.
+                clean = self._normalize_messy_file(spectrum_paths[0])
+                if not clean:
+                    return {
+                        "status": "error",
+                        "error": {"error": "Failed to load spectrum", "details": str(e)},
+                        "output_directory": str(self.output_dir)
+                    }
+                spectrum_paths[0] = clean  # downstream per-spectrum loads use the clean file
+                first_spectrum = load_curve_data(clean, system_info=system_info)
+            first_spectrum_name = Path(spectrum_paths[0]).stem
+            # Capture the raw column structure for the planner (best-effort);
+            # the per-spectrum fit re-loads lazily with the locked mapping.
+            try:
+                _raw0 = load_curve_data(spectrum_paths[0], auto_orient=False)
+                column_info = describe_columns(
+                    _raw0, names=sniff_column_names(spectrum_paths[0]))
+            except Exception:
+                column_info = None
         
         # No separate preprocessing: the fit script owns preprocessing (see
         # docs/preprocessing_in_fit_loop.md). The planner sees the raw first
@@ -899,6 +910,37 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "y_std": float(np.nanstd(y)),
             "has_nans": bool(np.any(np.isnan(curve_data))),
         }
+
+    def _normalize_messy_file(self, path) -> str | None:
+        """Split a combined data+metadata file the deterministic loader couldn't
+        read into a clean data file, returning that path (or None).
+
+        Reuses the meta agent's lossless, round-trip-verified split (LLM proposes
+        the parse from the raw file head, code verifies losslessness) — so the
+        long tail of instrument-export layouts is handled by the model instead of
+        an ever-growing deterministic attempt-ladder. The data file it writes is
+        a clean headed CSV, which the deterministic loader then reads normally.
+        """
+        try:
+            from ..meta_agent.meta_orchestrator_tools import _probe_file
+            from ...utils.file_prep import prepare_inputs
+            try:
+                probe = _probe_file(Path(path))
+            except Exception:  # noqa: BLE001 - probe is best-effort context
+                probe = None
+            out_dir = self.output_dir / "normalized"
+            res = prepare_inputs(Path(path), model=self.model, executor=self.executor,
+                                 output_dir=out_dir, probe=probe,
+                                 logger=self.logger, max_retries=2)
+            if res.get("status") == "success":
+                self.logger.info(
+                    f"  🔧 Normalized unreadable file via LLM split → {res['data_path']}"
+                )
+                return res["data_path"]
+            self.logger.warning(f"  File normalization did not verify: {res.get('message','')[:160]}")
+        except Exception as e:  # noqa: BLE001 - normalization is a fallback, never fatal
+            self.logger.warning(f"  File normalization failed: {e}")
+        return None
 
     def _load_auxiliary_items(self, auxiliary_data, auxiliary_label) -> dict:
         """Load one or several auxiliary datasets into the multi-aux state.

--- a/scilink/skills/_shared/curve_fitting_tools.py
+++ b/scilink/skills/_shared/curve_fitting_tools.py
@@ -164,36 +164,106 @@ def describe_columns(data, names=None):
             "per_column": per_column, "preview_rows": arr[:5].tolist()}
 
 
+def _hdr_isnum(s):
+    cands = [s]
+    if s.count(".") > 1:           # drop pandas '.N' duplicate-name suffix
+        cands.append(s.rsplit(".", 1)[0])
+    for c in cands:
+        try:
+            float(c); return True
+        except ValueError:
+            pass
+    return False
+
+
+def _recover_commented_header(data_path, ext):
+    """Recover a column-header row that sits behind a comment marker.
+
+    Format-agnostic ("header row adjacent to the data"): find the first numeric
+    data row, then test the nearest non-blank line above it as a header after
+    stripping any leading comment punctuation (``#``/``##``/``%``/``;``/``//``).
+    Works for any delimiter / column count. Returns names or None — None when the
+    line above the data is not a plausible header (token-count mismatch or mostly
+    numeric), so a headerless file or a trailing metadata line never yields a
+    spurious header. Used only as a fallback after the plain pandas read finds no
+    usable header (e.g. instrument exports whose column line is itself ``#``-led).
+    """
+    import re as _re
+
+    def split_delim(s):
+        if ext == ".csv":
+            return [t.strip() for t in s.split(",")]
+        if ext == ".tsv":
+            return [t.strip() for t in s.split("\t")]
+        return s.split()
+
+    def is_comment(line):
+        return line.strip().startswith(("#", "%", ";", "//"))
+
+    try:
+        with open(data_path, "r", errors="replace") as fh:
+            raw = [ln.rstrip("\n") for ln in fh.readlines()[:200]]
+    except OSError:
+        return None
+
+    # First numeric data row: non-blank, non-comment, >=2 tokens, mostly numeric.
+    data_idx, ncols = None, None
+    for i, ln in enumerate(raw):
+        if not ln.strip() or is_comment(ln):
+            continue
+        toks = split_delim(ln.strip())
+        if len(toks) >= 2 and sum(_hdr_isnum(t) for t in toks) >= 0.8 * len(toks):
+            data_idx, ncols = i, len(toks)
+            break
+    if not data_idx:        # None (no data) or 0 (data on line 0) → no header above
+        return None
+
+    # Candidate header = nearest non-blank line above the data block, with any
+    # leading comment punctuation stripped.
+    for j in range(data_idx - 1, -1, -1):
+        if not raw[j].strip():
+            continue
+        stripped = _re.sub(r"^\s*(?:#+|%+|;+|//+)\s*", "", raw[j].strip())
+        cand = split_delim(stripped)
+        if (len(cand) == ncols and all(t for t in cand)
+                and sum(_hdr_isnum(t) for t in cand) * 2 < len(cand)):
+            return cand
+        return None         # nearest line above data isn't a plausible header
+    return None
+
+
 def sniff_column_names(data_path):
     """Best-effort header sniff for a delimited text file → column names or None.
 
     None for headerless files (every header token parses as a number) and for
-    formats without a textual header (.npy / binary)."""
+    formats without a textual header (.npy / binary). When the plain read finds
+    no usable header — because the column-name row is itself hidden behind a
+    comment marker (common in instrument exports, e.g. a ``##Temp\\tMass`` line) —
+    falls back to recovering that adjacent header row, which the comment-stripping
+    read would otherwise discard."""
     ext = os.path.splitext(str(data_path))[1].lower()
     if ext not in (".csv", ".tsv", ".dat", ".txt"):
         return None
+    # Primary path (unchanged): handles every file whose header row is NOT hidden
+    # behind a comment marker — plain CSV, #-metadata + plain header, units rows,
+    # pandas duplicate-name suffixes — exactly as before.
     try:
         import pandas as pd
         sep = "\t" if ext == ".tsv" else ("," if ext == ".csv" else r"\s+")
         df = pd.read_csv(data_path, sep=sep, comment="#", nrows=5, engine="python")
         cols = [str(c) for c in df.columns]
-
-        def _isnum(s):
-            cands = [s]
-            if s.count(".") > 1:           # drop pandas '.N' duplicate-name suffix
-                cands.append(s.rsplit(".", 1)[0])
-            for c in cands:
-                try:
-                    float(c); return True
-                except ValueError:
-                    pass
-            return False
         # If most "names" parse as numbers, there was no header row (the data row
         # was misread as the header) → positional names are the safe choice.
-        numeric = sum(_isnum(c) for c in cols)
-        return None if numeric * 2 >= len(cols) else cols
+        numeric = sum(_hdr_isnum(c) for c in cols)
+        # A header whose first cell starts with a non-# comment marker (%, ;, //)
+        # is a comment line pandas misread (it only strips #) → defer to recovery.
+        looks_commented = bool(cols) and cols[0].strip().startswith(("%", ";", "//"))
+        if numeric * 2 < len(cols) and not looks_commented:
+            return cols
     except Exception:
-        return None
+        pass
+    # Recovery path: only reached when the primary read found no usable header.
+    return _recover_commented_header(data_path, ext)
 
 
 def load_curve_data(data_path: str, auto_orient: bool = True,

--- a/scilink/skills/_shared/curve_fitting_tools.py
+++ b/scilink/skills/_shared/curve_fitting_tools.py
@@ -86,11 +86,23 @@ def _choose_xy_indices(arr, system_info, column_names, log):
                            next((i for i in range(n) if i != x_guess), None))
             return x_guess, y_guess
 
-    for i in range(n):  # monotonic-column heuristic
-        col = arr[:, i]
-        if col.size >= 2 and np.all(np.isfinite(col)) and \
-                (np.all(np.diff(col) > 0) or np.all(np.diff(col) < 0)):
-            return i, next(j for j in range(n) if j != i)
+    # Monotonic-column heuristic (last-resort fallback). A monotonic column is
+    # almost always an axis (temperature, time, index), so use it as X — but pick
+    # a NON-monotonic column (a varying signal) as Y rather than blindly taking
+    # the next column, which is often a second axis (e.g. a time channel beside
+    # temperature). This only runs when there is no name signal and no LLM
+    # column_mapping; when names are known the LLM owns this choice, so the job
+    # here is just to avoid the catastrophic "axis as Y" guess.
+    def _is_mono(col):
+        return bool(col.size >= 2 and np.all(np.isfinite(col))
+                    and (np.all(np.diff(col) > 0) or np.all(np.diff(col) < 0)))
+
+    mono = [i for i in range(n) if _is_mono(arr[:, i])]
+    if mono:
+        xi = mono[0]
+        yi = next((j for j in range(n) if j != xi and j not in mono),
+                  next(j for j in range(n) if j != xi))
+        return xi, yi
 
     return 0, 1  # default: first two columns
 

--- a/scilink/utils/file_prep.py
+++ b/scilink/utils/file_prep.py
@@ -416,9 +416,49 @@ def _file_paths(input_path: Path, output_dir: Path) -> dict:
     }
 
 
+# Extensions whose bytes are human-readable text worth showing the split LLM
+# verbatim. Binary containers (.npy/.npz/.h5/.mat/.tif) surface their metadata
+# structurally in the probe, so a "raw head" is meaningless for them.
+_TEXT_HEAD_EXTS = {".csv", ".tsv", ".dat", ".txt", ".asc", ".xy", ".prn"}
+_HEAD_MAX_LINES = 60
+_HEAD_MAX_CHARS = 4000
+
+
+def _raw_text_head(input_path: Path) -> str:
+    """First lines of a text-like file, verbatim, for the split prompt.
+
+    Lets the codegen LLM SEE the metadata/comment block and the column-name row
+    (which the structural probe omits), so the generated split can separate data
+    from metadata and preserve column names instead of writing the script blind.
+    Returns "" for binary/container formats (their metadata is in the probe) or
+    on read error. Capped by lines AND chars so the head stays small regardless
+    of file size — the LLM reads STRUCTURE here, never bulk data values."""
+    if input_path.suffix.lower() not in _TEXT_HEAD_EXTS:
+        return ""
+    try:
+        lines = []
+        with open(input_path, "r", errors="replace") as fh:
+            for _ in range(_HEAD_MAX_LINES):
+                ln = fh.readline()
+                if not ln:
+                    break
+                lines.append(ln.rstrip("\n"))
+        return "\n".join(lines)[:_HEAD_MAX_CHARS]
+    except OSError:
+        return ""
+
+
 def _build_prompt(probe, input_path: Path) -> str:
     probe_str = json.dumps(probe, indent=2, default=str) if probe else \
         f"(no probe) extension={input_path.suffix}, size={input_path.stat().st_size} bytes"
+    head = _raw_text_head(input_path)
+    if head:
+        probe_str += (
+            "\n\nRaw file head (first lines, verbatim — use it to locate the "
+            "metadata/comment block, the column-name row, and where the numeric "
+            "data starts, and to preserve column names; do NOT assume the data "
+            "continues in this exact form beyond the head):\n" + head
+        )
     return _PROMPT.format(probe=probe_str)
 
 


### PR DESCRIPTION
## Summary

Curve fitting often starts from real instrument exports — files that mix a metadata header block with a multi-column data table (temperature, time, signal, mass, …). This PR makes that path reliable in three everyday situations that previously went wrong silently:

1. **When you correct the agent's column choice, the correction now sticks.** Previously, if the agent picked the wrong column, you pointed it out in the feedback step, it showed you a corrected plan, you accepted — and then it fit the *original* (wrong) column anyway. The accepted correction now actually drives the fit.

2. **Column names are no longer lost for common instrument files.** Many exports put the column-name row behind a comment marker (`#`, `##`, `%`). The old reader threw that row away, so the agent saw nameless columns and could pick an instrument axis (like a time channel) as the signal. Names are now recovered, so the agent knows which column is which.

3. **Files the loader couldn't read no longer fail outright.** A metadata block above a plain column header used to make loading fail entirely. Such files are now automatically separated into a clean data file + metadata and loaded successfully.

The guiding idea: let the model handle the *interpretation* of messy files (which column is what, where the data starts, what the names are), while deterministic code keeps doing the things it does reliably — extracting the numbers and verifying the result. This replaces brittle, format-specific parsing rules with a more general, model-driven path.

**Validation:** a cross-technique live stress matrix covering thermal, photoemission, diffraction, vibrational, magnetic-resonance, and optical spectroscopies (21 cases, synthetic data) — every case loaded correctly and locked the intended signal column.

---

## Technical details

Five commits, each scoped to its broken path with no-regression discipline.

### 1. Refinement honors the human-feedback column correction
`controllers/curve_fitting_controllers.py` — `HumanFeedbackRefinementController._refine_plan`
- The refinement path updated the narrative plan (`physical_model`/`fitting_strategy`) but never re-extracted `column_mapping`, so `_resolve_column_mapping` locked the *original* selection. Now re-extracts `column_mapping`/`column_mapping_note` (guarded by `column_info`, falls back to prior when omitted), surfaces the current mapping in the plan summary, and injects the column-structure block into the refine prompt so the model can actually change the X/Y choice.

### 2. Recover comment-hidden column headers
`skills/_shared/curve_fitting_tools.py` — `sniff_column_names` + `_recover_commented_header`
- `pd.read_csv(comment="#")` discards a header row that itself begins with a comment marker. Added a fallback — reached **only** when the primary read finds no usable header — that locates the header row adjacent to the numeric data block and strips leading comment punctuation (`#`/`##`/`%`/`;`/`//`). Format-agnostic (any delimiter / column count). A first-cell comment-marker guard defers `%`/`;`/`//` headers (which `comment="#"` misreads) to the same recovery. Primary path unchanged → currently-working files return byte-identical results.

### 3. Show the raw file head to the split codegen
`utils/file_prep.py` — `_build_prompt` + `_raw_text_head`
- The lossless split codegen only received a structural probe (`{n_columns, dtypes}`) — never the metadata block or column-name row — so it wrote splits blind and could not preserve names. `_build_prompt` now appends the first ~60 raw lines of text-like files (capped by lines AND chars — head, not bulk values). Binary containers (`.npy`/`.npz`/`.h5`/`.mat`/`.tif`) keep the structural probe (their metadata is already in it).

### 4. Safe X/Y fallback — prefer a non-monotonic signal
`skills/_shared/curve_fitting_tools.py` — `_choose_xy_indices`
- The monotonic branch used the first monotonic column as X then blindly took the next column as Y — often a second axis (e.g. a time channel beside temperature). Now picks X = first monotonic column and Y = first **non-monotonic** column, falling back to "next column" only if all candidates are monotonic. Last-resort deterministic fallback (the model owns this via `column_mapping` when names exist); reasons about column shape, not names → technique-agnostic.

### 5. LLM-normalizer load fallback
`agents/exp_agents/curve_fitting_agent.py` — `_normalize_messy_file` + first-spectrum load
- When deterministic `load_curve_data` fails (e.g. a metadata block above a plain non-`#` header that `np.loadtxt`'s fixed `skiprows∈{0,1}` attempts can't skip), the agent routes the file through the lossless, round-trip-verified split (`utils/file_prep.prepare_inputs`) into a clean data file, then retries the load. The normalized path replaces the input downstream so per-spectrum series loads use the clean file. On any failure the original load error is returned unchanged. Embodies "model owns interpretation, code owns value-extraction + verification" — rather than grow the deterministic attempt-ladder per format.

### Validation
- Unit + full orchestrated end-to-end (refinement binding through to the locked fit, R²=1.0).
- 11-case sniff regression+recovery matrix (plain/headerless/`#`/`##`/`%`/gnuplot/`savetxt`, 2..N columns).
- 21-case cross-technique live stress matrix (thermal, photoemission, diffraction, vibrational, magnetic-resonance, optical): 21/21 loaded correctly and locked the intended Y channel; includes normalizer fallback, safe headerless heuristic, and name-based channel selection (e.g. real-vs-imaginary, a named channel among several, signal-vs-baseline).
- Binary-format split regression (HDF5 attrs / `.npz` keys) confirmed unaffected by the raw-head change.

### Known limits (deliberately left to the model-normalizer rather than chased deterministically)
Numeric/wavelength column headers read as headerless; EU `;`-delimiter; spaces-in-names under whitespace delimiters; comma-data saved as `.txt`. Also: split name-capture is prompt-encouraged but not yet asserted post-split (round-trip proves losslessness only) — a candidate follow-up.