### PR TITLE
Objective fidelity + STEM tooling fixes (plan-validation goal-awareness, NN-vs-lattice-constant, float-TIFF loading)

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1832,6 +1832,12 @@ class HumanFeedbackRefinementController:
         )
 
         prompt_parts = [prompt_text]
+        # Inject the user's objective so the validator judges the plan against
+        # what was actually asked — not the data plot alone. Without this, an
+        # explicit requirement (a region to exclude, a parameter to report) is
+        # invisible here and gets silently stripped when the data looks
+        # ambiguous. Mirrors the planning prompt and ImageAnalysis._validate_plan.
+        _append_objective_context(prompt_parts, state)
         _append_skill_context(prompt_parts, state, "planning")
 
         # For a series, show the multi-spectrum scout overlay (the single

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -1612,6 +1612,13 @@ class ImagePlanningController:
 
         prompt_parts = [prompt_text]
 
+        # Inject the user's objective so the validator judges the plan against
+        # what was actually asked — not image appearance alone. Without this,
+        # an explicit requirement (e.g. "exclude the substrate region") is
+        # invisible here and gets silently stripped when the image looks
+        # ambiguous.
+        _append_objective_context(prompt_parts, state)
+
         # Include skill context so validator understands domain guidance
         _append_skill_context(prompt_parts, state, "planning")
 

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2402,6 +2402,14 @@ If you identify problems, return:
 }}}}
 Include series_analysis_plan only if this is a series with regimes that need revision.
 Only flag genuine problems — do not redesign a reasonable plan.
+
+An explicit requirement in the stated objective (e.g. a region to exclude, a parameter
+to report) is a constraint, not an assumption to second-guess. If the data make such a
+requirement look hard to satisfy — a feature you cannot clearly see, a region that looks
+ambiguous — flag it and propose a more robust way to meet it; do NOT remove the
+requirement from the model, parameters, or strategy. The user saw something you may not.
+Drop a requirement only if it is physically impossible on this data, and then say so
+explicitly in `issues`.
 """
 
 

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -3344,6 +3344,14 @@ If you identify problems, return:
 Include `series_analysis_plan` only if the image is part of a series with regimes.
 Each regime must have its own pipeline and features. Every image index must appear in exactly one regime.
 Only flag genuine problems that would cause incorrect results — do not redesign a reasonable plan.
+
+An explicit requirement in the stated objective (e.g. a region to exclude, a quantity to
+report) is a constraint, not an assumption to second-guess. If the image makes such a
+requirement look hard to satisfy — a boundary that looks subtle or absent, a feature you
+cannot clearly see — flag it and propose a more robust way to meet it; do NOT remove the
+requirement from the pipeline, features, or quality criteria. The user saw something you
+may not (and your view here may be a downsampled thumbnail). Drop a requirement only if it
+is physically impossible on this data, and then say so explicitly in `issues`.
 """
 
 

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -234,6 +234,12 @@ attempt to delegate simulation work.
   conversation. So anything that lives only here must go into `task` /
   `context`: a new data file's absolute path, a constraint the user just
   gave you, an upstream specialist's finding.
+- Carry the user's objective into `task` in their OWN words — quote the
+  scientific ask verbatim rather than paraphrasing it. You may add the data
+  path, upstream findings, and framing around that quote, but do not reword,
+  normalize, or reinterpret the quantity the user asked for: a paraphrase can
+  silently change the meaning (e.g. turning "X or Y" into "X, i.e. Y"), and
+  the specialist cannot see the original message to catch the drift.
 - Pass upstream findings via the `context` dict, not by re-typing them into
   `task`.
 - Give each call a short `label` (required) — a 2-5 word noun phrase, NOT a

--- a/scilink/skills/_shared/image_analysis_tools.py
+++ b/scilink/skills/_shared/image_analysis_tools.py
@@ -5,6 +5,8 @@ from io import BytesIO
 import os
 import logging
 
+from ._spec import ToolSpec
+
 logger = logging.getLogger(__name__)
 
 MAX_THUMBNAIL_DIM = 1024
