### PR TITLE
Hyperspectral X-ray K-edge thickness: baseline operand, edge-step tool, combined verifier + salvage judge

### DIFF
--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -2300,10 +2300,21 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                                             {"title": "Representative mean spectrum"})
                                     except Exception:
                                         mean_spec_bytes = b""  # tolerate; runs without it
+                                # Coverage: fraction of pixels carrying a real
+                                # (finite, non-zero) value. A tiny coverage for a
+                                # feature expected to fill a coherent region is a
+                                # masking/segmentation COLLAPSE the value stats
+                                # alone don't reveal (a few dozen plausible-valued
+                                # pixels look fine by range/mean).
+                                _finite = np.isfinite(result_map)
+                                _real = _finite & (np.abs(result_map) > 1e-9)
+                                _cov = 100.0 * float(_real.sum()) / max(result_map.size, 1)
                                 summary = (
                                     f"value range [{float(np.nanmin(result_map)):.4g}, "
                                     f"{float(np.nanmax(result_map)):.4g}], mean "
-                                    f"{float(np.nanmean(result_map)):.4g} {current_unit}")
+                                    f"{float(np.nanmean(result_map)):.4g} {current_unit}; "
+                                    f"valid coverage {_cov:.1f}% "
+                                    f"({int(_real.sum())} of {result_map.size} pixels finite & non-zero)")
                                 tool_descriptions = _used_tool_descriptions(state, code_str)
                                 self.logger.info(f"    🔎 Combined review on {feature_name}...")
                                 is_valid, critique = self._review_required_output(
@@ -2462,6 +2473,15 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                         rep_dash, code_str, mean_spec_bytes or None,
                         state.get("system_info"), state.get("analysis_objective"),
                         _used_tool_descriptions(state, code_str), result_summary)
+
+                    # Record the degradation so the top-level status reflects it
+                    # (a salvage is NOT a clean success). Threaded up to analyze().
+                    state.setdefault("degradation_notes", []).append({
+                        "kind": "withheld" if not present else "approximate",
+                        "confidence": "none" if not present else conf,
+                        "missing_required": missing,
+                        "caveat": caveat,
+                    })
 
                     if not present:
                         self.logger.warning(

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -24,9 +24,11 @@ from ..instruct import (
     SPECTROSCOPY_REFLECTION_UPDATE_INSTRUCTIONS,
     SPECTROSCOPY_VALIDATION_INTERPRETATION_INSTRUCTIONS,
     SPECTROSCOPY_VISUAL_QC_INSTRUCTIONS,
+    SPECTROSCOPY_PHYSICS_SANITY_INSTRUCTIONS,
 )
 
 from ....skills.hyperspectral.eels.eels import AGENT_METADATA_KEYS_TO_STRIP
+from ....skills._shared.curve_fitting_tools import plot_curve_to_bytes
 from ....executors import ExecutionTimeout
 from ....utils.codegen_parse import parse_codegen_response
 
@@ -2123,6 +2125,7 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                     total_maps_expected = len(maps_dict)
                     raw_units = result_dict.get("units", "a.u.")
                     desc = result_dict.get("description", "")
+                    mean_spec_bytes = None  # rendered lazily for the sanity check
 
                     for feature_name, result_map in maps_dict.items():
                         # Shape/NaN Check
@@ -2155,6 +2158,40 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                             # 3. Visual QC (Generator-Judge Loop)
                             self.logger.info(f"    👀 Performing Visual QC on {feature_name}...")
                             is_valid, critique = self._check_result_visually(dashboard_bytes, f"{target_desc} ({feature_name})")
+
+                            # 3b. Physics sanity check (LLM, voted) — only for the
+                            # user-asked-for quantitative deliverables, only once
+                            # visual QC has passed. Visual QC sees plausibility, not
+                            # correctness; this reads the METHOD (code) + a
+                            # representative spectrum + the objective to catch a
+                            # smooth-but-wrong VALUE (e.g. a biased global fit). It
+                            # is conservative (majority vote, fail-open).
+                            if is_valid and feature_name in required_outputs:
+                                if mean_spec_bytes is None:
+                                    try:
+                                        _ms = np.asarray(optimal_data).reshape(
+                                            -1, optimal_data.shape[-1]).mean(0)
+                                        mean_spec_bytes = plot_curve_to_bytes(
+                                            np.column_stack(
+                                                [np.asarray(state["energy_axis"]), _ms]),
+                                            {"title": "Representative mean spectrum"})
+                                    except Exception:
+                                        mean_spec_bytes = b""  # tolerate; check runs without it
+                                summary = (
+                                    f"value range [{float(np.nanmin(result_map)):.4g}, "
+                                    f"{float(np.nanmax(result_map)):.4g}], mean "
+                                    f"{float(np.nanmean(result_map)):.4g} {current_unit}")
+                                self.logger.info(f"    🔬 Physics sanity check on {feature_name}...")
+                                sane, sane_crit = self._sanity_check_result(
+                                    dashboard_bytes, code_str, mean_spec_bytes or None,
+                                    state.get("system_info"),
+                                    state.get("analysis_objective"),
+                                    feature_name, summary)
+                                if not sane:
+                                    is_valid, critique = False, sane_crit
+                                    self.logger.warning(
+                                        f"    🔬 Physics sanity check rejected "
+                                        f"{feature_name}: {critique}")
 
                             if is_valid:
                                 # STAGE DATA (Do not commit to state yet)
@@ -2321,6 +2358,70 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
         except Exception as e:
             self.logger.warning(f"QC check crashed: {e}")
             return True, ""
+
+    # Number of independent judgments and the votes-to-reject majority. A single
+    # judgment is too noisy near the decision boundary (it false-rejects a
+    # correct result ~half the time in validation), but it never false-PASSES a
+    # gross error — so requiring a majority of independent judgments to agree
+    # before flagging removes the false-rejects while keeping the true catches.
+    SANITY_VOTES = 3
+    SANITY_REJECT_MAJORITY = 2
+
+    def _sanity_check_one(self, dashboard_bytes, code_str, mean_spec_bytes,
+                          system_info, objective, feature_desc, result_summary):
+        meta_str = (json.dumps(system_info, default=str)[:1500]
+                    if system_info else "(none)")
+        prompt = [SPECTROSCOPY_PHYSICS_SANITY_INSTRUCTIONS.format(
+            objective=objective or "(not specified)",
+            metadata=meta_str,
+            method=(code_str or "(unavailable)")[:6000],
+            result_summary=f"Output '{feature_desc}': {result_summary}",
+        )]
+        prompt.append("Result dashboard (map + histogram):")
+        prompt.append({"mime_type": "image/jpeg", "data": dashboard_bytes})
+        if mean_spec_bytes:
+            prompt.append("Representative mean spectrum of the data:")
+            prompt.append({"mime_type": "image/png", "data": mean_spec_bytes})
+        resp = self.model.generate_content(
+            prompt, generation_config=None, safety_settings=self.safety_settings,
+        )
+        result, _ = self._parse_llm_response(resp)
+        return bool(result.get("valid", True)), result.get("critique", "")
+
+    def _sanity_check_result(self, dashboard_bytes, code_str, mean_spec_bytes,
+                             system_info, objective, feature_desc,
+                             result_summary) -> tuple[bool, str]:
+        """LLM physical-soundness check: given the objective, data context, the
+        METHOD (generated code) and a representative spectrum, judge whether the
+        result is physically plausible and the method sound. Complements visual
+        QC, which only sees the output dashboard and so cannot catch a smooth-
+        but-wrong VALUE (e.g. a biased global fit).
+
+        Votes ``SANITY_VOTES`` independent judgments and rejects only when at
+        least ``SANITY_REJECT_MAJORITY`` agree the result is flawed — robust to
+        single-judgment noise, and biased toward accept (so it does not suppress
+        surprising-but-sound results). Fails open on error, and short-circuits
+        once the outcome is decided.
+        """
+        reject_votes, last_crit = 0, ""
+        for i in range(self.SANITY_VOTES):
+            try:
+                ok, crit = self._sanity_check_one(
+                    dashboard_bytes, code_str, mean_spec_bytes,
+                    system_info, objective, feature_desc, result_summary)
+            except Exception as e:
+                self.logger.warning(f"Physics sanity check crashed: {e}")
+                return True, ""  # fail-open
+            if not ok:
+                reject_votes += 1
+                last_crit = crit or last_crit
+            # short-circuit: decided either way
+            remaining = self.SANITY_VOTES - (i + 1)
+            if reject_votes >= self.SANITY_REJECT_MAJORITY:
+                return False, last_crit
+            if reject_votes + remaining < self.SANITY_REJECT_MAJORITY:
+                return True, ""
+        return True, ""
     
 
 class RunSelfReflectionController:

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -25,11 +25,15 @@ from ..instruct import (
     SPECTROSCOPY_VALIDATION_INTERPRETATION_INSTRUCTIONS,
     SPECTROSCOPY_VISUAL_QC_INSTRUCTIONS,
     SPECTROSCOPY_PHYSICS_SANITY_INSTRUCTIONS,
+    SPECTROSCOPY_RESULT_REVIEW_INSTRUCTIONS,
+    SPECTROSCOPY_SALVAGE_JUDGE_INSTRUCTIONS,
 )
 
 from ....skills.hyperspectral.eels.eels import AGENT_METADATA_KEYS_TO_STRIP
 from ....skills._shared.curve_fitting_tools import plot_curve_to_bytes
-from ....skills._shared._registry import get_tools_for, get_tool_function
+from ....skills._shared._registry import (
+    get_tools_for, get_tool_function, VERIFIER_TOOL_SCRUTINY_PRINCIPLE,
+)
 from ....executors import ExecutionTimeout
 from ....utils.codegen_parse import parse_codegen_response
 
@@ -144,6 +148,37 @@ def _hyperspectral_tool_specs(state: dict):
         return []
 
 
+def _planning_tool_awareness(state: dict) -> str | None:
+    """Minimal names + when_to_use for the downstream code tools, plus a
+    discipline directive telling the PLANNER to stay method-level.
+
+    The planner does NOT get the full tool inventory (that stays at the codegen
+    step, to keep planning prompts tight). It gets just enough to avoid the
+    failure this fixes: a tool-unaware plan prescribes hand-rolled physics
+    ("embed a NIST mu tabulation", "use a 76-80 / 81-86 keV window") which the
+    codegen then follows *instead of* calling the vetted tool — reintroducing
+    the very bias the tool removes. Naming the tools + forbidding hand-rolled
+    coefficient tables / prescribed windows keeps method selection in the plan
+    and implementation detail in the tool. Returns None when no tools apply.
+    """
+    specs = _hyperspectral_tool_specs(state)
+    if not specs:
+        return None
+    lines = [
+        "\n\n--- Downstream Code Tools (available to the implementation step) ---",
+        "The code implementing your plan can call these vetted helpers. Plan at the "
+        "METHOD level and rely on them for the details they own. Do NOT embed your own "
+        "coefficient/attenuation tables, and do NOT prescribe specific numeric windows "
+        "or parameters that a tool below already handles — name the method (e.g. "
+        "'measure the K-edge step', 'obtain mu from tables') and leave the exact "
+        "windows / coefficients to the tool.",
+    ]
+    for s in specs:
+        wtu = getattr(s, "when_to_use", "") or getattr(s, "description", "")
+        lines.append(f"- `{s.name}`: {wtu}")
+    return "\n".join(lines)
+
+
 def _registry_tool_callables(state: dict) -> dict:
     """{name: callable} for the registered hyperspectral tools, resolved from
     each spec's ``import_line`` (``from MODULE import NAME``). Best-effort — a
@@ -163,6 +198,31 @@ def _registry_tool_callables(state: dict) -> dict:
         except Exception:
             continue
     return out
+
+
+def _used_tool_descriptions(state: dict, code_str: str, max_bytes: int = 1500) -> str:
+    """Descriptions of the registered tools the generated code actually CALLS,
+    for the required-output review.
+
+    Tells the verifier WHAT each used tool already handles robustly (window
+    selection, flux gating, measurability, …) so it does not reject the result
+    by second-guessing internals the tool owns — without feeding any per-run
+    output. Names + description + when_to_use only. Bounded so it can never
+    dominate the prompt.
+    """
+    if not code_str:
+        return ""
+    lines = []
+    for s in _hyperspectral_tool_specs(state):
+        if f"{s.name}(" in code_str:
+            desc = (getattr(s, "description", "") or "").strip()
+            wtu = (getattr(s, "when_to_use", "") or "").strip()
+            entry = f"- `{s.name}`: {desc}"
+            if wtu:
+                entry += f" (When to use: {wtu})"
+            lines.append(entry)
+    blob = "\n".join(lines)
+    return blob[:max_bytes] + ("…" if len(blob) > max_bytes else "")
 
 
 def _auxiliary_display_items(state: dict) -> list:
@@ -1399,6 +1459,14 @@ refinement targets are meaningful here — do not request `spatial` or
 `spectral` zoom refinement.
 """)
 
