### PR TITLE
Raman and IR skills for the curve-fitting agent

### DIFF
--- a/scilink/skills/curve_fitting/ir/ir.md
+++ b/scilink/skills/curve_fitting/ir/ir.md
@@ -1,0 +1,107 @@
+---
+description: Infrared (FTIR) absorption spectroscopy of solids — transmittance/absorbance handling, baseline restraint for broad bands, and resolution of diagnostic band multiplets.
+technique: [IR, FTIR, infrared, "infrared spectroscopy", "IR absorption"]
+---
+
+# Infrared Spectroscopy (FTIR)
+
+## Overview
+
+Mid-IR spectra (~400–4000 cm⁻¹) plot absorbance or transmittance against
+wavenumber. **Check the orientation first**: absorbance-style data has
+bands pointing UP from a low baseline; transmittance-style data has bands
+pointing DOWN from a high plateau (often near 100 %). Convert transmittance
+to absorbance (A = 2 − log₁₀(%T), or A = −log₁₀(T) for fractional T)
+before fitting, and say that the conversion was applied. Strong bands in
+raw absorbance data may be saturated (flat-topped) — apex positions of
+saturated bands are unreliable.
+
+## Planning
+
+1. Determine orientation (dips vs peaks) and convert if needed.
+2. **Fit the full measured range.** Never restrict fitting to one region
+   (e.g., only the OH-stretch or only the fingerprint region) unless the
+   user asked for it — the fingerprint region below ~1300 cm⁻¹ and the
+   stretch region above 2800 cm⁻¹ carry complementary information and both
+   must be modeled. If any region is excluded, say so and why.
+3. **Broad bands are signal, not background.** O–H/N–H stretch envelopes
+   (2800–3700 cm⁻¹), hydrogen-bonded water (~1630 plus broad 3000–3600),
+   and broad ν3 envelopes are analyte absorption. Anchor any baseline ONLY
+   in genuinely band-free windows (typically ~1900–2200 and ~2500–2700
+   cm⁻¹, away from CO₂) — a baseline free to bend inside band regions will
+   eat real absorption and cannot be recovered by the peak components.
+4. Exclude or down-weight the atmospheric CO₂ region (2300–2380 cm⁻¹) and
+   note narrow water-vapor structure (1400–1800, 3500–3900) when present.
+5. Plan components for the fine structure of diagnostic multiplets: a
+   resolved doublet or shoulder (e.g., sulfate ν3 splitting) must get its
+   own components — the splitting pattern carries the site-symmetry
+   information.
+
+## Implementation
+
+Fit pseudo-Voigt components on the (converted, baseline-restrained)
+spectrum. Baseline: linear or single low-order polynomial pinned to the
+band-free anchor windows from Planning — do not use aggressive iterative
+baselines (ALS with low stiffness) on IR data with broad OH envelopes.
+Saturated strong bands: fit the flanks and report the apex as uncertain
+rather than forcing a narrow component through the flat top.
+
+**Asymmetric bands.** A dispersive (S-shaped) residual across a single
+band that persists after a symmetric refit indicates real asymmetry
+(particle-size/shape effects in powders, hydrogen-bonding distributions,
+unresolved fine structure). Refit that band with a split pseudo-Voigt —
+independent left/right FWHM, apex height preserved, asymmetry ratio
+bounded to 0.3–3 (use the same functional form as in the Raman recipe:
+width chosen per side of the center). Decision order: a KNOWN multiplet
+(e.g., sulfate ν3 splitting) gets separate symmetric components first;
+asymmetry is not a substitute for resolving real splitting. If all bands
+show the same strong asymmetry, suspect baseline or saturation problems
+instead.
+
+Report per band: center, FWHM (left/right if asymmetric), relative
+intensity, and (for multiplets) the number of resolved components and
+their splitting.
+
+## Interpretation
+
+The table below is **non-exhaustive** — for unlisted phases reason from
+group frequencies rather than forcing a match, and treat a candidate as
+supported only when multiple bands match, not just the strongest one.
+
+Diagnostic mid-IR bands (cm⁻¹, ±5 unless noted):
+
+- **Carbonates**: ν3 asym stretch broad **1420–1450**, ν2 sharp 875
+  (calcite) / 881 (dolomite) / 856 (witherite), ν4 712 / 728 / 693
+  respectively; combination ~1795, ~2513 weak.
+- **Sulfates**: ν3 **1050–1150** — watch for SPLITTING into 2–3 components
+  (site symmetry); ν4 590–680 multiplet; hydrated sulfates add water bends
+  ~1630 and OH stretches.
+- **Phosphates/arsenates**: ν3 ~**1000–1100** (phosphate), ~800–850
+  (arsenate); OH bands where hydrated/hydroxylated.
+- **Silicates**: Si–O stretch envelope **900–1100** (structure-rich —
+  resolve its components), Si–O bends 400–550; sheet silicates add sharp
+  structural OH 3620–3680 (talc 3677); amphiboles ~3630–3675.
+- **Borates**: B–O stretches 1300–1450 (trigonal) and 950–1100
+  (tetrahedral); hydrated borates show rich OH structure 3200–3600.
+- **Oxides**: Sb₂O₃/As₂O₃ few strong bands 650–800; broad metal-oxide
+  lattice absorption below 700.
+- Water vs hydroxyl: molecular H₂O shows the 1630 bend + broad 3000–3600;
+  structural OH gives sharp isolated 3500–3700 stretches without the bend.
+
+Element consistency: reject candidates whose essential elements are absent
+from provided chemistry; pattern-only identifications should be flagged as
+such.
+
+## Validation
+
+- Zoomed residuals over every strong band and every diagnostic multiplet,
+  acting on the residual's SHAPE: bimodal = unresolved component (split
+  and refit); dispersive S-shape on a single band = asymmetry (switch that
+  band to the asymmetric profile). Do not accept while either signature
+  remains above ~3× noise. R² alone must not accept.
+- Verify the baseline did not absorb broad bands: overlay raw data,
+  baseline, and corrected data; if the baseline tracks the OH envelope or
+  any band's flank, re-anchor it and refit.
+- Every band above ~5× noise gets a component; no component sits on noise.
+- For saturated bands, confirm the reported center comes from the flanks
+  and is flagged uncertain.

