### PR TITLE
NMR curve-fitting + relaxation skills: new fitters, honesty guards, and generalizable decision rules

### DIFF
--- a/scilink/skills/curve_fitting/nmr/detection.py
+++ b/scilink/skills/curve_fitting/nmr/detection.py
@@ -1,0 +1,218 @@
+"""Detection-significance guard for low-SNR 1D NMR fits.
+
+The skill rightly tells the agent to *recover* weak, broad resonances (common
+for low-γ quadrupolar nuclei like ⁶⁷Zn, ²⁵Mg, ³³S near their detection limit)
+rather than declaring "no signal". But that guidance has no counterweight: on a
+spectrum that is essentially noise, a flexible Voigt+baseline model will still
+report a confident-looking fit (a high peak-region R²) by fitting the noise —
+overstating a measurement the data cannot support.
+
+``assess_detection`` supplies the missing test. It estimates the noise robustly
+from the signal-free wings, measures the peak SNR, and — when given the fitted
+model — runs an F-test of "peak present" vs. "baseline only" (extra-sum-of-
+squares). It returns a graded verdict:
+
+  * ``"detected"``  — SNR above the Rose criterion AND the peak model is
+                      statistically justified → fit and report normally.
+  * ``"marginal"``  — some excess but not significant → report the shift/width
+                      with a wide uncertainty or as an upper bound; do not claim
+                      a precise lineshape.
+  * ``"absent"``    — indistinguishable from noise → report a non-detection
+                      (intensity upper bound), do NOT report a fitted lineshape.
+
+The thresholds are the standard ones (Rose-criterion SNR, an F-test α), not
+tuned to any spectrum; the noise and SNR are measured from the data at run time.
+This is a *diagnostic* — it never edits the fit, it tells the agent and the
+verifier whether the fit is supportable.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence
+
+import numpy as np
+from scipy import stats
+
+
+def _robust_noise(resid: np.ndarray) -> float:
+    med = np.median(resid)
+    mad = np.median(np.abs(resid - med))
+    return float(1.4826 * mad) or float(np.std(resid)) or 1.0
+
+
+def _has_contiguous_feature(yb: np.ndarray, noise: float, k: float, min_run: int) -> tuple[bool, float]:
+    """Is there a *resolved* feature — ``min_run`` contiguous points above
+    ``k·noise`` — and if so what is its peak |amplitude|?
+
+    A single-point max/σ is the wrong detection test on a long spectrum: the
+    maximum of N noise samples is ~√(2·lnN)·σ (≈4σ for a few thousand points),
+    so a per-point threshold flags pure noise. A genuine resonance instead spans
+    several contiguous points; requiring a contiguous run removes that
+    extreme-value false alarm while still catching a real broad line.
+    """
+    mask = np.abs(yb) > k * noise
+    best = 0.0
+    i, n = 0, len(mask)
+    while i < n:
+        if mask[i]:
+            j = i
+            while j < n and mask[j]:
+                j += 1
+            if j - i >= min_run:
+                best = max(best, float(np.max(np.abs(yb[i:j]))))
+            i = j
+        else:
+            i += 1
+    return best > 0.0, best
+
+
+def assess_detection(
+    x: Sequence[float],
+    y: Sequence[float],
+    y_fit: Optional[Sequence[float]] = None,
+    baseline: Optional[Sequence[float]] = None,
+    n_model_params: Optional[int] = None,
+    snr_detect: float = 3.0,
+    snr_quantify: float = 10.0,
+    alpha: float = 0.01,
+) -> dict[str, Any]:
+    """Grade whether an NMR resonance is real enough to fit/quantify.
+
+    Estimates noise from the signal-free region, computes the peak SNR, and (if
+    ``y_fit`` and ``n_model_params`` are given) F-tests the peak model against a
+    baseline-only model. Returns ``verdict`` ∈ {detected, marginal, absent}, the
+    measured ``snr``, the F-test ``p_value``, an intensity ``upper_bound`` for a
+    non-detection, and a ``recommendation`` string.
+
+    ``snr_detect`` (Rose criterion, default 3) is the floor for a real feature;
+    ``snr_quantify`` (default 10, the textbook quantitative-NMR SNR floor) the
+    floor for a quantitative lineshape; ``alpha``
+    the F-test significance. Defaults are standard, not sample-specific.
+    """
+    x = np.asarray(x, float)
+    y = np.asarray(y, float)
+    base = (np.asarray(baseline, float) if baseline is not None
+            else np.full_like(y, np.median(y)))
+    yb = y - base
+
+    # Noise from points the data itself calls signal-free (robust to the peak).
+    coarse = np.abs(yb) <= 3.0 * _robust_noise(yb)
+    noise = _robust_noise(yb[coarse]) if coarse.sum() > 50 else _robust_noise(yb)
+    noise = noise or 1.0
+    point_amp = float(np.max(np.abs(yb)))           # single-point max (reported)
+    has_feature, feat_amp = _has_contiguous_feature(yb, noise, snr_detect, min_run=3)
+    # SNR of the resolved feature drives the verdict; fall back to the point max
+    # only for reporting when nothing is resolved.
+    peak_amp = feat_amp if has_feature else point_amp
+    snr = peak_amp / noise
+
+    # F-test: does the peak model explain variance beyond a flat baseline?
+    p_value = None
+    f_stat = None
+    if y_fit is not None and n_model_params:
+        y_fit = np.asarray(y_fit, float)
+        n = y.size
+        ss_full = float(np.sum((y - y_fit) ** 2))
+        ss_base = float(np.sum((y - base) ** 2))
+        p_full = int(n_model_params)
+        p_base = 1  # baseline-only (constant/known background)
+        df1 = max(p_full - p_base, 1)
+        df2 = max(n - p_full, 1)
+        if ss_full > 0 and ss_base > ss_full:
+            f_stat = ((ss_base - ss_full) / df1) / (ss_full / df2)
+            p_value = float(stats.f.sf(f_stat, df1, df2))
+        else:
+            p_value = 1.0
+
+    significant = (p_value is not None) and (p_value < alpha)
+    # A resonance is real if it is RESOLVED (a contiguous feature) or if the
+    # peak model is statistically justified over a flat baseline (F-test) — the
+    # latter rescues a broad, shallow line that never clears the per-point
+    # threshold. Pure noise satisfies neither. The F-test, when run, can also
+    # downgrade an apparent feature the model does not actually justify.
+    real = has_feature or significant
+    if not real:
+        verdict = "absent"
+        rec = ("No resolved feature (no run of points above the noise) and the "
+               "fit is not justified over a flat baseline. Report a "
+               "NON-DETECTION with an intensity upper bound; do NOT report a "
+               "fitted peak — a high peak-region R² here is overfitting the "
+               "noise. Recommend more scans / longer acquisition.")
+    elif has_feature and (p_value is not None) and not significant:
+        verdict = "marginal"
+        rec = ("Apparent peak is NOT statistically justified over a flat "
+               "baseline (F-test). Report the shift as tentative with a wide "
+               "uncertainty / as an upper bound; do not claim a precise "
+               "lineshape, linewidth, or quantitative integral.")
+    elif snr >= snr_quantify:
+        verdict = "detected"
+        rec = ("Signal well above noise — fit and report the lineshape "
+               "(shift, width) normally.")
+    else:
+        verdict = "detected"
+        rec = ("Weak but real resonance (above the Rose criterion / F-test "
+               "justified, but below the quantitative-SNR floor). Recover it; "
+               "report shift and width WITH explicit uncertainty, and flag that "
+               "quantification is SNR-limited.")
+
+    return {
+        "verdict": verdict,
+        "snr": float(snr),
+        "has_resolved_feature": bool(has_feature),
+        "noise": float(noise),
+        "peak_amplitude": peak_amp,
+        "f_stat": (float(f_stat) if f_stat is not None else None),
+        "p_value": p_value,
+        "significant": bool(significant) if p_value is not None else None,
+        "upper_bound": float(snr_detect * noise),
+        "snr_detect": float(snr_detect),
+        "snr_quantify": float(snr_quantify),
+        "recommendation": rec,
+    }
+
+
+from ..._shared._spec import ToolSpec  # noqa: E402  (kept next to the spec below)
+
+TOOL_SPEC = ToolSpec(
+    name="assess_detection",
+    description=(
+        "Grade whether an NMR resonance is real enough to fit and quantify, so a "
+        "near-noise spectrum is not 'fit' into a confident-looking lineshape. "
+        "Estimates noise from the signal-free region, computes the peak SNR, and "
+        "(given the fit) F-tests the peak model against a baseline-only model. "
+        "Returns a verdict — detected / marginal / absent — with an SNR, p-value, "
+        "intensity upper bound, and a recommended reporting action. The "
+        "counterweight to 'recover weak lines': recover a real broad resonance, "
+        "but abstain (report a non-detection / upper bound) when the data cannot "
+        "support a fit."
+    ),
+    import_line="from scilink.skills.curve_fitting.nmr.detection import assess_detection",
+    signature=(
+        "assess_detection(x, y, y_fit=None, baseline=None, n_model_params=None, "
+        "snr_detect=3.0, snr_quantify=10.0, alpha=0.01) -> dict"
+    ),
+    parameters={
+        "x": {"type": "list[float]", "description": "Chemical-shift axis (ppm)."},
+        "y": {"type": "list[float]", "description": "Spectrum intensity."},
+        "y_fit": {"type": "list[float]", "description": "Fitted model on x (optional). Provide it (with n_model_params) to enable the F-test of peak-vs-baseline; omit for an SNR-only screen before fitting."},
+        "baseline": {"type": "list[float]", "description": "Fitted baseline on x (default: median of y)."},
+        "n_model_params": {"type": "int", "description": "Number of free parameters in the peak model (e.g. 4 per Voigt + 1 offset). Needed for the F-test; the test is skipped if omitted."},
+        "snr_detect": {"type": "float", "description": "Rose-criterion SNR floor for a real feature (default 3). Below this → 'absent'."},
+        "snr_quantify": {"type": "float", "description": "SNR floor for a quantitative lineshape (default 10, the textbook quantitative-NMR floor). Between snr_detect and this → recover the line but report SNR-limited, with explicit uncertainty."},
+        "alpha": {"type": "float", "description": "F-test significance level (default 0.01)."},
+    },
+    required=["x", "y"],
+    returns=(
+        "dict with 'verdict' (detected/marginal/absent), 'snr', 'p_value', "
+        "'significant', 'upper_bound', and a 'recommendation'. Use it to decide "
+        "whether to report a fitted lineshape or a non-detection / upper bound."
+    ),
+    when_to_use=(
+        "Any low-SNR or low-γ spectrum (⁶⁷Zn, ²⁵Mg, ³³S, dilute species) where it "
+        "is unclear whether there is a quantifiable resonance — run it before "
+        "trusting a fit, and again with the fit to F-test it. Skip it for an "
+        "obviously strong, high-SNR peak."
+    ),
+)
+
+TOOL_SPECS = [TOOL_SPEC]

--- a/scilink/skills/curve_fitting/nmr/multiplet.py
+++ b/scilink/skills/curve_fitting/nmr/multiplet.py
@@ -1,0 +1,341 @@
+"""Constrained first-order J-coupled multiplet fitting for 1D NMR.
+
+A scalar-coupled resonance (a doublet, triplet, quartet, …) is a *single*
+chemical environment split into ``m`` equally-spaced lines by ``J``. Fitting it
+as ``m`` independent Voigts is badly under-determined: the lines share one
+chemical shift, one linewidth, and a fixed (binomial, for first-order coupling
+to equivalent spin-½ neighbours) intensity pattern, yet a free multi-Voigt fit
+has ~4·m free parameters that can wander into split/merged/asymmetric solutions
+and is sensitive to the starting guess.
+
+``fit_jcoupled_multiplet`` imposes the physics instead: the whole manifold is
+parametrized by just **(centroid, J, σ, γ, amplitude, offset)** — one shift, one
+coupling, one shared Voigt lineshape, binomial (or caller-supplied) relative
+intensities — regardless of how many lines there are. That collapses a quartet
+from ~16 free parameters to 6, removing the instability while still returning the
+quantity of interest: the coupling constant ``J`` (in Hz) and the underlying
+(coupling-free) chemical shift and linewidth.
+
+General by construction, not tuned to any sample: the multiplicity and J are
+inferred from the data (or supplied by the caller), the intensity pattern is the
+physical binomial law, and the lineshape is a standard Voigt. For a single
+uncoupled line use a 1-component Voigt; for several *distinct chemical
+environments* (different shifts) use ``fit_multipeak_voigt``; for a quadrupolar
+powder lineshape use ``fit_quad_ct``.
+"""
+
+from __future__ import annotations
+
+from math import comb
+from typing import Any, Optional, Sequence
+
+import numpy as np
+from scipy.optimize import least_squares
+from scipy.signal import find_peaks
+from scipy.special import wofz
+
+from ..._shared._spec import ToolSpec
+from .quality import peak_region_r2
+
+
+def _voigt_height_norm(x, c, sigma, gamma):
+    """Voigt profile normalized to unit peak height (so amp == line height)."""
+    sigma = max(abs(sigma), 1e-6)
+    gamma = max(abs(gamma), 1e-9)
+    z = ((x - c) + 1j * gamma) / (sigma * np.sqrt(2.0))
+    z0 = (1j * gamma) / (sigma * np.sqrt(2.0))
+    return np.real(wofz(z)) / np.real(wofz(z0))
+
+
+def _fwhm(sigma, gamma):
+    """Olivero-Longbothum Voigt FWHM approximation."""
+    fg = 2.0 * sigma * np.sqrt(2.0 * np.log(2.0))
+    fl = 2.0 * gamma
+    return 0.5346 * fl + np.sqrt(0.2166 * fl * fl + fg * fg)
+
+
+def _pattern_weights(multiplicity: int, pattern) -> np.ndarray:
+    """Relative line intensities, normalized so the tallest line is 1.0.
+
+    ``"binomial"`` gives the first-order coupling pattern (Pascal's triangle):
+    a doublet 1:1, triplet 1:2:1, quartet 1:3:3:1, … i.e. C(m-1, k). A list/tuple
+    is taken verbatim (must match ``multiplicity``) for non-binomial cases.
+    """
+    if isinstance(pattern, (list, tuple, np.ndarray)):
+        w = np.asarray(pattern, float)
+        if w.size != multiplicity:
+            raise ValueError(
+                f"pattern has {w.size} weights but multiplicity={multiplicity}")
+    elif pattern == "binomial":
+        n = multiplicity - 1
+        w = np.array([comb(n, k) for k in range(multiplicity)], float)
+    elif pattern == "uniform":
+        w = np.ones(multiplicity, float)
+    else:
+        raise ValueError(f"unknown pattern {pattern!r}")
+    return w / (w.max() or 1.0)
+
+
+def _line_centers(centroid: float, J_ppm: float, multiplicity: int) -> np.ndarray:
+    """Equally-spaced line positions symmetric about the centroid."""
+    k = np.arange(multiplicity) - (multiplicity - 1) / 2.0
+    return centroid + k * J_ppm
+
+
+def _model(x, centroid, J_ppm, sigma, gamma, amp, offset, weights):
+    out = np.full_like(x, offset, dtype=float)
+    for c, w in zip(_line_centers(centroid, J_ppm, len(weights)), weights):
+        out = out + amp * w * _voigt_height_norm(x, c, sigma, gamma)
+    return out
+
+
+def _autodetect(x, y, noise):
+    """Seed (multiplicity, centroid, J_ppm) from regularly-spaced maxima.
+
+    Returns ``None`` when fewer than two clear lines are present (caller should
+    pass ``multiplicity`` explicitly, or treat as a singlet).
+    """
+    # Sub-peaks that clear BOTH an absolute noise floor and a relative floor
+    # (a fraction of the tallest line), AND have real PROMINENCE. The prominence
+    # requirement is essential: without it, noise ripples on the rounded top of a
+    # broad line register as dozens of spurious sub-maxima and wreck the spacing
+    # estimate. Prominence demands each counted line stand out from its
+    # surroundings, so only genuine, separated lines survive.
+    ymax = float(np.max(y))
+    floor = max(4.0 * noise, 0.05 * ymax)
+    pk, props = find_peaks(y, height=floor, prominence=max(3.0 * noise, 0.05 * ymax),
+                           distance=3)
+    if pk.size < 2:
+        return None
+    # Order by position; estimate spacing from consecutive gaps (median is robust
+    # to a missing weak outer line).
+    xs = np.sort(x[pk])
+    gaps = np.diff(xs)
+    J_ppm = float(np.median(gaps))
+    if J_ppm <= 0:
+        return None
+    # Multiplicity from the span / spacing (rounded); centroid = intensity-weighted.
+    span = xs[-1] - xs[0]
+    m = int(round(span / J_ppm)) + 1
+    m = max(2, min(m, pk.size))  # don't claim more lines than detected maxima
+    centroid = float(np.average(x[pk], weights=props["peak_heights"]))
+    return m, centroid, J_ppm
+
+
+def _envelope_width(x, y, noise, k=3.0, min_run=3):
+    """ppm extent of the signal envelope (first→last *contiguous* run above
+    ``k·noise``).
+
+    For a multiplet of known line count this gives a robust J seed —
+    ``≈ (m-1)·J`` from outer line to outer line — without needing to resolve the
+    individual lines, which noise on broad lines can defeat. Contiguous runs
+    (not bare min/max of all above-threshold points) are required so that
+    isolated noise spikes far from the multiplet do not blow out the width.
+    """
+    mask = np.abs(y - np.median(y)) > k * noise
+    runs = []
+    i, n = 0, len(mask)
+    while i < n:
+        if mask[i]:
+            j = i
+            while j < n and mask[j]:
+                j += 1
+            if j - i >= min_run:
+                runs.append((i, j - 1))
+            i = j
+        else:
+            i += 1
+    if not runs:
+        return None
+    return float(x[runs[-1][1]] - x[runs[0][0]])
+
+
+def fit_jcoupled_multiplet(
+    x: Sequence[float],
+    y: Sequence[float],
+    baseline: Optional[Sequence[float]] = None,
+    multiplicity: Optional[int] = None,
+    pattern: "str | Sequence[float]" = "binomial",
+    nu_L_MHz: Optional[float] = None,
+    J_hz: Optional[float] = None,
+    center_ppm: Optional[float] = None,
+    allow_negative: bool = False,
+) -> dict[str, Any]:
+    """Fit a first-order J-coupled multiplet as one constrained manifold.
+
+    The manifold is ``multiplicity`` equally-spaced Voigt lines sharing one
+    centroid, one coupling ``J``, one (σ, γ) lineshape, and fixed ``pattern``
+    intensities — fit with just 6 free parameters (centroid, J, σ, γ, amplitude,
+    offset). ``multiplicity``/``J``/``center`` are seeded from the data when not
+    given. Crop ``x``/``y`` to the multiplet first.
+
+    Returns the coupling constant (Hz and ppm), the coupling-free chemical shift
+    and linewidth, the per-line positions/intensities, the fit, and the
+    peak-region quality. ``nu_L_MHz`` is needed to report J and widths in Hz.
+    """
+    x = np.asarray(x, float)
+    y0 = np.asarray(y, float)
+    base = np.zeros_like(y0) if baseline is None else np.asarray(baseline, float)
+    y = y0 - base
+    order = np.argsort(x)
+    x, y, base = x[order], y[order], base[order]
+
+    noise = 1.4826 * np.median(np.abs(y - np.median(y))) or float(np.std(y)) or 1.0
+    span = float(x.max() - x.min())
+    sgn = -1.0 if (allow_negative and abs(y.min()) > abs(y.max())) else 1.0
+
+    # --- seed multiplicity / centroid / J from the data when not supplied -----
+    det = _autodetect(x, sgn * y, noise)
+    if multiplicity is None:
+        multiplicity = det[0] if det else 1
+    if center_ppm is None:
+        center_ppm = det[1] if det else float(x[np.argmax(np.abs(y))])
+    multiplicity = max(1, int(multiplicity))
+    if J_hz is not None and nu_L_MHz:
+        J_ppm0 = float(J_hz) / float(nu_L_MHz)
+    elif multiplicity > 1:
+        # Two J estimates: the per-line spacing (det[2]) and the envelope width
+        # /(m-1). The per-line value is sharp when lines are cleanly resolved but
+        # is wrong when a narrow noisy line splits into several detected maxima;
+        # the envelope (outer-to-outer extent over (m-1) gaps) is the robust
+        # cross-check. Trust det only when the two AGREE; otherwise use the
+        # envelope. This is the crucial guard against a bad seed (which lets the
+        # manifold collapse onto the central line).
+        W = _envelope_width(x, sgn * y, noise)
+        J_env = (W / (multiplicity - 1)) if W else None
+        J_det = det[2] if det else None
+        if J_det and J_env and 0.4 * J_env <= J_det <= 1.6 * J_env:
+            J_ppm0 = J_det
+        elif J_env:
+            J_ppm0 = J_env
+        elif J_det:
+            J_ppm0 = J_det
+        else:
+            J_ppm0 = span / max(multiplicity * 4, 8)
+    else:
+        J_ppm0 = span / max(multiplicity * 4, 8)  # singlet: J unused
+    weights = _pattern_weights(multiplicity, pattern)
+
+    # --- bounds & initial guess ----------------------------------------------
+    amax = float(np.max(np.abs(y)) * 5 + 1e-30)
+    wlo = max(span / len(x), 1e-4)
+    whi = span / 2.0
+    a0 = sgn * float(np.max(np.abs(y)))
+    # J lower bound: for a resolved multiplet J ≫ linewidth, so floor J at a
+    # fraction of the data-seeded spacing. This blocks the failure mode where the
+    # optimizer collapses all lines onto the dominant central line (J→0) and fits
+    # the manifold as one fat peak — a strong local minimum for a 1:2:1 triplet.
+    J_floor = max(wlo, 0.2 * J_ppm0) if multiplicity > 1 else wlo
+
+    def resid(p):
+        return _model(x, p[0], p[1], p[2], p[3], p[4], p[5], weights) - y
+
+    def _fit_from(sg_seed, j_anchor=False):
+        jlo = (0.7 * J_ppm0 if j_anchor else J_floor)
+        jhi = (1.3 * J_ppm0 if j_anchor else whi)
+        p0 = [center_ppm, min(max(J_ppm0, jlo), jhi), sg_seed, sg_seed, a0, 0.0]
+        lo = [x.min(), jlo, wlo, wlo, (-amax if allow_negative else 0.0), -amax]
+        hi = [x.max(), jhi, whi, whi, amax, amax]
+        if multiplicity == 1:  # no coupling: pin J at its floor (don't fit it)
+            lo[1], hi[1] = J_floor, J_floor + 1e-9   # strict lo<hi for least_squares
+            p0[1] = J_floor
+        p0 = [min(max(v, l), h) for v, l, h in zip(p0, lo, hi)]
+        r = least_squares(resid, p0, bounds=(lo, hi), method="trf",
+                          x_scale="jac", max_nfev=800)
+        yf = _model(x, *r.x[:6], weights)
+        return r.x, peak_region_r2(x.tolist(), y.tolist(), yf.tolist())["peak_region_r2"]
+
+    # Multi-start over the shared linewidth seed (the lineshape is the part the
+    # data-seed is weakest on): a narrow line vs a J/4-broad start can land in
+    # different basins. The final start ANCHORS J near the data-seeded spacing —
+    # it cannot collapse (all lines onto the centre) or run away (lines off the
+    # data), so it reliably anchors a good fit whenever the seed is sound. Keep
+    # the best peak-region R² across starts, so an anchored start never hurts.
+    base_w = (J_ppm0 if multiplicity > 1 else span / 100.0)
+    starts = [(0.25, False), (0.1, False), (0.04, False)]
+    if multiplicity > 1:
+        starts.append((0.1, True))
+    best = None
+    for frac, anchor in starts:
+        sg = max(min(base_w * frac, whi), 1.5 * wlo)
+        try:
+            xr_, r2_ = _fit_from(sg, j_anchor=anchor)
+        except Exception:
+            continue
+        if best is None or r2_ > best[1]:
+            best = (xr_, r2_)
+    centroid, J_ppm, sigma, gamma, amp, offset = best[0]
+    y_fit = _model(x, centroid, J_ppm, sigma, gamma, amp, offset, weights)
+    q = peak_region_r2(x.tolist(), y.tolist(), y_fit.tolist())
+
+    centers = _line_centers(centroid, J_ppm, multiplicity)
+    fwhm_ppm = float(_fwhm(sigma, gamma))
+    nu = float(nu_L_MHz) if nu_L_MHz else None
+    return {
+        "multiplicity": int(multiplicity),
+        "pattern": (list(map(float, weights)) if not isinstance(pattern, str) else pattern),
+        "center_ppm": float(centroid),
+        "J_ppm": float(J_ppm) if multiplicity > 1 else 0.0,
+        "J_hz": (float(J_ppm * nu) if (nu and multiplicity > 1) else None),
+        "fwhm_ppm": fwhm_ppm,
+        "fwhm_hz": (fwhm_ppm * nu if nu else None),
+        "sigma_ppm": float(abs(sigma)),
+        "gamma_ppm": float(abs(gamma)),
+        "amplitude": float(amp),
+        "offset": float(offset),
+        "lines": [
+            {"center_ppm": float(c), "rel_intensity": float(w), "height": float(amp * w)}
+            for c, w in zip(centers, weights)
+        ],
+        "total_area": float(amp * fwhm_ppm * float(weights.sum())),
+        "fit_quality": {"peak_region_r2": q["peak_region_r2"], "r_squared": q["r_squared"]},
+        "y_fit": (y_fit + base).tolist(),
+    }
+
+
+TOOL_SPEC = ToolSpec(
+    name="fit_jcoupled_multiplet",
+    description=(
+        "Fit a first-order J-coupled NMR multiplet (doublet, triplet, quartet, …) "
+        "as ONE constrained manifold: m equally-spaced Voigt lines sharing a "
+        "single chemical shift, one coupling constant J, one Voigt linewidth, and "
+        "a fixed binomial intensity pattern — just 6 free parameters regardless of "
+        "the number of lines. Far more stable than fitting m independent Voigts, "
+        "and it returns J directly. Use for a SINGLE coupled environment; for "
+        "several distinct chemical shifts use fit_multipeak_voigt, and for a "
+        "quadrupolar powder lineshape use fit_quad_ct."
+    ),
+    import_line="from scilink.skills.curve_fitting.nmr.multiplet import fit_jcoupled_multiplet",
+    signature=(
+        "fit_jcoupled_multiplet(x, y, baseline=None, multiplicity=None, "
+        "pattern='binomial', nu_L_MHz=None, J_hz=None, center_ppm=None, "
+        "allow_negative=False) -> dict"
+    ),
+    parameters={
+        "x": {"type": "list[float]", "description": "Chemical-shift axis (ppm). Crop to the multiplet for a stable fit."},
+        "y": {"type": "list[float]", "description": "Spectrum intensity over the multiplet."},
+        "baseline": {"type": "list[float]", "description": "Fitted baseline on x (or omit if pre-subtracted)."},
+        "multiplicity": {"type": "int", "description": "Number of lines (2=doublet, 3=triplet, 4=quartet, …). Omit to auto-detect from the regularly-spaced sub-peaks; pass it explicitly when you can read the line count off the spectrum."},
+        "pattern": {"type": "str | list[float]", "description": "Relative line intensities. 'binomial' (default) = first-order coupling to equivalent spin-½ neighbours (1:1, 1:2:1, 1:3:3:1, …). 'uniform' for equal intensities, or pass an explicit symmetric list for an irregular pattern."},
+        "nu_L_MHz": {"type": "float", "description": "Larmor frequency of the observed nucleus (MHz), from spectrometer_frequency_MHz. Required to report J and linewidths in Hz."},
+        "J_hz": {"type": "float", "description": "Optional initial guess for the coupling constant (Hz); refined by the fit. Omit to seed J from the observed line spacing."},
+        "center_ppm": {"type": "float", "description": "Optional initial guess for the multiplet centroid (ppm); omit to seed from the data."},
+        "allow_negative": {"type": "bool", "description": "Permit an inverted (negative) multiplet for a 180°-phased spectrum (default False)."},
+    },
+    required=["x", "y"],
+    returns=(
+        "dict with 'multiplicity', 'J_hz'/'J_ppm', the coupling-free 'center_ppm' "
+        "and 'fwhm_ppm'/'fwhm_hz', per-line 'lines' (center_ppm/rel_intensity), "
+        "'total_area', 'fit_quality' (peak_region_r2, r_squared), and 'y_fit'."
+    ),
+    when_to_use=(
+        "A resolved scalar-coupled multiplet from ONE chemical environment — any "
+        "doublet/triplet/quartet/… of equally-spaced lines with a binomial "
+        "(1:1, 1:2:1, 1:3:3:1, …) intensity ratio — when the coupling constant J "
+        "is the deliverable. Use it instead of fitting the lines as independent "
+        "Voigts. NOT for separate chemical environments (use fit_multipeak_voigt) "
+        "or a single uncoupled line (a 1-component Voigt)."
+    ),
+)
+
+TOOL_SPECS = [TOOL_SPEC]

--- a/scilink/skills/curve_fitting/nmr/nmr.md
+++ b/scilink/skills/curve_fitting/nmr/nmr.md
@@ -30,11 +30,16 @@ dictates the lineshape:
   quadrupolar nuclei show an asymmetric **second-order quadrupolar
   central-transition** lineshape that carries C_Q and η_Q.
 
-**Out of scope (v0):** 2D experiments; J-coupling multiplet structure (treat
-resolved multiplets as separate peaks); satellite transitions, MQMAS, CSA
-tensor extraction from sideband intensities; relaxation/T1–T2 series (a separate
-"integral vs. delay" task, not a single-spectrum fit); raw-FID reprocessing
-(this skill works on the processed spectrum).
+**Resolved J-coupled multiplets** (a doublet/triplet/quartet from one chemical
+environment, e.g. a CF₃ carbon split by fluorines) are fit as ONE constrained
+manifold with `fit_jcoupled_multiplet`, not as independent Voigts — see the
+routing in Implementation.
+
+**Out of scope (v0):** 2D experiments; second-order / non-binomial multiplet
+patterns (roofing, second-order strong coupling); satellite transitions, MQMAS,
+CSA tensor extraction from sideband intensities; relaxation/T1–T2 series (a
+separate "integral vs. delay" task, not a single-spectrum fit); raw-FID
+reprocessing (this skill works on the processed spectrum).
 
 ## planning
 
@@ -61,6 +66,17 @@ A weak, broad, or inverted line (common for low-γ quadrupolar nuclei like ⁶�
 ²⁵Mg, ³³S near their detection limit) is still a resonance — recover it rather
 than declaring "no signal" and fitting baseline only.
 
+**But abstain when the data cannot support a fit — the counterweight to "recover
+weak lines".** On a near-noise spectrum a flexible Voigt+baseline model will
+"succeed" by fitting the noise, reporting a confident lineshape and a high
+peak-region R² for a measurement that is not there. Before trusting a low-SNR
+fit, run `assess_detection` (see Implementation): it returns a verdict —
+**detected** (fit and report), **marginal** (report the shift tentatively / as an
+upper bound, no precise linewidth or integral), or **absent** (report a
+NON-DETECTION with an intensity upper bound; do not report a fitted peak). A
+resonance must be either a resolved contiguous feature OR statistically justified
+over a flat baseline (F-test); a high R² alone does not make it real.
+
 **Step 2 — Correct a rolling baseline BEFORE fitting.** Processed spectra
 (especially ¹H MAS) frequently carry a broad oscillating baseline distortion
 (first-point / digital-filter / probe-background artifact — wide humps and deep
@@ -76,8 +92,7 @@ flat and need none. (See Implementation for the recipe.)
 |---|---|
 | Solution-state, any nucleus | Sum of **Voigt** (Lorentzian-dominant); use a pure Lorentzian only if the Gaussian width refines to ~0 |
 | Solid MAS, spin-½ (¹³C, ³¹P, ¹⁹F, ¹H) | Sum of **Voigt** centrebands; account for sidebands (Step 4) |
-| Solid MAS, half-integer quadrupolar, **symmetric narrow** line | **pseudo-Voigt** — and report FWHM, *not* C_Q (see below) |
-| Solid MAS, half-integer quadrupolar, **visibly asymmetric / broad** line | second-order quadrupolar central-transition lineshape via `fit_quad_ct` |
+| Solid MAS, half-integer quadrupolar | **`fit_quad_ct`** — attempt it by *default* (C_Q/η_Q is the deliverable); do not pre-judge "looks symmetric → skip it". The tool returns `Cq_resolved`: if False, fall back to a **pseudo-Voigt** and report FWHM, not C_Q (Step 5). A broad, washed-out *disordered* line → **`fit_quad_czjzek`**. |
 
 Default to **Voigt over pure Lorentzian** — real NMR lines carry a Gaussian
 (shim/disorder) contribution, and a pure Lorentzian over-peaks the apex.
@@ -90,21 +105,31 @@ sidebands as satellites at ±k·ν_r sharing the centreband's shape. **Either wa
 any integrated-intensity / quantification claim must include sideband intensity**
 — excluding it undercounts. Verify the spacing equals the known MAS rate.
 
-**Step 5 — When to use the quadrupolar lineshape (and when not).** The
-central-transition second-order lineshape pins C_Q and η_Q **only when it is
-resolved** — i.e. the quadrupolar broadening clearly exceeds the
-instrumental/disorder broadening, giving a visibly asymmetric line with
-"horn"+"foot" structure. For a narrow, near-symmetric quadrupolar line, C_Q and
-the linewidth are **degenerate** (a smaller C_Q + more broadening fits equally
-well); `fit_quad_ct` returns a `Cq_resolved=False` flag in that case — then
-treat C_Q as an upper bound and report the pseudo-Voigt FWHM as the primary
-descriptor, recommending MQMAS / satellite-transition data to pin C_Q.
+**Step 5 — Let the tool, not the eye, decide whether C_Q is determined.** For a
+solid half-integer quadrupolar line, *run* `fit_quad_ct` rather than pre-judging
+from the apparent symmetry — the second-order lineshape pins C_Q and η_Q only
+when the quadrupolar broadening exceeds the instrumental/disorder broadening, and
+the tool reports this for you via `Cq_resolved`. When `Cq_resolved=True`, report
+C_Q/η_Q. When `Cq_resolved=False` (a narrow, near-symmetric line where C_Q and the
+linewidth are **degenerate**), treat C_Q as an upper bound and report the
+pseudo-Voigt FWHM as the primary descriptor, recommending MQMAS / satellite data
+to pin C_Q. Either way you have *attempted* the physics and let the fit — not a
+visual guess — set whether C_Q is reportable.
 
-**Series fits (composition / temperature / treatment ladders).** Lock the model
-(number of sites, lineshape, baseline strategy) across the series; let
-shift/width/amplitude (and C_Q/η_Q where resolved) float per spectrum. The
-scientific signal is then a single per-sample column (e.g. δ_iso vs. x,
-linewidth vs. T) read across the series.
+**Series fits (composition / temperature / treatment ladders).** Lock the *form*
+— lineshape type and baseline strategy — across the series so shifts and widths
+stay comparable, and let shift/width/amplitude (and C_Q/η_Q where resolved) float
+per spectrum. **Do NOT lock the number of components.** The structure can change
+along the series — a new phase or site appearing/disappearing, a line splitting
+under slow exchange, a polymorph emerging — and that change is usually the
+scientific signal, not noise to suppress. At each point let the data set the
+component count under the same parsimony test you use for a single spectrum (add
+a component only if it materially improves the peak-region fit; drop one that
+refines to negligible amplitude). Report **two** things across the series: the
+per-sample parameter column (e.g. δ_iso vs x, C_Q vs x, linewidth vs T) **and the
+component count vs the variable** — the value(s) of the variable where the count
+changes mark the transition / onset. Do not assume the number of components is
+fixed (or that it is one); let it be whatever the data justify at each point.
 
 ## implementation
 
@@ -153,10 +178,54 @@ to Hz with the Larmor frequency for reporting. (Edge case the tool does not
 robustly separate: two peaks at the *same* shift differing only in width
 — a sharp+broad co-centred pair; fit those manually if present.)
 
-**Routing — which fitter:** one symmetric line → single Voigt; several distinct
-chemical shifts → `fit_multipeak_voigt`; a single *asymmetric quadrupolar*
-powder line → `fit_quad_ct` (do NOT mimic a quadrupolar lineshape with a stack
-of Voigts).
+**J-coupled multiplet fitting** (a resolved doublet/triplet/quartet from ONE
+chemical environment — equally-spaced lines with a binomial 1:1 / 1:2:1 / 1:3:3:1
+intensity ratio). Do NOT fit these as independent Voigts (badly under-determined,
+unstable, and it discards the coupling). Use the constrained manifold fitter,
+which shares one shift, one J, one linewidth across all lines (6 parameters total)
+and returns J directly:
+
+```python
+from scilink.skills.curve_fitting.nmr.multiplet import fit_jcoupled_multiplet
+# crop x/y to the multiplet. Pass the line count you read off the spectrum as
+# `multiplicity` (4 for a quartet); omit it to auto-detect. nu_L_MHz gives J in Hz.
+res = fit_jcoupled_multiplet(xroi.tolist(), yroi.tolist(), baseline=base.tolist(),
+                             multiplicity=4, nu_L_MHz=NU_L)
+# res['J_hz'], res['center_ppm'] (coupling-free shift), res['fwhm_hz']
+```
+
+A multiplet is one *environment*: two coupled species at different shifts are two
+calls (or `fit_multipeak_voigt` for the centroids). This handles first-order
+binomial coupling only — for second-order / roofing patterns fall back to
+`fit_multipeak_voigt`.
+
+**Disordered (Czjzek) quadrupolar lineshape.** A *disordered* solid — amorphous,
+glassy, a solid solution, or heavily defective — does not have one well-defined
+(C_Q, η); every site sees a slightly different EFG, so the central transition is
+the average over a *distribution* of (C_Q, η). The line is then broad and
+**smoothly skewed with the sharp single-site horns washed out**, and neither a
+pseudo-Voigt nor a single-site `fit_quad_ct` reproduces it (they leave systematic
+residual — `residual_structured=True`). Fit it with the Czjzek model, which
+returns the EFG-distribution width σ_Cz:
+
+```python
+from scilink.skills.curve_fitting.nmr.quadrupolar import fit_quad_czjzek
+res = fit_quad_czjzek(ppm_roi.tolist(), y_roi.tolist(), nu_L_MHz=NU_L, I=1.5)
+# res['parameters']: sigma_cz_MHz (disorder width), mean_Cq_MHz, delta_iso_ppm
+```
+
+Decide single-site vs Czjzek by the lineshape and the residual: visible, sharp
+horns → `fit_quad_ct`; washed-out, smoothly skewed, or `fit_quad_ct` leaves
+`residual_structured=True` → `fit_quad_czjzek`. (Solution-state quadrupolar
+nuclei tumble fast → plain Voigt, neither model.)
+
+**Routing — which fitter:** one symmetric uncoupled line → single Voigt; a
+resolved J-coupled multiplet (equal spacing, binomial ratio) → `fit_jcoupled_multiplet`;
+several distinct chemical shifts → `fit_multipeak_voigt`; a single *asymmetric
+quadrupolar* powder line with sharp horns → `fit_quad_ct`; a *broad, disordered*
+quadrupolar line (washed-out horns) → `fit_quad_czjzek` (do NOT mimic a
+quadrupolar lineshape with a stack of Voigts). For any low-SNR spectrum, gate the
+result with `assess_detection` before reporting (see Planning Step 1).
 
 **Let the residual drive escalation — don't stop at a single component while
 structure remains.** After any fit, inspect the residual *within the peak
@@ -168,6 +237,18 @@ it to `fit_multipeak_voigt`; for a half-integer quadrupolar line whose residual
 shows the characteristic asymmetric foot, try `fit_quad_ct` (one quadrupolar
 site) before adding Voigts. This is residual-driven, not nucleus-driven — apply
 it whenever a single symmetric component leaves real structure behind.
+
+**A gate-passing fit is not automatically done.** If `peak_region_r2` clears the
+gate but `residual_structured` is True, the (pseudo-)Voigt is the wrong *model*
+(it returns no C_Q / J), so re-fit with the matching physical model and compare.
+Trigger on the `residual_structured` flag only — it is calibrated on the
+signal-relative `apex_resid_frac` / `resid_rms_frac`; do not escalate on
+`apex_resid_over_noise` or `frac_resid_gt_3sigma`, which stay large even for a
+perfect fit of a high-SNR line. Keep whichever fit has the lower `resid_rms_frac`
+and clears the flag — **never adopt a model that fits worse** — and make sure the
+physical model represents every site/environment the line actually contains (a
+multi-site line needs a multi-site model). Fall back to the (pseudo-)Voigt with a
+stated limitation when no physical model improves it.
 
 **Second-order quadrupolar central transition** (solid half-integer, resolved
 asymmetric line): call the skill tool — it does the orientation-averaged powder
@@ -182,6 +263,21 @@ p, d = res["parameters"], res["derived"]
 # Honor d["Cq_resolved"]: if False, report p["Cq_MHz"] as an upper bound only.
 ```
 
+**Detection check for low-SNR spectra.** When the signal is weak or the nucleus
+is insensitive (low-γ, dilute), screen the result before reporting a lineshape:
+
+```python
+from scilink.skills.curve_fitting.nmr.detection import assess_detection
+# pass the fit and its free-parameter count to enable the peak-vs-baseline F-test.
+det = assess_detection(x.tolist(), y.tolist(), y_fit=y_fit.tolist(),
+                       n_model_params=n_params, baseline=baseline.tolist())
+# det["verdict"] in {detected, marginal, absent}; honor det["recommendation"].
+```
+
+If the verdict is **absent**, report a non-detection with `det["upper_bound"]`,
+not a fitted peak; if **marginal**, report the shift with a wide uncertainty and
+no quantitative integral.
+
 **Quality metric (MANDATORY — the gate scores by `peak_region_r2`).** NMR's
 wide digitized window makes a whole-window R² meaningless for a narrow peak
 (noise dominates the variance), so after fitting, compute the peak-region R²
@@ -195,6 +291,16 @@ from scilink.skills.curve_fitting.nmr.quality import peak_region_r2
 q = peak_region_r2(x.tolist(), y.tolist(), y_fit.tolist(), baseline=baseline.tolist())
 # q["peak_region_r2"] is the gate metric; q["r_squared"] is the global value.
 ```
+
+**A high `peak_region_r2` is necessary but not sufficient — also read the
+residual-structure diagnostics the same call returns.** `q["residual_structured"]`
+is True when the residual is both large relative to the peak height
+(`q["apex_resid_frac"]`) and systematically correlated (`q["resid_autocorr_lag1"]`
+near 1, `q["frac_resid_gt_3sigma"]` high) — the signature of a fit that misses
+where the signal is (an unmodeled shoulder, a wrong lineshape, a quadrupolar foot
+forced into a Voigt) even at R² ≈ 0.96. When it is True, escalate the model
+(add an environment, switch to `fit_quad_ct` / `fit_jcoupled_multiplet`) rather
+than accept the fit on R² alone.
 
 Emit `FIT_RESULTS_JSON:` with `fit_quality` containing **`peak_region_r2`** (the
 gate metric) and the global `r_squared`, plus per-peak δ (ppm) and width
@@ -274,7 +380,12 @@ intensity envelope encodes the CSA (spin-½) or the satellite/CSA interplay
   as a measurement only when resolved; otherwise as an upper bound with an
   MQMAS/satellite recommendation. Watch for η railing to 0 or 1 (poorly
   determined) — reported in `reliability_flags`.
-- **Cross-series consistency.** In a composition/temperature ladder, δ_iso and
-  linewidth should vary smoothly; an outlier spectrum usually means a
-  mis-assigned sideband, an uncorrected baseline, or a phase flip — re-inspect
-  rather than accept a discontinuity.
+- **Cross-series consistency.** In a composition/temperature ladder the per-sample
+  parameters and the component count usually vary smoothly. A discontinuity has
+  two possible causes — distinguish them, don't assume it is an error: a
+  *spurious* jump from a mis-assigned sideband, an uncorrected baseline, or a
+  phase flip (re-inspect and fix), versus a *real* structural transition — a new
+  phase/site appearing, a peak splitting — which is a genuine result to report
+  with the variable value at which it occurs. A locked-count model will hide the
+  latter, so verify the count is data-driven before calling a discontinuity an
+  artifact.

--- a/scilink/skills/curve_fitting/nmr/quadrupolar.py
+++ b/scilink/skills/curve_fitting/nmr/quadrupolar.py
@@ -282,6 +282,210 @@ def fit_quad_ct(
 
 
 # --------------------------------------------------------------------------
+#  Czjzek (distribution of EFGs) central-transition lineshape
+#
+#  Disordered / amorphous / glassy solids (and many defective or solid-solution
+#  crystalline phases) do not have ONE well-defined (C_Q, η); each site sees a
+#  slightly different electric-field gradient, so the central-transition line is
+#  the AVERAGE over a *distribution* of (C_Q, η). A single-site `fit_quad_ct`
+#  (sharp horns) or a plain pseudo-Voigt cannot reproduce the resulting smooth,
+#  skewed line — it leaves systematic residual structure (the failure mode the
+#  quality flag `residual_structured` flags on broad ²³Na/⁶⁷Zn solids).
+#
+#  The Czjzek Gaussian Isotropic Model (Czjzek et al., 1981) gives the standard
+#  EFG distribution, parametrized by a single width σ (MHz):
+#
+#      P(C_Q, η) ∝ C_Q⁴ · η · (1 − η²/9) · exp[ −C_Q²(1 + η²/3) / (2σ²) ]
+#
+#  The observed line is Σ over that distribution of the single-site CT lineshape.
+#  Because the CT pattern translates rigidly with δ_iso, we precompute a fixed
+#  (C_Q, η) lineshape basis ONCE and only re-weight it as σ varies — so the fit
+#  stays cheap.
+# --------------------------------------------------------------------------
+
+def _czjzek_weights(cq_grid: np.ndarray, eta_grid: np.ndarray, sigma: float) -> np.ndarray:
+    """Normalized Czjzek GIM weights on the (C_Q, η) grid for width ``sigma`` (MHz)."""
+    Cq, Eta = np.meshgrid(cq_grid, eta_grid, indexing="ij")
+    sig = max(float(sigma), 1e-6)
+    P = (Cq ** 4) * Eta * (1.0 - Eta ** 2 / 9.0) \
+        * np.exp(-(Cq ** 2) * (1.0 + Eta ** 2 / 3.0) / (2.0 * sig ** 2))
+    P = np.clip(P, 0.0, None)
+    s = float(P.sum())
+    return P / s if s > 0 else P
+
+
+def _czjzek_basis(grid_ppm, ref_delta, cq_grid, eta_grid, nu_L_MHz, I, mas,
+                  lw_intrinsic, n_theta, n_phi) -> np.ndarray:
+    """Area-normalized single-site CT lineshapes for every (C_Q, η), at ``ref_delta``."""
+    basis = np.empty((len(cq_grid), len(eta_grid), grid_ppm.size), float)
+    for i, cq in enumerate(cq_grid):
+        for j, et in enumerate(eta_grid):
+            L = simulate_quad_ct(grid_ppm, ref_delta, max(cq, 1e-3), et, nu_L_MHz, I=I,
+                                 lw_gauss_ppm=lw_intrinsic, lw_lorentz_ppm=lw_intrinsic,
+                                 amplitude=1.0, mas=mas, n_theta=n_theta, n_phi=n_phi)
+            s = float(L.sum())
+            basis[i, j] = L / s if s > 0 else L
+    return basis
+
+
+def simulate_quad_czjzek(
+    ppm: Sequence[float],
+    delta_iso: float,
+    sigma_cz_MHz: float,
+    nu_L_MHz: float,
+    I: float = 1.5,
+    lw_gauss_ppm: float = 0.5,
+    lw_lorentz_ppm: float = 0.5,
+    amplitude: float = 1.0,
+    mas: bool = True,
+    n_cq: int = 24,
+    n_eta: int = 6,
+    cq_max_MHz: float | None = None,
+    n_theta: int = 48,
+    n_phi: int = 24,
+) -> np.ndarray:
+    """Czjzek (distribution-of-EFG) central-transition lineshape on ``ppm``.
+
+    Averages the single-site CT lineshape over the Czjzek GIM distribution of
+    (C_Q, η) with width ``sigma_cz_MHz``, then applies residual Voigt broadening.
+    Returns intensity on ``ppm``. (For fitting use ``fit_quad_czjzek``, which
+    caches the basis.)
+    """
+    ppm = np.asarray(ppm, float)
+    cq_max = cq_max_MHz or max(4.0 * sigma_cz_MHz, 0.5)
+    cq_grid = np.linspace(0.05, cq_max, n_cq)
+    eta_grid = np.linspace(0.0, 1.0, n_eta)
+    lo, hi = float(ppm.min()), float(ppm.max())
+    pad = 0.05 * (hi - lo + 1e-9)
+    grid = np.linspace(lo - pad, hi + pad, min(8192, max(2048, ppm.size)))
+    dgrid = grid[1] - grid[0]
+    basis = _czjzek_basis(grid, delta_iso, cq_grid, eta_grid, nu_L_MHz, I, mas,
+                          max(3 * dgrid, 1e-6), n_theta, n_phi)
+    w = _czjzek_weights(cq_grid, eta_grid, sigma_cz_MHz)
+    czj = np.tensordot(w, basis, axes=([0, 1], [0, 1]))
+    kx = np.arange(-grid.size // 2, grid.size // 2) * dgrid
+    sigma = max(lw_gauss_ppm, 1e-6) / 2.3548
+    gamma = max(lw_lorentz_ppm, 1e-6) / 2.0
+    kernel = np.convolve(np.exp(-0.5 * (kx / sigma) ** 2),
+                         (gamma ** 2) / (kx ** 2 + gamma ** 2), mode="same")
+    kernel /= kernel.sum() + 1e-30
+    czj = np.convolve(czj, kernel, mode="same")
+    y = np.interp(ppm, grid, czj)
+    m = y.max()
+    return (y / m * amplitude) if m > 0 else y
+
+
+def fit_quad_czjzek(
+    ppm: Sequence[float],
+    intensity: Sequence[float],
+    nu_L_MHz: float,
+    I: float = 1.5,
+    mas: bool = True,
+    delta_iso_init: float | None = None,
+    bounds_sigma_cz_MHz: tuple[float, float] = (0.02, 4.0),
+    lw_ppm_init: float = 1.0,
+    bounds_delta_iso: tuple[float, float] | None = None,
+    n_cq: int = 24,
+    n_eta: int = 6,
+    n_theta: int = 64,
+    n_phi: int = 36,
+) -> dict[str, Any]:
+    """Fit a Czjzek distribution-broadened central-transition lineshape.
+
+    For a DISORDERED half-integer quadrupolar solid whose line is broad and
+    smoothly skewed (no sharp single-site horns) — the model averages the CT
+    lineshape over a Czjzek (C_Q, η) distribution of width σ. Returns
+    ``parameters`` (delta_iso_ppm, sigma_cz_MHz, mean_Cq_MHz, broadening,
+    amplitude, baseline), ``fit_quality`` (r_squared, rmse), and ``y_fit``.
+    Crop to the central transition and remove the background first.
+    """
+    x = np.asarray(ppm, float)
+    y = np.asarray(intensity, float)
+    order = np.argsort(x)
+    x, y = x[order], y[order]
+    yspan = float(np.nanmax(y) - np.nanmin(y)) or 1.0
+    if delta_iso_init is None:
+        delta_iso_init = float(x[np.argmax(y)])
+    if bounds_delta_iso is None:
+        bounds_delta_iso = (float(x.min()), float(x.max()))
+
+    # Fixed (C_Q, η) basis at a reference δ — large enough in C_Q to cover the
+    # upper σ bound. The CT pattern translates rigidly with δ_iso, so we shift
+    # the precomputed sum rather than rebuild the basis each iteration.
+    ref = delta_iso_init
+    cq_max = 4.0 * bounds_sigma_cz_MHz[1]
+    cq_grid = np.linspace(0.05, cq_max, n_cq)
+    eta_grid = np.linspace(0.0, 1.0, n_eta)
+    lo, hi = float(x.min()), float(x.max())
+    pad = 0.05 * (hi - lo + 1e-9)
+    grid = np.linspace(lo - pad, hi + pad, min(8192, max(2048, x.size)))
+    dgrid = grid[1] - grid[0]
+    basis = _czjzek_basis(grid, ref, cq_grid, eta_grid, nu_L_MHz, I, mas,
+                          max(3 * dgrid, 1e-6), n_theta, n_phi)
+    kx = np.arange(-grid.size // 2, grid.size // 2) * dgrid
+
+    def _shape(delta, sigma_cz, lw_g, lw_l):
+        czj = np.tensordot(_czjzek_weights(cq_grid, eta_grid, sigma_cz), basis,
+                           axes=([0, 1], [0, 1]))
+        if abs(delta - ref) > 1e-9:                      # rigid translation
+            czj = np.interp(grid - (delta - ref), grid, czj, left=0.0, right=0.0)
+        sg = max(lw_g, 1e-6) / 2.3548
+        gm = max(lw_l, 1e-6) / 2.0
+        ker = np.convolve(np.exp(-0.5 * (kx / sg) ** 2),
+                          (gm ** 2) / (kx ** 2 + gm ** 2), mode="same")
+        ker /= ker.sum() + 1e-30
+        czj = np.convolve(czj, ker, mode="same")
+        s = np.interp(x, grid, czj)
+        m = s.max()
+        return s / m if m > 0 else s
+
+    # p = [delta_iso, sigma_cz, lw_gauss, lw_lorentz, amplitude, baseline]
+    lo_b = [bounds_delta_iso[0], bounds_sigma_cz_MHz[0], 1e-3, 1e-3, 0.0, -abs(yspan)]
+    hi_b = [bounds_delta_iso[1], bounds_sigma_cz_MHz[1], 50.0, 50.0, 10.0 * yspan, abs(yspan)]
+
+    def resid(p):
+        d, scz, lg, ll, amp, base = p
+        return (base + amp * _shape(d, scz, lg, ll)) - y
+
+    base0, amp0 = float(np.nanmin(y)), yspan
+    best, best_cost = None, np.inf
+    for scz_seed in np.linspace(bounds_sigma_cz_MHz[0] * 2, bounds_sigma_cz_MHz[1] * 0.6, 4):
+        p0 = [delta_iso_init, scz_seed, lw_ppm_init, lw_ppm_init, amp0, base0]
+        p0 = [min(max(v, l), h) for v, l, h in zip(p0, lo_b, hi_b)]
+        try:
+            r = least_squares(resid, p0, bounds=(lo_b, hi_b), method="trf",
+                              x_scale="jac", max_nfev=300)
+        except Exception:
+            continue
+        if r.cost < best_cost:
+            best_cost, best = r.cost, r
+    res = best
+    yfit = res.x[5] + res.x[4] * _shape(res.x[0], res.x[1], res.x[2], res.x[3])
+    ss_res = float(np.sum((y - yfit) ** 2))
+    ss_tot = float(np.sum((y - np.mean(y)) ** 2)) or 1e-30
+    r2 = 1.0 - ss_res / ss_tot
+
+    d, scz, lg, ll, amp, base = res.x
+    w = _czjzek_weights(cq_grid, eta_grid, scz)
+    mean_cq = float(np.tensordot(w, np.meshgrid(cq_grid, eta_grid, indexing="ij")[0],
+                                 axes=([0, 1], [0, 1])))
+    return {
+        "parameters": {
+            "delta_iso_ppm": float(d), "sigma_cz_MHz": float(scz),
+            "mean_Cq_MHz": mean_cq, "lw_gauss_ppm": float(lg),
+            "lw_lorentz_ppm": float(ll), "amplitude": float(amp), "baseline": float(base),
+        },
+        "derived": {"spin_I": I, "regime": "MAS" if mas else "static",
+                    "model": "Czjzek GIM distribution of (C_Q, η)"},
+        "fit_quality": {"r_squared": float(r2),
+                        "rmse": float(np.sqrt(ss_res / max(len(y), 1)))},
+        "y_fit": yfit.tolist(),
+        "nu_L_MHz": nu_L_MHz,
+        "model_used": f"Czjzek distribution CT ({'MAS' if mas else 'static'}), I={I}",
+    }
+
+
+# --------------------------------------------------------------------------
 #  Tool registry
 # --------------------------------------------------------------------------
 
@@ -354,11 +558,61 @@ TOOL_SPEC_FIT = ToolSpec(
         "'fit_quality' (r_squared, rmse), and 'y_fit'."
     ),
     when_to_use=(
-        "A SOLID-state half-integer quadrupolar central transition with a "
-        "visibly asymmetric / quadrupolar-broadened line. For a symmetric "
-        "Lorentzian/Voigt (solution, or motionally narrowed), use a plain "
-        "Voigt instead."
+        "Any SOLID-state half-integer quadrupolar central transition where C_Q/η_Q "
+        "is the deliverable — run it by DEFAULT rather than pre-judging a line as "
+        "'too symmetric to bother'. It returns Cq_resolved=False when the line "
+        "cannot determine C_Q, which is the signal to fall back to reporting a "
+        "linewidth. NOT for solution / motionally-narrowed lines (fast tumbling "
+        "gives a plain Lorentzian/Voigt)."
     ),
 )
 
-TOOL_SPECS = [TOOL_SPEC_SIMULATE, TOOL_SPEC_FIT]
+TOOL_SPEC_CZJZEK = ToolSpec(
+    name="fit_quad_czjzek",
+    description=(
+        "Fit a Czjzek distribution-broadened second-order quadrupolar "
+        "central-transition lineshape — for a DISORDERED / amorphous / glassy or "
+        "solid-solution half-integer quadrupolar solid whose line is broad and "
+        "smoothly skewed with NO sharp single-site horns. Models the line as an "
+        "average of CT lineshapes over a Czjzek (C_Q, η) distribution of width σ, "
+        "which a single-site fit_quad_ct or a pseudo-Voigt cannot reproduce. "
+        "Returns σ_Cz (the EFG-distribution width) and the mean C_Q."
+    ),
+    import_line="from scilink.skills.curve_fitting.nmr.quadrupolar import fit_quad_czjzek",
+    signature=(
+        "fit_quad_czjzek(ppm, intensity, nu_L_MHz, I=1.5, mas=True, "
+        "delta_iso_init=None, bounds_sigma_cz_MHz=(0.02,4.0), lw_ppm_init=1.0, "
+        "bounds_delta_iso=None, n_cq=24, n_eta=6, n_theta=64, n_phi=36) -> dict"
+    ),
+    parameters={
+        "ppm": {"type": "list[float]", "description": "Chemical-shift axis (ppm). Crop to the central-transition region first."},
+        "intensity": {"type": "list[float]", "description": "Spectrum intensity (background pre-removed)."},
+        "nu_L_MHz": {"type": "float", "description": "Larmor frequency (MHz) — REQUIRED, from metadata."},
+        "I": {"type": "float", "description": "Nuclear spin: 1.5 for ²³Na/⁶⁷Zn (⁶⁷Zn is I=5/2 — set 2.5); 2.5 for ²⁷Al/¹⁷O/²⁵Mg. Set to the observed nucleus."},
+        "mas": {"type": "bool", "description": "True for MAS data (infinite-MAS lineshape); False for static/wideline. Match the acquisition."},
+        "delta_iso_init": {"type": "float", "description": "Initial chemical-shift guess (ppm); default = peak max."},
+        "bounds_sigma_cz_MHz": {"type": "tuple", "description": "(lo, hi) bounds for the Czjzek width σ in MHz (default (0.02, 4.0)). RAISE the upper bound for very broad lines / large-C_Q nuclei; the internal C_Q grid auto-scales to 4× this upper bound."},
+        "lw_ppm_init": {"type": "float", "description": "Initial residual (instrumental/extra) broadening in ppm (default 1.0)."},
+        "bounds_delta_iso": {"type": "tuple", "description": "(lo, hi) bounds for the chemical shift (ppm); default = data range."},
+        "n_cq": {"type": "int", "description": "C_Q grid points for the distribution average (default 24). Increase for a sharper σ estimate; decrease for speed."},
+        "n_eta": {"type": "int", "description": "η grid points for the distribution average (default 6)."},
+        "n_theta": {"type": "int", "description": "Polar powder-averaging grid for each basis lineshape (default 64)."},
+        "n_phi": {"type": "int", "description": "Azimuthal powder-averaging grid (default 36)."},
+    },
+    required=["ppm", "intensity", "nu_L_MHz"],
+    returns=(
+        "dict with 'parameters' (delta_iso_ppm, sigma_cz_MHz, mean_Cq_MHz, "
+        "linewidths, amplitude, baseline), 'fit_quality' (r_squared, rmse), and "
+        "'y_fit'."
+    ),
+    when_to_use=(
+        "A DISORDERED-solid half-integer quadrupolar line (amorphous / glassy / "
+        "solid-solution / heavily defective), where the EFG-distribution width "
+        "σ_Cz is the deliverable. Fit it alongside single-site fit_quad_ct and keep "
+        "whichever fits better: a single well-defined site favors fit_quad_ct, a "
+        "distribution of sites (washed-out horns, or systematic residual left by a "
+        "single site) favors this. NOT for solution / motionally-narrowed lines."
+    ),
+)
+
+TOOL_SPECS = [TOOL_SPEC_SIMULATE, TOOL_SPEC_FIT, TOOL_SPEC_CZJZEK]

--- a/scilink/skills/curve_fitting/nmr/quality.py
+++ b/scilink/skills/curve_fitting/nmr/quality.py
@@ -60,6 +60,8 @@ def peak_region_r2(
     dilate: int = 5,
     model_frac: float = 0.02,
     min_points: int = 15,
+    struct_apex_frac: float = 0.15,
+    struct_autocorr: float = 0.9,
 ) -> dict[str, Any]:
     """R² over the signal region only (see module docstring).
 
@@ -99,11 +101,50 @@ def peak_region_r2(
     global_r2 = _r2(np.ones_like(y, dtype=bool))
     fell_back = int(sig.sum()) < min_points
     region_r2 = global_r2 if fell_back else _r2(sig)
+
+    # --- residual-structure diagnostics (over the signal region) -------------
+    # A high R² can still hide a fit that misses where the signal actually is:
+    # on a tall, finely-sampled peak the variance is dominated by the apex, so a
+    # systematic apex/shoulder miss barely moves R² yet leaves large, correlated
+    # residuals. These quantities expose that — judge a fit by them, not R² alone.
+    rmask = sig if not fell_back else np.ones_like(y, dtype=bool)
+    resid = (y - y_fit)[rmask]
+    peak_height = float(np.max(np.abs(y[rmask] - base[rmask]))) or 1.0
+    if resid.size >= 4 and np.std(resid) > 0:
+        apex_over_noise = float(np.max(np.abs(resid)) / noise)
+        apex_frac = float(np.max(np.abs(resid)) / peak_height)
+        autocorr = float(np.corrcoef(resid[:-1], resid[1:])[0, 1])
+        frac_gt_3 = float(np.mean(np.abs(resid) > 3.0 * noise))
+        # SNR-ROBUST overall-misfit size: RMS residual as a fraction of the peak
+        # height. Unlike apex_resid_over_noise / frac_resid_gt_3sigma (both
+        # noise-relative, so they are large even for a PERFECT fit of a very
+        # high-SNR peak — e.g. ~0.8 of points exceed 3σ on a clean ¹⁹F line),
+        # this is normalized to the signal, so it measures how far the fit is
+        # from the data in physically meaningful (fraction-of-peak) terms.
+        resid_rms_frac = float(np.sqrt(np.mean(resid ** 2)) / peak_height)
+    else:
+        apex_over_noise = apex_frac = autocorr = frac_gt_3 = resid_rms_frac = 0.0
+    # "Structured" = the residual is SYSTEMATIC (high lag-1 autocorrelation, i.e.
+    # not random noise) AND SEVERE at the apex (a large miss relative to the peak
+    # height — judging on the fraction, not σ, so ultra-high-SNR peaks aren't
+    # false-flagged and a localized cusp miss is still caught). frac_resid_gt_3sigma
+    # is returned for context but deliberately NOT an AND-gate: a finely-sampled
+    # good fit can have many sub-percent residuals (high frac_gt_3, tiny apex) and
+    # must not be flagged. Thresholds are tunable knobs; raw values always returned.
+    structured = bool(autocorr > struct_autocorr and apex_frac > struct_apex_frac)
+
     return {
         "peak_region_r2": float(region_r2),
         "r_squared": float(global_r2),
         "n_signal_points": int(sig.sum()),
         "fell_back_to_global": bool(fell_back),
+        # Residual-structure diagnostics (added; do not replace peak_region_r2):
+        "apex_resid_over_noise": apex_over_noise,
+        "apex_resid_frac": apex_frac,
+        "resid_autocorr_lag1": autocorr,
+        "frac_resid_gt_3sigma": frac_gt_3,
+        "resid_rms_frac": resid_rms_frac,
+        "residual_structured": structured,
     }
 
 
@@ -131,12 +172,25 @@ TOOL_SPEC = ToolSpec(
         "dilate": {"type": "int", "description": "Points to grow the signal mask on each side, to include peak wings (default 5). Increase for broad lines so the wings are scored; decrease for very sharp lines."},
         "model_frac": {"type": "float", "description": "Also count points where the fitted model exceeds this fraction of its own max as signal (default 0.02) — so the metric scores where the model claims peaks even if data there is weak."},
         "min_points": {"type": "int", "description": "If fewer than this many signal points are found, fall back to the global R² (default 15) — guards the metric when there is essentially no signal."},
+        "struct_apex_frac": {"type": "float", "description": "Threshold on apex_resid_frac (largest residual as a fraction of peak height) for the residual_structured flag (default 0.15 = a ≥15% apex miss). The raw value is always returned; raise it to flag only gross misfits, lower it to be stricter."},
+        "struct_autocorr": {"type": "float", "description": "Threshold on lag-1 residual autocorrelation for residual_structured (default 0.9) — near 1 means a systematic (non-random) residual rather than noise."},
     },
     required=["x", "y", "y_fit"],
     returns=(
         "dict with 'peak_region_r2', global 'r_squared', 'n_signal_points', "
-        "and 'fell_back_to_global'. Put 'peak_region_r2' (and 'r_squared') into "
-        "the fit_quality block of FIT_RESULTS_JSON."
+        "'fell_back_to_global', and residual-structure diagnostics over the "
+        "signal region. Judge fit adequacy by the SIGNAL-RELATIVE quantities — "
+        "'apex_resid_frac' (largest residual / peak height) and 'resid_rms_frac' "
+        "(RMS residual / peak height) — together with 'resid_autocorr_lag1'. "
+        "NOTE: 'apex_resid_over_noise' and 'frac_resid_gt_3sigma' are "
+        "NOISE-relative and are therefore large even for a PERFECT fit of a "
+        "high-SNR peak (e.g. ~0.8 of points exceed 3σ on a clean line) — do not "
+        "read them as misfit on their own. 'residual_structured' (boolean) = "
+        "systematic (autocorr high) AND severe at the apex (apex_resid_frac "
+        "above threshold). Put 'peak_region_r2' and 'r_squared' into the "
+        "fit_quality block; if 'residual_structured' is True the fit has the "
+        "wrong MODEL where the signal is — escalate (see the skill), don't accept "
+        "it on R² alone."
     ),
     when_to_use=(
         "Always, as the final quality step of an NMR fit — the skill's quality "

--- a/scilink/skills/curve_fitting/nmr_relaxation/nmr_relaxation.md
+++ b/scilink/skills/curve_fitting/nmr_relaxation/nmr_relaxation.md
@@ -43,11 +43,16 @@ model-type field if the metadata carries one) and pass it to `fit_relaxation`.
 An inversion recovery is signed (negative at short t); never force its amplitude
 positive.
 
-**Decide mono vs stretched.** Start mono-exponential (β = 1). Use a **stretched
-exponent (β < 1)** when a single τ underfits — a systematic residual that a mono-
-exponential leaves, typical of a **disordered solid / glassy electrolyte / broad
-quadrupolar line** (e.g. ²³Na, ⁷Li in a solid electrolyte). Solution-state and
-clean crystalline sites are almost always mono-exponential.
+**Decide mono vs stretched — by the system, then let β decide; don't drop β on a
+gate pass.** For a **disordered / glassy / solid-electrolyte / broad-quadrupolar**
+system, β (the width of the relaxation-time distribution) IS a deliverable, so fit
+**stretched by default** and read β: if it refines to ~1 within its uncertainty
+the relaxation is effectively mono-exponential; otherwise β < 1 quantifies the
+heterogeneity (smaller β = broader distribution). Do **not** default to mono and
+omit β just because a mono fit clears the R² gate — a gate-passing mono fit on a
+disordered solid silently discards the disorder measurement that is the point of
+the experiment. **Solution-state and clean crystalline sites** are genuinely
+mono-exponential (β = 1) — use mono there.
 
 **Decide one vs two components.** Two relaxation times (`n_components=2`) when
 the residual of a single-component fit is systematic and the sample has two
@@ -55,12 +60,30 @@ known environments (e.g. mobile + bound, surface + bulk). Don't add a second
 component to chase noise — keep it only if R² improves materially and both
 populations are non-negligible.
 
-**Variable-temperature (VT) series → activation energy.** When the same
-relaxation experiment is run across temperature, fit T1/T2 at each T, then
-extract the **activation energy** from the motional regime: in the fast-motion
-limit 1/T1 ∝ τc and τc = τ0·exp(Ea/kT), so a plot of ln(1/T1) (or ln τc) vs 1/T
-is linear with slope ±Ea/k. Report Ea (eV or kJ/mol) — for an ion conductor this
-is the **hopping barrier**, the headline number.
+**Relaxation series → trend vs the series variable.** Read the variable from the
+series metadata; **do NOT assume it is temperature.**
+
+- **vs temperature → activation energy.** 1/T1 ∝ τc and τc = τ0·exp(Ea/kT), so
+  ln(1/T1) (or ln τc) vs 1/T is *piecewise* linear, slope ±Ea/k. **Do not assume
+  a single line, and do not assume two.** Fit one Arrhenius line first, then add a
+  breakpoint only while each added segment **materially and statistically**
+  improves the fit **and** spans enough temperatures to be real (never claim a
+  regime from ~2 points). Report however many regimes (1, 2, …) the data justify,
+  with the crossover temperature(s) and the per-regime Ea (each is a hopping
+  barrier). If the best piecewise residual is itself **systematically curved**,
+  the process is continuously non-Arrhenius (e.g. VFT) — report curvature, not a
+  stack of straight lines. Quote Ea only where the points lie on one side of the
+  BPP minimum; an upturn (V-shape) means the data straddle it.
+- **vs any other variable** (composition, pressure, hydration, …) → there is no
+  Arrhenius. Report the relaxation-time trend and any **extremum / turning point**
+  (a T1 minimum signals a crossover in the dynamics) — without forcing an
+  activation energy.
+
+**Lock the form, not the count, across the series.** Hold the lineshape *form*
+fixed (mono vs stretched — choosing mono at some points and stretched at others
+makes β jump artificially and corrupts the β trend), but let `n_components`
+follow the data at each point: a second relaxation component appearing along the
+series (a new environment/phase) is a result, not noise to suppress.
 
 ## implementation
 
@@ -71,14 +94,19 @@ from scilink.skills.curve_fitting.nmr_relaxation.relaxation import fit_relaxatio
 # delays in seconds, integrals signed (negative at short t for inversion recovery)
 res = fit_relaxation(delay.tolist(), integral.tolist(),
                      model=MODEL,        # from the pulse program (see table); never guess
-                     stretched=False)    # set True for disordered solids
+                     stretched=STRETCHED) # True by default for a disordered/electrolyte
+                                          # solid; False for solution / clean crystalline
 p = res["parameters"]   # T1_s (or T2_s), beta, I0, A_inversion / populations
 ```
 
-If the mono-exponential residual is systematic, re-fit with `stretched=True`
-(or `n_components=2`) and keep the better fit. Emit `FIT_RESULTS_JSON:` with
-`fit_quality` (`r_squared`), the relaxation time in **seconds**, β, and — for a
-VT series — the per-temperature T1 so the Arrhenius fit can run downstream.
+Clearing the R² gate does not end the decision: on a disordered solid, also read
+β — if a stretched fit returns β meaningfully below 1, keep it (the heterogeneity
+is real) rather than reverting to the gate-passing mono fit. Use `n_components=2`
+when a single component leaves a systematic residual and the sample has two known
+environments; keep it only if it improves the fit and both populations are
+non-negligible. Emit `FIT_RESULTS_JSON:` with `fit_quality` (`r_squared`), the
+relaxation time in **seconds**, β, and — for a VT series — the per-temperature T1
+so the Arrhenius fit can run downstream.
 
 ## interpretation
 
@@ -116,6 +144,9 @@ measurement for solid-electrolyte ion mobility.
   shortest, is unconstrained — widen the delay list or report it as a bound.
 - **Stretched β ∈ (0, 1].** β pinned at 1 with a poor fit → try a second
   component; β ≪ 1 → quote a distribution, not a single time.
-- **VT Arrhenius:** check the ln(1/T1)-vs-1/T points are linear and on one side
-  of the BPP minimum before quoting Ea; a V-shape means the data straddle the
-  minimum and the simple slope is invalid.
+- **VT Arrhenius:** before quoting a *single* Ea, check the ln(1/T1)-vs-1/T points
+  are actually linear over the whole range and on one side of the BPP minimum. A
+  reproducible slope change (not noise) = multiple regimes → report per-regime Ea
+  + crossover T, not one averaged slope; smooth curvature = continuously
+  non-Arrhenius (report curvature); a V-shape = the data straddle the BPP minimum.
+  Forcing a single line through any of these understates the physics.


### PR DESCRIPTION
Improvements to the `nmr` and `nmr_relaxation` curve-fitting skill bundles, validated on synthetic spectra and a held-out set of experimental 1D NMR series (solution and solid-state MAS, spin-½ and half-integer quadrupolar nuclei, plus variable-temperature relaxation). **All changes are confined to the two skill bundles** — no agent/pipeline code touched, so other curve-fitting skills cannot regress. Single commit; independent of the OptimizationAgent/BO work.

### New tools / diagnostics
- `fit_jcoupled_multiplet` — constrained first-order J-multiplet (doublet/triplet/quartet…), 6 parameters regardless of line count; returns J directly. Stress-tested 80/80 across noise seeds × multiplet shapes.
- `assess_detection` — low-SNR abstention guard (Rose / quantitative-NMR thresholds + F-test + contiguous-feature requirement). Abstains on noise / blank acquisitions; recovers weak but real resonances.
- `fit_quad_czjzek` — Czjzek (GIM) distribution-of-EFG central-transition lineshape for disordered half-integer quadrupolar solids; does not false-beat single-site `fit_quad_ct` on ordered lines.
- `peak_region_r2` now also returns residual-structure diagnostics, including the SNR-robust `resid_rms_frac` and a `residual_structured` flag.

### Decision-rule reframes, each validated to not over-fire
- **Default to the physical model; fall back on the tool's own flag** (`Cq_resolved`, β) rather than a subjective shape call.
- **Series: lock the form, not the count** — let `n_components` follow the data across a series; a component appearing/disappearing along the sweep is the result.
- **Relaxation series: variable- and regime-agnostic** — don't assume the series variable is temperature; for a temperature sweep don't assume one Arrhenius line or two: report however many regimes (1…K) or continuous curvature the data justify.

### Known limitation (documented)
Multi-regime Arrhenius detection remains an *operational-prompt* gap — the agent should run the piecewise model-selection in its generated code (codegen-able; no tool needed). Fully deterministic escalation would require the agent's verification loop, outside these bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)