### PR TITLE
Series plumbing: manifest/embedded-header conditions reach the feature table

### DIFF
--- a/scilink/agents/exp_agents/feature_table.py
+++ b/scilink/agents/exp_agents/feature_table.py
@@ -103,10 +103,13 @@ def _curve_fit_rows(output_dir: Path) -> List[Dict[str, Any]]:
         if not isinstance(r, dict) or not r.get("success"):
             continue
         row: Dict[str, Any] = {"unit": r.get("name") or f"index_{r.get('index')}"}
-        # series_metadata first (manifest/series conditions), then sidecars so a
-        # real per-file sidecar overrides the coarser series list on conflict.
-        row.update(_series_conditions(series_meta, r.get("index"), r.get("data_path")))
-        row.update(_sidecar_conditions(r.get("data_path")))
+        # A per-file sidecar is the authoritative, complete per-unit condition
+        # record; fall back to the coarser series_metadata ONLY for units without
+        # one. Using it as a strict fallback (not an additive layer) avoids
+        # double-counting the same control variable under different names — e.g.
+        # sidecar 'temperature_C' alongside a series 'temperature' column.
+        row.update(_sidecar_conditions(r.get("data_path"))
+                   or _series_conditions(series_meta, r.get("index"), r.get("data_path")))
         row.update(_flatten_scalars(r.get("parameters")))
         row.update(_flatten_scalars(r.get("fit_quality"), "fit_"))
         rows.append(row)
@@ -130,8 +133,10 @@ def _image_series_rows(output_dir: Path) -> List[Dict[str, Any]]:
         if not isinstance(r, dict) or not r.get("success"):
             continue
         row: Dict[str, Any] = {"unit": r.get("name") or f"index_{r.get('index')}"}
-        row.update(_series_conditions(series_meta, r.get("index"), r.get("data_path")))
-        row.update(_sidecar_conditions(r.get("data_path")))
+        # Sidecar is authoritative per unit; series_metadata is a strict fallback
+        # for units lacking one (see _curve_fit_rows for the rationale).
+        row.update(_sidecar_conditions(r.get("data_path"))
+                   or _series_conditions(series_meta, r.get("index"), r.get("data_path")))
         row.update(_flatten_scalars(r.get("extracted_features")))
         row.update(_flatten_scalars(r.get("quality_metrics"), "quality_"))
         rows.append(row)

--- a/scilink/agents/exp_agents/feature_table.py
+++ b/scilink/agents/exp_agents/feature_table.py
@@ -52,6 +52,42 @@ def _sidecar_conditions(data_path: Optional[str]) -> Dict[str, Any]:
     return {k: v for k, v in cond.items() if isinstance(v, (int, float, str))}
 
 
+def _series_conditions(series_meta: Any, index: Any,
+                       data_path: Optional[str]) -> Dict[str, Any]:
+    """Per-unit conditions from the run's top-level ``series_metadata`` — the
+    control variable(s) when conditions are supplied as a manifest / series list
+    rather than per-file sidecar JSONs. Each block is
+    ``{"variable", "values", "unit"}`` where ``values`` is either a list aligned
+    to the spectrum ``index`` or a ``{filename-or-stem: value}`` map; the primary
+    block is joined together with any ``secondary_variables`` (grid designs).
+    Returns ``{}`` on anything unexpected — a malformed block must not break the
+    run, and sidecar conditions (read separately) take precedence over these."""
+    if not isinstance(series_meta, dict):
+        return {}
+    blocks = [series_meta]
+    sec = series_meta.get("secondary_variables")
+    if isinstance(sec, list):
+        blocks.extend(sec)
+    name = Path(data_path).name if data_path else None
+    stem = Path(data_path).stem if data_path else None
+    out: Dict[str, Any] = {}
+    for b in blocks:
+        if not isinstance(b, dict):
+            continue
+        var, vals = b.get("variable"), b.get("values")
+        if not isinstance(var, str) or vals is None:
+            continue
+        val = None
+        if isinstance(vals, dict):
+            val = vals.get(name, vals.get(stem))
+        elif isinstance(vals, (list, tuple)):
+            if isinstance(index, int) and 0 <= index < len(vals):
+                val = vals[index]
+        if isinstance(val, (int, float, str)):
+            out[var] = val
+    return out
+
+
 def _curve_fit_rows(output_dir: Path) -> List[Dict[str, Any]]:
     """One row per spectrum from a curve-fitting run's series_fit_results.json."""
     sfr = output_dir / "series_fit_results.json"