--- a/scilink/skills/curve_fitting/raman/raman.md
+++ b/scilink/skills/curve_fitting/raman/raman.md
@@ -1,0 +1,215 @@
+---
+description: Raman spectroscopy band fitting and phase identification — fluorescence background handling, full-range multi-band deconvolution, and band-to-phase assignment for common mineral and materials classes.
+technique: [Raman, "Raman spectroscopy", "micro-Raman", "Raman microscopy"]
+---
+
+# Raman Spectroscopy
+
+## Overview
+
+Raman spectra plot intensity against Raman shift (cm⁻¹). Bands are phonon
+or molecular vibrational modes: sharp bands (FWHM a few cm⁻¹) indicate a
+well-ordered crystal; broad bands indicate disorder, glass, or overlapping
+modes. Band *positions* carry the chemistry and structure; absolute
+intensities are arbitrary (relative intensities within one spectrum are
+meaningful). Two artifacts dominate real spectra: **fluorescence** — a
+broad, smooth background that can be orders of magnitude stronger than the
+Raman bands, especially with visible excitation on colored or defective
+samples — and cosmic-ray spikes (single-pixel). True Raman bands appear at
+the same shift regardless of excitation wavelength; features that move
+between excitations are fluorescence or artifacts.
+
+## Planning
+
+1. **Assess the background FIRST.** Estimate a rolling-minimum baseline and
+   its share of total spectral area. If the baseline accounts for more than
+   ~40 % of the area, the spectrum is fluorescence-dominated: plan an
+   iterative asymmetric baseline subtraction (ALS, recipe in
+   Implementation) BEFORE any peak fitting. Never fit peak components to
+   the raw curve in this regime — a smooth curve through the ramp gives
+   near-perfect R² while ignoring every Raman band.
+2. **Fit the full measured range.** Do not restrict fitting to the
+   dominant band region unless the user asked for it; weak low-wavenumber
+   and high-wavenumber bands (lattice modes, OH stretches, overtones) carry
+   identification-critical information. If any region is excluded, say so
+   explicitly and why.
+3. **Plan one component per resolved band, plus shoulders.** Count
+   candidate bands by prominence above the noise floor on the
+   baseline-corrected signal. A visible shoulder or asymmetry on a strong
+   band is a component, not a nuisance.
+4. Multiple excitation wavelengths of the same sample, when available, are
+   a cross-check: keep bands that replicate across excitations; discount
+   features that move or appear in only one.
+
+## Implementation
+
+When the background assessment (Planning step 1) indicates fluorescence
+dominance, subtract an ALS baseline first:
+
+```python
+import numpy as np
+from scipy import sparse
+from scipy.sparse.linalg import spsolve
+
+def als_baseline(y, lam=1e6, p=0.001, niter=15):
+    """Asymmetric least squares baseline (Eilers & Boelens).
+    lam: stiffness, 1e5-1e7. RAISE if the baseline bends up into broad
+         bands (eating signal); LOWER if it fails to follow the
+         fluorescence curvature.
+    p:   asymmetry, 0.001-0.01. RAISE slightly if the baseline sits below
+         the noise floor between bands.
+    """
+    L = len(y)
+    D = sparse.diags([1, -2, 1], [0, -1, -2], shape=(L, L - 2))
+    D = lam * D.dot(D.transpose())
+    w = np.ones(L)
+    W = sparse.spdiags(w, 0, L, L)
+    for _ in range(niter):
+        W.setdiag(w)
+        Z = W + D
+        z = spsolve(Z, w * y)
+        w = p * (y > z) + (1 - p) * (y < z)
+    return z
+
+y_corr = y - als_baseline(y)
+```
+
+Then fit the corrected signal with a sum of pseudo-Voigt components plus at
+most a constant offset (the structured background is already gone — a
+sloped or polynomial residual baseline at this stage usually means the ALS
+parameters need adjusting, not that more baseline freedom is needed).
+
+**The model must explain the peaks, not the ramp.** After fitting, check
+where the model's variance lives: if the fitted curve with all peak
+components removed still tracks most of the data (i.e., the "peaks" are
+reproducing background curvature), the fit has failed regardless of R².
+
+**Asymmetric bands.** Real Raman bands are often asymmetric — from
+instrumental response, phonon-coupling (Fano-type) interactions,
+disorder, or unresolved fine structure. The signature is a dispersive
+(S-shaped, sign-flipping) residual centered on a single band that
+persists after a symmetric refit. Handle it with a split pseudo-Voigt
+(independent left/right widths, apex-preserving):
+
+```python
+import numpy as np
+
+def split_pseudo_voigt(x, amp, center, fwhm_l, fwhm_r, eta):
+    """Pseudo-Voigt with different left/right FWHM; amp = apex height.
+    Constrain 0<=eta<=1 and 0.3 <= fwhm_r/fwhm_l <= 3 (larger asymmetry
+    usually means unresolved structure, not lineshape)."""
+    fwhm = np.where(x < center, fwhm_l, fwhm_r)
+    s = fwhm / 2.3548
+    g = np.exp(-0.5 * ((x - center) / s) ** 2)
+    l = 1.0 / (1.0 + ((x - center) / (fwhm / 2)) ** 2)
+    return amp * (eta * l + (1 - eta) * g)
+```
+
+Decision order matters: if the band is a KNOWN doublet (e.g., a
+crystallographic splitting listed in the tables), fit two symmetric
+components — never use asymmetry to absorb real splitting. Reach for the
+asymmetric profile only when a second component fails to converge or has
+no physical meaning, and report the asymmetry ratio per band. If EVERY
+band comes out strongly asymmetric in the same direction, suspect a
+baseline or calibration problem instead of lineshape physics.
+
+Report per band: center (cm⁻¹), FWHM (left/right if asymmetric), relative
+intensity (strongest = 1), and lineshape mixing. Cosmic spikes
+(single-pixel) are removed by median filtering, never fitted.
+
+## Interpretation
+
+Assign every fitted band before concluding. The tables below cover common
+classes and are **non-exhaustive** — for phases not listed, reason from
+group frequencies (anion internal modes, metal-oxygen lattice-mode ranges,
+OH/CH/NH stretch regions) rather than forcing a match to a listed entry.
+**Never snap to the nearest table entry**: a candidate is supported only
+when several bands (positions AND relative intensities) match within a few
+cm⁻¹; if only the strongest band matches, say the pattern is not fully
+explained and rank the candidate accordingly.
+
+Diagnostic bands for common classes (positions ±3 cm⁻¹ unless noted;
+strongest band in bold):
+
+- **Carbonates**: calcite **1086**, 712, 282, 156; aragonite **1085**,
+  705+701 doublet, 206, 152 (the ν4 region and lattice modes separate the
+  CaCO₃ polymorphs — do not report "calcite" for aragonite); dolomite
+  **1097**, 725, 299.
+- **Sulfates**: gypsum **1008**, 415/494, 620, ~1141 (w); anhydrite
+  **1017**, 417 (w)/499, 628/675, 1128 (the ν1 shift 1008→1017 separates
+  hydrated from anhydrous); barite **988**, 462, 617.
+- **Phosphates**: apatite group **964** (ν1, dominant); weak families at
+  430–450 (ν2), 580–610 (ν4), 1030–1060 (ν3); F vs OH endmember needs the
+  OH-stretch region (~3575 hydroxylapatite).
+- **Silica/silicates**: α-quartz **464** (sharp, Lorentzian), 128, 206
+  (broad), 355/394/401 (weak); feldspars **505–515 + 475–480 doublet** (microcline
+  ~513+475, albite ~507+479) plus 150–290 lattice modes — a sharp
+  ~465–515 doublet with no carbonate/sulfate ν1 says tectosilicate;
+  olivine **doublet 815–825 + 838–857** (forsterite 824+856; both members
+  shift down with Fe) with weak 920/965 and weak 300–620 SiO₄ modes;
+  pyroxene (diopside) **665–670** + 1010–1015 + 320–395; amphibole
+  (tremolite) **670–675** + 928/1028–1060 + sharp OH 3670–3675;
+  serpentine (antigorite) **230/375–390/685–692** + OH 3665–3700; zircon
+  **1008** + 974 + 356/439; kyanite **485–490 + 300/325** multiplet.
+- **TiO₂ and oxides**: anatase **144** (very strong) + 399/516/639 + 197
+  (weak, often below detection); rutile **447/612** + broad ~235 (no 144);
+  hematite **225/292** + 245/412/498/613 + broad ~1320 two-magnon;
+  magnetite broad **660–670**; spinel/chromite broad 680–700 (needs Cr/Fe
+  chemistry).
+- **Sulfides**: cinnabar **254**, 288, 343; chalcopyrite **292** + ~320
+  (weak, resonance-prone); pyrite **343/379**; orpiment 310/355/384;
+  molecular As-S (realgar) rich 180–370 multiplet.
+- **Carbon**: D ~1350 + G ~1580–1600 (both broad = disordered sp²);
+  graphene oxide shows intense broad D+G with weak, broad 2D ~2700;
+  well-ordered graphite: sharp G, weak D, strong 2D; diamond single sharp
+  **1332**.
+- **Molecular anions in salts/solutions**: TFSI⁻ **740–745** (S–N–S
+  expansion, sharp, solvation-sensitive), 280–350 cluster, 1240s;
+  uranyl UO₂²⁺ ν1 **830–870** single symmetric band.
+- Sulfur (α-S₈) **153/219/473**.
+
+**Trap disambiguation — single strong band near 820–880.** Olivine, uranyl,
+tungstates/molybdates (scheelite ~911, wolframite ~880), and some
+phosphates all put their strongest band here. Olivine is a resolved PAIR
+(≈30 cm⁻¹ apart) with weak 920/965 companions; uranyl is a single
+symmetric band; scheelite-type adds 320–400 bending modes and nothing at
+920–965. Never assign this region from the strongest band alone — use the
+full pattern.
+
+If literature context is provided with the task, weigh it against the
+*fitted* band positions and prefer literature-confirmed assignments over
+the tables above — the tables are a compact bootstrap, not an authority;
+published spectra of the specific candidate phases are. Whether or not
+literature is provided, always report a compact, machine-readable band
+summary (centers and relative intensities, strongest first) alongside the
+interpretation, so downstream identification steps can search the
+literature from the measured features.
+
+**Element consistency is a hard constraint.** When the sample's elements
+are provided (from EDX/XRF or metadata), reject any candidate whose
+essential elements are absent from that list (e.g., do not propose a
+Cr-spinel when Cr is not among the reported elements). State when a
+candidate is rejected for this reason. If no chemistry is given, say the
+identification is pattern-only and rank candidates accordingly.
+
+## Validation
+
+- Inspect zoomed residuals across every strong band and act on the
+  residual's SHAPE: a bimodal residual (two humps) means an unresolved
+  shoulder/doublet — add a component; a dispersive S-shaped residual on a
+  single band means asymmetry — switch that band to the asymmetric
+  profile (Implementation). Do not accept while either signature remains
+  above ~3× noise. R² alone must not accept a fit: near-unity R² is
+  achievable while missing every real band (by fitting the background),
+  while merging resolved structure, or while leaving structured residuals
+  that are small relative to the strongest band.
+- Completeness check: every band visible above ~5× noise in the
+  baseline-corrected data must correspond to a fitted component; every
+  fitted component must correspond to visible intensity (no components
+  parked on noise or reproducing background curvature).
+- If fluorescence was subtracted, report both the corrected fit and the
+  baseline fraction so the user can judge the correction.
+- For identification tasks: the top candidate must explain the strongest
+  three bands AND not conflict with provided chemistry; alternatives
+  within the same family should be listed when band positions cannot
+  separate them (state which additional measurement would).

