### PR TITLE
Atom-detection QC: verify by zoom panels + NN/heatmap metrics, not a count

### DIFF
--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -2657,7 +2657,12 @@ target objects that are NOT marked in the visualization, estimate the fraction
 missed, and lower Completeness by that fraction (also list them under
 `missed_features`). Treat under-detection (missing real objects) as exactly as
 serious as over-detection (adding false ones) — do NOT score misses with a
-lighter touch than false positives. This does NOT apply to data-driven
+lighter touch than false positives. For DENSE atom-column detection, judge
+over/under-detection from the zoom-in overlay panels and the reported
+NN/heatmap metrics (short-NN-distance spike = duplicates; coverage gaps =
+misses), NOT from a count-vs-expected ratio — that ratio is only
+order-of-magnitude for multi-sublattice materials, so a moderate value
+(~1.3x) is not over-detection. This does NOT apply to data-driven
 decompositions (NMF/PCA/ICA/FFT), which produce basis patterns rather than a
 per-object census, and it does not mean nitpicking a few small/ambiguous
 features (see below) — it means catching the case where a substantial,

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -3281,7 +3281,11 @@ Judge primarily from the visualizations against the original image:
    capture? Missed objects do not appear as errors — a clean overlay can still
    be badly incomplete. Actively scan the original image for clearly-visible
    targets a candidate failed to mark, and weight under-detection exactly as
-   seriously as over-detection.
+   seriously as over-detection. For DENSE atom-column detection, judge from the
+   zoom-in overlay panels and the reported NN/heatmap metrics (a spike of short
+   NN distances = duplicates; coverage gaps = misses) — NOT from a count-vs-
+   expected ratio, which is only order-of-magnitude for multi-sublattice
+   materials, so a moderate ratio (~1.3x) is not over-detection.
 2. **Correctness**: does the output correspond to real structures (not noise,
    artifacts, or hallucinated features)? Do reported values match visual
    estimates from the image?

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -107,13 +107,23 @@ Refine detected positions with 2D Gaussian fitting (built into
 `detect_atoms`, available via `refine_positions` after
 `detect_atoms_dcnn`) for sub-pixel precision.
 
-**Validate the choice with an expected count:** estimate the visible
-atomic columns from image dimensions, pixel calibration (if available),
-and known lattice parameters for the material — count all sublattices
-visible in HAADF (number of unit cells × visible column types per
-cell). Compare detected count against this estimate; significant
-discrepancy (outside 0.90-1.10×) suggests detection issues or a
-structurally interesting region worth reporting.
+**QC the detection with `detection_quality_panels`, not a count.** After
+detecting columns, call the registered tool `detection_quality_panels`
+(image, positions, pixel_size_nm, and the DCNN `heatmap` when available)
+and **save its `figure_bytes` as the step visualization** — a full-frame
+overlay of thousands of marks is an unjudgeable haze, so the tool adds
+targeted zoom-in panels (placed at the most-suspect regions) plus the
+nearest-neighbor distance histogram, which is what actually reveals
+problems. Read its `metrics`: `short_pair_fraction` (a spike of
+anomalously short NN distances → duplicate/split marks = over-detection),
+`coverage_gap_fraction` (large unmarked regions = misses), and
+`heatmap_hit_fraction` (detections off every DCNN peak = spurious). Do
+NOT judge detection by an absolute count or an a-priori "expected count":
+the resolved columns-per-cell depends on the zone axis and on which
+columns are bright enough to resolve, which is unreliable to predict for
+multi-sublattice / complex structures — so a moderate detected/expected
+ratio (e.g. ~1.3×) is NOT over-detection. An expected count is at most an
+order-of-magnitude sanity check (~0.5-2×).
 
 **Calibration awareness.** Absolute spacings derived from images
 typically carry a few percent uncertainty in scale: pixel-size metadata
@@ -535,10 +545,20 @@ phase channel of the same reflection is a displacement/strain field (GPA).
 ## validation
 
 ### foundational
-**Detection completeness:** Detected vs expected column count (from
-image area and unit cell) should be within 0.90-1.10.
+**Detection completeness / over-detection:** judge from
+`detection_quality_panels` — its targeted zoom-in overlays and metrics, not
+a count ratio. Over-detection = high `short_pair_fraction` (a spike of
+anomalously short NN distances from split/duplicate marks) and/or
+detections off the DCNN peaks (low `heatmap_hit_fraction`); under-detection
+= high `coverage_gap_fraction` and clearly-visible columns unmarked in the
+gap zoom. A structure-based expected count is only an order-of-magnitude
+sanity check (~0.5-2×): resolved columns-per-cell is unreliable to predict
+for multi-sublattice / complex structures, so a moderate detected/expected
+ratio is NOT over-detection.
 