+        # Give the planner MINIMAL awareness of the downstream code tools (names +
+        # when_to_use) plus a method-level discipline directive, so the plan stops
+        # prescribing hand-rolled physics that overrides those tools. See
+        # _planning_tool_awareness.
+        tool_note = _planning_tool_awareness(state)
+        if tool_note:
+            prompt_parts.append(tool_note)
+
         # Add system info
         if state.get("system_info"):
             sys_info_str = json.dumps(state["system_info"], indent=2)
@@ -2213,18 +2281,15 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                         )
 
                         if dashboard_bytes:
-                            # 3. Visual QC (Generator-Judge Loop)
-                            self.logger.info(f"    👀 Performing Visual QC on {feature_name}...")
-                            is_valid, critique = self._check_result_visually(dashboard_bytes, f"{target_desc} ({feature_name})")
-
-                            # 3b. Physics sanity check (LLM, voted) — only for the
-                            # user-asked-for quantitative deliverables, only once
-                            # visual QC has passed. Visual QC sees plausibility, not
-                            # correctness; this reads the METHOD (code) + a
-                            # representative spectrum + the objective to catch a
-                            # smooth-but-wrong VALUE (e.g. a biased global fit). It
-                            # is conservative (majority vote, fail-open).
-                            if is_valid and feature_name in required_outputs:
+                            if feature_name in required_outputs:
+                                # Combined review (visual + physical + tool
+                                # evidence) in ONE voted pass for the user-asked-
+                                # for deliverables. Merges what were two gates so a
+                                # single reviewer weighs the dashboard, the method,
+                                # the spectrum AND the deterministic tool evidence
+                                # together — preventing the split-brain false
+                                # reject (visual 'noise' vs physical 'saturation',
+                                # each blind to the tool's measurability proof).
                                 if mean_spec_bytes is None:
                                     try:
                                         _ms = np.asarray(optimal_data).reshape(
@@ -2234,22 +2299,28 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                                                 [np.asarray(state["energy_axis"]), _ms]),
                                             {"title": "Representative mean spectrum"})
                                     except Exception:
-                                        mean_spec_bytes = b""  # tolerate; check runs without it
+                                        mean_spec_bytes = b""  # tolerate; runs without it
                                 summary = (
                                     f"value range [{float(np.nanmin(result_map)):.4g}, "
                                     f"{float(np.nanmax(result_map)):.4g}], mean "
                                     f"{float(np.nanmean(result_map)):.4g} {current_unit}")
-                                self.logger.info(f"    🔬 Physics sanity check on {feature_name}...")
-                                sane, sane_crit = self._sanity_check_result(
+                                tool_descriptions = _used_tool_descriptions(state, code_str)
+                                self.logger.info(f"    🔎 Combined review on {feature_name}...")
+                                is_valid, critique = self._review_required_output(
                                     dashboard_bytes, code_str, mean_spec_bytes or None,
                                     state.get("system_info"),
                                     state.get("analysis_objective"),
-                                    feature_name, summary)
-                                if not sane:
-                                    is_valid, critique = False, sane_crit
+                                    feature_name, summary, tool_descriptions)
+                                if not is_valid:
                                     self.logger.warning(
-                                        f"    🔬 Physics sanity check rejected "
+                                        f"    🔎 Combined review rejected "
                                         f"{feature_name}: {critique}")
+                            else:
+                                # Diagnostic (non-required) map: lighter single
+                                # visual QC — no method/physics gate needed.
+                                self.logger.info(f"    👀 Performing Visual QC on {feature_name}...")
+                                is_valid, critique = self._check_result_visually(
+                                    dashboard_bytes, f"{target_desc} ({feature_name})")
 
                             if is_valid:
                                 # STAGE DATA (Do not commit to state yet)
@@ -2364,17 +2435,57 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                 # unsatisfiable required one. The required-output failure is still
                 # surfaced (the task did not cleanly succeed).
                 if best_attempt["valid_count"] > 0:
-                    self.logger.warning(
-                        f"    ⛑️  Committing best partial attempt "
-                        f"({best_attempt['req_passed']}/{len(required_outputs)} required "
-                        f"outputs, {best_attempt['valid_count']} map(s) passed QC); some "
-                        f"required output(s) never passed."
-                    )
-                    for img_item in best_attempt["images"]:
-                        tools.save_image_bytes(img_item['data'], output_dir, img_item['filename'], self.logger)
-                        state.setdefault("analysis_images", []).append(img_item)
-                    all_valid_maps.extend(best_attempt["maps"])
-                    all_valid_meta.extend(best_attempt["meta"])
+                    # Physics-aware salvage Judge: decide (from physics, not just
+                    # QC-pass count) whether the best partial is a defensible
+                    # APPROXIMATE result to present with honest caveats, or is
+                    # meaningless and should be withheld. Simple: one call.
+                    if mean_spec_bytes is None:
+                        try:
+                            _ms = np.asarray(optimal_data).reshape(
+                                -1, optimal_data.shape[-1]).mean(0)
+                            mean_spec_bytes = plot_curve_to_bytes(
+                                np.column_stack(
+                                    [np.asarray(state["energy_axis"]), _ms]),
+                                {"title": "Representative mean spectrum"})
+                        except Exception:
+                            mean_spec_bytes = b""
+                    passed_names = [m["name"] for m in best_attempt["meta"]]
+                    missing = [n for n in required_outputs if n not in passed_names]
+                    result_summary = (
+                        f"{best_attempt['req_passed']}/{len(required_outputs)} required "
+                        f"outputs passed verification. Committed (passed QC): "
+                        f"{passed_names or 'none'}. Never passed / withheld: "
+                        f"{missing or 'none'}.")
+                    rep_dash = (best_attempt["images"][0]["data"]
+                                if best_attempt["images"] else None)
+                    present, conf, caveat = self._judge_salvage(
+                        rep_dash, code_str, mean_spec_bytes or None,
+                        state.get("system_info"), state.get("analysis_objective"),
+                        _used_tool_descriptions(state, code_str), result_summary)
+
+                    if not present:
+                        self.logger.warning(
+                            f"    ⚖️  Salvage judge WITHHELD the partial result "
+                            f"(no physically defensible signal): {caveat}")
+                    else:
+                        self.logger.warning(
+                            f"    ⚖️  Salvage judge: presenting APPROXIMATE result "
+                            f"({conf} confidence) — {caveat}")
+                        self.logger.warning(
+                            f"    ⛑️  Committing best partial attempt "
+                            f"({best_attempt['req_passed']}/{len(required_outputs)} "
+                            f"required outputs, {best_attempt['valid_count']} map(s) "
+                            f"passed QC); some required output(s) never passed.")
+                        marker = f"[APPROXIMATE — {conf} confidence: {caveat}] "
+                        for img_item in best_attempt["images"]:
+                            tools.save_image_bytes(img_item['data'], output_dir, img_item['filename'], self.logger)
+                            state.setdefault("analysis_images", []).append(img_item)
+                        for m in best_attempt["meta"]:
+                            m["description"] = marker + m.get("description", "")
+                            m["confidence"] = conf
+                            m["salvage_caveat"] = caveat
+                        all_valid_maps.extend(best_attempt["maps"])
+                        all_valid_meta.extend(best_attempt["meta"])
 
         # --- FINAL AGGREGATION ---
         if not all_valid_maps:
@@ -2480,7 +2591,103 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
             if reject_votes + remaining < self.SANITY_REJECT_MAJORITY:
                 return True, ""
         return True, ""
