### PR TITLE
Distinguish meta vs. specialist reasoning by color (UI + CLI) and pronounce the handoff

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1644,7 +1644,15 @@ class AnalysisOrchestratorAgent:
         style, reset = (("\033[2;3;36m", "\033[0m")
                         if sys.stdout.isatty() else ("", ""))
         body = text.replace("\n", "\n     ")  # indent continuation lines
-        print(f"\n  {style}💭 {body}{reset}\n")
+        # Tag a meta-delegated run's reasoning with an INVISIBLE marker (U+2063)
+        # right after 💭 so the UI renders it a distinct color from the meta's
+        # own 💭 while the visible glyph stays identical. ANSI color can't carry
+        # this: the UI captures non-tty output (no ANSI emitted) and re-colors by
+        # the 💭 marker, so the source must ride in the text. Gated on
+        # `_agent_label` (the 🤖-answer attribution mechanism); a standalone
+        # session keeps a plain 💭, unchanged.
+        mark = "\u2063" if getattr(self, "_agent_label", "Agent") != "Agent" else ""
+        print(f"\n  {style}💭{mark} {body}{reset}\n")
 
     def _print_agent_answer(self, text) -> None:
         """Print the agent's final answer — a *deliverable*, the third output

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1641,7 +1641,11 @@ class AnalysisOrchestratorAgent:
         # structural tool-call log — but only on a real terminal, else the raw
         # escape codes would litter captured/redirected output. Blank lines
         # before and after set the thought apart from the tool call it triggers.
-        style, reset = (("\033[2;3;36m", "\033[0m")
+        # A meta-delegated run reasons in AMBER (33), the meta's own in CYAN (36),
+        # so the CLI distinguishes them the way the UI does (dim + italic either way).
+        specialist = getattr(self, "_agent_label", "Agent") != "Agent"
+        color = "33" if specialist else "36"
+        style, reset = ((f"\033[2;3;{color}m", "\033[0m")
                         if sys.stdout.isatty() else ("", ""))
         body = text.replace("\n", "\n     ")  # indent continuation lines
         # Tag a meta-delegated run's reasoning with an INVISIBLE marker (U+2063)
@@ -1651,7 +1655,7 @@ class AnalysisOrchestratorAgent:
         # the 💭 marker, so the source must ride in the text. Gated on
         # `_agent_label` (the 🤖-answer attribution mechanism); a standalone
         # session keeps a plain 💭, unchanged.
-        mark = "\u2063" if getattr(self, "_agent_label", "Agent") != "Agent" else ""
+        mark = "\u2063" if specialist else ""
         print(f"\n  {style}💭{mark} {body}{reset}\n")
 
     def _print_agent_answer(self, text) -> None:
@@ -1664,8 +1668,16 @@ class AnalysisOrchestratorAgent:
         """
         import sys
         label = getattr(self, "_agent_label", "Agent")
-        bold, reset = ("\033[1;96m", "\033[0m") if sys.stdout.isatty() else ("", "")
-        print(f"\n{bold}🤖 {label}:{reset}")
+        # A delegated specialist's answer header takes the specialist color (bold
+        # AMBER, 33) so it matches that specialist's reasoning; the meta's own
+        # answer stays bold BRIGHT CYAN (96). The UI mirrors this by the invisible
+        # U+2063 marker after 🤖 (it captures non-tty output, so it can't read the
+        # ANSI and re-colors by the marker instead).
+        specialist = label != "Agent"
+        code = "1;33" if specialist else "1;96"
+        mark = "\u2063" if specialist else ""
+        bold, reset = (f"\033[{code}m", "\033[0m") if sys.stdout.isatty() else ("", "")
+        print(f"\n{bold}🤖{mark} {label}:{reset}")
         print(text if text is not None else "")
 
     def _handle_litellm_chat(self, user_input: str) -> str:

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -25,6 +25,20 @@ def _handoff(text: str) -> str:
     return f"\033[1;33m{text}\033[0m" if sys.stdout.isatty() else text
 
 
+def _task_summary(task: str, n: int = 80) -> str:
+    """One-line preview of a delegated task for the handoff banner.
+
+    The banner styles its whole line (bold on the terminal, a band in the UI).
+    A task is often multi-line — a one-line instruction followed by structured
+    detail such as a 'Primary data file: <path>' line — and the raw ``task[:80]``
+    used to carry those newlines into the banner, so the styling bled across the
+    blank line onto the next line in the terminal. Collapse to the first
+    non-blank line, truncated, with an ellipsis when anything was dropped."""
+    first = next((ln.strip() for ln in (task or "").splitlines() if ln.strip()), "")
+    dropped = len(first) > n or len((task or "").strip().splitlines()) > 1
+    return first[:n] + ("…" if dropped else "")
+
+
 # ── Upload inspection ────────────────────────────────────────────────
 # Lightweight, content-based file probes so the meta-agent routes each
 # uploaded file from evidence (array shape, table columns, document text)
