### PR TITLE
Planning-step UX: accurate controller name + narrated progress; remove Sonnet 5 from UI

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1786,9 +1786,19 @@ class GenerateCurveFittingReportController:
 # UNIFIED CONTROLLERS (for series analysis support)
 # ============================================================================
 
-class HumanFeedbackRefinementController:
+class CurveFittingPlanningController:
     """
-    Facilitates human-in-the-loop parameter refinement for the first spectrum.
+    Plans the fitting analysis for the first spectrum: drafts the plan (one
+    large model call over the plot + metadata + skill guidance), validates it
+    against the data and any mandatory skill rules (revising if needed), and
+    optionally runs a human-in-the-loop refinement gate before locking.
+
+    Renamed from ``HumanFeedbackRefinementController`` (kept as an alias) —
+    the old name described only the optional gate, not the planning work
+    that dominates the step.
+
+    Original description: facilitates human-in-the-loop parameter refinement
+    for the first spectrum.
     
     Works identically for single spectra and series:
     - Single spectrum: Refine fitting, then process that one spectrum
@@ -1940,6 +1950,10 @@ class HumanFeedbackRefinementController:
         )
 
     def _plan_analysis(self, state: dict) -> dict:
+        self.logger.info(
+            "  ⏳ Drafting fitting plan — one large model call over the plot, "
+            "statistics and domain guidance (typically ~1 min; longer for "
+            "crowded spectra)...")
         prompt = [
             self.instructions,
             "\n## Data Plot",
@@ -2070,6 +2084,7 @@ class HumanFeedbackRefinementController:
         _append_structure_zoom(prompt_parts, state)
 
         try:
+            self.logger.info("  ⏳ Validating plan against the data and skill rules (second model call)...")
             response = self.model.generate_content(
                 prompt_parts, generation_config=self.generation_config,
             )
@@ -2524,6 +2539,10 @@ def _write_series_fit_results(output_dir, state, series_results, quality_setting
         json.dump(payload, f, indent=2, default=str)
     return str(results_path)
 
+
+
+# Backwards-compatible alias (pre-rename import path).
+HumanFeedbackRefinementController = CurveFittingPlanningController
 
 class UnifiedSeriesProcessingController:
     """

