### PR TITLE
Feature-conditioned post-fit literature refinement for curve fitting (part of #323)

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -396,6 +396,10 @@ answer — do NOT call `run_analysis` in the same turn as the question.
 - On no: call `run_analysis` normally.
 - Ask once per dataset; do not re-offer on follow-up `run_analysis` calls
   for the same data.
+- EXCEPTION — identification-mode runs (`task_mode="identification"`): do NOT
+  offer or run a pre-fit search; the fit must stay literature-blind. After the
+  fit completes, call `refine_interpretation` instead — it searches from the
+  fitted features.
 
 {_LIT_TOOL_BLURB}
 """
@@ -410,6 +414,10 @@ interpretation). If so, call `search_literature(query=...)` and pass the
 returned `file_path` to `run_analysis` as `literature_file`; otherwise call
 `run_analysis` directly. Do NOT ask the user — decide from the data and
 objective. Decide once per dataset.
+EXCEPTION — identification-mode runs (`task_mode="identification"`): never
+pre-fit-search; the fit must stay literature-blind. Call
+`refine_interpretation` after the fit instead — it searches from the fitted
+features, which is what finally identifies the material.
 
 {_LIT_TOOL_BLURB}
 """
@@ -1451,6 +1459,17 @@ class AnalysisOrchestratorAgent:
                 suggested_followups.append(
                     f"Assess novelty / get recommendations for analysis "
                     f"{rec.get('analysis_id')}."
+                )
+        # A successful analysis whose interpretation has not been literature-
+        # refined yet is the other natural follow-up: `refine_interpretation`
+        # searches from the FITTED features (issue #323 Channel B). Strongest
+        # prior for identification-mode runs, which are literature-free in-run.
+        for rec in new_analyses:
+            if rec.get("status") == "success" and not rec.get("interpretation_revisions"):
+                suggested_followups.append(
+                    f"Refine interpretation of analysis {rec.get('analysis_id')} "
+                    f"against literature searched from its fitted features "
+                    f"(refine_interpretation)."
                 )
 
         warnings: List[str] = []

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -3329,6 +3329,13 @@ class AnalysisOrchestratorTools:
                 
                 # Get the stored analysis result
                 full_result = record.get("full_result")
+                # Prefer the latest literature-refined interpretation when one
+                # exists (refine_interpretation, issue #323) — append-only on
+                # the record, so swap into a copy rather than mutating.
+                revisions = record.get("interpretation_revisions") or []
+                if full_result is not None and revisions:
+                    full_result = dict(full_result)
+                    full_result["detailed_analysis"] = revisions[-1]["revised_analysis"]
                 if full_result is None:
                     return json.dumps({
                         "status": "error",
@@ -3674,6 +3681,190 @@ class AnalysisOrchestratorTools:
                 }
             },
             required=["query"]
+        )
+
+
+        # =====================================================================
+        # REFINE INTERPRETATION (issue #323 — Channel B, curve fitting v1)
+        # =====================================================================
+        def refine_interpretation(analysis_id: str = None, analysis_index: int = -1,
+                                  focus: str = None) -> str:
+            """
+            Post-analysis, feature-conditioned literature refinement (Channel B).
+            Searches the literature FROM the fitted features (peak positions,
+            trends) of a completed analysis and revises its interpretation
+            against what is published. Append-only: the original interpretation
+            is preserved; revisions accumulate on the analysis record.
+            """
+            print(f"  ⚡ Tool: Refining interpretation against feature-conditioned literature...")
+
+            if not self.orch.futurehouse_api_key:
+                return json.dumps({
+                    "status": "error",
+                    "message": "No FutureHouse/Edison API Key provided in Orchestrator initialization."
+                })
+
+            # 1. Retrieve the analysis record (same contract as assess_novelty).
+            record = None
+            record_index = None
+            if analysis_id:
+                for i, r in enumerate(self.orch.analysis_results):
+                    if r.get("analysis_id") == analysis_id:
+                        record, record_index = r, i
+                        break
+                if record is None:
+                    return json.dumps({"status": "error",
+                                       "message": f"Analysis ID not found: {analysis_id}"})
+            else:
+                if not self.orch.analysis_results:
+                    return json.dumps({"status": "error",
+                                       "message": "No analysis history available."})
+                record_index = (analysis_index if analysis_index >= 0
+                                else len(self.orch.analysis_results) + analysis_index)
+                record = self.orch.analysis_results[record_index]
+
+            full_result = record.get("full_result") or {}
+            detailed = (full_result.get("detailed_analysis")
+                        or full_result.get("full_analysis") or "")
+            if not detailed.strip():
+                return json.dumps({"status": "error",
+                                   "message": "Analysis record has no interpretation text to refine."})
+
+            # 2. Surface the measured features (curve modality).
+            # Series runs are trend-conditioned: once a parameter trend exists,
+            # static per-spectrum peaks barely matter (issue #323 §5.2).
+            features = {}
+            for key in ("model_type", "fit_quality"):
+                if full_result.get(key):
+                    features[key] = full_result[key]
+            trends = full_result.get("parameter_trends")
+            if trends:
+                features["parameter_trends"] = trends
+                if full_result.get("flagged_spectra_analysis"):
+                    features["flagged_spectra_analysis"] = full_result["flagged_spectra_analysis"]
+                locked = (full_result.get("summary") or {}).get("locked_model") if isinstance(full_result.get("summary"), dict) else None
+                if locked:
+                    features["locked_model"] = locked
+            elif full_result.get("fitting_parameters"):
+                features["fitting_parameters"] = full_result["fitting_parameters"]
+            if not features:
+                return json.dumps({"status": "error",
+                                   "message": "No fitted features surfaced on this record — nothing to condition the search on."})
+            features_text = json.dumps(features, default=str)[:4000]
+
+            # 3. Feature → query builder: an LLM micro-call, because feature
+            # MEANING is technique-dependent (peaks at 1349/1582 cm^-1 only
+            # read as D/G bands with domain context). Falls back to a plain
+            # template on any failure.
+            focus_line = f"\nUser focus: {focus}" if focus else ""
+            builder_prompt = (
+                "You are building ONE focused scientific-literature search query.\n"
+                "A spectral/curve fit produced these measured features:\n"
+                f"{features_text}\n"
+                f"Experimental context: {json.dumps(getattr(self.orch, 'current_metadata', None) or {}, default=str)[:800]}"
+                f"{focus_line}\n\n"
+                "Write a single natural-language query (<= 40 words) that asks what "
+                "materials/phases/processes are reported for these SPECIFIC measured "
+                "features (positions, widths, trends) — not a generic method query. "
+                "Return ONLY the query text."
+            )
+            try:
+                q_resp = self.orch.model.generate_content(contents=[builder_prompt])
+                query = (q_resp.text or "").strip().strip('"')
+                assert 10 < len(query) < 400
+            except Exception:
+                query = f"Interpretation of measured features: {features_text[:200]}"
+            print(f"  🔍 Feature-conditioned query: {query[:100]}")
+
+            # 4. Literature search (CROW backend — "what is reported for these
+            # features", not the novelty question).
+            try:
+                lit_agent = FittingModelLiteratureAgent(
+                    api_key=self.orch.futurehouse_api_key, max_wait_time=3000
+                )
+                result = lit_agent.query_for_models(query)
+            except Exception as e:
+                logging.error(f"refine_interpretation literature error: {e}", exc_info=True)
+                return json.dumps({"status": "error", "message": str(e)})
+            if result.get("status") != "success":
+                return json.dumps({"status": result.get("status", "error"),
+                                   "message": result.get("message", "Literature search did not succeed")})
+            content = result.get("formatted_answer", "") or ""
+
+            # Persist the search output (inspectable, same shape as search_literature).
+            query_hash = hashlib.md5(query.encode("utf-8")).hexdigest()[:8]
+            lit_path = self.orch.base_dir / f"interpretation_lit_{query_hash}.md"
+            with open(lit_path, "w") as f:
+                f.write(f"# Feature-Conditioned Literature (Channel B)\n\n"
+                        f"**Analysis:** {record.get('analysis_id')}\n"
+                        f"**Query:** {query}\n\n{content}")
+
+            # 5. Tier-A refinement: text-in/text-out — revise the existing
+            # interpretation against the literature. No pixel/state re-invoke.
+            refine_prompt = (
+                "You are revising the interpretation of a completed analysis "
+                "against literature that was searched from its MEASURED features.\n\n"
+                f"## Current interpretation\n{detailed[:6000]}\n\n"
+                f"## Measured features\n{features_text}\n\n"
+                f"## Feature-conditioned literature\n{content[:8000]}\n\n"
+                "Rewrite the interpretation: keep every conclusion the data still "
+                "supports, revise or qualify what the literature contradicts, and "
+                "add what it newly explains (cite the literature inline where used). "
+                "Where the literature identifies the material/phase from these "
+                "features, say so explicitly. Do not soften data-supported "
+                "conclusions merely because the literature is silent. Return ONLY "
+                "the revised interpretation text."
+            )
+            try:
+                r_resp = self.orch.model.generate_content(contents=[refine_prompt])
+                revised = (r_resp.text or "").strip()
+                if not revised:
+                    raise ValueError("empty refinement")
+            except Exception as e:
+                return json.dumps({"status": "error",
+                                   "message": f"Literature saved to {lit_path} but refinement failed: {e}"})
+
+            # 6. Append-only storage (mirrors novelty_assessment attach).
+            revision = {
+                "timestamp": datetime.now().isoformat(),
+                "query": query,
+                "literature_file": str(lit_path),
+                "revised_analysis": revised,
+            }
+            self.orch.analysis_results[record_index].setdefault(
+                "interpretation_revisions", []).append(revision)
+
+            print(f"  ✅ Interpretation refined ({len(revised)} chars). Literature: {lit_path.name}")
+            return json.dumps({
+                "status": "success",
+                "analysis_id": record.get("analysis_id"),
+                "query": query,
+                "literature_file": str(lit_path),
+                "revised_interpretation_preview": revised[:600],
+                "note": "Original interpretation preserved; revision appended to the record."
+            })
+
+        self._register_tool(
+            func=refine_interpretation,
+            name="refine_interpretation",
+            description=(
+                "Refine a completed analysis's interpretation against literature searched "
+                "from its FITTED features (peak positions/widths, parameter trends) — the "
+                "post-fit counterpart of search_literature. Call AFTER run_analysis when the "
+                "interpretation would materially benefit from published context. Strongly "
+                "recommended after identification-mode runs (they are literature-free in-run; "
+                "this step is what identifies the material from the fitted bands). Append-only: "
+                "the original interpretation is preserved."
+            ),
+            parameters={
+                "analysis_id": {"type": "string",
+                                "description": "ID of the completed analysis (default: most recent)."},
+                "analysis_index": {"type": "integer",
+                                   "description": "Alternative: index into the analysis history (default -1, most recent)."},
+                "focus": {"type": "string",
+                          "description": "Optional steer for the literature query (e.g., 'candidate phases for the 742 cm-1 band')."},
+            },
+            required=[]
         )
 
         # =====================================================================

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -3148,7 +3148,11 @@ class AnalysisOrchestratorTools:
                         "agent_name": r.get("agent_name"),
                         "status": r.get("status"),
                         "output_directory": r.get("output_directory"),
