### PR TITLE
Default the landing page to Mission Control mode

### DIFF
--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -420,7 +420,7 @@ if not st.session_state.agent_initialized:
     with col_c:
         # Mode selector — centered above the logo
         if st.session_state.app_mode is None:
-            st.session_state.app_mode = "analyze"
+            st.session_state.app_mode = "meta"
         # Fall back if a stale session_state still says "simulate" but the
         # [sim] extras are no longer installed.
         if st.session_state.app_mode == "simulate" and not simulate_enabled():
@@ -445,7 +445,7 @@ if not st.session_state.agent_initialized:
         _cur_mode = _mode_map[st.session_state.app_mode]
         _cur_desc = _cur_mode["description"]
         if _cur_mode.get("beta"):
-            _cur_desc = f"BETA · {_cur_desc}"
+            _cur_desc = f"Mission Control · {_cur_desc}"
         st.markdown(
             f'<p style="text-align:center;color:#6B7A8C;font-size:0.85em;'
             f'margin-top:-4px;margin-bottom:12px">'


### PR DESCRIPTION
## Summary

The landing page now opens in **Mission Control** mode (the meta router) instead of Analyze, so users land on the entry point that routes their goal to the right specialist. The mode-selector caption under the buttons reads **"Mission Control · …"** instead of **"BETA · …"**.

Scope is the landing page only — the BETA badge shown *inside* the meta mode (the goal-entry hero) is intentionally left unchanged.

(Follow-up to the UI fixes in #298, which had already merged before this change was pushed.)

## Technical details

`scilink/ui/app.py`:
- Initial `st.session_state.app_mode` default `"analyze"` → `"meta"` (the only landing-time default; the `meta` button renders as the active/primary mode on first load).
- Mode-selector caption prefix `f"BETA · {desc}"` → `f"Mission Control · {desc}"` (still gated by the unchanged `beta` flag in `APP_MODES`).

Verified in a headless browser: on load the Mission Control button is `kind="primary"` (active) with Analyze/Plan secondary, and the caption renders "Mission Control · Routes your research goal to the Analyze & Plan specialists".