### PR TITLE
Add Claude Sonnet 5 (Bedrock) to the UI model selector

### DIFF
--- a/scilink/ui/config.py
+++ b/scilink/ui/config.py
@@ -15,6 +15,12 @@ MODEL_OPTIONS = [
     # the ``us.`` prefix. For EU/JP/AU keys swap the prefix:
     # ``eu.``/``jp.``/``au.``. (Base model ID: anthropic.claude-opus-4-8.)
     "bedrock/us.anthropic.claude-opus-4-8",
+    # Claude Sonnet 5 on Bedrock, same US inference-profile convention. Faster
+    # per call and cheaper per token than Opus 4.8; on the curve-fitting
+    # benchmarks it matches Opus on skill-protocol compliance but hedges more
+    # on judgment calls and converges slower end-to-end — a cost/latency
+    # option, not the default.
+    "bedrock/us.anthropic.claude-sonnet-5",
 ]
 
 EMBEDDING_MODEL_OPTIONS = [


### PR DESCRIPTION
Adds `bedrock/us.anthropic.claude-sonnet-5` to the UI model dropdown, following the same US cross-region inference-profile convention as the existing Opus 4.8 entry. Sonnet 5 is the cost/latency option: faster per call and cheaper per token than Opus 4.8.

---

## Technical details

One-line list addition in `scilink/ui/config.py::MODEL_OPTIONS` (consumed by `sidebar.py`'s selectbox); credential routing is prefix-based (`providers.py` matches `bedrock/`), so no provider changes. The model ID is live-validated: the full 8-dataset Custom blind-identification benchmark ran on exactly this ID via LiteLLM/Bedrock. Benchmark-observed behavior vs Opus 4.8, noted in the entry's comment so users pick deliberately: equal skill-protocol compliance and same candidate sets, but more hedging on judgment calls (family-level vs exact identifications) and ~2.5-4x slower end-to-end convergence on hard cases — a cost option, not a new default.