### PR TITLE
Fix misleading refit-rejection log message

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -3990,8 +3990,8 @@ Return JSON with:
                             elif verified_r2 < R2_FLOOR:
                                 state["locked_fitting_config"] = best_config
                                 self.logger.info(
-                                    f"   Refit R² = {verified_r2:.4f} "
-                                    f"(best stays {best_r2:.4f} — below R² floor {R2_FLOOR:.2f})"
+                                    f"   Refit R² = {verified_r2:.4f} below R² floor "
+                                    f"{R2_FLOOR:.2f} → rejected (best stays {best_r2:.4f})"
                                 )
                             else:
                                 self.logger.info(


### PR DESCRIPTION
## Summary

The curve-fitting refit loop printed a log line that looked like an arithmetic error — e.g. `Refit R² = 0.8922 (best stays 0.9669 — below R² floor 0.90)`, which reads as if 0.9669 is below the 0.90 floor. It isn't: the selection logic is correct (the refit at 0.8922 fell below the floor and was rejected; the best at 0.9669 is above the floor and was kept). Only the **wording** was wrong — the "below R² floor" clause was attached to the best instead of the refit.

No behavior change; logging only.

## Technical details

`scilink/agents/exp_agents/controllers/curve_fitting_controllers.py`, the `verified_r2 < R2_FLOOR` branch of the post-refit promotion rule. The message now attaches the floor comparison to the refit and states the outcome:

> `Refit R² = 0.8922 below R² floor 0.90 → rejected (best stays 0.9669)`

The sibling in-band line ("deferred to next verifier for physics check") was reviewed and is not misattributed, so it's left unchanged.