@@ -272,7 +286,7 @@ class MetaOrchestratorTools:
         def delegate_to_analysis(task: str, context: dict = None,
                                  context_from: list = None,
                                  label: str = None) -> str:
-            print("  " + _handoff(f"🧪 Delegating to analysis specialist: {task[:80]}..."))
+            print("  " + _handoff(f"🧪 Delegating to analysis specialist: {_task_summary(task)}"))
             return self.orch._delegate("analysis", task, context, context_from, label)
 
         self._register_tool(
@@ -345,7 +359,7 @@ class MetaOrchestratorTools:
         def delegate_to_planning(task: str, context: dict = None,
                                  context_from: list = None,
                                  label: str = None) -> str:
-            print("  " + _handoff(f"📋 Delegating to planning specialist: {task[:80]}..."))
+            print("  " + _handoff(f"📋 Delegating to planning specialist: {_task_summary(task)}"))
             return self.orch._delegate("planning", task, context, context_from, label)
 
         self._register_tool(

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -13,8 +13,16 @@ refactor".
 
 import json
 import logging
+import sys
 from pathlib import Path
 from typing import Any, Callable, Dict
+
+
+def _handoff(text: str) -> str:
+    """Bold a meta -> specialist handoff banner on a real terminal so the
+    delegation transition stands out; plain on non-tty (captured/redirected
+    output, e.g. the UI, which styles the banner itself in `_log_to_html`)."""
+    return f"\033[1;33m{text}\033[0m" if sys.stdout.isatty() else text
 
 
 # ── Upload inspection ────────────────────────────────────────────────
@@ -264,7 +272,7 @@ class MetaOrchestratorTools:
         def delegate_to_analysis(task: str, context: dict = None,
                                  context_from: list = None,
                                  label: str = None) -> str:
-            print(f"  🧪 Delegating to analysis specialist: {task[:80]}...")
+            print("  " + _handoff(f"🧪 Delegating to analysis specialist: {task[:80]}..."))
             return self.orch._delegate("analysis", task, context, context_from, label)
 
         self._register_tool(
@@ -337,7 +345,7 @@ class MetaOrchestratorTools:
         def delegate_to_planning(task: str, context: dict = None,
                                  context_from: list = None,
                                  label: str = None) -> str:
-            print(f"  📋 Delegating to planning specialist: {task[:80]}...")
+            print("  " + _handoff(f"📋 Delegating to planning specialist: {task[:80]}..."))
             return self.orch._delegate("planning", task, context, context_from, label)
 
         self._register_tool(
@@ -488,7 +496,7 @@ class MetaOrchestratorTools:
 
         # -- fuse_delegations -----------------------------------------------
         def fuse_delegations(delegation_indices: list, focus: str = None) -> str:
-            print(f"  🧬 Fusing delegations {delegation_indices}...")
+            print("  " + _handoff(f"🧬 Fusing delegations {delegation_indices}..."))
             return self.orch._fuse_delegations(delegation_indices, focus)
 
         self._register_tool(

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -1603,7 +1603,11 @@ class PlanningOrchestratorAgent:
         if not text:
             return
         import sys
-        style, reset = (("\033[2;3;36m", "\033[0m")
+        # A meta-delegated run reasons in AMBER (33), the meta's own in CYAN (36),
+        # so the CLI distinguishes them the way the UI does (dim + italic either way).
+        specialist = getattr(self, "_agent_label", "Agent") != "Agent"
+        color = "33" if specialist else "36"
+        style, reset = ((f"\033[2;3;{color}m", "\033[0m")
                         if sys.stdout.isatty() else ("", ""))
         body = text.replace("\n", "\n     ")  # indent continuation lines
         # Tag a meta-delegated run's reasoning with an INVISIBLE marker (U+2063)
@@ -1613,7 +1617,7 @@ class PlanningOrchestratorAgent:
         # the 💭 marker, so the source must ride in the text. Gated on
         # `_agent_label` (the 🤖-answer attribution mechanism); a standalone
         # session keeps a plain 💭, unchanged.
-        mark = "\u2063" if getattr(self, "_agent_label", "Agent") != "Agent" else ""
+        mark = "\u2063" if specialist else ""
         print(f"\n  {style}💭{mark} {body}{reset}\n")
 
     def _print_agent_answer(self, text) -> None:
@@ -1624,8 +1628,14 @@ class PlanningOrchestratorAgent:
         mistaken for the meta's own user-facing response."""
         import sys
         label = getattr(self, "_agent_label", "Agent")
-        bold, reset = ("\033[1;96m", "\033[0m") if sys.stdout.isatty() else ("", "")
-        print(f"\n{bold}🤖 {label}:{reset}")
+        # A delegated specialist's answer header takes the specialist color (bold
+        # AMBER, 33) to match its reasoning; the meta's own stays bold BRIGHT CYAN
+        # (96). The UI mirrors this via the invisible U+2063 marker after 🤖.
+        specialist = label != "Agent"
+        code = "1;33" if specialist else "1;96"
+        mark = "\u2063" if specialist else ""
+        bold, reset = (f"\033[{code}m", "\033[0m") if sys.stdout.isatty() else ("", "")
+        print(f"\n{bold}🤖{mark} {label}:{reset}")
         print(text if text is not None else "")
 
     def _handle_litellm_chat(self, user_input: str) -> str:

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -1606,7 +1606,15 @@ class PlanningOrchestratorAgent:
         style, reset = (("\033[2;3;36m", "\033[0m")
                         if sys.stdout.isatty() else ("", ""))
         body = text.replace("\n", "\n     ")  # indent continuation lines
-        print(f"\n  {style}💭 {body}{reset}\n")
+        # Tag a meta-delegated run's reasoning with an INVISIBLE marker (U+2063)
+        # right after 💭 so the UI renders it a distinct color from the meta's
+        # own 💭 while the visible glyph stays identical. ANSI color can't carry
+        # this: the UI captures non-tty output (no ANSI emitted) and re-colors by
+        # the 💭 marker, so the source must ride in the text. Gated on
+        # `_agent_label` (the 🤖-answer attribution mechanism); a standalone
+        # session keeps a plain 💭, unchanged.
+        mark = "\u2063" if getattr(self, "_agent_label", "Agent") != "Agent" else ""
+        print(f"\n  {style}💭{mark} {body}{reset}\n")
 
     def _print_agent_answer(self, text) -> None:
         """Print the agent's final answer — a deliverable, emphasized (bold +

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -455,7 +455,11 @@ class SimulationOrchestratorAgent:
         #      loop in BOTH handlers (the two `for tool_call in …` sites in
         #      `_handle_openai_chat` / `_handle_litellm_chat`). Shows the interim
         #      reasoning dim+italic so a deliberate step doesn't read as a silent
-        #      jump to "🔧 Calling tool".
+        #      jump to "🔧 Calling tool". Mirror the analysis/planning copy
+        #      exactly, including the invisible U+2063 specialist marker
+        #      (`mark = "\u2063" if _agent_label != "Agent" else ""`,
+        #      printed as `💭{mark} …`) so a meta-delegated sim run's reasoning
+        #      gets the specialist color in the UI; standalone keeps a plain 💭.
         #   2. 🤖 Answer — copy `_print_agent_answer(self, text)` and call
         #      `self._print_agent_answer(response)` just before `return response`
         #      below. NB: unlike analysis/planning (which print "🤖 Agent:" in
@@ -466,7 +470,8 @@ class SimulationOrchestratorAgent:
         #      `child._agent_label = "Simulation specialist"` (mirrors the
         #      analysis/planning children in MetaOrchestratorAgent).
         #   4. UI — no change needed; `ui/app.py::_log_to_html` already styles 💭
-        #      (dim italic) and the 🤖 header (bold) regardless of source.
+        #      (dim italic, cool meta / warm specialist by the U+2063 marker) and
+        #      the 🤖 header (bold) regardless of source.
         self._last_chat_hit_iter_cap = False
         if self.use_openai:
             response = self._handle_openai_chat(user_input)

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -45,18 +45,24 @@ _HANDOFF_PREFIXES = ("🧪 Delegating to", "📋 Delegating to", "🧬 Fusing de
 
 def _log_to_html(text: str) -> str:
     """ANSI-strip a captured log and HTML-escape it. The agent's 💭 reasoning
-    lines render dim+italic (a muted aside) — cool for the meta, warm for a
-    meta-delegated specialist (tagged by an invisible U+2063 marker); the 🤖
-    answer header renders bold+bright (the deliverable)."""
+    lines render dim+italic (a muted aside) and the 🤖 answer header bold+bright
+    — cool cyan for the meta, warm amber for a meta-delegated specialist (both
+    tagged by an invisible U+2063 marker, so a specialist's reasoning AND answer
+    header match its color)."""
     import html as _html
 
     out, in_thought, thought_color = [], False, _META_THOUGHT_COLOR
     for line in _strip_ansi(text).split("\n"):
         stripped = line.lstrip()
         if stripped.startswith("🤖"):
-            # Final-answer header — emphasized, and it ends any reasoning block.
+            # Answer header — emphasized, and it ends any reasoning block. A
+            # delegated specialist's header carries the marker -> specialist
+            # color (matching its reasoning); the meta's own stays bright cyan.
             in_thought = False
-            out.append(f'<span style="color:#7fdfff;font-weight:bold">{_html.escape(line)}</span>')
+            ans_color = (_SPECIALIST_THOUGHT_COLOR if _THOUGHT_MARK in line
+                         else "#7fdfff")
+            clean = _html.escape(line.replace(_THOUGHT_MARK, ""))
+            out.append(f'<span style="color:{ans_color};font-weight:bold">{clean}</span>')
             continue
         if stripped.startswith(_HANDOFF_PREFIXES):
             # Meta -> specialist handoff — a pronounced section divider so the

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -28,13 +28,23 @@ def _strip_ansi(text: str) -> str:
     return _ANSI_RE.sub("", text or "")
 
 
+# 💭 reasoning colors. Meta and specialist both print the SAME 💭 glyph; a
+# meta-delegated specialist tags its line with an invisible U+2063 marker so its
+# reasoning renders in a distinct (warm) color from the meta's own (cool) 💭,
+# without changing the visible glyph. The marker is stripped before display.
+_THOUGHT_MARK = "\u2063"           # INVISIBLE SEPARATOR — specialist source tag
+_META_THOUGHT_COLOR = "#6ec1e4"    # muted cyan — meta's own deliberation
+_SPECIALIST_THOUGHT_COLOR = "#c9a06a"  # muted amber — a delegated specialist
+
+
 def _log_to_html(text: str) -> str:
     """ANSI-strip a captured log and HTML-escape it. The agent's 💭 reasoning
-    lines render dim+italic (a muted aside); the 🤖 answer header renders
-    bold+bright (the deliverable) — the HTML equivalents of the terminal styling."""
+    lines render dim+italic (a muted aside) — cool for the meta, warm for a
+    meta-delegated specialist (tagged by an invisible U+2063 marker); the 🤖
+    answer header renders bold+bright (the deliverable)."""
     import html as _html
 
-    out, in_thought = [], False
+    out, in_thought, thought_color = [], False, _META_THOUGHT_COLOR
     for line in _strip_ansi(text).split("\n"):
         stripped = line.lstrip()
         if stripped.startswith("🤖"):
@@ -44,11 +54,15 @@ def _log_to_html(text: str) -> str:
             continue
         if stripped.startswith("💭"):
             in_thought = True
+            # A specialist's first thought line carries the invisible marker; pick
+            # the color from it and hold it across this block's continuation lines.
+            thought_color = (_SPECIALIST_THOUGHT_COLOR if _THOUGHT_MARK in line
+                             else _META_THOUGHT_COLOR)
         elif in_thought and not line.startswith("     "):
             in_thought = False
-        esc = _html.escape(line)
+        esc = _html.escape(line.replace(_THOUGHT_MARK, ""))  # drop the source tag
         if in_thought:
-            esc = f'<span style="color:#6ec1e4;font-style:italic">{esc}</span>'
+            esc = f'<span style="color:{thought_color};font-style:italic">{esc}</span>'
         out.append(esc)
     return "\n".join(out)
 

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -35,6 +35,12 @@ def _strip_ansi(text: str) -> str:
 _THOUGHT_MARK = "\u2063"           # INVISIBLE SEPARATOR — specialist source tag
 _META_THOUGHT_COLOR = "#6ec1e4"    # muted cyan — meta's own deliberation
 _SPECIALIST_THOUGHT_COLOR = "#c9a06a"  # muted amber — a delegated specialist
+_HANDOFF_COLOR = "#f0c674"         # bright gold — meta -> specialist handoff banner
+
+# Meta handoff announcements (printed by MetaOrchestratorTools): the meta
+# delegating to / fusing specialists. Matched on emoji+phrase so a generic
+# 🧪/📋 structural header elsewhere is not mistaken for a handoff.
+_HANDOFF_PREFIXES = ("🧪 Delegating to", "📋 Delegating to", "🧬 Fusing delegations")
 
 
 def _log_to_html(text: str) -> str:
@@ -51,6 +57,18 @@ def _log_to_html(text: str) -> str:
             # Final-answer header — emphasized, and it ends any reasoning block.
             in_thought = False
             out.append(f'<span style="color:#7fdfff;font-weight:bold">{_html.escape(line)}</span>')
+            continue
+        if stripped.startswith(_HANDOFF_PREFIXES):
+            # Meta -> specialist handoff — a pronounced section divider so the
+            # transition into (and back out of) a delegation is obvious. Rendered
+            # as a banded row (bold gold on a faint tint with a left rule), which
+            # the <pre> log pane supports. Ends any reasoning block.
+            in_thought = False
+            out.append(
+                f'<span style="display:inline-block;color:{_HANDOFF_COLOR};'
+                f"font-weight:bold;background:#2e2a1f;border-left:3px solid "
+                f'{_HANDOFF_COLOR};padding:1px 8px">{_html.escape(stripped)}</span>'
+            )
             continue
         if stripped.startswith("💭"):
             in_thought = True

--- a/tests/test_specialist_thought_color.py
+++ b/tests/test_specialist_thought_color.py
@@ -13,6 +13,7 @@ from scilink.agents.exp_agents.analysis_orchestrator import AnalysisOrchestrator
 from scilink.agents.planning_agents.planning_orchestrator import PlanningOrchestratorAgent
 from scilink.ui.app import (
     _log_to_html, _THOUGHT_MARK, _META_THOUGHT_COLOR, _SPECIALIST_THOUGHT_COLOR,
+    _HANDOFF_COLOR,
 )
 
 THOUGHT = "\U0001F4AD"  # 💭
@@ -75,3 +76,36 @@ def test_structural_headers_not_thought_colored():
         html = _log_to_html(f"  {header}")
         assert _META_THOUGHT_COLOR not in html
         assert _SPECIALIST_THOUGHT_COLOR not in html
+
+
+@pytest.mark.parametrize("banner", [
+    "  🧪 Delegating to analysis specialist: fit the edge...",
+    "  📋 Delegating to planning specialist: design campaign...",
+    "  🧬 Fusing delegations [0, 1]...",
+])
+def test_handoff_banner_is_pronounced(banner):
+    html = _log_to_html(banner)
+    assert _HANDOFF_COLOR in html and "font-weight:bold" in html
+
+
+def test_structural_emoji_headers_are_not_handoffs():
+    # A bare 📋/🧪 header (plan/step) must NOT be styled as a handoff banner.
+    for header in ("  📋 PROPOSED FITTING PLAN", "  🧪 Step 1: ForceFieldAgent"):
+        assert _HANDOFF_COLOR not in _log_to_html(header)
+
+
+def test_handoff_ends_preceding_thought_block():
+    # A 💭 line immediately followed by a handoff: the banner must render as a
+    # handoff (gold), not inherit the thought color.
+    html = _log_to_html("  💭 I will delegate\n"
+                        "  🧪 Delegating to analysis specialist: x")
+    banner_line = next(l for l in html.split("\n") if "Delegating" in l)
+    assert _HANDOFF_COLOR in banner_line
+    assert _META_THOUGHT_COLOR not in banner_line
+
+
+def test_handoff_matches_ansi_wrapped_terminal_form():
+    # The terminal emits a bold-ANSI-wrapped banner; after ANSI strip it must
+    # still be recognized as a handoff.
+    html = _log_to_html("  \x1b[1;33m🧪 Delegating to analysis specialist: x\x1b[0m")
+    assert _HANDOFF_COLOR in html

--- a/tests/test_specialist_thought_color.py
+++ b/tests/test_specialist_thought_color.py
@@ -181,6 +181,26 @@ def test_cli_answer_header_color_differs(cls):
     assert f"{ESC}[1;33m" in spec     # bold amber
 
 
+# ── handoff banner: a multi-line task must not bleed into the banner ─────────
+
+def test_handoff_task_summary_collapses_multiline():
+    # The reported CLI bug: a multi-line task carried its newline + the
+    # "Primary data file:" line into the bold banner span. The summary must be
+    # one line so the styling can't span past it.
+    from scilink.agents.meta_agent.meta_orchestrator_tools import _task_summary
+    task = ("Analyze a STEM HAADF microscopy image of an LLTO thin film.\n\n"
+            "Primary data file: /path/to/data.npy")
+    s = _task_summary(task)
+    assert "\n" not in s
+    assert "Primary data file" not in s
+    assert s.startswith("Analyze a STEM HAADF")
+
+
+def test_handoff_task_summary_no_ellipsis_when_complete():
+    from scilink.agents.meta_agent.meta_orchestrator_tools import _task_summary
+    assert _task_summary("Fit the decay") == "Fit the decay"  # short, single line
+
+
 def test_handoff_ends_preceding_thought_block():
     # A 💭 line immediately followed by a handoff: the banner must render as a
     # handoff (gold), not inherit the thought color.

--- a/tests/test_specialist_thought_color.py
+++ b/tests/test_specialist_thought_color.py
@@ -1,10 +1,16 @@
-"""Meta vs. meta-delegated-specialist reasoning are the SAME visible 💭 glyph
-but render in different UI colors, driven by an invisible U+2063 source marker.
+"""Meta vs. meta-delegated-specialist output is told apart by COLOR while the
+visible 💭 glyph stays identical:
 
-Guards: the marker is emitted only when delegated (gated on `_agent_label`),
-the visible glyph is unchanged, and `_log_to_html` colors + strips it.
+  * UI — driven by an invisible U+2063 source marker (emitted only when
+    delegated); `_log_to_html` colors meta cool cyan / specialist warm amber for
+    both the 💭 reasoning lines AND the 🤖 answer header, and strips the marker.
+  * CLI — the reasoning/answer ANSI color itself differs (cyan vs amber), since
+    captured non-tty output carries no ANSI for the UI to read.
+
+Both are gated on `_agent_label`; a standalone session is unchanged.
 """
 import io
+import sys
 from contextlib import redirect_stdout
 
 import pytest
@@ -17,10 +23,21 @@ from scilink.ui.app import (
 )
 
 THOUGHT = "\U0001F4AD"  # 💭
+ROBOT = "\U0001F916"    # 🤖
+ESC = "\x1b"            # ANSI escape — what the CLI emits on a real tty
+
+ALL = [AnalysisOrchestratorAgent, PlanningOrchestratorAgent]
 
 
 class _Stub:
     pass
+
+
+class _FakeTTY(io.StringIO):
+    """A StringIO that reports as a terminal, so the printers emit ANSI."""
+
+    def isatty(self):
+        return True
 
 
 def _emit(cls, label, text="reasoning here"):
@@ -30,6 +47,21 @@ def _emit(cls, label, text="reasoning here"):
     buf = io.StringIO()
     with redirect_stdout(buf):
         cls._print_assistant_reasoning(s, text)
+    return buf.getvalue()
+
+
+def _emit_tty(cls, method, label, text="text"):
+    """Capture a printer's output as if writing to a real terminal (ANSI on)."""
+    s = _Stub()
+    if label is not None:
+        s._agent_label = label
+    buf = _FakeTTY()
+    old = sys.stdout
+    sys.stdout = buf
+    try:
+        getattr(cls, method)(s, text)
+    finally:
+        sys.stdout = old
     return buf.getvalue()
 
 
@@ -92,6 +124,61 @@ def test_structural_emoji_headers_are_not_handoffs():
     # A bare 📋/🧪 header (plan/step) must NOT be styled as a handoff banner.
     for header in ("  📋 PROPOSED FITTING PLAN", "  🧪 Step 1: ForceFieldAgent"):
         assert _HANDOFF_COLOR not in _log_to_html(header)
+
+
+# ── 🤖 answer header: specialist matches its thought color (UI) ──────────────
+
+def _emit_answer(cls, label, text="the answer"):
+    s = _Stub()
+    if label is not None:
+        s._agent_label = label
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        cls._print_agent_answer(s, text)
+    return buf.getvalue()
+
+
+@pytest.mark.parametrize("cls", ALL)
+def test_specialist_answer_header_marked_visible_glyph_unchanged(cls):
+    out = _emit_answer(cls, "Analysis specialist")
+    assert _THOUGHT_MARK in out
+    assert ROBOT in out.replace(_THOUGHT_MARK, "")  # plain 🤖 still visible
+
+
+@pytest.mark.parametrize("cls", ALL)
+def test_standalone_answer_header_has_no_marker(cls):
+    assert _THOUGHT_MARK not in _emit_answer(cls, None)
+
+
+def test_ui_specialist_answer_header_is_specialist_color():
+    html = _log_to_html(_emit_answer(AnalysisOrchestratorAgent, "Analysis specialist"))
+    assert _SPECIALIST_THOUGHT_COLOR in html   # same color as its thoughts
+    assert "#7fdfff" not in html               # not the meta cyan
+    assert _THOUGHT_MARK not in html           # marker stripped
+
+
+def test_ui_meta_answer_header_stays_cyan():
+    html = _log_to_html(_emit_answer(AnalysisOrchestratorAgent, None))
+    assert "#7fdfff" in html
+    assert _SPECIALIST_THOUGHT_COLOR not in html
+
+
+# ── CLI: the ANSI color itself differs (cyan meta / amber specialist) ────────
+
+@pytest.mark.parametrize("cls", ALL)
+def test_cli_reasoning_color_differs(cls):
+    meta = _emit_tty(cls, "_print_assistant_reasoning", None)
+    spec = _emit_tty(cls, "_print_assistant_reasoning", "Analysis specialist")
+    assert f"{ESC}[2;3;36m" in meta   # dim italic cyan
+    assert f"{ESC}[2;3;33m" in spec   # dim italic amber
+
+
+@pytest.mark.parametrize("cls", ALL)
+def test_cli_answer_header_color_differs(cls):
+    meta = _emit_tty(cls, "_print_agent_answer", None)
+    spec = _emit_tty(cls, "_print_agent_answer", "Analysis specialist")
+    assert f"{ESC}[1;96m" in meta     # bold bright cyan
+    assert f"{ESC}[1;33m" in spec     # bold amber
 
 
 def test_handoff_ends_preceding_thought_block():

--- a/tests/test_specialist_thought_color.py
+++ b/tests/test_specialist_thought_color.py
@@ -1,0 +1,77 @@
+"""Meta vs. meta-delegated-specialist reasoning are the SAME visible 💭 glyph
+but render in different UI colors, driven by an invisible U+2063 source marker.
+
+Guards: the marker is emitted only when delegated (gated on `_agent_label`),
+the visible glyph is unchanged, and `_log_to_html` colors + strips it.
+"""
+import io
+from contextlib import redirect_stdout
+
+import pytest
+
+from scilink.agents.exp_agents.analysis_orchestrator import AnalysisOrchestratorAgent
+from scilink.agents.planning_agents.planning_orchestrator import PlanningOrchestratorAgent
+from scilink.ui.app import (
+    _log_to_html, _THOUGHT_MARK, _META_THOUGHT_COLOR, _SPECIALIST_THOUGHT_COLOR,
+)
+
+THOUGHT = "\U0001F4AD"  # 💭
+
+
+class _Stub:
+    pass
+
+
+def _emit(cls, label, text="reasoning here"):
+    s = _Stub()
+    if label is not None:
+        s._agent_label = label
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        cls._print_assistant_reasoning(s, text)
+    return buf.getvalue()
+
+
+@pytest.mark.parametrize("cls", [AnalysisOrchestratorAgent, PlanningOrchestratorAgent])
+def test_standalone_has_no_marker(cls):
+    out = _emit(cls, None)  # default label "Agent" -> standalone
+    assert _THOUGHT_MARK not in out
+    assert THOUGHT in out
+
+
+@pytest.mark.parametrize("cls", [AnalysisOrchestratorAgent, PlanningOrchestratorAgent])
+def test_delegated_carries_invisible_marker(cls):
+    out = _emit(cls, "Analysis specialist")
+    assert _THOUGHT_MARK in out
+    # The visible glyph is unchanged: stripping the marker leaves a plain 💭.
+    assert THOUGHT in out.replace(_THOUGHT_MARK, "")
+    # The marker sits adjacent to the glyph, not as a separate visible token.
+    assert THOUGHT + _THOUGHT_MARK in out
+
+
+def test_renderer_colors_meta_cool():
+    html = _log_to_html(_emit(AnalysisOrchestratorAgent, None))
+    assert _META_THOUGHT_COLOR in html
+    assert _SPECIALIST_THOUGHT_COLOR not in html
+
+
+def test_renderer_colors_specialist_warm_and_strips_marker():
+    html = _log_to_html(_emit(AnalysisOrchestratorAgent, "Analysis specialist"))
+    assert _SPECIALIST_THOUGHT_COLOR in html
+    assert _META_THOUGHT_COLOR not in html
+    assert _THOUGHT_MARK not in html  # invisible tag never reaches the DOM
+
+
+def test_specialist_color_persists_across_continuation_lines():
+    html = _log_to_html(_emit(AnalysisOrchestratorAgent, "Analysis specialist",
+                              "line one\nline two\nline three"))
+    # Each line of the multi-line thought is wrapped in the specialist color.
+    assert html.count(_SPECIALIST_THOUGHT_COLOR) == 3
+
+
+def test_structural_headers_not_thought_colored():
+    # A 📋/🔬 header is not a 💭 line, so it must stay unstyled (no thought color).
+    for header in ("📋 PROPOSED FITTING PLAN", "🔬 SINGLE SPECTRUM INTERPRETATION"):
+        html = _log_to_html(f"  {header}")
+        assert _META_THOUGHT_COLOR not in html
+        assert _SPECIALIST_THOUGHT_COLOR not in html


### PR DESCRIPTION
## Summary (for scientists)

In a meta-agent session, the orchestrator delegates work to specialist agents (analysis, planning). Previously the meta's own "thinking" and a specialist's "thinking" looked identical in the log — both a cyan `💭` — so when they interleaved you couldn't tell who was reasoning. This PR makes the distinction visible:

- **The meta reasons in cool cyan; a delegated specialist reasons in warm amber.** The visible `💭` glyph is unchanged — only the color differs — so nothing about the text changes, it's just colored by who's speaking.
- **The specialist's answer header (`🤖 Analysis specialist:`) is now amber too**, matching that specialist's reasoning, instead of the meta's cyan.
- **The handoff line (`🧪 Delegating to analysis specialist…`) is a pronounced divider** — a bold gold band in the UI, bold on the terminal — so the moment work passes to a specialist (and comes back to the meta) is obvious.
- Works in **both** the Streamlit UI and the CLI. A standalone analysis/planning session (no meta) is **unchanged** — plain cyan, as before.

So a meta session now reads as: cyan meta thinking → **gold "handing off"** → amber specialist thinking → amber specialist answer → back to cyan meta.

---
## Technical details

### Source-of-reasoning signal — invisible marker, not ANSI
The constraint that shapes the whole design: the Streamlit UI captures agent stdout through a **non-tty** `TeeStream`, so the agents emit **no ANSI** on that path, and `_log_to_html` strips ANSI anyway and re-applies its own styling keyed off the leading `💭`. With the glyph identical for meta and specialist there is nothing in the captured text to color on. So a meta-delegated run tags its reasoning line with an **invisible `U+2063`** separator right after `💭` (and after `🤖` on the answer header); `_log_to_html` colors on the marker and strips it before display. The visible glyph stays byte-identical. Gated on `_agent_label` (the same attribute the meta sets on its children — `"Analysis specialist"` / `"Planning specialist"` / `"Analysis branch"` — and that already attributes the `🤖` header), so a standalone session (default label `"Agent"`) is untouched.

### CLI — the ANSI color itself differs
On a real terminal the marker is irrelevant; instead the printers choose the ANSI color directly. In `_print_assistant_reasoning` (analysis + planning orchestrators): `color = "33" if specialist else "36"` → dim-italic amber vs cyan (`\033[2;3;{color}m`). In `_print_agent_answer`: `1;33` (bold amber) vs `1;96` (bold bright cyan). `sim_agents/simulation_orchestrator.py`'s reasoning-printer TODO is updated to mirror the marker + amber convention when that path lands.

### UI renderer — `scilink/ui/app.py::_log_to_html`
Color constants: `_META_THOUGHT_COLOR = #6ec1e4` (cyan), `_SPECIALIST_THOUGHT_COLOR = #c9a06a` (amber), `_HANDOFF_COLOR = #f0c674` (gold). The `💭` branch picks the thought color by `_THOUGHT_MARK in line` and holds it across the block's continuation lines; the `🤖` branch picks the answer-header color the same way (specialist → amber matching its reasoning, meta → bright cyan `#7fdfff`); both strip the marker. A `_HANDOFF_PREFIXES` branch renders the delegation/fusion announcements as a banded row (bold gold, faint tint, left rule), matched on **emoji+phrase** so a generic `📋 PROPOSED FITTING PLAN` / `🧪 Step 1` structural header is **not** mistaken for a handoff; the banner also ends any open reasoning block so a preceding `💭` can't bleed its color onto it.

### Handoff banner — keep multi-line task text out of the styling
`MetaOrchestratorTools` embedded `task[:80]` in the banner. The terminal banner is a single bold-ANSI span whose reset sits at end-of-line, so a multi-line task (a one-line instruction followed by e.g. a `Primary data file: <path>` line) carried its newline into the span and the bold styling bled onto the data-file line. New `_task_summary()` collapses the task to its first non-blank line (truncated, ellipsis only when something was dropped) before it enters the banner, so the styled text is always one clean line. The terminal banners are also wrapped in a tty-gated `_handoff()` bold helper (plain when captured, since the UI styles the banner itself).

### Tests — `tests/test_specialist_thought_color.py` (26)
Marker emitted only when delegated (gated on `_agent_label`); visible `💭`/`🤖` glyph unchanged; UI specialist-amber vs meta-cyan for both reasoning and answer header; marker stripped from the DOM; specialist color persists across continuation lines; `📋`/`🔬` structural headers stay uncolored and are not handoffs; all three handoff kinds render pronounced; handoff ends a preceding thought block; ANSI-wrapped terminal banner still recognized; CLI ANSI color split for reasoning and answer (via a fake-tty capture); `_task_summary` collapses a multi-line task and omits the ellipsis when complete.

### Notes / limits
- Colors are one-line constants in `app.py` — trivial to retune.
- Display surfaces only; no change to agent logic, delegation, or `run_task`.
- Branch was brought up to date with `main` (merge) so the diff is exactly these display files — it does not touch the lattice-constant work merged via #311.
