### PR TITLE
atomic_stem: ferroelectric polarization, per-sublattice defect typing, and lattice-discontinuity mapping

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -3713,7 +3713,12 @@ Remember: Rejecting a good fit ({metric_label} {accept_cmp} {accept_threshold:.2
             prompt_parts.append("\n\n**ORIGINAL (RAW) DATA for reference:**")
             prompt_parts.append({"mime_type": "image/png", "data": state["original_plot_bytes"]})
 
-        
+        # Scrutinize-don't-reimplement: when a registered curve-fitting tool
+        # (e.g. fit_pattern, fit_sideband_manifold) produced the fit, judge it by
+        # the tool's QC + domain knowledge + cross-checks, not by re-deriving.
+        from ....skills._shared._registry import VERIFIER_TOOL_SCRUTINY_PRINCIPLE
+        prompt_parts.append("\n\n" + VERIFIER_TOOL_SCRUTINY_PRINCIPLE)
+
         try:
             response = self.model.generate_content(
                 contents=prompt_parts,

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -3501,9 +3501,19 @@ Return JSON with:
                         # noisy quality scores keep resetting the stall
                         # counter. Each level gets ~max_iter/n_levels slots
                         # before the floor forces the next one.
-                        _floor = min(
-                            verification_iter // 2,
+                        # Front-loaded floor, adaptive to max_verification_iterations:
+                        # one iteration at level 0, then spread the remaining N-1
+                        # iterations evenly across the upper levels. This unlocks the
+                        # permissive T=1 (swap/modify) rung at iter 1 regardless of N
+                        # — swapping is then an OPTION, not a requirement, so reaching
+                        # it early is low-risk — while full-freedom T=2 (custom code,
+                        # where vetted tools get abandoned) stays a later resort
+                        # (~midway for a 3-level ladder). For N=7 this is
+                        # (0,1,1,1,2,2,2). Was linear `verification_iter // 2`.
+                        _N = max(self.max_verification_iterations, 2)
+                        _floor = 0 if verification_iter == 0 else min(
                             _n_anneal_levels - 1,
+                            1 + ((verification_iter - 1) * (_n_anneal_levels - 1)) // (_N - 1),
                         )
                         if _floor > _annealing_level:
                             self.logger.info(

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -1984,7 +1984,14 @@ class UnifiedImageProcessingController:
         "Prefer keeping registered tools in the pipeline and expressing fixes "
         "through their documented parameters. If you must recommend replacing a "
         "tool with custom code, briefly state why the tool's parameters could "
-        "not address the issue.\n",
+        "not address the issue.\n"
+        "If the pipeline is effectively a SINGLE registered-tool call (its "
+        "documented parameters were already explored at the previous level), do "
+        "not keep re-tweaking those parameters — the next step is to REPLACE the "
+        "tool: prefer a DIFFERENT registered tool that targets the same goal a "
+        "different way; only if no such sibling tool fits is custom code "
+        "justified, and then state why the tool's parameters and the available "
+        "registered tools cannot address the issue.\n",
         # T=2 open — main annealing already grants full freedom
         "",
     )

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -2628,6 +2628,8 @@ Your guidance: '''
 **PROCESSING PIPELINE:** {processing_pipeline}
 **QUALITY CRITERIA (defined during planning):** {quality_criteria}
 
+**DATASET METADATA** (judge against THIS imaging modality's physics — do not invoke an artifact mechanism, or a correction, that belongs to a different technique): {metadata}
+
 **EXTRACTED FEATURES:**
 {features}
 
@@ -2810,10 +2812,16 @@ Return JSON:
         tool_schedule = self._TOOL_CONSTRAINT_SCHEDULE
         tool_constraint = tool_schedule[min(level, len(tool_schedule) - 1)]
 
+        sysinfo = state.get("system_info")
+        metadata_str = (
+            json.dumps(sysinfo) if isinstance(sysinfo, dict) and sysinfo
+            else (str(sysinfo).strip() if sysinfo else "Not provided")
+        )
         prompt_text = self.QUALITY_VERIFICATION_PROMPT.format(
             analysis_approach=config.get("analysis_approach", "Unknown"),
             processing_pipeline=config.get("processing_pipeline", "Unknown"),
             quality_criteria=config.get("quality_criteria", "Visual inspection"),
+            metadata=metadata_str,
             features=features_str,
             metrics=metrics_str,
             quality_threshold=self.quality_threshold,
@@ -2857,15 +2865,29 @@ Return JSON:
                 "data": state["original_image_bytes"]
             })
 
-        # Include domain-specific validation criteria from skill
+        # Include domain context from the skill. The verifier judges physical
+        # plausibility, so it needs the same domain PHYSICS the analysis stage
+        # had — without it, it falls back on generic-imaging priors (e.g.
+        # "horizontal contrast band -> illumination/scan artifact") that may not
+        # apply to this modality. Inject the interpretation (physics) section as
+        # well as the validation criteria, not validation alone.
         skill_sections = state.get("skill_sections")
-        if skill_sections and skill_sections.get("validation"):
+        if skill_sections:
             skill_name = state.get("skill_name", "domain skill")
-            prompt_parts.append(
-                f"\n\n**Domain Validation Criteria ({skill_name}):**\n"
-                "Use these criteria when scoring completeness and correctness.\n\n"
-                + skill_sections["validation"]
-            )
+            if skill_sections.get("interpretation"):
+                prompt_parts.append(
+                    f"\n\n**Domain Physics & Interpretation ({skill_name}):**\n"
+                    "Judge physical plausibility against THIS modality's physics; "
+                    "do not invoke an artifact mechanism or correction that this "
+                    "modality does not support.\n\n"
+                    + skill_sections["interpretation"]
+                )
+            if skill_sections.get("validation"):
+                prompt_parts.append(
+                    f"\n\n**Domain Validation Criteria ({skill_name}):**\n"
+                    "Use these criteria when scoring completeness and correctness.\n\n"
+                    + skill_sections["validation"]
+                )
 
         state["_last_verify_error"] = None
         try:

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -271,6 +271,7 @@ def _append_tool_inventory(
     from ....skills._shared._registry import (
         format_library_inventory,
         get_tools_for,
+        TOOL_USE_PRINCIPLE,
     )
 
     specs = get_tools_for(agent, active_skills=active_skills)
@@ -282,6 +283,7 @@ def _append_tool_inventory(
             "code for post-processing. A tool call anchoring the hard step followed "
             "by custom code is usually more reliable than an all-custom pipeline."
         )
+        prompt.append(TOOL_USE_PRINCIPLE)
         for spec in specs:
             prompt.append(spec.to_prompt())
 

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -2891,6 +2891,9 @@ Return JSON:
                     + skill_sections["validation"]
                 )
 
+        from ....skills._shared._registry import VERIFIER_TOOL_SCRUTINY_PRINCIPLE
+        prompt_parts.append("\n\n" + VERIFIER_TOOL_SCRUTINY_PRINCIPLE)
+
         state["_last_verify_error"] = None
         try:
             response = self.model.generate_content(

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -2676,6 +2676,22 @@ Score: 0.0 (nothing captured) to 1.0 (everything captured).
 - For measurement tasks: do extracted values match visual estimates from the image?
 Score: 0.0 (entirely wrong) to 1.0 (all output is correct).
 
+**Wrong science vs. over-production — two causes of low Correctness that need
+opposite feedback.** *Wrong science*: the output is in the wrong place or
+absent — edges off the real boundary, the wrong region analyzed, hallucinated
+or missed structure. The fix is to reanalyze. *Over-production*: a single
+coherent dominant finding IS present and correctly located, but the output
+renders far more structure than the evidence supports — a per-object/per-atom
+edge mesh, dozens of micro-regions, a marker haze — so most of the rendered
+detail is noise riding on a correct result. Score the noise honestly in both
+cases (do NOT inflate an over-produced result), but DIAGNOSE which one it is:
+when the cause is over-production, set `recommended_action` (and the matching
+`suggested_fix`) to "the dominant finding is correct — reduce the output to the
+evidence-supported structure (e.g. the single dominant boundary contour) and
+re-render; prefer simplifying the existing result over switching approach."
+This steers refinement to simplify a correct result rather than abandon it for
+a worse one.
+
 ### C. Relevance — does the output address what was asked?
 - Does the analysis extract the features listed in the quality criteria?
 - **Does the PRIMARY reported summary statistic and the headline figure

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -3419,6 +3419,12 @@ original image, and the second MUST show a segmentation overlay (original image 
 colored semi-transparent masks and contour boundaries for each detected object). For \
 multi-channel images, show each channel as a separate grayscale subplot (do not try to \
 display a 2-channel array directly with imshow). \
+**`visualization.png` MUST contain the actual headline result figure.** If a registered tool \
+returns a `figure_bytes` that IS the result (e.g. a polarization/defect/QC map), write those \
+bytes directly to `visualization.png` (or embed them as panels in it). NEVER save the result to \
+a separate file and leave a placeholder panel in its place (e.g. a subplot titled "see \
+other_file.png") — only `visualization.png` is embedded in the report and shown to the verifier; \
+a placeholder there means the result is lost. \
 All visualizations must be saved to the current working directory. Use `dpi=100`.
 4. Save key output arrays to the current working directory as `.npy` files. \
 At minimum save the primary detection/segmentation result (label map, binary \
@@ -3507,7 +3513,14 @@ Check the image shape — it may have 2 or more channels that are not RGB. Acces
 via `image[:,:,0]`, `image[:,:,1]`, etc. Do not assume grayscale or RGB.
 2. Implement the refined analysis pipeline.
 3. Save visualization(s): `visualization.png` showing original image alongside \
-key analysis results. Use subplots with clear labels. All visualizations must be saved \
+key analysis results. Use subplots with clear labels. \
+**`visualization.png` MUST contain the actual headline result figure.** If a registered tool \
+returns a `figure_bytes` that IS the result (e.g. a polarization/defect/QC map), write those \
+bytes directly to `visualization.png` (or embed them as panels in it). NEVER save the result to \
+a separate file and leave a placeholder panel in its place (e.g. a subplot titled "see \
+other_file.png") — only `visualization.png` is embedded in the report and shown to the verifier; \
+a placeholder there means the result is lost. \
+All visualizations must be saved \
 to the current working directory. Use `dpi=100`.
 4. Save key output arrays to the current working directory as `.npy` files. \
 At minimum save the primary detection/segmentation result.

--- a/scilink/skills/_shared/_registry.py
+++ b/scilink/skills/_shared/_registry.py
@@ -71,16 +71,13 @@ def format_tool_inventory(
             "by custom code is usually more reliable than an all-custom pipeline."
         )
         parts.append(
-            "USE WHAT A TOOL RETURNS — DO NOT RE-DERIVE IT. Each tool returns its "
-            "computed results in the result dict (see its **Returns**) and often a "
-            "finished figure. Read those returned fields, and save the tool's figure "
-            "as the visualization when it has one. Do NOT recompute, re-segment, "
-            "re-render, rescale, or re-bin a quantity a tool you called already "
-            "returns: re-deriving a tool's own output is the most common source of "
-            "units / scaling / normalization bugs (e.g. recomputing a distance the "
-            "tool already reports in nm, or re-clustering domains the tool already "
-            "labelled). Post-process ONLY what no tool provides, and operate on the "
-            "tool's returned values rather than reimplementing the tool."
+            "USE WHAT A TOOL RETURNS — DO NOT RE-DERIVE IT. A tool returns its "
+            "computed results (see its **Returns**) and often a finished figure. "
+            "Read those fields and reuse the figure; do not recompute, re-render, "
+            "or otherwise reimplement a quantity a tool you called already returns — "
+            "re-deriving a tool's own output is a top source of units / scaling / "
+            "normalization bugs. Post-process only what no tool provides, on the "
+            "tool's returned values."
         )
         for spec in specs:
             parts.append(spec.to_prompt())

--- a/scilink/skills/_shared/_registry.py
+++ b/scilink/skills/_shared/_registry.py
@@ -70,6 +70,18 @@ def format_tool_inventory(
             "code for post-processing. A tool call anchoring the hard step followed "
             "by custom code is usually more reliable than an all-custom pipeline."
         )
+        parts.append(
+            "USE WHAT A TOOL RETURNS — DO NOT RE-DERIVE IT. Each tool returns its "
+            "computed results in the result dict (see its **Returns**) and often a "
+            "finished figure. Read those returned fields, and save the tool's figure "
+            "as the visualization when it has one. Do NOT recompute, re-segment, "
+            "re-render, rescale, or re-bin a quantity a tool you called already "
+            "returns: re-deriving a tool's own output is the most common source of "
+            "units / scaling / normalization bugs (e.g. recomputing a distance the "
+            "tool already reports in nm, or re-clustering domains the tool already "
+            "labelled). Post-process ONLY what no tool provides, and operate on the "
+            "tool's returned values rather than reimplementing the tool."
+        )
         for spec in specs:
             parts.append(spec.to_prompt())
 

--- a/scilink/skills/_shared/_registry.py
+++ b/scilink/skills/_shared/_registry.py
@@ -64,6 +64,24 @@ TOOL_USE_PRINCIPLE = (
 )
 
 
+# The verifier-facing counterpart of TOOL_USE_PRINCIPLE (shared across the image
+# and curve verifiers). Deliberately NOT "defer to the tool": it preserves the
+# verifier's independent-scrutiny role (a tool can be wrong) while forbidding the
+# specific failure mode — reimplementing a tool's computation to second-guess it,
+# or instructing the agent to re-derive what the tool already returns.
+VERIFIER_TOOL_SCRUTINY_PRINCIPLE = (
+    "SCRUTINIZE TOOL RESULTS — DON'T REIMPLEMENT THEM. When a registered tool "
+    "produced the result, judge it by the tool's OWN quality fields (coherence, "
+    "flags, SNR, sanity outputs), by domain physics, and by independent "
+    "cross-checks (a second tool, a physical bound) — NOT by reimplementing the "
+    "tool's computation to second-guess it, and do NOT instruct the agent to "
+    "recompute or re-derive a quantity the tool already returns (point it at the "
+    "returned field instead). Apply your own numeric thresholds only to "
+    "quantities no tool vouches for. A tool can still be wrong, so keep "
+    "scrutinizing — just via its QC + physics + cross-checks, not by re-deriving."
+)
+
+
 def format_tool_inventory(
     agent: str = "image_analysis",
     active_skills: list[str] | None = None,

--- a/scilink/skills/_shared/_registry.py
+++ b/scilink/skills/_shared/_registry.py
@@ -46,6 +46,24 @@ def format_library_inventory() -> str:
     return "\n".join(lines)
 
 
+# Shared across every tool-using prompt (planning AND code-gen, all agents) — the
+# single statement of "lean on the tool". Used by format_tool_inventory and by the
+# controllers' list-based _append_tool_inventory so both stages get it identically.
+TOOL_USE_PRINCIPLE = (
+    "USE WHAT A TOOL RETURNS — DO NOT RE-DERIVE IT. A tool returns its "
+    "computed results (see its **Returns**) and often a finished figure. "
+    "Read those fields and reuse the figure; do not recompute, re-render, "
+    "or otherwise reimplement a quantity a tool you called already returns — "
+    "re-deriving a tool's own output is a top source of units / scaling / "
+    "normalization bugs. Post-process only what no tool provides, on the "
+    "tool's returned values. When a tool already answers the objective, keep "
+    "the pipeline THIN (call → read → report) and base any accept/reject "
+    "check on the tool's OWN quality fields (coherence, flags, sanity "
+    "outputs), not on a numeric threshold you impose on its results — a "
+    "self-imposed threshold the real data exceeds causes false-fail loops."
+)
+
+
 def format_tool_inventory(
     agent: str = "image_analysis",
     active_skills: list[str] | None = None,
@@ -70,15 +88,7 @@ def format_tool_inventory(
             "code for post-processing. A tool call anchoring the hard step followed "
             "by custom code is usually more reliable than an all-custom pipeline."
         )
-        parts.append(
-            "USE WHAT A TOOL RETURNS — DO NOT RE-DERIVE IT. A tool returns its "
-            "computed results (see its **Returns**) and often a finished figure. "
-            "Read those fields and reuse the figure; do not recompute, re-render, "
-            "or otherwise reimplement a quantity a tool you called already returns — "
-            "re-deriving a tool's own output is a top source of units / scaling / "
-            "normalization bugs. Post-process only what no tool provides, on the "
-            "tool's returned values."
-        )
+        parts.append(TOOL_USE_PRINCIPLE)
         for spec in specs:
             parts.append(spec.to_prompt())
 

--- a/scilink/skills/_shared/_registry.py
+++ b/scilink/skills/_shared/_registry.py
@@ -71,14 +71,15 @@ TOOL_USE_PRINCIPLE = (
 # or instructing the agent to re-derive what the tool already returns.
 VERIFIER_TOOL_SCRUTINY_PRINCIPLE = (
     "SCRUTINIZE TOOL RESULTS — DON'T REIMPLEMENT THEM. When a registered tool "
-    "produced the result, judge it by the tool's OWN quality fields (coherence, "
-    "flags, SNR, sanity outputs), by domain physics, and by independent "
-    "cross-checks (a second tool, a physical bound) — NOT by reimplementing the "
-    "tool's computation to second-guess it, and do NOT instruct the agent to "
-    "recompute or re-derive a quantity the tool already returns (point it at the "
-    "returned field instead). Apply your own numeric thresholds only to "
-    "quantities no tool vouches for. A tool can still be wrong, so keep "
-    "scrutinizing — just via its QC + physics + cross-checks, not by re-deriving."
+    "produced or anchored the result, judge it by the tool's OWN quality fields "
+    "(e.g. fit metrics, coherence, SNR, uncertainties, sanity flags), by domain "
+    "knowledge/physics, and by independent cross-checks (a second tool, a known "
+    "or physical bound) — NOT by reimplementing the tool's computation to "
+    "second-guess it, and do NOT instruct the agent to recompute or re-derive a "
+    "quantity the tool already returns (point it at the returned field instead). "
+    "Apply your own numeric thresholds only to quantities no tool vouches for. A "
+    "tool can still be wrong, so keep scrutinizing — just via its QC + domain "
+    "knowledge + cross-checks, not by re-deriving."
 )
 
 

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -938,7 +938,7 @@ TOOL_SPECS = [
             },
             "target_pixel_size": {
                 "type": "float",
-                "description": "Target pixel size in Angstroms (default 0.25).",
+                "description": "Target pixel size in Angstroms the image is resampled to before inference (default 0.25). If a dense lattice's dim sublattice is missed (sparse detection), LOWER it (finer); too coarse a value drops the dim sublattice.",
             },
             "threshold": {
                 "type": "float",

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -1182,7 +1182,12 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
         px/nm, per-cell 'polarization' vectors, 'xy', 'magnitude', 'angle',
         'direction_coherence' ~1 for a smooth/domain-structured field and ~0 for
         salt-and-pepper noise — a magnitude-independent way to tell a real field
-        from a degenerate one), and 'flags' (incl. low_direction_coherence_possible_noise).
+        from a degenerate one — but it assumes domains LARGER than the NN scale:
+        a finely-twinned/antiferroelectric ordering on the ~1-2-cell scale reads
+        as LOW coherence too, so low coherence means "random noise OR domains
+        finer than ~3 cells" — for the latter check fourier_reflection_map for a
+        superstructure satellite before concluding noise), and 'flags' (incl.
+        low_direction_coherence_noise_OR_finer_than_NN_domains).
         The DIRECTION panel of the figure is a SMOOTHED domain map (locally
         averaged unit vectors; opacity = local coherence) so coherent domains/walls
         show as solid colour while noise washes out — do not judge coherence from a
@@ -1293,7 +1298,7 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
         ii = cKDTree(sx).query(sx, k=kk)[1]
         coherence = float(np.median([np.mean(su[i] @ su[ii[i, 1:]].T) for i in range(len(sx))]))
     if coherence == coherence and coherence < 0.5:
-        flags.append("low_direction_coherence_possible_noise")
+        flags.append("low_direction_coherence_noise_OR_finer_than_NN_domains")
 
     # --- smoothed / coherence-gated direction-domain map ----------------------
     # Locally average the unit vectors on a coarse grid: the resultant angle is
@@ -1769,7 +1774,9 @@ TOOL_SPECS = [
             "dict with 'figure_bytes' (PNG: polarization quiver + direction-domain map + "
             "magnitude map; the DIRECTION panel is a SMOOTHED domain map, opacity=local "
             "coherence, so domains/walls show solid and noise washes out), 'metrics' (n_cells, "
-            "median_magnitude_px/nm, direction_coherence ~1=coherent/domains ~0=noise, and "
+            "median_magnitude_px/nm, direction_coherence ~1=coherent/domains ~0=noise OR "
+            "domains finer than ~3 cells [check fourier_reflection_map for a satellite before "
+            "calling low coherence noise], and "
             "per-cell polarization/xy/magnitude/angle lists), and "
             "'flags' (e.g. weak_sublattice_intensity_separation). Sign follows the "
             "displaced->reference convention; flip via 'displaced' to match a specific reference."

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -1180,7 +1180,13 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
     Returns: dict with 'figure_bytes' (PNG: polarization quiver + direction-
         domain map + magnitude map), and 'metrics' (n_cells, median magnitude
         px/nm, per-cell 'polarization' vectors, 'xy', 'magnitude', 'angle',
-        'n_direction_clusters' as a domain-count proxy), and 'flags'. NOTE: the
+        'direction_coherence' ~1 for a smooth/domain-structured field and ~0 for
+        salt-and-pepper noise — a magnitude-independent way to tell a real field
+        from a degenerate one), and 'flags' (incl. low_direction_coherence_possible_noise).
+        The DIRECTION panel of the figure is a SMOOTHED domain map (locally
+        averaged unit vectors; opacity = local coherence) so coherent domains/walls
+        show as solid colour while noise washes out — do not judge coherence from a
+        raw per-cell scatter. NOTE: the
         sign follows the displacement→reference convention above (polarization
         is often reported opposite to the cation displacement; flip via
         ``displaced`` if matching a specific reference). LIMITS: direction/domains
@@ -1272,33 +1278,55 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
     if len(P) < 5:
         return {"figure_bytes": None, "metrics": {"error": "no valid cells", "n_cells": int(len(P))}, "flags": flags}
     mag = np.linalg.norm(P, axis=1); ang = (np.degrees(np.arctan2(P[:, 1], P[:, 0]))) % 360
-    # domain proxy: cluster polarization direction (cos/sin) of cells with sizable |P|
+    unit = P / (mag[:, None] + 1e-9)
     strong = mag > np.median(mag) * 0.5
-    nclust = 0
+
+    # --- spatial coherence metric (the noise guard) ---------------------------
+    # Mean direction correlation to each strong cell's nearest neighbours:
+    # ~1 for a smooth/domain-structured field, ~0 for salt-and-pepper noise.
+    # This lets a verifier distinguish a real (even weak) polarization field from
+    # a degenerate one independent of how the per-cell figure happens to render.
+    coherence = float("nan")
     if strong.sum() > 20:
-        feat = np.column_stack([np.cos(np.radians(ang[strong])), np.sin(np.radians(ang[strong]))])
-        from sklearn.cluster import KMeans
-        best_k, best_in = 1, -1
-        for k in (1, 2, 3, 4):
-            if k >= strong.sum():
-                break
-            km = KMeans(k, n_init=3, random_state=int(random_state)).fit(feat)
-            # silhouette-ish: within vs spread
-            inertia = km.inertia_ / strong.sum()
-            if k == 1:
-                base = inertia
-            elif inertia < 0.3 * base and k > best_k:
-                best_k = k
-        nclust = best_k
+        sx = XY[strong]; su = unit[strong]
+        kk = min(7, len(sx))
+        ii = cKDTree(sx).query(sx, k=kk)[1]
+        coherence = float(np.median([np.mean(su[i] @ su[ii[i, 1:]].T) for i in range(len(sx))]))
+    if coherence == coherence and coherence < 0.5:
+        flags.append("low_direction_coherence_possible_noise")
+
+    # --- smoothed / coherence-gated direction-domain map ----------------------
+    # Locally average the unit vectors on a coarse grid: the resultant angle is
+    # the local domain direction (hue) and the resultant length is the LOCAL
+    # coherence (used as opacity) — so coherent domains/walls show as solid
+    # colour while incoherent (noise) regions wash out to the grey image beneath.
+    import matplotlib.cm as cm
+    G = 64
+    gx = np.linspace(0, W, G); gy = np.linspace(0, H, G)
+    GX, GY = np.meshgrid(gx, gy)
+    gpts = np.column_stack([GX.ravel(), GY.ravel()])
+    rad = 2.5 * nn_ref
+    if strong.sum() >= 5:
+        st = cKDTree(XY[strong]); su = unit[strong]
+        nbr = st.query_ball_point(gpts, rad)
+    else:
+        nbr = [[] for _ in gpts]
+    hue = np.zeros(len(gpts)); coh_local = np.zeros(len(gpts))
+    for i, nb in enumerate(nbr):
+        if len(nb) >= 3:
+            v = su[nb].mean(0)
+            hue[i] = (np.degrees(np.arctan2(v[1], v[0])) % 360) / 360.0
+            coh_local[i] = min(1.0, np.hypot(v[0], v[1]))
+    rgba = cm.hsv(hue.reshape(G, G)); rgba[..., 3] = coh_local.reshape(G, G)
 
     fig, ax = plt.subplots(1, 3, figsize=(18, 6))
     for a in ax:
         a.imshow(img, cmap="gray"); a.axis("off"); a.set_aspect("equal")
-    ax[0].quiver(XY[:, 0], XY[:, 1], P[:, 0], P[:, 1], mag, cmap="viridis",
-                 scale=max(1e-6, np.median(mag)) * 40, width=0.003)
-    ax[0].set_title("polarization vectors")
-    s1 = ax[1].scatter(XY[:, 0], XY[:, 1], c=ang, cmap="hsv", s=6, vmin=0, vmax=360)
-    ax[1].set_title("polarization DIRECTION (domains)"); plt.colorbar(s1, ax=ax[1], fraction=0.046, label="deg")
+    ax[0].quiver(XY[strong, 0], XY[strong, 1], P[strong, 0], P[strong, 1], mag[strong],
+                 cmap="viridis", scale=max(1e-6, np.median(mag)) * 40, width=0.003)
+    ax[0].set_title("polarization vectors (|P|>0.5·median)")
+    ax[1].imshow(rgba, extent=[0, W, H, 0])
+    ax[1].set_title(f"DIRECTION domains (smoothed; coherence={coherence:.2f})")
     s2 = ax[2].scatter(XY[:, 0], XY[:, 1], c=mag * (pixel_size_nm or 1), cmap="magma", s=6,
                        vmax=np.percentile(mag, 98) * (pixel_size_nm or 1))
     ax[2].set_title("|P| magnitude" + (" (nm)" if pixel_size_nm else " (px)")); plt.colorbar(s2, ax=ax[2], fraction=0.046)
@@ -1310,7 +1338,7 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
             "n_cells": int(len(P)),
             "median_magnitude_px": float(np.median(mag)),
             "median_magnitude_nm": float(np.median(mag) * pixel_size_nm) if pixel_size_nm else None,
-            "n_direction_clusters": int(nclust),
+            "direction_coherence": coherence,   # ~1 coherent/domains, ~0 noise
             "displaced_sublattice": displaced,
             "polarization": P.tolist(), "xy": XY.tolist(),
             "magnitude": mag.tolist(), "angle": ang.tolist(),
@@ -1739,8 +1767,10 @@ TOOL_SPECS = [
         required=["image", "positions"],
         returns=(
             "dict with 'figure_bytes' (PNG: polarization quiver + direction-domain map + "
-            "magnitude map), 'metrics' (n_cells, median_magnitude_px/nm, n_direction_clusters "
-            "as a domain-count proxy, and per-cell polarization/xy/magnitude/angle lists), and "
+            "magnitude map; the DIRECTION panel is a SMOOTHED domain map, opacity=local "
+            "coherence, so domains/walls show solid and noise washes out), 'metrics' (n_cells, "
+            "median_magnitude_px/nm, direction_coherence ~1=coherent/domains ~0=noise, and "
+            "per-cell polarization/xy/magnitude/angle lists), and "
             "'flags' (e.g. weak_sublattice_intensity_separation). Sign follows the "
             "displaced->reference convention; flip via 'displaced' to match a specific reference."
         ),

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -1146,8 +1146,9 @@ def type_sublattice_defects(
 def map_polarization(image, positions, displaced="auto", n_cage=4,
                      pixel_size_nm=None, edge_margin_px=None,
                      max_offset_frac=0.45, magnitude_outlier_k=6.0,
-                     domain_coherence_floor=0.4, max_wall_fraction=0.15,
-                     local_coherence_floor=0.82, random_state=1):
+                     max_magnitude_nm=0.12, domain_coherence_floor=0.4,
+                     max_wall_fraction=0.15, local_coherence_floor=0.82,
+                     random_state=1):
     """Per-unit-cell ferroelectric polarization / cation off-centering map.
 
     For a two-sublattice (ABO3-type / interpenetrating) lattice where BOTH
@@ -1347,11 +1348,26 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
     # (median/MAD are robust, so a genuinely uniform large field is NOT clipped).
     _m0 = np.linalg.norm(P, axis=1)
     _med0 = float(np.median(_m0)); _mad0 = float(np.median(np.abs(_m0 - _med0))) + 1e-9
-    _keep = _m0 <= _med0 + magnitude_outlier_k * 1.4826 * _mad0
-    n_outliers = int((~_keep).sum())
-    if n_outliers and int(_keep.sum()) >= 5:
-        P, XY = P[_keep], XY[_keep]
-        flags.append(f"clipped_{n_outliers}_unphysical_magnitude_outliers_likely_misfit")
+    _drop = _m0 > _med0 + magnitude_outlier_k * 1.4826 * _mad0           # relative (MAD) outliers
+    # Absolute physical ceiling: the MAD guard is magnitude-relative, so on a
+    # STRONG field (large median -> large MAD) a >physical tail survives. A
+    # ferroelectric cation off-centering above ~max_magnitude_nm (default 120 pm,
+    # well over the 40-80 pm common range) is almost surely a sublattice-pairing /
+    # fit failure, not a real displacement. Needs pixel_size_nm to convert.
+    n_over_ceiling = 0
+    if pixel_size_nm and max_magnitude_nm:
+        _over = _m0 > (float(max_magnitude_nm) / float(pixel_size_nm))
+        n_over_ceiling = int(_over.sum())
+        _drop = _drop | _over
+    n_dropped = int(_drop.sum())
+    if n_dropped and (len(P) - n_dropped) >= 5:
+        P, XY = P[~_drop], XY[~_drop]
+        flags.append(f"clipped_{n_dropped}_unphysical_magnitude_cells_likely_misfit")
+    # Surface the ceiling SPECIFICALLY only when a non-trivial FRACTION is over it
+    # (a systematic pairing/scale error worth the caller's attention) — a 1% tail is
+    # already covered by the generic clip flag above, so don't cry wolf on it.
+    if n_over_ceiling >= max(5, int(0.03 * len(_m0))):
+        flags.append(f"{n_over_ceiling}_cells_above_physical_ceiling_{int(round(max_magnitude_nm * 1000))}pm_check_pairing_or_scale")
     mag = np.linalg.norm(P, axis=1); ang = (np.degrees(np.arctan2(P[:, 1], P[:, 0]))) % 360
     unit = P / (mag[:, None] + 1e-9)
     strong = mag > np.median(mag) * 0.5
@@ -1910,8 +1926,8 @@ TOOL_SPECS = [
         signature=(
             "map_polarization(image, positions, displaced='auto', n_cage=4, "
             "pixel_size_nm=None, edge_margin_px=None, max_offset_frac=0.45, "
-            "magnitude_outlier_k=6.0, domain_coherence_floor=0.4, max_wall_fraction=0.15, "
-            "local_coherence_floor=0.82, random_state=1) -> dict"
+            "magnitude_outlier_k=6.0, max_magnitude_nm=0.12, domain_coherence_floor=0.4, "
+            "max_wall_fraction=0.15, local_coherence_floor=0.82, random_state=1) -> dict"
         ),
         agents=["image_analysis"],
         when_to_use=(
@@ -1947,7 +1963,8 @@ TOOL_SPECS = [
             "pixel_size_nm": {"type": "float", "description": "nm/px; if given, magnitude is also reported in nm."},
             "edge_margin_px": {"type": "float", "description": "Exclude cells within this many px of the border (default 1.5x NN)."},
             "max_offset_frac": {"type": "float", "description": "Robustness to extra/spurious columns: a displaced cation is accepted only within this fraction of the reference-cage NN spacing from the cage centre (default 0.45). RAISE (~0.6) if large genuine displacements are dropped; LOWER (~0.3) if extra columns inflate the field. Scale is the reference sublattice NN, robust to over-detection."},
-            "magnitude_outlier_k": {"type": "float", "description": "Robust per-cell |P| outlier clip, in MADs above the field median (default 6.0): a cell beyond this is a position-fit / A-B-pairing failure with unphysical |P| (e.g. >>80 pm) and is dropped (flag clipped_N_unphysical_magnitude_outliers). LOWER (~4) if stray huge vectors still corrupt the figure/stats; RAISE (~8) if genuine large displacements get clipped. Median/MAD are robust, so a uniformly large real field is NOT clipped."},
+            "magnitude_outlier_k": {"type": "float", "description": "Robust per-cell |P| outlier clip, in MADs above the field median (default 6.0): drops position-fit / A-B-pairing failures (flag clipped_N_unphysical_magnitude_cells). RELATIVE (median/MAD), so a uniformly large real field is NOT clipped, but on a strong field its high MAD lets a >physical tail through — that tail is caught by max_magnitude_nm. LOWER (~4) if stray huge vectors persist; RAISE (~8) if genuine large displacements get clipped."},
+            "max_magnitude_nm": {"type": "float", "description": "Absolute physical ceiling on per-cell |P| in nm (default 0.12 = 120 pm; needs pixel_size_nm; None disables). Complements the relative MAD clip: a displacement above this is almost surely a sublattice-pairing/scale error, not real ferroelectric off-centering (40-80 pm common, ~100 pm extreme). Cells above it are dropped and counted in the N_cells_above_physical_ceiling flag (the flag fires even when too many to drop = whole-field scale error). RAISE (~0.2) for exotic large-displacement materials; LOWER (~0.1) to be stricter."},
             "domain_coherence_floor": {"type": "float", "description": "Global-coherence floor for the noise guard (default 0.4): if direction_coherence is below this the field is treated as pure noise and a multi-domain partition is collapsed to ONE 'disordered' domain (flag field_noise_dominated_domains_unreliable). RAISE (~0.5) to be stricter; LOWER (~0.3) if real low-contrast domains get suppressed."},
             "max_wall_fraction": {"type": "float", "description": "Fragmentation half of the noise guard (default 0.15): a fragmented partition (wall_fraction above this) is collapsed to one 'disordered' domain ONLY when it is ALSO locally incoherent (see local_coherence_floor). A genuine multi-domain field has contiguous domains separated by a THIN wall (~0.05); noise speckle is ~0.25+. RAISE (~0.25) if real finely-twinned mosaics are collapsed; LOWER (~0.1) to reject more weak-field speckle. NOTE wall_fraction grows with domain count/fineness and with smaller crops, which is why it is gated by local_coherence (count/size-invariant) rather than used alone."},
             "local_coherence_floor": {"type": "float", "description": "Coherence half of the noise guard (default 0.82): the median within-neighbourhood direction agreement. A fragmented partition collapses only if local_coherence is BELOW this (= noise). A real multi-domain mosaic stays locally coherent (~0.95+) regardless of how many/small its domains are, so it is preserved. RAISE (~0.88) to treat more borderline fields as noise; LOWER (~0.75) if real low-contrast/imperfect domains are wrongly collapsed."},

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -1381,6 +1381,65 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
     ax[2].set_title("|P| magnitude" + (" (nm)" if pixel_size_nm else " (px)")); plt.colorbar(s2, ax=ax[2], fraction=0.046)
     buf = BytesIO(); fig.tight_layout(); fig.savefig(buf, format="png", dpi=110); plt.close(fig)
 
+    # --- domain segmentation + wall localization (returned as DATA) -----------
+    # The smoothed direction-domain map above is the gold-standard domain view;
+    # return its structure as data too, so a caller reads domains/walls from the
+    # tool instead of re-deriving them (e.g. quantizing per-cell angles into
+    # fixed cardinal bins, which fragments the field). Domain directions are the
+    # PEAKS of the smoothed-direction histogram (adaptive — NOT fixed 0/90/180/270
+    # bins), so non-cardinal ferroelectric domains are captured.
+    domains = []; n_domains = 0; domain_labels = None; wall_fraction = float("nan")
+    try:
+        smv = np.full((len(XY), 2), np.nan)
+        if strong.sum() >= 5:
+            stree = cKDTree(XY[strong]); su_s = unit[strong]
+            for i, nb in enumerate(stree.query_ball_point(XY, 2.5 * nn_ref)):
+                if len(nb) >= 3:
+                    smv[i] = su_s[nb].mean(0)            # per-cell smoothed direction
+        valid_c = ~np.isnan(smv[:, 0]) & (np.hypot(smv[:, 0], smv[:, 1]) > 0.2)
+        if valid_c.sum() >= 10:
+            th = np.degrees(np.arctan2(smv[valid_c, 1], smv[valid_c, 0])) % 360
+            hist, edges = np.histogram(th, bins=36, range=(0, 360))
+            hsm = np.convolve(np.r_[hist[-3:], hist, hist[:3]], np.ones(3) / 3, "same")[3:-3]
+            centers = (edges[:-1] + edges[1:]) / 2
+            peaks = [k for k in range(36)
+                     if hsm[k] >= 0.25 * hsm.max()
+                     and hsm[k] >= hsm[(k - 1) % 36] and hsm[k] >= hsm[(k + 1) % 36]]
+            dirs = []
+            for k in sorted(peaks, key=lambda k: -hsm[k]):       # merge peaks <30 deg apart
+                a = float(centers[k])
+                if all(min(abs(a - d), 360 - abs(a - d)) > 30 for d in dirs):
+                    dirs.append(a)
+            dirs = dirs[:6] or [float(np.median(th))]
+            lab = np.full(len(XY), -1, int); idxv = np.where(valid_c)[0]
+            da = np.array(dirs); diff = np.abs(th[:, None] - da[None, :])
+            lab[idxv] = np.argmin(np.minimum(diff, 360 - diff), axis=1)
+            domain_labels = lab
+            for di, d in enumerate(dirs):
+                m = lab == di
+                if m.sum() >= 5:
+                    domains.append({"label": int(di), "n_cells": int(m.sum()),
+                                    "mean_angle_deg": round(d, 1),
+                                    "fraction": round(float(m.sum()) / max(1, valid_c.sum()), 3)})
+            n_domains = len(domains)
+            if n_domains >= 2:                               # wall cells = label change among spatial NN
+                labv = lab[idxv]; kk = min(7, len(idxv))
+                nn_i = cKDTree(XY[idxv]).query(XY[idxv], k=kk)[1]
+                wall = np.array([np.any(labv[nn_i[i, 1:]] != labv[i]) for i in range(len(idxv))])
+                wall_fraction = round(float(wall.mean()), 3)
+    except Exception:
+        flags.append("domain_segmentation_failed")
+
+    # Net (mean) displacement vs the per-cell magnitude: a registration / scan-
+    # offset indicator. net_to_local_ratio « 1 → genuine multi-domain field (the
+    # net cancels); » 1 → a uniform offset dominates (registration/scan drift),
+    # so the absolute magnitude/direction is suspect even if the field looks
+    # coherent. Lets a caller judge the offset instead of hedging about it.
+    meanP = P.mean(0)
+    net_to_local_ratio = float(np.hypot(meanP[0], meanP[1]) / (np.median(mag) + 1e-9))
+    if net_to_local_ratio > 1.5:
+        flags.append("offset_dominated_field_check_registration")
+
     return {
         "figure_bytes": buf.getvalue(),
         "metrics": {
@@ -1388,9 +1447,17 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
             "median_magnitude_px": float(np.median(mag)),
             "median_magnitude_nm": float(np.median(mag) * pixel_size_nm) if pixel_size_nm else None,
             "direction_coherence": coherence,   # ~1 coherent/domains, ~0 noise
+            "n_domains": int(n_domains),
+            "domains": domains,                 # adaptive (peak-clustered) directions, NOT cardinal bins
+            "wall_fraction": wall_fraction,
+            "net_polarization_px": [float(meanP[0]), float(meanP[1])],
+            "net_polarization_nm": ([float(meanP[0] * pixel_size_nm), float(meanP[1] * pixel_size_nm)]
+                                    if pixel_size_nm else None),
+            "net_to_local_ratio": net_to_local_ratio,
             "displaced_sublattice": displaced,
             "polarization": P.tolist(), "xy": XY.tolist(),
             "magnitude": mag.tolist(), "angle": ang.tolist(),
+            "domain_label": domain_labels.tolist() if domain_labels is not None else None,
         },
         "flags": flags,
     }
@@ -1820,15 +1887,21 @@ TOOL_SPECS = [
         },
         required=["image", "positions"],
         returns=(
-            "dict with 'figure_bytes' (PNG: polarization quiver + direction-domain map + "
-            "magnitude map; the DIRECTION panel is a SMOOTHED domain map, opacity=local "
-            "coherence, so domains/walls show solid and noise washes out), 'metrics' (n_cells, "
-            "median_magnitude_px/nm, direction_coherence ~1=coherent/domains ~0=noise OR "
-            "domains finer than ~3 cells [check fourier_reflection_map for a satellite before "
-            "calling low coherence noise], and "
-            "per-cell polarization/xy/magnitude/angle lists), and "
-            "'flags' (e.g. weak_sublattice_intensity_separation). Sign follows the "
-            "displaced->reference convention; flip via 'displaced' to match a specific reference."
+            "dict with 'figure_bytes' (PNG: polarization quiver + SMOOTHED direction-domain map "
+            "+ magnitude map — SAVE THIS as the visualization; do NOT re-render your own quiver "
+            "[a wrong scale makes pm-displacements huge/unreadable] or re-segment the domains). "
+            "'metrics': n_cells, median_magnitude_px/nm, direction_coherence (~1=coherent/domains "
+            "~0=noise OR domains finer than ~3 cells [check fourier_reflection_map for a satellite "
+            "first]); the DOMAIN SEGMENTATION as data — n_domains, domains (list of {label, "
+            "n_cells, mean_angle_deg, fraction}; directions are PEAK-CLUSTERED, adaptive — NOT "
+            "fixed 0/90/180/270 bins), wall_fraction, and per-cell domain_label; net_polarization_"
+            "px/nm and net_to_local_ratio (mean/median|P|: «1 = genuine multi-domain field [net "
+            "cancels]; »1 = a uniform offset / scan-registration drift dominates, so absolute "
+            "magnitude is suspect — flag offset_dominated_field_check_registration); and per-cell "
+            "polarization/xy/magnitude/angle lists. READ domains/walls from these fields rather "
+            "than quantizing per-cell angles yourself. 'flags' (e.g. "
+            "weak_sublattice_intensity_separation). Sign follows the displaced->reference "
+            "convention; flip via 'displaced' to match a specific reference."
         ),
     ),
 ]

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -1134,6 +1134,147 @@ def type_sublattice_defects(
     }
 
 
+def map_polarization(image, positions, displaced="auto", n_cage=4,
+                     pixel_size_nm=None, edge_margin_px=None, random_state=1):
+    """Per-unit-cell ferroelectric polarization / cation off-centering map.
+
+    For a two-sublattice (ABO3-type / interpenetrating) lattice where BOTH
+    sublattices are already resolved by detection, this measures the polar
+    distortion: the displacement of the "displaced" cation sublattice from the
+    centrosymmetric position defined by the surrounding "reference cage"
+    sublattice. That displacement field is the ferroelectric order parameter —
+    its direction maps domains, its discontinuities map domain walls.
+
+    Method (lattice-agnostic, no material constants): refine positions to
+    sub-pixel (polarization IS a sub-pixel displacement), split the columns
+    into two sublattices by intensity (2-component GMM — robust, not a fixed
+    threshold), pick the displaced sublattice, and for each displaced atom take
+    the centroid of its ``n_cage`` nearest reference-sublattice neighbours as
+    the centrosymmetric reference. ``P = reference_centroid - displaced_atom``.
+
+    Args:
+        image: 2D grayscale HAADF array (RAW — intensity separates the species).
+        positions: (N, 2) detected columns (x, y) with BOTH sublattices
+            resolved (confirm NN sits at the inter-sublattice spacing first).
+        displaced: which sublattice is the off-centering one — ``'auto'``
+            (default = the dimmer sublattice, the usual lighter B-cation
+            convention), ``'dim'``, or ``'bright'`` (when the off-centering
+            cation is the heavier/brighter one). Only flips the reference
+            choice / overall sign; the domain structure is unchanged.
+        n_cage: number of reference neighbours forming the centrosymmetric
+            cage (default 4 for a perovskite [100] projection; raise to match
+            the projected coordination of other structures/zone axes).
+        pixel_size_nm: nm/px; if given, magnitude is also reported in nm.
+        edge_margin_px: drop cells within this of the border (default 1.5×NN).
+        random_state: GMM seed.
+
+    Returns: dict with 'figure_bytes' (PNG: polarization quiver + direction-
+        domain map + magnitude map), and 'metrics' (n_cells, median magnitude
+        px/nm, per-cell 'polarization' vectors, 'xy', 'magnitude', 'angle',
+        'n_direction_clusters' as a domain-count proxy), and 'flags'. NOTE: the
+        sign follows the displacement→reference convention above (polarization
+        is often reported opposite to the cation displacement; flip via
+        ``displaced`` if matching a specific reference). Magnitude precision is
+        limited for very small polar displacements near the detection-noise
+        floor — direction/domains stay robust; treat tiny |P| cells cautiously.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from io import BytesIO
+    from sklearn.mixture import GaussianMixture
+
+    img = np.asarray(image, float)
+    if img.ndim != 2:
+        img = img[..., 0] if (img.ndim == 3 and img.shape[-1] <= 4) else img.reshape(img.shape[-2:])
+    H, W = img.shape
+    pos = np.asarray(positions, float)[:, :2]
+    if len(pos) < 20:
+        return {"figure_bytes": None, "metrics": {"error": "too few columns"}, "flags": ["insufficient_columns"]}
+    flags = []
+    try:
+        pos = np.asarray(refine_positions(img, pos)["positions"])[:, :2]  # sub-pixel for accurate |P|
+    except Exception:
+        flags.append("refine_failed_using_raw_positions")
+
+    nn = float(np.median(cKDTree(pos).query(pos, k=2)[0][:, 1]))
+    margin = float(edge_margin_px) if edge_margin_px is not None else 1.5 * nn
+    rr = max(1, int(round(0.2 * nn)))
+    I = np.array([img[max(0, int(round(p[1])) - rr):int(round(p[1])) + rr + 1,
+                      max(0, int(round(p[0])) - rr):int(round(p[0])) + rr + 1].max() for p in pos])
+    gm = GaussianMixture(2, random_state=int(random_state)).fit(I.reshape(-1, 1))
+    lab = gm.predict(I.reshape(-1, 1)); bright = int(np.argmax(gm.means_.ravel()))
+    sep = abs(gm.means_.ravel()[0] - gm.means_.ravel()[1]) / (np.sqrt(gm.covariances_.ravel()).mean() + 1e-9)
+    if sep < 1.5:
+        flags.append("weak_sublattice_intensity_separation")
+    disp_lab = bright if displaced == "bright" else (1 - bright)  # 'auto'/'dim' -> dimmer is displaced
+    disp = pos[lab == disp_lab]; ref = pos[lab != disp_lab]
+    if len(disp) < 10 or len(ref) < 10:
+        return {"figure_bytes": None, "metrics": {"error": "sublattice split failed",
+                "n_displaced": int(len(disp)), "n_reference": int(len(ref))}, "flags": flags + ["split_failed"]}
+
+    tref = cKDTree(ref); P = []; XY = []
+    for d in disp:
+        dd, ii = tref.query(d, k=int(n_cage))
+        if dd.max() > 1.3 * nn * np.sqrt(2):
+            continue
+        cen = ref[ii].mean(0)
+        if np.linalg.norm(cen - d) > 0.9 * nn:   # cage not centrosymmetric around d (edge) -> skip
+            continue
+        if not (margin < d[0] < W - margin and margin < d[1] < H - margin):
+            continue
+        P.append(cen - d); XY.append(d)
+    P = np.array(P); XY = np.array(XY)
+    if len(P) < 5:
+        return {"figure_bytes": None, "metrics": {"error": "no valid cells", "n_cells": int(len(P))}, "flags": flags}
+    mag = np.linalg.norm(P, axis=1); ang = (np.degrees(np.arctan2(P[:, 1], P[:, 0]))) % 360
+    # domain proxy: cluster polarization direction (cos/sin) of cells with sizable |P|
+    strong = mag > np.median(mag) * 0.5
+    nclust = 0
+    if strong.sum() > 20:
+        feat = np.column_stack([np.cos(np.radians(ang[strong])), np.sin(np.radians(ang[strong]))])
+        from sklearn.cluster import KMeans
+        best_k, best_in = 1, -1
+        for k in (1, 2, 3, 4):
+            if k >= strong.sum():
+                break
+            km = KMeans(k, n_init=3, random_state=int(random_state)).fit(feat)
+            # silhouette-ish: within vs spread
+            inertia = km.inertia_ / strong.sum()
+            if k == 1:
+                base = inertia
+            elif inertia < 0.3 * base and k > best_k:
+                best_k = k
+        nclust = best_k
+
+    fig, ax = plt.subplots(1, 3, figsize=(18, 6))
+    for a in ax:
+        a.imshow(img, cmap="gray"); a.axis("off"); a.set_aspect("equal")
+    ax[0].quiver(XY[:, 0], XY[:, 1], P[:, 0], P[:, 1], mag, cmap="viridis",
+                 scale=max(1e-6, np.median(mag)) * 40, width=0.003)
+    ax[0].set_title("polarization vectors")
+    s1 = ax[1].scatter(XY[:, 0], XY[:, 1], c=ang, cmap="hsv", s=6, vmin=0, vmax=360)
+    ax[1].set_title("polarization DIRECTION (domains)"); plt.colorbar(s1, ax=ax[1], fraction=0.046, label="deg")
+    s2 = ax[2].scatter(XY[:, 0], XY[:, 1], c=mag * (pixel_size_nm or 1), cmap="magma", s=6,
+                       vmax=np.percentile(mag, 98) * (pixel_size_nm or 1))
+    ax[2].set_title("|P| magnitude" + (" (nm)" if pixel_size_nm else " (px)")); plt.colorbar(s2, ax=ax[2], fraction=0.046)
+    buf = BytesIO(); fig.tight_layout(); fig.savefig(buf, format="png", dpi=110); plt.close(fig)
+
+    return {
+        "figure_bytes": buf.getvalue(),
+        "metrics": {
+            "n_cells": int(len(P)),
+            "median_magnitude_px": float(np.median(mag)),
+            "median_magnitude_nm": float(np.median(mag) * pixel_size_nm) if pixel_size_nm else None,
+            "n_direction_clusters": int(nclust),
+            "displaced_sublattice": displaced,
+            "polarization": P.tolist(), "xy": XY.tolist(),
+            "magnitude": mag.tolist(), "angle": ang.tolist(),
+        },
+        "flags": flags,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Tool specs
 # ---------------------------------------------------------------------------
@@ -1503,6 +1644,49 @@ TOOL_SPECS = [
             "lists each with x/y[/x_nm/y_nm], sublattice index, and for dopants a signed z "
             "and lighter/heavier-substitution label), and 'flags' (e.g. "
             "low_separation_score when the sublattices are not cleanly distinguished)."
+        ),
+    ),
+    ToolSpec(
+        name="map_polarization",
+        description=(
+            "Per-unit-cell ferroelectric polarization / cation off-centering map for a "
+            "two-sublattice (ABO3-type / interpenetrating) lattice. Measures the displacement "
+            "of the displaced cation sublattice from the centrosymmetric centroid of its "
+            "reference-cage neighbours — the ferroelectric order parameter whose direction maps "
+            "domains and whose discontinuities map domain walls. Returns figure + per-cell vectors."
+        ),
+        import_line="from scilink.skills.image_analysis.atomic_stem.atom_finding import map_polarization",
+        signature=(
+            "map_polarization(image, positions, displaced='auto', n_cage=4, "
+            "pixel_size_nm=None, edge_margin_px=None, random_state=1) -> dict"
+        ),
+        agents=["image_analysis"],
+        when_to_use=(
+            "Ferroic/ferroelectric distortion mapping on a perovskite or other interpenetrating "
+            "two-sublattice lattice, AFTER detection has resolved BOTH sublattices (the cage "
+            "cations AND the off-centering cations) — confirm both are resolved by an NN at the "
+            "inter-sublattice spacing, NOT the intra-sublattice repeat. Lattice-agnostic and "
+            "free of material constants. Assumes HAADF bright-column intensity. Reports the polar "
+            "displacement field; for tetragonality/shear, characterise the reference sublattice "
+            "with gpa_strain. Magnitude precision is limited for very small displacements near "
+            "the detection-noise floor (direction/domains remain robust)."
+        ),
+        parameters={
+            "image": {"type": "ndarray", "description": "2D grayscale HAADF (RAW — intensity separates the two species)."},
+            "positions": {"type": "ndarray", "description": "(N,2) detected columns (x,y) with BOTH sublattices resolved."},
+            "displaced": {"type": "str", "description": "Which sublattice off-centers: 'auto' (default, the dimmer/lighter cation — standard convention), 'dim', or 'bright' (when the off-centering cation is the heavier/brighter one). Only flips the reference/sign; domains unchanged."},
+            "n_cage": {"type": "int", "description": "Number of reference neighbours forming the centrosymmetric cage (default 4 = perovskite [100]; raise to match the projected coordination of another structure/zone axis)."},
+            "pixel_size_nm": {"type": "float", "description": "nm/px; if given, magnitude is also reported in nm."},
+            "edge_margin_px": {"type": "float", "description": "Exclude cells within this many px of the border (default 1.5x NN)."},
+            "random_state": {"type": "int", "description": "Seed for the intensity-split GMM (default 1)."},
+        },
+        required=["image", "positions"],
+        returns=(
+            "dict with 'figure_bytes' (PNG: polarization quiver + direction-domain map + "
+            "magnitude map), 'metrics' (n_cells, median_magnitude_px/nm, n_direction_clusters "
+            "as a domain-count proxy, and per-cell polarization/xy/magnitude/angle lists), and "
+            "'flags' (e.g. weak_sublattice_intensity_separation). Sign follows the "
+            "displaced->reference convention; flip via 'displaced' to match a specific reference."
         ),
     ),
 ]

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -1145,7 +1145,9 @@ def type_sublattice_defects(
 
 def map_polarization(image, positions, displaced="auto", n_cage=4,
                      pixel_size_nm=None, edge_margin_px=None,
-                     max_offset_frac=0.45, random_state=1):
+                     max_offset_frac=0.45, magnitude_outlier_k=6.0,
+                     domain_coherence_floor=0.4, max_wall_fraction=0.15,
+                     random_state=1):
     """Per-unit-cell ferroelectric polarization / cation off-centering map.
 
     For a two-sublattice (ABO3-type / interpenetrating) lattice where BOTH
@@ -1338,6 +1340,18 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
 
     if len(P) < 5:
         return {"figure_bytes": None, "metrics": {"error": "no valid cells", "n_cells": int(len(P))}, "flags": flags}
+    # Robust per-cell |P| outlier guard: a cell whose offset sits many MADs above
+    # the field median is a position-fit failure / mis-paired A-B column, not a
+    # real polar distortion — it shows up as an unphysical |P| (e.g. >>80 pm) that
+    # corrupts the quiver, the |P| colorbar, and the domain field. Drop these cells
+    # (median/MAD are robust, so a genuinely uniform large field is NOT clipped).
+    _m0 = np.linalg.norm(P, axis=1)
+    _med0 = float(np.median(_m0)); _mad0 = float(np.median(np.abs(_m0 - _med0))) + 1e-9
+    _keep = _m0 <= _med0 + magnitude_outlier_k * 1.4826 * _mad0
+    n_outliers = int((~_keep).sum())
+    if n_outliers and int(_keep.sum()) >= 5:
+        P, XY = P[_keep], XY[_keep]
+        flags.append(f"clipped_{n_outliers}_unphysical_magnitude_outliers_likely_misfit")
     mag = np.linalg.norm(P, axis=1); ang = (np.degrees(np.arctan2(P[:, 1], P[:, 0]))) % 360
     unit = P / (mag[:, None] + 1e-9)
     strong = mag > np.median(mag) * 0.5
@@ -1412,6 +1426,7 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
     # PEAKS of the smoothed-direction histogram (adaptive — NOT fixed 0/90/180/270
     # bins), so non-cardinal ferroelectric domains are captured.
     domains = []; n_domains = 0; domain_labels = None; wall_fraction = float("nan")
+    local_coherence = float("nan")
     try:
         smv = np.full((len(XY), 2), np.nan)
         if strong.sum() >= 5:
@@ -1420,6 +1435,8 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
                 if len(nb) >= 3:
                     smv[i] = su_s[nb].mean(0)            # per-cell smoothed direction
         valid_c = ~np.isnan(smv[:, 0]) & (np.hypot(smv[:, 0], smv[:, 1]) > 0.2)
+        local_coherence = (float(np.median(np.hypot(smv[valid_c, 0], smv[valid_c, 1])))
+                           if valid_c.sum() else float("nan"))
         if valid_c.sum() >= 10:
             th = np.degrees(np.arctan2(smv[valid_c, 1], smv[valid_c, 0])) % 360
             hist, edges = np.histogram(th, bins=36, range=(0, 360))
@@ -1450,6 +1467,22 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
                 nn_i = cKDTree(XY[idxv]).query(XY[idxv], k=kk)[1]
                 wall = np.array([np.any(labv[nn_i[i, 1:]] != labv[i]) for i in range(len(idxv))])
                 wall_fraction = round(float(wall.mean()), 3)
+            # Noise / speckle guard: a genuine multi-domain partition has CONTIGUOUS
+            # domains separated by a thin wall (low wall_fraction); a noise-dominated
+            # weak field (vectors at/below the position-fit noise floor) fragments
+            # into spatially-interspersed speckle (high wall_fraction) or has globally
+            # incoherent directions. Either way the multi-domain count is spurious —
+            # collapse to ONE 'disordered' field rather than reporting fake domains.
+            if n_domains >= 2 and (
+                (coherence == coherence and coherence < domain_coherence_floor)      # globally incoherent => pure noise
+                or (wall_fraction == wall_fraction and wall_fraction > max_wall_fraction
+                    and coherence == coherence and coherence < 0.85)):               # speckle partition on a NOT-strongly-coherent field (a genuine multi-domain stays ~0.95+, so it is never collapsed regardless of grid size)
+                flags.append("field_noise_dominated_domains_unreliable")
+                domains = [{"label": 0, "n_cells": int(valid_c.sum()), "mean_angle_deg": None,
+                            "fraction": 1.0, "disordered": True}]
+                n_domains = 1
+                domain_labels = np.zeros(len(XY), int)
+                wall_fraction = float("nan")
     except Exception:
         flags.append("domain_segmentation_failed")
 
@@ -1470,6 +1503,7 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
             "median_magnitude_px": float(np.median(mag)),
             "median_magnitude_nm": float(np.median(mag) * pixel_size_nm) if pixel_size_nm else None,
             "direction_coherence": coherence,   # ~1 coherent/domains, ~0 noise
+            "local_coherence": local_coherence, # median resultant of the smoothed local direction; < domain_coherence_floor => noise-dominated, domain count unreliable
             "n_domains": int(n_domains),
             "domains": domains,                 # adaptive (peak-clustered) directions, NOT cardinal bins
             "wall_fraction": wall_fraction,
@@ -1870,6 +1904,7 @@ TOOL_SPECS = [
         signature=(
             "map_polarization(image, positions, displaced='auto', n_cage=4, "
             "pixel_size_nm=None, edge_margin_px=None, max_offset_frac=0.45, "
+            "magnitude_outlier_k=6.0, domain_coherence_floor=0.4, max_wall_fraction=0.15, "
             "random_state=1) -> dict"
         ),
         agents=["image_analysis"],
@@ -1906,6 +1941,9 @@ TOOL_SPECS = [
             "pixel_size_nm": {"type": "float", "description": "nm/px; if given, magnitude is also reported in nm."},
             "edge_margin_px": {"type": "float", "description": "Exclude cells within this many px of the border (default 1.5x NN)."},
             "max_offset_frac": {"type": "float", "description": "Robustness to extra/spurious columns: a displaced cation is accepted only within this fraction of the reference-cage NN spacing from the cage centre (default 0.45). RAISE (~0.6) if large genuine displacements are dropped; LOWER (~0.3) if extra columns inflate the field. Scale is the reference sublattice NN, robust to over-detection."},
+            "magnitude_outlier_k": {"type": "float", "description": "Robust per-cell |P| outlier clip, in MADs above the field median (default 6.0): a cell beyond this is a position-fit / A-B-pairing failure with unphysical |P| (e.g. >>80 pm) and is dropped (flag clipped_N_unphysical_magnitude_outliers). LOWER (~4) if stray huge vectors still corrupt the figure/stats; RAISE (~8) if genuine large displacements get clipped. Median/MAD are robust, so a uniformly large real field is NOT clipped."},
+            "domain_coherence_floor": {"type": "float", "description": "Global-coherence floor for the noise guard (default 0.4): if direction_coherence is below this the field is treated as pure noise and a multi-domain partition is collapsed to ONE 'disordered' domain (flag field_noise_dominated_domains_unreliable). RAISE (~0.5) to be stricter; LOWER (~0.3) if real low-contrast domains get suppressed."},
+            "max_wall_fraction": {"type": "float", "description": "Spatial-incoherence gate on domains (default 0.15): a genuine multi-domain field has contiguous domains separated by a THIN wall (small wall_fraction, ~0.05); a noise-dominated weak field fragments into interspersed speckle (high wall_fraction, ~0.25+). If n_domains>=2 and wall_fraction exceeds this, the partition is judged spurious and collapsed to one 'disordered' domain. LOWER (~0.1) to reject more weak-field speckle; RAISE (~0.25) if real finely-twinned domains (legitimately higher wall_fraction) are being collapsed."},
             "random_state": {"type": "int", "description": "Seed for the intensity-split GMM (default 1)."},
         },
         required=["image", "positions"],
@@ -1913,7 +1951,11 @@ TOOL_SPECS = [
             "dict with 'figure_bytes' (PNG: polarization quiver + SMOOTHED direction-domain map "
             "+ magnitude map). 'metrics': n_cells, median_magnitude_px/nm, direction_coherence "
             "(~1=coherent/domains ~0=noise OR domains finer than ~3 cells [check "
-            "fourier_reflection_map for a satellite first]); the DOMAIN SEGMENTATION as data — "
+            "fourier_reflection_map for a satellite first]); local_coherence (median local "
+            "smoothed-direction resultant; below domain_coherence_floor => noise-dominated, the "
+            "field is reported as a single 'disordered' domain via "
+            "field_noise_dominated_domains_unreliable — do NOT read a domain count or a clean "
+            "single domain off such a field); the DOMAIN SEGMENTATION as data — "
             "n_domains, domains (list of {label, n_cells, mean_angle_deg, fraction}; directions are "
             "PEAK-CLUSTERED, adaptive — NOT fixed 0/90/180/270 bins), wall_fraction, per-cell "
             "domain_label; net_polarization_px/nm and net_to_local_ratio (mean/median|P|: «1 = "

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -872,25 +872,51 @@ def _sublattice_vacancies(cp, med_nn, margin, shape, enclosure,
     if len(cp) < 12:
         return []
     tree = cKDTree(cp)
-    k = min(9, len(cp))
-    dists, idxs = tree.query(cp, k=k)
-    # NN spacing WITHIN this sublattice (not the global inter-sublattice
-    # spacing) — the bond scale for a sublattice is its own lattice constant.
-    nn = float(np.median(dists[:, 1]))
-    bond_max = 1.4 * nn
-    empty_tol = 0.4 * nn
+    # Primitive vectors of THIS sublattice, from the most frequent short
+    # neighbour displacements (a high-recurrence displacement is a true lattice
+    # translation). This carries the correct, possibly anisotropic per-direction
+    # lengths — square, rectangular (a≠b), hexagonal and oblique alike — and is
+    # more reliable for a single sublattice than generic zone-axis detection.
+    kk = min(7, len(cp))
+    dists0, idxs0 = tree.query(cp, k=kk)
+    short = float(np.median(dists0[:, 1]))
+    binsz = 0.3 * short
+    counts = {}
+    for i in range(len(cp)):
+        for j in range(1, kk):
+            d = cp[idxs0[i, j]] - cp[i]
+            key = (int(round(d[0] / binsz)), int(round(d[1] / binsz)))
+            if key == (0, 0):
+                continue
+            counts.setdefault(key, []).append(d)
+    # keep displacements recurring across a meaningful fraction of atoms
+    vecs = sorted((np.mean(v, 0) for k, v in counts.items() if len(v) > 0.2 * len(cp)),
+                  key=lambda u: np.hypot(*u))
+    if len(vecs) < 2:
+        return []
+    v1 = vecs[0]
+    v2 = None
+    for v in vecs[1:]:
+        if abs(v1[0] * v[1] - v1[1] * v[0]) > 0.2 * np.linalg.norm(v1) * np.linalg.norm(v):
+            v2 = v
+            break
+    if v2 is None:
+        return []
+    Lmin = min(np.linalg.norm(v1), np.linalg.norm(v2))
+    Lmax = max(np.linalg.norm(v1), np.linalg.norm(v2))
+    empty_tol = 0.35 * Lmin
+    # Every lattice site sits at p ± v1 or p ± v2 from a neighbour, so these
+    # offsets generate all candidate sites (including around a vacancy).
     cand = []
-    for i, p in enumerate(cp):
-        for j in range(1, k):
-            q = cp[idxs[i, j]]
-            if dists[i, j] > bond_max:
-                break  # neighbours are distance-sorted; no closer bonds left
-            r = 2.0 * p - q  # site opposite q across p
-            if tree.query(r)[0] > empty_tol:  # genuinely empty
-                cand.append(r)
+    for p in cp:
+        for off in (v1, -v1, v2, -v2):
+            s = p + off
+            if tree.query(s)[0] > empty_tol:  # genuinely empty
+                cand.append(s)
     if not cand:
         return []
     cand = np.array(cand)
+    bond_max = 1.2 * Lmax
     # Merge votes for the same empty site, then keep only interior, enclosed ones.
     ctree = cKDTree(cand)
     used = np.zeros(len(cand), bool)
@@ -911,7 +937,7 @@ def _sublattice_vacancies(cp, med_nn, margin, shape, enclosure,
             # reject missed detections: a real (undetected) column still has
             # near-full intensity here; a true vacancy sits near background.
             xi, yi = int(round(s[0])), int(round(s[1]))
-            rr = max(1, int(round(0.15 * nn)))
+            rr = max(1, int(round(0.15 * Lmin)))
             patch = image[max(0, yi - rr):yi + rr + 1, max(0, xi - rr):xi + rr + 1]
             if patch.size and float(patch.max()) > 0.6 * occupied_intensity:
                 continue
@@ -1055,6 +1081,23 @@ def type_sublattice_defects(
         sublattices.append({"rank": rank, "n_columns": int(len(cp)),
                             "mean_intensity": means[c],
                             "n_vacancies": len(vacs), "n_dopants": len(dops)})
+
+    # Superstructure / ordered-phase guard. This tool assumes a COMPLETE
+    # sublattice with SPARSE, random point defects. When the flagged defect
+    # fraction is large, the columns are more likely an ordered phase (ordered
+    # vacancies/dopants, charge ordering) than a population of independent
+    # point defects — that regime is a superstructure to MAP, not point defects
+    # to count (use fourier_reflection_map on the satellite reflection).
+    defect_frac = (len(all_vac) + len(all_dop)) / max(1, len(spos))
+    if defect_frac > 0.15:
+        flags.append("high_defect_fraction_possible_superstructure")
+    # A large sublattice-population imbalance is the other superstructure tell
+    # (e.g. ordered vacancies that leave a self-consistent sparser lattice the
+    # geometry alone cannot see as vacancies): flag it for a reflection check.
+    if len(sublattices) >= 2:
+        cnts = sorted(s["n_columns"] for s in sublattices)
+        if cnts[0] > 0 and cnts[-1] / cnts[0] > 1.5:
+            flags.append("sublattice_population_imbalance_check_superstructure")
 
     # figure
     fig, ax = plt.subplots(1, 2, figsize=(13, 6.5))
@@ -1425,7 +1468,21 @@ TOOL_SPECS = [
             "yourself — that misfiles a dim dopant into the dim sublattice and hides it; "
             "this tool separates by local environment. Lattice-agnostic (square, "
             "hexagonal, oblique). Assumes bright-column (HAADF) intensity convention. "
-            "Requires the atomai package (used for the local-environment separation)."
+            "Requires the atomai package (used for the local-environment separation). "
+            "LIMITS (read the 'flags'): (1) needs clean detection — over/under-"
+            "detection fabricates or hides defects, so fix target_pixel_size first "
+            "(NN at the physical column spacing). (2) Dopant typing and superstructure "
+            "flagging are robust across lattice types; vacancy recall is high on "
+            "hexagonal/rectangular lattices and for vacancy clusters, but PARTIAL on "
+            "tightly-interpenetrating square lattices where the defective sublattice "
+            "sits at dim interstitial sites enclosed by bright neighbours — cross-check "
+            "vacancies with fft_defect_map (reciprocal-space, geometry-independent) and "
+            "consider lowering vacancy_enclosure. (3) Assumes a COMPLETE sublattice with "
+            "SPARSE random defects: an ORDERED/abundant defect arrangement is a "
+            "superstructure, not point defects — when 'high_defect_fraction_possible_"
+            "superstructure' or 'sublattice_population_imbalance_check_superstructure' is "
+            "flagged, map the satellite reflection with fourier_reflection_map instead of "
+            "counting sites. (4) HAADF bright-column intensity convention."
         ),
         parameters={
             "image": {"type": "ndarray", "description": "2D grayscale array. Pass RAW (un-normalized) — intensity carries the Z-contrast that distinguishes species and dopants."},

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -1070,14 +1070,25 @@ def type_sublattice_defects(
         med = np.median(metric); mad = np.median(np.abs(metric - med)) * 1.4826 + 1e-9
         z = (metric - med) / mad
         dops = []
-        for p, zz in zip(cp[np.abs(z) > dopant_sigma], z[np.abs(z) > dopant_sigma]):
-            if _interior(p):
-                d = {"x": float(p[0]), "y": float(p[1]), "z": float(zz),
-                     "kind": "lighter-substitution" if zz < 0 else "heavier-substitution",
-                     "sublattice": rank}
-                if pixel_size_nm:
-                    d["x_nm"], d["y_nm"] = float(p[0] * pixel_size_nm), float(p[1] * pixel_size_nm)
-                dops.append(d)
+        _sel = np.abs(z) > dopant_sigma
+        for p, zz, mv in zip(cp[_sel], z[_sel], metric[_sel]):
+            if not _interior(p):
+                continue
+            # On a very UNIFORM sublattice the MAD is tiny, so a real, moderately
+            # off-intensity column (e.g. a substitution 40% dimmer/brighter than its
+            # neighbours) scores an absurd |z| (~25) and gets wrongly dismissed
+            # downstream as "physically impossible". Report a sanity-CAPPED z for the
+            # outlier flag, plus the raw intensity_ratio (this column / median of its
+            # same-sublattice neighbours) as the PHYSICAL descriptor — a ratio well
+            # above background (~vacancy) but below 1 is a genuine lighter substitution.
+            d = {"x": float(p[0]), "y": float(p[1]),
+                 "z": float(np.clip(zz, -10.0, 10.0)),
+                 "intensity_ratio": round(float(mv), 3),
+                 "kind": "lighter-substitution" if zz < 0 else "heavier-substitution",
+                 "sublattice": rank}
+            if pixel_size_nm:
+                d["x_nm"], d["y_nm"] = float(p[0] * pixel_size_nm), float(p[1] * pixel_size_nm)
+            dops.append(d)
         vacs = []
         for vx, vy in _sublattice_vacancies(cp, med_nn, margin, (H, W),
                                             int(vacancy_enclosure),
@@ -1909,8 +1920,14 @@ TOOL_SPECS = [
             "+ dopants (circles)), 'metrics' (separation_score, per-sublattice "
             "n_columns/mean_intensity/n_vacancies/n_dopants, and 'vacancies'/'dopants' "
             "lists each with x/y[/x_nm/y_nm], sublattice index, and for dopants a signed z "
-            "and lighter/heavier-substitution label), and 'flags' (e.g. "
-            "low_separation_score when the sublattices are not cleanly distinguished)."
+            "(robust MAD z, CAPPED at +-10 so a real outlier on a very uniform sublattice "
+            "is not reported as an absurd ~25-sigma 'impossible' value), an intensity_ratio "
+            "(this column / its same-sublattice neighbour median — the PHYSICAL descriptor: "
+            "<1 dimmer=lighter substitution, >1 brighter=heavier; a ratio near background "
+            "would be a vacancy not a dopant), and a lighter/heavier-substitution label), and "
+            "'flags' (e.g. low_separation_score when the sublattices are not cleanly "
+            "distinguished). To catch subtler substitutions, LOWER dopant_sigma; judge "
+            "candidates by intensity_ratio, not the (capped) z."
         ),
     ),
     ToolSpec(

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -638,9 +638,18 @@ def detect_atoms_dcnn(
         fov_nm: Field of view in **nanometers** (from metadata or calibration).
         model_dir: Path to directory containing ``atomnet3*.tar`` model files.
             If *None*, models are auto-discovered or downloaded on first call.
-        target_pixel_size: Target pixel size in **Angstroms** for the model.
-            Default 0.25.  This value is approximate and may need tuning
-            for different materials.
+        target_pixel_size: Target pixel size in **ÅNGSTRÖMS (Å), NOT nm** — the
+            only parameter on this tool in Å; ``fov_nm`` here and
+            ``pixel_size_nm`` on the other atomic_stem tools are in nm. Default
+            0.25 Å (= 0.025 nm/px). The image is resampled to this size before
+            inference: ``resampled_px = fov_nm * 10 / target_pixel_size``. Keep
+            it within ~1–2× of the image's native pixel size in Å
+            (= ``fov_nm * 10 / image_width_px``); a typical good range is
+            0.15–0.30 Å. WARNING: passing an nm value here (e.g. 0.02 instead of
+            0.20) is ~10× too small, over-resamples to a tiny grid, and collapses
+            detection to ~0 columns — if detection collapses, suspect a unit
+            error first. Lower (finer) to recover a missed dim sublattice; raise
+            (coarser) if columns split/duplicate.
         threshold: Detection confidence threshold (0-1). Default 0.8.
         refine: Sub-pixel Gaussian refinement on detected peaks.
 
@@ -1258,45 +1267,80 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
         return {"figure_bytes": None, "metrics": {"error": "sublattice split failed",
                 "n_displaced": int(len(disp)), "n_reference": int(len(ref))}, "flags": flags + ["split_failed"]}
 
-    # Robustness to extra / spurious columns (over-detection, or a real third
-    # faint population the 2-way split lumps in): anchor everything on the
-    # REFERENCE-cage NN spacing (the bright, well-localized sublattice is the
-    # cleanest scale, unaffected by extra dim columns), and accept a displaced
-    # candidate only when it sits ~at the centrosymmetric centre of its cage —
-    # a genuine off-centering cation is within max_offset_frac of a cage centre,
-    # whereas an extra/spurious column elsewhere is not. This keeps real signal
-    # (we do NOT delete detections) while rejecting non-cage columns from the
-    # polarization pairing.
-    nn_ref = float(np.median(cKDTree(ref).query(ref, k=2)[0][:, 1]))
-    tref = cKDTree(ref); P = []; XY = []
-    for d in disp:
-        dd, ii = tref.query(d, k=int(n_cage))
-        if dd.max() > 1.3 * nn_ref * np.sqrt(2):   # cage neighbours must be local to the ref lattice
-            continue
-        cen = ref[ii].mean(0)
-        if np.linalg.norm(cen - d) > max_offset_frac * nn_ref:  # must sit ~at the cage centre
-            continue
-        if not (margin < d[0] < W - margin and margin < d[1] < H - margin):
-            continue
-        P.append(cen - d); XY.append(d)
-    P = np.array(P); XY = np.array(XY)
+    # Pair each off-centering cation to its reference cage and measure the offset.
+    # Robustness to extra / spurious columns (over-detection, or a real third faint
+    # population the 2-way split lumps in): anchor everything on the REFERENCE-cage
+    # NN spacing (the cleanest scale, unaffected by extra dim columns), and accept a
+    # displaced candidate only when it sits ~at the centrosymmetric centre of its
+    # cage — a genuine off-centering cation is within max_offset_frac of a cage
+    # centre, whereas an extra/spurious column elsewhere is not. This keeps real
+    # signal (we do NOT delete detections) while rejecting non-cage columns.
+    def _field(disp_s, ref_s):
+        nnr = float(np.median(cKDTree(ref_s).query(ref_s, k=2)[0][:, 1]))
+        tr = cKDTree(ref_s); Pl = []; XYl = []
+        for d in disp_s:
+            dd, ii = tr.query(d, k=int(n_cage))
+            if dd.max() > 1.3 * nnr * np.sqrt(2):   # cage neighbours must be local to the ref lattice
+                continue
+            cen = ref_s[ii].mean(0)
+            if np.linalg.norm(cen - d) > max_offset_frac * nnr:  # must sit ~at the cage centre
+                continue
+            if not (margin < d[0] < W - margin and margin < d[1] < H - margin):
+                continue
+            Pl.append(cen - d); XYl.append(d)
+        return np.array(Pl), np.array(XYl), nnr
+
+    # Spatial coherence (the noise guard): mean direction correlation to each strong
+    # cell's nearest neighbours — ~1 for a smooth/domain-structured field, ~0 for
+    # salt-and-pepper noise. Lets a verifier distinguish a real (even weak)
+    # polarization field from a degenerate one independent of how the per-cell
+    # figure renders, and drives the geometric-fallback decision below.
+    def _coherence(Pl, XYl):
+        if len(Pl) < 5:
+            return float("nan")
+        m = np.linalg.norm(Pl, axis=1); u = Pl / (m[:, None] + 1e-9)
+        st = m > np.median(m) * 0.5
+        if st.sum() <= 20:
+            return float("nan")
+        sx = XYl[st]; su = u[st]; kk = min(7, len(sx))
+        jj = cKDTree(sx).query(sx, k=kk)[1]
+        return float(np.median([np.mean(su[i] @ su[jj[i, 1:]].T) for i in range(len(sx))]))
+
+    P, XY, nn_ref = _field(disp, ref)
+    coherence = _coherence(P, XY)
+
+    # Outcome-based geometric-separation fallback for weak intensity contrast
+    # (near-identical-Z cations / weak HAADF contrast where the intensity GMM split
+    # is unreliable): if the intensity-split field is incoherent or empty, retry
+    # with a GEOMETRIC split by local environment (local_env_gmm) — the two
+    # interpenetrating sublattices have distinct neighbour arrangements in
+    # projection even when equally bright — and keep whichever split yields the more
+    # coherent field. Outcome-based (not a brittle intensity-separation threshold)
+    # because GMM separation on near-degenerate intensities is itself noise-
+    # dependent. The reference/displaced choice is then arbitrary, but the field is
+    # invariant to it up to a global sign (a convention anyway).
+    if not (coherence == coherence) or coherence < 0.5 or len(P) < 5:
+        try:
+            win = max(8, int(round(1.5 * nn)))
+            lg = local_env_gmm(img, pos, n_components=2, window_size=win,
+                               random_state=int(random_state))
+            gpos = np.asarray(lg["positions"], float)[:, :2]
+            gcls = np.asarray(lg["classes"])
+            dg = gpos[gcls == 0]; rg = gpos[gcls == 1]
+            if len(dg) >= 10 and len(rg) >= 10:
+                Pg, XYg, nng = _field(dg, rg)
+                cg = _coherence(Pg, XYg)
+                if (cg == cg) and len(Pg) >= 5 and (not (coherence == coherence) or cg > coherence):
+                    P, XY, nn_ref, coherence = Pg, XYg, nng, cg
+                    flags.append("geometric_separation_used_intensity_ambiguous")
+        except Exception:
+            flags.append("geometric_separation_attempt_failed")
+
     if len(P) < 5:
         return {"figure_bytes": None, "metrics": {"error": "no valid cells", "n_cells": int(len(P))}, "flags": flags}
     mag = np.linalg.norm(P, axis=1); ang = (np.degrees(np.arctan2(P[:, 1], P[:, 0]))) % 360
     unit = P / (mag[:, None] + 1e-9)
     strong = mag > np.median(mag) * 0.5
-
-    # --- spatial coherence metric (the noise guard) ---------------------------
-    # Mean direction correlation to each strong cell's nearest neighbours:
-    # ~1 for a smooth/domain-structured field, ~0 for salt-and-pepper noise.
-    # This lets a verifier distinguish a real (even weak) polarization field from
-    # a degenerate one independent of how the per-cell figure happens to render.
-    coherence = float("nan")
-    if strong.sum() > 20:
-        sx = XY[strong]; su = unit[strong]
-        kk = min(7, len(sx))
-        ii = cKDTree(sx).query(sx, k=kk)[1]
-        coherence = float(np.median([np.mean(su[i] @ su[ii[i, 1:]].T) for i in range(len(sx))]))
     if coherence == coherence and coherence < 0.5:
         flags.append("low_direction_coherence_noise_OR_finer_than_NN_domains")
 
@@ -1443,7 +1487,7 @@ TOOL_SPECS = [
             },
             "target_pixel_size": {
                 "type": "float",
-                "description": "Target pixel size in Angstroms the image is resampled to before inference (default 0.25). If a dense lattice's dim sublattice is missed (sparse detection), LOWER it (finer); too coarse a value drops the dim sublattice.",
+                "description": "Target pixel size in ÅNGSTRÖMS (Å), NOT nm — the only Å param here (fov_nm and pixel_size_nm elsewhere are in nm); default 0.25 Å = 0.025 nm/px. Image is resampled to it before inference (resampled_px = fov_nm*10/target_pixel_size); keep within ~1–2× of native (= fov_nm*10/image_width_px), typically 0.15–0.30 Å. WARNING: passing an nm value (e.g. 0.02 not 0.20) is ~10× too small and COLLAPSES detection to ~0 columns — suspect a unit error first if detection collapses. LOWER (finer) to recover a missed dim sublattice; RAISE (coarser) if columns split/duplicate.",
             },
             "threshold": {
                 "type": "float",
@@ -1757,7 +1801,12 @@ TOOL_SPECS = [
             "centre and the two cation sublattices are the INTENSITY EXTREMES (brightest = cage "
             "reference, dimmest = off-centering cation); a middle intensity population is ignored "
             "(reported via the third_intensity_population_present_using_extremes flag); exotic "
-            "orderings may violate these assumptions."
+            "orderings may violate these assumptions. (4) when the two sublattices are NOT "
+            "intensity-distinguishable (near-identical-Z cations, weak HAADF contrast), the tool "
+            "AUTOMATICALLY falls back to GEOMETRIC separation by local environment "
+            "(local_env_gmm) — flagged geometric_separation_used_intensity_ambiguous; the "
+            "reference/sign is then arbitrary (direction/magnitude unchanged up to a global sign), "
+            "so do NOT pre-decline a weak-contrast ferroelectric as single-sublattice."
         ),
         parameters={
             "image": {"type": "ndarray", "description": "2D grayscale HAADF (RAW — intensity separates the two species)."},

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -1888,20 +1888,17 @@ TOOL_SPECS = [
         required=["image", "positions"],
         returns=(
             "dict with 'figure_bytes' (PNG: polarization quiver + SMOOTHED direction-domain map "
-            "+ magnitude map — SAVE THIS as the visualization; do NOT re-render your own quiver "
-            "[a wrong scale makes pm-displacements huge/unreadable] or re-segment the domains). "
-            "'metrics': n_cells, median_magnitude_px/nm, direction_coherence (~1=coherent/domains "
-            "~0=noise OR domains finer than ~3 cells [check fourier_reflection_map for a satellite "
-            "first]); the DOMAIN SEGMENTATION as data — n_domains, domains (list of {label, "
-            "n_cells, mean_angle_deg, fraction}; directions are PEAK-CLUSTERED, adaptive — NOT "
-            "fixed 0/90/180/270 bins), wall_fraction, and per-cell domain_label; net_polarization_"
-            "px/nm and net_to_local_ratio (mean/median|P|: «1 = genuine multi-domain field [net "
-            "cancels]; »1 = a uniform offset / scan-registration drift dominates, so absolute "
-            "magnitude is suspect — flag offset_dominated_field_check_registration); and per-cell "
-            "polarization/xy/magnitude/angle lists. READ domains/walls from these fields rather "
-            "than quantizing per-cell angles yourself. 'flags' (e.g. "
-            "weak_sublattice_intensity_separation). Sign follows the displaced->reference "
-            "convention; flip via 'displaced' to match a specific reference."
+            "+ magnitude map). 'metrics': n_cells, median_magnitude_px/nm, direction_coherence "
+            "(~1=coherent/domains ~0=noise OR domains finer than ~3 cells [check "
+            "fourier_reflection_map for a satellite first]); the DOMAIN SEGMENTATION as data — "
+            "n_domains, domains (list of {label, n_cells, mean_angle_deg, fraction}; directions are "
+            "PEAK-CLUSTERED, adaptive — NOT fixed 0/90/180/270 bins), wall_fraction, per-cell "
+            "domain_label; net_polarization_px/nm and net_to_local_ratio (mean/median|P|: «1 = "
+            "genuine multi-domain field [net cancels]; »1 = a uniform offset / scan-registration "
+            "drift dominates, so absolute magnitude is suspect — flag "
+            "offset_dominated_field_check_registration); per-cell polarization/xy/magnitude/angle "
+            "lists. 'flags' (e.g. weak_sublattice_intensity_separation). Sign follows the "
+            "displaced->reference convention; flip via 'displaced' to match a specific reference."
         ),
     ),
 ]

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -1183,9 +1183,16 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
         'n_direction_clusters' as a domain-count proxy), and 'flags'. NOTE: the
         sign follows the displacement→reference convention above (polarization
         is often reported opposite to the cation displacement; flip via
-        ``displaced`` if matching a specific reference). Magnitude precision is
-        limited for very small polar displacements near the detection-noise
-        floor — direction/domains stay robust; treat tiny |P| cells cautiously.
+        ``displaced`` if matching a specific reference). LIMITS: direction/domains
+        are the robust output; magnitude is trustworthy only on CLEAN detection —
+        over-detection inflates it (~20% on real data) and extreme over-detection
+        returns ``{'error': 'no valid cells'}`` (fix ``target_pixel_size`` first
+        when magnitude matters), and magnitude is also imprecise for very small
+        |P| near the position-fit noise floor. Assumes a displacive perovskite-
+        type structure (off-centering cation ~at the cage centre; the two cation
+        sublattices are the intensity extremes — brightest cage, dimmest
+        off-centering; a middle population is ignored and flagged); exotic
+        orderings may violate this.
     """
     import matplotlib
     matplotlib.use("Agg")
@@ -1706,8 +1713,18 @@ TOOL_SPECS = [
             "inter-sublattice spacing, NOT the intra-sublattice repeat. Lattice-agnostic and "
             "free of material constants. Assumes HAADF bright-column intensity. Reports the polar "
             "displacement field; for tetragonality/shear, characterise the reference sublattice "
-            "with gpa_strain. Magnitude precision is limited for very small displacements near "
-            "the detection-noise floor (direction/domains remain robust)."
+            "with gpa_strain. "
+            "LIMITS: (1) DIRECTION/domains are the robust output; MAGNITUDE is trustworthy only "
+            "on CLEAN detection (NN at the inter-sublattice spacing, low nn_cv) — over-detected "
+            "input inflates magnitude (~20% on real over-detection), and EXTREME over-detection "
+            "returns {'error':'no valid cells'} (an honest failure, not a result), so fix "
+            "target_pixel_size first when magnitude matters. (2) magnitude is also imprecise for "
+            "very small displacements near the position-fit noise floor. (3) assumes a DISPLACIVE "
+            "perovskite-type structure: the off-centering cation sits ~at the reference-cage "
+            "centre and the two cation sublattices are the INTENSITY EXTREMES (brightest = cage "
+            "reference, dimmest = off-centering cation); a middle intensity population is ignored "
+            "(reported via the third_intensity_population_present_using_extremes flag); exotic "
+            "orderings may violate these assumptions."
         ),
         parameters={
             "image": {"type": "ndarray", "description": "2D grayscale HAADF (RAW — intensity separates the two species)."},

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -1369,14 +1369,23 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
     rgba = cm.hsv(hue.reshape(G, G)); rgba[..., 3] = coh_local.reshape(G, G)
 
     fig, ax = plt.subplots(1, 3, figsize=(18, 6))
+    # Show the dark HAADF image only FAINTLY as context, so the coloured
+    # overlays (arrows / magnitude scatter) stay clearly visible on top of it.
     for a in ax:
-        a.imshow(img, cmap="gray"); a.axis("off"); a.set_aspect("equal")
-    ax[0].quiver(XY[strong, 0], XY[strong, 1], P[strong, 0], P[strong, 1], mag[strong],
-                 cmap="viridis", scale=max(1e-6, np.median(mag)) * 40, width=0.003)
-    ax[0].set_title("polarization vectors (|P|>0.5·median)")
+        a.imshow(img, cmap="gray", alpha=0.5); a.axis("off"); a.set_aspect("equal")
+    # Panel 0: arrows coloured by DIRECTION (hsv = always saturated, so they are
+    # visible regardless of |P|, and the hue matches the direction-domain map in
+    # panel 1); length ∝ |P|; thin dark edge for contrast on any background.
+    if strong.sum() > 0:
+        ang = (np.degrees(np.arctan2(P[strong, 1], P[strong, 0])) % 360) / 360.0
+        ax[0].quiver(XY[strong, 0], XY[strong, 1], P[strong, 0], P[strong, 1], ang,
+                     cmap="hsv", clim=(0.0, 1.0), scale=max(1e-6, np.median(mag)) * 40,
+                     width=0.005, headwidth=4.0, edgecolor="k", linewidth=0.3)
+    ax[0].set_title("polarization vectors (colour = direction, |P|>0.5·median)")
     ax[1].imshow(rgba, extent=[0, W, H, 0])
     ax[1].set_title(f"DIRECTION domains (smoothed; coherence={coherence:.2f})")
-    s2 = ax[2].scatter(XY[:, 0], XY[:, 1], c=mag * (pixel_size_nm or 1), cmap="magma", s=6,
+    s2 = ax[2].scatter(XY[:, 0], XY[:, 1], c=mag * (pixel_size_nm or 1), cmap="plasma", s=14,
+                       edgecolors="white", linewidths=0.3,
                        vmax=np.percentile(mag, 98) * (pixel_size_nm or 1))
     ax[2].set_title("|P| magnitude" + (" (nm)" if pixel_size_nm else " (px)")); plt.colorbar(s2, ax=ax[2], fraction=0.046)
     buf = BytesIO(); fig.tight_layout(); fig.savefig(buf, format="png", dpi=110); plt.close(fig)

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -1135,7 +1135,8 @@ def type_sublattice_defects(
 
 
 def map_polarization(image, positions, displaced="auto", n_cage=4,
-                     pixel_size_nm=None, edge_margin_px=None, random_state=1):
+                     pixel_size_nm=None, edge_margin_px=None,
+                     max_offset_frac=0.45, random_state=1):
     """Per-unit-cell ferroelectric polarization / cation off-centering map.
 
     For a two-sublattice (ABO3-type / interpenetrating) lattice where BOTH
@@ -1166,6 +1167,14 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
             the projected coordination of other structures/zone axes).
         pixel_size_nm: nm/px; if given, magnitude is also reported in nm.
         edge_margin_px: drop cells within this of the border (default 1.5×NN).
+        max_offset_frac: a displaced cation is accepted only if it sits within
+            this fraction of the reference-cage NN spacing from the cage centre
+            (default 0.45). This is the robustness knob against extra/spurious
+            columns (over-detection or a real third faint population): RAISE
+            toward ~0.6 if genuine large polar displacements are being dropped,
+            LOWER toward ~0.3 to be stricter when extra columns inflate the
+            field. The scale is the *reference* sublattice NN, so it is not
+            corrupted by extra dim columns.
         random_state: GMM seed.
 
     Returns: dict with 'figure_bytes' (PNG: polarization quiver + direction-
@@ -1202,24 +1211,52 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
     rr = max(1, int(round(0.2 * nn)))
     I = np.array([img[max(0, int(round(p[1])) - rr):int(round(p[1])) + rr + 1,
                       max(0, int(round(p[0])) - rr):int(round(p[0])) + rr + 1].max() for p in pos])
-    gm = GaussianMixture(2, random_state=int(random_state)).fit(I.reshape(-1, 1))
-    lab = gm.predict(I.reshape(-1, 1)); bright = int(np.argmax(gm.means_.ravel()))
-    sep = abs(gm.means_.ravel()[0] - gm.means_.ravel()[1]) / (np.sqrt(gm.covariances_.ravel()).mean() + 1e-9)
+    # Intensity-cluster the columns. Pick the number of populations by BIC over
+    # {2, 3}: real data often has a THIRD faint population (extra/O columns, or
+    # over-detection) beyond the two cation sublattices — forcing k=2 would lump
+    # it into the reference and corrupt the cage. With k=3 we use only the
+    # cleanest extremes (brightest = reference cage, dimmest = off-centering
+    # cation) and simply ignore the middle population.
+    Iv = I.reshape(-1, 1)
+    cand = []
+    for k in (2, 3):
+        if len(pos) > k * 5:
+            g = GaussianMixture(k, random_state=int(random_state)).fit(Iv)
+            cand.append((g.bic(Iv), g))
+    gm = min(cand, key=lambda t: t[0])[1]
+    means = gm.means_.ravel(); lab = gm.predict(Iv); order = np.argsort(means)
+    bright_lab, dim_lab = int(order[-1]), int(order[0])
+    sep = abs(means[bright_lab] - means[dim_lab]) / (np.sqrt(gm.covariances_.ravel()).mean() + 1e-9)
     if sep < 1.5:
         flags.append("weak_sublattice_intensity_separation")
-    disp_lab = bright if displaced == "bright" else (1 - bright)  # 'auto'/'dim' -> dimmer is displaced
-    disp = pos[lab == disp_lab]; ref = pos[lab != disp_lab]
+    if gm.n_components == 3:
+        flags.append("third_intensity_population_present_using_extremes")
+    if displaced == "bright":
+        disp_lab, ref_lab = bright_lab, dim_lab
+    else:  # 'auto' / 'dim' -> the dimmer (lighter) cation off-centers
+        disp_lab, ref_lab = dim_lab, bright_lab
+    disp = pos[lab == disp_lab]; ref = pos[lab == ref_lab]   # middle cluster (if any) ignored
     if len(disp) < 10 or len(ref) < 10:
         return {"figure_bytes": None, "metrics": {"error": "sublattice split failed",
                 "n_displaced": int(len(disp)), "n_reference": int(len(ref))}, "flags": flags + ["split_failed"]}
 
+    # Robustness to extra / spurious columns (over-detection, or a real third
+    # faint population the 2-way split lumps in): anchor everything on the
+    # REFERENCE-cage NN spacing (the bright, well-localized sublattice is the
+    # cleanest scale, unaffected by extra dim columns), and accept a displaced
+    # candidate only when it sits ~at the centrosymmetric centre of its cage —
+    # a genuine off-centering cation is within max_offset_frac of a cage centre,
+    # whereas an extra/spurious column elsewhere is not. This keeps real signal
+    # (we do NOT delete detections) while rejecting non-cage columns from the
+    # polarization pairing.
+    nn_ref = float(np.median(cKDTree(ref).query(ref, k=2)[0][:, 1]))
     tref = cKDTree(ref); P = []; XY = []
     for d in disp:
         dd, ii = tref.query(d, k=int(n_cage))
-        if dd.max() > 1.3 * nn * np.sqrt(2):
+        if dd.max() > 1.3 * nn_ref * np.sqrt(2):   # cage neighbours must be local to the ref lattice
             continue
         cen = ref[ii].mean(0)
-        if np.linalg.norm(cen - d) > 0.9 * nn:   # cage not centrosymmetric around d (edge) -> skip
+        if np.linalg.norm(cen - d) > max_offset_frac * nn_ref:  # must sit ~at the cage centre
             continue
         if not (margin < d[0] < W - margin and margin < d[1] < H - margin):
             continue
@@ -1658,7 +1695,8 @@ TOOL_SPECS = [
         import_line="from scilink.skills.image_analysis.atomic_stem.atom_finding import map_polarization",
         signature=(
             "map_polarization(image, positions, displaced='auto', n_cage=4, "
-            "pixel_size_nm=None, edge_margin_px=None, random_state=1) -> dict"
+            "pixel_size_nm=None, edge_margin_px=None, max_offset_frac=0.45, "
+            "random_state=1) -> dict"
         ),
         agents=["image_analysis"],
         when_to_use=(
@@ -1678,6 +1716,7 @@ TOOL_SPECS = [
             "n_cage": {"type": "int", "description": "Number of reference neighbours forming the centrosymmetric cage (default 4 = perovskite [100]; raise to match the projected coordination of another structure/zone axis)."},
             "pixel_size_nm": {"type": "float", "description": "nm/px; if given, magnitude is also reported in nm."},
             "edge_margin_px": {"type": "float", "description": "Exclude cells within this many px of the border (default 1.5x NN)."},
+            "max_offset_frac": {"type": "float", "description": "Robustness to extra/spurious columns: a displaced cation is accepted only within this fraction of the reference-cage NN spacing from the cage centre (default 0.45). RAISE (~0.6) if large genuine displacements are dropped; LOWER (~0.3) if extra columns inflate the field. Scale is the reference sublattice NN, robust to over-detection."},
             "random_state": {"type": "int", "description": "Seed for the intensity-split GMM (default 1)."},
         },
         required=["image", "positions"],

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -1368,10 +1368,14 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
             coh_local[i] = min(1.0, np.hypot(v[0], v[1]))
     rgba = cm.hsv(hue.reshape(G, G)); rgba[..., 3] = coh_local.reshape(G, G)
 
-    fig, ax = plt.subplots(1, 3, figsize=(18, 6))
+    # Near-square 2x2 layout (renders large in the HTML report's grid cell — a
+    # wide 1x3 strip collapses to an unreadable sliver there). Cells: quiver,
+    # direction-domain map, |P| magnitude, and a direction colour-wheel key.
+    fig, axes = plt.subplots(2, 2, figsize=(13, 12.5))
+    ax = axes.ravel()
     # Show the dark HAADF image only FAINTLY as context, so the coloured
     # overlays (arrows / magnitude scatter) stay clearly visible on top of it.
-    for a in ax:
+    for a in (ax[0], ax[1], ax[2]):
         a.imshow(img, cmap="gray", alpha=0.5); a.axis("off"); a.set_aspect("equal")
     # Panel 0: arrows coloured by DIRECTION (hsv = always saturated, so they are
     # visible regardless of |P|, and the hue matches the direction-domain map in
@@ -1388,6 +1392,16 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
                        edgecolors="white", linewidths=0.3,
                        vmax=np.percentile(mag, 98) * (pixel_size_nm or 1))
     ax[2].set_title("|P| magnitude" + (" (nm)" if pixel_size_nm else " (px)")); plt.colorbar(s2, ax=ax[2], fraction=0.046)
+    # Panel 3: direction colour-wheel — the hue legend for panels 0 & 1 (which
+    # had no colorbar). hue at angle theta == arrow/domain hue for direction theta.
+    ax[3].remove()
+    axk = fig.add_subplot(2, 2, 4, projection="polar")
+    _tt = np.linspace(0, 2 * np.pi, 361); _rr = np.linspace(0.55, 1.0, 24)
+    _TT, _RR = np.meshgrid(_tt, _rr)
+    axk.pcolormesh(_TT, _RR, np.degrees(_TT), cmap="hsv", vmin=0, vmax=360, shading="auto")
+    axk.set_yticks([]); axk.set_xticks(np.deg2rad([0, 90, 180, 270]))
+    axk.set_xticklabels(["0°", "90°", "180°", "270°"])
+    axk.set_title("colour = polarization direction", fontsize=10, pad=14)
     buf = BytesIO(); fig.tight_layout(); fig.savefig(buf, format="png", dpi=110); plt.close(fig)
 
     # --- domain segmentation + wall localization (returned as DATA) -----------

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -847,6 +847,250 @@ def local_env_gmm(
     }
 
 
+def _sublattice_vacancies(cp, med_nn, margin, shape, enclosure,
+                          image=None, occupied_intensity=None):
+    """Interior sites of one sublattice with no detected column (vacancies).
+
+    Data-driven and lattice-agnostic (no global indexing, so no drift over
+    large or strained fields): for every atom, reflect each of its nearest
+    neighbours to the opposite side (``2p - q``) — that opposite site is where
+    the lattice "expects" another atom. A reflected site that is (a) empty,
+    (b) interior, and (c) enclosed by at least ``enclosure`` detected columns
+    within ~1 NN is a vacancy candidate. Works for square, hexagonal, and
+    oblique sublattices alike.
+
+    Critical disambiguation (when ``image``/``occupied_intensity`` are given):
+    a true vacancy has *no atom*, so the image there sits near the
+    inter-column background; a mere *detection miss* still has a real column
+    (full intensity) at the site. Candidates whose image intensity is a sizable
+    fraction of a real column are rejected as missed detections, not vacancies
+    — so vacancy counts do not inflate when detection under-finds a dim
+    sublattice.
+    """
+    H, W = shape
+    cp = np.asarray(cp, float)
+    if len(cp) < 12:
+        return []
+    tree = cKDTree(cp)
+    k = min(9, len(cp))
+    dists, idxs = tree.query(cp, k=k)
+    # NN spacing WITHIN this sublattice (not the global inter-sublattice
+    # spacing) — the bond scale for a sublattice is its own lattice constant.
+    nn = float(np.median(dists[:, 1]))
+    bond_max = 1.4 * nn
+    empty_tol = 0.4 * nn
+    cand = []
+    for i, p in enumerate(cp):
+        for j in range(1, k):
+            q = cp[idxs[i, j]]
+            if dists[i, j] > bond_max:
+                break  # neighbours are distance-sorted; no closer bonds left
+            r = 2.0 * p - q  # site opposite q across p
+            if tree.query(r)[0] > empty_tol:  # genuinely empty
+                cand.append(r)
+    if not cand:
+        return []
+    cand = np.array(cand)
+    # Merge votes for the same empty site, then keep only interior, enclosed ones.
+    ctree = cKDTree(cand)
+    used = np.zeros(len(cand), bool)
+    vac = []
+    for i in range(len(cand)):
+        if used[i]:
+            continue
+        grp = ctree.query_ball_point(cand[i], empty_tol)
+        used[list(grp)] = True
+        s = cand[list(grp)].mean(0)
+        if not (margin < s[0] < W - margin and margin < s[1] < H - margin):
+            continue
+        if tree.query(s)[0] <= empty_tol:  # an atom is actually there
+            continue
+        if len(tree.query_ball_point(s, bond_max)) < enclosure:  # not enclosed
+            continue
+        if image is not None and occupied_intensity:
+            # reject missed detections: a real (undetected) column still has
+            # near-full intensity here; a true vacancy sits near background.
+            xi, yi = int(round(s[0])), int(round(s[1]))
+            rr = max(1, int(round(0.15 * nn)))
+            patch = image[max(0, yi - rr):yi + rr + 1, max(0, xi - rr):xi + rr + 1]
+            if patch.size and float(patch.max()) > 0.6 * occupied_intensity:
+                continue
+        vac.append((float(s[0]), float(s[1])))
+    return vac
+
+
+def type_sublattice_defects(
+    image,
+    positions,
+    n_sublattices=2,
+    window_size=None,
+    pixel_size_nm=None,
+    dopant_sigma=3.5,
+    edge_margin_px=None,
+    vacancy_enclosure=3,
+    random_state=1,
+):
+    """Per-sublattice point-defect typing on a multi-sublattice lattice.
+
+    Encapsulates the chain that an LLM tends to get wrong when it improvises:
+    (1) separate sublattices by **local environment** (``local_env_gmm``) —
+    NOT by raw column intensity, because a substitutional dopant is itself an
+    anomalous-intensity column, so an intensity split misfiles it into the
+    wrong sublattice and hides it; (2) per sublattice, flag **vacancies**
+    (interior ideal-lattice sites with no detected column) and **dopants**
+    (amplitude outliers *within* that sublattice). Border columns are excluded
+    (unreliable fits). Run only after BOTH sublattices are resolved by
+    detection (confirm via NN at the inter-sublattice spacing).
+
+    Args:
+        image: 2D grayscale array — pass it RAW (un-normalized); intensity
+            carries the Z-contrast that distinguishes species and dopants.
+        positions: (N, 2) detected column positions (x, y).
+        n_sublattices: number of sublattices to separate (default 2).
+        window_size: local-environment patch side in px (default ~1.5× median
+            NN ≈ one lattice parameter). Larger captures more neighbourhood.
+        pixel_size_nm: nm/px; if given, defect coordinates are also in nm.
+        dopant_sigma: robust (MAD) z-score threshold for an intensity outlier
+            within a sublattice. LOWER (e.g. 2.5) to catch subtler
+            substitutions, RAISE (e.g. 5) if noise produces false dopants.
+        edge_margin_px: exclude defects within this many px of the border
+            (default 1.5× median NN). RAISE if border fits are unreliable,
+            LOWER to include near-edge defects.
+        vacancy_enclosure: how many of a candidate empty site's 4 lattice
+            neighbours must be occupied for it to count (default 3 of 4).
+            RAISE to 4 for only fully-enclosed vacancies (fewer false
+            positives at domain edges), LOWER to 2 near boundaries.
+        random_state: seed for the GMM separation.
+
+    Returns:
+        dict with 'figure_bytes' (PNG: sublattices colour-coded + vacancies +
+        dopants), 'metrics' (per-sublattice counts, separation_score,
+        vacancies, dopants — each with x/y[/x_nm/y_nm], sublattice, and for
+        dopants a signed z and a lighter/heavier-substitution label), and
+        'flags'.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from io import BytesIO
+
+    img = np.asarray(image, float)
+    if img.ndim != 2:
+        img = img[..., 0] if (img.ndim == 3 and img.shape[-1] <= 4) else img.reshape(img.shape[-2:])
+    H, W = img.shape
+    pos = np.asarray(positions, float)
+    if pos.ndim != 2 or pos.shape[1] < 2:
+        raise ValueError(f"positions must be (N,2); got {pos.shape}")
+    pos = pos[:, :2]
+    flags = []
+    if len(pos) < 20:
+        return {"figure_bytes": None,
+                "metrics": {"error": "too few columns for sublattice typing"},
+                "flags": ["insufficient_columns"]}
+
+    med_nn = float(np.median(cKDTree(pos).query(pos, k=2)[0][:, 1]))
+    win = int(window_size) if window_size else max(8, int(round(1.5 * med_nn)))
+    margin = float(edge_margin_px) if edge_margin_px is not None else 1.5 * med_nn
+
+    # (1) separation by LOCAL ENVIRONMENT (not raw intensity)
+    sep = local_env_gmm(img, pos, n_components=int(n_sublattices),
+                        window_size=win, random_state=int(random_state))
+    spos, scls = sep["positions"], sep["classes"]
+    if len(spos) < 12:
+        return {"figure_bytes": None,
+                "metrics": {"error": "sublattice separation produced too few classified columns"},
+                "flags": ["separation_failed"]}
+
+    r = max(1, int(round(med_nn * 0.2)))
+    def _peak(p):
+        x, y = int(round(p[0])), int(round(p[1]))
+        return float(img[max(0, y - r):y + r + 1, max(0, x - r):x + r + 1].max())
+    inten = np.array([_peak(p) for p in spos])
+
+    present = [c for c in range(int(n_sublattices)) if np.any(scls == c)]
+    means = {c: float(inten[scls == c].mean()) for c in present}
+    order = sorted(present, key=lambda c: -means[c])  # brightest first
+    pooled = np.mean([inten[scls == c].std() for c in present]) + 1e-9
+    sep_score = (max(means.values()) - min(means.values())) / pooled if len(present) > 1 else 0.0
+    if sep_score < 2.0:
+        flags.append("low_separation_score")
+
+    def _interior(p):
+        return margin < p[0] < W - margin and margin < p[1] < H - margin
+
+    sublattices, all_vac, all_dop = [], [], []
+    for rank, c in enumerate(order):
+        cp, ci = spos[scls == c], inten[scls == c]
+        # Gradient-robust intensity: ratio of each column to the median of its
+        # OWN-sublattice neighbours, so a slow illumination/thickness gradient
+        # across the field does not masquerade as dopants. A dopant is then a
+        # column anomalous vs its LOCAL same-species surroundings.
+        if len(cp) >= 8:
+            kk = min(13, len(cp))
+            nb_idx = cKDTree(cp).query(cp, k=kk)[1]
+            local_ref = np.array([np.median(ci[nb_idx[t, 1:]]) for t in range(len(cp))])
+            metric = ci / (local_ref + 1e-9)
+        else:
+            metric = ci
+        med = np.median(metric); mad = np.median(np.abs(metric - med)) * 1.4826 + 1e-9
+        z = (metric - med) / mad
+        dops = []
+        for p, zz in zip(cp[np.abs(z) > dopant_sigma], z[np.abs(z) > dopant_sigma]):
+            if _interior(p):
+                d = {"x": float(p[0]), "y": float(p[1]), "z": float(zz),
+                     "kind": "lighter-substitution" if zz < 0 else "heavier-substitution",
+                     "sublattice": rank}
+                if pixel_size_nm:
+                    d["x_nm"], d["y_nm"] = float(p[0] * pixel_size_nm), float(p[1] * pixel_size_nm)
+                dops.append(d)
+        vacs = []
+        for vx, vy in _sublattice_vacancies(cp, med_nn, margin, (H, W),
+                                            int(vacancy_enclosure),
+                                            image=img, occupied_intensity=float(np.median(ci))):
+            v = {"x": vx, "y": vy, "sublattice": rank}
+            if pixel_size_nm:
+                v["x_nm"], v["y_nm"] = float(vx * pixel_size_nm), float(vy * pixel_size_nm)
+            vacs.append(v)
+        all_dop += dops; all_vac += vacs
+        sublattices.append({"rank": rank, "n_columns": int(len(cp)),
+                            "mean_intensity": means[c],
+                            "n_vacancies": len(vacs), "n_dopants": len(dops)})
+
+    # figure
+    fig, ax = plt.subplots(1, 2, figsize=(13, 6.5))
+    colors = plt.cm.tab10(np.linspace(0, 1, 10))
+    for a in ax:
+        a.imshow(img, cmap="gray"); a.axis("off")
+    ax[0].set_title("Sublattices (by local environment)")
+    for rank, c in enumerate(order):
+        cp = spos[scls == c]
+        ax[0].scatter(cp[:, 0], cp[:, 1], s=8, color=colors[rank],
+                      label=f"sublattice {rank} (I~{means[c]:.2f})")
+    ax[0].legend(loc="upper right", fontsize=8, framealpha=0.7)
+    ax[1].set_title(f"Defects: {len(all_vac)} vacancies (□), {len(all_dop)} dopants (○)")
+    for v in all_vac:
+        ax[1].scatter(v["x"], v["y"], s=90, facecolors="none", edgecolors="cyan", marker="s", linewidths=1.6)
+    for d in all_dop:
+        col = "lime" if d["z"] < 0 else "magenta"
+        ax[1].scatter(d["x"], d["y"], s=90, facecolors="none", edgecolors=col, marker="o", linewidths=1.6)
+    buf = BytesIO(); fig.tight_layout(); fig.savefig(buf, format="png", dpi=110); plt.close(fig)
+
+    return {
+        "figure_bytes": buf.getvalue(),
+        "metrics": {
+            "n_columns_classified": int(len(spos)),
+            "separation_score": float(sep_score),
+            "sublattices": sublattices,
+            "n_vacancies": len(all_vac),
+            "n_dopants": len(all_dop),
+            "vacancies": all_vac,
+            "dopants": all_dop,
+            "median_nn_px": med_nn,
+        },
+        "flags": flags,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Tool specs
 # ---------------------------------------------------------------------------
@@ -1154,6 +1398,54 @@ TOOL_SPECS = [
             "average local-environment image per cluster), 'positions' ((M, 2) (x, y) "
             "of atoms successfully classified — may be smaller than N if patches were "
             "cropped at the image border), and 'classes' ((M,) 0-indexed cluster id)."
+        ),
+    ),
+    ToolSpec(
+        name="type_sublattice_defects",
+        description=(
+            "Per-sublattice point-defect typing for a multi-sublattice atomic lattice. "
+            "Separates sublattices by LOCAL ENVIRONMENT (not raw intensity, which would "
+            "hide a substitutional dopant), then flags vacancies (interior ideal-lattice "
+            "sites with no detected column) and dopants (intensity outliers within a "
+            "sublattice). Returns a figure and per-sublattice defect lists."
+        ),
+        import_line="from scilink.skills.image_analysis.atomic_stem.atom_finding import type_sublattice_defects",
+        signature=(
+            "type_sublattice_defects(image, positions, n_sublattices=2, window_size=None, "
+            "pixel_size_nm=None, dopant_sigma=3.5, edge_margin_px=None, "
+            "vacancy_enclosure=3, random_state=1) -> dict"
+        ),
+        agents=["image_analysis"],
+        when_to_use=(
+            "After BOTH sublattices of a multi-sublattice lattice are resolved by "
+            "detection (perovskite ABO3, dichalcogenide MoS2-type, any structure with a "
+            "basis) and the objective is per-sublattice point defects. Confirm both "
+            "sublattices are resolved first (NN at the inter-sublattice spacing, not the "
+            "unit-cell repeat). Do NOT separate sublattices by raw column intensity "
+            "yourself — that misfiles a dim dopant into the dim sublattice and hides it; "
+            "this tool separates by local environment. Lattice-agnostic (square, "
+            "hexagonal, oblique). Assumes bright-column (HAADF) intensity convention. "
+            "Requires the atomai package (used for the local-environment separation)."
+        ),
+        parameters={
+            "image": {"type": "ndarray", "description": "2D grayscale array. Pass RAW (un-normalized) — intensity carries the Z-contrast that distinguishes species and dopants."},
+            "positions": {"type": "ndarray", "description": "(N, 2) detected column positions (x, y) from detect_atoms / detect_atoms_dcnn, with BOTH sublattices resolved."},
+            "n_sublattices": {"type": "int", "description": "Number of sublattices / distinct column species to separate (default 2; set to 3+ for more complex bases)."},
+            "window_size": {"type": "int", "description": "Local-environment patch side in px for separation (default ~1.5x median NN, i.e. ~one lattice parameter). Larger captures more neighbourhood context."},
+            "pixel_size_nm": {"type": "float", "description": "nm/px; if given, defect coordinates are also reported in nm."},
+            "dopant_sigma": {"type": "float", "description": "Robust (MAD) z-score threshold for an intensity outlier within a sublattice. LOWER (e.g. 2.5) to catch subtler substitutions; RAISE (e.g. 5) if noise produces false dopants."},
+            "edge_margin_px": {"type": "float", "description": "Exclude defects within this many px of the border (default 1.5x median NN). RAISE if border fits are unreliable; LOWER to include near-edge defects."},
+            "vacancy_enclosure": {"type": "int", "description": "How many of a candidate empty site's 4 lattice neighbours must be occupied to count as a vacancy (default 3 of 4). RAISE to 4 for only fully-enclosed vacancies (fewer false positives at domain/grain edges); LOWER to 2 to catch vacancies near boundaries."},
+            "random_state": {"type": "int", "description": "Seed for the GMM separation (default 1; fixed for reproducibility)."},
+        },
+        required=["image", "positions"],
+        returns=(
+            "dict with 'figure_bytes' (PNG: sublattices colour-coded + vacancies (squares) "
+            "+ dopants (circles)), 'metrics' (separation_score, per-sublattice "
+            "n_columns/mean_intensity/n_vacancies/n_dopants, and 'vacancies'/'dopants' "
+            "lists each with x/y[/x_nm/y_nm], sublattice index, and for dopants a signed z "
+            "and lighter/heavier-substitution label), and 'flags' (e.g. "
+            "low_separation_score when the sublattices are not cleanly distinguished)."
         ),
     ),
 ]

--- a/scilink/skills/image_analysis/atomic_stem/atom_finding.py
+++ b/scilink/skills/image_analysis/atomic_stem/atom_finding.py
@@ -1147,7 +1147,7 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
                      pixel_size_nm=None, edge_margin_px=None,
                      max_offset_frac=0.45, magnitude_outlier_k=6.0,
                      domain_coherence_floor=0.4, max_wall_fraction=0.15,
-                     random_state=1):
+                     local_coherence_floor=0.82, random_state=1):
     """Per-unit-cell ferroelectric polarization / cation off-centering map.
 
     For a two-sublattice (ABO3-type / interpenetrating) lattice where BOTH
@@ -1476,7 +1476,13 @@ def map_polarization(image, positions, displaced="auto", n_cage=4,
             if n_domains >= 2 and (
                 (coherence == coherence and coherence < domain_coherence_floor)      # globally incoherent => pure noise
                 or (wall_fraction == wall_fraction and wall_fraction > max_wall_fraction
-                    and coherence == coherence and coherence < 0.85)):               # speckle partition on a NOT-strongly-coherent field (a genuine multi-domain stays ~0.95+, so it is never collapsed regardless of grid size)
+                    and local_coherence == local_coherence and local_coherence < local_coherence_floor)):
+                # Collapse a fragmented partition (high wall_fraction) ONLY when it
+                # is ALSO locally incoherent (low within-neighbourhood agreement) =
+                # noise. A GENUINE multi-domain mosaic is fragmented but locally
+                # COHERENT, so it survives regardless of domain count/size or crop
+                # size — local_coherence is count/size-invariant, wall_fraction is
+                # not. (wall_fraction alone would over-collapse real fine mosaics.)
                 flags.append("field_noise_dominated_domains_unreliable")
                 domains = [{"label": 0, "n_cells": int(valid_c.sum()), "mean_angle_deg": None,
                             "fraction": 1.0, "disordered": True}]
@@ -1905,7 +1911,7 @@ TOOL_SPECS = [
             "map_polarization(image, positions, displaced='auto', n_cage=4, "
             "pixel_size_nm=None, edge_margin_px=None, max_offset_frac=0.45, "
             "magnitude_outlier_k=6.0, domain_coherence_floor=0.4, max_wall_fraction=0.15, "
-            "random_state=1) -> dict"
+            "local_coherence_floor=0.82, random_state=1) -> dict"
         ),
         agents=["image_analysis"],
         when_to_use=(
@@ -1943,7 +1949,8 @@ TOOL_SPECS = [
             "max_offset_frac": {"type": "float", "description": "Robustness to extra/spurious columns: a displaced cation is accepted only within this fraction of the reference-cage NN spacing from the cage centre (default 0.45). RAISE (~0.6) if large genuine displacements are dropped; LOWER (~0.3) if extra columns inflate the field. Scale is the reference sublattice NN, robust to over-detection."},
             "magnitude_outlier_k": {"type": "float", "description": "Robust per-cell |P| outlier clip, in MADs above the field median (default 6.0): a cell beyond this is a position-fit / A-B-pairing failure with unphysical |P| (e.g. >>80 pm) and is dropped (flag clipped_N_unphysical_magnitude_outliers). LOWER (~4) if stray huge vectors still corrupt the figure/stats; RAISE (~8) if genuine large displacements get clipped. Median/MAD are robust, so a uniformly large real field is NOT clipped."},
             "domain_coherence_floor": {"type": "float", "description": "Global-coherence floor for the noise guard (default 0.4): if direction_coherence is below this the field is treated as pure noise and a multi-domain partition is collapsed to ONE 'disordered' domain (flag field_noise_dominated_domains_unreliable). RAISE (~0.5) to be stricter; LOWER (~0.3) if real low-contrast domains get suppressed."},
-            "max_wall_fraction": {"type": "float", "description": "Spatial-incoherence gate on domains (default 0.15): a genuine multi-domain field has contiguous domains separated by a THIN wall (small wall_fraction, ~0.05); a noise-dominated weak field fragments into interspersed speckle (high wall_fraction, ~0.25+). If n_domains>=2 and wall_fraction exceeds this, the partition is judged spurious and collapsed to one 'disordered' domain. LOWER (~0.1) to reject more weak-field speckle; RAISE (~0.25) if real finely-twinned domains (legitimately higher wall_fraction) are being collapsed."},
+            "max_wall_fraction": {"type": "float", "description": "Fragmentation half of the noise guard (default 0.15): a fragmented partition (wall_fraction above this) is collapsed to one 'disordered' domain ONLY when it is ALSO locally incoherent (see local_coherence_floor). A genuine multi-domain field has contiguous domains separated by a THIN wall (~0.05); noise speckle is ~0.25+. RAISE (~0.25) if real finely-twinned mosaics are collapsed; LOWER (~0.1) to reject more weak-field speckle. NOTE wall_fraction grows with domain count/fineness and with smaller crops, which is why it is gated by local_coherence (count/size-invariant) rather than used alone."},
+            "local_coherence_floor": {"type": "float", "description": "Coherence half of the noise guard (default 0.82): the median within-neighbourhood direction agreement. A fragmented partition collapses only if local_coherence is BELOW this (= noise). A real multi-domain mosaic stays locally coherent (~0.95+) regardless of how many/small its domains are, so it is preserved. RAISE (~0.88) to treat more borderline fields as noise; LOWER (~0.75) if real low-contrast/imperfect domains are wrongly collapsed."},
             "random_state": {"type": "int", "description": "Seed for the intensity-split GMM (default 1)."},
         },
         required=["image", "positions"],

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -243,10 +243,17 @@ goal you picked above:
   `gamma_deg`), `lattice_constant_nm`, and `nn_distance_nm` with `nn_basis`
   stating the projection relation (NN = a, or a/√2 for a centered/perovskite
   sublattice). Crop to a single crystalline domain first (exclude
-  substrate/vacuum) and pass the true square-pixel size. ALWAYS check the
-  returned `multi_lattice` / `low_confidence` flags: if set, the field of
-  view holds more than one lattice or is under-sampled — crop to one domain
-  (ROI) and re-run rather than trusting the number. Do NOT hand-roll this
+  substrate/vacuum) and pass the true square-pixel size. Here "domain" means a
+  single CRYSTALLOGRAPHIC lattice (a grain / phase / orientation) — **ferroelectric
+  POLARIZATION domains do NOT count: they share one lattice (differing only by a
+  ~pm B-site off-centering), so the cell and inter-sublattice NN are identical
+  across them.** So when measuring the NN as a detection-tuning target for ferroic
+  mapping, run on the FULL field (it returns `multi_lattice=False`); do not hunt
+  for a "single-domain ROI" (the polarization domains aren't even known until
+  after the mapping the NN feeds into). ALWAYS check the returned `multi_lattice`
+  / `low_confidence` flags: if set, the field of view holds more than one
+  *lattice* or is under-sampled — crop to one crystallographic domain (ROI) and
+  re-run rather than trusting the number. Do NOT hand-roll this
   from `fourier_reflection_map` + manual fundamental-picking (that is the
   exact failure mode — choosing the strongest σ reflection, often a harmonic);
   `measure_lattice_constant` exists to remove it. Use `find_zone_axes` (real

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -262,6 +262,21 @@ goal you picked above:
   neither a Z-contrast step nor a superstructure change is found, the interface
   is genuinely absent from the field of view (report that) — but do not
   conclude "no interface" merely because the FFT was uniform.
+- *If goal is ferroic / ferroelectric distortion (polarization, cation
+  off-centering, domains/domain walls) on a perovskite or other two-sublattice
+  lattice:* this needs BOTH cation sublattices resolved (the cage cations AND
+  the off-centering cations). They are interpenetrating, so the nearest neighbour
+  of every column is the *other* sublattice: a clean detection has its NN at the
+  **inter-sublattice spacing** (shorter than the intra-sublattice repeat). Do NOT
+  read that as a single-sublattice result, do NOT demand a *bimodal* NN split to
+  "prove" the second sublattice, and do NOT apply the over-detection / short-pair
+  guard to it — that guard rejects *duplicate marks on one column*, not a genuine
+  interleaved sublattice sitting one inter-sublattice spacing away. Once both are
+  resolved, map the polarization with the registered tool **`map_polarization`**
+  (see `analysis`): it splits the sublattices, takes each off-centering cation's
+  offset from the centrosymmetric centroid of its reference-cage neighbours, and
+  returns the per-cell polarization field (direction → domains, discontinuities →
+  walls). Tetragonality/shear come from `gpa_strain` on the reference sublattice.
 - *If goal is vacancy / missing-column search:* two complementary
   routes — pick by data quality, or run both as a cross-check.
   **Real-space route** (defect typing, needs reliable columns): requires
@@ -616,6 +631,22 @@ report no boundary rather than forcing one.
 **Strain and displacement:** Map displacements from ideal lattice
 positions spatially across the image. Only report distortions exceeding
 the position fit uncertainty.
+
+**Ferroelectric polarization** — use the registered tool `map_polarization`
+once detection has resolved BOTH cation sublattices (see the ferroic planning
+bullet). It refines positions to sub-pixel, splits the two sublattices by
+intensity, and for each off-centering cation measures the offset from the
+centrosymmetric centroid of its reference-cage neighbours; `figure_bytes` is
+the polarization quiver + direction-domain map + magnitude map, save it as the
+visualization. Set `displaced='bright'` if the off-centering cation is the
+heavier/brighter column; `n_cage` to the projected cage coordination (4 for
+[100] perovskite). Direction/domains are robust; treat very small |P| (near the
+position-fit noise floor) cautiously.
+```
+from scilink.skills.image_analysis.atomic_stem.atom_finding import map_polarization
+res = map_polarization(image, positions, pixel_size_nm=px)   # positions = BOTH sublattices
+# res['metrics']: per-cell 'polarization'/'xy'/'magnitude'/'angle', median_magnitude_nm, n_direction_clusters
+```
 
 **Superlattice / satellite-reflection mapping** — use the registered
 tool `fourier_reflection_map` (reciprocal-space, atom-detection-free;

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -810,6 +810,12 @@ or vice versa (they differ by a projection-dependent factor). A value that
 misses a ballpark *only* because the wrong quantity was compared is a
 labeling error to fix in reporting, not a bad measurement to reject.
 
+**Reject only against the actual imaging modality's physics.** Before discounting
+a finding as an artifact, confirm the proposed artifact mechanism — and any
+correction it implies — exists for this modality, not one imported from a
+different technique. A deterministic discriminator the tool already computed
+outranks a generic visual-coincidence suspicion.
+
 **DCNN preprocessing check:** if the step uses `detect_atoms_dcnn`,
 flag any pipeline step that preprocesses the image before the DCNN
 call (CLAHE, contrast normalization, background subtraction, bandpass

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -111,6 +111,26 @@ when `fov_nm` is unknown or the DCNN result looks poor.
   fine; just avoid the coarse end, where detection collapses sharply.) Do
   not preprocess.
 
+  **The detector returns column POSITIONS only — it does NOT label species or
+  sublattice** (single-class detector). Sublattice/species identity is always
+  recovered *downstream* (intensity GMM, `local_env_gmm`, or inside a tool such
+  as `map_polarization`), never read off the detection itself. Consequence: the
+  NN histogram of the detected cloud reports detection *completeness*, NOT how
+  many sublattices the material has. A fully resolved interleaved A+B lattice is
+  ONE point cloud with a single SHORT NN (the inter-sublattice spacing — both
+  sublattices detected); do not mistake that unimodal NN for a single-sublattice
+  material. The genuine single-sublattice / under-detection signature is the
+  opposite: a NN at the larger intra-sublattice repeat (the lattice constant).
+
+  **`target_pixel_size` is in ÅNGSTRÖMS (Å), not nm.** This is the one
+  atomic_stem parameter in Å — `fov_nm` and the `pixel_size_nm` on
+  `map_polarization` / `fourier_reflection_map` are in nm. Default 0.25 Å
+  (= 0.025 nm/px); a typical good range is 0.15–0.30 Å, and the native pixel
+  size in Å is `fov_nm * 10 / image_width_px`. Do NOT pass an nm value
+  (e.g. 0.02): it is ~10× too small, over-resamples to a tiny grid, and
+  collapses detection to ~0 columns — if detection collapses to near-zero,
+  suspect a unit error before retuning anything else.
+
   **Choosing `target_pixel_size` — narrow by NN, DECIDE by eye.** The NN
   number alone is not a sufficient arbiter (a lattice can read a plausible NN
   yet still resolve only one of two sublattices). When separate sublattices
@@ -271,8 +291,17 @@ goal you picked above:
   read that as a single-sublattice result, do NOT demand a *bimodal* NN split to
   "prove" the second sublattice, and do NOT apply the over-detection / short-pair
   guard to it — that guard rejects *duplicate marks on one column*, not a genuine
-  interleaved sublattice sitting one inter-sublattice spacing away. Once both are
-  resolved, map the polarization with the registered tool **`map_polarization`**
+  interleaved sublattice sitting one inter-sublattice spacing away. **Do not
+  pre-decide sublattice resolvability from the NN histogram or the detection
+  count and then decline** — that decision is deterministic and belongs to
+  `map_polarization` itself, not to prose reasoning over the detection summary.
+  The tool performs the sublattice split (by intensity, or — for weak-contrast /
+  near-identical-Z cations — automatically by GEOMETRIC local environment) and
+  returns `split_failed` ONLY if the columns are genuinely one population. So
+  when the goal is ferroic, **run `map_polarization` and read its verdict**
+  rather than concluding "single, well-ordered sublattice" from a unimodal NN
+  and stopping. Once both are resolved, map the polarization with the registered
+  tool **`map_polarization`**
   (see `analysis`): it splits the sublattices, takes each off-centering cation's
   offset from the centrosymmetric centroid of its reference-cage neighbours, and
   returns the per-cell polarization field (direction → domains, discontinuities →
@@ -646,7 +675,12 @@ over-detection makes the tool return `{'error':'no valid cells'}`, so get the
 detection clean (NN at the inter-sublattice spacing, low nn_cv) before trusting
 |P|; also treat very small |P| (near the position-fit noise floor) cautiously.
 The tool assumes a displacive perovskite-type cage (off-centering cation at the
-cage centre, the two cation sublattices being the intensity extremes).
+cage centre, the two cation sublattices being the intensity extremes). When the
+two cations are NOT intensity-distinguishable (near-identical Z, weak HAADF
+contrast), it AUTOMATICALLY falls back to a GEOMETRIC split by local environment
+(`local_env_gmm`), flagged `geometric_separation_used_intensity_ambiguous`; the
+field is then valid up to a global sign (an arbitrary convention) — so weak
+intensity contrast is NOT a reason to decline.
 ```
 from scilink.skills.image_analysis.atomic_stem.atom_finding import map_polarization
 res = map_polarization(image, positions, pixel_size_nm=px)   # positions = BOTH sublattices

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -110,6 +110,22 @@ when `fov_nm` is unknown or the DCNN result looks poor.
   band and rescaling affects only completeness — the default is usually
   fine; just avoid the coarse end, where detection collapses sharply.) Do
   not preprocess.
+
+  **Choosing `target_pixel_size` — narrow by NN, DECIDE by eye.** The NN
+  number alone is not a sufficient arbiter (a lattice can read a plausible NN
+  yet still resolve only one of two sublattices). When separate sublattices
+  must be resolved — any multi-sublattice material, and always before
+  `type_sublattice_defects` — select it visually: sweep the few NN-bracketed
+  candidates, run `detection_quality_panels` (full-frame overlay + zoom crops +
+  NN/heatmap metrics) for each, assemble them into ONE comparison figure, and
+  **save that as the step visualization** so the verification step makes (or
+  confirms) the choice. Pick the value whose zoom crops show BOTH sublattices
+  resolved with no split/duplicate columns and no coverage gaps — not merely
+  the largest column count. A detected NN at the *lattice constant* rather than
+  the *inter-sublattice* spacing means the dim sublattice is unresolved → go
+  finer. Do NOT run `type_sublattice_defects` until detection visually resolves
+  the target sublattices; spending the verification step on this choice is the
+  right use of it, because every downstream defect call depends on it.
 - `detect_atoms` (classical peak detection): more general-purpose
   baseline; use when `fov_nm` is unknown or when DCNN results look poor. **Preprocessing
   applies here, not to the DCNN path** — background subtraction or

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -141,9 +141,17 @@ when `fov_nm` is unknown or the DCNN result looks poor.
   **save that as the step visualization** so the verification step makes (or
   confirms) the choice. Pick the value whose zoom crops show BOTH sublattices
   resolved with no split/duplicate columns and no coverage gaps — not merely
-  the largest column count. A detected NN at the *lattice constant* rather than
-  the *inter-sublattice* spacing means the dim sublattice is unresolved → go
-  finer. Do NOT run `type_sublattice_defects` until detection visually resolves
+  the largest column count. **Get the target NN deterministically from
+  `measure_lattice_constant`** (its `nn_distance_nm` is the FFT-measured spacing
+  of the resolved sublattices) instead of computing the inter-sublattice spacing
+  from the lattice constant by hand — that projected distance is easy to
+  mis-derive, and aiming at a too-small target makes the loop keep lowering
+  `target_pixel_size` until it over-detects. Tune toward that measured NN:
+  detected NN *above* it (near the full lattice constant) → the dim sublattice is
+  unresolved → go finer; detected NN *below* it together with a
+  `short_pair_fraction` spike / `duplicate_suspect` flag → OVER-detection
+  (split/duplicate columns) → go COARSER, do not keep lowering. Do NOT run
+  `type_sublattice_defects` until detection visually resolves
   the target sublattices; spending the verification step on this choice is the
   right use of it, because every downstream defect call depends on it.
 - `detect_atoms` (classical peak detection): more general-purpose

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -517,7 +517,14 @@ resolved AND not over-detected (confirm via NN at the inter-sublattice
 spacing; over-detection / column-splitting fabricates false defects, so fix
 `target_pixel_size` first). The paragraph below is what the tool does (and
 why), and how to tune it via its knobs (`dopant_sigma`, `vacancy_enclosure`,
-`edge_margin_px`).
+`edge_margin_px`). **Limits (check the returned `flags`):** dopant typing and
+superstructure flagging generalize across lattice types; vacancy recall is
+high on hexagonal/rectangular lattices and clusters but only PARTIAL on
+tightly-interpenetrating square lattices (dim interstitial sites) — cross-
+check vacancies with `fft_defect_map`. And it assumes a complete sublattice
+with sparse random defects: if a superstructure flag fires (ordered/abundant
+defects), map the satellite with `fourier_reflection_map` rather than counting
+point defects.
 
 **Why per-sublattice, done right:** a defect is defined relative to its own
 sublattice. Assign each column to a sublattice by **local environment /

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -254,17 +254,41 @@ goal you picked above:
   preprocessing that suppresses a background/banding component — de-streaking,
   row/column-mean or background subtraction, high-pass — will also erase a
   defect that lives in that component, so search on data that preserves it.
-  Then separate a localized structural discontinuity (the defect) from a
-  periodic full-width modulation (normal layering) or a uniform line (detector
-  artifact).
-- *If goal is displacement / strain mapping:* requires an ideal
-  lattice from a prior step. Map displacements spatially; report only
-  distortions exceeding the position fit uncertainty. Distinguish
-  fitted-lattice residuals (local disorder) from deviations against a
-  known ideal lattice (true strain). (A reciprocal-space alternative —
-  the *phase* channel of the superlattice-mapping pipeline below — gives
-  a continuous strain/displacement field without first detecting atoms;
-  prefer it when columns are too noisy to fit reliably.)
+  Localize and classify it with `lattice_discontinuity_map` (next bullet),
+  which runs on the RAW image; separate a localized structural discontinuity
+  (the defect) from a periodic full-width modulation (normal layering) or a
+  uniform line (detector artifact).
+- *If goal is displacement / strain mapping (incl. dislocations / Burgers
+  vectors, precipitate-interface coherency, twin-boundary displacement):*
+  the dedicated tool is the **`gpa_strain` skill** (Geometric Phase
+  Analysis) — it returns the referenced in-plane strain tensor
+  (εxx, εyy, εxy) and lattice rotation (ωxy) against an undistorted
+  reference region, without first detecting atoms. Co-activate it; do NOT
+  hand-roll strain from the *unreferenced* raw FFT phase. Its caveat: GPA
+  assumes ONE dominant lattice, so it is for SMALL distortions / coherent
+  regions — across a large misorientation use `lattice_discontinuity_map`
+  (below) instead. (A real-space alternative when columns fit cleanly: map
+  displacements of detected positions vs an ideal lattice from a prior
+  step.)
+
+- *If goal is locating / classifying a grain or twin boundary, a planar
+  defect (stacking fault, intergrowth, antiphase band), or an incoherent
+  interface:* use the registered tool **`lattice_discontinuity_map`** — a
+  sliding-window local-FFT map whose neighbour spectral dissimilarity
+  detects the boundary line and whose orientation/spacing jumps classify
+  it (orientation→grain/twin, spacing→interface/second-phase, coherence
+  drop only→stacking fault/disorder). Save its `figure_bytes` as the
+  visualization and read `boundaries`. Run it on the RAW image — do not
+  de-streak / background-subtract first (that erases a defect that lives
+  in the banding). Pick among the reciprocal-space tools by question:
+  `run_fft_nmf_analysis` is the EXPLORATORY decomposer (unknown
+  heterogeneity, "how many domains"); `lattice_discontinuity_map` is the
+  sharp LOCALIZER (where is the boundary + what type); `gpa_strain` gives
+  the strain MAGNITUDE near it; `fourier_reflection_map` maps a specific
+  superstructure reflection's domain. NOTE the scope: a COHERENT
+  lattice-matched chemical interface (same orientation+spacing+coherence
+  both sides) is invisible to this tool — detect that via the per-column
+  Z-contrast step (see the film/substrate interface bullet above).
 
 - *If goal is superlattice / satellite-reflection mapping:* use the
   registered tool `fourier_reflection_map` (see `analysis` for the call).

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -289,6 +289,20 @@ goal you picked above:
   lattice-matched chemical interface (same orientation+spacing+coherence
   both sides) is invisible to this tool — detect that via the per-column
   Z-contrast step (see the film/substrate interface bullet above).
+- *If the lattice-change tools above (`lattice_discontinuity_map`,
+  `fourier_reflection_map`) come back silent/unconvincing BUT a sustained
+  dark/bright trough or step crosses the field:* you are in the
+  **intensity/thickness-step regime**, not the lattice-change regime. A
+  boundary whose projected lattice is near-continuous — an INCLINED
+  grain/phase boundary (seen as a Z-contrast/thickness trough) or a
+  lattice-matched CHEMICAL interface — carries no orientation or spacing
+  jump, so *no* lattice-orientation method (FFT, structure tensor, per-column
+  angle map) can localize it: the signal is in the intensity field, not the
+  lattice. Detect the step itself with the intensity-step recipe (see
+  `## analysis`) — de-lattice the RAW image, isolate a sustained step from
+  smooth shading, trace the connected gradient ridge (orientation-agnostic).
+  Report it as an inclined/chemical boundary; if only smooth shading is
+  present and no ridge forms, report no boundary rather than forcing one.
 
 - *If goal is superlattice / satellite-reflection mapping:* use the
   registered tool `fourier_reflection_map` (see `analysis` for the call).
@@ -508,6 +522,26 @@ reflections is reconstructed as part of the pattern and will NOT appear.
 If a clearly visible lattice returns `periodic=False`, the note reports
 the best candidate snr — lower `min_peak_snr` only when that margin is
 small; far below the gate means the image is not periodic.
+
+**Intensity/thickness-step (Z-contrast) boundary detection** — for a
+boundary that does NOT change the projected lattice and is therefore
+invisible to every FFT/lattice-change tool: an INCLINED grain/phase
+boundary (its projected lattice is near-continuous, so it shows only as a
+Z-contrast/thickness trough) or a lattice-matched CHEMICAL interface. The
+signal lives in the non-periodic intensity field, not the lattice. No
+registered tool — generate the detector (it is standard image processing;
+the choice of operator is yours). The non-obvious constraints, not the
+exact code, are what matter: (1) work on the RAW image — flat-fielding
+erases the very step you are after; (2) remove the periodic lattice
+(unit-cell-scale local mean, or notch the Bragg peaks) to expose the
+slowly-varying intensity field; (3) separate a *sustained, localized*
+step/trough from a *smooth, global* shading ramp (e.g. against a
+much-larger-scale background) — the ramp is thickness/shading, not a
+boundary; (4) the boundary is an *extended line* (a connected ridge),
+orientation-agnostic so it handles horizontal, vertical, and diagonal/V
+loci alike, whereas an isolated compact dip is a point defect
+(→ `fft_defect_map`). If no ridge forms and only smooth shading is present,
+report no boundary rather than forcing one.
 
 **Strain and displacement:** Map displacements from ideal lattice
 positions spatially across the image. Only report distortions exceeding

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -105,7 +105,12 @@ when `fov_nm` is unknown or the DCNN result looks poor.
   inference) to recover the dim sublattice. Conversely, if the detected NN
   falls *below* the physical column spacing (spurious/split columns, common
   on noisy data), it is too fine — raise it. Tune by matching the detected
-  NN to the expected physical column spacing. (For a *single*-sublattice
+  NN to the expected column spacing — and get that expected spacing
+  deterministically from `measure_lattice_constant` (its `nn_distance_nm`)
+  rather than computing it by hand, since aiming at a too-small target makes
+  the loop keep lowering `target_pixel_size` until it over-detects (the
+  `short_pair_fraction` / `duplicate_suspect` signature → go COARSER, not
+  finer). (For a *single*-sublattice
   material there is no dim sublattice to recover, so NN stays put across the
   band and rescaling affects only completeness — the default is usually
   fine; just avoid the coarse end, where detection collapses sharply.) Do
@@ -131,29 +136,22 @@ when `fov_nm` is unknown or the DCNN result looks poor.
   collapses detection to ~0 columns — if detection collapses to near-zero,
   suspect a unit error before retuning anything else.
 
-  **Choosing `target_pixel_size` — narrow by NN, DECIDE by eye.** The NN
-  number alone is not a sufficient arbiter (a lattice can read a plausible NN
-  yet still resolve only one of two sublattices). When separate sublattices
-  must be resolved — any multi-sublattice material, and always before
-  `type_sublattice_defects` — select it visually: sweep the few NN-bracketed
+  **Resolving SEPARATE sublattices — DECIDE by eye, not the NN number alone.**
+  This applies ONLY when separate sublattices must be resolved (a multi-
+  sublattice material, and always before `type_sublattice_defects` or ferroic
+  polarization mapping); for a single-sublattice lattice the general NN-matching
+  above is sufficient. In the multi-sublattice case the NN number alone is not a
+  sufficient arbiter — a lattice can read a plausible NN yet still resolve only
+  one of two sublattices — so select visually: sweep the few NN-bracketed
   candidates, run `detection_quality_panels` (full-frame overlay + zoom crops +
   NN/heatmap metrics) for each, assemble them into ONE comparison figure, and
   **save that as the step visualization** so the verification step makes (or
   confirms) the choice. Pick the value whose zoom crops show BOTH sublattices
-  resolved with no split/duplicate columns and no coverage gaps — not merely
-  the largest column count. **Get the target NN deterministically from
-  `measure_lattice_constant`** (its `nn_distance_nm` is the FFT-measured spacing
-  of the resolved sublattices) instead of computing the inter-sublattice spacing
-  from the lattice constant by hand — that projected distance is easy to
-  mis-derive, and aiming at a too-small target makes the loop keep lowering
-  `target_pixel_size` until it over-detects. Tune toward that measured NN:
-  detected NN *above* it (near the full lattice constant) → the dim sublattice is
-  unresolved → go finer; detected NN *below* it together with a
-  `short_pair_fraction` spike / `duplicate_suspect` flag → OVER-detection
-  (split/duplicate columns) → go COARSER, do not keep lowering. Do NOT run
-  `type_sublattice_defects` until detection visually resolves
-  the target sublattices; spending the verification step on this choice is the
-  right use of it, because every downstream defect call depends on it.
+  resolved with no split/duplicate columns and no coverage gaps — not merely the
+  largest column count. Do NOT run `type_sublattice_defects` until detection
+  visually resolves the target sublattices; spending the verification step on
+  this choice is the right use of it, because every downstream defect call
+  depends on it.
 - `detect_atoms` (classical peak detection): more general-purpose
   baseline; use when `fov_nm` is unknown or when DCNN results look poor. **Preprocessing
   applies here, not to the DCNN path** — background subtraction or

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -683,8 +683,13 @@ once detection has resolved BOTH cation sublattices (see the ferroic planning
 bullet). It refines positions to sub-pixel, splits the two sublattices by
 intensity, and for each off-centering cation measures the offset from the
 centrosymmetric centroid of its reference-cage neighbours; `figure_bytes` is
-the polarization quiver + direction-domain map + magnitude map, save it as the
-visualization. Set `displaced='bright'` if the off-centering cation is the
+the polarization quiver + direction-domain map + magnitude map. **This 3-panel
+figure IS the headline deliverable — write `figure_bytes` directly to disk as
+`visualization.png` (the one figure embedded in the report and inspected by the
+verifier). Do NOT save it only to a side file (e.g. `polarization.png`) and leave
+a "see other file" placeholder panel inside `visualization.png`; detection QC
+panels belong in their own file (`detection_qc.png`), never in place of the result
+figure.** Set `displaced='bright'` if the off-centering cation is the
 heavier/brighter column; `n_cage` to the projected cage coordination (4 for
 [100] perovskite). **The direction-domain map is the deliverable; |P| MAGNITUDE
 is a secondary, soft output — do NOT make it a hard accept/reject gate.** Real

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -300,12 +300,11 @@ goal you picked above:
   returns `split_failed` ONLY if the columns are genuinely one population. So
   when the goal is ferroic, **run `map_polarization` and read its verdict**
   rather than concluding "single, well-ordered sublattice" from a unimodal NN
-  and stopping. Once both are resolved, map the polarization with the registered
-  tool **`map_polarization`**
-  (see `analysis`): it splits the sublattices, takes each off-centering cation's
-  offset from the centrosymmetric centroid of its reference-cage neighbours, and
-  returns the per-cell polarization field (direction → domains, discontinuities →
-  walls). Tetragonality/shear come from `gpa_strain` on the reference sublattice.
+  and stopping. The registered tool **`map_polarization`** (see `analysis`) does
+  the rest: it splits the sublattices, takes each off-centering cation's offset
+  from the centrosymmetric centroid of its reference-cage neighbours, and returns
+  the per-cell polarization field (direction → domains, discontinuities → walls).
+  Tetragonality/shear come from `gpa_strain` on the reference sublattice.
 - *If goal is vacancy / missing-column search:* two complementary
   routes — pick by data quality, or run both as a cross-check.
   **Real-space route** (defect typing, needs reliable columns): requires

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -349,7 +349,17 @@ goal you picked above:
   sliding-window local-FFT map whose neighbour spectral dissimilarity
   detects the boundary line and whose orientation/spacing jumps classify
   it (orientation→grain/twin, spacing→interface/second-phase, coherence
-  drop only→stacking fault/disorder). Save its `figure_bytes` as the
+  drop with a fractional-period `lateral_shift_frac`→stacking
+  fault/antiphase boundary, coherence drop with ~zero shift→non-
+  translational disorder band or scan/contrast artifact). **In a LAYERED
+  material a planar fault runs PARALLEL to the layers, so a genuine
+  stacking fault / intergrowth appears as a layer-parallel (often
+  horizontal), full-width coherence-drop band with NO orientation or
+  spacing change — that geometry is evidence FOR a planar fault, not for a
+  scan artifact. Trust the tool's `lateral_shift_frac` (a fractional-period
+  lateral shift = a real translational fault); do NOT invent a "horizontal
+  full-width band = scan artifact" rule that overrides the tool's
+  classification.** Save its `figure_bytes` as the
   visualization and read `boundaries`. Run it on the RAW image — do not
   de-streak / background-subtract first (that erases a defect that lives
   in the banding). Pick among the reciprocal-space tools by question:

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -686,11 +686,19 @@ centrosymmetric centroid of its reference-cage neighbours; `figure_bytes` is
 the polarization quiver + direction-domain map + magnitude map, save it as the
 visualization. Set `displaced='bright'` if the off-centering cation is the
 heavier/brighter column; `n_cage` to the projected cage coordination (4 for
-[100] perovskite). Direction/domains are the robust output; MAGNITUDE is
-trustworthy only on clean detection — over-detection inflates it and extreme
-over-detection makes the tool return `{'error':'no valid cells'}`, so get the
-detection clean (NN at the inter-sublattice spacing, low nn_cv) before trusting
-|P|; also treat very small |P| (near the position-fit noise floor) cautiously.
+[100] perovskite). **The direction-domain map is the deliverable; |P| MAGNITUDE
+is a secondary, soft output — do NOT make it a hard accept/reject gate.** Real
+ferroelectric off-centering commonly reaches ~40–80 pm (PbTiO3/BiFeO3-class), so
+do not impose a tight ceiling (e.g. 30 pm) the true field exceeds — most cells
+landing above such a ceiling means the ceiling is wrong, not the field. Judge the
+result by `direction_coherence` (high) and `net_to_local_ratio` (small = a
+genuine field, not an offset): if both are good, the domains are real even when
+|P| sits above a naive ceiling — report them. A genuinely suspect magnitude
+(`net_to_local_ratio`≫1, or extreme over-detection → `{'error':'no valid
+cells'}`) is a cue to re-check detection / offset, NOT to HALT and discard the
+direction result. Get detection clean (NN at the inter-sublattice spacing, low
+nn_cv) before quoting absolute |P|, and treat very small |P| (near the
+position-fit noise floor) cautiously.
 The tool assumes a displacive perovskite-type cage (off-centering cation at the
 cage centre, the two cation sublattices being the intensity extremes). When the
 two cations are NOT intensity-distinguishable (near-identical Z, weak HAADF
@@ -852,6 +860,16 @@ intensities between clusters.
 displacement from ideal lattice should be small (<0.3× lattice
 spacing). Large systematic displacements indicate fitting errors, not
 real strain.
+
+**Ferroelectric polarization** (when the step runs `map_polarization`): judge
+the result by `direction_coherence` (high), `net_to_local_ratio` (small = a
+genuine multi-domain field, not a registration offset), and a spatially coherent
+domain structure — NOT by a hard |P|-magnitude ceiling. Ferroelectric
+off-centering commonly reaches ~40–80 pm, so a large fraction of cells above a
+naive ceiling (e.g. 30 pm) is the ceiling being too strict, not an invalid field:
+do not reject or HALT a high-coherence, low-`net_to_local_ratio` result on
+magnitude alone (`|P|` magnitude is the secondary output; direction/domains are
+the deliverable).
 
 **Point-defect mapping** (when the step targets vacancies / point
 defects): if both routes ran, every `fft_defect_map` deficit candidate

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -313,20 +313,28 @@ goal you picked above:
   from the centrosymmetric centroid of its reference-cage neighbours, and returns
   the per-cell polarization field (direction → domains, discontinuities → walls).
   Tetragonality/shear come from `gpa_strain` on the reference sublattice.
-- *If goal is vacancy / missing-column search:* two complementary
-  routes — pick by data quality, or run both as a cross-check.
-  **Real-space route** (defect typing, needs reliable columns): requires
-  an ideal lattice — use detected positions plus zone vectors from a
-  prior step (load via `prior_analysis_paths`). Compare ideal sites to
-  detected positions; restrict to image interior; verify candidates with
-  forced Gaussian fits. **Reciprocal-space route** (no atom finding):
-  the registered tool `fft_defect_map` (see `analysis`) reconstructs the
-  perfect lattice from its significant reflections and maps localized
-  deviations against a noise null — prefer it when columns are too noisy
-  / low-dose to detect reliably, when the field of view is large, or as
-  an independent confirmation of real-space candidates. It returns typed
-  signatures (deficit vs excess, lattice-coherence dip) but candidates
-  still need real-space confirmation crops for chemical interpretation.
+- *If goal is vacancy / missing-column / dopant TYPING:* two complementary
+  routes — run BOTH (real-space primary, reciprocal-space corroboration); they
+  are NOT substitutes for each other.
+  **Real-space route — the PRIMARY route for per-column vacancy/dopant typing.**
+  Detect the target sublattice(s) (DCNN), then call the registered tool
+  `type_sublattice_defects` (documented below): it compares each sublattice
+  against its own ideal lattice and types vacancies vs intensity-outlier dopants
+  per column. This is the MOST SENSITIVE route for SUBTLE single-column vacancies
+  — prefer it whenever columns are detectable. (Do not hand-roll an ideal-vs-
+  detected comparison when this tool fits.)
+  **Reciprocal-space route** (no atom finding): the registered tool
+  `fft_defect_map` (see `analysis`) reconstructs the perfect lattice from its
+  significant reflections and maps localized deviations against a noise null —
+  use it when columns are too noisy / low-dose to detect reliably, when the
+  field of view is large, for vacancy-ORDERING / superstructure, or as
+  independent confirmation. It returns typed signatures (deficit vs excess,
+  lattice-coherence dip) and catches STRONG anomalies (dopants, pronounced
+  vacancies) well, but it UNDER-recovers subtle single-column vacancies on its
+  own — so a `periodic=True` / few-or-zero-defect result from `fft_defect_map`
+  is NOT grounds to conclude "defect-free" when the goal is point-defect typing;
+  cross-check with `type_sublattice_defects`. Either route's candidates still
+  need real-space confirmation crops for chemical interpretation.
 - *If goal is planar-defect detection (stacking fault, intergrowth, anti-
   phase / twin boundary):* the defect is a *localized break in periodicity* —
   a fringe-spacing jump, inserted/missing plane, or lateral phase shift across

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -105,14 +105,12 @@ when `fov_nm` is unknown or the DCNN result looks poor.
   inference) to recover the dim sublattice. Conversely, if the detected NN
   falls *below* the physical column spacing (spurious/split columns, common
   on noisy data), it is too fine — raise it. Tune by matching the detected
-  NN to the expected column spacing. Read BOTH from tools, do not hand-compute
-  either: the detected NN is `detection_quality_panels`' `nn_median` (already in
-  nm when you pass `pixel_size_nm`), and the expected spacing is
-  `measure_lattice_constant`'s `nn_distance_nm` — recomputing NN from the
-  position array yourself invites a units/normalization slip that silently
-  breaks the match. Aiming at a too-small target makes the loop keep lowering
-  `target_pixel_size` until it over-detects (the `short_pair_fraction` /
-  `duplicate_suspect` signature → go COARSER, not finer). (For a *single*-sublattice
+  NN to the expected column spacing — and get that expected spacing
+  deterministically from `measure_lattice_constant` (its `nn_distance_nm`)
+  rather than computing it by hand, since aiming at a too-small target makes
+  the loop keep lowering `target_pixel_size` until it over-detects (the
+  `short_pair_fraction` / `duplicate_suspect` signature → go COARSER, not
+  finer). (For a *single*-sublattice
   material there is no dim sublattice to recover, so NN stays put across the
   band and rescaling affects only completeness — the default is usually
   fine; just avoid the coarse end, where detection collapses sharply.) Do

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -105,12 +105,14 @@ when `fov_nm` is unknown or the DCNN result looks poor.
   inference) to recover the dim sublattice. Conversely, if the detected NN
   falls *below* the physical column spacing (spurious/split columns, common
   on noisy data), it is too fine — raise it. Tune by matching the detected
-  NN to the expected column spacing — and get that expected spacing
-  deterministically from `measure_lattice_constant` (its `nn_distance_nm`)
-  rather than computing it by hand, since aiming at a too-small target makes
-  the loop keep lowering `target_pixel_size` until it over-detects (the
-  `short_pair_fraction` / `duplicate_suspect` signature → go COARSER, not
-  finer). (For a *single*-sublattice
+  NN to the expected column spacing. Read BOTH from tools, do not hand-compute
+  either: the detected NN is `detection_quality_panels`' `nn_median` (already in
+  nm when you pass `pixel_size_nm`), and the expected spacing is
+  `measure_lattice_constant`'s `nn_distance_nm` — recomputing NN from the
+  position array yourself invites a units/normalization slip that silently
+  breaks the match. Aiming at a too-small target makes the loop keep lowering
+  `target_pixel_size` until it over-detects (the `short_pair_fraction` /
+  `duplicate_suspect` signature → go COARSER, not finer). (For a *single*-sublattice
   material there is no dim sublattice to recover, so NN stays put across the
   band and rescaling affects only completeness — the default is usually
   fine; just avoid the coarse end, where detection collapses sharply.) Do

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -650,7 +650,8 @@ cage centre, the two cation sublattices being the intensity extremes).
 ```
 from scilink.skills.image_analysis.atomic_stem.atom_finding import map_polarization
 res = map_polarization(image, positions, pixel_size_nm=px)   # positions = BOTH sublattices
-# res['metrics']: per-cell 'polarization'/'xy'/'magnitude'/'angle', median_magnitude_nm, n_direction_clusters
+# res['metrics']: per-cell 'polarization'/'xy'/'magnitude'/'angle', median_magnitude_nm,
+#   direction_coherence (~1 coherent/domains, ~0 noise — judge realness by this, not figure appearance)
 ```
 
 **Superlattice / satellite-reflection mapping** — use the registered

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -651,7 +651,9 @@ cage centre, the two cation sublattices being the intensity extremes).
 from scilink.skills.image_analysis.atomic_stem.atom_finding import map_polarization
 res = map_polarization(image, positions, pixel_size_nm=px)   # positions = BOTH sublattices
 # res['metrics']: per-cell 'polarization'/'xy'/'magnitude'/'angle', median_magnitude_nm,
-#   direction_coherence (~1 coherent/domains, ~0 noise — judge realness by this, not figure appearance)
+#   direction_coherence (~1 coherent/domains, ~0 noise — judge realness by this, not figure appearance;
+#   low coherence = random noise OR domains finer than ~3 cells: for the latter, fourier_reflection_map
+#   shows a superstructure satellite, so check that before calling low coherence "noise")
 ```
 
 **Superlattice / satellite-reflection mapping** — use the registered

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -701,14 +701,12 @@ intensity contrast is NOT a reason to decline.
 ```
 from scilink.skills.image_analysis.atomic_stem.atom_finding import map_polarization
 res = map_polarization(image, positions, pixel_size_nm=px)   # positions = BOTH sublattices
-# SAVE res['figure_bytes'] as the visualization — do NOT re-render your own quiver (a wrong
-#   scale draws pm-displacements as huge overlapping arrows) or re-segment the domains.
-# res['metrics'] gives the DOMAIN STRUCTURE as data — read it, don't re-derive:
-#   n_domains, domains[{label,n_cells,mean_angle_deg,fraction}] (directions PEAK-CLUSTERED,
-#     adaptive — do NOT quantize per-cell angles into fixed 0/90/180/270 bins),
-#   wall_fraction, per-cell domain_label;
+# res['figure_bytes']: quiver + smoothed direction-domain map + magnitude.
+# res['metrics'] gives the DOMAIN STRUCTURE as data:
+#   n_domains, domains[{label,n_cells,mean_angle_deg,fraction}] (directions peak-clustered/adaptive,
+#     not fixed cardinal bins), wall_fraction, per-cell domain_label;
 #   net_to_local_ratio (mean/median|P|: «1 = genuine multi-domain [net cancels]; »1 = a uniform
-#     offset / scan-registration drift dominates -> absolute |P| suspect, do not over-claim it);
+#     offset / scan-registration drift dominates -> absolute |P| suspect);
 #   direction_coherence (~1 coherent/domains, ~0 noise — judge realness by this, not figure appearance;
 #   low coherence = random noise OR domains finer than ~3 cells: for the latter, fourier_reflection_map
 #   shows a superstructure satellite, so check that before calling low coherence "noise");

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -699,10 +699,18 @@ intensity contrast is NOT a reason to decline.
 ```
 from scilink.skills.image_analysis.atomic_stem.atom_finding import map_polarization
 res = map_polarization(image, positions, pixel_size_nm=px)   # positions = BOTH sublattices
-# res['metrics']: per-cell 'polarization'/'xy'/'magnitude'/'angle', median_magnitude_nm,
+# SAVE res['figure_bytes'] as the visualization — do NOT re-render your own quiver (a wrong
+#   scale draws pm-displacements as huge overlapping arrows) or re-segment the domains.
+# res['metrics'] gives the DOMAIN STRUCTURE as data — read it, don't re-derive:
+#   n_domains, domains[{label,n_cells,mean_angle_deg,fraction}] (directions PEAK-CLUSTERED,
+#     adaptive — do NOT quantize per-cell angles into fixed 0/90/180/270 bins),
+#   wall_fraction, per-cell domain_label;
+#   net_to_local_ratio (mean/median|P|: «1 = genuine multi-domain [net cancels]; »1 = a uniform
+#     offset / scan-registration drift dominates -> absolute |P| suspect, do not over-claim it);
 #   direction_coherence (~1 coherent/domains, ~0 noise — judge realness by this, not figure appearance;
 #   low coherence = random noise OR domains finer than ~3 cells: for the latter, fourier_reflection_map
-#   shows a superstructure satellite, so check that before calling low coherence "noise")
+#   shows a superstructure satellite, so check that before calling low coherence "noise");
+#   per-cell 'polarization'/'xy'/'magnitude'/'angle', median_magnitude_nm.
 ```
 
 **Superlattice / satellite-reflection mapping** — use the registered

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -640,8 +640,13 @@ centrosymmetric centroid of its reference-cage neighbours; `figure_bytes` is
 the polarization quiver + direction-domain map + magnitude map, save it as the
 visualization. Set `displaced='bright'` if the off-centering cation is the
 heavier/brighter column; `n_cage` to the projected cage coordination (4 for
-[100] perovskite). Direction/domains are robust; treat very small |P| (near the
-position-fit noise floor) cautiously.
+[100] perovskite). Direction/domains are the robust output; MAGNITUDE is
+trustworthy only on clean detection — over-detection inflates it and extreme
+over-detection makes the tool return `{'error':'no valid cells'}`, so get the
+detection clean (NN at the inter-sublattice spacing, low nn_cv) before trusting
+|P|; also treat very small |P| (near the position-fit noise floor) cautiously.
+The tool assumes a displacive perovskite-type cage (off-centering cation at the
+cage centre, the two cation sublattices being the intensity extremes).
 ```
 from scilink.skills.image_analysis.atomic_stem.atom_finding import map_polarization
 res = map_polarization(image, positions, pixel_size_nm=px)   # positions = BOTH sublattices

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -509,21 +509,31 @@ sites; restrict the vacancy search to the interior to avoid edge false
 positives; verify candidates with a forced Gaussian fit at the expected
 position.
 
-For a multi-sublattice lattice (ABO3 perovskite, dichalcogenide, …)
-**separate the sublattices first, then type defects per sublattice** — a
-defect is defined relative to its own sublattice. Assign each column to a
-sublattice by **local environment / geometry** — `local_env_gmm` (patch-
-based) or the honeycomb/lattice site from detect-subtract-detect — **NOT by
-raw column intensity**: a substitutional dopant is a column of *anomalous
-intensity on its sublattice*, so an intensity-based split misfiles it into
-the other sublattice (a dim dopant on the bright sublattice lands in the
-dim cluster) and hides it. Then, within each geometric class: a **vacancy**
-is a site the class's ideal lattice predicts (`find_missing_atoms` on that
-class) with no detection; a **substitution / dopant** is an *intensity
-outlier within that class* (amplitude anomalous for its sublattice —
-comparing amplitudes *across* sublattices is meaningless, the species
-differ). Use raw intensities for the outlier test. Two common failures:
-skipping the separation entirely (all columns treated as one population),
+For a multi-sublattice lattice (ABO3 perovskite, dichalcogenide, …) use the
+registered tool **`type_sublattice_defects(image, positions)`** — it runs the
+whole per-sublattice chain in one call and returns a figure + per-sublattice
+vacancy/dopant lists. **Prerequisite: clean detection** — both sublattices
+resolved AND not over-detected (confirm via NN at the inter-sublattice
+spacing; over-detection / column-splitting fabricates false defects, so fix
+`target_pixel_size` first). The paragraph below is what the tool does (and
+why), and how to tune it via its knobs (`dopant_sigma`, `vacancy_enclosure`,
+`edge_margin_px`).
+
+**Why per-sublattice, done right:** a defect is defined relative to its own
+sublattice. Assign each column to a sublattice by **local environment /
+geometry** (`local_env_gmm`, patch-based) — **NOT by raw column intensity**:
+a substitutional dopant is a column of *anomalous intensity on its
+sublattice*, so an intensity-based split misfiles it into the other
+sublattice (a dim dopant on the bright sublattice lands in the dim cluster)
+and hides it. Then, within each geometric class: a **vacancy** is an interior
+ideal-lattice site with no detected column *and* image intensity at
+background (a site with column-level intensity is a missed detection, not a
+vacancy); a **substitution / dopant** is an *intensity outlier within that
+class*, measured against the column's *local* same-sublattice neighbours so a
+slow illumination/thickness gradient is not mistaken for dopants (comparing
+amplitudes *across* sublattices is meaningless — the species differ). Use raw
+intensities. Two common failures the tool avoids: skipping the separation
+entirely (all columns treated as one population),
 and separating by intensity (which buries the very dopants being sought).
 
 Do NOT infer "the dim sublattice was not resolved" from the absence of a

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -242,18 +242,13 @@ goal you picked above:
   the fundamental), and returns the axis-resolved cell (`a1_nm`, `a2_nm`,
   `gamma_deg`), `lattice_constant_nm`, and `nn_distance_nm` with `nn_basis`
   stating the projection relation (NN = a, or a/√2 for a centered/perovskite
-  sublattice). Crop to a single crystalline domain first (exclude
-  substrate/vacuum) and pass the true square-pixel size. Here "domain" means a
-  single CRYSTALLOGRAPHIC lattice (a grain / phase / orientation) — **ferroelectric
-  POLARIZATION domains do NOT count: they share one lattice (differing only by a
-  ~pm B-site off-centering), so the cell and inter-sublattice NN are identical
-  across them.** So when measuring the NN as a detection-tuning target for ferroic
-  mapping, run on the FULL field (it returns `multi_lattice=False`); do not hunt
-  for a "single-domain ROI" (the polarization domains aren't even known until
-  after the mapping the NN feeds into). ALWAYS check the returned `multi_lattice`
-  / `low_confidence` flags: if set, the field of view holds more than one
-  *lattice* or is under-sampled — crop to one crystallographic domain (ROI) and
-  re-run rather than trusting the number. Do NOT hand-roll this
+  sublattice). Crop to a single **crystallographic** domain (grain / phase /
+  orientation — NOT a ferroelectric polarization domain, which shares one
+  lattice), excluding substrate/vacuum, and pass the true square-pixel size; for
+  a ferroic NN target this means run on the full field, no ROI. ALWAYS check the
+  returned `multi_lattice` / `low_confidence` flags: if set, the field of view
+  holds more than one *lattice* or is under-sampled — crop to one crystallographic
+  domain (ROI) and re-run rather than trusting the number. Do NOT hand-roll this
   from `fourier_reflection_map` + manual fundamental-picking (that is the
   exact failure mode — choosing the strongest σ reflection, often a harmonic);
   `measure_lattice_constant` exists to remove it. Use `find_zone_axes` (real

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.md
@@ -84,21 +84,34 @@ orientation-only heterogeneity.
 
 **For atom-resolved detection — choose the detector:**
 
-Default to `detect_atoms_dcnn` when the material is in its training set
-**and** `fov_nm` is available from metadata; otherwise use the
-classical `detect_atoms`.
+Default to `detect_atoms_dcnn` for a crystalline zone-axis lattice when
+`fov_nm` is available from metadata; fall back to classical `detect_atoms`
+when `fov_nm` is unknown or the DCNN result looks poor.
 
-- `detect_atoms_dcnn` (AtomNet3 DCNN ensemble): best for transition-
+- `detect_atoms_dcnn` (AtomNet3 DCNN ensemble): trained on transition-
   metal oxides (perovskites, layered perovskites, cuprate
-  superconductors) and graphene; needs `fov_nm` from metadata.
-  **Pass the raw image without preprocessing** — no CLAHE, no contrast
-  normalization, no background subtraction, no bandpass filtering. The
-  model is trained on raw images and handles intensity gradients
-  internally; added preprocessing degrades detection. If weak columns
-  are missed, lower the `threshold` parameter; do not preprocess.
+  superconductors) and graphene, but the honeycomb-trained model
+  generalizes well to other 2D honeycomb lattices — transition-metal
+  dichalcogenides (MoS2-type) included — so try it for any zone-axis
+  2D/honeycomb material, not only the named classes; needs `fov_nm` from
+  metadata. **Pass the raw image without preprocessing** — no CLAHE, no
+  contrast normalization, no background subtraction, no bandpass
+  filtering. The model is trained on raw images and handles intensity
+  gradients internally; added preprocessing degrades detection. If weak
+  columns are missed, lower the `threshold` parameter. If a dense lattice
+  resolves only its bright sublattice — sparse detection, nearest-neighbor
+  spacing larger than expected — the resampling is too coarse: lower
+  `target_pixel_size` (finer; the image is resampled to it before
+  inference) to recover the dim sublattice. Conversely, if the detected NN
+  falls *below* the physical column spacing (spurious/split columns, common
+  on noisy data), it is too fine — raise it. Tune by matching the detected
+  NN to the expected physical column spacing. (For a *single*-sublattice
+  material there is no dim sublattice to recover, so NN stays put across the
+  band and rescaling affects only completeness — the default is usually
+  fine; just avoid the coarse end, where detection collapses sharply.) Do
+  not preprocess.
 - `detect_atoms` (classical peak detection): more general-purpose
-  baseline; use when material is outside the DCNN's training set, when
-  `fov_nm` is unknown, or when DCNN results look poor. **Preprocessing
+  baseline; use when `fov_nm` is unknown or when DCNN results look poor. **Preprocessing
   applies here, not to the DCNN path** — background subtraction or
   bandpass filtering before detection helps with non-uniform
   illumination.
@@ -491,10 +504,34 @@ analysis — local normalization removes the Z-contrast difference
 between species. Verify that each sublattice has consistent intensity
 and the expected stoichiometric ratio.
 
-**Defect identification:** Compare detected positions to ideal lattice
-sites. Restrict vacancy search to the interior of the detected region
-to avoid edge false positives. Verify vacancy candidates with forced
-Gaussian fit at expected position.
+**Defect identification.** Compare detected positions to ideal lattice
+sites; restrict the vacancy search to the interior to avoid edge false
+positives; verify candidates with a forced Gaussian fit at the expected
+position.
+
+For a multi-sublattice lattice (ABO3 perovskite, dichalcogenide, …)
+**separate the sublattices first, then type defects per sublattice** — a
+defect is defined relative to its own sublattice. Assign each column to a
+sublattice by **local environment / geometry** — `local_env_gmm` (patch-
+based) or the honeycomb/lattice site from detect-subtract-detect — **NOT by
+raw column intensity**: a substitutional dopant is a column of *anomalous
+intensity on its sublattice*, so an intensity-based split misfiles it into
+the other sublattice (a dim dopant on the bright sublattice lands in the
+dim cluster) and hides it. Then, within each geometric class: a **vacancy**
+is a site the class's ideal lattice predicts (`find_missing_atoms` on that
+class) with no detection; a **substitution / dopant** is an *intensity
+outlier within that class* (amplitude anomalous for its sublattice —
+comparing amplitudes *across* sublattices is meaningless, the species
+differ). Use raw intensities for the outlier test. Two common failures:
+skipping the separation entirely (all columns treated as one population),
+and separating by intensity (which buries the very dopants being sought).
+
+Do NOT infer "the dim sublattice was not resolved" from the absence of a
+bimodal nearest-neighbor peak: when both sublattices are resolved the NN
+distribution is unimodal *at the inter-sublattice spacing* (honeycomb edge,
+body-center), not the unit-cell repeat. Confirm resolution from the
+`local_env_gmm` classes, a detected count near the full two-sublattice
+expectation, or an NN matching the inter-column spacing.
 
 **FFT point-defect mapping** — use the registered tool `fft_defect_map`
 (reciprocal-space, atom-detection-free) when columns are unreliable to

--- a/scilink/skills/image_analysis/atomic_stem/discontinuity.py
+++ b/scilink/skills/image_analysis/atomic_stem/discontinuity.py
@@ -11,8 +11,11 @@ peak amplitude; a boundary is where those maps jump.
     disrupts the local periodicity, so the local FFT peak weakens right at it.
   * a jump in ORIENTATION classifies it as a grain / twin boundary;
   * a jump in SPACING classifies it as an interface / second phase / intergrowth;
-  * amplitude drop with neither → a stacking fault / antiphase band / amorphous
-    region.
+  * amplitude/coherence drop with neither → check the real-space LATERAL SHIFT
+    across the band: a fractional-period translational offset = a stacking fault
+    / antiphase boundary (the power spectrum is translation-invariant, so this is
+    the only signal that separates it from a non-translational disorder band or a
+    scan/contrast artifact, which show ~zero shift).
 
 Relationship to the other tools:
   * run_fft_nmf_analysis is the EXPLORATORY decomposer ("how many domains exist")
@@ -40,6 +43,54 @@ def _to_gray(a):
     if a.ndim == 3:
         a = a[..., :3].mean(-1)
     return a
+
+
+def _lateral_shift(gray, cy, cx, horizontal, win):
+    """Translational (lattice-phase) offset across a boundary, in REAL space.
+
+    The window power spectrum is translation-invariant, so a stacking fault /
+    antiphase boundary — which shifts the lattice laterally WITHOUT changing its
+    orientation or spacing — is invisible to the spectral dissimilarity. This
+    recovers exactly that: it cross-correlates a strip of the raw image on each
+    side of the boundary (offset past the disordered core) ALONG the boundary
+    direction, within +/- half a lattice period (so the offset is unambiguous),
+    and returns the shift as a fraction of the local period. ~0 = no shift (a
+    scan/contrast artifact or pure amorphization); a fractional-period shift =
+    a genuine translational planar fault. Returns None if not measurable.
+    """
+    H, W = gray.shape
+    t = max(6, int(round(win * 0.45)))      # strip thickness (~a couple of periods)
+    g = max(3, int(round(win * 0.25)))      # gap skipping the disordered band core
+    if horizontal:
+        y = int(round(cy))
+        a0, a1, b0, b1 = max(0, y - g - t), max(0, y - g), min(H, y + g), min(H, y + g + t)
+        if a1 - a0 < 4 or b1 - b0 < 4:
+            return None
+        pa, pb = gray[a0:a1].mean(0), gray[b0:b1].mean(0)
+    else:
+        x = int(round(cx))
+        a0, a1, b0, b1 = max(0, x - g - t), max(0, x - g), min(W, x + g), min(W, x + g + t)
+        if a1 - a0 < 4 or b1 - b0 < 4:
+            return None
+        pa, pb = gray[:, a0:a1].mean(1), gray[:, b0:b1].mean(1)
+    pa = pa - pa.mean(); pb = pb - pb.mean()
+    n = len(pa)
+    if n < 16 or pa.std() < 1e-6 or pb.std() < 1e-6:
+        return None
+    ac = np.correlate(pa, pa, "full")[n - 1:]          # local period from autocorr
+    lo = 3
+    if len(ac) <= lo + 2:
+        return None
+    period = int(np.argmax(ac[lo:]) + lo)
+    if period < 4:
+        return None
+    half = max(1, period // 2)
+    cc = np.correlate(pa, pb, "full"); mid = n - 1
+    seg = cc[mid - half: mid + half + 1]
+    lag = int(np.arange(-half, half + 1)[int(np.argmax(seg))])
+    return {"lateral_shift_px": float(abs(lag)),
+            "lateral_shift_frac": round(abs(lag) / period, 3),
+            "parallel_period_px": float(period)}
 
 
 def lattice_discontinuity_map(image, pixel_size_nm=None, params=None):
@@ -235,22 +286,44 @@ def lattice_discontinuity_map(image, pixel_size_nm=None, params=None):
         pkA = np.argmax(rA[1:]) + 1; pkB = np.argmax(rB[1:]) + 1
         dA, dB = win / max(pkA, 1), win / max(pkB, 1)
         sfrac = float(abs(dA - dB) / ((dA + dB) / 2 + 1e-9))
+        cyc, cxc = ndi.center_of_mass(cell)
+        cyp = float(cyc) * step + win / 2
+        cxp = float(cxc) * step + win / 2
+        ls = None
         if odeg >= orient_jump and odeg >= sfrac * 100:
             btype = "grain/twin boundary (orientation change)"
         elif sfrac >= spacing_jump:
             btype = "interface / second phase (spacing change)"
         else:
-            btype = "planar fault / disorder band (coherence drop)"
-        cyc, cxc = ndi.center_of_mass(cell)
-        boundaries.append({
+            # No orientation or spacing change: a coherence drop. This is the
+            # ambiguous class — a real translational planar fault (stacking
+            # fault / antiphase boundary) looks identical to a scan/contrast
+            # artifact or amorphization in the translation-invariant spectrum.
+            # Disambiguate in REAL space: a lateral lattice-phase shift across
+            # the band is the signature of a translational fault (an artifact
+            # shifts nothing). The boundary runs perpendicular to its long axis,
+            # so a "vertical" region (tall) is a vertical boundary -> measure the
+            # shift across x; a horizontal band -> across... measure along the
+            # boundary direction, which is the long axis (horizontal here).
+            ls = _lateral_shift(img, cyp, cxp, horizontal=not vertical, win=win)
+            lat = ls["lateral_shift_frac"] if ls else None
+            if lat is not None and lat >= 0.12:
+                btype = ("stacking fault / antiphase boundary "
+                         "(lateral lattice shift, no orientation/spacing change)")
+            else:
+                btype = "planar fault / disorder band (coherence drop)"
+        bd = {
             "type": btype,
-            "centroid_px": (round(float(cxc) * step + win / 2, 1),
-                            round(float(cyc) * step + win / 2, 1)),
+            "centroid_px": (round(cxp, 1), round(cyp, 1)),
             "orient_change_deg": round(odeg, 2),
             "spacing_change_pct": round(sfrac * 100, 2),
             "dissimilarity": round(float(diss[cell].mean()), 3),
             "n_cells": int(cell.sum()),
-        })
+        }
+        if ls:
+            bd["lateral_shift_frac"] = ls["lateral_shift_frac"]
+            bd["lateral_shift_px"] = round(ls["lateral_shift_px"], 1)
+        boundaries.append(bd)
     boundaries.sort(key=lambda b: -b["n_cells"])
 
     has_boundary = boundary_fraction >= min_bf and boundaries
@@ -337,12 +410,16 @@ TOOL_SPEC = ToolSpec(
         "chemical interface (perovskite film on perovskite substrate) has the "
         "same orientation/spacing/coherence on both sides and is INVISIBLE here "
         "— detect that via the per-column Z-contrast step instead (it is a "
-        "chemical, not structural, boundary). Likewise a perfectly COHERENT twin "
-        "whose mirror leaves the power spectrum unchanged shows no spectral "
-        "change — find it via a real-space displacement map / gpa_strain. The "
-        "tool detects boundaries that change local orientation, spacing, or "
-        "coherence; for very large or subtle-misorientation images tune "
-        "window_nm and dissim_floor."
+        "chemical, not structural, boundary). A layer-parallel planar fault "
+        "(stacking fault / antiphase boundary / intergrowth) shifts the lattice "
+        "TRANSLATIONALLY with no orientation or spacing change — invisible to the "
+        "(translation-invariant) power spectrum on its own, but the tool catches "
+        "it via a real-space lateral-shift check on every coherence-drop band and "
+        "reports lateral_shift_frac (so a horizontal/layer-parallel coherence "
+        "band with a fractional-period shift is a real stacking fault, NOT a scan "
+        "artifact — do not dismiss it as one). The tool detects boundaries that "
+        "change local orientation, spacing, or coherence; for very large or "
+        "subtle-misorientation images tune window_nm and dissim_floor."
     ),
     parameters={
         "image": {"type": "ndarray", "description": "2D grayscale atomic-resolution / lattice-fringe image."},
@@ -365,8 +442,13 @@ TOOL_SPEC = ToolSpec(
         "dict with 'figure_bytes' (PNG: raw, orientation map, spacing map, "
         "boundary overlay — SAVE as the visualization), 'metrics' "
         "(boundary_fraction; n_boundaries; dominant_type; 'boundaries' = list of "
-        "{type [grain/twin | interface/second-phase | planar-fault/disorder], "
-        "centroid_px, orient_change_deg, spacing_change_pct, dissimilarity, n_cells}; "
+        "{type [grain/twin | interface/second-phase | stacking-fault/antiphase | "
+        "planar-fault/disorder], centroid_px, orient_change_deg, "
+        "spacing_change_pct, dissimilarity, n_cells, and — for coherence-drop "
+        "bands — lateral_shift_frac (translational lattice-phase offset across "
+        "the band as a fraction of the period: ~0 = a non-translational disorder "
+        "band / scan-or-contrast artifact; a fractional-period shift, e.g. ~0.5, "
+        "= a genuine stacking fault / antiphase boundary)}; "
         "median_spacing; note), and 'flags' ('boundary_detected' or "
         "'single_crystal'; 'unresolved' if no clear lattice)."
     ),

--- a/scilink/skills/image_analysis/atomic_stem/discontinuity.py
+++ b/scilink/skills/image_analysis/atomic_stem/discontinuity.py
@@ -65,6 +65,11 @@ def lattice_discontinuity_map(image, pixel_size_nm=None, params=None):
                 spacing change above the latter → interface/second-phase.
             min_boundary_frac (0.03): below this boundary-cell fraction the field
                 is reported as a single crystal.
+            min_region_frac (0.01): minimum connected-component size (as a
+                fraction of the window grid) a boundary locus must reach to
+                count — speckle below this is dropped as false-positive
+                contrast. RAISE to suppress scattered patches on a noisy image,
+                LOWER to keep a short/faint boundary segment.
             azimuthal_bins (36): angular resolution of the orientation profile.
             smooth (0.6): Gaussian smoothing of the dissimilarity map.
 
@@ -82,6 +87,7 @@ def lattice_discontinuity_map(image, pixel_size_nm=None, params=None):
     orient_jump = float(p.get("orient_jump_deg", 8.0))
     spacing_jump = float(p.get("spacing_jump_frac", 0.05))
     min_bf = float(p.get("min_boundary_frac", 0.03))
+    min_region_frac = float(p.get("min_region_frac", 0.01))
     nb = int(p.get("azimuthal_bins", 36))
     smooth = float(p.get("smooth", 0.6))
     dissim_sigma = float(p.get("dissim_sigma", 2.0))
@@ -184,6 +190,17 @@ def lattice_discontinuity_map(image, pixel_size_nm=None, params=None):
     med = float(np.median(diss)); mad = float(np.median(np.abs(diss - med))) + 1e-9
     thr = max(med + dissim_sigma * 1.4826 * mad, abs_floor)
     bmask = diss > thr
+
+    # A real boundary is a connected locus; isolated speckle that clears the
+    # threshold on a noisy image is false-positive contrast, not a boundary.
+    # Drop sub-size connected components BEFORE measuring/displaying so the
+    # fraction and the overlay map reflect clean contours, not scattered patches.
+    min_region = max(2, int(gh * gw * min_region_frac))
+    lbl0, n0 = ndi.label(bmask)
+    if n0:
+        sizes = ndi.sum(np.ones_like(lbl0, float), lbl0, np.arange(1, n0 + 1))
+        keep = np.where(sizes >= min_region)[0] + 1
+        bmask = np.isin(lbl0, keep) if keep.size else np.zeros_like(bmask)
     boundary_fraction = float(bmask.mean())
     score = diss
 
@@ -192,7 +209,7 @@ def lattice_discontinuity_map(image, pixel_size_nm=None, params=None):
     boundaries = []
     for k in range(1, nlab + 1):
         cell = lbl == k
-        if cell.sum() < max(2, gh * gw * 0.01):
+        if cell.sum() < min_region:
             continue
         # classify by comparing the FULL azimuthal/radial profiles on the two
         # sides of the boundary (robust; per-cell argmax flips between symmetry-
@@ -339,7 +356,9 @@ TOOL_SPEC = ToolSpec(
             "subtle/coherent twin, RAISE if noise is flagged; "
             "orient_jump_deg (8.0) and spacing_jump_frac (0.05) — CLASSIFICATION "
             "thresholds; min_boundary_frac (0.03) — below this it is a single "
-            "crystal; azimuthal_bins (36); smooth (0.6).")},
+            "crystal; min_region_frac (0.01) — min connected boundary size, "
+            "RAISE to suppress scattered false-positive patches on a noisy "
+            "image; azimuthal_bins (36); smooth (0.6).")},
     },
     required=["image"],
     returns=(

--- a/scilink/skills/image_analysis/atomic_stem/discontinuity.py
+++ b/scilink/skills/image_analysis/atomic_stem/discontinuity.py
@@ -1,0 +1,349 @@
+"""Localize and classify STRUCTURAL lattice discontinuities in an
+atomic-resolution image — the single front door for planar defects, grain /
+twin boundaries, and incoherent interfaces.
+
+All three are the same thing physically: a line across which the local lattice
+changes its orientation, spacing, or coherence. A sliding-window local FFT
+turns the image into per-region maps of dominant orientation, spacing, and
+peak amplitude; a boundary is where those maps jump.
+
+  * AMPLITUDE / coherence drop is the UNIVERSAL detector — any boundary
+    disrupts the local periodicity, so the local FFT peak weakens right at it.
+  * a jump in ORIENTATION classifies it as a grain / twin boundary;
+  * a jump in SPACING classifies it as an interface / second phase / intergrowth;
+  * amplitude drop with neither → a stacking fault / antiphase band / amorphous
+    region.
+
+Relationship to the other tools:
+  * run_fft_nmf_analysis is the EXPLORATORY decomposer ("how many domains exist")
+    — this tool is the sharp LOCALIZER that returns the boundary line plus a
+    physical readout (delta-orientation in deg, delta-spacing in %). Same
+    explore-vs-localize split as FFT-NMF vs fourier_reflection_map.
+  * gpa_strain measures the continuous strain tensor against ONE reference
+    lattice — ideal for small distortions and coherent interfaces, but it
+    breaks at large misorientation (two grains = two reciprocal lattices). This
+    tool handles large misorientation (each window finds its own orientation).
+
+SCOPE: structural discontinuities only. A COHERENT, lattice-matched chemical
+interface (e.g. a perovskite film on a perovskite substrate) has the same
+orientation, spacing, and coherence on both sides — it is invisible here; that
+is a Z-contrast boundary (see the atomic_stem interface guidance).
+"""
+
+import io
+
+import numpy as np
+
+
+def _to_gray(a):
+    a = np.asarray(a, float)
+    if a.ndim == 3:
+        a = a[..., :3].mean(-1)
+    return a
+
+
+def lattice_discontinuity_map(image, pixel_size_nm=None, params=None):
+    """Map and classify structural lattice discontinuities (boundaries).
+
+    Args:
+        image: 2D grayscale (or HxWx3) atomic-resolution / lattice-fringe image.
+        pixel_size_nm: nm per pixel (square). If None, spacings are in pixels.
+        params: optional tunable dict (robust defaults):
+            window_px (64) / window_nm: sliding-window side; must span a few
+                lattice periods. SMALLER localizes a boundary more tightly but
+                resolves spacing/orientation worse; LARGER is the reverse.
+            overlap (0.5): fractional window overlap (grid step).
+            dissim_floor (0.05): absolute spectral-dissimilarity a boundary cell
+                must clear above the uniform-crystal baseline. LOWER to catch a
+                faint/subtle boundary, RAISE if noise is flagged.
+            dissim_sigma (4.0): robustness multiplier (median + sigma*MAD) for
+                the statistical part of the boundary threshold.
+            orient_jump_deg (8.0) / spacing_jump_frac (0.05): CLASSIFICATION
+                thresholds — orientation change above the former → grain/twin,
+                spacing change above the latter → interface/second-phase.
+            min_boundary_frac (0.03): below this boundary-cell fraction the field
+                is reported as a single crystal.
+            azimuthal_bins (36): angular resolution of the orientation profile.
+            smooth (0.6): Gaussian smoothing of the dissimilarity map.
+
+    Returns: dict with 'figure_bytes' (PNG: orientation map, spacing map,
+        boundary overlay), 'metrics', and 'flags'. Key metrics: boundary_fraction,
+        n_boundaries, dominant_type, boundaries (list of {type, centroid_px,
+        orient_change_deg, spacing_change_pct, dissimilarity}).
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    p = params or {}
+    overlap = float(p.get("overlap", 0.5))
+    orient_jump = float(p.get("orient_jump_deg", 8.0))
+    spacing_jump = float(p.get("spacing_jump_frac", 0.05))
+    min_bf = float(p.get("min_boundary_frac", 0.03))
+    nb = int(p.get("azimuthal_bins", 36))
+    smooth = float(p.get("smooth", 0.6))
+    dissim_sigma = float(p.get("dissim_sigma", 4.0))
+    abs_floor = float(p.get("dissim_floor", 0.05))
+
+    img = _to_gray(image)
+    H, W = img.shape
+    in_nm = pixel_size_nm is not None and pixel_size_nm > 0
+    scale = float(pixel_size_nm) if in_nm else 1.0
+    unit = "nm" if in_nm else "px"
+    # Window side: a physical ~window_nm (default 2 nm) spans several periods of
+    # a typical atomic lattice AND keeps the fundamental inside the analysis
+    # band — more robust than a fixed pixel count, which spans too few periods
+    # at fine pixel sizes. Clamped so the grid stays reasonably fine. For hard
+    # cases (subtle twin, very fine/coarse px) tune window_nm / window_px.
+    if "window_px" in p:
+        win = int(p["window_px"])
+    elif in_nm:
+        win = int(round(float(p.get("window_nm", 2.0)) / scale))
+    else:
+        win = int(p.get("window_px", 64))
+    win = int(np.clip(win, 40, min(H, W) // 6))
+    step = max(6, int(win * (1 - overlap)))
+
+    ys = list(range(0, H - win + 1, step))
+    xs = list(range(0, W - win + 1, step))
+    gh, gw = len(ys), len(xs)
+
+    # Per-window POWER SPECTRUM (translation-invariant): within one crystal,
+    # neighbouring windows have near-identical spectra; ANY boundary
+    # (orientation, spacing, or structural change) makes them differ. This is
+    # robust where peak-picking is not (the strongest reflection flips between
+    # symmetry-equivalent / different families window-to-window).
+    cy0, cx0 = win // 2, win // 2
+    yy, xx = np.mgrid[0:win, 0:win]
+    rr = np.hypot(yy - cy0, xx - cx0)
+    ang = (np.arctan2(yy - cy0, xx - cx0) % np.pi)     # mod pi
+    band = (rr > max(2, 0.04 * win)) & (rr < 0.47 * win)   # lattice-reflection band (incl. fundamental)
+    abin = np.clip((ang / np.pi * nb).astype(int), 0, nb - 1)
+    rbin = np.clip(rr.astype(int), 0, win)
+    hann = np.outer(np.hanning(win), np.hanning(win))
+
+    nr = win // 2
+    specvec = {}                                        # (iy,ix) -> band power vector
+    azim = np.zeros((gh, gw, nb))                       # azimuthal profile (orientation)
+    radp = np.zeros((gh, gw, nr + 1))                  # radial profile (spacing)
+    theta = np.full((gh, gw), np.nan)                   # display orientation (deg)
+    dmap = np.full((gh, gw), np.nan)                    # display spacing (px)
+    bidx = np.where(band.ravel())[0]
+    for iy, y0 in enumerate(ys):
+        for ix, x0 in enumerate(xs):
+            w = img[y0:y0 + win, x0:x0 + win]
+            if w.std() < 1e-6:
+                continue
+            P = np.abs(np.fft.fftshift(np.fft.fft2((w - w.mean()) * hann))) ** 2
+            v = P.ravel()[bidx]
+            specvec[(iy, ix)] = v / (v.sum() + 1e-12)
+            az = np.bincount(abin[band], weights=P[band], minlength=nb)
+            azim[iy, ix] = az
+            theta[iy, ix] = (np.argmax(az) + 0.5) / nb * 180.0
+            rad = np.bincount(rbin[band], weights=P[band], minlength=win + 1)[:nr + 1]
+            radp[iy, ix] = rad
+            rpk = np.argmax(rad[1:]) + 1
+            dmap[iy, ix] = win / max(rpk, 1)
+
+    valid = np.array([[(iy, ix) in specvec for ix in range(gw)] for iy in range(gh)])
+    if valid.sum() < 4:
+        return {"metrics": {"note": "too few resolvable windows; not a clear "
+                            "lattice (or window too small)", "boundary_fraction": 0.0},
+                "flags": ["unresolved"], "figure_bytes": b""}
+
+    # --- neighbour spectral dissimilarity = boundary detection signal -------
+    from scipy.ndimage import gaussian_filter
+    from scipy import ndimage as ndi
+    diss = np.zeros((gh, gw))
+    for iy in range(gh):
+        for ix in range(gw):
+            if (iy, ix) not in specvec:
+                diss[iy, ix] = 1.0; continue
+            v = specvec[(iy, ix)]; ds = []
+            for dy, dx in ((0, 1), (0, -1), (1, 0), (-1, 0)):
+                nb_ = (iy + dy, ix + dx)
+                if nb_ in specvec:
+                    u = specvec[nb_]
+                    ds.append(1.0 - float((u @ v) / (np.linalg.norm(u) * np.linalg.norm(v) + 1e-12)))
+            diss[iy, ix] = np.mean(ds) if ds else 1.0
+    diss = gaussian_filter(diss, smooth)
+
+    # boundary cell: spectral dissimilarity clearly above the uniform-crystal
+    # baseline. Robust statistical cut AND an absolute floor (a uniform crystal
+    # has tiny, uniform dissimilarity → nothing clears the floor → bf~0).
+    med = float(np.median(diss)); mad = float(np.median(np.abs(diss - med))) + 1e-9
+    thr = max(med + dissim_sigma * 1.4826 * mad, abs_floor)
+    bmask = diss > thr
+    boundary_fraction = float(bmask.mean())
+    score = diss
+
+    # --- classify each boundary region by what changes across it ------------
+    lbl, nlab = ndi.label(bmask)
+    boundaries = []
+    for k in range(1, nlab + 1):
+        cell = lbl == k
+        if cell.sum() < max(2, gh * gw * 0.01):
+            continue
+        # classify by comparing the FULL azimuthal/radial profiles on the two
+        # sides of the boundary (robust; per-cell argmax flips between symmetry-
+        # equivalent reflections and would fake an orientation change).
+        rows = np.where(cell.any(1))[0]; cols = np.where(cell.any(0))[0]
+        vertical = rows.size >= cols.size                 # tall region = vertical boundary
+        cc = ndi.center_of_mass(cell)
+        if vertical:
+            a = valid & (np.arange(gw)[None, :] < cc[1] - 0.5)
+            b = valid & (np.arange(gw)[None, :] > cc[1] + 0.5)
+        else:
+            a = valid & (np.arange(gh)[:, None] < cc[0] - 0.5)
+            b = valid & (np.arange(gh)[:, None] > cc[0] + 0.5)
+        if a.sum() < 2 or b.sum() < 2:
+            a, b = cell, cell
+        azA = azim[a].mean(0); azB = azim[b].mean(0)
+        azA /= azA.sum() + 1e-12; azB /= azB.sum() + 1e-12
+        # circular cross-correlation peak shift = orientation change (deg, mod 180)
+        xcorr = np.array([np.dot(azA, np.roll(azB, k)) for k in range(nb)])
+        shift = int(np.argmax(xcorr)); shift = min(shift, nb - shift)
+        odeg = float(shift / nb * 180.0)
+        rA = radp[a].mean(0); rB = radp[b].mean(0)
+        pkA = np.argmax(rA[1:]) + 1; pkB = np.argmax(rB[1:]) + 1
+        dA, dB = win / max(pkA, 1), win / max(pkB, 1)
+        sfrac = float(abs(dA - dB) / ((dA + dB) / 2 + 1e-9))
+        if odeg >= orient_jump and odeg >= sfrac * 100:
+            btype = "grain/twin boundary (orientation change)"
+        elif sfrac >= spacing_jump:
+            btype = "interface / second phase (spacing change)"
+        else:
+            btype = "planar fault / disorder band (coherence drop)"
+        cyc, cxc = ndi.center_of_mass(cell)
+        boundaries.append({
+            "type": btype,
+            "centroid_px": (round(float(cxc) * step + win / 2, 1),
+                            round(float(cyc) * step + win / 2, 1)),
+            "orient_change_deg": round(odeg, 2),
+            "spacing_change_pct": round(sfrac * 100, 2),
+            "dissimilarity": round(float(diss[cell].mean()), 3),
+            "n_cells": int(cell.sum()),
+        })
+    boundaries.sort(key=lambda b: -b["n_cells"])
+
+    has_boundary = boundary_fraction >= min_bf and boundaries
+    dominant = boundaries[0]["type"] if has_boundary else None
+    flags = ["boundary_detected"] if has_boundary else ["single_crystal"]
+
+    note = (f"{len(boundaries)} boundary region(s); dominant: {dominant}"
+            if has_boundary else
+            "No structural discontinuity resolved — single crystal / uniform "
+            "lattice (a coherent lattice-matched chemical interface would be "
+            "invisible here; use the Z-contrast interface route).")
+
+    # --- figure ------------------------------------------------------------
+    fig, ax = plt.subplots(2, 2, figsize=(11, 10))
+    vlo, vhi = np.percentile(img, [1, 99])
+    ext = [0, W, H, 0]
+    ax[0, 0].imshow(img, cmap="gray", vmin=vlo, vmax=vhi)
+    ax[0, 0].set_title("Raw image"); ax[0, 0].axis("off")
+    om = ax[0, 1].imshow(np.where(valid, theta, np.nan), cmap="hsv",
+                         extent=ext, vmin=0, vmax=180)
+    ax[0, 1].set_title("Local orientation (deg, mod 180)"); ax[0, 1].axis("off")
+    plt.colorbar(om, ax=ax[0, 1], fraction=0.046)
+    dm = ax[1, 0].imshow(np.where(valid, dmap, np.nan) * scale, cmap="viridis", extent=ext)
+    ax[1, 0].set_title(f"Local spacing ({unit})"); ax[1, 0].axis("off")
+    plt.colorbar(dm, ax=ax[1, 0], fraction=0.046)
+    ax[1, 1].imshow(img, cmap="gray", vmin=vlo, vmax=vhi)
+    ax[1, 1].imshow(np.ma.masked_where(~bmask, score), cmap="autumn",
+                    alpha=0.6, extent=ext)
+    for b in boundaries:
+        ax[1, 1].plot(*b["centroid_px"], "c+", ms=14, mew=2)
+    ax[1, 1].set_title(f"Boundary overlay (frac={boundary_fraction:.2f})\n{note[:60]}")
+    ax[1, 1].axis("off")
+    plt.tight_layout()
+    buf = io.BytesIO(); plt.savefig(buf, format="png", dpi=120); plt.close(fig)
+
+    metrics = {
+        "boundary_fraction": round(boundary_fraction, 3),
+        "n_boundaries": len(boundaries),
+        "dominant_type": dominant,
+        "boundaries": boundaries,
+        "window_px": win, "grid_shape": (gh, gw),
+        "median_spacing": round(float(np.nanmedian(dmap) * scale), 4), "units": unit,
+        "note": note,
+    }
+    return {"figure_bytes": buf.getvalue(), "metrics": metrics, "flags": flags}
+
+
+from scilink.skills._shared._spec import ToolSpec
+
+TOOL_SPEC = ToolSpec(
+    name="lattice_discontinuity_map",
+    description=(
+        "Localize and CLASSIFY structural lattice discontinuities — planar "
+        "defects (stacking faults, intergrowths, antiphase bands), grain / twin "
+        "boundaries, and incoherent interfaces — in one pass. A sliding-window "
+        "local FFT maps dominant orientation, spacing, and peak coherence; a "
+        "boundary is where they jump (coherence drop detects it; an orientation "
+        "jump = grain/twin, a spacing jump = interface/second phase). Returns a "
+        "boundary overlay + the change magnitudes."
+    ),
+    import_line=("from scilink.skills.image_analysis.atomic_stem.discontinuity "
+                 "import lattice_discontinuity_map"),
+    signature="lattice_discontinuity_map(image, pixel_size_nm=None, params=None) -> dict",
+    agents=["image_analysis"],
+    when_to_use=(
+        "Use to LOCATE and TYPE a boundary / planar defect / interface in a "
+        "crystalline atomic-resolution or lattice-fringe image — objectives like "
+        "'find the grain/twin boundary', 'locate the stacking fault / "
+        "intergrowth', 'where is the interface'. Save its `figure_bytes` as the "
+        "visualization and read `boundaries` (each typed with its "
+        "orient_change_deg / spacing_change_pct / dissimilarity).\n"
+        "\n"
+        "Pick among the reciprocal-space tools: `run_fft_nmf_analysis` is the "
+        "EXPLORATORY decomposer (unknown heterogeneity, 'how many domains') — "
+        "this tool is the sharp LOCALIZER that returns the boundary line + a "
+        "physical readout. `gpa_strain` measures the continuous strain tensor "
+        "against one reference lattice (small distortions, coherent interfaces, "
+        "fine same-orientation faults) but breaks at large misorientation; this "
+        "tool handles large misorientation, so use GPA for strain MAGNITUDE and "
+        "this tool to LOCATE/TYPE the boundary. `fourier_reflection_map` maps a "
+        "specific superstructure/satellite reflection's domain.\n"
+        "\n"
+        "SCOPE: structural discontinuities only. A COHERENT lattice-matched "
+        "chemical interface (perovskite film on perovskite substrate) has the "
+        "same orientation/spacing/coherence on both sides and is INVISIBLE here "
+        "— detect that via the per-column Z-contrast step instead (it is a "
+        "chemical, not structural, boundary). Likewise a perfectly COHERENT twin "
+        "whose mirror leaves the power spectrum unchanged shows no spectral "
+        "change — find it via a real-space displacement map / gpa_strain. The "
+        "tool detects boundaries that change local orientation, spacing, or "
+        "coherence; for very large or subtle-misorientation images tune "
+        "window_nm and dissim_floor."
+    ),
+    parameters={
+        "image": {"type": "ndarray", "description": "2D grayscale atomic-resolution / lattice-fringe image."},
+        "pixel_size_nm": {"type": "float", "description": "nm/px (square). If omitted, spacings are in pixels."},
+        "params": {"type": "dict", "description": (
+            "Optional knobs (robust defaults; tune them): window_px (64) / "
+            "window_nm — window side (must span a few periods; smaller = tighter "
+            "localization, worse orientation/spacing resolution); overlap (0.5); "
+            "dissim_floor (0.05) and dissim_sigma (4.0) — DETECTION threshold on "
+            "spectral dissimilarity, LOWER dissim_floor for a subtle boundary; "
+            "orient_jump_deg (8.0) and spacing_jump_frac (0.05) — CLASSIFICATION "
+            "thresholds; min_boundary_frac (0.03) — below this it is a single "
+            "crystal; azimuthal_bins (36); smooth (0.6).")},
+    },
+    required=["image"],
+    returns=(
+        "dict with 'figure_bytes' (PNG: raw, orientation map, spacing map, "
+        "boundary overlay — SAVE as the visualization), 'metrics' "
+        "(boundary_fraction; n_boundaries; dominant_type; 'boundaries' = list of "
+        "{type [grain/twin | interface/second-phase | planar-fault/disorder], "
+        "centroid_px, orient_change_deg, spacing_change_pct, dissimilarity, n_cells}; "
+        "median_spacing; note), and 'flags' ('boundary_detected' or "
+        "'single_crystal'; 'unresolved' if no clear lattice)."
+    ),
+    example=(
+        "res = lattice_discontinuity_map(image, pixel_size_nm=0.035)\n"
+        "open('visualization.png','wb').write(res['figure_bytes'])\n"
+        "for b in res['metrics']['boundaries']:\n"
+        "    print(b['type'], b['centroid_px'], b['orient_change_deg'], b['spacing_change_pct'])"
+    ),
+)

--- a/scilink/skills/image_analysis/atomic_stem/discontinuity.py
+++ b/scilink/skills/image_analysis/atomic_stem/discontinuity.py
@@ -56,8 +56,10 @@ def lattice_discontinuity_map(image, pixel_size_nm=None, params=None):
             dissim_floor (0.05): absolute spectral-dissimilarity a boundary cell
                 must clear above the uniform-crystal baseline. LOWER to catch a
                 faint/subtle boundary, RAISE if noise is flagged.
-            dissim_sigma (4.0): robustness multiplier (median + sigma*MAD) for
-                the statistical part of the boundary threshold.
+            dissim_sigma (2.0): robustness multiplier (median + sigma*MAD) for
+                the statistical part of the boundary threshold. LOWER (e.g. 1.5)
+                to recover a subtle/coherent twin the default misses, RAISE
+                (e.g. 4.0) if noise is being flagged as a boundary.
             orient_jump_deg (8.0) / spacing_jump_frac (0.05): CLASSIFICATION
                 thresholds — orientation change above the former → grain/twin,
                 spacing change above the latter → interface/second-phase.
@@ -82,7 +84,7 @@ def lattice_discontinuity_map(image, pixel_size_nm=None, params=None):
     min_bf = float(p.get("min_boundary_frac", 0.03))
     nb = int(p.get("azimuthal_bins", 36))
     smooth = float(p.get("smooth", 0.6))
-    dissim_sigma = float(p.get("dissim_sigma", 4.0))
+    dissim_sigma = float(p.get("dissim_sigma", 2.0))
     abs_floor = float(p.get("dissim_floor", 0.05))
 
     img = _to_gray(image)
@@ -332,8 +334,9 @@ TOOL_SPEC = ToolSpec(
             "Optional knobs (robust defaults; tune them): window_px (64) / "
             "window_nm — window side (must span a few periods; smaller = tighter "
             "localization, worse orientation/spacing resolution); overlap (0.5); "
-            "dissim_floor (0.05) and dissim_sigma (4.0) — DETECTION threshold on "
-            "spectral dissimilarity, LOWER dissim_floor for a subtle boundary; "
+            "dissim_floor (0.05) and dissim_sigma (2.0) — DETECTION threshold on "
+            "spectral dissimilarity, LOWER either (dissim_sigma→1.5) to recover a "
+            "subtle/coherent twin, RAISE if noise is flagged; "
             "orient_jump_deg (8.0) and spacing_jump_frac (0.05) — CLASSIFICATION "
             "thresholds; min_boundary_frac (0.03) — below this it is a single "
             "crystal; azimuthal_bins (36); smooth (0.6).")},

--- a/scilink/skills/image_analysis/atomic_stem/discontinuity.py
+++ b/scilink/skills/image_analysis/atomic_stem/discontinuity.py
@@ -139,11 +139,19 @@ def lattice_discontinuity_map(image, pixel_size_nm=None, params=None):
             specvec[(iy, ix)] = v / (v.sum() + 1e-12)
             az = np.bincount(abin[band], weights=P[band], minlength=nb)
             azim[iy, ix] = az
-            theta[iy, ix] = (np.argmax(az) + 0.5) / nb * 180.0
+            # DISPLAY orientation: circular MEAN of the azimuthal profile (mod
+            # 180), not argmax — argmax flips between symmetry-equivalent /
+            # different reflection families window-to-window and renders the map
+            # as a meaningless checkerboard.
+            phi = (np.arange(nb) + 0.5) / nb * np.pi
+            theta[iy, ix] = (np.degrees(0.5 * np.arctan2((az * np.sin(2 * phi)).sum(),
+                                                         (az * np.cos(2 * phi)).sum())) % 180.0)
             rad = np.bincount(rbin[band], weights=P[band], minlength=win + 1)[:nr + 1]
             radp[iy, ix] = rad
-            rpk = np.argmax(rad[1:]) + 1
-            dmap[iy, ix] = win / max(rpk, 1)
+            # DISPLAY spacing: power-weighted radial CENTROID (stable), not the
+            # argmax bin (which also flips between {100}/{110}-type rings).
+            ri = np.arange(1, nr + 1)
+            dmap[iy, ix] = win / max((ri * rad[1:]).sum() / (rad[1:].sum() + 1e-12), 1.0)
 
     valid = np.array([[(iy, ix) in specvec for ix in range(gw)] for iy in range(gh)])
     if valid.sum() < 4:

--- a/tests/test_atomic_stem_lattice_tools.py
+++ b/tests/test_atomic_stem_lattice_tools.py
@@ -244,6 +244,27 @@ class TestSublatticeDefects:
         assert m["n_vacancies"] <= 2          # clean -> ~no false vacancies
         assert m["n_dopants"] <= 2            # clean -> ~no false dopants
 
+    def test_dopant_z_capped_and_intensity_ratio(self):
+        # On a near-uniform sublattice (tiny MAD) the robust z inflates to absurd
+        # values (~25) and real substitutions get dismissed downstream as
+        # "physically impossible". Invariants: reported z is sanity-capped at +-10,
+        # every dopant carries a physical intensity_ratio, and the ratio is
+        # consistent with the lighter/heavier label (independent of over-detection).
+        img, pos, _ = _two_sublattice(
+            n=18, a=self._A, contrast=0.5,
+            dop_B={130: 1.9, 175: 0.45}, noise=0.005, seed=2)
+        r = type_sublattice_defects(img, pos, n_sublattices=2, pixel_size_nm=0.1,
+                                    edge_margin_px=2.0 * self._A)
+        dops = r["metrics"]["dopants"]
+        assert dops, "planted dopants should be detected"
+        for d in dops:
+            assert -10.0 <= d["z"] <= 10.0
+            assert d.get("intensity_ratio", 0) > 0
+            if d["kind"] == "lighter-substitution":
+                assert d["intensity_ratio"] < 1.0
+            else:
+                assert d["intensity_ratio"] > 1.0
+
 
 # --------------------------------------------------------------------------- #
 # lattice_discontinuity_map                                                   #

--- a/tests/test_atomic_stem_lattice_tools.py
+++ b/tests/test_atomic_stem_lattice_tools.py
@@ -103,6 +103,68 @@ def _bicrystal(shape=(512, 512), a=24, theta_deg=14.0, s=3.0, noise=0.02, seed=0
     return np.clip(img, 0, None).astype(np.float32)
 
 
+def _full_square(shape=(480, 480), a=16, s=2.6, shift_frac=0.0,
+                 fault_disorder=0.0, axis="h", noise=0.01, seed=0):
+    """Square lattice tiling the WHOLE frame (no vacuum margin -> no spurious
+    edge boundaries). A mid-frame band (horizontal for axis='h', vertical for
+    axis='v') gets local positional disorder (``fault_disorder``, the COHERENCE
+    DROP the universal detector keys on — a pure shift or pure intensity dip is
+    invisible to the translation-/scale-invariant spectrum). If ``shift_frac``>0
+    the far half is shifted by that fraction of a period ALONG the boundary -> an
+    antiphase (stacking-fault) boundary; shift_frac=0 -> a non-translational
+    disorder band."""
+    rng = np.random.default_rng(seed)
+    H, W = shape; img = np.zeros((H, W)); fy = H / 2.0; fx = W / 2.0
+    ny, nx = H // a + 4, W // a + 4
+    for i in range(-2, ny):
+        for j in range(-2, nx):
+            y = float(i * a); x = float(j * a)
+            if axis == "h":
+                if y > fy:
+                    x += shift_frac * a
+                near = abs(y - fy) < 0.4 * a
+            else:
+                if x > fx:
+                    y += shift_frac * a
+                near = abs(x - fx) < 0.4 * a
+            if fault_disorder > 0 and near:
+                x += rng.normal(0, fault_disorder * a)
+                y += rng.normal(0, fault_disorder * a)
+            _gauss(img, x, y, 1.0, s)
+    img += rng.normal(0, noise, img.shape)
+    return np.clip(img, 0, None).astype(np.float32)
+
+
+def _stacking_fault(shape=(480, 480), a=16, shift_frac=0.5, axis="h", seed=0):
+    # antiphase shift + a coherence drop at the seam (so it is detectable)
+    return _full_square(shape, a, shift_frac=shift_frac, fault_disorder=0.22,
+                        axis=axis, seed=seed)
+
+
+def _horizontal_disorder_band(shape=(480, 480), a=16, seed=0):
+    # a coherence-drop band with NO lateral shift (amorphous band / scan-like) —
+    # must be detected but NOT typed as a stacking fault
+    return _full_square(shape, a, shift_frac=0.0, fault_disorder=0.22, seed=seed)
+
+
+def _spacing_interface(shape=(480, 480), a1=16, a2=22, s=2.6, noise=0.01, seed=0):
+    """Two domains sharing a vertical seam at x=W/2 with DIFFERENT lattice
+    spacing (a1 left, a2 right) -> an interface / second-phase (spacing change),
+    not a stacking fault. Ensures the lateral-shift code doesn't disturb the
+    spacing-change classification."""
+    rng = np.random.default_rng(seed)
+    H, W = shape; img = np.zeros((H, W)); fx = int(W / 2.0)
+    for a, x0, x1 in ((a1, 0, fx), (a2, fx, W)):
+        ny, nx = H // a + 4, (x1 - x0) // a + 4
+        for i in range(-2, ny):
+            for j in range(-2, nx):
+                x = x0 + j * a; y = i * a
+                if x0 - 1 <= x < x1 + 1:
+                    _gauss(img, x, y, 1.0, s)
+    img += rng.normal(0, noise, img.shape)
+    return np.clip(img, 0, None).astype(np.float32)
+
+
 def _match_count(found_xy, truth_xy, tol):
     if not truth_xy:
         return 0
@@ -200,6 +262,42 @@ class TestDiscontinuity:
         img = _bicrystal((512, 512), a=24, theta_deg=0.0, seed=2)
         r = lattice_discontinuity_map(img, pixel_size_nm=0.1)
         assert r["metrics"]["boundary_fraction"] < 0.15
+
+    @pytest.mark.parametrize("axis,shift,seed", [
+        ("h", 0.5, 1), ("h", 0.5, 7), ("h", 0.3, 3),   # horizontal antiphase, varied
+        ("v", 0.5, 2), ("v", 0.4, 5),                   # vertical antiphase
+    ])
+    def test_stacking_fault_lateral_shift_detected(self, axis, shift, seed):
+        # antiphase boundary: no orient/spacing change, but a lateral shift ->
+        # must be caught via lateral_shift, not dismissed as an artifact.
+        img = _stacking_fault(a=16, shift_frac=shift, axis=axis, seed=seed)
+        m = lattice_discontinuity_map(img, pixel_size_nm=0.1)["metrics"]
+        assert m["n_boundaries"] >= 1
+        # the fault region should be the dominant boundary
+        b = m["boundaries"][0]
+        assert b["orient_change_deg"] < 8 and b["spacing_change_pct"] < 10   # neither
+        assert b.get("lateral_shift_frac", 0) >= 0.18                        # but a real shift
+        assert "stacking fault" in b["type"] or "antiphase" in b["type"]
+
+    def test_orient_or_spacing_boundary_not_hijacked(self):
+        # a boundary with a real orientation/spacing change must keep its class
+        # and get NO lateral_shift_frac — the lateral-shift logic is scoped to
+        # the coherence-drop branch only (regression guard for that addition).
+        img = _spacing_interface(a1=16, a2=22, seed=1)
+        m = lattice_discontinuity_map(img, pixel_size_nm=0.1)["metrics"]
+        assert m["n_boundaries"] >= 1
+        for b in m["boundaries"]:
+            assert "stacking fault" not in b["type"] and "antiphase" not in b["type"]
+            assert "lateral_shift_frac" not in b      # only on coherence-drop bands
+
+    def test_disorder_band_not_called_stacking_fault(self):
+        # a coherence-drop band with NO lattice shift must NOT be typed as a
+        # stacking fault (lateral_shift_frac stays small).
+        img = _horizontal_disorder_band(a=16, seed=2)
+        r = lattice_discontinuity_map(img, pixel_size_nm=0.1)
+        for b in r["metrics"]["boundaries"]:
+            assert b.get("lateral_shift_frac", 0.0) < 0.2
+            assert "stacking fault" not in b["type"] and "antiphase" not in b["type"]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_atomic_stem_lattice_tools.py
+++ b/tests/test_atomic_stem_lattice_tools.py
@@ -1,0 +1,229 @@
+"""Offline synthetic-truth tests for the atomic_stem lattice / defect / ferroic
+tools added on the lattice-boundary-tools branch:
+
+  - measure_lattice_constant   (FFT Bragg-geometry cell measurement)
+  - type_sublattice_defects     (per-sublattice vacancy + dopant typing)
+  - lattice_discontinuity_map   (grain / twin / interface localizer)
+  - map_polarization            (per-cell ferroelectric off-centering)
+
+Positions are fed directly (no DCNN), so these run in seconds. They assert
+planted-truth RECOVERY, that a tunable knob actually changes behavior, and
+NO-false-positive controls (clean lattice -> no fabricated defects/field).
+"""
+import numpy as np
+import pytest
+from scipy.spatial import cKDTree
+
+from scilink.skills.image_analysis.atomic_stem.lattice import measure_lattice_constant
+from scilink.skills.image_analysis.atomic_stem.atom_finding import (
+    type_sublattice_defects, map_polarization)
+from scilink.skills.image_analysis.atomic_stem.discontinuity import lattice_discontinuity_map
+from scilink.skills._shared.fft_defect import make_defective_lattice
+
+
+# --------------------------------------------------------------------------- #
+# synthetic generators                                                        #
+# --------------------------------------------------------------------------- #
+def _gauss(img, x, y, A, s):
+    H, W = img.shape
+    x0 = max(0, int(x - 4 * s)); x1 = min(W, int(x + 4 * s) + 1)
+    y0 = max(0, int(y - 4 * s)); y1 = min(H, int(y + 4 * s) + 1)
+    if x1 <= x0 or y1 <= y0:
+        return
+    yy, xx = np.mgrid[y0:y1, x0:x1]
+    img[y0:y1, x0:x1] += A * np.exp(-((xx - x) ** 2 + (yy - y) ** 2) / (2 * s * s))
+
+
+def _two_sublattice(n=16, a=26, s=3.0, contrast=0.5, P_px=(0.0, 0.0),
+                    domains=False, vac_B=None, dop_B=None, noise=0.01, seed=0):
+    """A square sublattice (bright, intensity 1.0) interpenetrated by a B
+    sublattice at the cell centres (intensity = ``contrast``), optionally
+    displaced by ``P_px`` (ferroelectric off-centering; sign flips per half if
+    ``domains``). ``vac_B`` = B indices to omit (planted vacancies); ``dop_B`` =
+    {B index: intensity multiplier} (planted substitutional dopants).
+    Returns (img float32, positions (x,y) of surviving columns, truth dict)."""
+    rng = np.random.default_rng(seed)
+    H = W = a * n + 2 * a
+    img = np.zeros((H, W)); A = []; B = []; vac_truth = []; dop_truth = []
+    vac_B = set(vac_B or []); dop_B = dict(dop_B or {})
+    bi = 0
+    for i in range(n):
+        for j in range(n):
+            ax = a + j * a; ay = a + i * a
+            _gauss(img, ax, ay, 1.0, s); A.append((ax, ay))
+            sign = 1 if (not domains or j < n // 2) else -1
+            bx = ax + a / 2 + P_px[0] * sign; by = ay + a / 2 + P_px[1] * sign
+            if bi in vac_B:
+                vac_truth.append((bx, by))                      # omitted column
+            else:
+                _gauss(img, bx, by, contrast * dop_B.get(bi, 1.0), s)
+                B.append((bx, by))
+                if bi in dop_B:
+                    dop_truth.append((bx, by))
+            bi += 1
+    img += rng.normal(0, noise, img.shape)
+    img = np.clip(img, 0, None)
+    return (img.astype(np.float32), np.array(A + B),
+            {"vac": vac_truth, "dop": dop_truth, "nA": len(A), "nB": len(B), "a": a})
+
+
+def _single_square(n=16, a=26, s=3.0, noise=0.01, seed=0):
+    """One square lattice, no second sublattice (negative control)."""
+    rng = np.random.default_rng(seed)
+    H = W = a * n + 2 * a
+    img = np.zeros((H, W)); pts = []
+    for i in range(n):
+        for j in range(n):
+            x = a + j * a; y = a + i * a
+            _gauss(img, x, y, 1.0, s); pts.append((x, y))
+    img += rng.normal(0, noise, img.shape)
+    return np.clip(img, 0, None).astype(np.float32), np.array(pts)
+
+
+def _bicrystal(shape=(512, 512), a=24, theta_deg=14.0, s=3.0, noise=0.02, seed=0):
+    """Two square domains sharing a vertical seam at x=W/2: the left domain is
+    axis-aligned, the right is rotated by ``theta_deg`` about the seam centre.
+    theta_deg=0 -> a single continuous lattice (no-boundary control)."""
+    rng = np.random.default_rng(seed)
+    H, W = shape; img = np.zeros((H, W)); cx = W / 2.0
+    seam = np.array([cx, H / 2.0])
+    th = np.deg2rad(theta_deg)
+    R = np.array([[np.cos(th), -np.sin(th)], [np.sin(th), np.cos(th)]])
+    nx = int(W / a) + 6; ny = int(H / a) + 6
+    for i in range(-3, ny):
+        for j in range(-3, nx):
+            base = np.array([j * a, i * a], float)
+            if base[0] < cx:
+                x, y = base
+            else:
+                x, y = R @ (base - seam) + seam
+            if 0 <= x < W and 0 <= y < H:
+                _gauss(img, x, y, 1.0, s)
+    img += rng.normal(0, noise, img.shape)
+    return np.clip(img, 0, None).astype(np.float32)
+
+
+def _match_count(found_xy, truth_xy, tol):
+    if not truth_xy:
+        return 0
+    if not found_xy:
+        return 0
+    tree = cKDTree(np.asarray(found_xy))
+    return int(sum(tree.query(np.asarray(t))[0] <= tol for t in truth_xy))
+
+
+# --------------------------------------------------------------------------- #
+# measure_lattice_constant                                                    #
+# --------------------------------------------------------------------------- #
+class TestMeasureLatticeConstant:
+    def test_resolves_square_cell(self):
+        img, _ = make_defective_lattice((512, 512), a_px=12.0, kind="square",
+                                        n_vacancies=0, noise=0.03, seed=1)
+        r = measure_lattice_constant(img, pixel_size_nm=0.1)
+        assert r["lattice_constant_nm"] is not None
+        assert abs(r["gamma_deg"] - 90.0) < 6.0        # right-angle cell
+        assert r["n_reflections"] >= 2
+        assert not r["low_confidence"]
+
+    def test_tracks_lattice_spacing(self):
+        # Convention-independent: the measured constant scales with the real
+        # lattice spacing. Use a fine pixel size so both fundamentals stay
+        # inside the (nm-based) d_range gate rather than being clipped.
+        c12 = measure_lattice_constant(
+            make_defective_lattice((512, 512), a_px=12.0, kind="square",
+                                   n_vacancies=0, noise=0.02, seed=1)[0], 0.05)
+        c20 = measure_lattice_constant(
+            make_defective_lattice((512, 512), a_px=20.0, kind="square",
+                                   n_vacancies=0, noise=0.02, seed=1)[0], 0.05)
+        assert c12["lattice_constant_nm"] and c20["lattice_constant_nm"]
+        ratio = c20["lattice_constant_nm"] / c12["lattice_constant_nm"]
+        assert abs(ratio - 20.0 / 12.0) < 0.15         # tracks real spacing
+
+    def test_min_sigma_knob_changes_behavior(self):
+        img, _ = make_defective_lattice((512, 512), a_px=12.0, kind="square",
+                                        n_vacancies=0, noise=0.12, seed=3)
+        strict = measure_lattice_constant(img, 0.1, params={"min_sigma": 8.0})
+        loose = measure_lattice_constant(img, 0.1, params={"min_sigma": 2.0})
+        # a stricter significance floor admits no more reflections than a loose one
+        assert loose["n_reflections"] >= strict["n_reflections"]
+
+
+# --------------------------------------------------------------------------- #
+# type_sublattice_defects                                                     #
+# --------------------------------------------------------------------------- #
+class TestSublatticeDefects:
+    # n=18, contrast 0.5 -> local_env_gmm separates the two sublattices cleanly
+    # (324/324); central planted defects + a 2a edge margin keep the test precise.
+    _A = 26
+
+    def test_vacancies_and_dopants_recovered(self):
+        # central B indices (i*18+j with i,j in ~7..11) so they sit well inside
+        # the 2a edge margin with full reference cages
+        img, pos, truth = _two_sublattice(
+            n=18, a=self._A, contrast=0.5,
+            vac_B=[133, 152, 171], dop_B={130: 1.9, 175: 0.45}, seed=2)
+        r = type_sublattice_defects(img, pos, n_sublattices=2, pixel_size_nm=0.1,
+                                    edge_margin_px=2.0 * self._A)
+        m = r["metrics"]
+        assert "error" not in m
+        assert len(m["sublattices"]) == 2
+        found_vac = [(d["x"], d["y"]) for d in m["vacancies"]]
+        found_dop = [(d["x"], d["y"]) for d in m["dopants"]]
+        assert _match_count(found_vac, truth["vac"], tol=0.7 * self._A) >= 2
+        assert _match_count(found_dop, truth["dop"], tol=0.7 * self._A) >= 1
+
+    def test_clean_lattice_no_fabricated_defects(self):
+        img, pos, _ = _two_sublattice(n=18, a=self._A, contrast=0.5, seed=5)
+        r = type_sublattice_defects(img, pos, n_sublattices=2, pixel_size_nm=0.1,
+                                    edge_margin_px=2.0 * self._A)
+        m = r["metrics"]
+        assert "error" not in m
+        assert len(m["sublattices"]) == 2
+        assert m["n_vacancies"] <= 2          # clean -> ~no false vacancies
+        assert m["n_dopants"] <= 2            # clean -> ~no false dopants
+
+
+# --------------------------------------------------------------------------- #
+# lattice_discontinuity_map                                                   #
+# --------------------------------------------------------------------------- #
+class TestDiscontinuity:
+    def test_orientation_boundary_localized(self):
+        img = _bicrystal((512, 512), a=24, theta_deg=15.0, seed=1)
+        r = lattice_discontinuity_map(img, pixel_size_nm=0.1)
+        m = r["metrics"]
+        assert m["n_boundaries"] >= 1
+        xs = [b["centroid_px"][0] for b in m["boundaries"]]
+        assert any(abs(x - 256) < 70 for x in xs)            # near the seam
+        assert max(b["orient_change_deg"] for b in m["boundaries"]) > 6.0
+
+    def test_single_domain_no_boundary(self):
+        img = _bicrystal((512, 512), a=24, theta_deg=0.0, seed=2)
+        r = lattice_discontinuity_map(img, pixel_size_nm=0.1)
+        assert r["metrics"]["boundary_fraction"] < 0.15
+
+
+# --------------------------------------------------------------------------- #
+# map_polarization                                                            #
+# --------------------------------------------------------------------------- #
+class TestMapPolarization:
+    def test_uniform_field_recovered(self):
+        img, pos, _ = _two_sublattice(contrast=0.5, P_px=(2.5, 0.0), seed=1)
+        m = map_polarization(img, pos, pixel_size_nm=0.1)["metrics"]
+        assert "error" not in m
+        assert m["direction_coherence"] > 0.8
+        assert abs(m["median_magnitude_px"] - 2.5) < 0.8
+
+    def test_geometric_fallback_identical_Z(self):
+        # equal-Z cations -> intensity split unreliable -> geometric fallback
+        img, pos, _ = _two_sublattice(contrast=1.0, P_px=(2.5, 0.0),
+                                      domains=True, seed=2)
+        res = map_polarization(img, pos, pixel_size_nm=0.1)
+        assert "geometric_separation_used_intensity_ambiguous" in res["flags"]
+        assert res["metrics"]["direction_coherence"] > 0.8
+
+    def test_no_fabricated_field_single_sublattice(self):
+        img, pos = _single_square(seed=3)
+        res = map_polarization(img, pos, pixel_size_nm=0.1)
+        m = res["metrics"]
+        # honest failure: either no valid cells, or a flagged incoherent field
+        assert ("error" in m) or (m.get("direction_coherence", 0.0) < 0.5)

--- a/tests/test_atomic_stem_lattice_tools.py
+++ b/tests/test_atomic_stem_lattice_tools.py
@@ -325,3 +325,21 @@ class TestMapPolarization:
         m = res["metrics"]
         # honest failure: either no valid cells, or a flagged incoherent field
         assert ("error" in m) or (m.get("direction_coherence", 0.0) < 0.5)
+
+    def test_domain_segmentation_two_domains(self):
+        # two opposite domains (sign flip across the midline) -> tool should
+        # report >=2 domains, a wall, and a SMALL net (domains cancel)
+        img, pos, _ = _two_sublattice(contrast=0.5, P_px=(2.6, 0.0),
+                                      domains=True, seed=4)
+        m = map_polarization(img, pos, pixel_size_nm=0.1)["metrics"]
+        assert m["n_domains"] >= 2
+        assert m["wall_fraction"] > 0.02
+        assert m["net_to_local_ratio"] < 0.6        # opposite domains cancel
+
+    def test_uniform_field_single_domain_offset_indicator(self):
+        # one uniform direction -> one domain, and net ~ per-cell magnitude
+        img, pos, _ = _two_sublattice(contrast=0.5, P_px=(2.6, 0.0),
+                                      domains=False, seed=5)
+        m = map_polarization(img, pos, pixel_size_nm=0.1)["metrics"]
+        assert m["n_domains"] == 1
+        assert m["net_to_local_ratio"] > 0.7        # uniform: net ~ |P|


### PR DESCRIPTION
## Summary

Adds three atomic-resolution STEM analysis capabilities to the `atomic_stem` skill, plus the routing/robustness fixes that let the agent reach them reliably — and a layer of cross-agent codegen/verifier/annealing hardening that the live runs surfaced as necessary.

- **Ferroelectric polarization maps** (`map_polarization`): measures, per unit cell, how far the off-centering cation is displaced from the centre of its surrounding cage — the ferroelectric order parameter. Its direction maps domains and its discontinuities map domain walls. Works on perovskite-type two-sublattice lattices and, for near-identical-Z cations where intensity can't tell the sublattices apart, falls back automatically to a geometric separation. On weak/near-noise-floor fields it now reports the field as *disordered* rather than inventing domains, and clips physically-impossible per-cell magnitudes.
- **Per-sublattice point-defect typing** (`type_sublattice_defects`): separates the sublattices, then flags vacancies (missing columns) and substitutional dopants (intensity outliers) *within each sublattice* — so a dopant isn't misfiled by a global intensity split. Dopants now report a physical `intensity_ratio` (and a sanity-capped z) so a real substitution on a very uniform sublattice isn't dismissed as an "impossible" outlier.
- **Grain/twin/interface + stacking-fault mapping** (`lattice_discontinuity_map`): localizes and classifies structural boundaries from orientation and spacing changes — and detects layer-parallel **stacking faults / antiphase boundaries**, which shift the lattice translationally with no orientation or spacing change (invisible to the translation-invariant power spectrum) via a real-space lateral-shift check.

Supporting fixes: DCNN detection works on 2D/TMD lattices and picks its resampling scale by vision; the agent no longer mis-reads a resolved two-sublattice lattice as "single sublattice" and declines; `target_pixel_size` units (Ångströms) are unmissable; the per-column defect-typing route is named (`type_sublattice_defects`, not `fft_defect_map` alone) so subtle vacancies stop being under-recovered; and the |P| magnitude is a soft realistic flag, not a hard accept/reject gate.

Validated against ferroelectric ground truth (3 real samples, multi-crop, incl. a 9-crop GT-scored battery), planted-truth simulations, and a real+synthetic discontinuity battery; **20 offline unit tests**, plus live agent validation (Bedrock opus-4-8) across polarization, discontinuity, and defect cases.

---

## Technical details

**`map_polarization`** (`atom_finding.py:1146`). Refines positions sub-pixel → splits sublattices by intensity GMM with BIC over k∈{2,3} (brightest=reference, dimmest=displaced; ignores a middle population) → per displaced cation, offset from the centroid of its `n_cage` nearest reference neighbours. P = cage_centroid − displaced. Over-detection robustness via a reusable `_field()` helper (cage anchored on the reference-sublattice NN, accept only within `max_offset_frac·nn_ref`). **Outcome-based geometric fallback**: if the intensity-split field is incoherent/empty, retry via `local_env_gmm` and keep whichever yields higher `direction_coherence` (flag `geometric_separation_used_intensity_ambiguous`). Returns the domain segmentation as data (peak-clustered adaptive directions, `n_domains`, `wall_fraction`, per-cell `domain_label`, `net_to_local_ratio`).

*Weak-field / noise robustness (GT-driven).* The 9-crop GT-scored battery showed three failure modes on weak fields (~20 pm, near the position-fit noise floor); all now handled with exposed, documented knobs (robust defaults):
- **Per-cell |P| outlier handling.** A relative MAD clip (`magnitude_outlier_k`, 6 MAD) drops fit/pairing failures; an absolute physical ceiling (`max_magnitude_nm`, 120 pm — the MAD clip is magnitude-relative and lets a >physical tail through on strong fields) drops the rest. The ceiling-specific flag fires only on a systematic fraction (≥3%), so a 1% tail doesn't cry wolf.
- **Noise-gated domains.** A spurious multi-domain partition is collapsed to one `disordered` field (flag `field_noise_dominated_domains_unreliable`) when globally incoherent (`coherence < domain_coherence_floor`) **or** spatially fragmented (`wall_fraction > max_wall_fraction`) **and** locally incoherent (`local_coherence < local_coherence_floor`). The decisive signal is `local_coherence` (within-neighbourhood agreement) because it is **count/size-invariant** — a genuine multi-domain mosaic stays locally coherent (~0.95+) regardless of domain count/size or crop size, so it is never collapsed, while only true noise (fragmented **and** locally incoherent) is.
- **Figure.** Near-square 2×2 layout (a wide 1×3 strip collapsed to an unreadable sliver in the HTML report grid) with a **direction colour-wheel** legend; arrows coloured by direction (always-saturated hsv), magnitude scatter on a faint image so overlays are visible.

GT-validated on the crop battery: clean diagonal 2-domain preserved (coh 0.97), weak/flat fields reported disordered (were 1–3 spurious domains), single-domain crops correct, soft magnitude gate held 16–77 pm with no HALT loops. Limits in TOOL_SPEC: direction/domains robust, magnitude trustworthy only on clean detection.

**`type_sublattice_defects`** (`atom_finding.py:957`). Separates sublattices by **local environment** (`local_env_gmm`), not raw intensity; per sublattice flags vacancies (`vacancy_enclosure` gate) and dopants (amplitude outliers, `dopant_sigma`). **Dopant reporting fix:** on a very uniform sublattice (tiny MAD) a genuine substitution ~40% off-intensity scored an absurd robust z (~25) and was dismissed downstream as "physically impossible" — though the tool had detected it. Dopants now report a **sanity-capped z (±10)** plus a physical **`intensity_ratio`** (column / same-sublattice-neighbour median; <1 lighter, >1 heavier, near-background = vacancy not dopant); the TOOL_SPEC says to judge by `intensity_ratio` not the capped z, and to LOWER `dopant_sigma` for subtler cases. Real-data validated (LLTO 3/3 planted vacancies, 0 FP; sq_perovskite substitutions now reported with `z=−10, ratio 0.59` instead of an "impossible" −26).

**Defect routing** (`atomic_stem.md`). The vacancy/dopant-search bullet now names `type_sublattice_defects` as the **primary per-column typing route** (most sensitive to subtle vacancies), with `fft_defect_map` for periodicity/superstructure and as corroboration — and states that a `periodic=True` / zero-defect `fft_defect_map` result is **not** grounds to conclude "defect-free" for a point-defect-typing goal. (Fixes a regression where the agent took the single-call `fft_defect_map` shortcut and under-recovered planted vacancies.)

**`lattice_discontinuity_map`** (`discontinuity.py:45`). Sliding-window local orientation + spacing → dissimilarity field → connected-component boundary cells classified (grain/twin/interface/planar). **Stacking-fault discriminator** (`_lateral_shift`): the per-window descriptor is the power spectrum (translation-invariant), so a stacking fault / antiphase boundary is invisible to spectral dissimilarity. On every coherence-drop band the tool cross-correlates raw-image strips on each side (within ±½ period) and reports `lateral_shift_frac`: a fractional-period shift → reclassify as `stacking fault / antiphase boundary`. Purely additive (orientation/spacing boundaries untouched). Battery: 6/6 synthetic; real YBCO intergrowth now typed correctly (was misjudged a scan artifact).

**Cross-agent codegen/verifier/annealing hardening** (`instruct.py`, `controllers/*`, `_shared/_registry.py`). Live traces showed the *agent wrapper* (plan → codegen → verify → iterate) re-deriving, re-gating, and looping around correct deterministic tool results. Encoded as general principles (one sentence each, not trace phrases):
- **`TOOL_USE_PRINCIPLE`** (codegen + planning): use what a tool returns, don't re-derive it; keep the pipeline thin (call → read → report); base accept/reject on the tool's own QC fields, not an imposed numeric threshold.
- **visualization.png must hold the actual result** (both image codegen variants): a tool's headline `figure_bytes` goes directly into `visualization.png`; never a placeholder panel pointing to a side file (only `visualization.png` is embedded in the report and seen by the verifier). Fixes a run where the polarization maps were orphaned from the report.
- **`VERIFIER_TOOL_SCRUTINY_PRINCIPLE`** (image + curve verifiers): scrutinize a tool's result via its QC fields + domain physics + independent cross-checks, not by reimplementing the tool or instructing re-derivation; keep independent judgment where no tool vouches. Generalized across modalities. The image verifier also now receives the skill's `interpretation` (physics) section + dataset `system_info` (modality), so it stops applying a wrong-modality "illumination/flat-field" reflex to atomic-resolution HAADF.
- **Annealing, single-tool pipelines.** When a pipeline is effectively one registered-tool call, the T=1 "warm" rung was degenerate (re-tweaking params already exhausted at T=0). It now **self-gates** to a swap-tool rung (prefer a different registered tool; custom code only if no sibling fits); multi-step pipelines are unchanged. The level floor is front-loaded (adaptive to `max_verification_iterations`) so the permissive T=1 rung unlocks at iteration 1 while full-freedom T=2 stays a later resort.

**Verifier** (`image_analysis_controllers.py`): over-production feedback mode (correct-but-noisy ≠ wrong); domain-physics context injection (`interpretation` + modality) so plausibility judgements use the right physics; scrutiny principle wired in (above).

**Tests** (`tests/test_atomic_stem_lattice_tools.py`, **20 tests**, ~12 s, no DCNN): planted-truth recovery + knob-changes-behavior + no-false-positive controls for all four lattice/defect/ferroic tools; parametrized stacking-fault variants + disorder/orientation-spacing no-hijack regressions; map_polarization domain-segmentation + noise-collapse; type_sublattice_defects dopant z-cap / `intensity_ratio` invariants.

**Known follow-ups (not in this PR):** (1) sandboxed correction attempts re-run the full pipeline incl. cold DCNN (~300 s) → a generalizable transparent tool-cache is in progress; (2) `gpa_strain_map` can be over-called in a robustness loop and exceed the executor timeout; (3) low-score detection cases (mostly-vacuum crops, `target_pixel_size`-sweep difficulty) and `map_polarization` masking part of a field on a multi-grain crop are detection-stage issues, not analysis-stage; (4) best-of-N candidate escalation (`n_candidates`/`candidate_escalation`) damps run-to-run detection variance on the orchestrator path; (5) bicrystal grain-boundary case classifies correctly but scores low (orientation-metric / verifier calibration).
