### PR TITLE
Object-API sweep of remaining in-process pyplot save sites (closes #335)

### DIFF
--- a/scilink/skills/_shared/image_analysis_tools.py
+++ b/scilink/skills/_shared/image_analysis_tools.py
@@ -253,9 +253,9 @@ def image_to_thumbnail_bytes(
             axes[c].imshow(np.nan_to_num(ch, nan=0), cmap="gray", aspect="equal")
             axes[c].set_title(f"Channel {c}", fontsize=10)
             axes[c].axis("off")
-        plt.tight_layout()
+        fig.tight_layout()
         buf = BytesIO()
-        plt.savefig(buf, format="jpeg", dpi=150, bbox_inches="tight")
+        fig.savefig(buf, format="jpeg", dpi=150, bbox_inches="tight")
         plt.close(fig)
         buf.seek(0)
         return buf.getvalue()
@@ -347,9 +347,9 @@ def create_image_montage(
     for i in range(n, len(axes)):
         axes[i].axis("off")
 
-    plt.tight_layout()
+    fig.tight_layout()
     buf = BytesIO()
-    plt.savefig(buf, format="jpeg", dpi=150, bbox_inches="tight")
+    fig.savefig(buf, format="jpeg", dpi=150, bbox_inches="tight")
     plt.close(fig)
     buf.seek(0)
     return buf.getvalue()

--- a/scilink/skills/_shared/image_processor.py
+++ b/scilink/skills/_shared/image_processor.py
@@ -193,7 +193,7 @@ def calculate_global_fft(image_array: np.ndarray, save_path: str | None = None) 
                 # Ensure directory exists
                 os.makedirs(os.path.dirname(save_path), exist_ok=True)
                 
-                plt.savefig(save_path, dpi=150, bbox_inches='tight')
+                fig.savefig(save_path, dpi=150, bbox_inches='tight')
                 plt.close(fig)
                 logger.info(f"   (Tool Info: ✅ Saved Global FFT plot to: {save_path})")
                 
@@ -307,11 +307,11 @@ def create_multi_abundance_overlays(structure_image: np.ndarray,
     for i in range(total_plots, len(axes)):
         axes[i].axis('off')
     
-    plt.tight_layout()
+    fig.tight_layout()
     
     # Convert to bytes
     buf = BytesIO()
-    plt.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
-    plt.close()
+    fig.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
+    plt.close(fig)
     buf.seek(0)
     return buf.getvalue()

--- a/scilink/skills/image_analysis/atomic_stem/atomic_stem.py
+++ b/scilink/skills/image_analysis/atomic_stem/atomic_stem.py
@@ -45,10 +45,10 @@ def create_intensity_gmm_visualization(
     ax.grid(True, alpha=0.3)
     
     buf = BytesIO()
-    plt.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
+    fig.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
     buf.seek(0)
     visualizations.append({'label': 'Intensity GMM Histogram', 'bytes': buf.getvalue()})
-    plt.close()
+    plt.close(fig)
           
     # Atoms on original image colored by intensity component
     fig, ax = plt.subplots(figsize=(10, 10))
@@ -67,10 +67,10 @@ def create_intensity_gmm_visualization(
     ax.axis('off')
     
     buf = BytesIO()
-    plt.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
+    fig.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
     buf.seek(0)
     visualizations.append({'label': 'Intensity-Based Atomic Clustering', 'bytes': buf.getvalue()})
-    plt.close()
+    plt.close(fig)
     
     return visualizations
 
@@ -123,13 +123,13 @@ def create_local_env_visualization(
         axes[idx].axis('off')
     
     fig.suptitle("Local Environment GMM Centroids")
-    plt.tight_layout()
+    fig.tight_layout()
     
     buf = BytesIO()
-    plt.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
+    fig.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
     buf.seek(0)
     visualizations.append({'label': 'Local Environment Centroids', 'bytes': buf.getvalue()})
-    plt.close()
+    plt.close(fig)
     
     # 2. Classified atom map
     fig, ax = plt.subplots(figsize=(10, 10))
@@ -150,10 +150,10 @@ def create_local_env_visualization(
     ax.axis('off')
     
     buf = BytesIO()
-    plt.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
+    fig.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
     buf.seek(0)
     visualizations.append({'label': 'Local Environment Classification Map', 'bytes': buf.getvalue()})
-    plt.close()
+    plt.close(fig)
     
     return visualizations
 
@@ -183,10 +183,10 @@ def create_nn_distance_visualization(
     ax.axis('off')
     
     buf = BytesIO()
-    plt.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
+    fig.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
     buf.seek(0)
     visualizations.append({'label': 'NN Distance Map', 'bytes': buf.getvalue()})
-    plt.close()
+    plt.close(fig)
     
     # 2. Distance histogram
     fig, ax = plt.subplots(figsize=(6, 4))
@@ -196,10 +196,10 @@ def create_nn_distance_visualization(
     ax.set_title("Nearest-Neighbor Distance Distribution")
     
     buf = BytesIO()
-    plt.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
+    fig.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
     buf.seek(0)
     visualizations.append({'label': 'NN Distance Histogram', 'bytes': buf.getvalue()})
-    plt.close()
+    plt.close(fig)
     
     return visualizations
 
@@ -439,13 +439,13 @@ def create_intensity_histogram_plot(intensities: np.ndarray, n_bins: int = 50) -
     ax.axvline(np.median(intensities), color='orange', linestyle='--', label=f'Median: {np.median(intensities):.2f}')
     ax.legend()
     
-    plt.tight_layout()
+    fig.tight_layout()
     
     buf = BytesIO()
-    plt.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
+    fig.savefig(buf, format='jpeg', dpi=150, bbox_inches='tight')
     buf.seek(0)
     image_bytes = buf.getvalue()
-    plt.close()
+    plt.close(fig)
     
     return image_bytes
 

--- a/scilink/skills/image_analysis/atomic_stem/detection_qc.py
+++ b/scilink/skills/image_analysis/atomic_stem/detection_qc.py
@@ -235,9 +235,9 @@ def detection_quality_panels(image, positions, pixel_size_nm=None,
 
     metrics["flags"] = flags
     metrics["zoom_centers"] = [(round(c[0], 1), round(c[1], 1)) for c in centers]
-    plt.tight_layout()
+    fig.tight_layout()
     buf = io.BytesIO()
-    plt.savefig(buf, format="png", dpi=130); plt.close(fig)
+    fig.savefig(buf, format="png", dpi=130); plt.close(fig)
     return {"figure_bytes": buf.getvalue(), "metrics": metrics, "flags": flags}
 
 

--- a/scilink/skills/image_analysis/atomic_stem/discontinuity.py
+++ b/scilink/skills/image_analysis/atomic_stem/discontinuity.py
@@ -356,8 +356,8 @@ def lattice_discontinuity_map(image, pixel_size_nm=None, params=None):
         ax[1, 1].plot(*b["centroid_px"], "c+", ms=14, mew=2)
     ax[1, 1].set_title(f"Boundary overlay (frac={boundary_fraction:.2f})\n{note[:60]}")
     ax[1, 1].axis("off")
-    plt.tight_layout()
-    buf = io.BytesIO(); plt.savefig(buf, format="png", dpi=120); plt.close(fig)
+    fig.tight_layout()
+    buf = io.BytesIO(); fig.savefig(buf, format="png", dpi=120); plt.close(fig)
 
     metrics = {
         "boundary_fraction": round(boundary_fraction, 3),


### PR DESCRIPTION
Closes #335.

Completes the sweep started in PR #334: every remaining in-process plotting site that saved figures through matplotlib's global "current figure" now saves through its own figure object, eliminating the race that could intermittently embed a blank image when several analyses plot concurrently (UI and meta-agent sessions, parallel workers).

---

## Technical details

**Converted (13 `savefig` sites + companion calls, all with a verified local `fig` from `plt.subplots`):**
- `skills/image_analysis/atomic_stem/atomic_stem.py` — 7 savefig, 2 tight_layout, 7 bare `plt.close()` → `plt.close(fig)` (bare close is the same race class: it closes the *current* figure, which under concurrency leaks ours and kills someone else's)
- `skills/image_analysis/atomic_stem/detection_qc.py`, `discontinuity.py` — 1 each (+ tight_layout)
- `skills/_shared/image_processor.py` — 2 (+ tight_layout, 1 bare close)
- `skills/_shared/image_analysis_tools.py` — 2 (+ 2 tight_layout)

**Deliberately untouched:** the issue's survey grep also matched `plt.savefig` inside prompt/codegen template strings (`lammps_analysis.py`, `lammps_analysis_updater.py`, `scalarizer_agent.py`, curve/image controllers' trend-script prompts). Those instruct *generated* scripts executed in their own subprocess — no shared pyplot state, and pyplot-style code is the correct idiom to teach the codegen there.

**Verification:** all files AST-parse; the 20-test `test_atomic_stem_lattice_tools.py` suite passes; and the PR #334 figure-stealing harness (a thread creating/destroying `plt.figure()` every 0.5 ms) renders 20/20 non-blank outputs through two representative swept helpers (`create_intensity_histogram_plot`, `image_to_thumbnail_bytes`).