@@ -351,3 +353,57 @@ def create_image_montage(
     plt.close(fig)
     buf.seek(0)
     return buf.getvalue()
+
+
+TOOL_SPECS = [
+    ToolSpec(
+        name="resolve_pixel_size_nm",
+        description=(
+            "Resolve nm-per-pixel from metadata + image shape. The robust, "
+            "calibration-correct way to get pixel size — use this instead of "
+            "hand-rolling the arithmetic. It divides field_of_view by the image "
+            "array SHAPE; never divide by a metadata pixel-count field like "
+            "n_cols/width (usually absent, silently leaving pixel size None). "
+            "Never raises."
+        ),
+        import_line=(
+            "from scilink.skills._shared.image_analysis_tools import resolve_pixel_size_nm"
+        ),
+        signature="resolve_pixel_size_nm(metadata, image_shape) -> dict | None",
+        agents=["image_analysis"],
+        when_to_use=(
+            "Whenever a step needs pixel size in nm (spacing/lattice measurements, "
+            "fourier_reflection_map, converting pixel distances to physical units). "
+            "Pass the system_info/metadata dict and image.shape."
+        ),
+        parameters={
+            "metadata": {
+                "type": "dict",
+                "description": (
+                    "The system_info / metadata dict (may nest the payload under "
+                    "a 'system_info' key; both are handled)."
+                ),
+            },
+            "image_shape": {
+                "type": "tuple",
+                "description": (
+                    "numpy image.shape — shape[0]=rows (height), shape[1]=cols (width)."
+                ),
+            },
+        },
+        required=["metadata", "image_shape"],
+        returns=(
+            "dict {'x': nm_per_px, 'y': nm_per_px, 'source': str} where 'x' is the "
+            "horizontal (column) pixel size, or None if it cannot be resolved. "
+            "Read the scalar as px['x'] — there are NO 'pixel_size_nm' / "
+            "'pixel_size_nm_x' keys; handle the None case with a guard."
+        ),
+        example=(
+            "px = resolve_pixel_size_nm(metadata, image.shape)\n"
+            "if px is None:\n"
+            "    raise ValueError('pixel size unavailable; cannot convert to nm')\n"
+            "nm_per_px = px['x']           # horizontal nm/pixel\n"
+            "distance_nm = distance_px * nm_per_px"
+        ),
+    ),
+]

--- a/scilink/skills/_shared/image_processor.py
+++ b/scilink/skills/_shared/image_processor.py
@@ -10,6 +10,25 @@ MAX_IMG_DIM = 1024
 logger = logging.getLogger(__name__)
 
 
+def _normalize_to_uint8(img_array):
+    """Min-max normalize a non-uint8 array to uint8 (no-op if already uint8)."""
+    if img_array.dtype == np.uint8:
+        return img_array
+    float_array = img_array.astype(np.float64)
+    # Guard against NaN/Inf (common in float-encoded scientific TIFFs)
+    if not np.all(np.isfinite(float_array)):
+        finite = float_array[np.isfinite(float_array)]
+        fill = float(np.min(finite)) if finite.size else 0.0
+        hi = float(np.max(finite)) if finite.size else 0.0
+        float_array = np.nan_to_num(float_array, nan=fill, posinf=hi, neginf=fill)
+    min_val, max_val = np.min(float_array), np.max(float_array)
+    if max_val - min_val > 1e-6:
+        normalized_array = (float_array - min_val) / (max_val - min_val)
+    else:
+        normalized_array = np.zeros_like(float_array)
+    return (normalized_array * 255).astype(np.uint8)
+
+
 def load_image(image_path):
     """Load an image from file (PNG, JPG, TIF, .npy, or .h5/.hdf5/.nxs)."""
     try:
@@ -22,26 +41,24 @@ def load_image(image_path):
             else:
                 from scilink.utils.hdf5_utils import load_hdf5_signal
                 img_array = load_hdf5_signal(image_path)
-            if img_array.dtype == np.uint8:
-                return img_array
-            else:
-                # Normalize float arrays to uint8
-                float_array = img_array.astype(np.float64)
-                min_val, max_val = np.min(float_array), np.max(float_array)
-                if max_val - min_val > 1e-6:
-                    normalized_array = (float_array - min_val) / (max_val - min_val)
-                else:
-                    normalized_array = np.zeros_like(float_array)
-                uint8_array = (normalized_array * 255).astype(np.uint8)
-                return uint8_array
+            return _normalize_to_uint8(img_array)
         else:
-            # Standard image loading
-            img = cv2.imread(image_path)
+            # Standard image loading. IMREAD_UNCHANGED preserves bit depth and
+            # channel count so high-bit-depth / 32-bit-float scientific TIFFs
+            # load (the default IMREAD_COLOR flag returns None on those).
+            img = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
             if img is None:
                 raise ValueError(f"Could not load image from {image_path}")
-            # Convert OpenCV's BGR to standard RGB
-            return cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-    
+            # Convert OpenCV's BGR to standard RGB for colour images;
+            # grayscale (2-D) and 2-channel images are left as-is.
+            if img.ndim == 3 and img.shape[2] == 3:
+                img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+            elif img.ndim == 3 and img.shape[2] == 4:
+                img = cv2.cvtColor(img, cv2.COLOR_BGRA2RGBA)
+            # Float / high-bit-depth arrays must be normalized to uint8 so
+            # downstream PIL/JPEG encoding works (mode 'F' has no JPEG path).
+            return _normalize_to_uint8(img)
+
     except Exception as e:
         print(f"Error loading image: {e}")
         raise

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -169,10 +169,20 @@ goal you picked above:
   structures. Verify stoichiometric ratios in all cases. Detected
   positions from a prior detection step should come from
   `prior_analysis_paths`, not be re-detected here.
-- *If goal is lattice parameter / zone axis:* use FFT for periodicity
-  (NN distance is not the lattice parameter for multi-sublattice
-  structures — true unit cell may be 2× or more of the shortest column
-  spacing) and `find_zone_axes` for lattice vectors.
+- *If goal is lattice parameter / lattice vector / zone axis:* a lattice
+  vector is the translation that maps the crystal onto itself — one column
+  onto the next column **of the same species**. Measure it from the FFT
+  fundamental reflections (or `find_zone_axes`), NOT from the nearest-
+  neighbor spacing of detected columns. When the projection resolves more
+  than one inequivalent column per cell (multiple sublattices / a basis),
+  the NN distance is *shorter* than the lattice constant by a projection-
+  dependent factor (√2, √3, 2×, … — derive it from the resolved geometry
+  or measure the repeat directly; never assume a value). Report the
+  quantity the objective names: "lattice constant / parameter / vector" →
+  the repeat period; "nearest-neighbor distance / bond length" → the NN. If
+  the request offers them as alternatives or is ambiguous, report both,
+  explicitly labeled, with their geometric relation — never silently
+  substitute one for the other.
 - *If goal is vacancy / missing-column search:* two complementary
   routes — pick by data quality, or run both as a cross-check.
   **Real-space route** (defect typing, needs reliable columns): requires
@@ -456,6 +466,16 @@ Report in both pixels and physical units when calibration is
 available, and note the calibration-driven uncertainty band when
 matching against literature.
 
+**Nearest-neighbor distance vs lattice constant:** these coincide only
+for a lattice with one column per projected cell. When the projection
+resolves more than one column per cell (multiple sublattices / a basis),
+the NN distance is a column-to-column spacing that is *not* a lattice
+translation and is smaller than the lattice constant by a geometry-
+dependent factor. Keep them as distinct quantities — never label an NN
+distance as the lattice constant. To report a lattice constant, take it
+from the periodicity (FFT fundamental / same-species repeat) or convert
+the NN by the factor implied by the resolved geometry.
+
 ### advanced
 **Sublattice assignment:** Use chemical identity from intensity and
 positional analysis to interpret which sublattice corresponds to which
@@ -497,6 +517,14 @@ literature as informational (likely calibration), not a pass/fail
 failure. Hard checks should be self-consistency: ratio of measured
 spacings (b/a) matching the expected ratio, or FFT peaks forming a
 consistent reciprocal lattice.
+
+**Reported quantity matches the request, and ballparks compare like with
+like:** confirm the headline number is the quantity the objective named,
+and that any expected-value check compares the same quantity — a lattice-
+constant expectation must not be applied to a nearest-neighbor measurement,
+or vice versa (they differ by a projection-dependent factor). A value that
+misses a ballpark *only* because the wrong quantity was compared is a
+labeling error to fix in reporting, not a bad measurement to reject.
 
 **DCNN preprocessing check:** if the step uses `detect_atoms_dcnn`,
 flag any pipeline step that preprocesses the image before the DCNN


### PR DESCRIPTION
## Summary

This PR fixes a chain of issues surfaced by a real, stuck run: an atomic-resolution STEM-HAADF lattice-measurement task on an LLTO thin film (on an LSAT substrate) that the agent could not complete. The user asked to *"measure the lattice constant (or the nearest-neighbor distance) in the LLTO film, excluding the LSAT substrate at the bottom."* The run failed in several independent ways, each fixed here:

- **The image wouldn't even preview.** The 32-bit-float TIFF couldn't be decoded by the preview loader, so the orchestrator was flying blind on the actual pixels.
- **The substrate-exclusion instruction was silently dropped.** A one-shot plan-validation step looked at the image, decided "there's no interface, just an illumination gradient," and rewrote the plan to analyze the *whole* frame — overriding the user's explicit request. It did this because it was never shown the user's objective.
- **A correct measurement was reported as the wrong quantity.** The agent measured the nearest-neighbor column distance (~0.27 nm) and labeled it the lattice constant — but for this crystal projection those differ by √2 (the lattice constant is ~0.40 nm). The verifier, correctly expecting ~0.38 nm, then rejected the result indefinitely.
- **The objective got garbled in routing.** The user's *"lattice constant **or** NN distance"* (two options) was paraphrased into *"lattice constant **(= NN spacing)**"* (a false equivalence) before reaching the analysis agent.

The net effect: the agent now (1) loads scientific TIFFs robustly, (2) keeps an explicit user requirement like "exclude the substrate" through planning, (3) knows the nearest-neighbor distance is not the lattice constant for multi-sublattice projections and reports the quantity actually asked for, and (4) receives the user's objective verbatim instead of a lossy paraphrase.

No behavior changes for runs that were already working; these are targeted robustness and faithfulness fixes.

---

## Technical details

Five commits, each independently scoped.

**1. `image_processor.load_image` — high-bit-depth / float TIFFs (`image_processor.py`).**
The standard-image branch used `cv2.imread(path)` (default `IMREAD_COLOR`), which returns `None` on 32-bit-float TIFFs (`OpenCV TIFF: ...can not handle images with 32-bit samples`) — the source of the `preview_image` `ValueError`. Switched to `cv2.IMREAD_UNCHANGED` (matching `image_analysis_tools.load_image_data`), added BGR→RGB for 3/4-channel, and factored the float→uint8 normalization (previously only on the `.npy`/`.h5` branch) into a shared `_normalize_to_uint8` with NaN/Inf guarding — required because `PIL` mode-`'F'` arrays have no JPEG path. Intentional behavior change: 8-bit grayscale now returns 2-D instead of cv2's 3-channel replication (consistent with `load_image_data`; all `image_processor` consumers handle 2-D). Verified on the real `LLTO.tif` plus uint8/uint16/RGB regression cases.

**2. Register `resolve_pixel_size_nm` as a TOOL_SPEC (`image_analysis_tools.py`).**
Pixel-size resolution was surfaced to codegen only as skill-markdown prose, so the codegen LLM reimplemented it (hitting the documented `n_cols` anti-pattern) and crashed on `float(None)` probing hallucinated dict keys (`pixel_size_nm_x`). Promoted to a registered `TOOL_SPEC` (always-on for `image_analysis`), so the exact signature and `{'x','y','source'}` return contract appear in the codegen tool inventory, with an `example` pinning the correct `px['x']` access and the `None` guard. Scoped to `image_analysis` only (verified not leaking to curve/hyperspectral inventories).

**3. `atomic_stem` skill — NN distance vs lattice vector (`atomic_stem.md`).**
Three coordinated, *general* edits (no perovskite/LLTO specifics; √2/√3/2× given only as examples to derive from geometry):
- `planning`: a lattice vector maps the crystal onto itself (same-species column → same-species column); measure it from the FFT fundamental / `find_zone_axes`, never from raw NN; report the quantity the objective names and never silently substitute one for the other.
- `interpretation`: NN and lattice constant coincide only for one column per projected cell; with a resolved basis the NN is shorter by a geometry-dependent factor and is not a lattice translation.
- `validation`: the reported quantity must match the request and ballpark checks must compare like with like — a value that misses a ballpark *only* because the wrong quantity was compared is a labeling error, not a measurement to reject. (This is what unblocks the iterative quality verifier.)

**4. One-shot plan validation made goal-aware + meta verbatim (`image_analysis_controllers.py`, `instruct.py`, `meta_orchestrator.py`).**
`ImagePlanningController._validate_plan` (the single pre-execution validator, fires once after `_plan_analysis`; distinct from the iterative `_verify_quality` loop) built its prompt from plan fields + image thumbnail + skill context but never injected the user's objective, although `state["analysis_objective"]` is populated and `_append_objective_context` already exists and is used by the planning prompts. Added the injection, and hardened `IMAGE_ANALYSIS_PLAN_VALIDATION_PROMPT` so a requirement stated in the objective is a constraint the validator may *flag-as-hard* but must not silently delete (drop only if physically impossible, stated in `issues`). Separately, the meta delegation contract (`meta_orchestrator.py`) now instructs the meta to carry the user's scientific ask verbatim into `task` and not reword/reinterpret a requested quantity, since the specialist cannot see the original message to catch the drift.

**5. Same goal-awareness for curve fitting (`curve_fitting_controllers.py`, `instruct.py`).**
`CurveFittingProcessingController._validate_plan` had the identical omission. Injected `_append_objective_context` and added the matching "a stated requirement is a constraint, not an assumption to second-guess" clause to `CURVE_FITTING_PLAN_VALIDATION_PROMPT`. Hyperspectral has no separate plan-validation step and is unaffected.

**Verification.** Import/format/scope-level checks pass for all touched modules; the float-TIFF fix and the `resolve_pixel_size_nm` registration were exercised directly. A full end-to-end live delegation on the LLTO image (confirming the substrate-exclusion step now survives planning and the lattice constant is reported as ~0.40 nm) has **not** been run — it needs the full Bedrock pipeline.

**Known limits.** The skill edit teaches the geometry but relies on the codegen LLM applying it; the plan-validation hardening relies on prompt adherence (the conformance/verifier backstops remain). The meta-verbatim instruction is prompt-level guidance, not an enforced transform.