-                        "has_novelty_assessment": r.get("novelty_assessment") is not None
+                        "has_novelty_assessment": r.get("novelty_assessment") is not None,
+                        # discoverability: downstream consumers already prefer
+                        # the latest revision; this flag lets the agent SEE
+                        # that a literature-refined interpretation exists
+                        "interpretation_revisions": len(r.get("interpretation_revisions") or [])
                     }
                     for r in self.orch.analysis_results
                 ]
@@ -3831,6 +3835,38 @@ class AnalysisOrchestratorTools:
                 return json.dumps({"status": "error",
                                    "message": f"Literature saved to {lit_path} but refinement failed: {e}"})
 
+            # Append the revised interpretation to the same document so the
+            # revision is human-readable on disk, not only in session state.
+            with open(lit_path, "a") as f:
+                f.write("\n\n---\n\n## Literature-Refined Interpretation\n\n" + revised)
+
+            # Companion HTML next to the agent's original report (append-only:
+            # a separate document, mirroring how assess_novelty writes its own
+            # doc rather than rewriting the analysis). Best-effort.
+            report_html = None
+            out_dir = record.get("output_directory")
+            if out_dir and Path(out_dir).is_dir():
+                try:
+                    import html as _html
+                    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+                    report_html = Path(out_dir) / f"Interpretation_Revision_{ts}.html"
+                    paras = "".join(f"<p>{_html.escape(x)}</p>"
+                                    for x in revised.split("\n\n") if x.strip())
+                    report_html.write_text(
+                        "<!doctype html><meta charset='utf-8'>"
+                        "<title>Literature-Refined Interpretation</title>"
+                        "<body style='font-family:sans-serif;max-width:800px;margin:2em auto'>"
+                        f"<h1>Literature-Refined Interpretation</h1>"
+                        f"<p><b>Analysis:</b> {_html.escape(str(record.get('analysis_id')))}<br>"
+                        f"<b>Query:</b> {_html.escape(query)}<br>"
+                        f"<b>Literature:</b> {_html.escape(lit_path.name)}</p><hr>"
+                        f"{paras}"
+                        "<hr><p><i>Post-fit revision (feature-conditioned literature); "
+                        "the original report is unchanged.</i></p></body>")
+                except Exception as e:
+                    logging.warning(f"Companion revision HTML failed: {e}")
+                    report_html = None
+
             # 6. Append-only storage (mirrors novelty_assessment attach).
             revision = {
                 "timestamp": datetime.now().isoformat(),
@@ -3838,6 +3874,8 @@ class AnalysisOrchestratorTools:
                 "literature_file": str(lit_path),
                 "revised_analysis": revised,
             }