--- a/tests/test_raman_ir_skills.py
+++ b/tests/test_raman_ir_skills.py
@@ -1,0 +1,52 @@
+"""Loader-level tests for the raman and ir curve-fitting skill bundles.
+
+Content-behavior validation (fluorescence protocol, band tables, blind-ID
+lift) was done live against RRUFF and in-house benchmarks; see the PR. These
+tests pin the packaging contract: bundles resolve by name, carry the full
+five-section vocabulary, and expose selector metadata.
+"""
+
+import pytest
+
+from scilink.skills.loader import load_skill
+
+CORE_SECTIONS = ("overview", "planning", "implementation",
+                 "interpretation", "validation")
+
+
+@pytest.mark.parametrize("name", ["raman", "ir"])
+class TestBundleContract:
+    def test_resolves_by_bare_name(self, name):
+        skill = load_skill(name)
+        assert skill is not None
+
+    def test_all_core_sections_populated(self, name):
+        skill = load_skill(name)
+        for section in CORE_SECTIONS:
+            assert skill[section].strip(), f"empty section: {section}"
+
+    def test_selector_metadata(self, name):
+        skill = load_skill(name)
+        meta = skill["meta"]
+        assert meta.get("description")
+        techs = meta.get("technique")
+        assert isinstance(techs, list) and len(techs) >= 2
+
+    def test_no_extras_lost(self, name):
+        skill = load_skill(name)
+        assert not skill.get("extras"), (
+            "off-vocabulary sections present — move content under the "
+            f"canonical headings: {sorted(skill['extras'])}")
+
+
+def test_raman_carries_fluorescence_protocol():
+    skill = load_skill("raman")
+    assert "als_baseline" in skill["implementation"]
+    assert "asymmetric" in skill["implementation"].lower()
+    assert "background" in skill["planning"].lower()
+
+
+def test_ir_carries_orientation_and_range_rules():
+    skill = load_skill("ir")
+    assert "transmittance" in skill["overview"].lower()
+    assert "full measured range" in skill["planning"].lower()