-    
+
+    def _review_required_output_one(self, dashboard_bytes, code_str, mean_spec_bytes,
+                                    system_info, objective, feature_desc,
+                                    result_summary, tool_descriptions):
+        meta_str = (json.dumps(system_info, default=str)[:1500]
+                    if system_info else "(none)")
+        prompt = [SPECTROSCOPY_RESULT_REVIEW_INSTRUCTIONS.format(
+            objective=objective or "(not specified)",
+            metadata=meta_str,
+            method=(code_str or "(unavailable)")[:6000],
+            result_summary=f"Output '{feature_desc}': {result_summary}",
+            tool_descriptions=tool_descriptions or "(no registered tool was called)",
+            tool_scrutiny=VERIFIER_TOOL_SCRUTINY_PRINCIPLE,
+        )]
+        prompt.append("Result dashboard (map + histogram):")
+        prompt.append({"mime_type": "image/jpeg", "data": dashboard_bytes})
+        if mean_spec_bytes:
+            prompt.append("Representative mean spectrum of the data:")
+            prompt.append({"mime_type": "image/png", "data": mean_spec_bytes})
+        resp = self.model.generate_content(
+            prompt, generation_config=None, safety_settings=self.safety_settings,
+        )
+        result, _ = self._parse_llm_response(resp)
+        return bool(result.get("valid", True)), result.get("critique", "")
+
+    def _review_required_output(self, dashboard_bytes, code_str, mean_spec_bytes,
+                                system_info, objective, feature_desc,
+                                result_summary, tool_descriptions) -> tuple[bool, str]:
+        """Combined visual + physical review for a REQUIRED output, in ONE voted
+        pass. Replaces the separate visual-QC then physics-sanity gates for
+        required deliverables: a single reviewer weighs the dashboard, the
+        method, the spectrum AND the deterministic tool evidence together, so it
+        cannot split-brain into 'looks like noise' (visual) vs 'saturation'
+        (physical) each blind to the tool's measurability proof. Same voting
+        policy as the physics sanity check (majority-to-reject, fail-open,
+        short-circuit); diagnostics (non-required maps) keep the lighter single
+        visual QC.
+        """
+        reject_votes, last_crit = 0, ""
+        for i in range(self.SANITY_VOTES):
+            try:
+                ok, crit = self._review_required_output_one(
+                    dashboard_bytes, code_str, mean_spec_bytes,
+                    system_info, objective, feature_desc,
+                    result_summary, tool_descriptions)
+            except Exception as e:
+                self.logger.warning(f"Combined result review crashed: {e}")
+                return True, ""  # fail-open
+            if not ok:
+                reject_votes += 1
+                last_crit = crit or last_crit
+            remaining = self.SANITY_VOTES - (i + 1)
+            if reject_votes >= self.SANITY_REJECT_MAJORITY:
+                return False, last_crit
+            if reject_votes + remaining < self.SANITY_REJECT_MAJORITY:
+                return True, ""
+        return True, ""
+
+    def _judge_salvage(self, dashboard_bytes, code_str, mean_spec_bytes,
+                       system_info, objective, tool_descriptions, result_summary):
+        """Final salvage judge (single call). When ALL attempts fail, decide from
+        the physics whether the best partial result is a defensible APPROXIMATE
+        answer worth presenting with caveats, or is meaningless and should be
+        withheld. Returns (present: bool, confidence: 'low'|'medium', caveat).
+        Fails OPEN (present, low, generic caveat) so a crash never silently drops
+        recoverable data — honesty via the caveat, not by discarding.
+        """
+        try:
+            meta_str = (json.dumps(system_info, default=str)[:1500]
+                        if system_info else "(none)")
+            prompt = [SPECTROSCOPY_SALVAGE_JUDGE_INSTRUCTIONS.format(
+                objective=objective or "(not specified)",
+                metadata=meta_str,
+                method=(code_str or "(unavailable)")[:6000],
+                tool_descriptions=tool_descriptions or "(no registered tool was called)",
+                result_summary=result_summary,
+            )]
+            if dashboard_bytes:
+                prompt.append("Representative result dashboard (map + histogram):")
+                prompt.append({"mime_type": "image/jpeg", "data": dashboard_bytes})
+            if mean_spec_bytes:
+                prompt.append("Representative mean spectrum of the data:")
+                prompt.append({"mime_type": "image/png", "data": mean_spec_bytes})
+            resp = self.model.generate_content(
+                prompt, generation_config=None, safety_settings=self.safety_settings)
+            result, _ = self._parse_llm_response(resp)
+            present = bool(result.get("present", True))
+            conf = str(result.get("confidence", "low")).lower()
+            if conf not in ("low", "medium"):
+                conf = "low"
+            caveat = (result.get("caveat") or
+                      "Result did not pass full verification; treat as approximate.")
+            return present, conf, caveat
+        except Exception as e:
+            self.logger.warning(f"Salvage judge crashed: {e}")
+            return True, "low", "Result did not pass full verification; treat as approximate."
+
 
 class RunSelfReflectionController:
     """

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -29,6 +29,7 @@ from ..instruct import (
 
 from ....skills.hyperspectral.eels.eels import AGENT_METADATA_KEYS_TO_STRIP
 from ....skills._shared.curve_fitting_tools import plot_curve_to_bytes
+from ....skills._shared._registry import get_tools_for, get_tool_function
 from ....executors import ExecutionTimeout
 from ....utils.codegen_parse import parse_codegen_response
 
@@ -125,6 +126,43 @@ def _append_prior_knowledge_context(prompt: list, state: dict) -> None:
             prompt.append("\nKey findings:")
             for f in findings:
                 prompt.append(f"- {f}")
+
+
+def _active_skill_names(state: dict) -> list:
+    """Names of the skills currently active for this run (for registry tool
+    scoping). Empty when running skill-free (cold)."""
+    return [s.get("name") for s in (state.get("skills_loaded") or [])
+            if isinstance(s, dict) and s.get("name")]
+
+
+def _hyperspectral_tool_specs(state: dict):
+    """ToolSpecs the _shared registry exposes to the hyperspectral agent given
+    the active skills — the optional tools generated code may call."""
+    try:
+        return get_tools_for("hyperspectral", active_skills=_active_skill_names(state) or None)
+    except Exception:
+        return []
+
+
+def _registry_tool_callables(state: dict) -> dict:
+    """{name: callable} for the registered hyperspectral tools, resolved from
+    each spec's ``import_line`` (``from MODULE import NAME``). Best-effort — a
+    tool whose module/callable can't be imported is skipped, so a missing
+    optional dependency never breaks the sandbox setup.
+    """
+    import importlib
+    out = {}
+    for spec in _hyperspectral_tool_specs(state):
+        try:
+            il = getattr(spec, "import_line", "") or ""
+            if il.startswith("from ") and " import " in il:
+                mod_path, _, nm = il[len("from "):].partition(" import ")
+                out[spec.name] = getattr(importlib.import_module(mod_path.strip()), nm.strip())
+            else:
+                out[spec.name] = get_tool_function(spec.name, active_skills=_active_skill_names(state))
+        except Exception:
+            continue
+    return out
 
 
 def _auxiliary_display_items(state: dict) -> list:
@@ -2039,6 +2077,20 @@ class RunDynamicAnalysisController:
                 auxiliary_operands={k: v.shape for k, v in auxiliary_operands.items()},
             )
 
+            # Registered tools from the _shared registry (this agent + active
+            # skills). Pre-loaded into the sandbox globals below, so generated
+            # code MAY call them by name (no import) when one fits — the same
+            # optional-tool mechanism the image / curve agents use.
+            _tool_specs = _hyperspectral_tool_specs(state)
+            if _tool_specs:
+                base_prompt += (
+                    "\n\n### REGISTERED TOOLS (pre-loaded — call by name, no import)\n"
+                    "These functions are already in scope. Prefer one when it fits "
+                    "the task (e.g. deriving physical constants) over reimplementing it."
+                )
+                for _spec in _tool_specs:
+                    base_prompt += "\n" + _spec.to_prompt()
+
             # Append a preprocessing-mask hint when one exists and identifies
             # excluded pixels. The mask is already applied to the data (zero-
             # filled), so per-pixel fits will produce garbage values on
@@ -2089,8 +2141,14 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                         "nnls": __import__("scipy.optimize", fromlist=["nnls"]).nnls,
                         "linregress": __import__("scipy.stats", fromlist=["linregress"]).linregress,
                         "find_peaks": __import__("scipy.signal", fromlist=["find_peaks"]).find_peaks,
-                        "gaussian_filter": __import__("scipy.ndimage", fromlist=["gaussian_filter"]).gaussian_filter
+                        "gaussian_filter": __import__("scipy.ndimage", fromlist=["gaussian_filter"]).gaussian_filter,
                     }
+                    # Inject registered tools (from the _shared registry) for the
+                    # hyperspectral agent + active skills, so generated code can
+                    # optionally call them by name — same mechanism the image /
+                    # curve agents use, not domain code hardcoded in this generic
+                    # controller.
+                    global_scope.update(_registry_tool_callables(state))
                     
                     # Execute Code
                     with ExecutionTimeout(seconds=self.executor_timeout):

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -131,6 +131,38 @@ def _auxiliary_display_items(state: dict) -> list:
     return [it for it in (state.get("auxiliary_items") or []) if it.get("plot_bytes")]
 
 
+def _resample_ref_to_signal_axis(arr, ref_axis, energy_axis, e_):
+    """Resample a 1D reference sampled on its OWN axis onto the data's signal
+    (energy) axis, so it can serve as a per-channel codegen operand.
+
+    Returns the resampled length-``e_`` array, or ``None`` when resampling is
+    not warranted — i.e. the reference is not a 1D curve carrying its own axis,
+    the signal axis is unknown/degenerate, or the two axes don't overlap (so
+    they plausibly describe different quantities and interpolation would
+    fabricate values rather than align them). Only the previously-dropped
+    misaligned case is affected; aligned operands never reach here.
+    """
+    if ref_axis is None or arr is None:
+        return None
+    arr = np.asarray(arr, dtype=float)
+    ref_axis = np.asarray(ref_axis, dtype=float)
+    if arr.ndim != 1 or ref_axis.shape != arr.shape:
+        return None
+    # Need a real, length-matched signal axis to resample onto (not the
+    # channel-index fallback shape).
+    if energy_axis is None or np.asarray(energy_axis).shape != (e_,):
+        return None
+    energy_axis = np.asarray(energy_axis, dtype=float)
+    order = np.argsort(ref_axis)
+    ra, rv = ref_axis[order], arr[order]
+    # Require axis overlap — guards against interpolating, say, a keV table
+    # onto a channel-index axis (no shared range => not the same quantity).
+    lo, hi = max(ra.min(), float(energy_axis.min())), min(ra.max(), float(energy_axis.max()))
+    if not (hi > lo):
+        return None
+    return np.interp(energy_axis, ra, rv)
+
+
 def _append_auxiliary_context(prompt: list, state: dict) -> None:
     """Append auxiliary reference dataset(s) to an LLM prompt if available."""
     items = _auxiliary_display_items(state)
@@ -1880,10 +1912,16 @@ class RunDynamicAnalysisController:
         # Offer shape-aligned auxiliary dataset(s) as OPTIONAL numerical operands
         # (issue #226): the user-supplied companions (reference/baseline/other
         # channels) the generated code MAY divide by / subtract / mask with,
-        # keyed by label. Each is kept context-only (NOT an operand) when it can't
-        # be aligned to the primary — v1 does no resampling. Raw `data` stays base.
+        # keyed by label. Aligned companions pass through as index-matched
+        # operands. A 1D reference sampled on its OWN axis (e.g. a tabulated
+        # cross-section / attenuation / standard pulled from a database, never
+        # on the detector's grid) is resampled onto the signal axis here so it
+        # becomes a per-channel operand instead of being dropped — the operand
+        # stays index-aligned, so the codegen contract is unchanged. Anything
+        # still unalignable is kept context-only. Raw `data` stays base.
         auxiliary_operands = {}
         h_, w_, e_ = optimal_data.shape
+        energy_axis = np.asarray(state.get("energy_axis")) if state.get("energy_axis") is not None else None
         for it in (state.get("auxiliary_items") or []):
             arr = it.get("array")
             if arr is None:
@@ -1895,11 +1933,21 @@ class RunDynamicAnalysisController:
                 or (arr.ndim == 2 and arr.shape == (h_, w_))      # per-pixel map (mask/normalize)
                 or (arr.shape == optimal_data.shape)              # full companion cube
             )
+            resampled = (
+                None if aligned
+                else _resample_ref_to_signal_axis(arr, it.get("axis"), energy_axis, e_)
+            )
             if aligned:
                 auxiliary_operands[label] = arr
                 self.logger.info(
                     f"🧩 Offering auxiliary '{label}' {arr.shape} as an optional "
                     f"codegen operand."
+                )
+            elif resampled is not None:
+                auxiliary_operands[label] = resampled
+                self.logger.info(
+                    f"🧩 Auxiliary '{label}' ({arr.shape[0]} pts on its own axis) "
+                    f"resampled onto the {e_}-channel signal axis as an operand."
                 )
             else:
                 self.logger.info(

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -163,6 +163,53 @@ def _resample_ref_to_signal_axis(arr, ref_axis, energy_axis, e_):
     return np.interp(energy_axis, ra, rv)
 
 
+def _codegen_retry_feedback(failures: int, critique: str) -> str:
+    """Annealed retry guidance for the per-pixel code-gen loop.
+
+    Flat retries (re-prompt at the same setting with "fix the math") cannot
+    escape a wrong-but-self-consistent method — they re-sample the same basin.
+    So the guidance *anneals*: early failures patch the logic, repeated
+    failures push the model to question and then ABANDON the method for a
+    structurally different estimator. "Temperature" here is the prompt's
+    structural freedom — modern Claude/Bedrock models omit the sampling
+    temperature, so escalation is expressed in the instruction, not the knob.
+    The escape-hatch families are generic to per-pixel quantitative extraction,
+    so this helps any struggling analysis, not one technique.
+    """
+    block = [
+        "\n\n### ❌ PREVIOUS ATTEMPT FAILED",
+        f"Critique:\n```text\n{critique}\n```",
+    ]
+    if failures <= 1:
+        block.append("Fix the logic/math to address this critique.")
+    elif failures == 2:
+        block.append(
+            "This is the SECOND failure with the same approach — stop tweaking "
+            "parameters and question the METHOD itself. A common cause of a "
+            "non-physical or mostly-masked quantitative map is a fit performed "
+            "across the FULL measurement axis: channels that violate the model "
+            "(signal saturation, heavy absorption / near-zero transmission, low "
+            "SNR, near-zero reference) bias a global fit. Restrict the extraction "
+            "to the informative sub-range, or use a measure insensitive to those "
+            "channels."
+        )
+    else:
+        block.append(
+            "The current APPROACH has failed repeatedly. Do NOT patch it again — "
+            "ABANDON it and choose a STRUCTURALLY DIFFERENT estimator. If your "
+            "previous attempts fit a model across the whole measurement axis, "
+            "switch families: (a) restrict the fit to a narrow, informative "
+            "window around the diagnostic feature instead of the full axis; "
+            "(b) use a DIFFERENTIAL measure (difference of the signal just across "
+            "the feature/edge) that cancels smooth backgrounds and is feature-"
+            "specific; or (c) use a ROBUST estimator that down-weights saturated "
+            "or outlier channels. Negative / NaN / mostly-masked outputs are "
+            "strong evidence the global model is biased — change families, do not "
+            "re-fit the same way."
+        )
+    return "\n".join(block)
+
+
 def _append_auxiliary_context(prompt: list, state: dict) -> None:
     """Append auxiliary reference dataset(s) to an LLM prompt if available."""
     items = _auxiliary_display_items(state)
@@ -2011,6 +2058,8 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
             current_prompt = base_prompt
             retries = 0
             task_success = False
+            best_attempt = {"req_passed": -1, "valid_count": -1,
+                            "images": [], "maps": [], "meta": []}
 
             while retries < self.MAX_RETRIES:
                 try:
@@ -2106,7 +2155,7 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                             # 3. Visual QC (Generator-Judge Loop)
                             self.logger.info(f"    👀 Performing Visual QC on {feature_name}...")
                             is_valid, critique = self._check_result_visually(dashboard_bytes, f"{target_desc} ({feature_name})")
-                            
+
                             if is_valid:
                                 # STAGE DATA (Do not commit to state yet)
                                 current_run_valid_images.append({
@@ -2138,6 +2187,22 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                     # the partial-success threshold never silently drops the
                     # user-asked-for quantity.
                     valid_names = {m['name'] for m in current_run_valid_meta}
+
+                    # Track the strongest attempt so an UNSATISFIABLE required
+                    # output (e.g. a QC criterion a valid result can never meet)
+                    # doesn't discard the recoverable maps this attempt produced.
+                    # Ranked by (#required passed, #maps passed); committed as a
+                    # self-consistent partial result only if every attempt fails.
+                    n_req_passed = sum(1 for n in required_outputs if n in valid_names)
+                    if (n_req_passed, valid_count) > (best_attempt["req_passed"], best_attempt["valid_count"]):
+                        best_attempt = {
+                            "req_passed": n_req_passed,
+                            "valid_count": valid_count,
+                            "images": list(current_run_valid_images),
+                            "maps": list(current_run_valid_maps),
+                            "meta": list(current_run_valid_meta),
+                        }
+
                     missing_required = [n for n in required_outputs if n not in valid_names]
                     if missing_required:
                         relevant_critiques = [
@@ -2186,10 +2251,35 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                     
                     self.logger.warning(f"    ❌ Attempt {retries+1} failed: {error_msg}")
                     retries += 1
-                    current_prompt = base_prompt + f"\n\n### ❌ PREVIOUS ATTEMPT FAILED\nCritique:\n```text\n{error_msg}\n```\nFix the logic/math to address this critique."
+                    # Annealed retry: escalate from "patch the math" to "abandon
+                    # the method" as failures accumulate, so retries can leave a
+                    # wrong-but-self-consistent method basin instead of resampling
+                    # it. See _codegen_retry_feedback.
+                    current_prompt = base_prompt + _codegen_retry_feedback(retries, error_msg)
+                    if retries >= 2:
+                        self.logger.info(
+                            f"    ↻ Retry annealing engaged (failure {retries}): "
+                            "escalating from parameter-patch toward method-change."
+                        )
 
             if not task_success:
                 self.logger.error(f"    ⚠️ Task {i} failed after {self.MAX_RETRIES} attempts.")
+                # Salvage the strongest attempt rather than discarding all work:
+                # commit its passing maps so a recoverable output survives an
+                # unsatisfiable required one. The required-output failure is still
+                # surfaced (the task did not cleanly succeed).
+                if best_attempt["valid_count"] > 0:
+                    self.logger.warning(
+                        f"    ⛑️  Committing best partial attempt "
+                        f"({best_attempt['req_passed']}/{len(required_outputs)} required "
+                        f"outputs, {best_attempt['valid_count']} map(s) passed QC); some "
+                        f"required output(s) never passed."
+                    )
+                    for img_item in best_attempt["images"]:
+                        tools.save_image_bytes(img_item['data'], output_dir, img_item['filename'], self.logger)
+                        state.setdefault("analysis_images", []).append(img_item)
+                    all_valid_maps.extend(best_attempt["maps"])
+                    all_valid_meta.extend(best_attempt["meta"])
 
         # --- FINAL AGGREGATION ---
         if not all_valid_maps:

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -605,13 +605,21 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         try:
             is_curve = False
             is_image = False
+            is_cube = False
 
             if ext == '.npy':
-                arr = np.load(auxiliary_data)
+                arr = np.load(auxiliary_data, mmap_mode='r')
                 if arr.ndim == 1:
                     is_curve = True
                 elif arr.ndim == 2 and min(arr.shape) <= 2:
                     is_curve = True
+                elif arr.ndim >= 3 and arr.shape[-1] > 4:
+                    # A spectral datacube companion (e.g. an I0/flat-field
+                    # baseline), NOT an RGB(A) image. Keep it as a raw numerical
+                    # operand so the per-pixel code-gen can normalize against it
+                    # (e.g. transmission = data / baseline). A trailing axis of
+                    # 3 or 4 is treated as an image below.
+                    is_cube = True
                 else:
                     is_image = True
             elif ext in curve_extensions:
@@ -678,6 +686,41 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                         convert_numpy_to_jpeg_bytes(img)
                     )
                 result["auxiliary_mime_type"] = "image/jpeg"
+
+            elif is_cube:
+                # Same-grid companion datacube (e.g. an I0 / flat-field
+                # baseline). Loaded as a raw float array so it can serve as a
+                # per-pixel numerical operand for the code-gen (the operand
+                # alignment gate keeps it only if its shape matches the primary
+                # cube). We deliberately do NOT route it through ``load_image``,
+                # which would cast the counts to uint8 and destroy their scale.
+                cube = np.asarray(np.load(auxiliary_data), dtype=float)
+                result["auxiliary_array"] = cube
+                result["auxiliary_summary"] = (
+                    f"Companion datacube with shape {cube.shape} "
+                    f"(dtype: {cube.dtype}). Value range: "
+                    f"[{float(np.nanmin(cube)):.4g}, {float(np.nanmax(cube)):.4g}]. "
+                    "Intended as a same-grid per-pixel operand (e.g. an I0 / "
+                    "flat-field baseline to divide the primary by)."
+                )
+                # Show the spatial-mean spectrum so the LLM can see the
+                # baseline's spectral shape (a cube has no single 2D rendering).
+                try:
+                    mean_spec = np.asarray(cube).reshape(-1, cube.shape[-1]).mean(0)
+                    plot_data = np.column_stack(
+                        [np.arange(mean_spec.size), mean_spec]
+                    )
+                    result["auxiliary_plot_bytes"] = plot_curve_to_bytes(
+                        plot_data,
+                        {"title": f"{result['auxiliary_label']} "
+                                  "(spatial-mean spectrum)"},
+                    )
+                    result["auxiliary_mime_type"] = "image/png"
+                except Exception as _plot_err:
+                    self.logger.warning(
+                        f"Could not render mean spectrum for cube auxiliary: "
+                        f"{_plot_err}"
+                    )
 
         except Exception as e:
             self.logger.warning(f"Failed to load auxiliary data: {e}")

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -357,7 +357,22 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "scientific_claims": valid_claims,
             "output_directory": str(self.output_dir)
         }
-        
+
+        # A salvage / approximate / withheld outcome is NOT a clean success:
+        # downgrade the status and surface the honest caveats so a programmatic
+        # caller (or the meta agent) sees the uncertainty instead of a bare
+        # 'success'. Notes come from the dynamic-analysis salvage judge.
+        degradation = result_json.get("degradation_notes", [])
+        if degradation:
+            _rank = {"none": 0, "low": 1, "medium": 2}
+            worst = min(degradation,
+                        key=lambda d: _rank.get(d.get("confidence", "low"), 1))
+            response["status"] = "partial"
+            response["confidence"] = worst.get("confidence", "low")
+            response["warnings"] = [d["caveat"] for d in degradation if d.get("caveat")]
+            response["degraded_outputs"] = degradation
+
+
         self._log_action(
             action="analyze",
             input_ctx={"data": data_path},
@@ -838,7 +853,15 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                     break
 
             self.logger.info("--- Analysis pipeline finished ---")
-            return synthesis_state.get("result_json"), synthesis_state.get("error_dict")
+            # Surface any degradation the dynamic-analysis stage recorded (salvage
+            # / withheld / approximate) so the top-level status is not a clean
+            # 'success'. The notes live on iteration_state (set by the salvage
+            # judge); attach them to result_json for analyze() to read.
+            _rj = synthesis_state.get("result_json")
+            _notes = iteration_state.get("degradation_notes", [])
+            if _rj is not None and _notes:
+                _rj["degradation_notes"] = _notes
+            return _rj, synthesis_state.get("error_dict")
 
         except FileNotFoundError:
             self._clear_stored_images()

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -1561,6 +1561,55 @@ Return a JSON object with:
 """
 
 