+            if report_html:
+                revision["report_html"] = str(report_html)
             self.orch.analysis_results[record_index].setdefault(
                 "interpretation_revisions", []).append(revision)
 
@@ -3848,6 +3886,7 @@ class AnalysisOrchestratorTools:
                 "query": query,
                 "literature_file": str(lit_path),
                 "revised_interpretation_preview": revised[:600],
+                "report_html": str(report_html) if report_html else None,
                 "note": "Original interpretation preserved; revision appended to the record."
             })
 

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -3152,7 +3152,8 @@ class AnalysisOrchestratorTools:
                         # discoverability: downstream consumers already prefer
                         # the latest revision; this flag lets the agent SEE
                         # that a literature-refined interpretation exists
-                        "interpretation_revisions": len(r.get("interpretation_revisions") or [])
+                        "interpretation_revisions": len(r.get("interpretation_revisions") or []),
+                        "novelty_assessment_stale": bool((r.get("novelty_assessment") or {}).get("stale"))
                     }
                     for r in self.orch.analysis_results
                 ]
@@ -3373,7 +3374,8 @@ class AnalysisOrchestratorTools:
                     "analysis_id": record.get("analysis_id"),
                     "recommendations": result.get("measurement_recommendations", []),
                     "analysis_integration": result.get("analysis_integration", ""),
