### PR TITLE
UI fixes: migrate deprecated st.html API + fix mode-selector layout at narrow widths

### DIFF
--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -430,13 +430,11 @@ if not st.session_state.agent_initialized:
         _modes = [m for m in APP_MODES
                   if m["key"] != "simulate" or simulate_enabled()]
         st.markdown('<div class="mode-selector-anchor"></div>', unsafe_allow_html=True)
-        # Side padding shrinks when [sim] extras add a 4th button so each
-        # button keeps the same fraction of the center column; the fixed 1.5
-        # padding squeezed 4 buttons tight enough that their styled borders
-        # visually collided.
-        _pad = 1.5 if len(_modes) <= 3 else 0.75
-        _cols = st.columns([_pad] + [1.0] * len(_modes) + [_pad])
-        for _m, _col in zip(_modes, _cols[1:-1]):
+        # One equal column per mode (no side padding). The buttons size to their
+        # labels and the row centers/wraps via CSS, so they never truncate or
+        # collide regardless of window width or OS display scaling.
+        _cols = st.columns(len(_modes))
+        for _m, _col in zip(_modes, _cols):
             with _col:
                 _btype = ("primary" if st.session_state.app_mode == _m["key"]
                           else "secondary")

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -535,15 +535,14 @@ def render_sidebar() -> None:
                     task.feedback_request.event.set()
             # Inject JS to replace the page with a goodbye message,
             # then kill the server after a short delay.
