### PR TITLE
Fix intermittently blank Original Data plot in curve-fitting reports

### DIFF
--- a/scilink/skills/_shared/curve_fitting_tools.py
+++ b/scilink/skills/_shared/curve_fitting_tools.py
@@ -349,10 +349,14 @@ def plot_curve_to_bytes(curve_data: np.ndarray, system_info: dict, title_suffix:
     ax.set_ylabel(ylabel_text)
     
     ax.grid(True, linestyle='--')
-    plt.tight_layout()
-    
+    # Object API on purpose: plt.tight_layout()/plt.savefig() act on pyplot's
+    # CURRENT figure, which another thread (UI / meta / parallel workers) can
+    # swap between our subplots() and the save — intermittently producing a
+    # blank "Original Data" image in the report.
+    fig.tight_layout()
+
     buf = BytesIO()
-    plt.savefig(buf, format='png', dpi=150)
+    fig.savefig(buf, format='png', dpi=150)
     buf.seek(0)
     image_bytes = buf.getvalue()
     plt.close(fig)


### PR DESCRIPTION
Sometimes the "Original Data" image in a curve-fitting HTML report came out completely blank (observed in a meta-UI session on 2026-07-07). Root cause: the shared plotting helper drew onto its own figure but *saved* through matplotlib's pyplot-state API, which writes whatever figure is globally "current" — and in UI/meta sessions with concurrent activity, another thread's freshly created empty figure could occupy that slot at save time. One-line class of fix: save through the figure object itself.

---

## Technical details

`scilink/skills/_shared/curve_fitting_tools.py::plot_curve_to_bytes` — `plt.tight_layout()` / `plt.savefig(buf)` → `fig.tight_layout()` / `fig.savefig(buf)`. Behavior identical single-threaded; race eliminated under concurrency.

**Reproduction/verification** (figure-stealing thread creating `plt.figure()` every 0.5 ms while plotting 20 curves): pre-fix implementation produced **20/20 blank** PNGs; fixed implementation **20/20 correct**. The production race window is much narrower, hence the intermittent symptom.

**Known follow-up, deliberately out of scope:** a survey finds 26 more `plt.savefig` (pyplot-state) call sites across `sim_agents`, `image_analysis_controllers`, `curve_fitting_controllers`, `scalarizer_agent`, and `atomic_stem` with the same latent race. This PR fixes the reported path (report's Original Data card, which also feeds the synthesis prompt's data image); a mechanical object-API sweep of the rest should be its own reviewed pass since each site needs a local figure-handle check.