-                    "novelty_informed": novelty_assessment is not None
+                    "novelty_informed": novelty_assessment is not None,
+                    "novelty_assessment_stale": bool((novelty_assessment or {}).get("stale"))
                 }
                 
                 # Add novelty-specific recommendations if available
@@ -3867,6 +3869,34 @@ class AnalysisOrchestratorTools:
                     logging.warning(f"Companion revision HTML failed: {e}")
                     report_html = None
 
+            # Revise the scientific claims to match the new interpretation
+            # (optional per plan — skipped on any parse failure). Without
+            # this, a post-revision novelty re-run would re-assess claims
+            # anchored to the superseded reading.
+            revised_claims = None
+            orig_claims = full_result.get("scientific_claims") or []
+            if orig_claims:
+                claims_prompt = (
+                    "An analysis interpretation was revised against literature. "
+                    "Update its scientific claims to match the REVISED interpretation: "
+                    "keep claims still supported, revise ones the new reading changes, "
+                    "drop invalidated ones, add clearly warranted new ones.\n\n"
+                    f"## Revised interpretation\n{revised[:6000]}\n\n"
+                    f"## Original claims (JSON)\n{json.dumps(orig_claims)[:4000]}\n\n"
+                    "Return ONLY a JSON array with the SAME schema per claim "
+                    "(claim, has_anyone_question, keywords, scientific_impact)."
+                )
+                try:
+                    c_resp = self.orch.model.generate_content(contents=[claims_prompt])
+                    raw = (c_resp.text or "").strip()
+                    m = re.search(r"\[.*\]", raw, re.DOTALL)
+                    parsed = json.loads(m.group(0)) if m else None
+                    if (isinstance(parsed, list) and parsed
+                            and all(isinstance(c, dict) and c.get("claim") for c in parsed)):
+                        revised_claims = parsed
+                except Exception as e:
+                    logging.warning(f"Claims revision skipped (parse failure): {e}")
+
             # 6. Append-only storage (mirrors novelty_assessment attach).
             revision = {
                 "timestamp": datetime.now().isoformat(),
@@ -3874,10 +3904,22 @@ class AnalysisOrchestratorTools:
                 "literature_file": str(lit_path),
                 "revised_analysis": revised,
             }
+            if revised_claims:
+                revision["revised_claims"] = revised_claims
             if report_html:
                 revision["report_html"] = str(report_html)
             self.orch.analysis_results[record_index].setdefault(
                 "interpretation_revisions", []).append(revision)