@@ -61,11 +97,15 @@ def _curve_fit_rows(output_dir: Path) -> List[Dict[str, Any]]:
         data = json.loads(sfr.read_text())
     except Exception:  # noqa: BLE001
         return []
+    series_meta = data.get("series_metadata")
     rows: List[Dict[str, Any]] = []
     for r in data.get("results", []):
         if not isinstance(r, dict) or not r.get("success"):
             continue
         row: Dict[str, Any] = {"unit": r.get("name") or f"index_{r.get('index')}"}
+        # series_metadata first (manifest/series conditions), then sidecars so a
+        # real per-file sidecar overrides the coarser series list on conflict.
+        row.update(_series_conditions(series_meta, r.get("index"), r.get("data_path")))
         row.update(_sidecar_conditions(r.get("data_path")))
         row.update(_flatten_scalars(r.get("parameters")))
         row.update(_flatten_scalars(r.get("fit_quality"), "fit_"))
@@ -84,11 +124,13 @@ def _image_series_rows(output_dir: Path) -> List[Dict[str, Any]]:
         data = json.loads(sar.read_text())
     except Exception:  # noqa: BLE001
         return []
+    series_meta = data.get("series_metadata")
     rows: List[Dict[str, Any]] = []
     for r in data.get("results", []):
         if not isinstance(r, dict) or not r.get("success"):
             continue
         row: Dict[str, Any] = {"unit": r.get("name") or f"index_{r.get('index')}"}
+        row.update(_series_conditions(series_meta, r.get("index"), r.get("data_path")))
         row.update(_sidecar_conditions(r.get("data_path")))
         row.update(_flatten_scalars(r.get("extracted_features")))
         row.update(_flatten_scalars(r.get("quality_metrics"), "quality_"))

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -149,6 +149,14 @@ attempt to delegate simulation work.
 - If it is missing, ask the user for it conversationally FIRST, then put it
   into the delegation's `task` / `context`. Do not delegate a data task with
   no metadata and let the specialist stop midway to ask for it.
+- Per-file conditions given as a MANIFEST (a .txt/.csv/README mapping each data
+  file to its conditions, e.g. "filename, temperature, pH"), when the data files
+  have NO matching sidecar JSONs, do NOT become feature-table columns if you only
+  quote them in the task text — and the specialist will fall back to a positional
+  index. Read the mapping and call `materialize_sidecars({filename: {conditions}},
+  data_dir)` to write per-file sidecars FIRST, then delegate the folder; the
+  conditions then flow into the feature table as columns (which downstream
+  optimization needs as inputs).
 
 **EQUIPMENT & SETUP — A HARD PRE-DELEGATION GATE:**
 - This gate applies to any task whose output guides what the user does next

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -800,8 +800,10 @@ class MetaOrchestratorTools:
         # file into a data file + a metadata JSON. Round-trip verified; NEVER
         # used for analysis/computation — that is always delegated.
         def prepare_inputs(path) -> str:
+            import hashlib as _hashlib
             from ...utils.file_prep import (prepare_inputs as _split_file,
-                                            prepare_inputs_batch as _split_batch)
+                                            prepare_inputs_batch as _split_batch,
+                                            stage_pairs_flat as _stage_flat)
             from ...executors import ScriptExecutor, require_sandbox_approval
             paths = [path] if isinstance(path, str) else list(path or [])
             if not paths:
@@ -838,6 +840,22 @@ class MetaOrchestratorTools:
                 result = _split_batch(pths, model=self.orch.model, executor=executor,
                                       output_dir=out_dir, probes=probes,
                                       logger=self.logger, max_retries=2)
