### PR TITLE
Route touching convex objects to classical splitting (not SAM); fix .npy UI preview

### DIFF
--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -3067,7 +3067,8 @@ that fails.
 When a registered tool already does the hard step (e.g. `run_fft_nmf_analysis`
 with a window size tuned to the spatial scale of the features of interest
 for disorder / defect / multi-phase analysis, or `run_sam_analysis` for
-instance segmentation), a single tool call followed by a simple post-
+instance segmentation of touching/overlapping objects that classical
+detection and splitting cannot separate), a single tool call followed by a simple post-
 processing step is already a complete pipeline. Do not pad it with
 additional processing steps for the sake of thoroughness — the tool
 output plus a focused interpretation is the deliverable.

--- a/scilink/skills/image_analysis/overlapping_objects/overlapping_objects.md
+++ b/scilink/skills/image_analysis/overlapping_objects/overlapping_objects.md
@@ -43,7 +43,13 @@ calibrated sizing for free — so prefer it over hand-calling `blob_log`. **Set
 `polarity` from the image** (dark vs. bright objects) and **tune `threshold_rel`
 from the overlay** (LoG over-detects at a default threshold; raise it until the
 count matches what you see). For **well-separated** objects, Otsu + connected
-components. For **touching** objects, SAM.
+components. For **touching** objects, classical splitting comes FIRST: round /
+blob-like cores → `log_blob_detect`; clear contrast or a visible boundary
+between neighbours → distance-transform watershed. Reserve **SAM only for the
+touching case where NO boundary feature is extractable** (and for the
+crop-then-SAM regimes below) — it is the heavy last resort, not the default for
+"touching". A high-contrast, near-monodisperse field (e.g. dark nanoparticles on
+a light substrate with thin bright gaps) is the classical case, not a SAM case.
 
 A second registered tool, **`scale_matched_blob_detect`**, addresses ONE specific
 FAILURE MODE — when detection **OVER-detects on a speckled / noisy background**:
@@ -155,21 +161,28 @@ When the foundational checks above rule out classical methods —
 i.e. objects genuinely touch with no boundary feature you can extract —
 connected component labeling on a binary mask will merge all touching
 pixels into one object, so the pipeline must include a dedicated
-splitting step. Within this case, in order of preference:
+splitting step. Order the splitting method by object **shape**, not by
+reaching for the heaviest model first:
 
-1. **SAM instance segmentation**: Use `run_sam_analysis` from
-   `scilink.skills._shared.sam`. SAM detects individual object instances
-   directly, even when they overlap, without requiring thresholding or
-   binary masks. Works for any object shape. Tune via `sam_parameters`
-   preset and `min_area` / `pruning_iou_threshold`. Avoid Gaussian blur
-   before SAM unless noise is very high.
+1. **Watershed splitting (roughly convex objects — the common case)**:
+   Create a binary mask (any method) → distance transform → find markers
+   (local maxima of the distance transform) → watershed on the inverted
+   distance transform. This splits touching convex objects (discs,
+   spheres, droplets, nanoparticles) by shape alone — it needs no
+   intensity boundary between them and no learned model, so it is the
+   first choice whenever the objects are approximately convex. Key
+   parameter: `min_distance` in `peak_local_max` should approximate the
+   object radius.
 
-2. **Watershed splitting**: Create binary mask (any method) → distance
-   transform → find markers (local maxima of distance transform) →
-   watershed on inverted distance transform. Use when objects are
-   roughly convex and SAM produces poor results (over-merged or
-   over-split for the size scale). Key parameter: `min_distance` in
-   `peak_local_max` should approximate the object radius.
+2. **SAM instance segmentation (irregular / arbitrary shapes, or when
+   watershed over-/under-splits)**: Use `run_sam_analysis` from
+   `scilink.skills._shared.sam`. SAM detects individual instances
+   directly, even when they overlap, without thresholding or binary
+   masks, and handles arbitrary shapes a distance transform cannot. It is
+   the heavy last resort — reach for it when the objects are NOT convex
+   enough for watershed, not as the default for "touching". Tune via
+   `sam_parameters` preset and `min_area` / `pruning_iou_threshold`.
+   Avoid Gaussian blur before SAM unless noise is very high.
 
 3. **Instance detection**: Detect individual objects directly from
    the image without relying on a binary mask. For elliptical objects:

