### PR TITLE
Skip plan re-approval on reuse turns; normalize dict-shaped series values

### DIFF
--- a/scilink/agents/exp_agents/base_agent.py
+++ b/scilink/agents/exp_agents/base_agent.py
@@ -358,6 +358,38 @@ class LLMAgentMixin:
             series_metadata = system_info.pop("series")
         return system_info, series_metadata
 
+    @staticmethod
+    def _normalize_series_values(
+        series_metadata: dict | None,
+        ordered_paths: list | None,
+    ) -> dict | None:
+        """Coerce ``series_metadata['values']`` from a filename-keyed dict into
+        a list aligned to *ordered_paths* (file order) — the contract every
+        downstream consumer assumes (``values[idx]``, ``min``/``max``, the trend
+        codegen). The orchestrator normalizes this when it sorts a series, but
+        sidecar / continuation paths can hand the agent the raw
+        ``{filename: value}`` dict; a dict reaching a list-expecting consumer
+        raises ``'<' not supported between instances of 'dict' and 'dict'``
+        (min/max) or a ``KeyError`` (``values[int]``).
+
+        Idempotent: a list passes through unchanged. Only rewrites when every
+        spectrum finds a value — a partial/mismatched map is left as-is so the
+        caller's existing fallbacks (and the defensive consumer guards) handle
+        it rather than silently mis-aligning values to spectra.
+        """
+        if not series_metadata or not ordered_paths:
+            return series_metadata
+        values = series_metadata.get("values")
+        if not isinstance(values, dict):
+            return series_metadata
+        import os
+        by_name = {os.path.basename(str(k)): v for k, v in values.items()}
+        aligned = [by_name.get(os.path.basename(str(p))) for p in ordered_paths]
+        if aligned and all(v is not None for v in aligned):
+            series_metadata = dict(series_metadata)
+            series_metadata["values"] = aligned
+        return series_metadata
+
     def _build_system_info_prompt_section(self, system_info: Dict[str, Any]) -> str:
         """Build the system information section for LLM prompts."""
         if not system_info:

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1643,6 +1643,12 @@ class HumanFeedbackRefinementController:
 
             series_metadata = state.get("series_metadata", {})
             values = series_metadata.get("values", [])
+            # Defensive: a filename-keyed dict should be normalized upstream
+            # (_normalize_series_values), but tolerate it here so a stray dict
+            # can't crash planning (min/max over dicts) — display only needs the
+            # scalar range, so value-order is irrelevant.
+            if isinstance(values, dict):
+                values = list(values.values())
             unit = series_metadata.get("unit", "")
 
             for i, regime in enumerate(regimes, 1):
@@ -2125,7 +2131,11 @@ class HumanFeedbackRefinementController:
             self.logger.info(f"  Approach: {state['analysis_approach']}")
             self.logger.info(f"  Model: {state['physical_model']}")
 
-            if self.enable_human_feedback:
+            # On a verbatim locked-script reuse turn (#172) the plan is
+            # foreordained to re-run the prior script unchanged, so re-approving
+            # it is pointless interruption. Planning still ran above (downstream
+            # stages need its fields); we only skip the display/approval gate.
+            if self.enable_human_feedback and not state.get("reuse_locked_script"):
                 iteration = 0
                 while iteration < self.max_iterations:
                     state = self._get_human_feedback(state)

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -1150,6 +1150,11 @@ class ImagePlanningController:
 
             series_metadata = state.get("series_metadata", {})
             values = series_metadata.get("values", [])
+            # Defensive: tolerate a filename-keyed dict (normalized upstream by
+            # _normalize_series_values) so a stray dict can't crash planning via
+            # min/max — display only needs the scalar range.
+            if isinstance(values, dict):
+                values = list(values.values())
             unit = series_metadata.get("unit", "")
 
             for i, regime in enumerate(regimes, 1):
@@ -1714,7 +1719,11 @@ class ImagePlanningController:
             # Validate plan against actual images
             state = self._validate_plan(state)
 