+                # Stage the verified pairs into ONE flat, stem-matched directory so
+                # the specialist can consume the whole batch as a series directory
+                # (run_analysis pairs each data file with its <stem>.json sidecar).
+                # Without this the model is left with scattered per-file subfolders
+                # and resorts to passing a path LIST, which the series loader rejects.
+                if result.get("status") in ("success", "partial"):
+                    try:
+                        key = _hashlib.sha1(
+                            "|".join(sorted(str(p) for p in pths)).encode()
+                        ).hexdigest()[:8]
+                        staged = _stage_flat(result.get("results", []),
+                                             out_dir / f"series_{key}")
+                        if staged["n"] > 1:
+                            result["prepared_dir"] = staged["staged_dir"]
+                    except Exception as e:  # noqa: BLE001
+                        self.logger.warning(f"Flat staging skipped: {e}")
             return json.dumps(result, default=str)
 
         self._register_tool(
@@ -849,8 +867,12 @@ class MetaOrchestratorTools:
                 "clean (data, metadata) pairs. Single file → returns data_path + "
                 "metadata_path. Pass a LIST of paths to split several SAME-TYPE files "
                 "in ONE call → returns a per-file 'results' list + a 'summary'; thread "
-                "the pairs into ONE batched delegation (never loop one delegation per "
-                "file). In batch mode a single split is generated and reused across "
+                "the pairs into ONE batched delegation. When >=2 files split, the result "
+                "also has a 'prepared_dir' — one flat folder of the cleaned data files "
+                "each beside its stem-matched sidecar JSON; pass that 'prepared_dir' "
+                "DIRECTORY as the delegation's data (do NOT pass the per-file data paths "
+                "as a list — the series loader takes a directory), and never loop one "
+                "delegation per file. In batch mode a single split is generated and reused across "
                 "structurally identical files (each still round-trip verified), so it "
                 "is cheaper and yields a uniform schema; a file that doesn't match "
                 "falls back to its own split. Use after inspect_uploads when a probe "

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -794,6 +794,84 @@ class MetaOrchestratorTools:
             required=[],
         )
 
+        # ----- materialize_sidecars (manifest -> per-file sidecar JSONs) -------
+        # Conditions supplied as a free-text manifest reach the specialist only as
+        # prose unless turned into per-file sidecars; this writes <stem>.json next
+        # to each data file so the analysis feature table gets a column per
+        # condition. Deterministic, additive, and NEVER overwrites an existing
+        # sidecar (so genuine per-file metadata can't be clobbered).
+        def materialize_sidecars(conditions, data_dir: str = None) -> str:
+            if isinstance(conditions, str):
+                try:
+                    conditions = json.loads(conditions)
+                except Exception:
+                    return json.dumps({"status": "error", "message":
+                                       "conditions must be a JSON object {filename: {key: value}}"})
+            if not isinstance(conditions, dict) or not conditions:
+                return json.dumps({"status": "error", "message":
+                                   "conditions must be a non-empty {filename: {key: value}} mapping"})
+            base = Path(data_dir) if data_dir else None
+            written, skipped, unresolved = [], [], []
+            for fname, cond in conditions.items():
+                if not isinstance(cond, dict):
+                    unresolved.append(f"{fname} (conditions not an object)")
+                    continue
+                p = Path(fname)
+                cands = [p] if p.is_absolute() else (
+                    ([base / fname] if base is not None else []) + [Path.cwd() / fname])
+                target = next((c for c in cands if c.is_file()), None)
+                if target is None:
+                    unresolved.append(str(fname))
+                    continue
+                sidecar = target.with_suffix(".json")
+                if sidecar.exists():                       # never clobber real metadata
+                    skipped.append(str(sidecar))
+                    continue
+                scalars = {k: v for k, v in cond.items()
+                           if isinstance(v, (int, float, str, bool))}
+                sidecar.write_text(json.dumps(scalars, indent=2))
+                written.append(str(sidecar))
+            return json.dumps({
+                "status": "success" if written or skipped else "error",
+                "sidecars_written": len(written), "paths": written,
+                "skipped_existing": skipped, "unresolved": unresolved,
+            })
+
+        self._register_tool(
+            func=materialize_sidecars,
+            name="materialize_sidecars",
+            description=(
+                "Write per-file sidecar metadata JSONs from a conditions MANIFEST the "
+                "user supplied as free text (a .txt/.csv/README mapping each data file "
+                "to its experimental conditions, e.g. 'filename, temperature, pH'). Pass "
+                "`conditions` as a JSON object {data_filename: {condition_key: value, "
+                "...}} that you read from the manifest, plus `data_dir` (the folder "
+                "holding the data files). It writes <stem>.json next to each data file so "
+                "the analysis specialist's feature table gains one COLUMN per condition — "
+                "conditions quoted only in the delegation task text do NOT become feature "
+                "columns (which downstream optimization needs as inputs). Use this BEFORE "
+                "delegating whenever per-file conditions arrive as a manifest and the data "
+                "files have no matching sidecar JSONs. It never overwrites an existing "
+                "sidecar, and only records conditions — it never transforms data."
+            ),
+            parameters={
+                "conditions": {
+                    "type": "object",
+                    "description": (
+                        "{data_filename: {condition_key: value}} read from the manifest; "
+                        "values are scalars (numbers or strings). Filenames may be bare "
+                        "(resolved against data_dir) or absolute."
+                    ),
+                },
+                "data_dir": {
+                    "type": "string",
+                    "description": "Absolute path to the folder holding the data files "
+                                   "(used to resolve bare filenames).",
+                },
+            },
+            required=["conditions"],
+        )
+
         # ----- prepare_inputs (lossless data/metadata split) ------------------
         # The meta's ONLY code-generation surface, restricted to LOSSLESS file
         # repackaging before delegation: split a single combined data+metadata

