### PR TITLE
atomic_stem/fourier_reflection: route cell params to measure_lattice_constant; don't de-streak planar defects

### DIFF
--- a/scilink/skills/_shared/fourier_reflection.py
+++ b/scilink/skills/_shared/fourier_reflection.py
@@ -135,7 +135,15 @@ def fourier_reflection_map(image_array, pixel_size_nm, d_nm=None, params=None):
             if r["is_satellite_candidate"] and r["sigma"] >= min_sigma]
     strongest_sat = sats[0]["d_nm"] if sats else None   # reflections sorted by sigma
 
-    out = {"reflections": reflections, "strongest_satellite_d_nm": strongest_sat}
+    out = {"reflections": reflections, "strongest_satellite_d_nm": strongest_sat,
+           # Guard against a common misuse: these are reflection SPACINGS, not
+           # real-space lattice vectors. Pairing two of them as cell axes (e.g.
+           # a {110} face-diagonal at ~a/sqrt2 with a {100} axial spot) gives a
+           # spurious ~45deg "oblique" cell. For the unit cell / lattice
+           # constant / inter-axis angle, use measure_lattice_constant instead.
+           "cell_note": ("reflection spacings, NOT lattice vectors — do not pair "
+                         "them as cell axes; use measure_lattice_constant for the "
+                         "unit cell / lattice constant / angle")}
 
     # --- choose which reflection to map ---
     # Default = STRONGEST significant reflection (general, defensible: the main
@@ -230,6 +238,13 @@ TOOL_SPEC = ToolSpec(
         "heterogeneity is unknown ('what domains exist?'); reach for "
         "fourier_reflection_map when you can name or first detect the reflection "
         "of interest and want to map WHERE it is.\n"
+        "\n"
+        "NOT for the unit cell: the returned `reflections` are spacings, not "
+        "lattice vectors. Do NOT pick two of them as cell axes — a {110} "
+        "face-diagonal (~a/sqrt2) paired with a {100} axial spot yields a "
+        "spurious ~45deg oblique cell. For the lattice constant / cell "
+        "parameters / inter-axis angle (even as a byproduct), use "
+        "measure_lattice_constant.\n"
         "\n"
         "Calibrate first: pass the true square-pixel size (nm/px). If pixels are "
         "anisotropic, resample to square physical pixels before calling.\n"

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -196,6 +196,16 @@ goal you picked above:
   distance / bond length" → the NN. If the request offers them as
   alternatives or is ambiguous, report both, explicitly labeled, with their
   geometric relation — never silently substitute one for the other.
+  **This applies even when the lattice constant is a BYPRODUCT of another
+  objective** (e.g. reporting the cell while characterizing fringe spacing for
+  a defect study): whenever a lattice constant, cell parameter, or inter-axis
+  angle is reported, get it from `measure_lattice_constant`, NOT by hand-picking
+  two spacings from a `fourier_reflection_map` census as "the axes". The census
+  lists reflection *spacings*, not lattice vectors — pairing e.g. a {110}
+  face-diagonal (≈ a/√2) with a {100} axial spot yields a spurious ~45°
+  "oblique" cell. `measure_lattice_constant` resolves the true basis (and flags
+  `low_confidence` when the lattice is layered or under-sampled, e.g. below
+  ~12 px per cell), so route cell determination through it every time.
 - *If goal is locating or excluding a film/substrate (or grain) interface:*
   between two lattice-matched phases (e.g. a perovskite film on a perovskite
   substrate) the boundary is CHEMICAL, not structural — the reflection set /
@@ -227,6 +237,16 @@ goal you picked above:
   an independent confirmation of real-space candidates. It returns typed
   signatures (deficit vs excess, lattice-coherence dip) but candidates
   still need real-space confirmation crops for chemical interpretation.
+- *If goal is planar-defect detection (stacking fault, intergrowth, anti-
+  phase / twin boundary):* the defect is a *localized break in periodicity* —
+  a fringe-spacing jump, inserted/missing plane, or lateral phase shift across
+  a line. General caution (the same one as flat-fielding an interface): any
+  preprocessing that suppresses a background/banding component — de-streaking,
+  row/column-mean or background subtraction, high-pass — will also erase a
+  defect that lives in that component, so search on data that preserves it.
+  Then separate a localized structural discontinuity (the defect) from a
+  periodic full-width modulation (normal layering) or a uniform line (detector
+  artifact).
 - *If goal is displacement / strain mapping:* requires an ideal
   lattice from a prior step. Map displacements spatially; report only
   distortions exceeding the position fit uncertainty. Distinguish


### PR DESCRIPTION
Follow-up to #311 (merged). Two small skill/tool guards prompted by a live YBCO defect-localization run, where the agent (a) built a spurious ~45° "oblique" cell by hand-pairing FFT census spacings as axes, and (b) de-streaked an obvious horizontal intergrowth band out of existence and reported zero planar defects.

## Summary (for scientists)
- **Cell parameters always go through `measure_lattice_constant`** — even when the lattice constant is a byproduct of another objective. The `fourier_reflection_map` census lists reflection *spacings*, not lattice *vectors*; pairing two of them (e.g. a {110} face-diagonal ≈ a/√2 with a {100} axial spot) yields a fake oblique cell. The tool resolves the true basis and flags `low_confidence` on layered/under-sampled lattices.
- **Don't remove the signal as an "artifact" when hunting planar defects.** A stacking fault / intergrowth / antiphase-twin boundary is a localized break in periodicity, often a band parallel to the planes — so any preprocessing that suppresses banding/background (de-streaking, row/column-mean or background subtraction, high-pass) erases it. This is the same class of error as flat-fielding away a Z-contrast interface. Search on data that preserves the feature; separate a localized structural discontinuity (defect) from periodic full-width modulation (layering) or a uniform line (detector artifact).

## Technical details
- `atomic_stem.md`: extend the lattice-constant bullet (byproduct → still use `measure_lattice_constant`, don't hand-pick census spacings as axes); new planar-defect bullet stating the general artifact-removal caution (principle-level, not trace-specific).
- `fourier_reflection.py`: add a `cell_note` field to the returned dict and a "NOT for the unit cell → use `measure_lattice_constant`" line in `when_to_use`, so the census can't be silently mis-used as cell axes.

No code-path/algorithm changes; documentation + one output field. Skill loads clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>