### PR DESCRIPTION
## Raman and IR skills for the curve-fitting agent

Two new domain skills teach the curve-fitting agent how a vibrational-spectroscopy practitioner actually works.

**What they fix.** Benchmarked against 40 RRUFF datasets (difficulty-stratified Raman + IR), the baseline agent fit well-behaved spectra beautifully but failed in four characteristic ways: it fit fluorescence backgrounds instead of the Raman bands riding on them (one case reached R² = 1.000 while recovering 9% of the real peaks), silently restricted fitting to the dominant band region, merged clearly resolved doublets into single components, and let aggressive baselines eat broad OH envelopes in IR data. On blind identification it either never committed to a name or, on near-identical replicate spectra, named the compound in one run and missed it in the next — the knowledge was present but not reliably retrieved.

**What the skills contain.** Practitioner protocol (assess background first and subtract an iterative asymmetric baseline when fluorescence dominates; fit the full measured range; convert transmittance to absorbance; anchor IR baselines only in band-free windows), residual-shape rules (a bimodal residual means an unresolved shoulder — split it; an S-shaped residual means asymmetry — use the provided split pseudo-Voigt), diagnostic band tables for common mineral and materials classes with trap disambiguation (e.g., the olivine / uranyl / tungstate ~820–880 cm⁻¹ confusion), and hard constraints for identification (candidates must be consistent with known chemistry; never force-match a table entry on a single band).

