### PR TITLE
verifier: tool-capability awareness + which-tools-ran + evidence-based retraction

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -4302,6 +4302,7 @@ Return JSON with:
                             "metric_value": _cur_metric,
                             "best_metric_value": _best_metric,
                             "metric_label": _metric_label,
+                            "tools_used": state.get("_last_tools_used", []),
                             "config_used": state.get("locked_fitting_config", {}),
                             "issues_found": verification.get("issues_found", []),
                             "overall_assessment": verification.get("overall_assessment", ""),
@@ -6069,6 +6070,7 @@ Return JSON with:
                 {
                     "r_squared": entry.get("r_squared"),
                     "annealing_level": entry.get("annealing_level", 0),
+                    "tools_used": entry.get("tools_used", []),
                     # The model in force at this iteration — lets a consumer
                     # (e.g. the self-evolution figure) show the per-attempt
                     # model alongside its R² and issues.

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -3747,7 +3747,10 @@ Remember: Rejecting a good fit ({metric_label} {accept_cmp} {accept_threshold:.2
                     if _hits:
                         with open(_hits[0]) as _sf:
                             _src = _sf.read()
-                _used = [n for n in _names if n in _src]
+                import re as _re
+                _used = [n for n in _names
+                         if _re.search(rf"\b{_re.escape(n)}\b", _src)]
+                state["_last_tools_used"] = _used   # persisted into quality_history
                 if _used:
                     prompt_parts.append(
                         "\n\n**Registered tools this iteration's script actually CALLED:** "

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -638,8 +638,14 @@ def build_verification_prompt_with_history(
         "caveat (the plateau/convergence rule takes precedence).",
         "3. If a previous fix was NOT applied due to an API error, "
         "re-suggest it or propose an alternative",
+        "4. A previously-raised issue may have been MISTAKEN. RETRACT it (drop it; "
+        "stop demanding fixes) when STRONG evidence shows the concern was unfounded "
+        "— the plot, a registered tool's documented behaviour/guarantees, clear "
+        "physics, or an independent cross-check. Absent strong evidence, keep "
+        "scrutinizing: 'persists' means still demonstrably real, not merely "
+        "un-disproven.",
     ])
-    
+
     return "\n".join(lines)
 
 
@@ -3717,6 +3723,12 @@ Remember: Rejecting a good fit ({metric_label} {accept_cmp} {accept_threshold:.2
         # (e.g. fit_pattern, fit_sideband_manifold) produced the fit, judge it by
         # the tool's QC + domain knowledge + cross-checks, not by re-deriving.
         from ....skills._shared._registry import VERIFIER_TOOL_SCRUTINY_PRINCIPLE
+        _tool_inv = _tool_inventory_text(state)
+        if _tool_inv:
+            prompt_parts.append(
+                "\n\n**REGISTERED TOOLS AVAILABLE TO THIS FIT** — judge the result "
+                "against what each tool actually does and what its outputs mean; do not "
+                "re-derive a failure mode the tool already controls for:\n" + _tool_inv)
         prompt_parts.append("\n\n" + VERIFIER_TOOL_SCRUTINY_PRINCIPLE)
 
         try:

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -3138,6 +3138,7 @@ Your guidance: '''
                     script, diagnosis = self._correct_script(state, script, last_error)
                     script_errors.append({"error": last_error, "diagnosis": diagnosis})
 
+                state["_verify_working_dir"] = str(item_dir)
                 run = stage_and_run(self.executor, script, curve_data, item_dir,
                                     aux=extra_operands)
                 exec_result = run["exec"]
@@ -3722,13 +3723,38 @@ Remember: Rejecting a good fit ({metric_label} {accept_cmp} {accept_threshold:.2
         # Scrutinize-don't-reimplement: when a registered curve-fitting tool
         # (e.g. fit_pattern, fit_sideband_manifold) produced the fit, judge it by
         # the tool's QC + domain knowledge + cross-checks, not by re-deriving.
-        from ....skills._shared._registry import VERIFIER_TOOL_SCRUTINY_PRINCIPLE
+        from ....skills._shared._registry import (
+            VERIFIER_TOOL_SCRUTINY_PRINCIPLE, get_tools_for)
         _tool_inv = _tool_inventory_text(state)
         if _tool_inv:
             prompt_parts.append(
                 "\n\n**REGISTERED TOOLS AVAILABLE TO THIS FIT** — judge the result "
                 "against what each tool actually does and what its outputs mean; do not "
                 "re-derive a failure mode the tool already controls for:\n" + _tool_inv)
+            # Which of those tools THIS iteration's script actually called
+            # (authoritative — the prose pipeline description can deviate from the
+            # executed code). Parsed from the saved fitting script; only the name
+            # list is injected, never the script source.
+            try:
+                import glob as _g
+                _wd = state.get("_verify_working_dir")
+                _names = [t.name for t in get_tools_for(
+                    "curve_fitting", active_skills=_active_skill_names(state))]
+                _src = ""
+                if _wd:
+                    _hits = (_g.glob(os.path.join(_wd, "scripts", "*.py"))
+                             or _g.glob(os.path.join(_wd, "*.py")))
+                    if _hits:
+                        with open(_hits[0]) as _sf:
+                            _src = _sf.read()
+                _used = [n for n in _names if n in _src]
+                if _used:
+                    prompt_parts.append(
+                        "\n\n**Registered tools this iteration's script actually CALLED:** "
+                        + ", ".join(_used) + " — apply each one's documented behaviour "
+                        "(above) when judging the result.")
+            except Exception:
+                pass
         prompt_parts.append("\n\n" + VERIFIER_TOOL_SCRUTINY_PRINCIPLE)
 
         try:

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -219,6 +219,12 @@ def build_verification_prompt_with_history(
         "2. If a fix didn't work, suggest something DIFFERENT",
         "3. If a previous fix was NOT applied due to an API error, "
         "re-suggest it or propose an alternative",
+        "4. A previously-raised issue may have been MISTAKEN. RETRACT it (drop it; "
+        "stop demanding fixes) when STRONG evidence shows the concern was unfounded "
+        "— the images, a registered tool's documented behaviour/guarantees, clear "
+        "physics, or an independent cross-check. Absent strong evidence, keep "
+        "scrutinizing: 'persists' means still demonstrably real, not merely "
+        "un-disproven.",
     ])
 
     return "\n".join(lines)
@@ -2929,7 +2935,38 @@ Return JSON:
                     + skill_sections["validation"]
                 )
 
-        from ....skills._shared._registry import VERIFIER_TOOL_SCRUTINY_PRINCIPLE
+        from ....skills._shared._registry import (
+            VERIFIER_TOOL_SCRUTINY_PRINCIPLE, format_tool_inventory, get_tools_for)
+        _active = _active_skill_names(state)
+        _tool_inv = format_tool_inventory("image_analysis", active_skills=_active)
+        if _tool_inv:
+            prompt_parts.append(
+                "\n\n**REGISTERED TOOLS AVAILABLE TO THIS ANALYSIS** — judge the result "
+                "against what each tool actually does and what its outputs mean; do not "
+                "re-derive or hypothesize a failure mode the tool already controls for:\n"
+                + _tool_inv)
+            # Which of those tools THIS iteration's script actually called
+            # (authoritative — the prose pipeline description above can deviate from
+            # the executed code). Parsed from the saved script in the working dir.
+            try:
+                import glob as _g
+                _wd = state.get("_verify_working_dir")
+                _names = [t.name for t in get_tools_for("image_analysis", active_skills=_active)]
+                _src = ""
+                if _wd:
+                    _hits = (_g.glob(os.path.join(_wd, "scripts", "*.py"))
+                             or _g.glob(os.path.join(_wd, "*.py")))
+                    if _hits:
+                        with open(_hits[0]) as _sf:
+                            _src = _sf.read()
+                _used = [n for n in _names if n in _src]
+                if _used:
+                    prompt_parts.append(
+                        "\n\n**Registered tools this iteration's script actually CALLED:** "
+                        + ", ".join(_used) + " — apply each one's documented behaviour "
+                        "(above) when judging the result.")
+            except Exception:
+                pass
         prompt_parts.append("\n\n" + VERIFIER_TOOL_SCRUTINY_PRINCIPLE)
 
         state["_last_verify_error"] = None

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -2959,7 +2959,10 @@ Return JSON:
                     if _hits:
                         with open(_hits[0]) as _sf:
                             _src = _sf.read()
-                _used = [n for n in _names if n in _src]
+                import re as _re
+                _used = [n for n in _names
+                         if _re.search(rf"\b{_re.escape(n)}\b", _src)]
+                state["_last_tools_used"] = _used   # persisted into quality_history
                 if _used:
                     prompt_parts.append(
                         "\n\n**Registered tools this iteration's script actually CALLED:** "
@@ -3620,6 +3623,7 @@ Return JSON with:
                         verification_history.append({
                             "quality_score": v_score,
                             "result_type": verification.get("result_type"),
+                            "tools_used": state.get("_last_tools_used", []),
                             "config_used": state.get("locked_analysis_config", {}),
                             "issues_found": verification.get("issues_found", []),
                             "overall_assessment": verification.get(
@@ -4720,6 +4724,7 @@ Return JSON with:
                         }
                         for iss in entry.get("issues_found", [])
                     ],
+                    "tools_used": entry.get("tools_used", []),
                     "fix_applied": entry.get("recommended_action", ""),
                 }
                 for entry in verification_history


### PR DESCRIPTION
## Summary

Gives the result-verifier the context it was missing, so it stops fighting correct deterministic tool outputs. Surfaced by a YBCO stacking-fault run where the verifier kept demanding flat-field "proof" that a real lateral lattice shift wasn't a brightness artifact — even though the tool's shift metric is brightness-invariant by construction, and the verifier had no way to drop the mistaken objection.

Three changes (image + curve verifiers):
- **The verifier now sees the available tools' capabilities** — it judges a result against what each tool actually does and returns, instead of a generic imaging prior. (Previously that inventory only reached codegen/planning.)
- **It sees which tools the iteration actually ran** (image: parsed from the saved script), so capability-matching is authoritative rather than inferred from the prose pipeline description (which can deviate from the executed code).
- **It can retract a prior objection under strong evidence** — previously it could only escalate ("still persists? try a different fix"), so a wrong concern ratcheted into ever-heavier proof demands. Now a mistaken issue can be dropped when the images, a tool's documented behaviour, physics, or a cross-check show it was unfounded; absent strong evidence it keeps scrutinizing.

This is a robustness / per-iteration-floor improvement (best-of-N already rescues the final output); its highest value is the single-candidate path, where nothing rescues a spiraling verdict.

---

## Technical details

- `image_analysis_controllers._verify_quality`: injects `format_tool_inventory("image_analysis", active_skills=…)`; then parses `scripts/analysis_script.py` in the stashed `_verify_working_dir` and lists the registered tools (`get_tools_for` names) the script actually called. Working dir is stashed in `state["_verify_working_dir"]` at both run sites.
- `curve_fitting_controllers._verify_fit_with_llm`: injects `_tool_inventory_text(state)` (curve inventory). (Used-tools-from-script parsing is image-only for now — curve fits are mostly all-codegen with few registered tools, and the curve working dir isn't stashed yet; clean follow-up.)
- `build_verification_prompt_with_history` (both controllers): added an evidence-gated retraction item to the `## IMPORTANT` framing — `RETRACT` under STRONG evidence; "persists" = still demonstrably real, not merely un-disproven.
- No new invariance schema — reuses the existing tool inventory (per request). For this to pay off, tools should document their guarantees in `TOOL_SPEC` (e.g. `lateral_shift_frac` brightness-invariance) — a content follow-up.
- 20/20 offline tests pass; both controllers import clean.
