### PR TITLE
xrd_profile: peak-region gate, fit_range/air-scatter handling, fit_curve_raw, and prose hardening for real lab XRD

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -4016,6 +4016,21 @@ Return JSON with:
             self.logger.error(f"Failed to refine model from feedback: {e}")
             return config
 
+    def _gate_metric_str(self, state: dict, result: Optional[dict], fallback_r2: float) -> str:
+        """`"<label> = <value>"` for the active gate metric, for approval log
+        lines. Falls back to the global R² when the gate is r_squared or the
+        metric is missing — so a non-R² gate (e.g. peak_region_r2) is not logged
+        as "R²" with the global value it doesn't gate on."""
+        g = _gate(state)
+        if g is not None and getattr(g, "metric", "r_squared") != "r_squared":
+            try:
+                v = g.extract((result or {}).get("fit_quality"))
+                if v is not None:
+                    return f"{g.label} = {v:.4f}"
+            except Exception:
+                pass
+        return f"R² = {fallback_r2:.4f}"
+
     def _fit_with_quality_control(self, state: dict, curve_data: np.ndarray, data_path: str, spectrum_name: str, spectrum_idx: int, is_regime_anchor: bool = False, reuse_script: Optional[str] = None, reuse_source: Optional[str] = None) -> dict:
         """
         Fit a single spectrum with quality control, verification, and optional judge selection.
@@ -4322,7 +4337,7 @@ Return JSON with:
                             best_verification = verification
                             best_ever_rejected = False
                             state["locked_fitting_config"] = best_config
-                            self.logger.info(f"   ✅ Fit approved (R² = {best_r2:.4f})")
+                            self.logger.info(f"   ✅ Fit approved ({self._gate_metric_str(state, best_result, best_r2)})")
                             fit_was_approved = True
                             break
 
@@ -4558,7 +4573,7 @@ Return JSON with:
                             if current_result is best_result:
                                 best_verification = final_verification
                                 if not _final_rejected:
-                                    self.logger.info(f"   ✅ Final fit approved (R² = {best_r2:.4f})")
+                                    self.logger.info(f"   ✅ Final fit approved ({self._gate_metric_str(state, best_result, best_r2)})")
                                     fit_was_approved = True
                                     best_ever_rejected = False
                                 else:
@@ -4575,7 +4590,7 @@ Return JSON with:
 
             # --- Verifier-approved fits bypass the R² threshold check ---
             if fit_was_approved:
-                self.logger.info(f"✅ Verifier approved fit (R² = {best_r2:.4f})")
+                self.logger.info(f"✅ Verifier approved fit ({self._gate_metric_str(state, best_result, best_r2)})")
                 quality_history = self._build_quality_history(
                     best_r2, self.r2_threshold, all_attempts,
                     verification_history, None,
@@ -5601,10 +5616,15 @@ Return JSON with:
             )
         else:
             _cmp = "≥" if _gate_obj.direction == "higher_is_better" else "≤"
+            # Bypass is governed by physical_review, not by the metric name:
+            # goodness-of-fit gates (peak_region_r2, …) still run the verifier.
+            if _gate_obj.physical_review:
+                _verifier_note = "verifier runs, framed against this metric (not R²)"
+            else:
+                _verifier_note = "skill scoring is the verification (curve-fit verifier bypassed)"
             self.logger.info(
                 f"   Quality: {_gate_obj.metric} {_cmp} {_gate_obj.accept_threshold:.3f} "
-                f"accepts ({_gate_obj.direction}); skill scoring is the verification "
-                f"(curve-fit R² verifier bypassed)."
+                f"accepts ({_gate_obj.direction}); {_verifier_note}."
             )
         self.logger.info(f"   Max verification iterations: {self.max_verification_iterations}")
         if not is_single:

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -675,11 +675,25 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             )
         else:
             cmp = "≥" if effective_gate.direction == "higher_is_better" else "≤"
+            # The verifier bypass is governed by physical_review, NOT by whether
+            # the metric is R². Goodness-of-fit gates (peak_region_r2, BIC, …)
+            # keep physical_review=True and DO run the verifier, framed against
+            # the gate's metric; only workflow-scoring gates (physical_review=
+            # False, e.g. xrd's figure_of_merit) bypass it for their own scoring.
+            if effective_gate.physical_review:
+                verifier_note = (
+                    "curve-fit verifier runs, framed against this metric "
+                    "(not R²)"
+                )
+            else:
+                verifier_note = (
+                    "curve-fit verifier bypassed — skill workflow's own scoring "
+                    "is the verification"
+                )
             self.logger.info(
                 f"   Quality: {effective_gate.metric} {cmp} "
                 f"{effective_gate.accept_threshold:.3f} accepts "
-                f"({effective_gate.direction}); curve-fit verifier bypassed "
-                f"— skill workflow's own scoring is the verification."
+                f"({effective_gate.direction}); {verifier_note}."
             )
 
         # Extract series metadata from system_info if not provided explicitly

--- a/scilink/skills/_shared/_quality_metrics.py
+++ b/scilink/skills/_shared/_quality_metrics.py
@@ -1,0 +1,113 @@
+"""Peak-region quality metric for 1D-spectroscopy fits (NMR, XRD, …).
+
+A 1D spectrum/diffractogram often has an enormous digitized width relative to
+the features that carry the science, so a *correct* fit can be dominated, in a
+whole-window R², by the noise-filled regions between peaks — a good fit then
+scores a misleadingly low R² (see the low-SNR ²³Na/⁶⁷Zn NMR references, or a
+weak, noisy powder-XRD pattern whose Bragg peaks are nonetheless well fit). The
+gate metric should instead measure how well the model reproduces the spectrum
+**where there is signal**.
+
+``peak_region_r2`` computes R² over the signal region only — the union of the
+points where the *data* rises above the noise (so a missed real peak is still
+penalized) and the points where the *fitted model* places intensity (so the
+metric tracks the claimed peaks). It falls back to the global R² when too few
+signal points are found, and is reported alongside the global R² rather than
+replacing it. This is a general 1D metric, not tuned to any sample or modality:
+the signal region is detected from the data/fit at run time.
+
+This is the shared implementation. Per-skill bundles re-export ``peak_region_r2``
+from here and declare their own (modality-flavoured) ``TOOL_SPEC`` so the tool is
+skill-gated — visible to the LLM only when that skill is active.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence
+
+import numpy as np
+
+
+def _robust_noise(resid: np.ndarray) -> float:
+    """MAD-based noise estimate; robust because signal occupies a small fraction
+    of the wide window."""
+    med = np.median(resid)
+    mad = np.median(np.abs(resid - med))
+    return float(1.4826 * mad) or float(np.std(resid)) or 1.0
+
+
+def _contiguous_runs(mask: np.ndarray, min_run: int) -> np.ndarray:
+    """Keep only contiguous True runs of length >= ``min_run`` (drops isolated
+    noise spikes; real peaks are contiguous)."""
+    out = np.zeros_like(mask)
+    i, n = 0, len(mask)
+    while i < n:
+        if mask[i]:
+            j = i
+            while j < n and mask[j]:
+                j += 1
+            if j - i >= min_run:
+                out[i:j] = True
+            i = j
+        else:
+            i += 1
+    return out
+
+
+def peak_region_r2(
+    x: Sequence[float],
+    y: Sequence[float],
+    y_fit: Sequence[float],
+    baseline: Optional[Sequence[float]] = None,
+    k_sigma: float = 3.0,
+    min_run: int = 3,
+    dilate: int = 5,
+    model_frac: float = 0.02,
+    min_points: int = 15,
+) -> dict[str, Any]:
+    """R² over the signal region only (see module docstring).
+
+    The signal region is ``(|y - baseline| > k_sigma·noise``, kept as contiguous
+    runs and dilated) ``OR (|y_fit - baseline| > model_frac·max)``. Returns a
+    dict with ``peak_region_r2``, the global ``r_squared``, ``n_signal_points``,
+    and ``fell_back_to_global`` (True when the signal region was too small to be
+    meaningful). ``baseline`` defaults to the median of ``y`` (pass an array of
+    zeros when ``y`` is already background-subtracted, as for a corrected XRD
+    pattern).
+    """
+    x = np.asarray(x, float)
+    y = np.asarray(y, float)
+    y_fit = np.asarray(y_fit, float)
+    base = (np.asarray(baseline, float) if baseline is not None
+            else np.full_like(y, np.median(y)))
+
+    resid_base = y - base
+    noise = _robust_noise(resid_base)
+    data_sig = _contiguous_runs(np.abs(resid_base) > k_sigma * noise, min_run)
+    if dilate > 0 and data_sig.any():
+        data_sig = np.convolve(data_sig, np.ones(2 * dilate + 1), mode="same") > 0
+    # Where the model places real intensity — thresholded at the SAME noise
+    # floor, so a (near-)flat model contributes nothing (no spurious all-True
+    # mask) while a hallucinated peak where the data is empty is still included
+    # and therefore penalized. ``model_frac`` only raises the floor for tall
+    # models so sub-percent model wings don't dominate the region.
+    model_dev = np.abs(y_fit - base)
+    model_floor = max(k_sigma * noise, model_frac * (model_dev.max() or 0.0))
+    model_sig = model_dev > model_floor
+    sig = data_sig | model_sig
+
+    def _r2(mask):
+        yr, yfr = y[mask], y_fit[mask]
+        ss_res = float(np.sum((yr - yfr) ** 2))
+        ss_tot = float(np.sum((yr - np.mean(yr)) ** 2)) or 1e-30
+        return 1.0 - ss_res / ss_tot
+
+    global_r2 = _r2(np.ones_like(y, dtype=bool))
+    fell_back = int(sig.sum()) < min_points
+    region_r2 = global_r2 if fell_back else _r2(sig)
+    return {
+        "peak_region_r2": float(region_r2),
+        "r_squared": float(global_r2),
+        "n_signal_points": int(sig.sum()),
+        "fell_back_to_global": bool(fell_back),
+    }