--- a/scilink/agents/exp_agents/pipelines/curve_fitting_pipelines.py
+++ b/scilink/agents/exp_agents/pipelines/curve_fitting_pipelines.py
@@ -26,7 +26,7 @@ from ..controllers.curve_fitting_controllers import (
     LiteratureSearchController,
     GenerateCurveFittingReportController,
     # Unified controllers for series support
-    HumanFeedbackRefinementController,
+    CurveFittingPlanningController,
     UnifiedSeriesProcessingController,
     AdaptiveRefitController,
     ConditionalTrendAnalysisController,
@@ -163,7 +163,7 @@ def create_unified_curve_fitting_pipeline(
         )
 
     # Step 2: Human feedback refinement on fitting approach
-    planning_controller = HumanFeedbackRefinementController(
+    planning_controller = CurveFittingPlanningController(
         model=model,
         logger=logger,
         generation_config=generation_config,

--- a/scilink/ui/config.py
+++ b/scilink/ui/config.py
@@ -15,12 +15,6 @@ MODEL_OPTIONS = [
     # the ``us.`` prefix. For EU/JP/AU keys swap the prefix:
     # ``eu.``/``jp.``/``au.``. (Base model ID: anthropic.claude-opus-4-8.)
     "bedrock/us.anthropic.claude-opus-4-8",
-    # Claude Sonnet 5 on Bedrock, same US inference-profile convention. Faster
-    # per call and cheaper per token than Opus 4.8; on the curve-fitting
-    # benchmarks it matches Opus on skill-protocol compliance but hedges more
-    # on judgment calls and converges slower end-to-end — a cost/latency
-    # option, not the default.
-    "bedrock/us.anthropic.claude-sonnet-5",
 ]
 
 EMBEDDING_MODEL_OPTIONS = [

--- a/tests/test_lit_planner_injection.py
+++ b/tests/test_lit_planner_injection.py
@@ -187,12 +187,11 @@ def test_curve_planner_omits_literature_when_absent():
 
 # --- Curve synthesis — unconditional lit injection ---------------------------
 
-def test_curve_synthesis_injects_literature_unconditionally():
-    """`UnifiedCurveSynthesisController` Stage-2 prompt builder appends
-    `## Literature` whenever `state["literature_context"]` is set, with no
-    task_mode guard. This means identification-mode candidate enumeration
-    still receives the lit context for ranking candidates against literature
-    evidence.
+def test_curve_synthesis_gates_literature_in_id_mode():
+    """`UnifiedCurveSynthesisController` Stage-1 appends `## Literature` for
+    non-ID runs (opportunistic Channel-A reuse, issue #323 D1) but MUST gate
+    it out in identification mode (D2: ID runs are literature-free in-run;
+    literature enters only post-fit via `refine_interpretation`).
 
     Construct-then-call is prohibitively heavy for this controller (many
     coupled state keys); a source-level check is the right granularity for
@@ -200,17 +199,12 @@ def test_curve_synthesis_injects_literature_unconditionally():
     """
     from scilink.agents.exp_agents.controllers import curve_fitting_controllers
     src = inspect.getsource(curve_fitting_controllers.UnifiedCurveSynthesisController)
-    # The Stage-2 prompt builder is the only consumer of literature_context
-    # inside this class. Confirm: (a) injection exists, (b) NO task_mode
-    # branch gates it.
-    assert 'state.get("literature_context")' in src
-    # Find every line that gates on literature_context; none may also test task_mode
     lit_gates = [
         line for line in src.splitlines()
         if 'state.get("literature_context")' in line
     ]
     assert lit_gates, "expected at least one lit-context conditional in synthesis"
     for line in lit_gates:
-        assert 'task_mode' not in line, (
-            f"unexpected task_mode guard on synthesis lit injection: {line!r}"
+        assert 'task_mode' in line and '"identification"' in line, (
+            f"synthesis lit injection missing the identification-mode gate: {line!r}"
         )


### PR DESCRIPTION
Three small user-facing improvements around the curve-fitting planning step, motivated by "why does STEP 4 always take so long":

1. **The step is named for what it does.** `HumanFeedbackRefinementController` → `CurveFittingPlanningController` (matching the sibling `ImagePlanningController`). The old name described only the optional human-approval gate; the step's dominant work is drafting and validating the fitting plan. The old name remains importable as an alias — no breaking change.
2. **The wait is narrated.** The step contains two model calls minimum (a large multimodal plan draft, then a data+skill-rules validation, plus revision rounds when validation objects). Each now announces itself with expected duration, so a user watching the log understands the ~1-minute planning wait instead of staring at a silent banner. Live-verified on a real Bedrock run.
3. **Claude Sonnet 5 removed from the UI model selector** (reverts #332): instrumented benchmarking showed its planning step is ~6× slower than Opus 4.8 (2.5× longer plan outputs at equal token speed, plus extra skill-rule conformance revision rounds) alongside weaker identification commitment — there is no cost case for it in this pipeline.

---

## Technical details

- Rename + alias in `curve_fitting_controllers.py` (`HumanFeedbackRefinementController = CurveFittingPlanningController` module-level; step banners print `controller.__class__.__name__`, so logs update automatically); pipeline instantiation updated in `curve_fitting_pipelines.py`. Grep confirms no other in-repo references; `tests/test_lit_planner_injection.py` exercises the alias path implicitly via module import.
- Progress lines: one `logger.info` before the `_plan_analysis` generation call (states it is a single large call over plot+stats+skill guidance, typical ~1 min, longer for crowded spectra) and one before the `_validate_plan` call ("second model call"). They join the existing `Plan validation: approved / N issue(s) found, revising` lines to make the step's call anatomy visible: measured medians are 49 s (Opus) for draft+validate, with revision rounds explaining outliers.
- UI: removes the `bedrock/us.anthropic.claude-sonnet-5` entry from `MODEL_OPTIONS` (prefix-routed provider config needs no change). Evidence: identical per-call latency and zero thinking tokens on controlled probes (text and multimodal), but in-pipeline planning at median 312 s vs 49 s across 8 matched runs — attribution: 7.4k-token plan outputs (vs ~3k) plus validation-triggered revision rounds (instrumented run: 91 s draft + 59 s validation that rejected the plan for conflating the skill's bimodal-vs-dispersive residual rules).
- Drive-by test repair: `test_curve_synthesis_injects_literature_unconditionally` asserted the pre-#331 contract and has been red on main since #331 merged; now `test_curve_synthesis_gates_literature_in_id_mode`, asserting the merged D1/D2 behavior.
