### PR TITLE
Conformance checker follows the skill annealing schedule; refits must justify departures

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -2895,7 +2895,11 @@ Your guidance: '''
                 "fit.npy save if present) verbatim; "
                 "only modify the model components, initial guesses, bounds, or "
                 "background treatment needed to address the issues. Do NOT "
-                "regenerate from scratch. If the RESIDUAL DIAGNOSTICS flagged a "
+                "regenerate from scratch. If an issue's fix departs from the "
+                "locked plan or a skill rule, implement it AND state the "
+                "justification explicitly in a script comment (deviations with "
+                "stated justification are acceptable; silent ones are flagged "
+                "as non-conformant). If the RESIDUAL DIAGNOSTICS flagged a "
                 "localized region with RMS far above noise and repeated "
                 "sign-changes, treat that as under-resolved real structure there "
                 "(add a physically-nameable component or fix the peak shape), not "
@@ -2969,7 +2973,10 @@ Your guidance: '''
                     rules_parts.append(f"### {stage.title()} rules\n{content}")
             if rules_parts:
                 skill_rules_text = (
-                    f"\n**MANDATORY Domain Skill Rules ({skill_name}):**\n"
+                    "\n" + self._SKILL_STRICTNESS_SCHEDULE[
+                        min(state.get("_annealing_level", 0),
+                            len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
+                    ].format(name=skill_name)
                     + "\n".join(rules_parts)
                     + "\n"
                 )

--- a/tests/test_conformance_annealing.py
+++ b/tests/test_conformance_annealing.py
@@ -1,0 +1,28 @@
+"""The plan-conformance checker must speak at the same skill temperature as
+codegen: PR #294 relaxes the skill with annealing in the codegen prompts, and
+the conformance framing must follow the same schedule instead of a frozen
+MANDATORY header (which contradicted verifier-directed refits at hot levels).
+"""
+
+import inspect
+
+from scilink.agents.exp_agents.controllers import curve_fitting_controllers as cc
+
+
+def _conformance_src():
+    src = inspect.getsource(cc)
+    i = src.index("Build skill rules text for conformance checking")
+    return src[i - 200: i + 1200]
+
+
+def test_conformance_framing_follows_annealing_schedule():
+    seg = _conformance_src()
+    assert "_SKILL_STRICTNESS_SCHEDULE" in seg
+    assert "_annealing_level" in seg
+    assert '**MANDATORY Domain Skill Rules' not in seg, (
+        "conformance still hardcodes the T=0 framing")
+
+
+def test_refit_prompt_requires_stated_justification_for_departures():
+    src = inspect.getsource(cc)
+    assert "stated justification are acceptable; silent ones are flagged" in src


### PR DESCRIPTION
At high annealing levels the fitting loop was getting contradictory instructions: the codegen prompt (per the whole-skill temperature annealing of #294) told it the skill rules were relaxable reference material, while the plan-conformance checker judged the same script against a frozen MANDATORY framing — so a refit that followed the verifier's own recommendation was flagged as a rule violation. Observed live on a fluorescence-dominated Raman fit (verifier: replace ALS with a spline; conformance: mandatory-ALS violation).

---

## Technical details

- Conformance skill framing now uses the same schedule as codegen: the hardcoded MANDATORY header in the conformance prompt builder is replaced by the schedule entry selected by the state's annealing level — T=0 mandatory, T=1 preferred-with-explanation, T=2 reference-override-with-explanation. The conformance reference plan remains the locked config by design (drift guard); only the skill temperature is aligned.
- The REFINEMENT MODE prompt now instructs: when an issue's fix departs from the locked plan or a skill rule, implement it and state the justification in a script comment — the conformance channel already classifies justified deviations separately; this closes the gap where verifier-directed refits deviated silently.
- Tests: source-level guards that the conformance segment references the schedule + annealing level and no longer hardcodes the T=0 framing, and that the refinement prompt carries the justification instruction.
- Related design question deliberately NOT addressed here (filed separately): whether the locked plan itself should relax under escalation, since at hot levels the verifier can recommend strategy changes the lock forbids regardless of skill temperature.