+SPECTROSCOPY_PHYSICS_SANITY_INSTRUCTIONS = """
+You are a senior scientist doing a PHYSICAL-SOUNDNESS review of one automated
+per-pixel result. Visual quality was already checked separately — your job is
+different: judge whether the METHOD is appropriate and the RESULT is physically
+plausible given what the data actually shows. Reason from the physics and the
+data, NEVER from a pre-expected number.
+
+### OBJECTIVE
+{objective}
+
+### DATA CONTEXT (metadata)
+{metadata}
+
+### METHOD — the generated code that produced this result
+```python
+{method}
+```
+
+### RESULT
+{result_summary}
+You are also shown the result dashboard (map + histogram) and a representative
+mean spectrum of the data.
+
+### YOUR TASK
+Decide if there is a CLEAR methodological or physical flaw that makes this
+result wrong. Typical real flaws:
+- the method uses an estimator that is BIASED for this data — e.g. a global
+  fit over a spectral region where the signal saturates / clips / violates the
+  model's assumptions, and the result reflects that bias;
+- the reported value is contradicted by a feature plainly visible in the
+  spectrum (e.g. a strong absorption edge/step or peak whose size is
+  inconsistent with the value by a large factor);
+- the method skips a step the physics/objective requires (e.g. no flat-field
+  normalization when an I0 is provided).
+
+Be CONSERVATIVE — default to VALID:
+- A merely SURPRISING value is NOT a flaw if the method is sound and the data
+  supports it. Do not suppress genuine findings.
+- Do not flag stylistic or minor issues, or values you simply cannot verify.
+- Reject ONLY when you can name the specific methodological/physical flaw AND
+  the direction of the fix (which estimator / window / step to use instead).
+
+### OUTPUT FORMAT
+Return a JSON object:
+- 'valid': boolean (true = physically sound enough to accept; false = clear flaw)
+- 'critique': string (if false: name the specific flaw and the corrective direction)
+"""
+
+
 # ============================================================================
 # NEW INSTRUCTION PROMPTS FOR BATCH ANALYSIS
 # ============================================================================

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -1604,6 +1604,16 @@ measurability, …):
   is the CORRECT result even if the objective calls the sample a localized
   coupon "on an otherwise empty field." Reject uniformity ONLY as a trivial
   collapse (uniform at exactly 0 / a clip bound — nothing extracted).
+- The RESULT states a valid coverage (fraction of the field with a real, finite
+  non-zero value). Reconcile it with the morphology the OBJECTIVE and the data
+  imply — do NOT apply a fixed coverage threshold. Low coverage is CORRECT for a
+  feature that is genuinely localized (defects, dopants/impurities, a small
+  domain, a phase boundary, a sparse population) — do not reject those. It is a
+  masking/segmentation COLLAPSE only when the feature was expected to fill a
+  region (film / continuous layer / coupon), OR the field-MEAN spectrum clearly
+  shows the signal, yet the map retained just a few scattered pixels — i.e. a
+  real signal was dropped. Judge coverage against what is physically expected,
+  either way; the number is evidence, not a verdict.
 - A merely SURPRISING value is not a flaw if the method is sound and the data
   and tool evidence support it. Do not suppress genuine findings.
 - Reject ONLY when you can name a SPECIFIC methodological/physical flaw AND the

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -1561,6 +1561,99 @@ Return a JSON object with:
 """
 
 
+SPECTROSCOPY_RESULT_REVIEW_INSTRUCTIONS = """
+You are a senior scientist doing a SINGLE combined review of one automated
+per-pixel result the user explicitly asked for. Judge BOTH in one decision:
+  (A) SIGNAL — does this capture a real extracted signal, not pure noise or a
+      trivial collapse (uniform at exactly 0 / a clip bound where something was
+      expected)?
+  (B) SOUNDNESS — is the METHOD appropriate and the VALUE physically plausible
+      given what the data actually shows?
+Reason from the physics, the data, and the evidence below — NEVER from a
+pre-expected number.
+
+### OBJECTIVE
+{objective}
+
+### DATA CONTEXT (metadata)
+{metadata}
+
+### METHOD — the generated code that produced this result
+```python
+{method}
+```
+
+### RESULT
+{result_summary}
+You are also shown the result dashboard (map + histogram) and a representative
+mean spectrum of the data.
+
+### TOOLS USED BY THE METHOD
+The generated code called these vetted, purpose-built helper tools — here is
+what each already handles robustly (window selection, flux gating,
+measurability, …):
+{tool_descriptions}
+
+{tool_scrutiny}
+
+### KEY PRINCIPLES
+- Trust the DATA over the objective's geometric framing. A uniform or
+  full-field result is VALID when the signal genuinely fills the field: if the
+  tool evidence shows a coherent, high-SNR feature present in most/all pixels
+  (e.g. a measurable edge in ~all pixels), a uniform map or an all-present mask
+  is the CORRECT result even if the objective calls the sample a localized
+  coupon "on an otherwise empty field." Reject uniformity ONLY as a trivial
+  collapse (uniform at exactly 0 / a clip bound — nothing extracted).
+- A merely SURPRISING value is not a flaw if the method is sound and the data
+  and tool evidence support it. Do not suppress genuine findings.
+- Reject ONLY when you can name a SPECIFIC methodological/physical flaw AND the
+  direction of the fix (which estimator / window / step to use instead).
+
+### OUTPUT FORMAT
+Return a JSON object:
+- 'valid': boolean (true = accept; false = clear flaw)
+- 'critique': string (if false: name the specific flaw and corrective direction)
+"""
+
+
+SPECTROSCOPY_SALVAGE_JUDGE_INSTRUCTIONS = """
+You are a senior scientist making a FINAL salvage decision. Automated extraction
+did NOT fully pass verification after all retries. You are shown the BEST partial
+result produced (a representative dashboard, the method code, a representative
+mean spectrum, and the tools it used). Judge FROM THE PHYSICS AND THE DATA
+whether this partial result is a physically DEFENSIBLE approximate answer worth
+reporting WITH EXPLICIT CAVEATS, or is physically meaningless (trivial collapse
+to zero, pure noise, or a clear artifact) and must be withheld.
+
+Presenting an APPROXIMATE / uncertain result is acceptable — provided its
+limitations and uncertainty are stated honestly. Withhold ONLY if there is no
+real signal to report.
+
+### OBJECTIVE
+{objective}
+
+### DATA CONTEXT (metadata)
+{metadata}
+
+### METHOD (generated code)
+```python
+{method}
+```
+
+### TOOLS USED BY THE METHOD
+{tool_descriptions}
+
+### PARTIAL RESULT
+{result_summary}
+
+### OUTPUT FORMAT
+Return a JSON object:
+- 'present': boolean (true = report it as approximate with caveats; false = withhold, no real signal)
+- 'confidence': "low" or "medium" (never "high" — this is a salvage of an unverified result)
+- 'caveat': ONE honest sentence stating the key limitation / uncertainty a reader MUST know
+"""
+
+
 SPECTROSCOPY_PHYSICS_SANITY_INSTRUCTIONS = """
 You are a senior scientist doing a PHYSICAL-SOUNDNESS review of one automated
 per-pixel result. Visual quality was already checked separately — your job is

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -1534,14 +1534,25 @@ Determine if this result captures a REAL physical signal, even if that signal is
 In spectroscopy, some features (like impurities) only exist in small regions.
 If the Histogram shows a large pile-up at zero/bounds (background) BUT there is a distinct, smaller population distribution elsewhere, **THIS IS VALID.**
 