--- a/scilink/utils/file_prep.py
+++ b/scilink/utils/file_prep.py
@@ -30,6 +30,7 @@ import ast
 import hashlib
 import json
 import re
+import shutil
 from pathlib import Path
 
 import numpy as np
@@ -664,3 +665,44 @@ def prepare_inputs_batch(input_paths, model, executor, output_dir, probes=None,
             "n_fallback": n_fallback, "n_failed": n_failed,
         },
     }
+
+
+def stage_pairs_flat(results: list, flat_dir) -> dict:
+    """Stage a batch's verified (data, metadata) pairs into ONE flat directory
+    with stem-matched names, so a series consumer can ingest the whole batch as a
+    directory and pair each data file with its sidecar by stem.
+
+    The per-file split machinery writes each pair into its own collision-safe
+    subdir with mismatched stems (``<stem>_data.csv`` + ``<stem>_metadata.json``)
+    — correct for the split/verify step but unusable by the directory-based series
+    loader, which excludes ``.json`` as metadata and pairs sidecars by EXACT stem
+    (``spec_00.csv`` ↔ ``spec_00.json``). This copies (never moves — the originals
+    and their round-trip provenance stay intact) each successful pair to
+    ``flat_dir/<input_stem><data_suffix>`` + ``flat_dir/<input_stem>.json``, using
+    the ORIGINAL input filename as the stem (meaningful ``unit`` rows downstream)
+    and disambiguating only on collision. Failed splits are skipped.
+
+    Returns ``{"staged_dir": str, "pairs": [{"data", "metadata"}], "n": int}``.
+    """
+    flat = Path(flat_dir)
+    flat.mkdir(parents=True, exist_ok=True)
+    pairs: list = []
+    used: set = set()
+    for r in results or []:
+        if r.get("status") != "success":
+            continue
+        dp, mp = Path(r.get("data_path", "")), Path(r.get("metadata_path", ""))
+        if not (dp.is_file() and mp.is_file()):
+            continue
+        base = re.sub(r"[^0-9A-Za-z_-]", "_", Path(r.get("file") or dp).stem) or "input"
+        stem, n = base, 1
+        while (stem in used or (flat / f"{stem}{dp.suffix}").exists()
+               or (flat / f"{stem}.json").exists()):
+            n += 1
+            stem = f"{base}_{n}"
+        used.add(stem)
+        data_dst, meta_dst = flat / f"{stem}{dp.suffix}", flat / f"{stem}.json"
+        shutil.copy2(dp, data_dst)
+        shutil.copy2(mp, meta_dst)
+        pairs.append({"data": str(data_dst), "metadata": str(meta_dst)})
+    return {"staged_dir": str(flat), "pairs": pairs, "n": len(pairs)}


### PR DESCRIPTION
## Summary (for scientists)

Two fixes to the multi-file / **series** analysis path that feeds the
analyze → feature-table → Bayesian-optimization loop. Both surfaced while
stress-testing real-world data layouts through mission control (the meta agent),
and both concern getting a *series* of spectra — and their experimental
conditions — through to the results table that downstream optimization reads.

1. **Manifest conditions now reach the feature table.** When a series gives
   per-spectrum conditions only as a plain-text manifest (e.g. a file mapping
   `spec_00.csv → 300 K`) instead of per-file sidecar JSONs, the control
   variable (temperature) was silently dropped from `features.csv` — so the
   scalarizer/BO had no input column to optimize over. It now appears, with the
   correct value per spectrum.

2. **Embedded-comment-header series no longer stalls.** A series of
   instrument-export files that bundle metadata in a comment header
   (`# temperature_K: 350`) now analyzes correctly as one batch and produces a
   feature table with the conditions. Previously the run could spin and time out.

