### PR TITLE
Output-space contract for baseline-subtracting fits (raman + ir skills)

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -3260,8 +3260,12 @@ Your guidance: '''
                 # the saved fit is genuinely better than the script claimed. A
                 # *lower* recompute is left alone: it usually means a deliberate
                 # windowed/partial fit, where the script's own (windowed) number
-                # is the meaningful one. None (length mismatch / no signal) also
-                # keeps the self-report.
+                # is the meaningful one — but it can ALSO mean space-broken saved
+                # artifacts (e.g. a peaks-only fit saved against raw data after a
+                # baseline subtraction); the skills' output-space contract is the
+                # guard for that case, since this heuristic cannot distinguish
+                # the two. None (length mismatch / no signal) also keeps the
+                # self-report.
                 recomputed_r2 = _canonical_r2(yy, fit_arr)
                 self_r2 = fit_quality.get("r_squared")
                 if recomputed_r2 is not None:

--- a/scilink/skills/curve_fitting/ir/ir.md
+++ b/scilink/skills/curve_fitting/ir/ir.md
@@ -46,6 +46,16 @@ baselines (ALS with low stiffness) on IR data with broad OH envelopes.
 Saturated strong bands: fit the flanks and report the apex as uncertain
 rather than forcing a narrow component through the flat top.
 
+**Output-space contract.** If the spectrum was transformed (transmittance
+to absorbance) or a baseline was subtracted, keep every saved output in
+ONE consistent space: the saved data array, the saved fit curve, and the
+reported R² must all refer to the same signal (transformed/corrected data
+with a matching-space fit, or raw data with a fit that includes the
+baseline term). Mixed spaces make the fit appear offset from the data and
+invalidate the reported R². **The reported R² must be computed from exactly
+the arrays you save** — any stricter alternative metric is reported
+separately, clearly labeled.
+
 **Asymmetric bands.** A dispersive (S-shaped) residual across a single
 band that persists after a symmetric refit indicates real asymmetry
 (particle-size/shape effects in powders, hydrogen-bonding distributions,

--- a/scilink/skills/curve_fitting/ir/ir.md
+++ b/scilink/skills/curve_fitting/ir/ir.md
@@ -54,7 +54,8 @@ with a matching-space fit, or raw data with a fit that includes the
 baseline term). Mixed spaces make the fit appear offset from the data and
 invalidate the reported R². **The reported R² must be computed from exactly
 the arrays you save** — any stricter alternative metric is reported
-separately, clearly labeled.
+separately, clearly labeled (a user-requested fit window is the exception:
+report the windowed R², labeled as windowed).
 
 **Asymmetric bands.** A dispersive (S-shaped) residual across a single
 band that persists after a symmetric refit indicates real asymmetry

--- a/scilink/skills/curve_fitting/raman/raman.md
+++ b/scilink/skills/curve_fitting/raman/raman.md
@@ -90,9 +90,11 @@ reported R² disagrees with R² recomputed from the saved arrays.
 
 **The reported R² MUST be computed from exactly the two arrays you save**
 (the saved data array vs the saved fit array) — not from the corrected
-signal, not from a fit window, not from any intermediate. If you also want
-a stricter corrected-space or peak-region metric, report it as a separate,
-clearly-labeled number; the primary R² is the saved-array one.
+signal, not from any intermediate. If you also want a stricter
+corrected-space or peak-region metric, report it as a separate,
+clearly-labeled number; the primary R² is the saved-array one. The one
+exception: when the user explicitly requested a fit window, the windowed
+R² is the meaningful primary metric — report it labeled as windowed.
 
 **The model must explain the peaks, not the ramp.** After fitting, check
 where the model's variance lives: if the fitted curve with all peak

--- a/scilink/skills/curve_fitting/raman/raman.md
+++ b/scilink/skills/curve_fitting/raman/raman.md
@@ -79,6 +79,21 @@ most a constant offset (the structured background is already gone — a
 sloped or polynomial residual baseline at this stage usually means the ALS
 parameters need adjusting, not that more baseline freedom is needed).
 
+**Output-space contract (critical when a baseline is subtracted).** All
+saved outputs must live in ONE consistent space: either (a) include the
+subtracted baseline in the saved fit curve so it overlays the RAW data, or
+(b) save the baseline-corrected signal as the data array next to a
+corrected-space fit. Never save a peaks-only fit against raw data — the
+verification overlay then shows the fit offset below the data by the
+entire continuum, every residual is background rather than misfit, and
+reported R² disagrees with R² recomputed from the saved arrays.
+
+**The reported R² MUST be computed from exactly the two arrays you save**
+(the saved data array vs the saved fit array) — not from the corrected
+signal, not from a fit window, not from any intermediate. If you also want
+a stricter corrected-space or peak-region metric, report it as a separate,
+clearly-labeled number; the primary R² is the saved-array one.
+
 **The model must explain the peaks, not the ramp.** After fitting, check
 where the model's variance lives: if the fitted curve with all peak
 components removed still tracks most of the data (i.e., the "peaks" are

--- a/tests/test_raman_ir_skills.py
+++ b/tests/test_raman_ir_skills.py
@@ -50,3 +50,12 @@ def test_ir_carries_orientation_and_range_rules():
     skill = load_skill("ir")
     assert "transmittance" in skill["overview"].lower()
     assert "full measured range" in skill["planning"].lower()
+
+
+def test_both_skills_pin_the_output_space_contract():
+    # A peaks-only fit saved against raw data after baseline subtraction
+    # breaks verification (fit offset by the whole continuum) and makes
+    # self-reported R² disagree with R² recomputed from saved arrays.
+    for name in ("raman", "ir"):
+        impl = load_skill(name)["implementation"].lower()
+        assert "one consistent space" in impl, name


### PR DESCRIPTION
Fixes a verification death spiral on fluorescence-dominated spectra: when the raman skill's subtract-then-fit recipe produced a peaks-only fit saved against the raw data, the verifier saw the fit offset below the data by the entire continuum, every residual read as background, and the reported R² disagreed with the R² recomputed from the saved arrays — so the refinement loop chased phantom issues for its whole budget. Both skills now pin an **output-space contract**: saved data, saved fit, and the reported R² must live in one consistent space, with the reported R² computed from exactly the saved arrays (user-requested fit windows excepted — the windowed number stays primary, labeled).

Live evidence on the failing case (GO spectrum, identification mode, budget 7):
- **Before**: recomputed R² −6.7 vs self-reported 0.62, fit offset ~100k counts, 7 rounds of thrash.
- **Contract v1** (space rule as a trailing sentence): arrays consistent, but the *reported* metric stayed wrong-space → divergence warnings every round, accepted at 0.47.
- **Contract v2** (R²-source as its own bolded rule): zero divergence warnings in any round, converged to a clean accept.

---

## Technical details

- `scilink/skills/curve_fitting/raman/raman.md` (Implementation): output-space contract paragraph — option (a) fit includes the baseline term in raw space, or (b) corrected data saved next to a corrected-space fit; never peaks-only-vs-raw. Separate bolded rule: reported R² computed from exactly the saved arrays; stricter corrected-space/peak-region metrics reported separately, clearly labeled; user-requested windows report the windowed R², labeled.
- `scilink/skills/curve_fitting/ir/ir.md`: same contract, extended to the transmittance→absorbance transform case.
- `curve_fitting_controllers.py`: comment-only update at the e9c2ddd upward-only trust heuristic, naming the second cause of a lower recompute (space-broken artifacts, guarded by this contract) alongside the original windowed-fit rationale — the heuristic itself is unchanged and the two mechanisms compose: it repairs broken *self-reports* upward; the contract keeps the *artifacts* honest so both numbers agree.
- `tests/test_raman_ir_skills.py`: loader test pinning the contract's presence in both skills' implementation sections.
- Known trade-off, stated: raw-space R² on continuum-dominated spectra runs high by construction (background variance dominates); the residual-shape gates and the separately-labeled corrected-space metric are the rigor backstops, per the benchmark findings.

**Scoped deliberately to raman + ir.** The `nmr` skill prescribes the same subtract-then-fit pattern (rolling-baseline Step 2) and therefore carries the same *theoretical* exposure, but with zero observed incidents across the NMR benchmark campaign and baseline distortions that are small relative to peak heights (a mismatch there would cost residual noise, not the Raman-scale death spiral), it is left unchanged per the scope-to-the-broken-path convention. `xrd_profile` is structurally immune (background is fitted inside the one global raw-space model). If an NMR run ever shows the `R² from saved fit diverges` signature alongside a baseline subtraction, the same one-paragraph contract applies there.
