### PR TITLE
Give the INCAR literature review the real Edison wait ceiling (was silently timing out)

### DIFF
--- a/scilink/agents/sim_agents/critics.py
+++ b/scilink/agents/sim_agents/critics.py
@@ -529,7 +529,14 @@ class InputValidator(_CriticBase):
         engine_label = (skill or "the engine").upper()
         try:
             from ..lit_agents.literature_agent import IncarLiteratureAgent
-            agent = IncarLiteratureAgent(api_key=self.futurehouse_api_key)
+            agent = IncarLiteratureAgent(
+                api_key=self.futurehouse_api_key,
+                # 50-min ceiling, matching every other literature call site
+                # (Edison CROW jobs routinely take 20-30 min; the class
+                # default of 300s timed out on essentially every real query,
+                # silently disabling INCAR literature validation).
+                max_wait_time=3000,
+            )
             result = agent.validate_inputs(
                 input_files_text=_format_input_files(input_files),
                 system_description=system_description,


### PR DESCRIPTION
One-line consistency fix: the DFT InputValidator's literature review inherited the 300s default wait while Edison CROW jobs routinely take 10-20 minutes, so the INCAR literature-validation step timed out on essentially every real query, stalled runs for 5 minutes, and silently degraded to 'Literature review unavailable' (observed live 2026-07-08 in a meta-session DFT-input preparation). Now uses the same 3000s ceiling as every other literature call site. Trade-off, stated: the DFT-input step may now legitimately wait tens of minutes for the review instead of failing fast — that is the feature working; if interactive latency becomes a complaint, threading a configurable timeout through the validator is the follow-up. @sarah-allec 