Net effect: temperature-series (and similar) campaigns whose conditions arrive
as a manifest or embedded header now flow end-to-end into the feature table and
the BO loop, the same as the already-working per-file-sidecar case.

<!-- ============================================================ -->
## Technical details (for reviewers)

Both bugs are in the **multi-file series plumbing**, not the deterministic 1-D
loader or the #297 instrument-export normalizer (those are left byte-identical;
an early "loader" diagnosis was wrong). Each fix is additive and localized.

### Fix 5 — join `series_metadata` into the feature table (`feature_table.py`, +42)
- **Root cause:** manifest-derived conditions *are* captured — the orchestrator
  writes them as top-level `series_metadata` (`{"variable","values","unit"}`) in
  `series_fit_results.json` / the image-series analog — but `feature_table` only
  read per-file `.json` sidecars (`_sidecar_conditions`, `feature_table.py:38`),
  so the block was never consumed. (`values` is a list aligned to the spectrum
  `index`, e.g. `[300,350,400,500]`, or a `{name: value}` map.)
- **Change:** new `_series_conditions(series_meta, index, data_path)` joins the
  primary control variable plus any `secondary_variables` by **index** (list) or
  **filename/stem** (dict). Called in both `_curve_fit_rows` and
  `_image_series_rows` **before** `_sidecar_conditions`, so a real per-file
  sidecar still overrides the coarser series list on conflict. Malformed blocks
  yield `{}` (never raises).
- **Scope:** one file, no orchestrator/controller/agent changes — reads data
  already present in the result JSON.

### Fix 6 — stage batched `prepare_inputs` into a flat, stem-matched series dir (`file_prep.py` +42, `meta_orchestrator_tools.py` +28)
- **Root cause:** the meta's batch `prepare_inputs` writes each verified
  `(data, metadata)` pair into its own collision-safe subdir with **mismatched
  stems** (`spec_00_data.csv` vs `spec_00_metadata.json`) — correct for the
  split/verify step, but unusable by the directory-based series loader, which
  excludes `.json` and pairs sidecars by **exact stem** (`_detect_sidecar_jsons`,
  `analysis_orchestrator_tools.py:246`). With no flat dir to hand over, the model
  passed a **path list** as `data_path`, which `run_analysis` does not accept
  (`Path('["..."]').is_dir()` is False, `analysis_orchestrator_tools.py:2210`) →
  the list-string was fed to the loader as one filename and crashed
  (`FileNotFoundError`).
- **Change:** new `file_prep.stage_pairs_flat(results, flat_dir)` **copies**
  (never moves) each verified pair into ONE flat dir as `<input_stem><suffix>` +
  `<input_stem>.json` (stem from the original input → meaningful `unit` rows;
  collision-disambiguated). The meta `prepare_inputs` tool stages a ≥2-file batch
  into `prepared/series_<hash>/`, returns a new `prepared_dir` key, and its
  description now tells the model to pass that **directory** (not a list) to one
  delegation. `run_analysis`'s existing directory path then handles series
  detection + sidecar pairing unchanged.
- **No regression to #297 / batch split:** the per-file split + round-trip
  verification and the single-file path are untouched; staging runs only for
  ≥2-file batches; `prepare_inputs`/`prepare_inputs_batch`/`_verify` are byte-
  for-byte unchanged.

### Validation
- **Deterministic:** `stage_pairs_flat` output flows through the real series
  loader + `_detect_sidecar_jsons` + `load_curve_data` + condition extraction;
  fix 5 verified on the **actual** bare-manifest failure's
  `series_fit_results.json` (recovers `temperature_K 300/350/400/500`), plus
  list/dict/secondary/malformed unit cases.
- **No-regression:** `tests/test_meta_fanout_robustness.py` 24/24 (offline);
  sidecar-based and staged runs regenerate `features.csv` identically (sidecar
  wins, one column, no dup); `curve_fitting_tools.py` 0 diff, `file_prep.py`
  0 deletions.
- **Live (Bedrock opus-4-8, meta agent):** embedded-header series, bare-manifest
  series, single combined-metadata file (#297 path, R²≈0.999), and clean-sidecar
  series — all produce correct feature tables; the embedded-header series was
  re-confirmed on the rebased `main`.

### Known non-goal
Multi-objective BO still gates formal qEHVI below ~10 points (1 input × 2
targets) — a sensible data-sufficiency guardrail, left as-is.