+
+            # Ripple: a prior novelty assessment was made against claims that
+            # predate this revision — mark it stale so consumers and the agent
+            # know it needs a re-run to be current.
+            novelty_stale = False
+            prior_novelty = self.orch.analysis_results[record_index].get("novelty_assessment")
+            if prior_novelty:
+                prior_novelty["stale"] = True
+                prior_novelty["staled_by_revision"] = revision["timestamp"]
+                novelty_stale = True
 
             print(f"  ✅ Interpretation refined ({len(revised)} chars). Literature: {lit_path.name}")
             return json.dumps({
@@ -3887,7 +3929,11 @@ class AnalysisOrchestratorTools:
                 "literature_file": str(lit_path),
                 "revised_interpretation_preview": revised[:600],
                 "report_html": str(report_html) if report_html else None,
+                "claims_revised": bool(revised_claims),
+                "prior_novelty_assessment_stale": novelty_stale,
                 "note": "Original interpretation preserved; revision appended to the record."
+                        + (" A prior novelty assessment predates this revision — "
+                           "re-run assess_novelty to update it." if novelty_stale else "")
             })
 
         self._register_tool(
@@ -3950,9 +3996,17 @@ class AnalysisOrchestratorTools:
                 record_index = analysis_index if analysis_index >= 0 else len(self.orch.analysis_results) + analysis_index
                 record = self.orch.analysis_results[record_index]
 
-            # 2. Extract Claims
+            # 2. Extract Claims — prefer the latest revision's revised claims
+            # (refine_interpretation, issue #323): assessing superseded claims
+            # would produce verdicts about assertions the analysis no longer
+            # makes.
             full_result = record.get("full_result", {})
-            claims = full_result.get("scientific_claims", [])
+            revisions = record.get("interpretation_revisions") or []
+            claims, claims_source = full_result.get("scientific_claims", []), "original"
+            for rev in reversed(revisions):
+                if rev.get("revised_claims"):
+                    claims, claims_source = rev["revised_claims"], "latest_revision"
+                    break
             
             if not claims:
                 return json.dumps({
@@ -4031,6 +4085,9 @@ class AnalysisOrchestratorTools:
             # 5. Build novelty assessment object
             novelty_assessment = {
                 "timestamp": datetime.now().isoformat(),
+                # ripple bookkeeping: which revision state these verdicts cover
+                "assessed_at_revision": len(record.get("interpretation_revisions") or []),
+                "claims_source": claims_source,
                 "assessments": scored_results,
                 "high_novelty_claims": high_novelty_claims,
                 "summary_stats": {

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -611,6 +611,18 @@ def _extract_series_from_sidecars(
     return series_meta, per_file_meta
 
 
+
+def _effective_full_result(record: dict) -> dict:
+    """The record's full_result with the latest literature-refined
+    interpretation swapped in when one exists (refine_interpretation,
+    issue #323). Returns a copy; the record is never mutated."""
+    full_result = record.get("full_result") or {}
+    revisions = record.get("interpretation_revisions") or []
+    if revisions and full_result:
+        full_result = dict(full_result)
+        full_result["detailed_analysis"] = revisions[-1]["revised_analysis"]
+    return full_result
+
 class AnalysisOrchestratorTools:
     """
     Manages tool definitions, schemas, and execution for the AnalysisOrchestratorAgent.
@@ -3329,13 +3341,8 @@ class AnalysisOrchestratorTools:
                 
                 # Get the stored analysis result
                 full_result = record.get("full_result")
-                # Prefer the latest literature-refined interpretation when one
-                # exists (refine_interpretation, issue #323) — append-only on
-                # the record, so swap into a copy rather than mutating.
-                revisions = record.get("interpretation_revisions") or []
-                if full_result is not None and revisions:
-                    full_result = dict(full_result)
-                    full_result["detailed_analysis"] = revisions[-1]["revised_analysis"]
+                if full_result is not None:
+                    full_result = _effective_full_result(record)
                 if full_result is None:
                     return json.dumps({
                         "status": "error",
@@ -4084,8 +4091,9 @@ class AnalysisOrchestratorTools:
                 record_index = analysis_index if analysis_index >= 0 else len(self.orch.analysis_results) + analysis_index
                 record = self.orch.analysis_results[record_index]
 
-            # 2. Extract analysis text
-            full_result = record.get("full_result") or {}
+            # 2. Extract analysis text (latest literature-refined
+            # interpretation preferred — issue #323)
+            full_result = _effective_full_result(record)
             analysis_text = (
                 full_result.get("detailed_analysis")
                 or full_result.get("full_analysis")
@@ -4740,7 +4748,7 @@ class AnalysisOrchestratorTools:
             for aid in source_ids:
                 for record in self.orch.analysis_results:
                     if record.get("analysis_id") == aid:
-                        full_result = record.get("full_result", {})
+                        full_result = _effective_full_result(record)
                         parts = [f"### Analysis: {aid}"]
 
                         da = full_result.get("detailed_analysis", "")

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -2758,7 +2758,10 @@ Your guidance: '''
     ) -> str:
         config = state.get("locked_fitting_config", {})
         context_parts = []
-        if state.get("literature_context"):
+        # Identification mode is literature-free in-run (issue #323, D2):
+        # literature must not shape the code that writes the fit, matching
+        # the planner gates. Covers hand-supplied literature_file too.
+        if state.get("literature_context") and state.get("task_mode") != "identification":
             context_parts.append(state["literature_context"])
         # Codegen recipe from ALL co-active skills (not just the top-ranked):
         # with several skills active each may own a different pipeline stage,
@@ -7235,7 +7238,12 @@ same trend.
                 + json.dumps(series_results[0]["quality_history"], indent=2)
             )
 
-        if state.get("literature_context"):
+        # Opportunistic Channel-A reuse (issue #323, D1): inject planning
+        # literature into interpretation when it exists — free when absent.
+        # The authoritative interpretation literature is the post-fit
+        # feature-conditioned pass (`refine_interpretation`). Gated off in
+        # identification mode (D2): ID runs are literature-free in-run.
+        if state.get("literature_context") and state.get("task_mode") != "identification":
             prompt_parts.extend(["\n## Literature", state["literature_context"]])
 
         _append_objective_context(prompt_parts, state)

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -776,9 +776,10 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
 
         # Pre-populate literature context if a search file was supplied via
         # the orchestrator's `search_literature` tool. Skips the in-pipeline
-        # `LiteratureSearchController`. In identification mode the planner
-        # ignores it (see _build_planning_prompt) to preserve the unbiased
-        # fit, but Stage-2 candidate enumeration still consumes it.
+        # `LiteratureSearchController`. In identification mode the run is
+        # literature-free end to end (planner, script generation, and
+        # interpretation all gate it out — issue #323, D2); literature
+        # enters ID runs only post-fit via `refine_interpretation`.
         if literature_file:
             lit_p = Path(literature_file)
             if lit_p.is_file():

--- a/tests/test_refine_interpretation.py
+++ b/tests/test_refine_interpretation.py
@@ -102,3 +102,30 @@ class TestOrchestratorSurface:
         import scilink.agents.exp_agents.analysis_orchestrator as orch_mod
         src = Path(orch_mod.__file__).read_text()
         assert src.count("refine_interpretation") >= 3  # copilot + autonomous offers + followup
+
+
+class TestNoveltyRipple:
+    def _refine_body(self):
+        idx = TOOLS_SRC.index("def refine_interpretation")
+        return TOOLS_SRC[idx: TOOLS_SRC.index("def assess_novelty")]
+
+    def test_revision_stales_prior_novelty_assessment(self):
+        body = self._refine_body()
+        assert 'prior_novelty["stale"] = True' in body
+        assert "staled_by_revision" in body
+
+    def test_revision_optionally_revises_claims(self):
+        body = self._refine_body()
+        assert "revised_claims" in body
+        assert "has_anyone_question" in body  # same claim schema demanded
+
+    def test_assess_novelty_prefers_revised_claims_and_stamps_coverage(self):
+        idx = TOOLS_SRC.index("def assess_novelty")
+        body = TOOLS_SRC[idx: idx + 6000]
+        assert 'rev.get("revised_claims")' in body
+        assert "assessed_at_revision" in body
+        assert "claims_source" in body
+
+    def test_staleness_is_visible_to_the_agent(self):
+        # list_results + get_recommendations both surface the stale flag
+        assert TOOLS_SRC.count("novelty_assessment_stale") >= 2

--- a/tests/test_refine_interpretation.py
+++ b/tests/test_refine_interpretation.py
@@ -80,6 +80,17 @@ class TestRefineInterpretationPlumbing:
         assert body.index("parameter_trends") < body.index('elif full_result.get("fitting_parameters")')
 
 
+    def test_revision_is_persisted_human_readably(self):
+        idx = TOOLS_SRC.index("def refine_interpretation")
+        body = TOOLS_SRC[idx: TOOLS_SRC.index("def assess_novelty")]
+        # revised text appended to the on-disk revision document...
+        assert "Literature-Refined Interpretation" in body
+        # ...and a companion HTML lands next to the original report when the
+        # record carries its output_directory (append-only: separate file)
+        assert "Interpretation_Revision_" in body
+        assert 'record.get("output_directory")' in body
+
+
 class TestOrchestratorSurface:
     def test_followups_suggest_refinement(self):
         import scilink.agents.exp_agents.analysis_orchestrator as orch_mod

--- a/tests/test_refine_interpretation.py
+++ b/tests/test_refine_interpretation.py
@@ -50,11 +50,26 @@ class TestRefineInterpretationPlumbing:
     def test_storage_is_append_only(self):
         assert 'setdefault(\n                "interpretation_revisions", []).append' in TOOLS_SRC
 
-    def test_get_recommendations_prefers_latest_revision(self):
-        idx = TOOLS_SRC.index("def get_recommendations")
-        body = TOOLS_SRC[idx: idx + 4000]
-        assert "interpretation_revisions" in body
-        assert 'revisions[-1]["revised_analysis"]' in body
+    def test_effective_full_result_helper(self):
+        from scilink.agents.exp_agents.analysis_orchestrator_tools import _effective_full_result
+        rec = {"full_result": {"detailed_analysis": "original", "x": 1},
+               "interpretation_revisions": [{"revised_analysis": "v1"},
+                                            {"revised_analysis": "v2"}]}
+        eff = _effective_full_result(rec)
+        assert eff["detailed_analysis"] == "v2" and eff["x"] == 1
+        assert rec["full_result"]["detailed_analysis"] == "original"  # no mutation
+        assert _effective_full_result({"full_result": {"detailed_analysis": "o"}})[
+            "detailed_analysis"] == "o"  # no revisions -> unchanged
+
+    def test_all_record_consumers_prefer_latest_revision(self):
+        # every downstream consumer of a record's interpretation must go
+        # through the helper: recommendations, DFT recommendations, and the
+        # multi-source context builder. (The post-run summary preview reads
+        # the fresh analyze() return, where no revision can exist yet.)
+        for func in ("def get_recommendations", "def recommend_dft_structures"):
+            idx = TOOLS_SRC.index(func)
+            assert "_effective_full_result" in TOOLS_SRC[idx: idx + 4000], func
+        assert TOOLS_SRC.count("_effective_full_result(record)") >= 3
 
     def test_series_features_are_trend_conditioned(self):
         idx = TOOLS_SRC.index("def refine_interpretation")

--- a/tests/test_refine_interpretation.py
+++ b/tests/test_refine_interpretation.py
@@ -1,0 +1,78 @@
+"""Offline tests for issue #323 Channel B (curve-fitting scope).
+
+Covers the two load-bearing behaviors that need no API key:
+- the ID-mode literature gates in the curve-fitting controllers (D2), and
+- `refine_interpretation` registration + record plumbing (revision storage,
+  get_recommendations preferring the latest revision) via source inspection
+  and a stubbed orchestrator.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import scilink.agents.exp_agents.controllers.curve_fitting_controllers as cc
+import scilink.agents.exp_agents.analysis_orchestrator_tools as tools_mod
+
+CTRL_SRC = Path(cc.__file__).read_text()
+TOOLS_SRC = Path(tools_mod.__file__).read_text()
+
+
+class TestIdModeLiteratureGates:
+    def test_all_literature_context_consumers_are_id_gated(self):
+        # Every site that injects literature_context into a prompt/context
+        # must carry the identification-mode gate (D2). Reads of the field
+        # for provenance/reporting are exempt.
+        lines = CTRL_SRC.split("\n")
+        injectors = [
+            i for i, l in enumerate(lines)
+            if re.search(r'if state\.get\("literature_context"\)', l)
+            # injection sites feed the value into a prompt/context on the next
+            # line; the in-pipeline search controller's skip guard does not
+            and re.search(r"append|extend", lines[i + 1])
+        ]
+        assert len(injectors) == 4, "expected planner x2 + script-gen + synthesis sites"
+        for i in injectors:
+            assert 'task_mode") != "identification"' in lines[i], (
+                f"ungated literature injection at line {i + 1}: {lines[i].strip()}"
+            )
+
+    def test_agent_docstring_no_longer_claims_stage2_consumption(self):
+        import scilink.agents.exp_agents.curve_fitting_agent as agent_mod
+        src = Path(agent_mod.__file__).read_text()
+        assert "Stage-2 candidate enumeration still consumes it" not in src
+
+
+class TestRefineInterpretationPlumbing:
+    def test_tool_is_registered(self):
+        assert 'name="refine_interpretation"' in TOOLS_SRC
+
+    def test_storage_is_append_only(self):
+        assert 'setdefault(\n                "interpretation_revisions", []).append' in TOOLS_SRC
+
+    def test_get_recommendations_prefers_latest_revision(self):
+        idx = TOOLS_SRC.index("def get_recommendations")
+        body = TOOLS_SRC[idx: idx + 4000]
+        assert "interpretation_revisions" in body
+        assert 'revisions[-1]["revised_analysis"]' in body
+
+    def test_series_features_are_trend_conditioned(self):
+        idx = TOOLS_SRC.index("def refine_interpretation")
+        body = TOOLS_SRC[idx: TOOLS_SRC.index("def assess_novelty")]
+        # series: trends preferred; single: fitting_parameters fallback
+        assert "parameter_trends" in body
+        assert "fitting_parameters" in body
+        assert body.index("parameter_trends") < body.index('elif full_result.get("fitting_parameters")')
+
+
+class TestOrchestratorSurface:
+    def test_followups_suggest_refinement(self):
+        import scilink.agents.exp_agents.analysis_orchestrator as orch_mod
+        src = Path(orch_mod.__file__).read_text()
+        assert "refine_interpretation" in src
+        assert "interpretation_revisions" in src
+
+    def test_id_mode_exception_in_both_literature_offers(self):
+        import scilink.agents.exp_agents.analysis_orchestrator as orch_mod
+        src = Path(orch_mod.__file__).read_text()
+        assert src.count("refine_interpretation") >= 3  # copilot + autonomous offers + followup


### PR DESCRIPTION
## Post-fit, feature-conditioned literature refinement for curve fitting (part of #323)

Today the literature the agent uses to *interpret* a result is the same search that ran *before* the fit — it never sees what the experiment actually measured. This PR adds the missing second channel for the curve-fitting agent: after a fit completes, a new `refine_interpretation` tool searches the literature **from the fitted features themselves** (peak positions and widths for a single spectrum; parameter trends and flagged transitions for a series) and revises the interpretation against what is published. The original interpretation is never overwritten — revisions accumulate on the analysis record, and downstream recommendations use the latest one.

It also closes a bias hole in identification mode. ID mode already withheld literature from the fit *planner* to keep the fit unbiased, but the same literature still reached the code that writes the fit and the first interpretation stage. ID runs are now literature-free end to end; literature enters them only through the new post-fit channel — which is the step that actually identifies the material from the fitted bands. This is the mechanism our Raman blind-identification benchmarking pointed to: the agent measures bands excellently, and species-level identification of the long tail needs published-evidence lookup from those measured features, not bigger prompts.

Curve-fitting scope only (build order per the design note): the shared shell is proven here; hyperspectral and image follow.

---

## Technical details

Implements §4–§5 and settled decisions D1–D3 of `feature_conditioned_literature_plan.md` (issue #323), curve scope.

**D2 — ID mode literature-free in-run.**
- `curve_fitting_controllers.py`: gated the two remaining ungated `literature_context` consumers on `task_mode != "identification"` — script generation (`_generate_fitting_script` context assembly) and synthesis Stage-1 evidence block — matching the existing planner gates (`_build_planning_prompt`, series-refinement prompt). The in-pipeline `LiteratureSearchController` skip-guard is a read, not an injection, and is untouched.
- `analysis_orchestrator.py`: both literature-offer prompt sections (co-pilot and autopilot/autonomous) carry an ID-mode exception — never pre-fit-search for `task_mode="identification"`; call `refine_interpretation` post-fit instead. Principle-stated, one sentence each, per prompt-patch conventions.
- `curve_fitting_agent.py`: corrected the `literature_file` docstring (previously claimed Stage-2 candidate enumeration still consumes literature in ID mode; it now accurately documents the end-to-end gate).

**D1 — kept, reclassified.** The synthesis Stage-1 injection survives for non-ID single runs as *opportunistic Channel-A reuse* (free when absent; no behavior change for existing non-ID runs), documented as such at the site. Deliberately **not** propagated to the series synthesis path — series gets its literature grounding from Channel B (trend-conditioned), per the plan's accepted asymmetry.

**Channel B tool** (`analysis_orchestrator_tools.py`, registered next to `search_literature`/`assess_novelty`):
`refine_interpretation(analysis_id=None, analysis_index=-1, focus=None)`
1. Record retrieval — same contract as `assess_novelty`.
2. Feature surfacing — series runs are trend-conditioned (`parameter_trends` + `flagged_spectra_analysis` + `summary.locked_model`; static peaks intentionally ignored once a trend exists); single runs use `model_type` + `fitting_parameters` + `fit_quality`.
3. Feature→query builder — one LLM micro-call (feature meaning is technique-dependent; falls back to a plain template on any failure).
4. Search — `FittingModelLiteratureAgent` (CROW: "what is reported for these features," not the OWL novelty question), 3000 s ceiling matching `search_literature`; search output persisted to `interpretation_lit_<md5[:8]>.md` in the session dir.
5. Tier-A refinement — text-in/text-out revision prompt (existing `detailed_analysis` + features + literature → revised text). No Tier-B synthesis re-invoke (deferred per plan §7).
6. Storage — append-only `interpretation_revisions: [{timestamp, query, literature_file, revised_analysis}]` on the record, mirroring the `novelty_assessment` attach pattern.

**D3 — agent-decided, mode-scaled encouragement.** Never auto-run. Surfaced in `suggested_followups` next to the novelty suggestion (any successful analysis without revisions); the ID-mode prompt exception carries the strongest steer since ID runs are otherwise literature-free.

**Consumer update.** `get_recommendations` swaps the latest `revised_analysis` into a *copy* of `full_result` before building recommendations — original record untouched.

**Testing.** `tests/test_refine_interpretation.py` (offline, 8 tests): all four injection sites gated with the skip-guard exempted; docstring claim removed; tool registered; storage append-only; series features trend-conditioned before the single-spectrum fallback; `get_recommendations` prefers the latest revision; both prompt offers + followups reference the tool. Functional smoke against a live orchestrator instance (Bedrock): tool present in `functions_map`, graceful no-key and no-history error paths verified. Live-validated end-to-end with a FutureHouse key on a real analysis record (a rare borate-sulfate mineral whose blind identification had failed in-run): the query builder produced a genuinely feature-conditioned question from the fitted peak list, the CROW search returned in ~15 min, and the Tier-A refinement revised a dead-miss interpretation into a citation-backed sulfate-group identification (correct oxoanion family; the rare species itself remains library-matching territory, as expected). Revision stored append-only; a second keyed run verified the human-readable artifacts — the revised interpretation is appended to the on-disk revision document and written as a self-contained companion HTML next to the original analysis report (original untouched), and `list_results` exposes a per-analysis revision count for discoverability.

**Novelty-invalidation ripple (built beyond the v1 plan, which had deferred it):** a revision optionally rewrites `scientific_claims` to match the refined interpretation (same schema; graceful skip on parse failure) and marks any prior `novelty_assessment` stale (`staled_by_revision`); `assess_novelty` prefers the latest revision's claims and stamps `assessed_at_revision` + `claims_source`; staleness is visible in `list_results` and `get_recommendations`. Live-validated in the adversarial order (assess → revise → re-assess): revision-0 original claims → staled + claims rewritten → re-assessment at revision 1 with `claims_source=latest_revision`.

**Deferred (named in the plan, not built):** Tier-B re-invoke, search→revise convergence loops, per-spectrum fan-out, and routing a user-supplied `literature_file` on ID runs into Channel B as a query seed.