+### CRITICAL: HANDLING HOMOGENEOUS RESULTS
+A uniform or single-valued map is NOT, by itself, a failure. The measured
+quantity or feature can be genuinely homogeneous — e.g. a uniform film or
+coating, a sample that fills the field of view, or a property that is
+constant across the region. In those cases a near-uniform map (or a presence
+mask that is all-present / all-absent) is the physically CORRECT result.
+Spatial contrast is not required for validity. Reject uniformity ONLY when the
+single value is a trivial collapse that means the algorithm extracted nothing
+where signal was expected (see Failure Criterion 2).
+
 ### FAILURE CRITERIA (Reject ONLY if these are true):
 1. **Total Noise:** The map is pure 'static' (salt-and-pepper) with ZERO recognizable structure.
-2. **Total Algorithm Failure:** The histogram is a **SINGLE** sharp spike (Dirac delta) containing 100% of the data.
-3. **Complete Rail-Gazing:** The data is piled up at the min/max edges with **NO secondary distribution** visible.
+2. **Trivial Collapse:** The map is uniform AT A TRIVIAL VALUE that means no signal was extracted (e.g. exactly 0 / exactly a clip bound everywhere) AND the feature is one that should vary or appear somewhere — i.e. the algorithm produced nothing, not a real homogeneous measurement. A uniform map at a NON-trivial, physically plausible value (a real thickness, a real concentration, all-present where the sample fills the frame) is NOT this — accept it.
+3. **Complete Rail-Gazing:** The data is piled up at the min/max edges with **NO secondary distribution** visible AND no physical reason for the field to be homogeneous.
 
 ### SUCCESS CRITERIA (Accept if present):
 - **Structure:** Does the map show ANY structured domains, even if they are small?
 - **Population:** Is there a visible distribution (bell curve, tail, or cluster) separate from the background spike?
+- **Plausible homogeneity:** Is the map uniform (or near-uniform) at a physically meaningful value consistent with a homogeneous sample or a feature that fills/is-absent-from the field? That is a valid measurement, not a failure.
 
 ### OUTPUT FORMAT
 Return a JSON object with:

--- a/scilink/agents/exp_agents/metadata_converter.py
+++ b/scilink/agents/exp_agents/metadata_converter.py
@@ -244,6 +244,39 @@ def _ci_pop(d: dict, aliases: list[str]):
     return None
 
 