--- a/scilink/ui/components/file_viewer.py
+++ b/scilink/ui/components/file_viewer.py
@@ -82,7 +82,14 @@ def render_file_preview(file_path: Path) -> None:
             arr = np.load(file_path)
             st.markdown(f"**shape:** `{arr.shape}` &nbsp; **dtype:** `{arr.dtype}`")
             if arr.ndim <= 2 and max(arr.shape) <= 2048:
-                st.image(arr, clamp=True)
+                # Normalize to [0,1] before display — raw arrays (e.g. int32
+                # microscopy with values far outside 0-255) otherwise saturate
+                # to a blank/white image under st.image's clamp. Mirrors the
+                # TIFF preview path above.
+                disp = arr.astype("float64")
+                if disp.max() > disp.min():
+                    disp = (disp - disp.min()) / (disp.max() - disp.min())
+                st.image(disp, clamp=True)
             else:
                 st.text(f"min={arr.min():.4g}  max={arr.max():.4g}  mean={arr.mean():.4g}")
         except Exception as exc:


### PR DESCRIPTION
## Summary (for scientists)

Two fixes surfaced while analyzing a TEM image of touching nanoparticles.

1. **The agent was using SAM (a heavy segmentation model) where a simple, faster classical method is the right tool.** For high-contrast, near-spherical, *touching* particles (nanoparticles, droplets, grains), distance-transform **watershed** cleanly separates them by shape — no learned model needed. The `overlapping_objects` skill was inadvertently steering toward SAM for *any* touching objects. Now it prefers watershed/blob-detection for convex, well-contrasted objects and reserves SAM for the genuinely hard case (touching objects with no extractable boundary, or irregular shapes). Result: faster, deterministic, more accurate particle sizing on the common case.

2. **`.npy` files previewed as a blank white image in the UI file explorer.** High-bit-depth microscopy arrays (e.g. int32 TEM) weren't normalized before display, so they saturated to white. They now render with proper contrast, like TIFFs already did.

## Technical details (for reviewers)

**SAM over-routing (`overlapping_objects.md` + `instruct.py`)**
- The skill `planning` section said *"For touching objects, SAM."* (unqualified) and its `implementation` splitting list ranked `1. SAM / 2. Watershed`, contradicting its own line-112 policy (*"only reach for SAM when objects touch AND no visible boundary feature delineates them"*). On the touching-but-bounded NP field the SAM-leaning lines dominated.
- Fix: gated the touching-object rule to *LoG (`log_blob_detect`) / distance-transform watershed first; SAM only when no boundary feature is extractable*; reordered the splitting preference list by **shape** (`1.` watershed for roughly-convex — the common case; `2.` SAM for irregular / no-boundary). 
- `instruct.py:3061` baseline prompt named `run_sam_analysis` as the generic example "for instance segmentation"; added a one-clause qualifier ("…of touching/overlapping objects that classical detection and splitting cannot separate") so the technique-neutral baseline no longer pre-biases toward SAM. The full classical-vs-SAM policy stays in the skill.

**`.npy` preview (`file_viewer.py:84`)**
- The `.npy` branch called `st.image(arr, clamp=True)` on the raw array; the image/TIFF branch already min-max normalized. For `nanoparticles.npy` (int32, range 169–3254) **99.9% of pixels are ≥255**, so `clamp` saturated nearly the whole frame to white.
- Fix: min-max normalize to `[0,1]` float before `st.image`, mirroring the TIFF path. Applies to all non-`uint8` `.npy` (float / int32). Size gate (`max(shape) ≤ 2048`) unchanged.

Verified: normalized array spans 0–1 (mean 0.39) vs 99.9% white before; both edited Python files AST-clean.