-**NN distance consistency:** CV below 15% for well-ordered crystals.
+**NN distance consistency:** CV below ~15% for well-ordered crystals — and a
+clean unimodal NN distribution at the expected column spacing means the
+detection is correct *regardless of the absolute count*.
 
 **Unit cell sanity:** Measured lattice parameters should be in the
 right ballpark of known bulk values, but absolute scale carries a

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -318,9 +318,13 @@ goal you picked above:
   illumination → built-in peak detection → 2D Gaussian refinement
   (built into `detect_atoms` via `refine=True`).
 
-Both paths end with the same statistics: column count, intensity
-distribution, nearest-neighbor distances, and lattice parameters from
-FFT.
+Both paths end the same way: QC the detection with
+`detection_quality_panels` (save its `figure_bytes` as the visualization,
+and judge over/under-detection from its metrics — see `## planning` and
+`## validation`), then report column count, intensity distribution, and
+nearest-neighbor distances. For the **lattice parameters**, use
+`measure_lattice_constant` (the deterministic, harmonic-safe tool), not a
+hand-rolled FFT-peak pick.
 
 ### advanced
 

--- a/scilink/skills/image_analysis/atomic_stem/detection_qc.py
+++ b/scilink/skills/image_analysis/atomic_stem/detection_qc.py
@@ -1,0 +1,308 @@
+"""Quality-control panels + prior-free metrics for dense atom-column detection.
+
+Verifying that a detector found the right columns in an atomic-resolution image
+is NOT a counting problem: a full-frame overlay of thousands of marks is an
+unjudgeable red haze, and an a-priori "expected count" needs the zone axis and
+per-column visibility (hard to predict for multi-sublattice materials), so a
+count ratio false-flags correct detections as over-detection.
+
+This tool verifies the way a microscopist actually does — spot-check zoomed
+regions + check the spacing statistics:
+
+  * TARGETED zoom-in overlays (dots drawn on the image crop) placed where
+    problems would be — the region with the most short nearest-neighbor pairs
+    (likely duplicates / over-detection) and the largest coverage gap (likely
+    misses) — not random, so localized errors are not sampled away.
+  * PRIOR-FREE metrics: the nearest-neighbor distance distribution (a spike of
+    anomalously short distances = split/duplicate marks; a clean unimodal peak =
+    correct regardless of the absolute count), coverage gaps, and — when a DCNN
+    heatmap is available — the fraction of detections sitting on a heatmap peak.
+
+The absolute count survives only as an order-of-magnitude sanity check.
+"""
+
+import io
+
+import numpy as np
+
+
+def _to_gray(a):
+    a = np.asarray(a, float)
+    if a.ndim == 3:
+        a = a[..., :3].mean(-1)
+    return a
+
+
+def _nn_distances(pos):
+    """Nearest-neighbor distance per point (pixels). Returns (dists, nn_index)."""
+    from scipy.spatial import cKDTree
+    if len(pos) < 2:
+        return np.array([]), np.array([], int)
+    tree = cKDTree(pos)
+    d, i = tree.query(pos, k=2)            # k=1 is self
+    return d[:, 1], i[:, 1]
+
+
+def detection_quality_panels(image, positions, pixel_size_nm=None,
+                             heatmap=None, params=None):
+    """QC a dense atom-column detection with targeted zoom panels + metrics.
+
+    Args:
+        image: 2D grayscale (or HxWx3) detector image the positions came from.
+        positions: (N, 2) array of detected column coordinates as (x, y) in
+            image pixels (the convention detect_atoms / detect_atoms_dcnn return).
+        pixel_size_nm: nm per pixel (square). If None, distances are in pixels
+            and zoom sizes are taken from `zoom_px` instead of `zoom_nm`.
+        heatmap: optional 2D DCNN probability map (same HxW as image). When
+            given, `heatmap_hit_fraction` reports how many detections sit on a
+            heatmap peak — detections off every peak are likely spurious.
+        params: optional tunable dict (robust defaults):
+            n_zoom (default 4): number of zoom-in panels.
+            zoom_nm (4.0) / zoom_px (200): side length of each zoom crop.
+            short_frac (0.5): a pair is "anomalously short" (duplicate/split
+                suspect) if its NN distance < short_frac x median NN. LOWER to
+                only flag near-coincident marks, RAISE to be stricter about
+                over-detection.
+            gap_grid (8): coarse NxN grid for the coverage-gap metric.
+            duplicate_flag_frac (0.04): short_pair_fraction above this sets the
+                `duplicate_suspect` flag.
+            heatmap_hit_radius_nm (0.08) / _px (4): a detection counts as "on a
+                peak" within this radius of a heatmap local maximum.
+            a_nm: optional lattice constant for the ORDER-OF-MAGNITUDE count
+                sanity only (never a pass/fail).
+
+    Returns: dict with 'figure_bytes' (PNG of the composite QC figure),
+        'metrics' (dict, see module docstring), and 'flags' (list of strings).
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    p = params or {}
+    n_zoom = int(p.get("n_zoom", 4))
+    short_frac = float(p.get("short_frac", 0.5))
+    gap_grid = int(p.get("gap_grid", 8))
+    dup_flag_frac = float(p.get("duplicate_flag_frac", 0.04))
+
+    img = _to_gray(image)
+    H, W = img.shape
+    pos = np.asarray(positions, float).reshape(-1, 2)
+    n = len(pos)
+
+    in_nm = pixel_size_nm is not None and pixel_size_nm > 0
+    unit = "nm" if in_nm else "px"
+    scale = float(pixel_size_nm) if in_nm else 1.0          # nm per px (or 1)
+    zoom_px = int(round((p.get("zoom_nm", 4.0) / scale) if in_nm
+                        else p.get("zoom_px", 200)))
+    zoom_px = max(24, min(zoom_px, min(H, W)))
+
+    # ----- nearest-neighbor distribution (prior-free) ------------------------
+    nn_px, _ = _nn_distances(pos)
+    nn = nn_px * scale
+    metrics = {"n_detected": int(n), "units": unit}
+    flags = []
+    if n >= 2:
+        med = float(np.median(nn))
+        metrics["nn_median"] = round(med, 4)
+        metrics["nn_cv"] = round(float(np.std(nn) / (np.mean(nn) + 1e-12)), 3)
+        short_cut = short_frac * med
+        short_mask = nn_px < (short_frac * np.median(nn_px))
+        metrics["short_pair_fraction"] = round(float(short_mask.mean()), 4)
+        metrics["short_cut"] = round(short_cut, 4)
+        if metrics["short_pair_fraction"] > dup_flag_frac:
+            flags.append("duplicate_suspect")
+    else:
+        med = float(min(H, W)) * scale
+        short_mask = np.zeros(n, bool)
+
+    # ----- coverage-gap metric on a coarse grid ------------------------------
+    gx = np.clip((pos[:, 0] / W * gap_grid).astype(int), 0, gap_grid - 1)
+    gy = np.clip((pos[:, 1] / H * gap_grid).astype(int), 0, gap_grid - 1)
+    occ = np.zeros((gap_grid, gap_grid), int)
+    for x, y in zip(gx, gy):
+        occ[y, x] += 1
+    gap_frac = float((occ == 0).mean())
+    metrics["coverage_gap_fraction"] = round(gap_frac, 3)
+    if gap_frac > 0.06:
+        flags.append("coverage_gap_suspect")
+
+    # ----- heatmap-hit fraction (DCNN only) ----------------------------------
+    hm_max = None
+    if heatmap is not None and n > 0:
+        hm = _to_gray(heatmap)
+        if hm.shape == (H, W):
+            from skimage.feature import peak_local_max
+            r = int(round((p.get("heatmap_hit_radius_nm", 0.08) / scale) if in_nm
+                          else p.get("heatmap_hit_radius_px", 4)))
+            hm_max = peak_local_max(hm, min_distance=max(2, r),
+                                    threshold_rel=0.2)
+            if len(hm_max):
+                from scipy.spatial import cKDTree
+                d, _ = cKDTree(hm_max[:, ::-1]).query(pos)   # hm_max is (row,col)
+                metrics["heatmap_hit_fraction"] = round(float((d <= max(2, r)).mean()), 3)
+
+    # ----- order-of-magnitude count sanity (labeled, never pass/fail) --------
+    a_nm = p.get("a_nm")
+    if a_nm and in_nm:
+        area = (H * scale) * (W * scale)
+        oom = n / (area / (float(a_nm) ** 2) + 1e-9)
+        metrics["count_sanity_ratio"] = round(float(oom), 2)
+        metrics["count_sanity_note"] = ("order-of-magnitude only (resolved "
+            "columns/cell unknown a priori); ~0.5-2x is consistent, NOT "
+            "over-detection")
+
+    # ----- choose TARGETED zoom centers --------------------------------------
+    centers = []
+    if n:
+        # 1) densest short-pair cell -> likely duplicates / over-detection
+        if short_mask.any():
+            sc = np.zeros((gap_grid, gap_grid), int)
+            for x, y, s in zip(gx, gy, short_mask):
+                if s:
+                    sc[y, x] += 1
+            yy, xx = np.unravel_index(int(sc.argmax()), sc.shape)
+            centers.append(((xx + 0.5) / gap_grid * W, (yy + 0.5) / gap_grid * H,
+                            "most short-NN pairs (over-detection check)"))
+        # 2) largest coverage gap -> likely misses
+        if (occ == 0).any():
+            # pick the empty cell whose neighbourhood is otherwise dense
+            empties = np.argwhere(occ == 0)
+            yy, xx = empties[len(empties) // 2]
+            centers.append(((xx + 0.5) / gap_grid * W, (yy + 0.5) / gap_grid * H,
+                            "coverage gap (missed-column check)"))
+        # 3) fill the rest evenly across the field
+        k = max(0, n_zoom - len(centers))
+        for j in range(k):
+            fx = (j + 0.5) / max(k, 1)
+            centers.append((fx * W, (0.5 if j % 2 == 0 else 0.78) * H, "field sample"))
+    centers = centers[:n_zoom]
+
+    # ----- compose the figure ------------------------------------------------
+    nz = len(centers)
+    ncols = 3
+    nrows = 1 + int(np.ceil(nz / ncols))
+    fig, axes = plt.subplots(nrows, ncols, figsize=(ncols * 4.2, nrows * 4.2))
+    axes = np.atleast_2d(axes)
+    for ax in axes.ravel():
+        ax.axis("off")
+
+    vlo, vhi = np.percentile(img, [1, 99])
+    # full-frame overlay
+    ax = axes[0, 0]; ax.imshow(img, cmap="gray", vmin=vlo, vmax=vhi)
+    if n:
+        ax.scatter(pos[:, 0], pos[:, 1], s=2, c="r", alpha=0.5, linewidths=0)
+    ax.set_title(f"Full frame overlay (n={n})\nglobal coverage only — see zooms"); ax.axis("off")
+    # heatmap or blank
+    ax = axes[0, 1]
+    if heatmap is not None:
+        ax.imshow(_to_gray(heatmap), cmap="inferno"); ax.set_title("DCNN heatmap")
+    else:
+        ax.set_title("(no heatmap)")
+    ax.axis("off")
+    # NN histogram
+    ax = axes[0, 2]; ax.axis("on")
+    if n >= 2:
+        spread = float(np.ptp(nn))
+        if spread > 1e-9:
+            ax.hist(nn, bins=min(40, max(5, n // 20)), range=(0, max(nn) * 1.05),
+                    color="steelblue", edgecolor="k", linewidth=0.3)
+        else:                                  # perfectly periodic (synthetic)
+            ax.axvspan(med * 0.99, med * 1.01, color="steelblue", alpha=0.6)
+        ax.axvline(med, color="k", ls="--", lw=1, label=f"median {med:.3f}")
+        ax.axvline(short_frac * med, color="r", ls=":", lw=1.2,
+                   label=f"short cut ({metrics.get('short_pair_fraction',0)*100:.1f}% below)")
+        ax.set_xlabel(f"NN distance ({unit})"); ax.set_ylabel("count")
+        ax.legend(fontsize=7); ax.set_title("NN-distance distribution")
+    else:
+        ax.set_title("NN distribution (n<2)")
+
+    # zoom panels
+    for idx, (cx, cy, label) in enumerate(centers):
+        ax = axes[1 + idx // ncols, idx % ncols]; ax.axis("off")
+        x0 = int(np.clip(cx - zoom_px / 2, 0, W - zoom_px))
+        y0 = int(np.clip(cy - zoom_px / 2, 0, H - zoom_px))
+        crop = img[y0:y0 + zoom_px, x0:x0 + zoom_px]
+        clo, chi = np.percentile(crop, [1, 99])
+        ax.imshow(crop, cmap="gray", vmin=clo, vmax=chi)
+        m = ((pos[:, 0] >= x0) & (pos[:, 0] < x0 + zoom_px) &
+             (pos[:, 1] >= y0) & (pos[:, 1] < y0 + zoom_px))
+        if m.any():
+            ax.scatter(pos[m, 0] - x0, pos[m, 1] - y0, s=28,
+                       facecolors="none", edgecolors="r", linewidths=0.9)
+        side = zoom_px * scale
+        ax.set_title(f"zoom: {label}\n{side:.1f} {unit}, {int(m.sum())} marks", fontsize=8)
+        ax.axis("off")
+
+    metrics["flags"] = flags
+    metrics["zoom_centers"] = [(round(c[0], 1), round(c[1], 1)) for c in centers]
+    plt.tight_layout()
+    buf = io.BytesIO()
+    plt.savefig(buf, format="png", dpi=130); plt.close(fig)
+    return {"figure_bytes": buf.getvalue(), "metrics": metrics, "flags": flags}
+
+
+from scilink.skills._shared._spec import ToolSpec
+
+TOOL_SPEC = ToolSpec(
+    name="detection_quality_panels",
+    description=(
+        "Quality-control a DENSE atom-column detection without counting: builds "
+        "a composite figure (full-frame overlay for global coverage + TARGETED "
+        "zoom-in overlays at the most-suspect regions + the nearest-neighbor "
+        "distance histogram) and returns prior-free metrics. Use this to judge "
+        "over/under-detection instead of an absolute count or an a-priori "
+        "'expected count' (which is unreliable for multi-sublattice materials). "
+        "A full-frame overlay of thousands of marks is unjudgeable; the zoom "
+        "panels and the NN distribution are what actually reveal duplicates and "
+        "misses."
+    ),
+    import_line=("from scilink.skills.image_analysis.atomic_stem.detection_qc "
+                 "import detection_quality_panels"),
+    signature=("detection_quality_panels(image, positions, pixel_size_nm=None, "
+               "heatmap=None, params=None) -> dict"),
+    agents=["image_analysis"],
+    when_to_use=(
+        "After ANY atom-column detection on a dense lattice (detect_atoms / "
+        "detect_atoms_dcnn), call this to produce the QC visualization and the "
+        "detection-quality metrics, and SAVE its `figure_bytes` as the step's "
+        "visualization so the verifier sees the zoom panels (not a thousand-dot "
+        "haze). Pass the DCNN `heatmap` when available for the heatmap-hit "
+        "check. Judge over-detection from `short_pair_fraction` (a spike of "
+        "anomalously short NN distances = duplicate/split marks) and the zoom "
+        "panels, and under-detection from `coverage_gap_fraction` and the gap "
+        "zoom — NOT from the absolute count or a count-vs-expected ratio. A "
+        "clean unimodal NN distribution with correct zoom panels is a good "
+        "detection regardless of how many columns were found."
+    ),
+    parameters={
+        "image": {"type": "ndarray", "description": "2D grayscale detector image the positions came from."},
+        "positions": {"type": "ndarray", "description": "(N,2) detected coordinates as (x, y) in image pixels."},
+        "pixel_size_nm": {"type": "float", "description": "nm/px (square). If omitted, metrics/zooms are in pixels."},
+        "heatmap": {"type": "ndarray", "description": "Optional DCNN probability map (HxW) for the heatmap-hit metric."},
+        "params": {"type": "dict", "description": (
+            "Optional knobs: n_zoom (4); zoom_nm (4.0) / zoom_px (200) — zoom "
+            "crop side; short_frac (0.5) — NN below short_frac x median is a "
+            "duplicate suspect, LOWER to flag only near-coincident marks, RAISE "
+            "to be stricter; duplicate_flag_frac (0.04) — short_pair_fraction "
+            "above this sets duplicate_suspect; gap_grid (8); "
+            "heatmap_hit_radius_nm (0.08); a_nm — lattice constant for an "
+            "order-of-magnitude count sanity only.")},
+    },
+    required=["image", "positions"],
+    returns=(
+        "dict with 'figure_bytes' (PNG of the QC composite — SAVE as the step "
+        "visualization), 'metrics' (n_detected, nn_median, nn_cv, "
+        "short_pair_fraction [over-detection signal], coverage_gap_fraction "
+        "[under-detection signal], heatmap_hit_fraction [if heatmap given], "
+        "count_sanity_ratio [order-of-magnitude only], zoom_centers), and "
+        "'flags' (e.g. 'duplicate_suspect', 'coverage_gap_suspect'; empty = no "
+        "detection-quality problem found)."
+    ),
+    example=(
+        "det = detect_atoms_dcnn(image, fov_nm=18.0)\n"
+        "qc = detection_quality_panels(image, det['positions'], "
+        "pixel_size_nm=0.035, heatmap=det['heatmap'])\n"
+        "open('visualization.png','wb').write(qc['figure_bytes'])\n"
+        "print(qc['metrics'])   # judge from short_pair_fraction / gaps, not the count"
+    ),
+)


### PR DESCRIPTION
## Summary (for scientists)
Checking whether an atom-column detector found the right columns has been done by an absolute / a-priori "expected" count — and that misfires. A full-frame overlay of thousands of red dots is an unjudgeable haze, and the "expected count" needs the zone axis and which columns are bright enough to resolve (hard to predict for a multi-sublattice material). So a **correct** detection gets flagged as over-detection: a recent YBCO DCNN run that found every column cleanly was reported as ~1.33× "over-detected."

This PR verifies detection the way a microscopist actually does — **spot-check zoomed regions + check the spacing statistics**:

- A new tool, **`detection_quality_panels`**, builds one composite QC figure: the full frame (global coverage only) + **targeted zoom-in overlays** placed where problems would be (the region with the most anomalously-close marks; the largest empty region) + the **nearest-neighbor distance histogram**. At the zoom scale (~50–150 columns) each mark is clearly judgeable.
- It returns **prior-free metrics**: `short_pair_fraction` (a spike of very short NN distances → duplicate/split marks = over-detection), `coverage_gap_fraction` (misses), `heatmap_hit_fraction` (marks off the DCNN peaks = spurious). The absolute count is kept only as an order-of-magnitude sanity check.

On the real YBCO detection this returns **clean** (no over-detection, 99.9% of marks on DCNN peaks); on injected duplicates it flags `duplicate_suspect`; on a deleted region it flags `coverage_gap_suspect`.

## Technical details
**New tool** `scilink/skills/image_analysis/atomic_stem/detection_qc.py` — `detection_quality_panels(image, positions, pixel_size_nm=None, heatmap=None, params=None) -> {figure_bytes, metrics, flags}`. Skill-gated to `atomic_stem`; registry-discovered. Zoom centers are targeted (densest short-NN cell + largest coverage-gap cell + evenly-spaced fill) so localized errors aren't sampled away; panels are sized to survive the verifier's single-image downsampling; each panel draws marks on the crop so it's self-contained. Tunables surfaced in `TOOL_SPEC` (`n_zoom`, `zoom_nm`, `short_frac`, `duplicate_flag_frac`, `gap_grid`, `heatmap_hit_radius_nm`, `a_nm`).

**Skill** `atomic_stem.md` — planning: after detection call the tool and save its `figure_bytes` as the step visualization; judge from its metrics. Validation: over/under-detection from `short_pair_fraction` / `coverage_gap_fraction` / `heatmap_hit_fraction` and the zoom panels; expected count is order-of-magnitude only; a clean unimodal NN distribution = correct regardless of count.

**Verifier rubric** `instruct.py` + `image_analysis_controllers.py` — for dense atom detection, judge over/under-detection from the zoom panels + reported NN/heatmap metrics, NOT a count-vs-expected ratio (order-of-magnitude only for multi-sublattice materials; ~1.3× is not over-detection). Minimal edits; the existing "scan the original visually" rubric is unchanged.

**Tests** `scilink-benchmarking/ImageAnalysisAgent/bench/test_detection_qc.py` — correct/over/under discrimination, a knob (`short_frac`) flips the duplicate verdict, and the real YBCO detection comes back clean: 5/5.

### Scope / limits
Zooms sample → mitigated by targeting suspect regions + global NN/gap metrics. `heatmap_hit` only for the DCNN path (classical detection falls back to NN-only). Genuinely disordered regions have high NN CV by nature, so CV is a soft signal and `short_pair_fraction` (duplicates) is the hard over-detection signal. Detection-specific; could later generalize to `overlapping_objects`.

Independent of #313 (different skill sections / different files).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>