+def _describes_spectral_imaging(metadata: dict) -> bool:
+    """True when the metadata describes a spectral-imaging / hyperspectral
+    datacube — a dataset whose defining third axis is an energy/spectral axis.
+
+    For such data the energy axis is *required* (downstream builds the channel
+    axis from it); for 1D curves or plain microscopy it is optional. Heuristic
+    on the free-text ``experiment_type`` + ``experiment.technique`` so a dict
+    that only names the technique in prose still routes correctly.
+    """
+    exp = metadata.get("experiment")
+    technique = exp.get("technique", "") if isinstance(exp, dict) else ""
+    blob = f"{metadata.get('experiment_type') or ''} {technique}".lower()
+    if "hyperspectral" in blob or "datacube" in blob:
+        return True
+    # "spectral/spectroscopy ... imaging/mapping/spectrum-image/cube"
+    return ("spectr" in blob
+            and any(w in blob for w in ("imag", "map", "cube", "spectrum image")))
+
+
+def _has_resolvable_energy_axis(metadata: dict) -> bool:
+    """True when an energy/signal axis with both endpoints can be resolved —
+    either legacy ``energy_range`` or ``axis_spec.axis_2`` carries start+end."""
+    er = metadata.get("energy_range")
+    if isinstance(er, dict) and er.get("start") is not None and er.get("end") is not None:
+        return True
+    ax = metadata.get("axis_spec")
+    if isinstance(ax, dict):
+        a2 = ax.get("axis_2")
+        if isinstance(a2, dict) and a2.get("start") is not None and a2.get("end") is not None:
+            return True
+    return False
+
+
 def check_schema_conformance(metadata: dict) -> tuple[bool, list[str]]:
     """Check whether *metadata* conforms to the canonical schema.
 
@@ -278,6 +311,16 @@ def check_schema_conformance(metadata: dict) -> tuple[bool, list[str]]:
         val = metadata.get(key)
         if val is not None and not isinstance(val, dict):
             issues.append(f"'{key}' should be a dict or null")
+
+    # A spectral-imaging / hyperspectral datacube MUST carry a resolvable energy
+    # axis (energy_range.start/end or axis_spec.axis_2.start/end). Without it the
+    # axis silently falls back to channel indices, so the spectral axis is only
+    # in prose — flag it non-conformant so the LLM normalizer re-extracts it.
+    if _describes_spectral_imaging(metadata) and not _has_resolvable_energy_axis(metadata):
+        issues.append(
+            "Spectral-imaging/hyperspectral metadata is missing a resolvable "
+            "energy axis (energy_range.start/end or axis_spec.axis_2.start/end)"
+        )
 
     return (len(issues) == 0, issues)
 

--- a/scilink/skills/_shared/edge_step.py
+++ b/scilink/skills/_shared/edge_step.py
@@ -1,0 +1,233 @@
+"""Per-pixel absorption-edge STEP measurement for spectrum-imaging cubes.
+
+Exposed to the hyperspectral code-gen sandbox as ``measure_edge_step(...)``.
+It isolates the discontinuous jump in optical depth across an absorption edge
+(K/L X-ray edge, XANES edge, EELS core-loss onset) using *wide, edge-offset*
+continuum windows and a photon-flux gate — the two things improvised per-run
+code kept getting wrong (tight adjacent windows + smoothing under-measure the
+jump ~2x; no flux gate lets a starved edge fabricate a coherent-looking signal).
+
+It returns the edge step ``Delta(mu*t)`` (a.k.a. Delta-OD) and its SNR — NOT a
+thickness. Downstream converts to a physical quantity itself, e.g.
+``t = edge_step / (delta_mu_over_rho * rho)`` with mu/rho from ``attenuation()``.
+Keeping thickness out of this primitive is deliberate: the edge step is generic
+to edge spectroscopy; the conversion is domain-specific and lives in a skill.
+
+Lives in ``_shared`` because edge-jump extraction is generic physics reusable
+across X-ray transmission, XANES, and EELS core-loss work.
+"""
+import numpy as np
+
+
+def _linfit_extrap(E_win, OD_win, x0):
+    """Vectorized per-pixel linear fit OD(E)=a+b*E over a window, extrapolated
+    to energy ``x0``. ``OD_win`` is (npix, nwin); returns (npix,) at x0."""
+    X = np.column_stack([np.ones_like(E_win), E_win])   # (nwin, 2)
+    beta, *_ = np.linalg.lstsq(X, OD_win.T, rcond=None)  # (2, npix)
+    return beta[0] + beta[1] * x0                         # a + b*x0
+
+
+def measure_edge_step(
+    data, i0, energy_kev, edge_kev,
+    pre_gap=2.0, post_gap=1.0, win_width=4.0,
+    low_e_cut_kev=5.0, flux_floor_counts=20.0,
+    auto_center=True, search_tol_kev=2.0, t_floor=1e-6,
+):
+    """Measure the per-pixel absorption-edge step (jump in optical depth).
+
+    Fits a local linear continuum on each side of the edge over *wide, offset*
+    windows, extrapolates both to the edge energy, and returns the
+    discontinuity ``Delta-OD = OD_above(edge) - OD_below(edge)`` per pixel —
+    which cancels the smooth (non-edge) background. Also gates on post-edge
+    photon flux so a flux-starved edge is reported as *not measurable* instead
+    of returning bremsstrahlung-slope noise.
+
+    Parameters
+    ----------
+    data : ndarray (H, W, E)
+        Transmitted-intensity datacube (counts). Energy is the trailing axis.
+    i0 : ndarray (H, W, E) or (E,)
+        Incident-flux reference (flat field / I0). A 1-D spectrum is broadcast.
+    energy_kev : array-like (E,)
+        Energy of each channel in keV (the cube's own energy axis).
+    edge_kev : float
+        Nominal edge energy in keV (e.g. Au K-edge 80.8).
+    pre_gap, post_gap : float
+        keV offset of each continuum window from the edge. Keep the windows a
+        little off the edge so finite edge width / detector broadening does not
+        eat into the step. RAISE if the edge is broad or mis-centered; LOWER to
+        hug the edge when the continuum is strongly curved.
+    win_width : float
+        Width (keV) of each continuum window. WIDEN to beat down noise on a
+        clean edge; NARROW if the continuum is curved or fluorescence lines sit
+        nearby (a wide window then biases the linear fit).
+    low_e_cut_kev : float
+        Ignore channels below this energy (noise / air-scatter).
+    flux_floor_counts : float
+        Measurability gate: if the median I0 counts in the post-edge window are
+        below this, the above-edge region is photon-starved and the step is
+        noise — the result is flagged ``measurable=False``. RAISE to be stricter
+        (reject marginal edges), LOWER only if you trust low-count statistics.
+    auto_center : bool
+        If True, locate the actual edge channel as the steepest rise of the
+        field-mean OD within ``search_tol_kev`` of ``edge_kev`` (handles small
+        energy-axis miscalibration). If False, use ``edge_kev`` verbatim.
+    search_tol_kev : float
+        Half-width (keV) of the auto-center search window around ``edge_kev``.
+        WIDEN if the energy axis may be off by more than a couple keV; NARROW
+        (or set ``auto_center=False``) if a nearby fluorescence line has a
+        steeper gradient than the edge and auto-center locks onto it.
+    t_floor : float
+        Lower clip on transmission before ``-ln`` (guards ``log(0)``). This is
+        the saturation knob for THICK samples: above a strong edge, transmission
+        can fall to this floor, saturating OD and biasing the step (hence the
+        thickness) HIGH. RAISE it (e.g. 1e-4) if a thick coupon reads high /
+        the post-edge window sits at the clip; LOWER it only if genuine deep
+        absorption is being clipped on a thin sample.
+
+    Returns
+    -------
+    dict with:
+        edge_step : (H, W) float   -- Delta-OD per pixel (the jump; multiply by
+                                      1/(delta_mu_over_rho*rho) for thickness).
+        snr       : (H, W) float   -- edge_step / photon-noise sigma per pixel.
+        measurable : bool          -- False if post-edge flux-starved or no
+                                      field-level edge (do NOT trust the map).
+        edge_kev_used : float      -- edge energy actually used (auto-centered).
+        pre_window, post_window : (lo, hi) keV of the continuum windows.
+        field_step : float         -- field-mean Delta-OD (edge present if >0).
+        post_flux_counts : float   -- median I0 counts in the post window.
+        reason : str               -- human-readable measurability verdict.
+    """
+    E = np.asarray(energy_kev, dtype=float)
+    H, W, ne = data.shape
+    npix = H * W
+    D = data.reshape(npix, ne).astype(float)
+    I0 = np.asarray(i0, dtype=float)
+    I0 = (I0.reshape(npix, ne) if I0.ndim == 3 else np.broadcast_to(I0, (npix, ne)))
+
+    valid_E = E >= low_e_cut_kev
+
+    # Transmission -> optical depth, guarded.
+    with np.errstate(divide="ignore", invalid="ignore"):
+        T = np.where(I0 > 0, D / I0, 1.0)
+    T = np.clip(T, t_floor, 1.0)
+    OD = -np.log(T)
+
+    # --- locate the edge (auto-center on steepest field-mean OD rise) ---
+    edge_used = float(edge_kev)
+    if auto_center:
+        near = valid_E & (E >= edge_kev - search_tol_kev) & (E <= edge_kev + search_tol_kev)
+        if near.sum() >= 3:
+            od_mean = np.nanmean(OD, axis=0)
+            grad = np.gradient(od_mean, E)
+            cand = np.where(near)[0]
+            edge_used = float(E[cand[np.argmax(grad[cand])]])
+
+    # --- wide, offset continuum windows ---
+    pre_lo, pre_hi = edge_used - pre_gap - win_width, edge_used - pre_gap
+    post_lo, post_hi = edge_used + post_gap, edge_used + post_gap + win_width
+    pre_mask = valid_E & (E >= pre_lo) & (E <= pre_hi)
+    post_mask = valid_E & (E >= post_lo) & (E <= post_hi)
+
+    reasons = []
+    if pre_mask.sum() < 2 or post_mask.sum() < 2:
+        return {
+            "edge_step": np.zeros((H, W)), "snr": np.zeros((H, W)),
+            "measurable": False, "edge_kev_used": edge_used,
+            "pre_window": (pre_lo, pre_hi), "post_window": (post_lo, post_hi),
+            "field_step": 0.0, "post_flux_counts": 0.0,
+            "reason": "continuum window(s) fall outside the energy axis",
+        }
+
+    # --- flux gate: is there real photon flux above the edge? ---
+    post_flux = float(np.median(np.nanmean(I0[:, post_mask], axis=1)))
+    if post_flux < flux_floor_counts:
+        reasons.append(
+            f"post-edge flux {post_flux:.0f} < floor {flux_floor_counts:.0f} counts "
+            "(photon-starved; step would be bremsstrahlung-slope noise)"
+        )
+
+    # --- per-pixel edge step via linear continuum extrapolation ---
+    E_pre, E_post = E[pre_mask], E[post_mask]
+    od_pre_edge = _linfit_extrap(E_pre, OD[:, pre_mask], edge_used)
+    od_post_edge = _linfit_extrap(E_post, OD[:, post_mask], edge_used)
+    edge_step = od_post_edge - od_pre_edge
+
+    # --- SNR from pre-edge residual scatter (photon + continuum noise):
+    # residual std on the pre window about its own linear fit ---
+    X = np.column_stack([np.ones_like(E_pre), E_pre])
+    beta_pre, *_ = np.linalg.lstsq(X, OD[:, pre_mask].T, rcond=None)
+    fit_pre = (X @ beta_pre).T                       # (npix, nb)
+    sigma = np.std(OD[:, pre_mask] - fit_pre, axis=1)
+    nb, na = E_pre.size, E_post.size
+    se = np.maximum(sigma, 1e-9) * np.sqrt(1.0 / nb + 1.0 / na)
+    snr = edge_step / se
+
+    field_step = float(np.nanmedian(edge_step))
+    if field_step <= 0:
+        reasons.append(f"field-median step {field_step:.3g} <= 0 (no coherent edge)")
+
+    measurable = len(reasons) == 0
+    return {
+        "edge_step": edge_step.reshape(H, W),
+        "snr": snr.reshape(H, W),
+        "measurable": measurable,
+        "edge_kev_used": edge_used,
+        "pre_window": (pre_lo, pre_hi), "post_window": (post_lo, post_hi),
+        "field_step": field_step, "post_flux_counts": post_flux,
+        "reason": "measurable edge" if measurable else "; ".join(reasons),
+    }
+
+
+from ._spec import ToolSpec  # noqa: E402
+
+TOOL_SPEC = ToolSpec(
+    name="measure_edge_step",
+    description=(
+        "Per-pixel absorption-edge STEP (jump in optical depth) across a K/L "
+        "X-ray edge (or XANES/EELS core-loss onset), using wide edge-offset "
+        "continuum windows + a photon-flux gate. Returns Delta-OD and SNR (NOT "
+        "thickness) plus a measurable flag — multiply by 1/(delta(mu/rho)*rho) "
+        "for thickness. Removes the ~2x under-measurement from tight/smoothed "
+        "windows and refuses flux-starved edges instead of fabricating a signal."
+    ),
+    signature=(
+        "measure_edge_step(data, i0, energy_kev, edge_kev, pre_gap=2.0, "
+        "post_gap=1.0, win_width=4.0, low_e_cut_kev=5.0, flux_floor_counts=20.0, "
+        "auto_center=True, search_tol_kev=2.0) -> dict"
+    ),
+    import_line="from scilink.skills._shared.edge_step import measure_edge_step",
+    parameters={
+        "data": "Transmitted-intensity datacube (H,W,E), counts, energy trailing.",
+        "i0": "Incident-flux reference (H,W,E) or 1-D (E,); flat field / I0.",
+        "energy_kev": "Per-channel energy in keV (the cube's own axis).",
+        "edge_kev": "Nominal edge energy in keV (e.g. Au K 80.8).",
+        "pre_gap": "keV offset of the PRE-edge window from the edge. RAISE if the edge is broad or mis-centered (step reads low because the window eats into the rising edge); LOWER to hug the edge when the continuum is strongly curved over the offset span.",
+        "post_gap": "keV offset of the POST-edge window from the edge. RAISE to clear edge broadening / white-line overshoot just above the edge; LOWER to stay in well-fluxed channels on a thick sample whose transmission dies fast above the edge.",
+        "win_width": "keV width of each continuum window. WIDEN to cut noise on a clean edge (more channels in the linear fit); NARROW if the step reads biased because the window straddles continuum curvature or fluorescence lines.",
+        "low_e_cut_kev": "Ignore channels below this energy. RAISE if low-E noise/air-scatter leaks in; rarely needs lowering.",
+        "flux_floor_counts": "Field-level measurability gate: flag measurable=False if median post-edge I0 counts < this (photon-starved -> step is bremsstrahlung-slope noise). RAISE to reject marginal edges; LOWER only if you trust low-count statistics. NOTE: this is a coarse whole-field gate; per-pixel measurability is the returned snr map (threshold snr>~3).",
+        "auto_center": "If True, snap the edge to the steepest field-mean OD rise within search_tol_kev (fixes small energy-axis miscalibration). Set False if a nearby fluorescence line is steeper than the true edge and auto-center locks onto it.",
+        "search_tol_kev": "Half-width (keV) of the auto-center search window. WIDEN if axis calibration is uncertain; NARROW if a competing feature nearby is being picked instead of the edge.",
+        "t_floor": "Transmission clip floor before -ln (saturation knob for THICK samples). RAISE (e.g. 1e-4) if a thick coupon reads HIGH or the post-edge window sits at the clip (OD saturates -> step biased high); LOWER only if genuine deep absorption on a thin sample is being clipped.",
+    },
+    required=["data", "i0", "energy_kev", "edge_kev"],
+    agents=["hyperspectral"],
+    when_to_use=(
+        "Quantifying an absorption-edge jump per pixel (X-ray K-edge thickness, "
+        "XANES edge height, EELS core-loss step). Use instead of hand-rolled "
+        "pre/post window means — it picks robust windows, gates on flux, and "
+        "reports whether the edge is measurable at all."
+    ),
+    returns=(
+        "dict: edge_step (H,W Delta-OD), snr (H,W), measurable (bool), "
+        "edge_kev_used, pre_window, post_window, field_step, post_flux_counts, reason."
+    ),
+    example=(
+        "r = measure_edge_step(data, aux['baseline_I0'], energy_kev, 80.8)\n"
+        "if r['measurable']:\n"
+        "    dmu = attenuation('Au', np.array([81.6]))[0] - attenuation('Au', np.array([80.0]))[0]\n"
+        "    thickness_um = r['edge_step'] / (dmu * 19.32) * 1e4"
+    ),
+)

--- a/scilink/skills/_shared/xray_attenuation.py
+++ b/scilink/skills/_shared/xray_attenuation.py
@@ -1,0 +1,118 @@
+"""X-ray mass / linear attenuation coefficients from spekpy (NIST tables).
+
+Exposed to the hyperspectral code-gen sandbox as ``attenuation(...)`` so
+generated scripts can obtain mu on the datacube's own energy axis instead of
+the user supplying a mu-table operand. spekpy is a heavy, OPTIONAL dependency,
+imported lazily inside the function — importing this module never pulls it in,
+and a missing install raises a clear, actionable error.
+
+Lives in ``_shared`` because X-ray attenuation is generic physics reusable
+across X-ray techniques; a graduated X-ray skill can re-export it as a
+``TOOL_SPEC`` for scoped visibility.
+"""
+import numpy as np
+
+# Element symbol -> atomic number (Z), 1..92. spekpy keys elements by Z.
+_SYMBOL_TO_Z = {
+    'H': 1, 'He': 2, 'Li': 3, 'Be': 4, 'B': 5, 'C': 6, 'N': 7, 'O': 8, 'F': 9,
+    'Ne': 10, 'Na': 11, 'Mg': 12, 'Al': 13, 'Si': 14, 'P': 15, 'S': 16, 'Cl': 17,
+    'Ar': 18, 'K': 19, 'Ca': 20, 'Sc': 21, 'Ti': 22, 'V': 23, 'Cr': 24, 'Mn': 25,
+    'Fe': 26, 'Co': 27, 'Ni': 28, 'Cu': 29, 'Zn': 30, 'Ga': 31, 'Ge': 32, 'As': 33,
+    'Se': 34, 'Br': 35, 'Kr': 36, 'Rb': 37, 'Sr': 38, 'Y': 39, 'Zr': 40, 'Nb': 41,
+    'Mo': 42, 'Tc': 43, 'Ru': 44, 'Rh': 45, 'Pd': 46, 'Ag': 47, 'Cd': 48, 'In': 49,
+    'Sn': 50, 'Sb': 51, 'Te': 52, 'I': 53, 'Xe': 54, 'Cs': 55, 'Ba': 56, 'La': 57,
+    'Ce': 58, 'Pr': 59, 'Nd': 60, 'Pm': 61, 'Sm': 62, 'Eu': 63, 'Gd': 64, 'Tb': 65,
+    'Dy': 66, 'Ho': 67, 'Er': 68, 'Tm': 69, 'Yb': 70, 'Lu': 71, 'Hf': 72, 'Ta': 73,
+    'W': 74, 'Re': 75, 'Os': 76, 'Ir': 77, 'Pt': 78, 'Au': 79, 'Hg': 80, 'Tl': 81,
+    'Pb': 82, 'Bi': 83, 'Po': 84, 'At': 85, 'Rn': 86, 'Fr': 87, 'Ra': 88, 'Ac': 89,
+    'Th': 90, 'Pa': 91, 'U': 92,
+}
+
+
+def attenuation(material, energy_kev, density=None):
+    """X-ray mass (cm^2/g) or linear (1/cm) attenuation coefficient vs energy.
+
+    Generates mu(E) from NIST tables (via spekpy) on any energy grid, with K/L
+    absorption edges at the correct energies automatically — replacing hand-built
+    tables or user-supplied mu files.
+
+    Parameters
+    ----------
+    material : str | int
+        Element symbol ('Au', 'Pb'), atomic number (79), or a spekpy-registered
+        material name.
+    energy_kev : array-like
+        Photon energies in keV (any grid, e.g. the datacube's energy axis).
+    density : float | None
+        If given (g/cm^3) -> returns LINEAR attenuation mu = (mu/rho)*density
+        [1/cm], directly usable in Beer-Lambert  -ln(T) = mu * t. If None ->
+        returns the MASS attenuation coefficient mu/rho [cm^2/g].
+
+    Returns
+    -------
+    np.ndarray, same shape as energy_kev — mu/rho (cm^2/g) or mu (1/cm).
+
+    Notes
+    -----
+    Energies below ~1 keV are clamped to the 1 keV table endpoint. Raises
+    ImportError (with an install hint) if spekpy is absent, ValueError for an
+    unknown element symbol / unregistered material.
+    """
+    try:
+        from spekpy import SpekTools as _T  # lazy: heavy optional dependency
+    except ImportError as e:
+        raise ImportError(
+            "attenuation() needs spekpy (optional). Install it with "
+            "`pip install spekpy`."
+        ) from e
+
+    mu_data, _, _ = _T.load_mu_data('nist')
+    E = np.clip(np.asarray(energy_kev, dtype=float), 1.0, None)
+
+    if isinstance(material, (int, np.integer)):
+        mor = mu_data.get_mu_over_rho(int(material), E)
+    elif isinstance(material, str) and material in _SYMBOL_TO_Z:
+        mor = mu_data.get_mu_over_rho(_SYMBOL_TO_Z[material], E)
+    elif isinstance(material, str):
+        try:
+            mor = mu_data.get_mu_over_rho_composition(material, E)
+        except Exception as e:
+            raise ValueError(
+                f"{material!r} is not an element symbol and not a spekpy-"
+                f"registered material. Use an element symbol ('Au') or Z (79)."
+            ) from e
+    else:
+        raise ValueError(f"Unrecognized material: {material!r}")
+
+    mor = np.asarray(mor, dtype=float)
+    return mor * float(density) if density is not None else mor
+
+
+from ._spec import ToolSpec  # noqa: E402
+
+TOOL_SPEC = ToolSpec(
+    name="attenuation",
+    description=(
+        "X-ray mass (cm^2/g) or linear (1/cm) attenuation coefficient vs energy "
+        "from NIST tables (spekpy). Returns mu on your energy axis for an element, "
+        "with K/L absorption edges at the correct energies — so you can derive mu "
+        "for Beer-Lambert / K-edge thickness from the element name instead of a "
+        "supplied mu-table operand."
+    ),
+    signature="attenuation(material, energy_kev, density=None) -> np.ndarray",
+    import_line="from scilink.skills._shared.xray_attenuation import attenuation",
+    parameters={
+        "material": "Element symbol ('Au','Pb'), atomic number (79), or a spekpy material name.",
+        "energy_kev": "Energies in keV — pass the datacube's energy axis so mu is returned grid-aligned.",
+        "density": "g/cm^3 -> LINEAR mu (1/cm) for -ln(T)=mu*t; omit -> MASS mu/rho (cm^2/g).",
+    },
+    required=["material", "energy_kev"],
+    agents=["hyperspectral"],
+    when_to_use=(
+        "X-ray transmission / K-edge thickness work when you need mu(E) for a known "
+        "element and no mu operand is supplied — derive it here from the element name."
+    ),
+    returns="np.ndarray of mu/rho (cm^2/g) or linear mu (1/cm), same shape as energy_kev.",
+    example="mu = attenuation('Au', energy_kev)   # cm^2/g on the data's energy axis",
+)
+

--- a/tests/test_edge_step.py
+++ b/tests/test_edge_step.py
@@ -1,0 +1,128 @@
+"""Offline tests for the measure_edge_step shared tool.
+
+Synthetic datacubes with a PLANTED edge step (no spekpy, no benchmark files)
+so the checks are deterministic and CI-portable. They pin the behaviour the
+X-ray coupon suite exposed: improvised per-pixel code under-measured the edge
+jump ~2x with tight/smoothed windows; this tool recovers the true step, is
+edge-specific (a fake edge energy yields ~0), gates on flux, and exposes every
+knob to the LLM (no locked defaults).
+
+  conda run -n scilink python -m pytest tests/test_edge_step.py -q
+"""
+import inspect
+
+import numpy as np
+
+from scilink.skills._shared.edge_step import measure_edge_step, TOOL_SPEC
+
+
+def _make_cube(
+    H=24, W=24, edge=80.8, step=0.5, coupon_frac=0.5,
+    i0_level=5000.0, i0_decay=None, cont_slope=0.005, cont_curv=0.0,
+    seed=0, noise=False,
+):
+    """A (H,W,E) transmission cube with a known edge step over `coupon_frac`
+    of the pixels. OD(E) = smooth continuum + step*H(E-edge); the tool should
+    recover `step` regardless of the (smooth) continuum. `i0_decay` makes the
+    incident flux fall with energy (to drive the post-edge flux gate)."""
+    rng = np.random.default_rng(seed)
+    E = np.arange(600, 1001) * 0.1          # 60.0 .. 100.0 keV, 401 channels
+    ne = E.size
+    cont = 0.2 + cont_slope * (E - 80.0) + cont_curv * (E - 80.0) ** 2
+    coupon_od = cont + step * (E >= edge).astype(float)
+
+    I0_spec = (np.full(ne, i0_level) if i0_decay is None
+               else i0_level * np.exp(-(E - E[0]) / i0_decay))
+    npix = H * W
+    I0 = np.broadcast_to(I0_spec, (npix, ne)).copy()
+
+    od = np.zeros((npix, ne))
+    od[: int(npix * coupon_frac)] = coupon_od           # coupon = first block
+    I = I0 * np.exp(-od)
+    if noise:
+        I = rng.poisson(np.clip(I, 0, None)).astype(float)
+    return I.reshape(H, W, ne), I0.reshape(H, W, ne), E
+
+
+def _coupon_empty(edge_step_map, coupon_frac=0.5):
+    es = edge_step_map.ravel()
+    cut = int(es.size * coupon_frac)
+    return es[:cut], es[cut:]
+
+
+def test_recovers_planted_step():
+    """The headline fix: recover the true jump (not ~2x low) on the coupon,
+    ~0 on the empty field."""
+    data, i0, E = _make_cube(step=0.5)
+    r = measure_edge_step(data, i0, E, 80.8)
+    assert r["measurable"]
+    coup, empty = _coupon_empty(r["edge_step"])
+    assert abs(np.median(coup) - 0.5) < 0.05      # true step, not 0.25
+    assert abs(np.median(empty)) < 0.05           # empty stays empty
+
+
+def test_recovers_step_with_noise():
+    data, i0, E = _make_cube(step=0.6, noise=True, seed=3)
+    r = measure_edge_step(data, i0, E, 80.8)
+    coup, _ = _coupon_empty(r["edge_step"])
+    assert abs(np.median(coup) - 0.6) < 0.06
+
+
+def test_edge_specific_fake_edge_gives_zero():
+    """Edge-specificity: measuring at an energy with NO edge yields ~0, so a
+    large step means a real discontinuity, not continuum-slope fitting."""
+    data, i0, E = _make_cube(step=0.5, edge=80.8)
+    r = measure_edge_step(data, i0, E, 90.0)      # no edge planted at 90 keV
+    assert abs(r["field_step"]) < 0.05
+
+
+def test_auto_center_snaps_to_offset_edge():
+    """A mis-specified edge energy is corrected toward the real edge."""
+    data, i0, E = _make_cube(step=0.6, edge=80.8)
+    r = measure_edge_step(data, i0, E, 80.0, auto_center=True, search_tol_kev=2.0)
+    assert abs(r["edge_kev_used"] - 80.8) < 0.3
+
+
+def test_flux_gate_rejects_starved_edge():
+    """Post-edge photon starvation -> measurable=False (refuse, don't fabricate)."""
+    data, i0, E = _make_cube(step=0.5, i0_level=4000.0, i0_decay=4.0)
+    r = measure_edge_step(data, i0, E, 80.8, flux_floor_counts=20.0)
+    assert not r["measurable"]
+    assert "flux" in r["reason"].lower()
+
+
+def test_win_width_knob_changes_output():
+    """A knob the LLM can turn must actually move the result (curved continuum
+    makes the window width matter)."""
+    data, i0, E = _make_cube(step=0.5, cont_curv=0.02)
+    narrow = measure_edge_step(data, i0, E, 80.8, win_width=2.0)
+    wide = measure_edge_step(data, i0, E, 80.8, win_width=6.0)
+    c_n, _ = _coupon_empty(narrow["edge_step"])
+    c_w, _ = _coupon_empty(wide["edge_step"])
+    assert abs(np.median(c_n) - np.median(c_w)) > 0.02
+
+
+def test_t_floor_knob_changes_opaque_result():
+    """t_floor is the saturation guard: on an opaque coupon (T below the floor
+    above the edge) it demonstrably changes the measured step."""
+    data, i0, E = _make_cube(step=14.0, cont_slope=0.0)   # post-edge OD ~14 -> T<1e-6
+    lo = measure_edge_step(data, i0, E, 80.8, t_floor=1e-6)
+    hi = measure_edge_step(data, i0, E, 80.8, t_floor=1e-3)
+    s_lo, _ = _coupon_empty(lo["edge_step"])
+    s_hi, _ = _coupon_empty(hi["edge_step"])
+    assert abs(np.median(s_lo) - np.median(s_hi)) > 1.0
+
+
+def test_all_knobs_exposed_to_llm():
+    """Anti-overfit contract: every function knob is surfaced in TOOL_SPEC (the
+    only surface the LLM sees) — no locked defaults."""
+    knobs = [p for p in inspect.signature(measure_edge_step).parameters]
+    for p in knobs:
+        assert p in TOOL_SPEC.parameters, f"{p} is hidden from the LLM"
+
+
+def test_registry_discovers_tool():
+    """The tool must be visible to hyperspectral codegen via the registry."""
+    from scilink.skills._shared._registry import get_tools_for
+    names = {t.name for t in get_tools_for("hyperspectral", active_skills=[])}
+    assert "measure_edge_step" in names

--- a/tests/test_hyperspectral_ref_resample.py
+++ b/tests/test_hyperspectral_ref_resample.py
@@ -1,0 +1,67 @@
+"""Offline regression test for auto-resampling a 1D reference operand.
+
+A tabulated reference (cross-section / attenuation / standard) pulled from a
+database is sampled on its OWN axis, never the detector's channel grid. The
+operand-alignment gate used to drop any 1D auxiliary whose length != channel
+count, so such a reference could not be used by the per-pixel codegen unless
+the user pre-resampled it. The gate now resamples a 1D reference that carries
+its own axis onto the signal axis, yielding an index-aligned per-channel
+operand (codegen contract unchanged). These checks are deterministic.
+
+  conda run -n scilink python -m pytest tests/test_hyperspectral_ref_resample.py -q
+"""
+import numpy as np
+
+from scilink.agents.exp_agents.controllers.hyperspectral_controllers import (
+    _resample_ref_to_signal_axis,
+)
+
+
+def _mu_like(n):
+    """A step-at-80.8-keV reference (mimics an Au K-edge attenuation table)."""
+    e = np.linspace(1.0, 200.0, n)
+    v = np.where(e < 80.8, 2.15, 8.34)
+    return e, v
+
+
+def test_resamples_reference_onto_signal_axis():
+    ref_axis, ref_vals = _mu_like(1990)            # foreign grid, foreign length
+    energy_axis = np.linspace(0.1, 204.8, 2048)    # data signal axis
+    out = _resample_ref_to_signal_axis(ref_vals, ref_axis, energy_axis, 2048)
+    assert out is not None and out.shape == (2048,)
+    # step preserved across the edge
+    assert out[np.argmin(np.abs(energy_axis - 79))] < 3.0
+    assert out[np.argmin(np.abs(energy_axis - 82))] > 7.0
+
+
+def test_unsorted_reference_axis_is_handled():
+    ref_axis, ref_vals = _mu_like(500)
+    perm = np.random.RandomState(0).permutation(ref_axis.size)
+    energy_axis = np.linspace(0.1, 204.8, 2048)
+    out = _resample_ref_to_signal_axis(ref_vals[perm], ref_axis[perm], energy_axis, 2048)
+    assert out is not None
+    assert out[np.argmin(np.abs(energy_axis - 82))] > 7.0
+
+
+def test_guards_return_none():
+    energy_axis = np.linspace(0.1, 204.8, 2048)
+    ref_axis, ref_vals = _mu_like(1990)
+    # no native axis -> cannot resample
+    assert _resample_ref_to_signal_axis(ref_vals, None, energy_axis, 2048) is None
+    # 2D operand -> not a 1D reference
+    assert _resample_ref_to_signal_axis(np.ones((5, 5)), np.arange(5), energy_axis, 2048) is None
+    # axis length mismatched to values
+    assert _resample_ref_to_signal_axis(ref_vals, ref_axis[:-1], energy_axis, 2048) is None
+    # no signal axis available (degenerate)
+    assert _resample_ref_to_signal_axis(ref_vals, ref_axis, None, 2048) is None
+    # signal axis shape doesn't match channel count
+    assert _resample_ref_to_signal_axis(ref_vals, ref_axis, energy_axis, 1024) is None
+    # non-overlapping axes (different physical quantity) -> don't fabricate
+    assert _resample_ref_to_signal_axis(
+        np.ones(100), np.linspace(400, 600, 100), energy_axis, 2048) is None
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_hyperspectral_sanity_vote.py
+++ b/tests/test_hyperspectral_sanity_vote.py
@@ -1,0 +1,73 @@
+"""Offline test for the physics-sanity-check VOTING logic.
+
+A single LLM judgment is too noisy near the decision boundary (it false-rejects
+a correct result ~half the time in validation) but never false-PASSES a gross
+error. So _sanity_check_result votes SANITY_VOTES independent judgments and
+rejects only when >= SANITY_REJECT_MAJORITY agree, short-circuiting once
+decided. These tests stub the single judgment to make the logic deterministic.
+
+  conda run -n scilink python -m pytest tests/test_hyperspectral_sanity_vote.py -q
+"""
+import logging
+import types
+
+from scilink.agents.exp_agents.controllers.hyperspectral_controllers import (
+    RunDynamicAnalysisController as C,
+)
+
+
+def _ctrl(verdicts):
+    """A controller whose single-judgment returns the given (valid, crit) seq,
+    counting how many times it was called."""
+    ctrl = C.__new__(C)
+    ctrl.logger = logging.getLogger("t")
+    seq = list(verdicts)
+    calls = {"n": 0}
+
+    def fake_one(self, *a, **k):
+        calls["n"] += 1
+        return seq.pop(0)
+    ctrl._sanity_check_one = types.MethodType(fake_one, ctrl)
+    ctrl._calls = calls
+    return ctrl
+
+
+ARGS = (b"dash", "code", None, {}, "obj", "feat", "summary")
+
+
+def test_two_rejects_reject_and_short_circuit():
+    # invalid, invalid -> reject after 2 calls (3rd not needed).
+    ctrl = _ctrl([(False, "x"), (False, "y"), (True, "")])
+    ok, crit = ctrl._sanity_check_result(*ARGS)
+    assert ok is False and ctrl._calls["n"] == 2
+
+
+def test_single_reject_accepts_majority_not_reached():
+    # valid, invalid, valid -> only 1 reject < majority 2 -> accept.
+    ctrl = _ctrl([(True, ""), (False, "x"), (True, "")])
+    ok, _ = ctrl._sanity_check_result(*ARGS)
+    assert ok is True
+
+
+def test_two_accepts_short_circuit_before_third():
+    # valid, valid -> can't reach 2 rejects in remaining -> accept after 2 calls.
+    ctrl = _ctrl([(True, ""), (True, ""), (False, "x")])
+    ok, _ = ctrl._sanity_check_result(*ARGS)
+    assert ok is True and ctrl._calls["n"] == 2
+
+
+def test_fail_open_on_judgment_error():
+    ctrl = C.__new__(C)
+    ctrl.logger = logging.getLogger("t")
+
+    def boom(self, *a, **k):
+        raise RuntimeError("model down")
+    ctrl._sanity_check_one = types.MethodType(boom, ctrl)
+    ok, crit = ctrl._sanity_check_result(*ARGS)
+    assert ok is True and crit == ""  # fail-open, does not block
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_metadata_conformance_energy_axis.py
+++ b/tests/test_metadata_conformance_energy_axis.py
@@ -1,0 +1,77 @@
+"""Offline regression test for the spectral-imaging energy-axis conformance gap.
+
+A hyperspectral / spectral-imaging metadata dict that lacks a resolvable energy
+axis used to pass ``check_schema_conformance`` (it had experiment/sample/
+technique), which SKIPPED the LLM normalizer that would extract ``energy_range``
+from prose — so the agent silently fell back to channel indices and the K-edge
+windows landed at the wrong energies. The fix flags such a dict non-conformant
+so Tier-2 LLM extraction fires. These assertions are deterministic (no LLM).
+
+  conda run -n scilink python -m pytest tests/test_metadata_conformance_energy_axis.py -q
+"""
+from scilink.agents.exp_agents.metadata_converter import check_schema_conformance
+
+
+def _ok(m):
+    return check_schema_conformance(m)[0]
+
+
+def test_spectral_imaging_without_energy_axis_is_nonconformant():
+    # The Hexitec X-ray case: technique names spectral imaging, no energy_range.
+    meta = {
+        "experiment_type": "Spectroscopy",
+        "experiment": {"technique": "Spectral X-ray Imaging"},
+        "sample": {"material": "Au"},
+    }
+    conformant, issues = check_schema_conformance(meta)
+    assert conformant is False
+    assert any("energy axis" in i for i in issues)
+
+
+def test_energy_axis_via_energy_range_or_axis_spec_is_conformant():
+    assert _ok({
+        "experiment_type": "Spectroscopy",
+        "experiment": {"technique": "Spectral X-ray Imaging"},
+        "sample": {"material": "Au"},
+        "energy_range": {"start": 0.1, "end": 204.8, "units": "keV"},
+    })
+    assert _ok({
+        "experiment_type": "Spectroscopy",
+        "experiment": {"technique": "STEM-EELS spectrum image"},
+        "sample": {"material": "TiOx"},
+        "axis_spec": {"axis_2": {"start": 450, "end": 550, "units": "eV"}},
+    })
+
+
+def test_partial_energy_range_units_only_still_nonconformant():
+    # units without start/end is not resolvable -> still flagged.
+    assert _ok({
+        "experiment_type": "hyperspectral imaging",
+        "experiment": {"technique": "Raman imaging"},
+        "sample": {"material": "polymer"},
+        "energy_range": {"units": "cm^-1"},
+    }) is False
+
+
+def test_no_false_positive_on_1d_curve_or_microscopy():
+    # 1D XRD curve: x-axis is 2theta, energy_range legitimately absent.
+    assert _ok({
+        "experiment_type": "Spectroscopy",
+        "experiment": {"technique": "XRD powder diffraction"},
+        "sample": {"material": "Anorthite"},
+        "data_columns": [{"name": "2theta", "units": "deg"},
+                         {"name": "Counts", "units": "counts"}],
+    })
+    # Plain microscopy image: no spectral axis at all.
+    assert _ok({
+        "experiment_type": "Microscopy",
+        "experiment": {"technique": "STEM-HAADF imaging"},
+        "sample": {"material": "SrTiO3"},
+        "spatial_info": {"field_of_view_x": 8, "field_of_view_units": "nm"},
+    })
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary (for scientists)

Enables the hyperspectral analysis agent to do **agentic per-pixel X-ray K-edge thickness mapping** from spectral X-ray transmission datacubes (e.g. Hexitec) — point it at the datacube + a flat-field baseline + a one-line goal, and it plans the analysis, writes the per-pixel code, **sources its own X-ray physics** (NIST μ by element, no attenuation file needed), self-verifies, and **honestly flags where the number is trustworthy vs approximate**.

Validated end-to-end on real experimental coupons (bedrock opus-4-8):
- **Uniform Au ≈ 39 µm** (edge-step ↔ thickness self-consistent to 3 digits).
- **Non-uniform sputtered Au** — resolves the full 0→~140 µm gradient dome at 0.25 mm/pixel.
- A full 14-run suite (7 coupons × cold/warm) lands correct on every *measurable* coupon, with the no-skill ("cold") agent matching the skill-guided one — because the key window/flux discipline now lives in a shared tool both use.
- On genuinely-hard coupons (flux-starved / fluorescence-contaminated edges) the agent **degrades honestly** — presents an approximate low-confidence result with caveats, or withholds it, rather than fabricating a value.

Also fixes the "point at data + baseline + a task and let it figure the rest out" UX: a 3D flat-field baseline is now ingested as a companion operand (previously mangled to uint8), and spectral-imaging metadata is required to carry a resolvable energy axis (so keV K-edge windows land at the right channels). No curve-fitting or image-analysis behavior is changed.

---

## Technical details (for reviewers)

Foundation-agent (hyperspectral) work; **no curve/image files touched** (verified). Nine commits, bottom-up:

**Inputs / metadata**
- `5824e23` — `_load_auxiliary_data` accepts a 3D `.npy` (trailing axis > 4) as a **companion datacube operand**: loaded raw `float64` (not via `load_image`, which cast to uint8 and destroyed scale), renders its mean spectrum, flows through the existing operand-alignment gate. RGB/1D/2D unchanged.
- `683abb3` — `metadata_converter.check_schema_conformance`: spectral-imaging metadata must carry a resolvable energy axis (`_describes_spectral_imaging` + `_has_resolvable_energy_axis`); otherwise it routes to the Tier-2 LLM normalizer that extracts `energy_range` from prose (else `resolve_axis_spec` fell back to channel indices in eV and keV windows mis-landed).
- `ec47697` — a 1D reference operand carrying its own axis is auto-resampled onto the signal axis (foreign length no longer dropped by the alignment gate).

**Extraction tools (shared, registry-discovered)**
- `8123b83` — `skills/_shared/xray_attenuation.py::attenuation(element, energy_kev)` — NIST μ/ρ via spekpy (lazy import), `agents=["hyperspectral"]`; registry-driven codegen wiring so generated scripts call it by name (no μ operand supplied).
- `fee7e2f` — `skills/_shared/edge_step.py::measure_edge_step(...)` — data-driven wide/offset continuum windows + photon-flux gate; returns edge step (ΔOD) + SNR + `measurable` flag (NOT thickness). All 8 knobs exposed in `TOOL_SPEC` with which-way-to-tune docs. Standalone recovers Au 39.1 where improvised code gave 20.2 (2× low). Also: `_planning_tool_awareness` (planner sees tool names + when_to_use + a "don't hand-roll μ/windows the tool owns" directive), and the combined required-output reviewer `_review_required_output` (merges the old Visual-QC + voted physics-sanity gates into one voted review carrying the used-tool descriptions + the shared `VERIFIER_TOOL_SCRUTINY_PRINCIPLE`; diagnostics keep the single Visual QC).

**Verification / robustness**
- `8e8ea36` — QC accepts a physically-valid *uniform* map (a real homogeneous measurement is not a "trivial collapse").
- `2699a54` — codegen retry anneals patch→method-question→abandon-to-different-estimator; best-attempt salvage keeps recoverable maps when a required output is unsatisfiable.
- `86b021a` — LLM physics sanity check (voted, majority-to-reject, fail-open) on required quantitative outputs.
- `09ca263` — (a) **status propagation**: salvage/approximate/withheld outcomes record `degradation_notes`, threaded up so `analyze()` returns `status="partial"` + `confidence` + `warnings` (a clean run stays `success`); (b) **coverage-collapse signal**: the reviewer's result summary now includes valid-coverage %, with a *symmetric* prompt rule (low coverage is correct for localized features — defects/dopants/domains — and a collapse only when a region-filling feature or the field-mean spectrum shows a dropped signal). `_judge_salvage`: when all attempts fail, one physics call decides present-with-caveats vs withhold the best partial.

**Tests** (offline, deterministic): `test_edge_step.py` (9), `test_hyperspectral_ref_resample.py`, `test_hyperspectral_sanity_vote.py`, `test_metadata_conformance_energy_axis.py` — 20 total, all green. EELS/plasmon path re-verified (no regression from the shared-controller changes).

**Known limits:** the X-ray tools are tagged broadly `agents=["hyperspectral"]` (always-on so *cold* runs are competent), so they also appear in other-modality prompts — confirmed benign (the plasmon run filters them by `when_to_use` and fits correctly); a modality-scoped registry tag would be the clean fix if it ever matters. Verifier is scale-blind on genuinely-marginal edges (surfaced as `partial`/low-confidence via status propagation).