-            import streamlit.components.v1 as components
-            components.html(
+            st.html(
                 '<script>'
                 'window.parent.document.body.innerHTML = '
                 '\'<div style="display:flex;align-items:center;justify-content:center;'
                 'height:100vh;font-family:sans-serif;color:#888;background:#0e1117;">'
                 '<h2>Server stopped. You can close this window.</h2></div>\';'
                 '</script>',
-                height=1,
+                unsafe_allow_javascript=True,
             )
             import time, signal
             time.sleep(1)

--- a/scilink/ui/theme.py
+++ b/scilink/ui/theme.py
@@ -123,17 +123,25 @@ div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) {
 div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div {
     margin-top: -2rem !important;
 }
-/* Mode selector — keep the buttons on one row.
-   Streamlit columns are flex items with a built-in min-width and the row
-   wraps by default; at higher OS display scaling / narrower windows the
-   buttons' combined min-width exceeds the centered column and the row wraps
-   (reproduces on some machines, not others). Force no-wrap and let the
-   columns shrink so the buttons stay on a single line. */
+/* Mode selector — full labels at EVERY width.
+   Each button sizes to its label (never narrower, so no "Analyze"->"Analy"
+   truncation or icon-cramming), and the row centers and wraps to a second
+   line only when the window is genuinely too narrow to fit them — rather than
+   forcing them onto one line and shrinking them into a mess. */
 div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div [data-testid="stHorizontalBlock"] {
-    flex-wrap: nowrap !important;
+    flex-wrap: wrap !important;
+    justify-content: center !important;
+    gap: 8px !important;
 }
 div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div [data-testid="stHorizontalBlock"] > [data-testid="stColumn"] {
-    min-width: 0 !important;
+    flex: 0 0 auto !important;
+    width: auto !important;
+    min-width: max-content !important;
+}
+div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div .stButton > button {
+    white-space: nowrap !important;
+    overflow: visible !important;
+    text-overflow: clip !important;
 }
 /* Sidebar buttons — original purple */
 section[data-testid="stSidebar"] .stButton > button {
@@ -676,17 +684,25 @@ div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) {
 div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div {
     margin-top: -2rem !important;
 }
-/* Mode selector — keep the buttons on one row.
-   Streamlit columns are flex items with a built-in min-width and the row
-   wraps by default; at higher OS display scaling / narrower windows the
-   buttons' combined min-width exceeds the centered column and the row wraps
-   (reproduces on some machines, not others). Force no-wrap and let the
-   columns shrink so the buttons stay on a single line. */
+/* Mode selector — full labels at EVERY width.
+   Each button sizes to its label (never narrower, so no "Analyze"->"Analy"
+   truncation or icon-cramming), and the row centers and wraps to a second
+   line only when the window is genuinely too narrow to fit them — rather than
+   forcing them onto one line and shrinking them into a mess. */
 div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div [data-testid="stHorizontalBlock"] {
-    flex-wrap: nowrap !important;
+    flex-wrap: wrap !important;
+    justify-content: center !important;
+    gap: 8px !important;
 }
 div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div [data-testid="stHorizontalBlock"] > [data-testid="stColumn"] {
-    min-width: 0 !important;
+    flex: 0 0 auto !important;
+    width: auto !important;
+    min-width: max-content !important;
+}
+div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div .stButton > button {
+    white-space: nowrap !important;
+    overflow: visible !important;
+    text-overflow: clip !important;
 }
 /* Mode selector secondary buttons — outlined purple */
 div:has(> [data-testid="stMarkdown"] .mode-selector-anchor) + div .stButton > button[kind="secondary"] {

--- a/scilink/ui/theme.py
+++ b/scilink/ui/theme.py
@@ -1399,15 +1399,14 @@ _COLLISION_JS = """
 
 def inject_theme() -> None:
     """Inject the Material Design CSS into the current page."""
-    import streamlit.components.v1 as components
-
     theme_mode = st.session_state.get("theme_mode", "dark")
     css = _MATERIAL_CSS_DARK if theme_mode == "dark" else _MATERIAL_CSS_LIGHT
     st.markdown(css, unsafe_allow_html=True)
 
-    # Force-restyle widgets via JS injected through components.html()
-    # (st.markdown strips <script> tags; components.html() runs in an
-    # iframe so we reach the parent document via window.parent.document).
+    # Force-restyle widgets via JS injected through st.html(unsafe_allow_javascript=True)
+    # (st.markdown strips <script> tags). st.html runs inline in the main
+    # document — not an iframe — so window.parent resolves to the app window
+    # and window.parent.document is the app document itself.
     if theme_mode == "light":
         _LIGHT_WIDGET_JS = """<script>
 (function(){
@@ -1439,11 +1438,11 @@ def inject_theme() -> None:
         .observe(doc.body, {childList:true, subtree:true, attributes:true});
 })();
 </script>"""
-        components.html(_LIGHT_WIDGET_JS, height=1)
+        st.html(_LIGHT_WIDGET_JS, unsafe_allow_javascript=True)
     else:
         # Keep DOM slot count stable; also undo any inline styles
         # left by the light-mode observer on the stop button.
-        components.html("""<script>
+        st.html("""<script>
 (function(){
     var doc = window.parent.document;
     function cleanup(){
@@ -1459,7 +1458,7 @@ def inject_theme() -> None:
     new MutationObserver(cleanup)
         .observe(doc.body, {childList:true, subtree:true});
 })();
-</script>""", height=1)
+</script>""", unsafe_allow_javascript=True)
 
     vibe = st.session_state.get("vibe_theme", "Professional")
 
@@ -1486,7 +1485,7 @@ def inject_theme() -> None:
         unsafe_allow_html=True,
     )
     # Slot 2: collision JS (always present, no-op script when inactive)
-    components.html(
+    st.html(
         _COLLISION_JS if use_collision_js else "<script>/* noop */</script>",
-        height=1,
+        unsafe_allow_javascript=True,
     )


### PR DESCRIPTION
## Summary

Two small, independent UI fixes:

1. **Silence the Streamlit deprecation warnings.** `st.components.v1.html` is deprecated in Streamlit 1.58 and printed repeated console warnings on every rerun. Migrated the affected calls to `st.html`.

2. **Fix the mode-selector buttons becoming a cramped/truncated mess when the window is resized narrow.** The `Mission Control / Analyze / Plan` buttons used to shrink until their labels truncated (e.g. `Analyze` → `Analy`) and the icon button collided with its neighbours. They now keep full labels and stay clean at every width.

Both are scoped to the UI layer; no agent or analysis behavior changes.

---

## Technical details

### 1. Migrate `st.components.v1.html` → `st.html`
`scilink/ui/theme.py` (3 calls), `scilink/ui/components/sidebar.py` (1 call)

- The deprecation message suggests `st.iframe`, but that takes a URL/Path — it cannot render the raw `<script>` HTML these call sites inject, so it is **not** a valid replacement here. These calls use `components.html` purely to run JS that restyles widgets (theme) or paints a shutdown screen (sidebar) by reaching the app DOM via `window.parent.document`.
- Correct replacement: `st.html(body, unsafe_allow_javascript=True)`, which inserts the HTML inline and executes its JS. `st.html` is not iframed, so `window.parent` resolves to the app window and the existing `window.parent.document` references keep working. Dropped the now-invalid `height=` argument and the `components` import.
- **Verified** headlessly with `streamlit.testing.v1.AppTest`: `inject_theme()` runs to completion in both light and dark branches plus the collision-JS slot, with no exceptions, and the emitted `st.html` elements carry their `<script>` payloads intact.

### 2. Mode-selector responsive layout
`scilink/ui/app.py`, `scilink/ui/theme.py`

- **Cause:** the buttons sat in the center column of `st.columns([1, 2, 1])` and were further inset by 1.5-unit padding columns, leaving the three buttons ~25% of the page width split three ways. A prior `flex-wrap: nowrap` rule stopped them wrapping to a second row but made them shrink-and-truncate at narrow widths / high display scaling.
- **Fix:**
  - `app.py`: dropped the padding columns — one equal column per mode (`st.columns(len(_modes))`).
  - `theme.py` (light + dark blocks): each mode button now sizes to its label (`min-width: max-content`, `white-space: nowrap`, no ellipsis); the row is centered with `flex-wrap: wrap` + `gap`. A button can no longer be narrower than its text, so truncation is impossible — worst case the row wraps to a centered second line.
- **Verified** with Playwright at 1440 / 1100 / 820 / 600 / 480 px: `truncated=False` for every button at every width (programmatic `scrollWidth`/`clientWidth` check), full labels, single clean centered row throughout — including 480px, the original failure width.