--- a/scilink/skills/curve_fitting/nmr/quality.py
+++ b/scilink/skills/curve_fitting/nmr/quality.py
@@ -6,105 +6,21 @@ noise-filled empty regions — a good fit can score R² ≈ 0.1 (see the low-SNR
 ²³Na / ⁶⁷Zn references). The gate metric should instead measure how well the
 model reproduces the spectrum **where there is signal**.
 
-``peak_region_r2`` computes R² over the signal region only — the union of the
-points where the *data* rises above the noise (so a missed real peak is still
-penalized) and the points where the *fitted model* places intensity (so the
-metric tracks the claimed peaks). It falls back to the global R² when too few
-signal points are found, and is reported alongside the global R² rather than
-replacing it. This is a general 1D-spectroscopy metric, not tuned to any
-sample: the signal region is detected from the data/fit at run time.
+The metric is implemented once in ``scilink.skills._shared._quality_metrics``
+(it is a general 1D-spectroscopy metric, shared with the XRD profile skill);
+this module re-exports it and declares the NMR-flavoured ``TOOL_SPEC`` so the
+tool stays skill-gated. The ``import_line`` below still resolves
+``peak_region_r2`` from here, so callers are unaffected.
 """
 
 from __future__ import annotations
 
-from typing import Any, Optional, Sequence
-
-import numpy as np
-
 from ..._shared._spec import ToolSpec
-
-
-def _robust_noise(resid: np.ndarray) -> float:
-    """MAD-based noise estimate; robust because signal occupies a small fraction
-    of the wide NMR window."""
-    med = np.median(resid)
-    mad = np.median(np.abs(resid - med))
-    return float(1.4826 * mad) or float(np.std(resid)) or 1.0
-
-
-def _contiguous_runs(mask: np.ndarray, min_run: int) -> np.ndarray:
-    """Keep only contiguous True runs of length >= ``min_run`` (drops isolated
-    noise spikes; real peaks are contiguous)."""
-    out = np.zeros_like(mask)
-    i, n = 0, len(mask)
-    while i < n:
-        if mask[i]:
-            j = i
-            while j < n and mask[j]:
-                j += 1
-            if j - i >= min_run:
-                out[i:j] = True
-            i = j
-        else:
-            i += 1
-    return out
-
-
-def peak_region_r2(
-    x: Sequence[float],
-    y: Sequence[float],
-    y_fit: Sequence[float],
-    baseline: Optional[Sequence[float]] = None,
-    k_sigma: float = 3.0,
-    min_run: int = 3,
-    dilate: int = 5,
-    model_frac: float = 0.02,
-    min_points: int = 15,
-) -> dict[str, Any]:
-    """R² over the signal region only (see module docstring).
-
-    The signal region is ``(|y - baseline| > k_sigma·noise``, kept as contiguous
-    runs and dilated) ``OR (|y_fit - baseline| > model_frac·max)``. Returns a
-    dict with ``peak_region_r2``, the global ``r_squared``, ``n_signal_points``,
-    and ``fell_back_to_global`` (True when the signal region was too small to be
-    meaningful). ``baseline`` defaults to the median of ``y``.
-    """
-    x = np.asarray(x, float)
-    y = np.asarray(y, float)
-    y_fit = np.asarray(y_fit, float)
-    base = (np.asarray(baseline, float) if baseline is not None
-            else np.full_like(y, np.median(y)))
-
-    resid_base = y - base
-    noise = _robust_noise(resid_base)
-    data_sig = _contiguous_runs(np.abs(resid_base) > k_sigma * noise, min_run)
-    if dilate > 0 and data_sig.any():
-        data_sig = np.convolve(data_sig, np.ones(2 * dilate + 1), mode="same") > 0
-    # Where the model places real intensity — thresholded at the SAME noise
-    # floor, so a (near-)flat model contributes nothing (no spurious all-True
-    # mask) while a hallucinated peak where the data is empty is still included
-    # and therefore penalized. ``model_frac`` only raises the floor for tall
-    # models so sub-percent model wings don't dominate the region.
-    model_dev = np.abs(y_fit - base)
-    model_floor = max(k_sigma * noise, model_frac * (model_dev.max() or 0.0))
-    model_sig = model_dev > model_floor
-    sig = data_sig | model_sig
-
-    def _r2(mask):
-        yr, yfr = y[mask], y_fit[mask]
-        ss_res = float(np.sum((yr - yfr) ** 2))
-        ss_tot = float(np.sum((yr - np.mean(yr)) ** 2)) or 1e-30
-        return 1.0 - ss_res / ss_tot
-
-    global_r2 = _r2(np.ones_like(y, dtype=bool))
-    fell_back = int(sig.sum()) < min_points
-    region_r2 = global_r2 if fell_back else _r2(sig)
-    return {
-        "peak_region_r2": float(region_r2),
-        "r_squared": float(global_r2),
-        "n_signal_points": int(sig.sum()),
-        "fell_back_to_global": bool(fell_back),
-    }
+from ..._shared._quality_metrics import (  # noqa: F401  (re-exported for the TOOL_SPEC import_line)
+    peak_region_r2,
+    _robust_noise,
+    _contiguous_runs,
+)
 
 
 TOOL_SPEC = ToolSpec(

--- a/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
+++ b/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
@@ -89,6 +89,14 @@ TOOL_SPEC = ToolSpec(
         "low peak_region_r2 means real reflections are mis/un-fit), "
         "'n_signal_points', 'residual_rms_over_noise' (global residual RMS / "
         "estimated point noise — the verifier's key statistic; < ~3 is clean), "
+        "'max_abs_residual_over_noise' (the WORST single local misfit in noise "
+        "units — the complement of the averaged R²/peak_region_r2/RMS, which hide "
+        "a localized error such as a mis-shaped sharp apex on a high-dynamic-range "
+        "pattern. Read it AGAINST residual_rms_over_noise: much larger than the RMS "
+        "= the misfit is localized -> look at the residual figure there. Do NOT "
+        "use an absolute threshold: its scale rises with dynamic range, so a large "
+        "value is expected on very sharp intense peaks, NOT a verdict — the figure "
+        "decides accept (irreducible apex) vs refine (unmodelled feature)), "
         "'n_peaks', "
         "'peaks' (list of dicts: center, fwhm (mean width; for Scherrer/W-H), "
         "amplitude (height), area, eta, sorted by 2-theta; split mode adds "
@@ -384,6 +392,18 @@ def _fit_corrected(
     ss_tot = float(np.sum((ycorr - ycorr.mean()) ** 2))
     r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
     rms_over_noise = float(np.sqrt(np.mean(resid ** 2)) / noise)
+    # Worst LOCAL misfit, in noise units. The global R² / peak_region_r2 / RMS
+    # all AVERAGE over the pattern, so a localized but severe error — a mis-shaped
+    # sharp, intense apex on a high-dynamic-range pattern — is invisible to them
+    # (it scores ~0.999 while the apex residual is tens of sigma). This is the
+    # complementary signal: a 3-point-smoothed (single-channel spikes ignored)
+    # max |residual| / noise. Threshold-free: high here with a high R²/region
+    # means a localized shape misfit, not a clean fit. No tuned constants.
+    if resid.size >= 3:
+        smoothed = np.convolve(resid, np.ones(3) / 3.0, mode="same")
+    else:
+        smoothed = resid
+    max_resid_over_noise = float(np.max(np.abs(smoothed)) / noise)
     # Peak-region R²: R² over the channels carrying diffracted intensity, so a
     # correct fit of a weak/noisy pattern is not scored down by the noise-only
     # background channels (global R² is kept too). The corrected pattern is fit
@@ -419,6 +439,7 @@ def _fit_corrected(
         "peak_region_r2": float(region["peak_region_r2"]),
         "n_signal_points": int(region["n_signal_points"]),
         "residual_rms_over_noise": rms_over_noise,
+        "max_abs_residual_over_noise": max_resid_over_noise,
         "n_peaks": len(centers),
         "peaks": peaks,
         "peak_centers": [p["center"] for p in peaks],

--- a/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
+++ b/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
@@ -60,7 +60,7 @@ TOOL_SPEC = ToolSpec(
         "background='snip', snip_iterations='auto', prominence_frac=0.02, "
         "max_peaks=30, min_distance_deg=0.15, init_fwhm_deg=0.2, "
         "center_leeway_deg=0.3, max_fwhm_deg=3.0, "
-        "peak_shape='split_pseudo_voigt') -> dict"
+        "peak_shape='split_pseudo_voigt', fit_range=None) -> dict"
     ),
     parameters={
         "exp_two_theta": {"type": "list[float]", "description": "Experimental 2-theta grid (degrees)."},
@@ -78,6 +78,7 @@ TOOL_SPEC = ToolSpec(
         "center_leeway_deg": {"type": "float", "description": "Each center may move +/- this much during the fit (degrees). Default 0.3."},
         "max_fwhm_deg": {"type": "float", "description": "Upper bound on fitted FWHM (degrees). Default 3.0."},
         "peak_shape": {"type": "str", "description": "'split_pseudo_voigt' (default) fits one extra width per peak to capture axial-divergence asymmetry — markedly lower residual on strong sharp lab-CuKa peaks, and it degenerates to symmetric when the data is symmetric (so it generalises safely). 'pseudo_voigt' forces a symmetric profile (fewer parameters; use only if asymmetry is known absent, e.g. synchrotron data)."},
+        "fit_range": {"type": "[float, float] | None", "description": "Restrict the analysis to a 2-theta window [lo, hi] (degrees); None (default) uses the whole pattern. Pass this to EXCLUDE a region that corrupts the fit — most often a steep low-angle air-scatter / beamstop upturn below ~5-6 deg, which makes SNIP background overshoot and starves prominence-based peak detection (symptom: only 1-2 peaks detected and a high R-squared on a near-empty fit). Also use it to exclude a detector artifact or a contaminant peak. Channels outside the window are excluded from background, detection, and the fit, and are marked as matched (zero residual) in the returned full-length arrays. Detection/fit/scores then behave as if the data were cropped, but the returned arrays stay the input length so downstream residual diagnostics still run."},
     },
     required=["exp_two_theta", "exp_intensity"],
     returns=(
@@ -93,7 +94,8 @@ TOOL_SPEC = ToolSpec(
         "amplitude (height), area, eta, sorted by 2-theta; split mode adds "
         "fwhm_left, fwhm_right, and asymmetry=(fwhm_right-fwhm_left)/sum), "
         "'peak_centers' (the centers actually fit — feed back as the locked "
-        "list for the next series frame), 'intensity_corrected', 'fit_curve' "
+        "list for the next series frame); when fit_range was used, 'fit_range' "
+        "(the kept window); 'intensity_corrected', 'fit_curve' "
         "(model evaluated on the full grid; use for the visualization), "
         "'background_method', 'peak_shape'."
     ),
@@ -187,16 +189,36 @@ def fit_pattern(
     center_leeway_deg: float = 0.3,
     max_fwhm_deg: float = 3.0,
     peak_shape: str = "split_pseudo_voigt",
+    fit_range: Optional[Sequence[float]] = None,
 ) -> dict[str, Any]:
     if peak_shape not in ("split_pseudo_voigt", "pseudo_voigt"):
         raise ValueError(
             f"peak_shape must be 'split_pseudo_voigt' or 'pseudo_voigt'; got {peak_shape!r}")
-    x = np.asarray(exp_two_theta, dtype=float)
-    y = np.asarray(exp_intensity, dtype=float)
-    if x.shape != y.shape:
+    x_full = np.asarray(exp_two_theta, dtype=float)
+    y_full = np.asarray(exp_intensity, dtype=float)
+    if x_full.shape != y_full.shape:
         raise ValueError("exp_two_theta and exp_intensity must have the same length")
-    if x.size < 10:
+    if x_full.size < 10:
         raise ValueError("pattern too short to fit")
+
+    # fit_range excludes 2-theta channels OUTSIDE [lo, hi] from background
+    # subtraction, peak detection, and the fit — so a steep low-angle air-scatter
+    # / beamstop upturn (which makes SNIP overshoot and starves prominence-based
+    # detection) cannot corrupt the analysis. Cropping happens BEFORE background
+    # because SNIP itself fails on the raw upturn. The returned length-N arrays
+    # are padded back to the full input grid with the excluded region marked as
+    # matched (zero residual), so the verifier's residual diagnostics still run.
+    fit_mask = None
+    if fit_range is not None:
+        lo, hi = float(fit_range[0]), float(fit_range[1])
+        fit_mask = (x_full >= lo) & (x_full <= hi)
+        if int(fit_mask.sum()) < 10:
+            raise ValueError(
+                f"fit_range {(lo, hi)} keeps < 10 points; widen it or drop it")
+        x = x_full[fit_mask]
+        y = y_full[fit_mask]
+    else:
+        x, y = x_full, y_full
     step = float(np.median(np.diff(x)))
 
     centers_locked = (
@@ -264,6 +286,22 @@ def fit_pattern(
         best["background_method"] = f"snip(iterations={best.pop('_iters')})"
     else:
         raise ValueError(f"Unknown background: {background!r}")
+
+    if fit_mask is not None:
+        # Pad the length-N arrays back to the full input grid. Outside the window
+        # set BOTH intensity_corrected and fit_curve to 0, so a downstream
+        # raw-scale reconstruction (fit_raw = fit_curve + (intensity -
+        # intensity_corrected)) returns the raw data there -> zero residual; the
+        # excluded region is "matched", contributing nothing to the verifier's
+        # residual diagnostics. Scores (r_squared, peak_region_r2, residual) stay
+        # window-only. 'fit_range' records the kept window.
+        def _pad(vals):
+            full = np.zeros(x_full.shape[0], dtype=float)
+            full[fit_mask] = np.asarray(vals, dtype=float)
+            return [float(v) for v in full]
+        best["intensity_corrected"] = _pad(best["intensity_corrected"])
+        best["fit_curve"] = _pad(best["fit_curve"])
+        best["fit_range"] = [float(fit_range[0]), float(fit_range[1])]
 
     return best
 

--- a/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
+++ b/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
@@ -35,6 +35,7 @@ from scipy.optimize import curve_fit
 from scipy.signal import find_peaks
 
 from ..._shared._spec import ToolSpec
+from ..._shared._quality_metrics import peak_region_r2
 from .background import fit_background
 
 _logger = logging.getLogger(__name__)
@@ -81,8 +82,13 @@ TOOL_SPEC = ToolSpec(
     required=["exp_two_theta", "exp_intensity"],
     returns=(
         "dict with 'r_squared' (GLOBAL, over the whole corrected pattern), "
-        "'residual_rms_over_noise' (global residual RMS / estimated point "
-        "noise — the verifier's key statistic; < ~3 is clean), 'n_peaks', "
+        "'peak_region_r2' (R² over only the channels carrying diffracted "
+        "intensity — report this as the gate metric; a low global R² with a high "
+        "peak_region_r2 means a low-SNR pattern whose peaks are well fit, while a "
+        "low peak_region_r2 means real reflections are mis/un-fit), "
+        "'n_signal_points', 'residual_rms_over_noise' (global residual RMS / "
+        "estimated point noise — the verifier's key statistic; < ~3 is clean), "
+        "'n_peaks', "
         "'peaks' (list of dicts: center, fwhm (mean width; for Scherrer/W-H), "
         "amplitude (height), area, eta, sorted by 2-theta; split mode adds "
         "fwhm_left, fwhm_right, and asymmetry=(fwhm_right-fwhm_left)/sum), "
@@ -340,6 +346,12 @@ def _fit_corrected(
     ss_tot = float(np.sum((ycorr - ycorr.mean()) ** 2))
     r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
     rms_over_noise = float(np.sqrt(np.mean(resid ** 2)) / noise)
+    # Peak-region R²: R² over the channels carrying diffracted intensity, so a
+    # correct fit of a weak/noisy pattern is not scored down by the noise-only
+    # background channels (global R² is kept too). The corrected pattern is fit
+    # about zero, so the baseline is zero. Equals the global R² on a high-SNR
+    # pattern and does NOT rescue a fit that misses real reflections.
+    region = peak_region_r2(x, ycorr, fit_curve, baseline=np.zeros_like(ycorr))
 
     stride = 5 if split else 4
     peaks = []
@@ -366,6 +378,8 @@ def _fit_corrected(
 
     return {
         "r_squared": float(r2),
+        "peak_region_r2": float(region["peak_region_r2"]),
+        "n_signal_points": int(region["n_signal_points"]),
         "residual_rms_over_noise": rms_over_noise,
         "n_peaks": len(centers),
         "peaks": peaks,

--- a/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
+++ b/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
@@ -103,8 +103,11 @@ TOOL_SPEC = ToolSpec(
         "fwhm_left, fwhm_right, and asymmetry=(fwhm_right-fwhm_left)/sum), "
         "'peak_centers' (the centers actually fit — feed back as the locked "
         "list for the next series frame); when fit_range was used, 'fit_range' "
-        "(the kept window); 'intensity_corrected', 'fit_curve' "
-        "(model evaluated on the full grid; use for the visualization), "
+        "(the kept window); 'intensity_corrected', 'fit_curve' (model on the "
+        "BACKGROUND-SUBTRACTED scale), 'fit_curve_raw' (model on the RAW scale = "
+        "fit_curve + background; SAVE THIS as the fit overlay / fit.npy so it "
+        "matches the raw data — do NOT save fit_curve, which plotted against raw "
+        "data makes a good fit look collapsed when the background is large), "
         "'background_method', 'peak_shape'."
     ),
     when_to_use=(
@@ -310,6 +313,16 @@ def fit_pattern(
         best["intensity_corrected"] = _pad(best["intensity_corrected"])
         best["fit_curve"] = _pad(best["fit_curve"])
         best["fit_range"] = [float(fit_range[0]), float(fit_range[1])]
+
+    # Raw-scale model = corrected model + the background that was subtracted
+    # (background = input intensity - corrected intensity). SAVE THIS as the fit
+    # overlay, NOT fit_curve: fit_curve is on the background-subtracted scale, so
+    # plotting it against the RAW data makes a good fit look collapsed (peaks at a
+    # fraction of height, gaps dropping to ~0) on patterns with a large
+    # background. Returning it ready-made removes that reconstruction error.
+    _ic = np.asarray(best["intensity_corrected"], dtype=float)
+    _fc = np.asarray(best["fit_curve"], dtype=float)
+    best["fit_curve_raw"] = [float(v) for v in (_fc + (y_full - _ic))]
 
     return best
 

--- a/scilink/skills/curve_fitting/xrd_profile/quality.py
+++ b/scilink/skills/curve_fitting/xrd_profile/quality.py
@@ -1,0 +1,71 @@
+"""Peak-region quality metric for XRD profile fits.
+
+A weak or noisy powder pattern can have its Bragg peaks fit correctly yet score
+a low whole-pattern R², because the long stretches of background-only channels
+between reflections are noise-dominated and inflate the total sum of squares. A
+correct fit of a low-SNR pattern is then mis-scored as a failure (see the
+RRUFF Hematite reference: global R² ≈ 0.55 on a fit whose peaks track the data,
+peak-region R² ≈ 0.89). The gate should measure the fit **where there is
+diffracted intensity**.
+
+``peak_region_r2`` is the shared 1D-spectroscopy metric (implemented in
+``scilink.skills._shared._quality_metrics`` and also used by the NMR skill). It
+computes R² over the union of the points where the *data* rises above the noise
+(so a missed real reflection is still penalized — a genuine peak-deficient fit on
+a dense low-symmetry pattern is NOT rescued) and the points where the *fitted
+model* places intensity. It degenerates to the global R² on a high-SNR pattern
+whose signal spans most channels, so it never inflates an already-good fit.
+
+For a background-subtracted (``intensity_corrected``) pattern pass
+``baseline=[0]*len`` so the signal/noise split is taken about zero.
+"""
+
+from __future__ import annotations
+
+from ..._shared._spec import ToolSpec
+from ..._shared._quality_metrics import peak_region_r2  # noqa: F401  (re-exported for the import_line)
+
+
+TOOL_SPEC = ToolSpec(
+    name="peak_region_r2",
+    description=(
+        "Compute the peak-region R² of an XRD profile fit — R² over the signal "
+        "region (channels where the data rises above noise ∪ where the model "
+        "places intensity) rather than the whole 2θ range — so a correct fit of "
+        "a weak/noisy pattern is not scored as a failure by the noise-dominated "
+        "background channels. It does NOT rescue a fit that genuinely misses real "
+        "reflections (those channels are above noise and stay in the region), and "
+        "it equals the global R² on a high-SNR pattern. Report it alongside the "
+        "global R² as the gate metric."
+    ),
+    import_line="from scilink.skills.curve_fitting.xrd_profile.quality import peak_region_r2",
+    signature=(
+        "peak_region_r2(x, y, y_fit, baseline=None, k_sigma=3.0, min_run=3, "
+        "dilate=5, model_frac=0.02, min_points=15) -> dict"
+    ),
+    parameters={
+        "x": {"type": "list[float]", "description": "2θ axis (degrees)."},
+        "y": {"type": "list[float]", "description": "Intensity the fit was computed against. Pass the SAME array fit_curve was fit to: the background-subtracted intensity_corrected when fitting a corrected pattern, or the raw intensity when the model includes the background."},
+        "y_fit": {"type": "list[float]", "description": "Fitted model evaluated on x (fit_curve)."},
+        "baseline": {"type": "list[float]", "description": "Baseline on x. For a background-subtracted pattern (y = intensity_corrected) pass [0]*len(x) so the signal/noise split is about zero; for a raw-intensity fit pass the fitted/estimated background so the split is correct."},
+        "k_sigma": {"type": "float", "description": "How many noise σ a channel must exceed to count as diffracted signal (default 3). RAISE (4–5) on very noisy patterns so the region excludes noise; LOWER (2) to include weak reflections that barely clear the noise."},
+        "min_run": {"type": "int", "description": "Minimum contiguous run length (points) for a data feature to count as a real peak vs an isolated noise spike (default 3). Increase for finely-sampled (0.01° step) scans."},
+        "dilate": {"type": "int", "description": "Points to grow the signal mask on each side, to include peak wings/tails (default 5). Increase for broad nanocrystalline peaks so the wings are scored; decrease for very sharp lines."},
+        "model_frac": {"type": "float", "description": "Also count channels where the fitted model exceeds this fraction of its own max as signal (default 0.02) — so the metric scores where the model claims reflections even if data there is weak."},
+        "min_points": {"type": "int", "description": "If fewer than this many signal points are found, fall back to the global R² (default 15) — guards the metric on a near-empty pattern."},
+    },
+    required=["x", "y", "y_fit"],
+    returns=(
+        "dict with 'peak_region_r2', global 'r_squared', 'n_signal_points', and "
+        "'fell_back_to_global'. Put 'peak_region_r2' (and 'r_squared') into the "
+        "fit_quality block of the fit-results JSON."
+    ),
+    when_to_use=(
+        "As the final quality step of an XRD profile fit — the skill's quality "
+        "gate scores by 'peak_region_r2'. A large gap (low global R², high "
+        "peak-region R²) means a low-SNR pattern whose peaks are nonetheless well "
+        "fit; a low peak-region R² means real reflections are mis- or un-fit."
+    ),
+)
+
+TOOL_SPECS = [TOOL_SPEC]

--- a/scilink/skills/curve_fitting/xrd_profile/quality.py
+++ b/scilink/skills/curve_fitting/xrd_profile/quality.py
@@ -67,5 +67,3 @@ TOOL_SPEC = ToolSpec(
         "fit; a low peak-region R² means real reflections are mis- or un-fit."
     ),
 )
-
-TOOL_SPECS = [TOOL_SPEC]

--- a/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
+++ b/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
@@ -68,6 +68,32 @@ known, proceed standalone.
 points below shape *that* fit — how many peaks matter, when Williamson-Hall
 is admissible, which background — rather than a peak-by-peak procedure.
 
+**Exclude a corrupting low-angle upturn — without clipping a real reflection.**
+Lab patterns often have a steep air-scatter / beamstop rise in the first few
+degrees. It is *not* diffraction, and it breaks the fit two ways: SNIP
+background overshoots on the steep edge, and the inflated intensity range
+starves prominence-based detection — the tell is `fit_pattern` returning only
+1–2 peaks with a deceptively high R² on a near-empty fit. When you see that
+rise, pass `fit_range=(lo, hi)` to exclude only the climb; excluded channels are
+dropped from background, detection, and the fit but returned as matched, so the
+residual diagnostics still work.
+
+The hazard is over-cropping: genuine low-angle Bragg peaks are common (layered
+materials, clays, MOFs, surfactants, many molecular/pharmaceutical crystals with
+large d-spacings) and live in the same first few degrees. The upturn is a
+**smooth, monotonic, featureless** decay; a Bragg reflection is a **distinct
+peak** sitting on it. So **do not use a fixed cutoff like 5°** — look at the
+low-angle data and set `lo` *just below the lowest genuine peak*, cutting only
+the featureless part of the climb. If a sharp peak rides partway up the upturn,
+keep it (lower `lo`, or don't crop). When you cannot tell a low-angle feature
+from the climb, **include it** — leaving a little upturn in costs a slightly
+worse background fit; clipping a real reflection corrupts the science. After
+fitting, sanity-check the lower bound: re-run once with `lo` a couple of degrees
+lower and confirm no new strong reflection appears in the widened window (if one
+does, it was real — keep the wider window). The same knob (with the same caution)
+excludes a detector artifact or a known contaminant region. For a series, set one
+window on the establishing frame and reuse it on every frame.
+
 **How many peaks to fit:**
 - Scherrer alone: 3–5 strongest, well-isolated peaks is enough — report
   size per peak and the mean.
@@ -234,14 +260,17 @@ print("FIT_RESULTS_JSON: " + json.dumps({
 }))
 ```
 
-The gate scores `peak_region_r2`. When the global `r_squared` is well below
-`peak_region_r2`, the pattern is low-SNR (weak counts, noisy background) but its
-reflections are well fit — accept it; that gap is the metric working as
-intended, not a bad fit. When `peak_region_r2` itself is low, real reflections
-are mis- or un-modelled (a genuine miss on a dense low-symmetry pattern) — that
-is **not** rescued, so refine (lower `prominence_frac`/`min_distance_deg` and
-re-run the single global `fit_pattern`). `peak_region_r2` equals the global R² on
-a high-SNR pattern, so this changes nothing for clean data.
+The gate scores `peak_region_r2`. A large global-`r_squared` ↔ `peak_region_r2`
+gap is **only** a benign low-SNR artifact when you have *verified* both that the
+pattern is genuinely low-SNR (weak counts over a noisy background) **and** that
+the residual in the gap regions is structureless (noise-only). Do not assume the
+gap is benign: on a high-SNR pattern a low global `r_squared` should be presumed
+a **real** problem (a missed reflection or a mis-shaped peak) until the residual
+is checked and found featureless. Conversely, when `peak_region_r2` itself is low,
+real reflections are mis- or un-modelled — that is **not** rescued, so refine
+(lower `prominence_frac`/`min_distance_deg` and re-run the single global
+`fit_pattern`). `peak_region_r2` equals the global R² on a high-SNR pattern, so
+on clean data there is no gap to explain.
 
 **In-situ / series use — lock the method, not the values.** `fit_pattern` is
 one fast call per frame, so it drops straight into the agent's per-spectrum

--- a/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
+++ b/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
@@ -252,13 +252,35 @@ print("FIT_RESULTS_JSON: " + json.dumps({
         "peak_region_r2": fit['peak_region_r2'],
         "r_squared": r_squared,                       # GLOBAL (reported for context)
         "residual_rms_over_noise": fit['residual_rms_over_noise'],
-        "verdict": "accept" if fit['peak_region_r2'] >= 0.90 else (
-            "marginal" if fit['peak_region_r2'] >= 0.55 else "reject"
-        ),
+        # Worst single LOCAL misfit in noise units. R²/peak_region_r2/RMS average
+        # and hide a localized error (a mis-shaped sharp apex on a tall peak); this
+        # exposes it. Read against residual_rms_over_noise (>> RMS = localized ->
+        # look at the figure); its scale rises with dynamic range, so it is an
+        # attention signal, not a thresholded verdict.
+        "max_abs_residual_over_noise": fit['max_abs_residual_over_noise'],
         "n_peaks_fitted": fit['n_peaks'],
     },
 }))
 ```
+
+**A high `peak_region_r2` is necessary but not sufficient — use
+`max_abs_residual_over_noise` to decide where to look.** The gate metric (like
+global R² and RMS) averages over the whole pattern, so on a high-dynamic-range
+pattern — one or two giant peaks dwarfing the rest — a localized error such as a
+mis-shaped sharp apex is invisible to it (`peak_region_r2 ≈ 0.99` while that apex
+is far off). `max_abs_residual_over_noise` is the **worst single local misfit**,
+the complement of the averaged statistics. Read it *against*
+`residual_rms_over_noise`: when it is much larger than the RMS, the misfit is
+**localized** (concentrated at a few channels) rather than spread out — that is a
+prompt to **look at the residual figure at that location**, not a verdict.
+Do **not** attach an absolute threshold to it: its scale rises with dynamic range
+(a tiny fractional residual on a giant peak is many σ), so a large value is
+*expected* on very sharp, intense peaks and is not by itself a failure. The
+figure decides: a single sharp apex is the split pseudo-Voigt's irreducible
+profile limit (accept, and **report the residual honestly rather than claiming a
+clean fit** — do not refine endlessly); a residual that is an unmodelled
+reflection or a missed shoulder is a real miss (refine). The value's job is to
+stop a high `peak_region_r2` from being rubber-stamped without that look.
 
 The gate scores `peak_region_r2`. A large global-`r_squared` ↔ `peak_region_r2`
 gap is **only** a benign low-SNR artifact when you have *verified* both that the

--- a/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
+++ b/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
@@ -80,19 +80,31 @@ residual diagnostics still work.
 
 The hazard is over-cropping: genuine low-angle Bragg peaks are common (layered
 materials, clays, MOFs, surfactants, many molecular/pharmaceutical crystals with
-large d-spacings) and live in the same first few degrees. The upturn is a
-**smooth, monotonic, featureless** decay; a Bragg reflection is a **distinct
-peak** sitting on it. So **do not use a fixed cutoff like 5°** — look at the
-low-angle data and set `lo` *just below the lowest genuine peak*, cutting only
-the featureless part of the climb. If a sharp peak rides partway up the upturn,
-keep it (lower `lo`, or don't crop). When you cannot tell a low-angle feature
-from the climb, **include it** — leaving a little upturn in costs a slightly
-worse background fit; clipping a real reflection corrupts the science. After
-fitting, sanity-check the lower bound: re-run once with `lo` a couple of degrees
-lower and confirm no new strong reflection appears in the widened window (if one
-does, it was real — keep the wider window). The same knob (with the same caution)
-excludes a detector artifact or a known contaminant region. For a series, set one
-window on the establishing frame and reuse it on every frame.
+large d-spacings) and live in the same first few degrees, so **do not blindly use
+a fixed cutoff** — look at the low-angle data and set `lo` deliberately. The
+decision is **where the steep climb flattens into ordinary background**, not just
+"below the lowest bump":
+- **Set `lo` where the climb has flattened.** A reflection that sits on **flat**
+  background just past the climb — keep it (put `lo` below it). A feature sitting
+  **on the steep part of the climb itself** — exclude it with the rest of the
+  climb. Do *not* lower `lo` into the climb to rescue such a feature: a peak
+  buried in air-scatter cannot be reliably fit there anyway, and — because
+  `fit_range` sets a single lower bound — keeping any of the steep climb keeps the
+  SNIP overshoot and the starved detection across the **whole** pattern, so you
+  trade one ambiguous low-angle peak for a bad fit everywhere.
+- **Read the result, not your intent.** If the fit comes back with only a handful
+  of peaks and/or a large oscillatory residual in the first few degrees, `lo` is
+  still **inside the climb** — raise it to where the background goes flat and
+  re-fit. A clean fit with many reflections and a structureless low-angle residual
+  means `lo` is right.
+- A genuine reflection truly buried on the climb is a **background problem**, not
+  a `fit_range` problem: report that the low-angle region needs a dedicated
+  background (or a measurement with a beam stop / variable slits) rather than
+  forcing the single-bound crop to do both jobs.
+
+The same knob (with the same caution) excludes a detector artifact or a known
+contaminant region. For a series, set one window on the establishing frame and
+reuse it on every frame.
 
 **How many peaks to fit:**
 - Scherrer alone: 3–5 strongest, well-isolated peaks is enough — report
@@ -102,12 +114,20 @@ window on the establishing frame and reuse it on every frame.
   becomes degenerate. Refuse W-H and fall back to peak-by-peak Scherrer
   when sin θ range < 0.1.
 
-**Background first, fit second.** Subtract a background (`fit_background`
-with `method='snip'` is the standard p-XRD choice) before per-peak
-fitting. SNIP handles smooth amorphous backgrounds and fluorescence
-floors without imposing a polynomial shape. Use `method='polynomial'`
-only when a polynomial is genuinely the right model (capillary
-scattering on a flat baseline).
+**Background: default to SNIP; do not switch to polynomial to "keep a
+pedestal".** `fit_background(method='snip')` (also `fit_pattern`'s default) is
+the right choice for almost every p-XRD pattern: it follows smooth amorphous
+humps, broad diffracted pedestals, and fluorescence floors without imposing a
+shape, and its iteration count (`snip_iterations='auto'` sweeps it) sets how much
+of a broad pedestal it treats as background. So if a broad pedestal under a
+cluster is being over-subtracted (crystalline apexes not reaching full data
+height), **tune the SNIP iterations** (fewer iterations leaves more of the
+pedestal) — do **not** change method. Reach for `method='polynomial'` only for a
+specific, known smooth scattering on a genuinely flat baseline (e.g. capillary
+scattering), **never** to preserve an amorphous pedestal: a Chebyshev/polynomial
+background oscillates and goes **negative between peaks**, producing a
+pathological model that dips below zero in the gaps — almost never what XRD data
+needs.
 
 **Line shape: pseudo-Voigt as default.** A pseudo-Voigt mixes Gaussian
 and Lorentzian contributions through a single mixing parameter `eta` —

--- a/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
+++ b/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
@@ -166,6 +166,31 @@ engine is wired, do not attempt a whole-pattern refine with the kinematic
 tools** — report tiers 1–2 and recommend Rietveld as the explicit next step,
 naming the matched CIF as the model to refine.
 
+*Refinement order (engine-pending — the protocol for when `refine_rietveld`
+exists; do not apply it to the tier-1/2 empirical `fit_pattern`, which has no
+such refinement groups).* A manual Rietveld runs in a set order, and that order
+is most of the skill: the logic is identical in GSAS-II or TOPAS, only the
+parameter names differ. **Nothing is freed all at once** — refine one group at a
+time, holding everything else at its current value and carrying the converged
+values forward; freeing everything together tends to diverge or settle in a
+false minimum on overlap-heavy data. The order:
+1. **Scale + background** first — just to get the calculated curve roughly onto
+   the observed one.
+2. **Sample/setup group** (the parameters with no "correct" value to look up —
+   they are whatever the packing and alignment produced that day): zero-shift /
+   sample displacement for peak positions, the profile terms for width and
+   shape, and preferred orientation if the intensities are off.
+3. **Structural group** (a separate bucket, anchored by the published CIF for a
+   known phase): the cell refines only a little for a fixed phase at fixed
+   conditions; atomic coordinates and occupancies stay fixed unless the data
+   really justify touching them.
+
+The step-2 corrections are exactly the ones that quietly absorb error from
+elsewhere and still produce a clean Rwp — judge each by the sample-and-mounting
+priors in **validation** (a large displacement or preferred-orientation or
+lattice change is suspect unless the sample/mounting/conditions make it real),
+not by the fit statistic.
+
 ## implementation
 
 **Default path: one global fit with `fit_pattern`.** Prefer `fit_pattern`
@@ -439,3 +464,21 @@ powder pattern whose Bragg peaks are well fit can sit at global R² ≈ 0.5 with
   resolution-limited. Report "size below sensitivity limit
   (~ Scherrer with β = instrumental)" rather than NaN or a complex
   number.
+
+**Sample-and-mounting priors — the fit statistic can't tell you these, the
+sample does.** The corrections that absorb position/intensity error (sample
+displacement, preferred orientation, and a refined lattice) will quietly soak up
+error from elsewhere and still leave a clean R²/Rwp, so a good fit statistic does
+*not* mean the correction is real. Judge each against what the sample is and how
+it was mounted, not against the fit:
+- **Sample displacement / zero-shift:** ~0 on a properly seated zero-background
+  holder. A large fitted displacement points to a misaligned sample, not a
+  correction worth trusting — flag it rather than reporting it as physical.
+- **Preferred orientation / intensity mismatch:** on a loosely packed random
+  powder there should be little texture, so a large PO correction usually means
+  something *else* is wrong (it is absorbing error); on a flat plate of platy or
+  needle crystals the texture is real and a correction along the right axis is
+  legitimate. Use the known morphology/mounting to decide which case you are in.
+- **Lattice change:** for a fixed phase at fixed conditions the cell should move
+  only a little; a large shift is suspect — *except* in a variable-temperature /
+  in-situ run, where the cell genuinely moves and tracking it is the point.

--- a/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
+++ b/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
@@ -97,6 +97,19 @@ decision is **where the steep climb flattens into ordinary background**, not jus
   still **inside the climb** — raise it to where the background goes flat and
   re-fit. A clean fit with many reflections and a structureless low-angle residual
   means `lo` is right.
+- **A dominant low-angle feature that suppresses the rest of the pattern is
+  air-scatter — exclude it.** Prominence-based detection scales its floor to the
+  tallest peak in the window, so one enormous low-angle feature (the air-scatter /
+  beam-stop maximum, often *orders of magnitude* above every real reflection)
+  starves detection of the weaker peaks. The tell is a fit that captures only the
+  two or three tallest peaks while the rest of the pattern — which plainly shows
+  reflections in the raw data — sits unmodeled at baseline. When you see that, the
+  giant low-angle feature is air-scatter, not a reflection you must keep: raise
+  `lo` above it and re-fit; recovering the full set of reflections confirms it.
+  The trigger is **suppression of otherwise-visible peaks**, not size alone — a
+  genuinely strong reflection leaves the rest of the pattern detectable and does
+  not fire this rule (e.g. a 100×-dominant peak whose neighbours are still fit is
+  fine; it is only a problem when the neighbours vanish from the fit).
 - A genuine reflection truly buried on the climb is a **background problem**, not
   a `fit_range` problem: report that the low-angle region needs a dedicated
   background (or a measurement with a beam stop / variable slits) rather than

--- a/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
+++ b/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
@@ -2,9 +2,9 @@
 description: 'p-XRD profile fitting — the quantitative follow-up to phase identification: per-peak pseudo-Voigt fits (position, intensity, FWHM), Scherrer crystallite size and Williamson-Hall microstrain, and a Rietveld tier (phase fractions / accurate lattice; engine pending) that refines against the identified-phase CIF.'
 technique: [XRD, "X-ray diffraction", "powder diffraction", pXRD]
 quality_gate:
-  metric: r_squared
-  accept_threshold: 0.95
-  hard_reject_threshold: 0.85
+  metric: peak_region_r2
+  accept_threshold: 0.90
+  hard_reject_threshold: 0.55
   direction: higher_is_better
 ---
 # p-XRD Profile Fitting Skill
@@ -220,15 +220,28 @@ print("FIT_RESULTS_JSON: " + json.dumps({
     "scherrer_per_peak_nm": sizes_nm,
     "williamson_hall": wh,
     "fit_quality": {
-        "r_squared": r_squared,                       # GLOBAL
+        # peak_region_r2 is the GATE METRIC: R² over the channels that carry
+        # diffracted intensity, so a correct fit of a weak/noisy pattern is not
+        # failed by the noise-only background channels. fit_pattern returns it.
+        "peak_region_r2": fit['peak_region_r2'],
+        "r_squared": r_squared,                       # GLOBAL (reported for context)
         "residual_rms_over_noise": fit['residual_rms_over_noise'],
-        "verdict": "accept" if r_squared >= 0.95 else (
-            "marginal" if r_squared >= 0.85 else "reject"
+        "verdict": "accept" if fit['peak_region_r2'] >= 0.90 else (
+            "marginal" if fit['peak_region_r2'] >= 0.55 else "reject"
         ),
         "n_peaks_fitted": fit['n_peaks'],
     },
 }))
 ```
+
+The gate scores `peak_region_r2`. When the global `r_squared` is well below
+`peak_region_r2`, the pattern is low-SNR (weak counts, noisy background) but its
+reflections are well fit — accept it; that gap is the metric working as
+intended, not a bad fit. When `peak_region_r2` itself is low, real reflections
+are mis- or un-modelled (a genuine miss on a dense low-symmetry pattern) — that
+is **not** rescued, so refine (lower `prominence_frac`/`min_distance_deg` and
+re-run the single global `fit_pattern`). `peak_region_r2` equals the global R² on
+a high-SNR pattern, so this changes nothing for clean data.
 
 **In-situ / series use — lock the method, not the values.** `fit_pattern` is
 one fast call per frame, so it drops straight into the agent's per-spectrum
@@ -331,9 +344,19 @@ auto-detect catches it and re-run the single global `fit_pattern` — keep the
 recipe auto-detecting (so it still generalises frame-to-frame), not spliced
 sub-fits or hardcoded centers.
 
-**Per-peak fit checks:**
-- `r_squared` ≥ 0.95 for each fit accepts; 0.85–0.95 marginal; below
-  0.85 reject the fit and either widen the window or drop the peak.
+**Gate on `peak_region_r2`, read the global R² as context.** The whole-pattern
+`r_squared` is depressed by noise-only background channels on a weak/noisy
+pattern, so a correct fit can score a misleadingly low global R² (e.g. a faint
+powder pattern whose Bragg peaks are well fit can sit at global R² ≈ 0.5 with
+`peak_region_r2` ≈ 0.9). Score acceptance on `peak_region_r2`:
+- `peak_region_r2` ≥ 0.90 accepts; 0.55–0.90 marginal (the verifier decides on
+  residual structure); below 0.55 reject.
+- A large `r_squared` ↔ `peak_region_r2` gap with a **structureless (noise-only)
+  residual** = low-SNR pattern, fit is good → accept. The same gap with
+  *peaked* residual (unmodelled-reflection spikes) = real miss → refine: lower
+  `prominence_frac`/`min_distance_deg` and re-run the single global `fit_pattern`.
+  `peak_region_r2` does not rescue a fit that genuinely misses reflections, so a
+  low `peak_region_r2` is a true reject, not a metric artifact.
 - FWHM sanity: 0.05° (typical instrumental floor for a lab CuKa
   diffractometer) ≤ FWHM ≤ 2.0° (very small crystallites; peak overlap
   dominates above this).

--- a/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
+++ b/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
@@ -274,6 +274,13 @@ fit = fit_pattern(
 peaks = fit['peaks']            # each: center, fwhm, amplitude, area, eta
 r_squared = fit['r_squared']    # GLOBAL R²
 
+# Save the fit overlay (fit.npy) on the RAW-intensity scale so it matches the raw
+# data. fit['fit_curve'] is on the BACKGROUND-SUBTRACTED scale; saving THAT makes a
+# good fit look collapsed (peaks at a fraction of height, gaps near zero) whenever
+# the background is large — use fit['fit_curve_raw'] (= fit_curve + background).
+import numpy as np
+np.save('fit.npy', np.asarray(fit['fit_curve_raw'], dtype=float))
+
 # ---- Step 3: Per-peak Scherrer size ----
 sizes_nm = []
 for p in peaks:

--- a/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
+++ b/scilink/skills/curve_fitting/xrd_profile/xrd_profile.md
@@ -370,6 +370,21 @@ interpretation, not from frozen centers.** Only pass an explicit `peak_centers`
 for a one-off re-fit of a single known-stable pattern — never as the series
 default.
 
+**The detection settings ARE part of the recipe — tune them, then freeze them.**
+`prominence_frac` and `min_distance_deg` are *settings*, not *values*: tune them
+on the establishing frame so every visible reflection is modelled, then carry the
+chosen numbers into the series call. Doing so is locking the *method* (correct);
+it is the peak *centers* that must never be frozen. Watch `prominence_frac` in
+particular — its floor scales with the pattern's intensity range, so the weakest
+(usually high-angle) reflections sit just above it and are the first to be
+dropped. **A residual statistic will not warn you**: a weak peak on a noisy
+high-angle floor reads only a few σ even when it is entirely unmodelled, so the
+fit can miss real reflections while R²/peak_region_r2/RMS all look clean. Verify
+coverage **by eye against the data across the full 2θ range** — a log-scale
+data-vs-fit overlay — not by the residual number: if the raw data plainly shows
+reflections the model leaves at baseline, lower `prominence_frac` (0.02 → 0.01 →
+0.005) until they are caught, then freeze that value for the series.
+
 For speed across a long series: the default `snip_iterations='auto'` sweeps
 a few background widths per frame (~4× the fit cost). Once the establishing
 frame reports its choice (in `background_method`, e.g. `snip(iterations=10)`),

--- a/tests/test_xrd_quality.py
+++ b/tests/test_xrd_quality.py
@@ -90,6 +90,55 @@ def test_fit_pattern_reports_peak_region_r2():
     assert 0.0 <= res["peak_region_r2"] <= 1.0
 
 
+def test_max_abs_residual_flags_localized_misfit():
+    """The dynamic-range diagnostic: max_abs_residual_over_noise is the worst
+    LOCAL misfit, the complement of the averaged R²/peak_region_r2/RMS. A clean,
+    modest-dynamic-range fit is a few sigma; a localized misfit makes it spike far
+    above the (averaged) residual_rms_over_noise — which is exactly why the
+    averaged metrics hide it. It is read AGAINST the RMS (localized-ness), not as
+    an absolute threshold: its scale rises with dynamic range (a tiny fractional
+    residual on a giant peak is many sigma), so it directs attention rather than
+    issuing a verdict."""
+    from scilink.skills.curve_fitting.xrd_profile.fit_pattern import fit_pattern
+
+    def make(amp, noise_frac, seed, apex_width=0.15):
+        x = np.linspace(10.0, 70.0, 2400)
+        y = np.full_like(x, 200.0)
+        # last peak's width is tunable: a sub-resolution apex_width makes a tall
+        # peak that IS detected (so peak_region_r2 stays high) but is too sharp
+        # for the model floor to fit -> a localized apex misfit.
+        # the apex peak is DOMINANT (high dynamic range, like a real super-peak):
+        # fittable at the default width (clean -> low max), sub-resolution sharp
+        # at apex_width=0.012 (misfit the smooth model cannot capture -> high max).
+        for c, f, w in [(20, 1.0, 0.15), (30, 0.6, 0.15), (45, 0.4, 0.15), (58, 4.0, apex_width)]:
+            s = w / 2.355
+            g = np.exp(-((x - c) ** 2) / (2 * s ** 2))
+            l = (w / 2) ** 2 / ((x - c) ** 2 + (w / 2) ** 2)
+            y += amp * f * (0.5 * l + 0.5 * g)
+        y += np.random.default_rng(seed).normal(0, noise_frac * amp, y.shape)
+        return x, y
+
+    # clean fits: low max-residual at BOTH high and low SNR (not just tracking noise)
+    clean_vals = []
+    for amp in (2e5, 5e3):
+        x, y = make(amp, 0.01, 0)
+        r = fit_pattern(x.tolist(), y.tolist())
+        assert "max_abs_residual_over_noise" in r
+        assert r["max_abs_residual_over_noise"] < 6.0, amp        # clean ~ few sigma
+        assert r["peak_region_r2"] > 0.95
+        clean_vals.append(r["max_abs_residual_over_noise"])
+
+    # A tall, sub-resolution-sharp apex the smooth model cannot capture -> a
+    # localized misfit. The whole point: it is HUGE in max_abs_residual_over_noise
+    # but small in the AVERAGED residual_rms_over_noise -- which is exactly why the
+    # averaged metrics (R²/peak_region_r2/RMS) hide it. (On a many-peak pattern the
+    # few misfit points also leave peak_region_r2 high; validated on real IBD data.)
+    x, y = make(2e5, 0.005, 0, apex_width=0.012)                  # << model FWHM floor
+    r = fit_pattern(x.tolist(), y.tolist())
+    assert r["max_abs_residual_over_noise"] > 8.0 * max(clean_vals)   # loudly flagged
+    assert r["max_abs_residual_over_noise"] > 5.0 * r["residual_rms_over_noise"]  # averaging hides it
+
+
 def test_fit_range_contract():
     """fit_range restricts detection/background/fit to a window, finds the in-window
     peaks, and returns FULL-length arrays with the excluded region at zero residual

