### PR TITLE
Fix: restore the Quit App exit screen (regressed by the components.html → st.html migration)

### DIFF
--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -533,16 +533,22 @@ def render_sidebar() -> None:
                 if task.feedback_request is not None:
                     task.feedback_request.response = ""
                     task.feedback_request.event.set()
-            # Inject JS to replace the page with a goodbye message,
-            # then kill the server after a short delay.
-            st.html(
+            # Inject JS to replace the page with a goodbye message, then kill the
+            # server after a short delay. Uses the (deprecated-in-1.58) iframed
+            # components.html on purpose: its <script> executes in an iframe, so
+            # window.parent.document.body reliably replaces the app page before
+            # SIGTERM. The st.html(unsafe_allow_javascript=True) replacement does
+            # not run this script in time, leaving the user on a dead-server
+            # connection error instead of the goodbye screen.
+            import streamlit.components.v1 as components
+            components.html(
                 '<script>'
                 'window.parent.document.body.innerHTML = '
                 '\'<div style="display:flex;align-items:center;justify-content:center;'
                 'height:100vh;font-family:sans-serif;color:#888;background:#0e1117;">'
                 '<h2>Server stopped. You can close this window.</h2></div>\';'
                 '</script>',
-                unsafe_allow_javascript=True,
+                height=1,
             )
             import time, signal
             time.sleep(1)


### PR DESCRIPTION
## Summary

Pressing **Quit App** in the UI was showing a browser *connection error* instead of the intended **"Server stopped. You can close this window."** goodbye screen. This restores the goodbye screen.

## What happened

A recent migration (`89a34a1`, "Migrate deprecated st.components.v1.html to st.html") swapped the iframed `components.html` call in the Quit handler for `st.html(..., unsafe_allow_javascript=True)` to clear a Streamlit 1.58 deprecation warning. After that change the goodbye `<script>` no longer replaces the page before the server is killed, so the user is left looking at the dead-server connection error.

## Why the JS is load-bearing (not cosmetic)

The goodbye script replaces `document.body`, which **destroys the Streamlit client** — that is *why* no connection error appears when the server then exits. A pure-Streamlit / no-JS goodbye would not help: the client would stay alive and surface the connection error anyway. So the fix has to keep running JS at quit time; the only question is which API delivers it reliably.

## Compatibility

The latest Streamlit on PyPI is **1.58.0**, and `components.v1.html` is **present and functional** there (deprecated, not removed). So this fixes the bug for all current users, including anyone installing the latest Streamlit. The only side effect is a one-line deprecation **warning** in the server console — no functional impact, not user-visible.

## Follow-up (tracked, not urgent)

A future-proof version should run the goodbye JS through the supported `st.html(unsafe_allow_javascript=True)`, but append a full-screen overlay to `document.documentElement` (outside React's `#root`, so React does not reconcile it away — the likely reason the inline `document.body` replacement failed) and disable reconnect. This is worth doing **before** Streamlit eventually removes `components.html`, but nothing breaks until then (no released version has removed it).

---

## Technical details

- **File:** `scilink/ui/components/sidebar.py`, the `Quit App` handler (~line 538).
- **Change:** revert the single call site from `st.html(<script…>, unsafe_allow_javascript=True)` back to `streamlit.components.v1.html(<script…>, height=1)`. The script is unchanged: `window.parent.document.body.innerHTML = '<goodbye div>'`. Under `components.html` the script executes inside the component iframe, so `window.parent` is the app window and the body replacement lands and sticks (React in the parent is not mid-render). Under inline `st.html`, the script runs inside the React-managed document and the `document.body` replacement is reverted by React's reconciliation before the `time.sleep(1); os.kill(SIGTERM)` fires.
- **Scope:** Quit handler only. `theme.py`'s `st.html` migration in the same commit is left untouched (not implicated — it restyles existing widgets rather than replacing the page).
- **Verification:** restores the exact pre-`89a34a1` behavior; recommend a manual click-test of **Quit App** before merge (UI interaction not exercisable headlessly). `py_compile` clean.