-            if self.enable_human_feedback:
+            # On a verbatim locked-script reuse turn (#172) the plan is
+            # foreordained to re-run the prior script unchanged, so re-approving
+            # it is pointless interruption. Planning still ran above (downstream
+            # stages need its fields); we only skip the display/approval gate.
+            if self.enable_human_feedback and not state.get("reuse_locked_script"):
                 iteration = 0
                 while iteration < self.max_iterations:
                     state = self._get_human_feedback(state)

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -687,6 +687,12 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         handled_system_info, series_metadata = self._extract_series_metadata(
             handled_system_info, series_metadata
         )
+        # Canonicalize a filename-keyed `values` dict into a file-ordered list
+        # (sidecar/continuation paths can hand us the raw dict; consumers expect
+        # a list — see _normalize_series_values).
+        series_metadata = self._normalize_series_values(
+            series_metadata, spectrum_paths
+        )
 
         # Build initial state
         state = {

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -431,6 +431,11 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         handled_system_info, series_metadata = self._extract_series_metadata(
             handled_system_info, series_metadata
         )
+        # Canonicalize a filename-keyed `values` dict into a file-ordered list
+        # (consumers expect a list — see _normalize_series_values).
+        series_metadata = self._normalize_series_values(
+            series_metadata, image_paths
+        )
 
         # Recover embedded file metadata (e.g. TIFF tags / ImageDescription) that
         # OpenCV-based pixel loading drops, and fold it into system_info without


### PR DESCRIPTION
## Summary

Two robustness fixes surfaced while driving the BO-loop simulator through the meta agent. Both made a real run misbehave:

1. **Pointless re-approval on reuse turns.** When a turn is a verbatim locked-script reuse (#172), the plan is foreordained to re-run the prior script unchanged — yet the agent still stopped to re-display and re-approve it under AUTOPILOT, interrupting the user for no decision.
2. **A continuation/sidecar series silently fell back to a generic model.** When series metadata arrived as a filename-keyed `{file: value}` dict (instead of the file-ordered list every consumer assumes), planning crashed internally (`'<' not supported between instances of 'dict' and 'dict'`), the exception was swallowed, the good plan was wiped, and the series fit degraded to a generic model — with no visible error.

After this PR, reuse turns skip the redundant approval gate (planning still runs; only the display/approval loop is skipped), and a dict-shaped series is canonicalized to a file-ordered list once at ingestion so the fit uses the intended model.

---

## Technical details

**`base_agent.py` — shared `LLMAgentMixin._normalize_series_values(series_metadata, ordered_paths)`.** Coerces `series_metadata["values"]` from a filename-keyed dict into a list aligned to `ordered_paths` (file order) — the contract every downstream consumer assumes (`values[idx]`, `min`/`max`, trend codegen). Idempotent (a list passes through). Conservative: rewrites only when *every* spectrum/image finds a value; a partial/mismatched map is left as-is so existing fallbacks and the defensive consumer guards handle it rather than silently mis-aligning values to spectra. Matches basenames to tolerate path differences.

**`curve_fitting_agent.py`, `image_analysis_agent.py`** — call `_normalize_series_values(series_metadata, spectrum_paths/image_paths)` immediately after `_extract_series_metadata`, canonicalizing at ingestion for both agents.

**`curve_fitting_controllers.py`, `image_analysis_controllers.py`** — two changes each:
- Guard the human-feedback gate on `not state.get("reuse_locked_script")` so a reuse turn skips the display/approval loop (planning fields are still produced upstream for downstream stages).
- Defensive dict guard at the `_display_plan` crash sites (`if isinstance(values, dict): values = list(values.values())`) — display only needs the scalar range, so value order is irrelevant there; this backstops any dict that slips past ingestion normalization.

**Scope/verification.** Self-contained; all three touched agent modules import cleanly. Cherry-picked verbatim from the original commit (content verified identical). This was previously on `fix-cand-prefix-single-candidate` but was not included in PR #305 (which merged the rest of the best-of-N work); this PR gives it a path to `main` on its own.