**Validation.** Band tables were verified empirically against RRUFF specimen ensembles (97 claims checked; 14 memory errors corrected from data before shipping). A/B on the failed benchmark cases: the fluorescence case went from an incoherent R² = 0.63 fit to a clean ALS-subtracted fit of the real bands; the windowing case recovered full-range fitting (peak recall 0.5 → 1.0); the merged sulfate ν3 doublet was resolved. Blind identification on a 38-dataset external benchmark rose from 12/15 → 15/15 (with metadata), 7/15 → 14/15 (pattern-only), and 3/8 → 7/8 (in-house non-minerals: Mg(TFSI)₂ electrolytes and graphene oxide). A 20-mineral held-out set built after skill authoring confirmed the gains are protocol- and family-level rather than memorized: no regressions on previously-correct cases, one table-induced confusion identified and documented (andradite/olivine), honest abstention on unlisted species. Skill effects replicated across models (Opus 4.8 and Sonnet 5 both reach 4/4 on TFSI replicates with the skill).

Markdown-only bundles — no agent code changes; the loader, selector, and codegen injection pick them up through the existing machinery.

---

## Technical details

**Files.**
- `scilink/skills/curve_fitting/raman/raman.md` — five canonical sections (`## Overview/Planning/Implementation/Interpretation/Validation`, parser lowercases); frontmatter `description` + `technique: [Raman, "Raman spectroscopy", "micro-Raman", "Raman microscopy"]` for the exclusive selector's technique matching.
- `scilink/skills/curve_fitting/ir/ir.md` — same shape; `technique: [IR, FTIR, infrared, "infrared spectroscopy", "IR absorption"]`.
- `tests/test_raman_ir_skills.py` — packaging-contract tests: bare-name resolution via `load_skill(name)`, all five sections non-empty, selector metadata present (`description`, `technique` list ≥ 2), no `extras` leakage, plus content pins (ALS recipe + asymmetric-lineshape guidance in raman `implementation`; transmittance-orientation + full-range rules in ir).