--- a/tests/test_xrd_quality.py
+++ b/tests/test_xrd_quality.py
@@ -139,6 +139,30 @@ def test_max_abs_residual_flags_localized_misfit():
     assert r["max_abs_residual_over_noise"] > 5.0 * r["residual_rms_over_noise"]  # averaging hides it
 
 
+def test_fit_curve_raw_overlays_raw_data():
+    """fit_pattern returns fit_curve_raw (= fit_curve + background) — the model on
+    the RAW-intensity scale. Saving THIS (not fit_curve, which is background-
+    subtracted) is what makes a good fit overlay the raw data instead of looking
+    collapsed when the background is large."""
+    from scilink.skills.curve_fitting.xrd_profile.fit_pattern import fit_pattern
+    x = np.linspace(10.0, 60.0, 3000)
+    bg = 50000.0 + 1e5 * np.exp(-(x - 10.0) * 0.3)        # large, sloping background
+    y = bg.copy()
+    for c, a in [(20.0, 8e5), (30.0, 4e5), (45.0, 2e5)]:
+        y += a * (0.1 ** 2) / ((x - c) ** 2 + 0.1 ** 2)
+    r = fit_pattern(x.tolist(), y.tolist())
+    assert "fit_curve_raw" in r
+    fcr = np.asarray(r["fit_curve_raw"]); fc = np.asarray(r["fit_curve"])
+    assert fcr.shape == x.shape
+    # fit_curve_raw overlays the raw data (peaks at full raw height); fit_curve does NOT
+    i = int(np.argmin(np.abs(x - 20.0)))
+    assert 0.9 < fcr[i] / y[i] < 1.1                      # raw-scale overlay matches data
+    assert fc[i] / y[i] < 0.7                             # bg-subtracted is well below raw
+    # in the gaps the raw-scale model sits at the background, not at ~0
+    g = int(np.argmin(np.abs(x - 15.0)))
+    assert fcr[g] > 0.5 * bg[g]
+
+
 def test_fit_range_contract():
     """fit_range restricts detection/background/fit to a window, finds the in-window
     peaks, and returns FULL-length arrays with the excluded region at zero residual

--- a/tests/test_xrd_quality.py
+++ b/tests/test_xrd_quality.py
@@ -1,0 +1,103 @@
+"""Offline tests for the XRD peak-region quality metric and its wiring.
+
+The metric is the shared 1D-spectroscopy ``peak_region_r2`` (hoisted to
+``_shared``). For XRD it must (a) RESCUE a correct fit of a weak/noisy powder
+pattern that a whole-pattern R² scores low, (b) still FAIL a fit that genuinely
+misses reflections, (c) leave a high-SNR fit unchanged (no regression), and be
+correctly skill-gated to the ``xrd_profile`` skill. ``fit_pattern`` must report
+it. The NMR skill must keep re-exporting the same implementation.
+"""
+
+from __future__ import annotations
+
+import re
+
+import numpy as np
+import pytest
+import yaml
+from pathlib import Path
+
+from scilink.skills._shared._quality_metrics import peak_region_r2
+
+N = 8000
+X = np.linspace(10.0, 80.0, N)  # 2-theta degrees
+
+
+def _pv(A, x0, w):
+    return A * (w / 2) ** 2 / ((X - x0) ** 2 + (w / 2) ** 2)
+
+
+def _pattern(amp, seed=0):
+    y = np.zeros(N)
+    for c in (22.0, 28.0, 35.0, 48.0, 61.0):
+        y += _pv(amp, c, 0.3)
+    return y + np.random.default_rng(seed).normal(0, 1.0, N)
+
+
+def _model(amp):
+    y = np.zeros(N)
+    for c in (22.0, 28.0, 35.0, 48.0, 61.0):
+        y += _pv(amp, c, 0.3)
+    return y
+
+
+def test_rescues_correct_low_snr_pattern():
+    # Weak peaks (5σ) on a noisy background: global R² low, region R² rescues.
+    y = _pattern(amp=5)
+    q = peak_region_r2(X, y, _model(5), baseline=np.zeros(N))
+    assert q["r_squared"] < q["peak_region_r2"]
+    assert q["peak_region_r2"] > 0.3
+
+
+def test_high_snr_pattern_unchanged():
+    # Strong peaks: region R² ≈ global R², both high → no regression on clean data.
+    y = _pattern(amp=200)
+    q = peak_region_r2(X, y, _model(200), baseline=np.zeros(N))
+    assert q["peak_region_r2"] > 0.9
+    assert abs(q["peak_region_r2"] - q["r_squared"]) < 0.05
+
+
+def test_missed_reflections_not_rescued():
+    # Model omits two of the five reflections: region R² must drop (genuine miss).
+    y = _pattern(amp=40)
+    partial = _pv(40, 22.0, 0.3) + _pv(40, 28.0, 0.3) + _pv(40, 35.0, 0.3)
+    q = peak_region_r2(X, y, partial, baseline=np.zeros(N))
+    full = peak_region_r2(X, y, _model(40), baseline=np.zeros(N))
+    assert q["peak_region_r2"] < full["peak_region_r2"] - 0.2
+
+
+def test_reexport_identity():
+    # NMR and XRD bundles must re-export the SAME shared implementation.
+    from scilink.skills.curve_fitting.nmr.quality import peak_region_r2 as nmr
+    from scilink.skills.curve_fitting.xrd_profile.quality import peak_region_r2 as xrd
+    assert nmr is xrd is peak_region_r2
+
+
+def test_tool_registered_and_skill_gated():
+    from scilink.skills._shared._registry import get_tools_for, get_tool_function
+    names = {t.name for t in get_tools_for("curve_fitting", active_skills=["xrd_profile"])}
+    assert "peak_region_r2" in names
+    assert "peak_region_r2" not in {
+        t.name for t in get_tools_for("curve_fitting", active_skills=[])}
+    assert callable(get_tool_function("peak_region_r2", active_skills=["xrd_profile"]))
+
+
+def test_fit_pattern_reports_peak_region_r2():
+    from scilink.skills.curve_fitting.xrd_profile.fit_pattern import fit_pattern
+    y = _pattern(amp=200)
+    res = fit_pattern(X.tolist(), y.tolist())
+    assert "peak_region_r2" in res and "n_signal_points" in res
+    assert 0.0 <= res["peak_region_r2"] <= 1.0
+
+
+def test_frontmatter_gate_is_peak_region_r2():
+    md = Path("scilink/skills/curve_fitting/xrd_profile/xrd_profile.md").read_text()
+    fm = yaml.safe_load(md.split("---")[1])
+    gate = fm["quality_gate"]
+    assert gate["metric"] == "peak_region_r2"
+    from scilink.agents.exp_agents.quality_gate import _coerce
+    g = _coerce(gate)
+    assert g.metric == "peak_region_r2"
+    assert g.hard_reject_threshold <= g.accept_threshold
+    # the gate reads the metric out of a fit_quality dict
+    assert g.extract({"peak_region_r2": 0.89, "r_squared": 0.55}) == pytest.approx(0.89)

--- a/tests/test_xrd_quality.py
+++ b/tests/test_xrd_quality.py
@@ -90,6 +90,49 @@ def test_fit_pattern_reports_peak_region_r2():
     assert 0.0 <= res["peak_region_r2"] <= 1.0
 
 
+def test_fit_range_contract():
+    """fit_range restricts detection/background/fit to a window, finds the in-window
+    peaks, and returns FULL-length arrays with the excluded region at zero residual
+    (so the verifier's length-N residual diagnostics still run). The real-data
+    recovery (low-angle upturn: 1 -> 20 peaks on the RRUFF/IBD series) is validated
+    in the benchmark; SNIP's exact overshoot is not reliably reproducible in a unit
+    synthetic, so here we assert the mechanical contract."""
+    from scilink.skills.curve_fitting.xrd_profile.fit_pattern import fit_pattern
+    x = np.linspace(2.0, 45.0, 4300)
+    y = np.full_like(x, 500.0)
+    for c, a in [(11.0, 8000), (17.0, 3000), (22.0, 9000), (29.0, 2000), (36.0, 1500)]:
+        y += a * (0.05 ** 2) / ((x - c) ** 2 + 0.05 ** 2)
+    y += 5e5 * np.exp(-(x - 2.0) * 3.0)   # non-Bragg low-angle upturn below ~4 deg
+
+    ranged = fit_pattern(x.tolist(), y.tolist(), fit_range=(5.0, 45.0))
+    assert ranged["n_peaks"] >= 5                       # finds the 5 in-window peaks
+    # full-length arrays preserved (residual-diagnostic length contract)
+    assert len(ranged["fit_curve"]) == x.size
+    assert len(ranged["intensity_corrected"]) == x.size
+    # excluded region is matched -> zero residual on raw-scale reconstruction
+    fc = np.asarray(ranged["fit_curve"]); ic = np.asarray(ranged["intensity_corrected"])
+    fit_raw = fc + (y - ic)
+    excl = x < 5.0
+    assert np.max(np.abs(y[excl] - fit_raw[excl])) < 1e-6
+    assert ranged["fit_range"] == [5.0, 45.0]
+    # scores reflect the window only and the in-window fit is good
+    assert ranged["peak_region_r2"] > 0.9
+
+
+def test_fit_range_none_is_default_behavior():
+    """fit_range=None must be byte-identical to omitting it (no regression)."""
+    from scilink.skills.curve_fitting.xrd_profile.fit_pattern import fit_pattern
+    x = np.linspace(10.0, 60.0, 2500)
+    y = np.full_like(x, 100.0)
+    for c in (20.0, 30.0, 45.0):
+        y += 2000 * (0.1 ** 2) / ((x - c) ** 2 + 0.1 ** 2)
+    a = fit_pattern(x.tolist(), y.tolist())
+    b = fit_pattern(x.tolist(), y.tolist(), fit_range=None)
+    assert a["n_peaks"] == b["n_peaks"]
+    assert a["r_squared"] == pytest.approx(b["r_squared"])
+    assert "fit_range" not in a  # only present when a window was applied
+
+
 def test_frontmatter_gate_is_peak_region_r2():
     md = Path("scilink/skills/curve_fitting/xrd_profile/xrd_profile.md").read_text()
     fm = yaml.safe_load(md.split("---")[1])


### PR DESCRIPTION
## Summary (for scientists)

Hardens the `xrd_profile` curve-fitting skill so it reliably handles **real lab powder-XRD data**, including in-situ variable-temperature series — exercised against a real heating series and the RRUFF mineral benchmark. The agent now correctly:

- **Doesn't fail a correct fit of a weak/noisy pattern** — scoring is on a peak-region R² (R² over the channels that actually carry diffracted intensity), so a faint pattern whose Bragg peaks are well fit is no longer hard-rejected by noise-only background channels.
- **Handles the low-angle air-scatter / beam-stop upturn** — a `fit_range` window excludes the steep low-angle climb (which otherwise makes the background overshoot and starves peak detection); a rule recognises a dominant low-angle feature that *suppresses the rest of the pattern* as air-scatter to exclude.
- **Keeps the background sane** (prefers SNIP over a polynomial that can go negative between peaks), tunes detection per phase in an in-situ series, and **plots the fit on the correct (raw) scale** so a good fit is no longer drawn as if it had collapsed.

On an in-situ heating series the agent tracks the Bragg reflections through a phase transition — including appearance/disappearance of reflections and per-phase peak sets — with clean, complete per-frame fits across the whole series.

## What was deliberately *not* done (and why)

- **`max_peaks` cap left at 30** — a sweep showed raising it is strictly worse (worse R², 3–7× slower) on dense patterns; the monolithic global fit doesn't scale.
- **`prominence_frac` default left at 0.02** — it is a *knob the LLM tunes per pattern*, not a default to change: lowering it to 0.01 over-detects on clean low-noise sparse patterns (verified, 6 true peaks → 18–26), while 0.02 mis-detects on dominant-peak patterns. No single default is right.
- **No new peak-detection heuristic** — a dominant-outlier prominence-floor fix was prototyped and rejected: it could not separate air-scatter (370–800×) from a legitimate dominant mineral peak (Anhydrite, 124×) without over-detecting normal patterns.
- **No windowed fitter** — the apparent dense-overlap "under-fit" on transition frames turned out to be a visualization scale bug, not a fitting failure (the global fit was always good).

## Technical details (for reviewers)

**Quality metric (`peak_region_r2`).** Hoisted the NMR `peak_region_r2` to `scilink/skills/_shared/_quality_metrics.py` (general 1D-spectroscopy metric); `nmr/quality.py` and new `xrd_profile/quality.py` re-export it with their own skill-gated `TOOL_SPEC`s. `fit_pattern` returns it; the `xrd_profile` frontmatter gate is `peak_region_r2` (accept 0.90 / hard-reject 0.55). Verified on a 24-mineral disjoint held-out: low-SNR rescue generalizes (Hausmannite global 0.63 → region 0.92), genuine misses not rescued (Axinite recall 0.64 stays 0.86), 0 false hard-rejects vs the old global gate failing 12/24.

**`fit_pattern` additions (all backward-compatible new return fields):**
- `fit_range=(lo,hi)` — excludes channels outside the window from background/detection/fit, padded back to full length with the excluded region matched (zero residual) so length-N residual diagnostics still run.
- `max_abs_residual_over_noise` — worst single local misfit; complements the averaged R²/region/RMS that hide a localized error. Framed as attention-directing (read against RMS; the figure decides), not a thresholded verdict — a generalization sweep showed an absolute threshold over-flags high-dynamic-range patterns.
- `fit_curve_raw` (= `fit_curve` + background) — the model on the raw-intensity scale. The template now saves `fit.npy = fit['fit_curve_raw']`. The previous reconstruction-in-the-script invited an LLM error that saved the background-subtracted `fit_curve`, making a good fit look collapsed against raw data on large-background frames (the in-situ "missing peaks" symptom). No metric flagged it; only the corrected overlay reveals it.

**Skill prose (`xrd_profile.md`):** low-SNR gate framing conditioned on verified low-SNR + structureless residual; `fit_range` low-angle guidance (set `lo` where the climb flattens; the dominant-air-scatter-suppression rule; read the result not the intent); SNIP-over-polynomial hardening; detection settings as part of the locked series recipe (tune-and-freeze, verify coverage by eye because the residual stat is blind to weak high-angle peaks); plus the Rietveld refinement-order and sample/mounting physical priors contributed by an XRD practitioner (fenced under the engine-pending tier-3 block).

**Agent log fix (`curve_fitting_agent.py`, `controllers/curve_fitting_controllers.py`):** the "verifier bypassed" / "Fit approved (R² = X)" log lines reported the global R² and a stale "bypassed" message for non-R² gates; now branch on `physical_review` and report the actual gate metric. Decisions were always correct; only the log text was misleading.

**Tests:** `tests/test_xrd_quality.py` (peak_region_r2 rescue/not-rescued/no-regression, skill-gating, re-export identity, `fit_range` contract + over-crop, `max_abs_residual` discrimination, `fit_curve_raw` raw-scale overlay, frontmatter gate). 37 offline tests pass; NMR untouched (re-export is the same object).

**Known limits / deferred:** genuine dense low-symmetry overlap (the agent compensates via codegen; a scalable windowed fitter is deferred architectural work); a peak-on-the-air-scatter-climb needs a dedicated low-angle background, not the single `fit_range` bound.
