### PR TITLE
litellm wrapper: retry transient provider errors (num_retries)

### DIFF
--- a/scilink/wrappers/litellm_wrapper.py
+++ b/scilink/wrappers/litellm_wrapper.py
@@ -244,6 +244,7 @@ def litellm_completion(*args, **kwargs):
     (or first positional arg) and scopes param-dropping to it before the call.
     """
     _scope_drop_params(kwargs.get("model") or (args[0] if args else None))
+    kwargs.setdefault("num_retries", 4)   # retry transient provider errors w/ backoff
     return litellm.completion(*args, **kwargs)
 
 
@@ -369,6 +370,11 @@ class LiteLLMGenerativeModel:
                 api_base=self.base_url,
                 stream=stream,
                 timeout=self.timeout,
+                # Retry transient provider errors (Bedrock ServiceUnavailable /
+                # InternalServer / RateLimit / Timeout) with LiteLLM's exponential
+                # backoff, so a momentary hiccup during e.g. a verification call is
+                # not mistaken for a failed step (which would tag the iteration 0.0).
+                num_retries=params.pop("num_retries", 4),
                 **params
             )
             


### PR DESCRIPTION
## Summary

A transient Bedrock `ServiceUnavailableError` during a verification call was caught as "verification failed, skipping" → the iteration was tagged **score 0.0** → the loop fell to the judge with a degraded picture and escalated to best-of-N unnecessarily. The error is transient ("Try your request again"), not a quality verdict.

Adds `num_retries=4` (LiteLLM exponential backoff; retryable set includes ServiceUnavailable / InternalServer / RateLimit / Timeout) to both `LiteLLMWrapper.generate_content` (verification + codegen path) and the shared `litellm_completion` helper (meta / sim paths). Callers can override via `num_retries`.

## Technical details
- `scilink/wrappers/litellm_wrapper.py`: `generate_content` passes `num_retries=params.pop('num_retries', 4)`; `litellm_completion` does `kwargs.setdefault('num_retries', 4)`. No behavior change on success; only transient-error paths now retry instead of propagating as a skipped step.