**Reliability rungs.** Both skills are prose + code-in-markdown (rung 2): the ALS baseline (Eilers–Boelens, λ/p knobs documented with tuning directions) and a split pseudo-Voigt (independent left/right FWHM, asymmetry ratio bounded 0.3–3) are pinned as verbatim snippets the codegen transcribes; the sandbox/verification loop backstops transcription. No `TOOL_SPEC` helpers in this PR — the identified promotion candidate (deterministic residual-shape gate at accept time; the prose gate was under-applied in 1 of ~60 live runs) is deliberately deferred until the enforcement gap recurs.

**Anti-overfit / anti-force-match guards** (validated on held-outs): tables declared non-exhaustive with group-frequency fallback; multi-band agreement required before naming a candidate ("never snap to the nearest table entry"); element-consistency as a hard constraint with explicit rejection reporting; systematic-asymmetry and all-bands-asymmetric tells routed to baseline/calibration suspicion rather than lineshape claims. Known limit (documented in the benchmark findings): mandatory-injection gravity can still pull neighbors of emphasized entries — observed once (andradite ~874 cm⁻¹ → olivine top-1, element filter can't discriminate Ca/Fe/O/Si); the trap-note extension for garnet is left out of this PR pending a decision on how trap coverage should scale.

**Behavioral contracts these skills assume (all pre-existing):** section injection via `_get_skill_context(section=…)`; codegen receives `implementation` (synonym fold to `analysis` handled by the loader); curve-fitting selector is `exclusive` (single technique skill), which these bundles respect — one file per technique, mutually exclusive `technique` tags.

**Validation protocol / provenance.** Development and A/B benchmark harness: `benchmarking_for_paper2/RamanIR/` (RRUFF loaders, difficulty-stratified staging, 4-condition blind-ID matrices, band-table validator `validate_skill_bands.py`, per-run forensic records). Skills were exercised through the external custom-skill path during development and re-verified in-package on this branch: 54 loader/selector tests pass; live end-to-end run on the hardest fluorescence case (`FaujasiteMg` RAW, baseline_frac 0.95) with bare `skill="raman"` confirmed authoritative pre-load (`📖 Skill loaded: raman`) and protocol-compliant fitting.
