### PR TITLE
Script bank (episodic script memory) + real-time analysis mode (#346)

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2110,6 +2110,7 @@ class AnalysisOrchestratorTools:
             task_mode: str = None,
             prior_analysis_paths: List[str] = None,
             reuse_locked_script: bool = False,
+            profile: str = None,
             literature_file: str = None,
             r2_threshold: float = None,
             max_verification_iterations: int = None,
@@ -2630,6 +2631,13 @@ class AnalysisOrchestratorTools:
                     analyze_kwargs["prior_analysis_paths"] = prior_analysis_paths
                 if reuse_locked_script:
                     analyze_kwargs["reuse_locked_script"] = True
+                if profile:
+                    # Operating profile (#346): forward only to agents whose
+                    # analyze() accepts it (all three do; introspection keeps
+                    # this robust for custom agents).
+                    import inspect as _inspect
+                    if "profile" in _inspect.signature(agent.analyze).parameters:
+                        analyze_kwargs["profile"] = profile
                 if literature_file:
                     analyze_kwargs["literature_file"] = literature_file
                 if r2_threshold is not None:
@@ -2991,6 +2999,27 @@ class AnalysisOrchestratorTools:
                         "verification or deeper-analysis follow-ups, or for a "
                         "different kind of measurement — leave it false so the "
                         "agent decides how to use the prior run as reference."
+                    )
+                },
+                "profile": {
+                    "type": "string",
+                    "enum": ["thorough", "realtime"],
+                    "description": (
+                        "Operating profile. Omit (or 'thorough') for the normal "
+                        "full-quality analysis. 'realtime' is the per-frame "
+                        "in-situ mode for curve data: it executes the locked "
+                        "script from `prior_analysis_paths` with ZERO LLM calls "
+                        "— requires `prior_analysis_paths` + "
+                        "`reuse_locked_script=true`, and the anchor frame must "
+                        "have been analyzed thoroughly first. The result carries "
+                        "`reuse_validity` with the gate verdict plus a `drift` "
+                        "field ('none'/'suspected') from a fingerprint "
+                        "comparison against the anchor frame — 'suspected' "
+                        "means the DATA changed (e.g. a phase transition) even "
+                        "if the fit still passes; recommend a thorough "
+                        "re-analysis of such frames. Use for high-cadence "
+                        "measurement streams; interpretation is deferred to a "
+                        "post-experiment sweep."
                     )
                 },
                 "literature_file": {

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -944,6 +944,43 @@ def _load_prior_curve_fit_state(raw_path):
     return anchor_dir, summary, script_text, script_label
 
 
+def _load_anchor_fingerprint(anchor_dir):
+    """Data fingerprint of the anchor run's first successful spectrum.
+
+    Feeds the realtime drift check (#346 step 3): a per-frame fingerprint is
+    compared against this to detect that the DATA changed even when the
+    reused script still fits well (the R² gate is blind to phase transitions
+    under auto-adaptive scripts). Prefers the fingerprint persisted in
+    ``series_fit_results.json`` (stamped when the script bank is enabled);
+    falls back to re-reading the anchor's data file. Returns ``None`` when
+    neither is possible — drift is then reported as unavailable, never
+    guessed.
+    """
+    try:
+        data = json.loads(
+            (Path(anchor_dir) / "series_fit_results.json").read_text())
+    except Exception:  # noqa: BLE001
+        return None
+    for r in data.get("results") or []:
+        if not (isinstance(r, dict) and r.get("success")):
+            continue
+        fp = r.get("_bank_fingerprint")
+        if isinstance(fp, dict) and fp.get("kind") == "curve":
+            return fp
+        dp = r.get("data_path")
+        if dp and Path(str(dp)).is_file():
+            try:
+                from scilink.skills._shared import _script_bank
+                from scilink.skills._shared.curve_fitting_tools import load_curve_data
+                xy = _extract_xy(load_curve_data(str(dp)))
+                if xy is not None:
+                    return _script_bank.curve_fingerprint(xy[0], xy[1])
+            except Exception:  # noqa: BLE001
+                return None
+        return None  # anchor = first successful result only
+    return None
+
+
 def _prior_curve_fit_block(state: dict) -> str:
     """A reference-context block for prior curve-fit runs named in
     ``state['prior_analysis_paths']`` — a compact fit summary plus each
@@ -4096,6 +4133,14 @@ Return JSON with:
             }
             if verdict == "poor":
                 reuse_result["quality_warning"] = message
+            # Realtime drift channel (#346 step 3): the gate metric measures
+            # fit quality, not data identity — an auto-adaptive locked script
+            # fits a NEW phase with a high R² (live-proven on the dehydration
+            # series). The fingerprint distance to the anchor frame sees the
+            # data change; both signals are reported, escalation stays the
+            # caller's move.
+            if ctx.state.get("_qc_profile") == "realtime":
+                self._attach_drift_signal(ctx, reuse_result["reuse_validity"])
             return reuse_result
         self.logger.warning(
             f"   ⚠️  Prior fitting script could not execute on this data "
@@ -4104,6 +4149,47 @@ Return JSON with:
             f"from the prior run."
         )
         return None
+
+    # Below this similarity to the anchor frame's fingerprint, a realtime
+    # frame is flagged drift="suspected". Calibrated on the in-situ
+    # dehydration series: same-phase frames score 1.000, transition-onset
+    # frames 0.900, post-transition frames 0.787 — 0.92 flags from onset.
+    DRIFT_SIMILARITY_THRESHOLD = 0.92
+
+    def _attach_drift_signal(self, ctx: QCItemContext, reuse_validity: dict) -> None:
+        """Fingerprint-distance drift check against the anchor frame (#346).
+
+        Deterministic and LLM-free: fingerprints this frame's data and scores
+        it against ``state['_anchor_fingerprint']`` with the script bank's
+        curve similarity. Adds ``fingerprint_similarity`` and ``drift``
+        ("none" | "suspected" | "unavailable") to ``reuse_validity``.
+        Failure-isolated — a drift-check error never affects the fit result.
+        """
+        try:
+            from scilink.skills._shared import _script_bank
+
+            anchor_fp = ctx.state.get("_anchor_fingerprint")
+            xy = _extract_xy(ctx.data)
+            if not anchor_fp or xy is None:
+                reuse_validity["drift"] = "unavailable"
+                return
+            frame_fp = _script_bank.curve_fingerprint(xy[0], xy[1])
+            sim = _script_bank._curve_similarity(frame_fp, anchor_fp)
+            reuse_validity["fingerprint_similarity"] = round(float(sim), 3)
+            drifted = sim < self.DRIFT_SIMILARITY_THRESHOLD
+            reuse_validity["drift"] = "suspected" if drifted else "none"
+            if drifted:
+                self.logger.warning(
+                    f"   🌡️ Drift suspected: fingerprint similarity to the "
+                    f"anchor frame is {sim:.3f} (< "
+                    f"{self.DRIFT_SIMILARITY_THRESHOLD}) — the data appears "
+                    f"to have changed even though the fit gate "
+                    f"{'passed' if reuse_validity.get('verdict') == 'good' else 'failed'}. "
+                    f"Consider re-anchoring or a thorough re-analysis of this frame."
+                )
+        except Exception as e:  # noqa: BLE001 - drift check never breaks the fit
+            reuse_validity.setdefault("drift", "unavailable")
+            self.logger.warning(f"Drift check skipped: {e}")
 
     def qc_run_initial(self, ctx: QCItemContext) -> dict:
         initial_model = ctx.state.get('locked_fitting_config', {}).get('physical_model') or 'Initial model'

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -944,6 +944,31 @@ def _load_prior_curve_fit_state(raw_path):
     return anchor_dir, summary, script_text, script_label
 
 
+def _degenerate_data_check(curve_data):
+    """Reason string when the data cannot support ANY fit, else ``None``.
+
+    The realtime pre-flight gate (#346): a detector-glitch frame (all-zero,
+    flat, runt, all-NaN) fails in milliseconds with an honest flag instead of
+    burning bounded LLM correction calls trying to rescue the unfittable
+    (measured: ~8 calls / ~4 min per glitch frame without this). Deliberately
+    conservative — partial corruption (e.g. a NaN-laced but otherwise real
+    spectrum) passes, because the correction path demonstrably salvages it.
+    Applied only under the realtime profile; thorough runs are untouched.
+    """
+    xy = _extract_xy(curve_data)
+    if xy is None:
+        return "unrecognizable data shape"
+    y = np.asarray(xy[1], dtype=float)
+    finite = y[np.isfinite(y)]
+    if finite.size < 32:
+        return (f"only {finite.size} finite data points "
+                f"(need ≥ 32 to support any fit)")
+    lo, hi = np.percentile(finite, [0.5, 99.5])
+    if not np.isfinite(hi - lo) or (hi - lo) <= 0:
+        return "zero dynamic range (flat or constant signal)"
+    return None
+
+
 def _load_anchor_fingerprint(anchor_dir):
     """Data fingerprint of the anchor run's first successful spectrum.
 
@@ -3033,6 +3058,31 @@ Your guidance: '''
         refine_from_r2: float = 0.0,
         refine_from_issues: Optional[list] = None,
     ) -> dict:
+        # Realtime pre-flight gate (#346): fail a glitch frame instantly —
+        # this single choke point covers reuse, non-anchor locked-script
+        # execution, AND the fallback codegen, so a degenerate frame costs
+        # milliseconds and zero LLM calls instead of the attempt ladders.
+        if state.get("_qc_profile") == "realtime":
+            _degenerate = _degenerate_data_check(curve_data)
+            if _degenerate:
+                self.logger.warning(
+                    f"   🚫 Pre-flight gate [{spectrum_name}]: {_degenerate} "
+                    f"— frame not analyzed (detector glitch?). Flagged for "
+                    f"the post-experiment sweep."
+                )
+                return {
+                    "index": spectrum_idx,
+                    "name": spectrum_name,
+                    "data_path": data_path,
+                    "success": False,
+                    "error": (f"Pre-flight degenerate-data gate: {_degenerate}. "
+                              f"The frame was not analyzed."),
+                    "parameters": {},
+                    "fit_quality": {},
+                    "script": None,
+                    "script_errors": [],
+                }
+
         stats = self._compute_statistics(curve_data)
         # Per-spectrum working dir: the locked script runs VERBATIM here with data
         # staged as the canonical DATA_NAME and viz written canonically — no
@@ -4761,9 +4811,18 @@ Return JSON with:
 
             return ctx.best_result
         else:
+            # Surface the last attempt's own error (e.g. the realtime
+            # pre-flight gate's reason) instead of only the generic summary.
+            last_err = next(
+                (e for e in ((a.get("result") or {}).get("error")
+                             for a in reversed(ctx.all_attempts)) if e),
+                None,
+            )
             return {
                 "index": ctx.item_idx, "name": ctx.item_name, "success": False,
-                "error": "All fitting attempts failed", "attempts": len(ctx.all_attempts),
+                "error": ("All fitting attempts failed"
+                          + (f": {last_err}" if last_err else "")),
+                "attempts": len(ctx.all_attempts),
                 "parameters": {}, "fit_quality": {},
             }
 

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -3178,7 +3178,7 @@ Your guidance: '''
         except Exception:
             residual_diag = None
 
-        return {
+        result = {
             "index": spectrum_idx,
             "name": spectrum_name,
             "data_path": data_path,
@@ -3196,6 +3196,22 @@ Your guidance: '''
             "script": script,
             "script_errors": script_errors,
         }
+        # Fingerprint of the data this script solved (script bank, #346) —
+        # stamped here because per-spectrum arrays for file inputs never reach
+        # the outer state the bank write hook reads. No-op unless the bank is
+        # enabled; never affects the fit.
+        try:
+            from scilink.skills._shared import _script_bank
+            if _script_bank.bank_enabled():
+                xy = _extract_xy(curve_data)
+                if xy is not None:
+                    result["_bank_fingerprint"] = _script_bank.curve_fingerprint(
+                        xy[0], xy[1],
+                        x_units=_script_bank.guess_x_units(state.get("system_info")),
+                    )
+        except Exception:
+            pass
+        return result
 
     FIT_VERIFICATION_PROMPT = '''You are a scientific data analysis expert reviewing a curve/spectral fit.
 

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -2686,6 +2686,14 @@ Your guidance: '''
         prior_runs = _prior_curve_fit_block(state)
         if prior_runs:
             context_parts.append(prior_runs)
+        # Script-bank exemplar (#346): first fresh generation only — never on
+        # refinements (prior_script) and never once annealing has escalated,
+        # so the hot script-drop's from-scratch regeneration stays exemplar-free.
+        exemplar = state.get("_bank_exemplar")
+        if (exemplar and prior_script is None
+                and state.get("_annealing_level", 0) == 0):
+            from scilink.skills._shared import _script_bank
+            context_parts.append(_script_bank.render_exemplar_block(exemplar))
 
         # Optional auxiliary operand(s) (#226): for each 1D auxiliary curve aligned
         # with the primary (same length), write it next to the spectrum and list
@@ -4102,10 +4110,50 @@ Return JSON with:
         ctx.initial_label = initial_model
         self.logger.info(f"   Attempt 1: {str(initial_model)[:80]}...")
 
+        self._offer_bank_exemplar(ctx)
         return self._fit_single_spectrum(
             state=ctx.state, curve_data=ctx.data, data_path=ctx.data_path,
             spectrum_name=ctx.item_name, spectrum_idx=ctx.item_idx, base_script=None
         )
+
+    def _offer_bank_exemplar(self, ctx: QCItemContext) -> None:
+        """Adapt-mode script-bank retrieval (#346 step 2).
+
+        Fingerprints the item's data and, when the bank holds a closely
+        matching proven script, stashes it in state for the FIRST codegen
+        attempt to adapt (consumed by ``_generate_fitting_script`` at
+        annealing level 0 only, so the hot script-drop is preserved).
+        Precedence: explicit ``prior_analysis_paths`` reference material wins
+        — the bank never competes with a user-supplied prior. Failure-isolated.
+        """
+        state = ctx.state
+        state.pop("_bank_exemplar", None)
+        try:
+            from scilink.skills._shared import _script_bank
+            if not _script_bank.bank_enabled() or state.get("prior_analysis_paths"):
+                return
+            xy = _extract_xy(ctx.data)
+            if xy is None:
+                return
+            fingerprint = _script_bank.curve_fingerprint(
+                xy[0], xy[1],
+                x_units=_script_bank.guess_x_units(state.get("system_info")),
+            )
+            matches = _script_bank.find_exemplar(
+                "curve_fitting", fingerprint,
+                _script_bank.measurement_context(state.get("system_info") or {}),
+            )
+            if matches:
+                match = matches[0]
+                state["_bank_exemplar"] = match
+                _script_bank.mark_retrieved("curve_fitting", match["record"]["id"])
+                self.logger.info(
+                    f"   🏦 Bank exemplar offered: id={match['record']['id']} "
+                    f"score={match['score']} "
+                    f"({str(match['record'].get('technique_signals', {}).get('model_type') or '')[:60]})"
+                )
+        except Exception as e:
+            self.logger.warning(f"Bank retrieval skipped: {e}")
 
     def qc_record_initial(self, ctx: QCItemContext, result: dict) -> None:
         r2 = result.get("fit_quality", {}).get("r_squared") or 0

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -5690,6 +5690,15 @@ Return JSON with:
             reuse_script, reuse_source = _first_prior_curve_fit_script(state)
         else:
             reuse_script, reuse_source = None, None
+        # Verbatim cold start (#346 step 4): a realtime run with no explicit
+        # prior locked its recipe by auditioning bank candidates against the
+        # first frame (agent-side, pre-pipeline). The winner flows through the
+        # SAME reuse path as a prior-run script — validity gate, drift check,
+        # correction retry all apply unchanged.
+        if not reuse_script and state.get("_cold_start_reuse"):
+            cs = state["_cold_start_reuse"]
+            reuse_script = cs.get("script")
+            reuse_source = f"script_bank:{cs.get('id')}"
         if reuse_script and regime_configs:
             self.logger.info(
                 "   ♻️  Locked-script reuse requested, but this run is "

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -2226,6 +2226,20 @@ class RunDynamicAnalysisController:
         optimal_data, processing_note = tools.get_optimal_analysis_data(state["original_hspy_data"])
         self.logger.info(f"📊 Dynamic Analysis Prep: {processing_note}")
 
+        # Script-bank retrieval inputs (#346 step 2): fingerprint the cube once
+        # per run; the per-target lookup below adds the target text to the
+        # context query. Failure-isolated; None disables retrieval entirely.
+        _bank_cube_fp = None
+        _bank_ctx = None
+        try:
+            from scilink.skills._shared import _script_bank
+            if _script_bank.bank_enabled() and not state.get("prior_analysis_paths"):
+                _bank_cube_fp = _script_bank.hyperspectral_fingerprint(
+                    optimal_data, state.get("energy_axis"), axis_units)
+                _bank_ctx = _script_bank.measurement_context(sys_info)
+        except Exception as e:
+            self.logger.warning(f"Bank fingerprint skipped: {e}")
+
         # Offer the rank-k decomposition reconstruction as an OPTIONAL, denoised
         # fit target alongside the raw cube (issue #219). The generated code may
         # use it for shape-based features on noisy data, but raw stays the base
@@ -2387,6 +2401,32 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
             ctx.required_outputs = required_outputs
             ctx.base_prompt = base_prompt
             ctx.current_prompt = base_prompt
+            # Script-bank exemplar (#346): appended to the FIRST attempt's
+            # prompt only — retries rebuild from the clean base_prompt, so
+            # the escalation ladder (up to "abandon the method family")
+            # stays exemplar-free. Failure-isolated.
+            if _bank_cube_fp is not None:
+                try:
+                    from scilink.skills._shared import _script_bank
+                    matches = _script_bank.find_exemplar(
+                        "hyperspectral", _bank_cube_fp,
+                        {**(_bank_ctx or {}), "analysis_target": target_desc},
+                    )
+                    if matches:
+                        match = matches[0]
+                        ctx.current_prompt = (
+                            base_prompt + "\n\n"
+                            + _script_bank.render_exemplar_block(match)
+                        )
+                        _script_bank.mark_retrieved(
+                            "hyperspectral", match["record"]["id"])
+                        self.logger.info(
+                            f"   🏦 Bank exemplar offered: "
+                            f"id={match['record']['id']} score={match['score']} "
+                            f"({str(match['record'].get('technique_signals', {}).get('analysis_target') or '')[:60]})"
+                        )
+                except Exception as e:
+                    self.logger.warning(f"Bank retrieval skipped: {e}")
             ctx.retries = 0
             ctx.best_attempt = {"req_passed": -1, "valid_count": -1,
                                 "images": [], "maps": [], "meta": []}

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -2515,7 +2515,7 @@ Your guidance: '''
                     pass
                 break
 
-        return {
+        result = {
             "index": image_idx,
             "name": image_name,
             "data_path": data_path,
@@ -2532,6 +2532,22 @@ Your guidance: '''
             "script": script,
             "script_errors": script_errors,
         }
+        # Fingerprint of the image this script solved (script bank, #346) —
+        # stamped here because per-image arrays for file inputs never reach
+        # the outer state the bank write hook reads. No-op unless the bank is
+        # enabled; never affects the analysis.
+        try:
+            from scilink.skills._shared import _script_bank
+            from scilink.skills._shared.image_analysis_tools import resolve_pixel_size_nm
+            if _script_bank.bank_enabled() and isinstance(image_data, np.ndarray):
+                result["_bank_fingerprint"] = _script_bank.image_fingerprint(
+                    image_data,
+                    pixel_size_nm=resolve_pixel_size_nm(
+                        state.get("system_info"), image_data.shape),
+                )
+        except Exception:
+            pass
+        return result
 
     QUALITY_VERIFICATION_PROMPT = '''You are a scientific image analysis expert reviewing an analysis result.
 

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -2066,6 +2066,15 @@ Your guidance: '''
             ].format(name=", ".join(n for n, _ in recipes))
             context_parts.append(preamble + _render_codegen_recipe(recipes))
 
+        # Script-bank exemplar (#346): first fresh generation only — never on
+        # refinements (base_script) and never once annealing has escalated,
+        # so the hot script-drop's from-scratch regeneration stays exemplar-free.
+        exemplar = state.get("_bank_exemplar")
+        if (exemplar and not base_script
+                and state.get("_annealing_level", 0) == 0):
+            from scilink.skills._shared import _script_bank
+            context_parts.append(_script_bank.render_exemplar_block(exemplar))
+
         # Add sub-agent preprocessing array paths
         for key in ("fft_preprocessing", "sam_preprocessing"):
             preproc = state.get(key)
@@ -3389,10 +3398,49 @@ Return JSON with:
         ctx.initial_label = initial_pipeline
         self.logger.info(f"   Attempt 1: {initial_pipeline[:80]}...")
 
+        self._offer_bank_exemplar(ctx)
         return self._process_single_image(
             state=ctx.state, image_data=ctx.data, data_path=ctx.data_path,
             image_name=ctx.item_name, image_idx=ctx.item_idx, base_script=None,
         )
+
+    def _offer_bank_exemplar(self, ctx: QCItemContext) -> None:
+        """Adapt-mode script-bank retrieval (#346 step 2) — image mirror of
+        the curve controller's hook: fingerprint the image, stash the best
+        bank match for the FIRST codegen attempt only (consumed by
+        ``_generate_analysis_script`` at annealing level 0, preserving the
+        hot script-drop). Explicit ``prior_analysis_paths`` wins over the
+        bank. Failure-isolated."""
+        state = ctx.state
+        state.pop("_bank_exemplar", None)
+        try:
+            from scilink.skills._shared import _script_bank
+            from scilink.skills._shared.image_analysis_tools import resolve_pixel_size_nm
+            if not _script_bank.bank_enabled() or state.get("prior_analysis_paths"):
+                return
+            img = np.asarray(ctx.data) if ctx.data is not None else None
+            if img is None or img.ndim < 2:
+                return
+            fingerprint = _script_bank.image_fingerprint(
+                img,
+                pixel_size_nm=resolve_pixel_size_nm(
+                    state.get("system_info"), img.shape),
+            )
+            matches = _script_bank.find_exemplar(
+                "image_analysis", fingerprint,
+                _script_bank.measurement_context(state.get("system_info") or {}),
+            )
+            if matches:
+                match = matches[0]
+                state["_bank_exemplar"] = match
+                _script_bank.mark_retrieved("image_analysis", match["record"]["id"])
+                self.logger.info(
+                    f"   🏦 Bank exemplar offered: id={match['record']['id']} "
+                    f"score={match['score']} "
+                    f"({str(match['record'].get('technique_signals', {}).get('analysis_type') or '')[:60]})"
+                )
+        except Exception as e:
+            self.logger.warning(f"Bank retrieval skipped: {e}")
 
     def qc_record_initial(self, ctx: QCItemContext, result: dict) -> None:
         # Initial score is provisional — LLM verification is authoritative

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -744,11 +744,23 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # thorough anchor run (which later frames can go realtime against).
         cold_start_info = None
         if realtime_cold_start:
-            cold_start_info = self._bank_cold_start_audition(
-                processed_first_spectrum, handled_system_info,
-                effective_r2_threshold,
-            )
-            if cold_start_info is None:
+            from .controllers.curve_fitting_controllers import _degenerate_data_check
+            _degenerate = _degenerate_data_check(processed_first_spectrum)
+            if _degenerate:
+                # Glitch frame: do NOT demote to thorough (that would burn
+                # LLM calls on unfittable data) — stay realtime and let the
+                # per-item pre-flight gate fail the frame instantly.
+                self.logger.warning(
+                    f"🚫 REALTIME cold start skipped: {_degenerate} — the "
+                    f"frame will be flagged by the pre-flight gate, not "
+                    f"analyzed."
+                )
+            else:
+                cold_start_info = self._bank_cold_start_audition(
+                    processed_first_spectrum, handled_system_info,
+                    effective_r2_threshold,
+                )
+            if cold_start_info is None and not _degenerate:
                 self.logger.warning(
                     "⚡→🐢 REALTIME cold start: no banked recipe fits this "
                     "data — running a THOROUGH anchor instead; subsequent "

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -865,6 +865,12 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         if fb_staged:
             final_results.setdefault("staged_solutions", []).extend(fb_staged)
 
+        # Bank every approved working script as episodic memory (script bank,
+        # #346) — deterministic, no LLM, failure-isolated.
+        banked = self._maybe_bank_scripts(state)
+        if banked:
+            final_results["banked_scripts"] = banked
+
         self.logger.info("")
         self.logger.info("✅ ANALYSIS COMPLETE")
         self.logger.info(f"   Results: {results_path}")
@@ -1252,6 +1258,85 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 f"`scilink memory staged` (upgrade an existing skill or consolidate)."
             )
         return staged
+
+    def _maybe_bank_scripts(self, state: dict) -> List[str]:
+        """Bank every approved working script in the script bank (#346).
+
+        Episodic complement to T=2 staging: no hot/novelty gate, no LLM —
+        each distinct approved script is stored once per run with the
+        measurement context, a fingerprint of the spectrum it solved, and
+        the outcome, so later runs can retrieve and adapt it. Re-banking an
+        identical script updates its usage stats instead of duplicating.
+        Fully failure-isolated; gated by ``SCILINK_SCRIPT_BANK`` /
+        persistent-memory setting.
+        """
+        from scilink.skills._shared import _script_bank
+        if not _script_bank.bank_enabled():
+            return []
+
+        banked: List[str] = []
+        try:
+            from .controllers.curve_fitting_controllers import _active_skill_names
+
+            locked = state.get("locked_fitting_config") or {}
+            active_skills = _active_skill_names(state)
+            system_info = state.get("system_info") or {}
+            x_units = _script_bank.guess_x_units(system_info)
+            stack = state.get("spectrum_stack")
+            seen_hashes = set()
+
+            for r in state.get("series_results", []) or []:
+                if not r.get("success"):
+                    continue
+                script = r.get("script")
+                if not script or not (r.get("quality_history") or {}).get("approved"):
+                    continue
+                h = _script_bank.script_hash(script)
+                if h in seen_hashes:  # locked-recipe series: bank once per run
+                    continue
+                seen_hashes.add(h)
+
+                fingerprint = None
+                xy = None
+                idx = r.get("index")
+                if stack is not None and idx is not None and 0 <= idx < len(stack):
+                    xy = np.asarray(stack[idx])
+                elif state.get("curve_data") is not None:
+                    xy = np.asarray(state["curve_data"])
+                if xy is not None and xy.ndim == 2 and xy.shape[0] == 2:
+                    fingerprint = _script_bank.curve_fingerprint(
+                        xy[0], xy[1], x_units=x_units
+                    )
+
+                r2 = (r.get("fit_quality") or {}).get("r_squared")
+                res = _script_bank.add_record("curve_fitting", {
+                    "technique_signals": {
+                        "active_skills": active_skills,
+                        "model_type": r.get("model_type") or locked.get("physical_model"),
+                    },
+                    "measurement_context": _script_bank.measurement_context(system_info),
+                    "data_fingerprint": fingerprint,
+                    "outcome": {
+                        "model_type": r.get("model_type"),
+                        "metric": ({"name": "r_squared", "value": round(float(r2), 4)}
+                                   if r2 is not None else None),
+                        "plan_summary": locked.get("analysis_approach"),
+                        "parameters_extracted": locked.get("parameters_to_extract"),
+                    },
+                    "provenance": {"session": self.output_dir.name,
+                                   "item": r.get("name"),
+                                   "data_file": os.path.basename(str(state.get("data_path") or ""))
+                                   or None},
+                    "working_script": script,
+                })
+                if res.get("id"):
+                    banked.append(res["id"])
+                    self.logger.info(
+                        f"   🏦 Banked script [{res['action']}] id={res['id']}"
+                    )
+        except Exception as e:
+            self.logger.warning(f"Script banking skipped: {e}")
+        return banked
 
     def _maybe_stage_feedback_errors(self, state: dict, final_results: dict) -> List[str]:
         """Stage human-feedback + resolved-error knowledge for later distillation.

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -475,30 +475,31 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             n_candidates = 1
         candidate_escalation = bool(candidate_escalation) and n_candidates > 1
 
-        # Operating profile (#346 step 3). "realtime" is the per-frame in-situ
-        # mode: the prior run's locked script executes with the arithmetic
-        # gate + fingerprint drift check and ZERO LLM calls on the happy path
-        # — every LLM stage around it is skipped. Requires a locked recipe;
-        # the anchor frame runs under the default (thorough) profile first.
+        # Operating profile (#346 steps 3-4). "realtime" is the per-frame
+        # in-situ mode: a locked script executes with the arithmetic gate +
+        # fingerprint drift check and ZERO LLM calls on the happy path —
+        # every LLM stage around it is skipped. The locked recipe comes from
+        # an explicit prior run (prior_analysis_paths + reuse_locked_script)
+        # or, without one, from a verbatim COLD START: top bank candidates
+        # are auditioned against this frame after the data loads, and the
+        # first to clear the gate becomes the recipe. No candidate passing
+        # demotes the run to a thorough anchor (loudly).
         from ._qc_profile import resolve_profile
         qc_profile = resolve_profile(profile)
         realtime = qc_profile.name == "realtime"
-        if realtime:
-            if not (prior_analysis_paths and reuse_locked_script):
+        realtime_cold_start = False
+        if realtime and not (prior_analysis_paths and reuse_locked_script):
+            from scilink.skills._shared import _script_bank as _sb
+            if not _sb.bank_enabled():
                 raise ValueError(
-                    "profile='realtime' executes a locked recipe: pass "
-                    "prior_analysis_paths=[<anchor run dir>] and "
+                    "profile='realtime' executes a locked recipe. Either pass "
+                    "prior_analysis_paths=[<anchor run dir>] with "
                     "reuse_locked_script=True (run the anchor under the "
-                    "default thorough profile first)."
+                    "default thorough profile first), or enable the script "
+                    "bank (SCILINK_SCRIPT_BANK=1) so a matching banked script "
+                    "can be cold-started."
                 )
-            effective_max_verification = 0
-            n_candidates, candidate_escalation = 1, False
-            self.logger.info(
-                "⚡ REALTIME profile: skill suggestion, planning, literature, "
-                "verification, refit, trend and synthesis are skipped; the "
-                "prior locked script executes under the arithmetic gate with "
-                "a fingerprint drift check."
-            )
+            realtime_cold_start = True
 
         # Resolve task_mode — caller sets this explicitly (standalone user or
         # orchestrator). Defaults to "fitting" when unset.
@@ -738,6 +739,34 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             series_metadata, spectrum_paths
         )
 
+        # Verbatim cold start (#346 step 4): audition banked scripts against
+        # this frame — numerics only, zero LLM. No winner → demote to a
+        # thorough anchor run (which later frames can go realtime against).
+        cold_start_info = None
+        if realtime_cold_start:
+            cold_start_info = self._bank_cold_start_audition(
+                processed_first_spectrum, handled_system_info,
+                effective_r2_threshold,
+            )
+            if cold_start_info is None:
+                self.logger.warning(
+                    "⚡→🐢 REALTIME cold start: no banked recipe fits this "
+                    "data — running a THOROUGH anchor instead; subsequent "
+                    "frames can run realtime against this run's directory."
+                )
+                realtime = False
+                from ._qc_profile import THOROUGH
+                qc_profile = THOROUGH
+        if realtime:
+            effective_max_verification = 0
+            n_candidates, candidate_escalation = 1, False
+            self.logger.info(
+                "⚡ REALTIME profile: skill suggestion, planning, literature, "
+                "verification, refit, trend and synthesis are skipped; the "
+                "locked script executes under the arithmetic gate with a "
+                "fingerprint drift check."
+            )
+
         # Build initial state
         state = {
             # Input data
@@ -778,6 +807,15 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             # Opt-in: force verbatim reuse of the prior locked script (#172).
             # Default False — prior runs are agent-judged reference material.
             "reuse_locked_script": bool(reuse_locked_script),
+            # Verbatim cold start (#346 step 4): the audition winner, threaded
+            # into the series controller's reuse path (None when not used).
+            "_cold_start_reuse": ({
+                "id": cold_start_info["id"],
+                "script": cold_start_info["script"],
+                "score": cold_start_info["score"],
+                "audition_r2": cold_start_info["r2"],
+                "n_auditioned": cold_start_info["n_auditioned"],
+            } if cold_start_info else None),
             # Best-of-N: independent parallel anchor fits; LLM judge selects
             # the winner (1 = no fan-out). Escalation runs attempt 0 alone
             # and fans out only when it is weak.
@@ -826,9 +864,26 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 self.logger.warning(f"literature_file not found: {literature_file}")
 
         # REALTIME: planning is skipped, so seed the locked config (and the
-        # anchor fingerprint for the drift check) from the prior run's saved
-        # summary before the pipeline starts. Zero LLM calls.
-        if realtime:
+        # anchor fingerprint for the drift check) before the pipeline starts.
+        # Zero LLM calls. Two anchor sources: the explicit prior run's saved
+        # summary, or — cold start — the winning bank record (its fingerprint
+        # is the data the script originally solved, so the drift check reads
+        # "how far is this frame from the script's proven territory").
+        if realtime and cold_start_info is not None:
+            rec = cold_start_info["record"]
+            outcome = rec.get("outcome") or {}
+            state["locked_fitting_config"] = {
+                "physical_model": ((rec.get("technique_signals") or {}).get("model_type")
+                                   or outcome.get("model_type")),
+                "analysis_approach": outcome.get("plan_summary"),
+                "fitting_strategy": (
+                    f"Verbatim reuse of banked script {rec.get('id')} "
+                    f"(cold start, audition R²={cold_start_info['r2']})"
+                ),
+                "parameters_to_extract": outcome.get("parameters_extracted"),
+            }
+            state["_anchor_fingerprint"] = rec.get("data_fingerprint")
+        elif realtime:
             from .controllers.curve_fitting_controllers import (
                 _load_anchor_fingerprint,
                 _load_prior_curve_fit_state,
@@ -1320,6 +1375,112 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             )
         return staged
 
+    # Verbatim cold-start audition (#346 step 4): how many bank candidates to
+    # execute against the first frame, and the retrieval-score floor they must
+    # clear to be auditioned at all. The floor is HIGHER than adapt mode's
+    # (0.45): a verbatim script runs as-is with no verification loop and no
+    # adapt framing, so candidate selection stays conservative — the
+    # arithmetic gate is the final arbiter but not a physics-identity check.
+    VERBATIM_AUDITION_K = 3
+    VERBATIM_MIN_SCORE = 0.55
+
+    def _bank_cold_start_audition(
+        self, curve_data, system_info, gate_threshold: float
+    ) -> Optional[Dict[str, Any]]:
+        """Execute top bank candidates against the first frame; first past
+        the arithmetic gate becomes the locked recipe.
+
+        Numerics only — zero LLM calls: candidates are ranked by the
+        deterministic retrieval scorer, each script is staged and run
+        verbatim (same mechanics as #172 reuse), and the parsed R² is checked
+        against the gate. The winner's bank stats record the cross-session
+        success (once per campaign — the realtime frames themselves never
+        bank). Returns ``{"id", "script", "record", "score", "r2",
+        "n_auditioned"}`` or ``None`` when nothing matches or passes; the
+        caller then demotes the run to a thorough anchor. The gate check is
+        R²-based in v1 (custom gate metrics fall back to the legacy
+        threshold). Failure-isolated.
+        """
+        try:
+            from scilink.skills._shared import _script_bank
+            from .controllers.curve_fitting_controllers import _extract_xy
+            from ._locked_exec import stage_and_run
+
+            xy = _extract_xy(curve_data)
+            if xy is None:
+                return None
+            fingerprint = _script_bank.curve_fingerprint(
+                xy[0], xy[1], x_units=_script_bank.guess_x_units(system_info))
+            candidates = _script_bank.find_exemplar(
+                "curve_fitting", fingerprint,
+                _script_bank.measurement_context(system_info or {}),
+                k=self.VERBATIM_AUDITION_K, min_score=self.VERBATIM_MIN_SCORE,
+            )
+            if not candidates:
+                self.logger.info(
+                    f"   🏦 Cold start: no banked recipe scores ≥ "
+                    f"{self.VERBATIM_MIN_SCORE} against this data."
+                )
+                return None
+
+            for i, cand in enumerate(candidates):
+                rec = cand["record"]
+                work = self.output_dir / "_cold_start" / f"cand_{i:02d}_{rec['id']}"
+                self.logger.info(
+                    f"   🏦 Cold-start audition {i + 1}/{len(candidates)}: "
+                    f"bank record {rec['id']} (score {cand['score']})..."
+                )
+                try:
+                    run = stage_and_run(
+                        self.executor, rec["working_script"], curve_data, work)
+                except Exception as e:  # noqa: BLE001
+                    self.logger.info(f"      ✗ execution error: {e}")
+                    continue
+                if (run["status"] != "success"
+                        or run["visualization_path"] is None
+                        or "FIT_RESULTS_JSON:" not in run["stdout"]):
+                    self.logger.info("      ✗ script did not complete cleanly")
+                    continue
+                r2 = self._parse_audition_r2(run["stdout"])
+                if r2 is None or r2 < gate_threshold:
+                    self.logger.info(
+                        f"      ✗ gate failed (R²={r2} < {gate_threshold})")
+                    continue
+                _script_bank.mark_retrieved("curve_fitting", rec["id"])
+                _script_bank.record_success(
+                    "curve_fitting", rec["id"], session=self.output_dir.name)
+                self.logger.info(
+                    f"   🏦 ✅ Cold start locked: bank record {rec['id']} "
+                    f"passes the gate on this frame (R²={r2:.4f})."
+                )
+                return {"id": rec["id"], "script": rec["working_script"],
+                        "record": rec, "score": cand["score"],
+                        "r2": round(float(r2), 4),
+                        "n_auditioned": i + 1}
+            self.logger.info(
+                f"   🏦 Cold start: {len(candidates)} candidate(s) auditioned, "
+                f"none passed the gate."
+            )
+        except Exception as e:  # noqa: BLE001 - cold start never breaks analyze
+            self.logger.warning(f"Cold-start audition skipped: {e}")
+        return None
+
+    @staticmethod
+    def _parse_audition_r2(stdout: str) -> Optional[float]:
+        for line in stdout.splitlines():
+            if line.startswith("FIT_RESULTS_JSON:"):
+                try:
+                    d = json.loads(line.split(":", 1)[1].strip())
+                    r2 = ((d.get("fit_quality") or {}).get("r_squared")
+                          if isinstance(d.get("fit_quality"), dict)
+                          else None)
+                    if r2 is None:
+                        r2 = d.get("r_squared")
+                    return float(r2) if r2 is not None else None
+                except (ValueError, TypeError, json.JSONDecodeError):
+                    return None
+        return None
+
     def _maybe_bank_scripts(self, state: dict) -> List[str]:
         """Bank every approved working script in the script bank (#346).
 
@@ -1484,6 +1645,11 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # (an LLM call) is skipped under this profile.
         if state.get("_qc_profile") == "realtime":
             results["profile"] = "realtime"
+            if state.get("_cold_start_reuse"):
+                cs = state["_cold_start_reuse"]
+                results["cold_start"] = {k: cs.get(k) for k in
+                                         ("id", "score", "audition_r2",
+                                          "n_auditioned")}
             for r in series_results:
                 if isinstance(r, dict):
                     r.setdefault("quality_history", {})[

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -1289,24 +1289,33 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 if not r.get("success"):
                     continue
                 script = r.get("script")
-                if not script or not (r.get("quality_history") or {}).get("approved"):
+                # Quality gate: QC approval, or the reuse fast path's own
+                # arithmetic gate — a reused script passing on NEW data is
+                # exactly the cross-session success signal the bank counts.
+                passed = ((r.get("quality_history") or {}).get("approved")
+                          or (r.get("reuse_validity") or {}).get("verdict") == "good")
+                if not script or not passed:
                     continue
                 h = _script_bank.script_hash(script)
                 if h in seen_hashes:  # locked-recipe series: bank once per run
                     continue
                 seen_hashes.add(h)
 
-                fingerprint = None
-                xy = None
-                idx = r.get("index")
-                if stack is not None and idx is not None and 0 <= idx < len(stack):
-                    xy = np.asarray(stack[idx])
-                elif state.get("curve_data") is not None:
-                    xy = np.asarray(state["curve_data"])
-                if xy is not None and xy.ndim == 2 and xy.shape[0] == 2:
-                    fingerprint = _script_bank.curve_fingerprint(
-                        xy[0], xy[1], x_units=x_units
-                    )
+                # Prefer the fingerprint stamped where the data was in scope
+                # (file inputs load per spectrum inside the controller); the
+                # stack fallback covers array inputs.
+                fingerprint = r.get("_bank_fingerprint")
+                if fingerprint is None:
+                    xy = None
+                    idx = r.get("index")
+                    if stack is not None and idx is not None and 0 <= idx < len(stack):
+                        xy = np.asarray(stack[idx])
+                    elif state.get("curve_data") is not None:
+                        xy = np.asarray(state["curve_data"])
+                    if xy is not None and xy.ndim == 2 and xy.shape[0] == 2:
+                        fingerprint = _script_bank.curve_fingerprint(
+                            xy[0], xy[1], x_units=x_units
+                        )
 
                 r2 = (r.get("fit_quality") or {}).get("r_squared")
                 res = _script_bank.add_record("curve_fitting", {

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -320,6 +320,11 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # Escalation mode: attempt 0 runs alone and is fast-accepted when
         # strong; the remaining n_candidates-1 launch only when it is weak.
         candidate_escalation: bool = False,
+        # Operating profile (#346): None/"thorough" = today's behavior;
+        # "realtime" = zero-LLM per-frame execution of a locked recipe
+        # (requires prior_analysis_paths + reuse_locked_script). Accepts a
+        # preset name or a QCProfile instance.
+        profile: Optional[Any] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """
@@ -469,6 +474,31 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         except (TypeError, ValueError):
             n_candidates = 1
         candidate_escalation = bool(candidate_escalation) and n_candidates > 1
+
+        # Operating profile (#346 step 3). "realtime" is the per-frame in-situ
+        # mode: the prior run's locked script executes with the arithmetic
+        # gate + fingerprint drift check and ZERO LLM calls on the happy path
+        # — every LLM stage around it is skipped. Requires a locked recipe;
+        # the anchor frame runs under the default (thorough) profile first.
+        from ._qc_profile import resolve_profile
+        qc_profile = resolve_profile(profile)
+        realtime = qc_profile.name == "realtime"
+        if realtime:
+            if not (prior_analysis_paths and reuse_locked_script):
+                raise ValueError(
+                    "profile='realtime' executes a locked recipe: pass "
+                    "prior_analysis_paths=[<anchor run dir>] and "
+                    "reuse_locked_script=True (run the anchor under the "
+                    "default thorough profile first)."
+                )
+            effective_max_verification = 0
+            n_candidates, candidate_escalation = 1, False
+            self.logger.info(
+                "⚡ REALTIME profile: skill suggestion, planning, literature, "
+                "verification, refit, trend and synthesis are skipped; the "
+                "prior locked script executes under the arithmetic gate with "
+                "a fingerprint drift check."
+            )
 
         # Resolve task_mode — caller sets this explicitly (standalone user or
         # orchestrator). Defaults to "fitting" when unset.
@@ -723,6 +753,9 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "analysis_hints": hints,
             "analysis_objective": objective,
             "task_mode": effective_task_mode,
+            # Operating profile name ("thorough" | "realtime") — controllers
+            # gate realtime-only behavior (drift check, bank suppression) on it.
+            "_qc_profile": qc_profile.name,
             # Annealing schedule start level (None/0 = start frozen at T=0).
             "_starting_annealing_level": starting_annealing_level,
 
@@ -792,6 +825,33 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             else:
                 self.logger.warning(f"literature_file not found: {literature_file}")
 
+        # REALTIME: planning is skipped, so seed the locked config (and the
+        # anchor fingerprint for the drift check) from the prior run's saved
+        # summary before the pipeline starts. Zero LLM calls.
+        if realtime:
+            from .controllers.curve_fitting_controllers import (
+                _load_anchor_fingerprint,
+                _load_prior_curve_fit_state,
+            )
+            anchor_dir, prior_summary, _ps, _pl = _load_prior_curve_fit_state(
+                prior_analysis_paths[0]
+            )
+            if anchor_dir is None:
+                raise ValueError(
+                    f"profile='realtime': no reusable prior run found at "
+                    f"{prior_analysis_paths[0]!r} (expected series_fit_results.json "
+                    f"from the anchor run)."
+                )
+            if (prior_summary or {}).get("locked_config"):
+                state["locked_fitting_config"] = prior_summary["locked_config"]
+            state["_anchor_fingerprint"] = _load_anchor_fingerprint(anchor_dir)
+            if state["_anchor_fingerprint"] is None:
+                self.logger.warning(
+                    "   Realtime drift check unavailable: the anchor run has no "
+                    "persisted data fingerprint and its data file could not be "
+                    "re-read."
+                )
+
         # Create unified pipeline with quality settings
         pipeline = create_unified_curve_fitting_pipeline(
             model=self.model,
@@ -804,13 +864,14 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             executor=self.executor,
             output_dir=str(self.output_dir),
             literature_agent=self.literature_agent,
-            enable_human_feedback=self.enable_human_feedback,
+            enable_human_feedback=self.enable_human_feedback and not realtime,
             r2_threshold=effective_r2_threshold,
             max_model_retries=effective_max_retries,
             outlier_sigma=effective_outlier_sigma,
             max_verification_iterations=effective_max_verification,
             parallel_workers=self.parallel_workers,
             load_skills_fn=self._load_skills_to_state,
+            profile=qc_profile.name,
         )
         
         # Execute pipeline
@@ -1270,6 +1331,12 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         Fully failure-isolated; gated by ``SCILINK_SCRIPT_BANK`` /
         persistent-memory setting.
         """
+        # Realtime frames never bank: a verbatim re-execution learns nothing
+        # new, and per-frame updates would inflate the anchor record's
+        # cross-session success stats (a 500-frame campaign is one success,
+        # not 500 — the graduation signal must stay honest).
+        if state.get("_qc_profile") == "realtime":
+            return []
         from scilink.skills._shared import _script_bank
         if not _script_bank.bank_enabled():
             return []
@@ -1409,6 +1476,34 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "output_directory": str(self.output_dir),
             "task_mode": state.get("task_mode", "fitting"),
         }
+
+        # Realtime provenance (#346 / plan §7.3): stamp the profile on the
+        # top-level result AND each per-item quality_history so a post-hoc
+        # sweep can select realtime frames for thorough re-analysis. Also
+        # synthesize a deterministic one-line summary — the synthesis stage
+        # (an LLM call) is skipped under this profile.
+        if state.get("_qc_profile") == "realtime":
+            results["profile"] = "realtime"
+            for r in series_results:
+                if isinstance(r, dict):
+                    r.setdefault("quality_history", {})[
+                        "produced_under_profile"] = "realtime"
+            if not synthesis.get("detailed_analysis") and series_results:
+                r0 = series_results[0]
+                rv = r0.get("reuse_validity") or {}
+                r2 = (r0.get("fit_quality") or {}).get("r_squared")
+                synthesis = dict(synthesis)
+                synthesis["detailed_analysis"] = (
+                    f"Realtime frame: locked script from "
+                    f"'{rv.get('source') or 'prior run'}' "
+                    f"{'reused' if rv.get('reused') else 'fallback-regenerated'}; "
+                    f"R² = {r2 if r2 is not None else 'n/a'}; "
+                    f"gate verdict: {rv.get('verdict', 'n/a')}; "
+                    f"drift: {rv.get('drift', 'n/a')} "
+                    f"(fingerprint similarity "
+                    f"{rv.get('fingerprint_similarity', 'n/a')}). "
+                    f"Interpretation is deferred to the post-experiment sweep."
+                )
 
         # In identification mode, surface the ranked candidate list if the
         # synthesis produced one. Additive/optional field — callers that don't

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -187,6 +187,10 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         auxiliary_data: str | list[str] | None = None,
         auxiliary_label: str | list[str] | None = None,
         literature_file: str | None = None,
+        # Operating profile (#346): plumbed for parity with the curve agent;
+        # realtime toggles are wired for curve only in v1 (hyperspectral
+        # per-frame cost is numerics-dominated). Thorough is unaffected.
+        profile: Any = None,
         **kwargs
     ) -> Dict[str, Any]:
         """
@@ -249,6 +253,16 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 structure_image_path="stem_image.png"
             )
         """
+        # Operating profile (#346): accepted for surface parity; see the
+        # parameter note — realtime is curve-only in v1.
+        from ._qc_profile import resolve_profile
+        if resolve_profile(profile).name == "realtime":
+            self.logger.warning(
+                "profile='realtime' is not wired for hyperspectral analysis "
+                "yet (per-frame cost is numerics-dominated); running under "
+                "the thorough profile."
+            )
+
         # Parse input
         data_path, data_paths, data_array, error = self._parse_data_input(data)
         

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -416,6 +416,15 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         if staged:
             response["staged_solutions"] = staged
 
+        # Bank every approved working script as episodic memory (script bank,
+        # #346) — deterministic, no LLM, failure-isolated.
+        banked = self._maybe_bank_scripts(
+            response.get("dynamic_analysis_records") or [], skill_state,
+            data_path, system_info,
+        )
+        if banked:
+            response["banked_scripts"] = banked
+
         self._log_action(
             action="analyze",
             input_ctx={"data": data_path},
@@ -515,6 +524,89 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 f"`scilink memory staged`."
             )
         return staged
+
+    def _maybe_bank_scripts(self, records: list, skill_state: dict,
+                            data_path: str, system_info) -> list:
+        """Bank every approved working script in the script bank (#346).
+
+        Hyperspectral mirror of the curve/image hooks, reading the per-target
+        ``dynamic_analysis_records`` — episodic complement to T=2 staging,
+        no hot gate, no LLM. The cube is reloaded lazily (only when there is
+        something to bank) and fingerprinted once for all records. Fully
+        failure-isolated; gated by ``SCILINK_SCRIPT_BANK`` /
+        persistent-memory setting.
+        """
+        from scilink.skills._shared import _script_bank
+        if not _script_bank.bank_enabled():
+            return []
+
+        banked: list = []
+        try:
+            bankable = [
+                rec for rec in records
+                if rec.get("script") and (rec.get("quality_history") or {}).get("approved")
+            ]
+            if not bankable:
+                return []
+
+            from .metadata_converter import resolve_axis_spec
+
+            si = self._handle_system_info(system_info)
+            active_skills = [
+                s.get("name") for s in (skill_state or {}).get("skills_loaded", [])
+                if isinstance(s, dict)
+            ]
+
+            fingerprint = None
+            try:
+                cube = self._load_hyperspectral_data(data_path)
+                axis_2 = resolve_axis_spec(si)["axis_2"]
+                e = cube.shape[-1]
+                if "start" in axis_2 and "end" in axis_2:
+                    axis = np.linspace(axis_2["start"], axis_2["end"], e)
+                    axis_units = axis_2.get("units", "arbitrary units")
+                else:
+                    axis, axis_units = np.arange(e), "channels"
+                fingerprint = _script_bank.hyperspectral_fingerprint(
+                    cube, axis, axis_units
+                )
+            except Exception as e:  # noqa: BLE001 - fingerprint is best-effort
+                self.logger.warning(f"Bank fingerprint skipped: {e}")
+
+            context = _script_bank.measurement_context(si)
+            seen_hashes = set()
+            for rec in bankable:
+                h = _script_bank.script_hash(rec["script"])
+                if h in seen_hashes:
+                    continue
+                seen_hashes.add(h)
+                qh = rec.get("quality_history") or {}
+                frac = qh.get("final_passed_fraction")
+                res = _script_bank.add_record("hyperspectral", {
+                    "technique_signals": {
+                        "active_skills": active_skills,
+                        "analysis_target": rec.get("target"),
+                    },
+                    "measurement_context": context,
+                    "data_fingerprint": fingerprint,
+                    "outcome": {
+                        "analysis_target": rec.get("target"),
+                        "required_outputs": rec.get("required_outputs"),
+                        "metric": ({"name": "passed_fraction", "value": round(float(frac), 4)}
+                                   if isinstance(frac, (int, float)) else None),
+                    },
+                    "provenance": {"session": self.output_dir.name,
+                                   "data_file": os.path.basename(str(data_path))},
+                    "working_script": rec["script"],
+                })
+                if res.get("id"):
+                    banked.append(res["id"])
+                    self.logger.info(
+                        f"   🏦 Banked script [{res['action']}] id={res['id']}"
+                    )
+        except Exception as e:  # noqa: BLE001 - banking never affects results
+            self.logger.warning(f"Script banking skipped: {e}")
+        return banked
 
     def _auto_select_skills(self, system_info, hint=None, custom_skills=None) -> list:
         """Pick relevant hyperspectral skill(s) from the metadata.

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -969,22 +969,31 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                     continue
                 script = r.get("script")
                 qh = r.get("quality_history") or {}
-                if not script or not qh.get("approved"):
+                # Quality gate: QC approval, or the reuse fast path's own
+                # gate — a reused script passing on NEW data is exactly the
+                # cross-session success signal the bank counts.
+                passed = (qh.get("approved")
+                          or (r.get("reuse_validity") or {}).get("verdict") == "good")
+                if not script or not passed:
                     continue
                 h = _script_bank.script_hash(script)
                 if h in seen_hashes:  # locked-recipe series: bank once per run
                     continue
                 seen_hashes.add(h)
 
-                fingerprint = None
-                img = None
-                idx = r.get("index")
-                if stack is not None and idx is not None and 0 <= idx < len(stack):
-                    img = np.asarray(stack[idx])
-                if img is not None and img.ndim >= 2:
-                    fingerprint = _script_bank.image_fingerprint(
-                        img, pixel_size_nm=resolve_pixel_size_nm(system_info, img.shape)
-                    )
+                # Prefer the fingerprint stamped where the image was in scope
+                # (file inputs load per image inside the controller); the
+                # stack fallback covers array inputs.
+                fingerprint = r.get("_bank_fingerprint")
+                if fingerprint is None:
+                    img = None
+                    idx = r.get("index")
+                    if stack is not None and idx is not None and 0 <= idx < len(stack):
+                        img = np.asarray(stack[idx])
+                    if img is not None and img.ndim >= 2:
+                        fingerprint = _script_bank.image_fingerprint(
+                            img, pixel_size_nm=resolve_pixel_size_nm(system_info, img.shape)
+                        )
 
                 score = qh.get("final_score")
                 res = _script_bank.add_record("image_analysis", {

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -260,6 +260,9 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # start higher (e.g. hot) so it does not re-obey early constraint stages
         # a prior run already found inadequate.
         starting_annealing_level: Optional[int] = None,
+        # Operating profile (#346): plumbed for parity with the curve agent;
+        # the realtime toggles are wired for curve only in v1 — see below.
+        profile: Optional[Any] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """
@@ -447,6 +450,19 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 self.logger.info(
                     f"   🏷️  Recovered embedded metadata from {Path(image_paths[0]).name}"
                 )
+
+        # Operating profile (#346): accepted for surface parity; realtime
+        # toggles are wired for the curve agent only in v1 (image lacks a
+        # deterministic per-frame gate metric — a design decision to make
+        # before a zero-LLM image frame is honest). Thorough is unaffected.
+        from ._qc_profile import resolve_profile
+        qc_profile = resolve_profile(profile)
+        if qc_profile.name == "realtime":
+            self.logger.warning(
+                "profile='realtime' is not wired for image analysis yet "
+                "(no deterministic per-frame gate metric); running under "
+                "the thorough profile."
+            )
 
         # Build initial state
         state = {

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -657,6 +657,12 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         if fb_staged:
             final_results.setdefault("staged_solutions", []).extend(fb_staged)
 
+        # Bank every approved working script as episodic memory (script bank,
+        # #346) — deterministic, no LLM, failure-isolated.
+        banked = self._maybe_bank_scripts(tier1_state)
+        if banked:
+            final_results["banked_scripts"] = banked
+
         # Save final merged results
         results_path = self.output_dir / "analysis_results.json"
         with open(results_path, "w") as f:
@@ -932,6 +938,83 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 f"`scilink memory staged`."
             )
         return staged
+
+    def _maybe_bank_scripts(self, state: dict) -> List[str]:
+        """Bank every approved working script in the script bank (#346).
+
+        Image-side mirror of ``CurveFittingAgent._maybe_bank_scripts``:
+        episodic complement to T=2 staging — no hot/novelty gate, no LLM.
+        Each distinct approved script is stored once per run with the
+        measurement context, a fingerprint of the image it solved, and the
+        outcome. Fully failure-isolated; gated by ``SCILINK_SCRIPT_BANK`` /
+        persistent-memory setting.
+        """
+        from scilink.skills._shared import _script_bank
+        if not _script_bank.bank_enabled():
+            return []
+
+        banked: List[str] = []
+        try:
+            from .controllers.image_analysis_controllers import _active_skill_names
+            from scilink.skills._shared.image_analysis_tools import resolve_pixel_size_nm
+
+            approach = state.get("analysis_approach")
+            active_skills = _active_skill_names(state)
+            system_info = state.get("system_info") or {}
+            stack = state.get("image_stack")
+            seen_hashes = set()
+
+            for r in state.get("series_results", []) or []:
+                if not r.get("success"):
+                    continue
+                script = r.get("script")
+                qh = r.get("quality_history") or {}
+                if not script or not qh.get("approved"):
+                    continue
+                h = _script_bank.script_hash(script)
+                if h in seen_hashes:  # locked-recipe series: bank once per run
+                    continue
+                seen_hashes.add(h)
+
+                fingerprint = None
+                img = None
+                idx = r.get("index")
+                if stack is not None and idx is not None and 0 <= idx < len(stack):
+                    img = np.asarray(stack[idx])
+                if img is not None and img.ndim >= 2:
+                    fingerprint = _script_bank.image_fingerprint(
+                        img, pixel_size_nm=resolve_pixel_size_nm(system_info, img.shape)
+                    )
+
+                score = qh.get("final_score")
+                res = _script_bank.add_record("image_analysis", {
+                    "technique_signals": {
+                        "active_skills": active_skills,
+                        "analysis_type": r.get("analysis_type") or approach,
+                    },
+                    "measurement_context": _script_bank.measurement_context(system_info),
+                    "data_fingerprint": fingerprint,
+                    "outcome": {
+                        "analysis_type": r.get("analysis_type"),
+                        "metric": ({"name": "quality_score", "value": round(float(score), 4)}
+                                   if isinstance(score, (int, float)) else None),
+                        "plan_summary": approach,
+                    },
+                    "provenance": {"session": self.output_dir.name,
+                                   "item": r.get("name"),
+                                   "data_file": os.path.basename(
+                                       str((state.get("image_paths") or [None])[0] or "")
+                                   ) or None},
+                    "working_script": script,
+                })
+                if res.get("id"):
+                    banked.append(res["id"])
+                    self.logger.info(
+                        f"   🏦 Banked script [{res['action']}] id={res['id']}"
+                    )
+        except Exception as e:
+            self.logger.warning(f"Script banking skipped: {e}")
+        return banked
 
     def _maybe_stage_feedback_errors(self, state: dict, final_results: dict) -> List[str]:
         """Image-side mirror of the feedback/error staging hook (see the curve-

--- a/scilink/agents/exp_agents/pipelines/curve_fitting_pipelines.py
+++ b/scilink/agents/exp_agents/pipelines/curve_fitting_pipelines.py
@@ -64,6 +64,7 @@ def create_unified_curve_fitting_pipeline(
     max_verification_iterations: int = 7,
     parallel_workers: int | None = None,
     load_skills_fn: Callable | None = None,
+    profile: str | None = None,
 ) -> List:
     """
     Factory function to create the unified curve fitting pipeline.
@@ -133,6 +134,49 @@ def create_unified_curve_fitting_pipeline(
     Returns:
         List of controller instances to execute in sequence
     """
+    # REALTIME profile (#346 step 3): the per-frame in-situ pipeline. Every
+    # LLM stage is omitted — no skill suggestion, planning, plan validation,
+    # literature, adaptive refit, trend, or synthesis. The locked config is
+    # seeded from the anchor run by the agent before the pipeline starts, and
+    # the series controller's reuse path executes the locked script under the
+    # arithmetic gate (verification is bypassed via
+    # max_verification_iterations=0). Zero LLM calls on the happy path; the
+    # fallback (prior script cannot execute) costs a single generation.
+    if profile == "realtime":
+        realtime_pipeline = [
+            AnalyzeDataController(logger, plot_fn),
+            UnifiedSeriesProcessingController(
+                model=model,
+                logger=logger,
+                generation_config=generation_config,
+                safety_settings=safety_settings,
+                parse_fn=parse_fn,
+                executor=executor,
+                script_instructions=FITTING_SCRIPT_INSTRUCTIONS,
+                correction_instructions=FITTING_SCRIPT_CORRECTION_INSTRUCTIONS,
+                quality_instructions=FIT_QUALITY_ASSESSMENT_INSTRUCTIONS,
+                output_dir=output_dir,
+                plot_fn=plot_fn,
+                r2_threshold=r2_threshold,
+                max_model_retries=max_model_retries,
+                enable_human_feedback=False,
+                outlier_sigma=outlier_sigma,
+                max_verification_iterations=0,
+                conformance_instructions=None,
+                parallel_workers=parallel_workers,
+                replanner=None,
+            ),
+            StoreAnalysisResultsController(logger, store_fn),
+            GenerateCurveFittingReportController(
+                logger, output_dir, r2_threshold=r2_threshold),
+            UnifiedCurveReportController(logger, output_dir),
+        ]
+        logger.info(
+            f"Realtime curve pipeline created: {len(realtime_pipeline)} steps "
+            f"(zero-LLM happy path)"
+        )
+        return realtime_pipeline
+
     pipeline = []
 
     # Step 1: Analyze first spectrum data (compute stats, initial plot)

--- a/scilink/skills/_shared/_script_bank.py
+++ b/scilink/skills/_shared/_script_bank.py
@@ -109,6 +109,10 @@ def add_record(domain: str, record: Dict[str, Any], *, root: Optional[Path] = No
 
     if existing is not None:
         rec, path = existing
+        # Backfill matching tiers an earlier write couldn't compute.
+        for key in ("data_fingerprint", "measurement_context", "technique_signals"):
+            if not rec.get(key) and record.get(key):
+                rec[key] = record[key]
         stats = rec.setdefault("stats", {"n_successes": 1, "n_retrievals": 0})
         stats["n_successes"] = int(stats.get("n_successes", 1)) + 1
         sessions = rec.setdefault("sessions", [])

--- a/scilink/skills/_shared/_script_bank.py
+++ b/scilink/skills/_shared/_script_bank.py
@@ -632,6 +632,32 @@ def mark_retrieved(domain: str, rid: str, *, root: Optional[Path] = None) -> Non
         pass
 
 
+def record_success(domain: str, rid: str, session: Optional[str] = None,
+                   *, root: Optional[Path] = None) -> None:
+    """Bump a record's cross-session success stats without re-banking.
+
+    For verbatim cold-start wins (#346 step 4): the banked script passed the
+    arithmetic gate on NEW data — exactly the "keeps passing on new data"
+    evidence the graduation signal counts — but the run itself is a realtime
+    frame and does not go through the write hook. One call per campaign.
+    Never raises.
+    """
+    try:
+        f = _domain_dir(domain, root=root) / f"{rid}.json"
+        rec = json.loads(f.read_text())
+        stats = rec.setdefault("stats", {})
+        stats["n_successes"] = int(stats.get("n_successes", 1)) + 1
+        if session:
+            sessions = rec.setdefault("sessions", [])
+            if session not in sessions:
+                sessions.append(session)
+                del sessions[:-_MAX_SESSIONS]
+        rec["updated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        f.write_text(json.dumps(rec, indent=2, default=str))
+    except Exception:
+        pass
+
+
 def render_exemplar_block(match: Dict[str, Any]) -> str:
     """LLM-facing prompt block offering a retrieved script as an exemplar.
 

--- a/scilink/skills/_shared/_script_bank.py
+++ b/scilink/skills/_shared/_script_bank.py
@@ -1,0 +1,445 @@
+"""Script bank — episodic memory of successful analysis scripts.
+
+Every approved analysis already produces a working script; without the bank
+that history is inert unless the user hand-points ``prior_analysis_paths`` at
+a specific run, or a rare hot success goes through the skill-graduation
+ceremony. The bank makes all of it retrievable: on every approved result the
+agents append a record here, and at analysis time the bank can be searched so
+a proven script is *adapted* instead of re-implemented from scratch.
+
+This is episodic memory alongside graduation's semantic memory: every
+success, zero ceremony (no distillation, no review gate). A record carries
+three tiers of matching signal, all computed deterministically at write time
+(no LLM):
+
+1. **Measurement context** — instrument / technique / sample / conditions,
+   trimmed from the run's metadata.
+2. **Data fingerprint** — numeric summary of the data the script actually
+   solved (axis range, peaks, SNR, …), so retrieval can say "this NEW
+   spectrum looks like the one this script solved" even when sample names
+   differ.
+3. **Outcome** — the verbatim script, model/pipeline type, gate metric,
+   plan summary, session provenance.
+
+Records live at ``scilink_home()/script_bank/<domain>/<id>.json`` — a sibling
+of ``graduated_skills/`` and ``distill_staging/``, honoring ``$SCILINK_HOME``.
+Re-banking the same script (hash match) updates the existing record's usage
+stats instead of duplicating it; those stats (how often a script keeps
+succeeding across sessions) are the intended evidence-based promotion signal
+for skill graduation.
+
+The module is package-neutral: stdlib + numpy/scipy (both hard deps), no
+``ase``, no agent imports.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from ..loader import scilink_home, memory_enabled, _TRUTHY, _FALSY
+from ._graduation import safe_path_component, warn_if_ephemeral_store
+
+
+def bank_dir() -> Path:
+    """Root of the script bank (honors ``$SCILINK_HOME``)."""
+    return scilink_home() / "script_bank"
+
+
+def bank_enabled() -> bool:
+    """Whether the bank write hooks are active.
+
+    ``SCILINK_SCRIPT_BANK`` overrides in both directions (so the bank can run
+    without the full persistent-memory feature, e.g. for real-time reuse, or
+    be switched off while memory stays on); otherwise it follows the
+    persistent-memory master switch.
+    """
+    flag = os.environ.get("SCILINK_SCRIPT_BANK", "").strip().lower()
+    if flag in _FALSY:
+        return False
+    if flag in _TRUTHY:
+        return True
+    return memory_enabled()
+
+
+def _domain_dir(domain: str, *, root: Optional[Path] = None) -> Path:
+    # domain is a filesystem component — sanitize to prevent path traversal.
+    return (root or bank_dir()) / safe_path_component(domain, fallback="unknown_domain")
+
+
+def script_hash(script: str) -> str:
+    """Content hash identifying a script up to trailing whitespace."""
+    normalized = "\n".join(line.rstrip() for line in (script or "").strip().splitlines())
+    return hashlib.sha1(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+# ──────────────────────────────────────────────────────────────
+# CRUD
+# ──────────────────────────────────────────────────────────────
+
+# A locked-recipe series banks once per run; sessions accumulate across runs.
+_MAX_SESSIONS = 20
+
+
+def add_record(domain: str, record: Dict[str, Any], *, root: Optional[Path] = None) -> Dict[str, Any]:
+    """Bank one successful script; return ``{"id", "action"}``.
+
+    ``record`` must carry ``working_script``; everything else (context,
+    fingerprint, outcome fields) is stored as given. If a record with the
+    same script hash already exists in the domain, its usage stats are
+    updated (``n_successes``, ``sessions``, best metric) instead of writing a
+    duplicate — call this once per distinct script per run so ``n_successes``
+    counts runs, not items in a series.
+    """
+    script = (record.get("working_script") or "").strip()
+    if not script:
+        return {"id": None, "action": "skipped_no_script"}
+    h = script_hash(script)
+
+    existing = _find_by_hash(domain, h, root=root)
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    session = (record.get("provenance") or {}).get("session")
+    metric = (record.get("outcome") or {}).get("metric")
+
+    if existing is not None:
+        rec, path = existing
+        stats = rec.setdefault("stats", {"n_successes": 1, "n_retrievals": 0})
+        stats["n_successes"] = int(stats.get("n_successes", 1)) + 1
+        sessions = rec.setdefault("sessions", [])
+        if session and session not in sessions:
+            sessions.append(session)
+            del sessions[:-_MAX_SESSIONS]
+        if metric is not None:
+            rec.setdefault("outcome", {})["last_metric"] = metric
+            best = rec["outcome"].get("best_metric") or rec["outcome"].get("metric")
+            if _metric_value(metric) is not None and (
+                _metric_value(best) is None or _metric_value(metric) > _metric_value(best)
+            ):
+                rec["outcome"]["best_metric"] = metric
+        rec["updated_at"] = now
+        path.write_text(json.dumps(rec, indent=2, default=str))
+        return {"id": rec["id"], "action": "updated"}
+
+    warn_if_ephemeral_store()
+    d = _domain_dir(domain, root=root)
+    d.mkdir(parents=True, exist_ok=True)
+    rid = uuid.uuid4().hex[:8]
+    payload = {
+        "id": rid,
+        "domain": domain,
+        "script_hash": h,
+        "created_at": now,
+        "sessions": [session] if session else [],
+        "stats": {"n_successes": 1, "n_retrievals": 0},
+        **record,
+    }
+    (d / f"{rid}.json").write_text(json.dumps(payload, indent=2, default=str))
+    return {"id": rid, "action": "created"}
+
+
+def _metric_value(metric: Any) -> Optional[float]:
+    if isinstance(metric, dict):
+        metric = metric.get("value")
+    try:
+        v = float(metric)
+        return v if np.isfinite(v) else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _find_by_hash(domain: str, h: str, *, root: Optional[Path] = None):
+    d = _domain_dir(domain, root=root)
+    if not d.is_dir():
+        return None
+    for f in sorted(d.glob("*.json")):
+        try:
+            rec = json.loads(f.read_text())
+        except Exception:
+            continue
+        if rec.get("script_hash") == h:
+            return rec, f
+    return None
+
+
+def list_records(domain: Optional[str] = None, *, root: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Return bank records, optionally filtered by domain."""
+    base = root or bank_dir()
+    out: List[Dict[str, Any]] = []
+    if not base.is_dir():
+        return out
+    domains = [base / domain] if domain else [
+        p for p in sorted(base.iterdir())
+        if p.is_dir() and not p.name.startswith((".", "_"))
+    ]
+    for dd in domains:
+        if not dd.is_dir():
+            continue
+        for f in sorted(dd.glob("*.json")):
+            try:
+                rec = json.loads(f.read_text())
+            except Exception:
+                continue
+            rec.setdefault("domain", dd.name)
+            out.append(rec)
+    return out
+
+
+def get_record(domain: str, rid: str, *, root: Optional[Path] = None) -> Optional[Dict[str, Any]]:
+    f = _domain_dir(domain, root=root) / f"{rid}.json"
+    if not f.exists():
+        return None
+    try:
+        return json.loads(f.read_text())
+    except Exception:
+        return None
+
+
+def remove_records(domain: str, ids: List[str], *, root: Optional[Path] = None) -> int:
+    """Delete bank records by id; return count removed."""
+    d = _domain_dir(domain, root=root)
+    n = 0
+    for rid in ids:
+        f = d / f"{rid}.json"
+        if f.exists():
+            f.unlink()
+            n += 1
+    return n
+
+
+# ──────────────────────────────────────────────────────────────
+# Tier 1 — measurement context (trimmed metadata)
+# ──────────────────────────────────────────────────────────────
+
+_CTX_MAX_FIELDS = 40
+_CTX_MAX_CHARS = 300
+
+
+def measurement_context(system_info: Any) -> Dict[str, Any]:
+    """Trim run metadata into a compact, JSON-safe matching record.
+
+    Keeps scalar fields (and short lists) up to a size cap; nested dicts are
+    flattened one level with dotted keys. Free-form — whatever the user's
+    metadata names (instrument, technique, sample, conditions) is what
+    retrieval will soft-match on.
+    """
+    out: Dict[str, Any] = {}
+    if isinstance(system_info, str):
+        return {"description": system_info[:_CTX_MAX_CHARS * 4]}
+    if not isinstance(system_info, dict):
+        return out
+
+    def _clip(v: Any) -> Any:
+        if isinstance(v, str):
+            return v[:_CTX_MAX_CHARS]
+        if isinstance(v, (int, float, bool)) or v is None:
+            return v
+        if isinstance(v, (list, tuple)) and len(v) <= 12:
+            return [_clip(x) for x in v]
+        return str(v)[:_CTX_MAX_CHARS]
+
+    for key, value in system_info.items():
+        if len(out) >= _CTX_MAX_FIELDS:
+            break
+        if isinstance(value, dict):
+            for k2, v2 in value.items():
+                if len(out) >= _CTX_MAX_FIELDS:
+                    break
+                out[f"{key}.{k2}"] = _clip(v2)
+        else:
+            out[str(key)] = _clip(value)
+    return out
+
+
+_X_UNIT_KEYS = ("x_units", "x_unit", "axis_units", "x_axis_units",
+                "xlabel", "x_label", "units")
+
+
+def guess_x_units(system_info: Any) -> Optional[str]:
+    """Best-effort x-axis units from free-form metadata (retrieval hard-filter)."""
+    if isinstance(system_info, dict):
+        for key in _X_UNIT_KEYS:
+            v = system_info.get(key)
+            if isinstance(v, str) and v.strip():
+                return v.strip()[:40]
+    return None
+
+
+# ──────────────────────────────────────────────────────────────
+# Tier 2 — data fingerprints (deterministic, numpy/scipy only)
+# ──────────────────────────────────────────────────────────────
+
+def _r(v: Any, nd: int = 4) -> Optional[float]:
+    try:
+        f = float(v)
+        return round(f, nd) if np.isfinite(f) else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _peak_summary(x: np.ndarray, y: np.ndarray, k: int = 5) -> Dict[str, Any]:
+    """Robust peak census of a 1D signal: count + top-k positions/widths.
+
+    The signal is lightly smoothed and the prominence threshold adapts to its
+    own point-to-point noise (reduced by the smoothing window), so the census
+    is stable across intensity scales and noise levels; positions/widths are
+    in x-axis units.
+    """
+    from scipy.ndimage import uniform_filter1d
+    from scipy.signal import find_peaks, peak_widths
+
+    x = np.asarray(x, dtype=float).ravel()
+    y = np.asarray(y, dtype=float).ravel()
+    finite = np.isfinite(x) & np.isfinite(y)
+    x, y = x[finite], y[finite]
+    if x.size < 8:
+        return {"count": 0, "top": []}
+
+    lo, hi = np.percentile(y, [0.5, 99.5])
+    rng = float(hi - lo)
+    if rng <= 0:
+        return {"count": 0, "top": []}
+    yn = (y - lo) / rng
+    # Per-point noise from first differences (signal varies slowly; noise doesn't).
+    noise = float(np.median(np.abs(np.diff(yn)))) / np.sqrt(2)
+    window = max(3, y.size // 400)
+    ys = uniform_filter1d(yn, window)
+    # 12σ post-smoothing threshold: exact peak counts across noise levels on
+    # synthetic benchmarks (3-peak clean+noisy, 12-peak crowded, weak shoulder).
+    prominence = max(0.05, 12.0 * noise / np.sqrt(window))
+    distance = max(2, y.size // 200)
+    peaks, props = find_peaks(ys, prominence=prominence, distance=distance)
+    if peaks.size == 0:
+        return {"count": 0, "top": []}
+
+    widths_samples = peak_widths(ys, peaks, rel_height=0.5)[0]
+    dx = float(np.median(np.abs(np.diff(x)))) if x.size > 1 else 1.0
+    order = np.argsort(props["prominences"])[::-1][:k]
+    top = [
+        {
+            "position": _r(x[peaks[i]]),
+            "fwhm": _r(widths_samples[i] * dx),
+            "prominence": _r(props["prominences"][i], 3),
+        }
+        for i in order
+    ]
+    return {"count": int(peaks.size), "top": top}
+
+
+def _snr_estimate(y: np.ndarray) -> Optional[float]:
+    """(p99 − p50) over first-difference noise, capped — scale-free SNR."""
+    y = np.asarray(y, dtype=float).ravel()
+    y = y[np.isfinite(y)]
+    if y.size < 8:
+        return None
+    noise = float(np.median(np.abs(np.diff(y)))) / np.sqrt(2)
+    if noise <= 0:
+        return 1000.0
+    p50, p99 = np.percentile(y, [50, 99])
+    return _r(min(float(p99 - p50) / noise, 1000.0), 1)
+
+
+def curve_fingerprint(x: Any, y: Any, x_units: Optional[str] = None) -> Dict[str, Any]:
+    """Fingerprint of a 1D curve: what a banked script actually solved."""
+    x = np.asarray(x, dtype=float).ravel()
+    y = np.asarray(y, dtype=float).ravel()
+    n = min(x.size, y.size)
+    x, y = x[:n], y[:n]
+    fp: Dict[str, Any] = {"kind": "curve", "n_points": int(n)}
+    if n == 0:
+        return fp
+    fp["x_units"] = x_units
+    fp["x_range"] = [_r(np.nanmin(x)), _r(np.nanmax(x))]
+    fp["snr"] = _snr_estimate(y)
+    fp["peaks"] = _peak_summary(x, y)
+    # Baseline character: net drift + where the median sits in the dynamic
+    # range (≈0 for peaks-on-flat-floor, ≈0.5 for oscillatory/step data).
+    yf = y[np.isfinite(y)]
+    if yf.size >= 10:
+        lo, hi = np.percentile(yf, [0.5, 99.5])
+        rng = float(hi - lo)
+        if rng > 0:
+            tail = max(1, yf.size // 10)
+            drift = (np.median(yf[-tail:]) - np.median(yf[:tail])) / rng
+            fp["baseline"] = {
+                "drift": _r(drift, 3),
+                "median_level": _r((np.median(yf) - lo) / rng, 3),
+            }
+    return fp
+
+
+def image_fingerprint(image: Any, pixel_size_nm: Optional[float] = None) -> Dict[str, Any]:
+    """Fingerprint of a 2D image: scale, contrast, edges, periodicity."""
+    img = np.asarray(image, dtype=float)
+    if img.ndim == 3:  # collapse channels
+        img = img.mean(axis=-1)
+    fp: Dict[str, Any] = {"kind": "image", "shape": [int(s) for s in img.shape]}
+    if img.ndim != 2 or img.size == 0:
+        return fp
+    fp["pixel_size_nm"] = _r(pixel_size_nm) if pixel_size_nm else None
+
+    finite = img[np.isfinite(img)]
+    if finite.size == 0:
+        return fp
+    p1, p50, p99 = np.percentile(finite, [1, 50, 99])
+    rng = float(p99 - p1)
+    fp["intensity"] = {
+        "p1": _r(p1), "p50": _r(p50), "p99": _r(p99),
+        "contrast": _r(float(np.std(finite)) / rng, 3) if rng > 0 else None,
+    }
+
+    # Downsample deterministically to bound cost on large frames.
+    step = max(1, max(img.shape) // 512)
+    small = np.nan_to_num(img[::step, ::step], nan=float(p50))
+    if rng > 0 and min(small.shape) >= 16:
+        gy, gx = np.gradient(small)
+        fp["edge_density"] = _r(float(np.mean(np.hypot(gx, gy))) / rng, 4)
+        # Periodicity: strongest non-DC ring of the radial power spectrum vs
+        # its median — high for lattices/gratings, ~1 for texture-free noise.
+        f = np.abs(np.fft.rfft2(small - small.mean())) ** 2
+        f[0, 0] = 0.0
+        ky = np.fft.fftfreq(small.shape[0])[:, None]
+        kx = np.fft.rfftfreq(small.shape[1])[None, :]
+        kr = np.hypot(ky, kx)
+        nbins = 32
+        bins = np.minimum((kr / (kr.max() or 1.0) * nbins).astype(int), nbins - 1)
+        ring = np.array([f[bins == b].mean() if np.any(bins == b) else 0.0
+                         for b in range(1, nbins)])
+        med = float(np.median(ring[ring > 0])) if np.any(ring > 0) else 0.0
+        fp["fft_periodicity"] = _r(float(ring.max()) / med, 2) if med > 0 else None
+    return fp
+
+
+def hyperspectral_fingerprint(cube: Any, axis: Any = None,
+                              axis_units: Optional[str] = None,
+                              n_bands: int = 16) -> Dict[str, Any]:
+    """Fingerprint of a 3D datacube via its field-mean spectrum."""
+    data = np.asarray(cube, dtype=float)
+    fp: Dict[str, Any] = {"kind": "hyperspectral",
+                          "shape": [int(s) for s in data.shape]}
+    if data.ndim != 3 or data.size == 0:
+        return fp
+    e = data.shape[-1]
+    if axis is None:
+        axis = np.arange(e)
+        axis_units = axis_units or "channels"
+    axis = np.asarray(axis, dtype=float).ravel()[:e]
+    fp["axis"] = {"units": axis_units,
+                  "start": _r(axis[0]), "end": _r(axis[-1]), "n_channels": int(e)}
+
+    mean_spec = np.nanmean(data.reshape(-1, e), axis=0)
+    peak = float(np.nanmax(mean_spec))
+    if peak > 0:
+        edges = np.linspace(0, e, n_bands + 1).astype(int)
+        fp["band_means"] = [
+            _r(float(np.nanmean(mean_spec[a:b])) / peak, 3) if b > a else None
+            for a, b in zip(edges[:-1], edges[1:])
+        ]
+    fp["snr"] = _snr_estimate(mean_spec)
+    fp["peaks"] = _peak_summary(axis, mean_spec)
+    return fp

--- a/scilink/skills/_shared/_script_bank.py
+++ b/scilink/skills/_shared/_script_bank.py
@@ -419,6 +419,252 @@ def image_fingerprint(image: Any, pixel_size_nm: Optional[float] = None) -> Dict
     return fp
 
 
+# ──────────────────────────────────────────────────────────────
+# Retrieval — adapt-mode exemplar lookup (deterministic v1)
+#
+# Ranking = fingerprint similarity (dominant) + context token overlap +
+# a small cross-session usage bonus. A single best match above the score
+# floor is offered to the FIRST codegen attempt as an exemplar to adapt;
+# the verification loop backstops a wrong pick and the annealing hot
+# script-drop keeps a bad exemplar from trapping the loop.
+# ──────────────────────────────────────────────────────────────
+
+_MIN_EXEMPLAR_SCORE = 0.45
+
+
+def _interval_overlap(a: Any, b: Any) -> float:
+    """Jaccard overlap of two [lo, hi] intervals (0 when unknown)."""
+    try:
+        a0, a1 = sorted(float(v) for v in a)
+        b0, b1 = sorted(float(v) for v in b)
+    except (TypeError, ValueError):
+        return 0.0
+    inter = max(0.0, min(a1, b1) - max(a0, b0))
+    union = max(a1, b1) - min(a0, b0)
+    if union <= 0:
+        return 1.0 if a0 == b0 else 0.0
+    return inter / union
+
+
+def _peak_positions(fp: Dict[str, Any]):
+    return [(p.get("position"), p.get("fwhm"))
+            for p in (fp.get("peaks") or {}).get("top", [])
+            if p.get("position") is not None]
+
+
+def _peak_match(fp_a: Dict[str, Any], fp_b: Dict[str, Any]) -> float:
+    """Symmetric fraction of top peaks matched within a width-aware tolerance."""
+    pa, pb = _peak_positions(fp_a), _peak_positions(fp_b)
+    ca = (fp_a.get("peaks") or {}).get("count", len(pa)) or 0
+    cb = (fp_b.get("peaks") or {}).get("count", len(pb)) or 0
+    if ca == 0 and cb == 0:
+        return 1.0  # two featureless signals match
+    if not pa or not pb:
+        return 0.0
+    try:
+        span = abs(float(fp_a["x_range"][1]) - float(fp_a["x_range"][0]))
+    except (TypeError, ValueError, KeyError, IndexError):
+        span = abs(max(p for p, _ in pa) - min(p for p, _ in pa)) or 1.0
+
+    def _frac(src, dst):
+        hit = 0
+        for pos, fwhm in src:
+            tol = max(fwhm or 0.0, 0.01 * span)
+            if any(abs(pos - q) <= max(tol, qw or 0.0) for q, qw in dst):
+                hit += 1
+        return hit / len(src)
+
+    return 0.5 * (_frac(pa, pb) + _frac(pb, pa))
+
+
+def _count_similarity(na: Any, nb: Any) -> float:
+    try:
+        na, nb = int(na), int(nb)
+    except (TypeError, ValueError):
+        return 0.0
+    if na == 0 and nb == 0:
+        return 1.0
+    if na == 0 or nb == 0:
+        return 0.0
+    return min(na, nb) / max(na, nb)
+
+
+def _curve_similarity(a: Dict[str, Any], b: Dict[str, Any]) -> float:
+    r = _interval_overlap(a.get("x_range"), b.get("x_range"))
+    pk = _peak_match(a, b)
+    cs = _count_similarity((a.get("peaks") or {}).get("count"),
+                           (b.get("peaks") or {}).get("count"))
+    return 0.35 * r + 0.45 * pk + 0.20 * cs
+
+
+def _log_ratio_sim(a: Any, b: Any, scale: float = 1.0) -> Optional[float]:
+    try:
+        a, b = float(a), float(b)
+    except (TypeError, ValueError):
+        return None
+    if a <= 0 or b <= 0:
+        return 1.0 if a == b else 0.0
+    return float(np.exp(-abs(np.log(a / b)) / scale))
+
+
+def _image_similarity(a: Dict[str, Any], b: Dict[str, Any]) -> float:
+    sims = []
+    ia, ib = a.get("intensity") or {}, b.get("intensity") or {}
+    if ia.get("contrast") is not None and ib.get("contrast") is not None:
+        sims.append(max(0.0, 1.0 - abs(ia["contrast"] - ib["contrast"]) / 0.5))
+    if a.get("edge_density") is not None and b.get("edge_density") is not None:
+        sims.append(max(0.0, 1.0 - abs(a["edge_density"] - b["edge_density"]) / 0.2))
+    s = _log_ratio_sim(a.get("fft_periodicity"), b.get("fft_periodicity"), scale=2.0)
+    if s is not None:
+        sims.append(s)
+    s = _log_ratio_sim(a.get("pixel_size_nm"), b.get("pixel_size_nm"), scale=1.0)
+    if s is not None:
+        sims.append(s)
+    return float(np.mean(sims)) if sims else 0.0
+
+
+def _hs_similarity(a: Dict[str, Any], b: Dict[str, Any]) -> float:
+    ax_a, ax_b = a.get("axis") or {}, b.get("axis") or {}
+    r = _interval_overlap((ax_a.get("start"), ax_a.get("end")),
+                          (ax_b.get("start"), ax_b.get("end")))
+    cos = 0.0
+    ba = [v if v is not None else 0.0 for v in (a.get("band_means") or [])]
+    bb = [v if v is not None else 0.0 for v in (b.get("band_means") or [])]
+    if ba and bb and len(ba) == len(bb):
+        va, vb = np.asarray(ba, float), np.asarray(bb, float)
+        denom = float(np.linalg.norm(va) * np.linalg.norm(vb))
+        if denom > 0:
+            cos = float(np.dot(va, vb) / denom)
+    # Reuse the curve peak matcher over the mean-spectrum census; it reads
+    # x_range for its tolerance span, so alias the axis range.
+    pk = _peak_match({**a, "x_range": [ax_a.get("start"), ax_a.get("end")]}, b)
+    # Damp by range agreement: band_means are range-relative, so an identical
+    # profile in a DISJOINT axis window (a different measurement) would
+    # otherwise score high on cosine alone.
+    return (0.30 * r + 0.40 * cos + 0.30 * pk) * (0.4 + 0.6 * r)
+
+
+_SIMILARITY_FNS = {
+    "curve": _curve_similarity,
+    "image": _image_similarity,
+    "hyperspectral": _hs_similarity,
+}
+
+
+def _context_tokens(*sources: Any) -> set:
+    import re
+    words = set()
+    for src in sources:
+        if isinstance(src, dict):
+            text = " ".join(str(v) for v in src.values())
+        else:
+            text = str(src or "")
+        words.update(w for w in re.findall(r"[a-z0-9]+", text.lower())
+                     if len(w) >= 3)
+    return words
+
+
+def _context_similarity(query: set, rec: Dict[str, Any]) -> float:
+    tokens = _context_tokens(rec.get("measurement_context"),
+                             rec.get("technique_signals"))
+    if not query or not tokens:
+        return 0.0
+    return len(query & tokens) / len(query | tokens)
+
+
+def _units_of(fp: Dict[str, Any]) -> Optional[str]:
+    u = fp.get("x_units") or (fp.get("axis") or {}).get("units")
+    return u.strip().lower() if isinstance(u, str) and u.strip() else None
+
+
+def find_exemplar(domain: str, fingerprint: Optional[Dict[str, Any]],
+                  context: Any = None, *, k: int = 1,
+                  min_score: float = _MIN_EXEMPLAR_SCORE,
+                  root: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Rank bank records against a new dataset; return the top match(es).
+
+    Hard filters: fingerprint kind must match; axis units must agree when
+    both sides declare them. Score = 0.8 × fingerprint similarity + 0.2 ×
+    context token overlap + a small usage bonus (capped at 0.05) for scripts
+    that keep succeeding across sessions. Returns ``[{"record", "score",
+    "fingerprint_score"}, ...]`` above ``min_score`` — empty when nothing in
+    the bank resembles this data (offering a poor exemplar is worse than
+    generating from scratch).
+    """
+    if not fingerprint or not fingerprint.get("kind"):
+        return []
+    kind = fingerprint["kind"]
+    simfn = _SIMILARITY_FNS.get(kind)
+    if simfn is None:
+        return []
+    query_units = _units_of(fingerprint)
+    query_tokens = _context_tokens(context)
+
+    scored = []
+    for rec in list_records(domain, root=root):
+        fp = rec.get("data_fingerprint") or {}
+        if fp.get("kind") != kind or not (rec.get("working_script") or "").strip():
+            continue
+        rec_units = _units_of(fp)
+        if query_units and rec_units and query_units != rec_units:
+            continue
+        s_fp = simfn(fingerprint, fp)
+        s_ctx = _context_similarity(query_tokens, rec)
+        n_succ = (rec.get("stats") or {}).get("n_successes", 1) or 1
+        usage = min(0.05, 0.01 * (int(n_succ) - 1))
+        score = 0.8 * s_fp + 0.2 * s_ctx + usage
+        if score >= min_score:
+            scored.append((score, s_fp, rec))
+    scored.sort(key=lambda t: (-t[0], t[2].get("id", "")))
+    return [{"record": rec, "score": round(sc, 3), "fingerprint_score": round(sfp, 3)}
+            for sc, sfp, rec in scored[:k]]
+
+
+def mark_retrieved(domain: str, rid: str, *, root: Optional[Path] = None) -> None:
+    """Increment a record's retrieval counter (usage stat; never raises)."""
+    try:
+        f = _domain_dir(domain, root=root) / f"{rid}.json"
+        rec = json.loads(f.read_text())
+        stats = rec.setdefault("stats", {})
+        stats["n_retrievals"] = int(stats.get("n_retrievals", 0)) + 1
+        f.write_text(json.dumps(rec, indent=2, default=str))
+    except Exception:
+        pass
+
+
+def render_exemplar_block(match: Dict[str, Any]) -> str:
+    """LLM-facing prompt block offering a retrieved script as an exemplar.
+
+    Shared framing across the agents: the exemplar is a starting point to
+    adapt, dataset-specific values must be re-derived, and the locked plan
+    stays authoritative.
+    """
+    rec = match["record"]
+    outcome = rec.get("outcome") or {}
+    signals = rec.get("technique_signals") or {}
+    what = (signals.get("model_type") or signals.get("analysis_type")
+            or signals.get("analysis_target") or "previous analysis")
+    metric = outcome.get("best_metric") or outcome.get("metric")
+    metric_txt = (f"{metric.get('name')} = {metric.get('value')}"
+                  if isinstance(metric, dict) else "quality gate passed")
+    n_succ = (rec.get("stats") or {}).get("n_successes", 1)
+    return f"""## Reference: proven script from a previous successful analysis (script bank)
+A previous run solved data closely matching this dataset (match score {match['score']}).
+What it did: {str(what)[:300]}
+Result: {metric_txt}; succeeded in {n_succ} session(s).
+
+Use it as a STARTING POINT to adapt: keep its overall structure and vetted
+approach where they fit THIS data, and change whatever does not. Dataset-specific
+values (peak positions/counts, ranges, thresholds) must be re-derived from the
+data at hand — do not copy them. The analysis plan above remains authoritative;
+where the exemplar conflicts with the plan, follow the plan.
+
+```python
+{(rec.get("working_script") or "").strip()}
+```
+"""
+
+
 def hyperspectral_fingerprint(cube: Any, axis: Any = None,
                               axis_units: Optional[str] = None,
                               n_bands: int = 16) -> Dict[str, Any]:

--- a/tests/qc_golden/goldens/curve_realtime_reuse.json
+++ b/tests/qc_golden/goldens/curve_realtime_reuse.json
@@ -1,0 +1,45 @@
+{
+  "llm_calls": [],
+  "result": {
+    "detailed_analysis": "Realtime frame: locked script from 'prior' reused; R² = 0.995; gate verdict: good; drift: none (fingerprint similarity 1.0). Interpretation is deferred to the post-experiment sweep.",
+    "fit_quality": {
+      "r_squared": 0.995,
+      "rmse": 0.01
+    },
+    "fitting_parameters": {
+      "amplitude": 5.0,
+      "center": 4.0,
+      "sigma": 0.8
+    },
+    "literature_files": null,
+    "model_type": "Gaussian + linear background",
+    "output_directory": "<OUTDIR>",
+    "profile": "realtime",
+    "quality_history": {
+      "produced_under_profile": "realtime"
+    },
+    "reuse_validity": {
+      "drift": "none",
+      "fingerprint_similarity": 1.0,
+      "message": "Reused the locked fitting script from prior run 'prior'; R² = 0.9950 meets the acceptance threshold 0.950.",
+      "r_squared": 0.995,
+      "reused": true,
+      "source": "prior",
+      "threshold": 0.95,
+      "verdict": "good"
+    },
+    "scientific_claims": [],
+    "status": "success",
+    "task_mode": "fitting"
+  },
+  "reuse_validity": {
+    "drift": "none",
+    "fingerprint_similarity": 1.0,
+    "message": "Reused the locked fitting script from prior run 'prior'; R² = 0.9950 meets the acceptance threshold 0.950.",
+    "r_squared": 0.995,
+    "reused": true,
+    "source": "prior",
+    "threshold": 0.95,
+    "verdict": "good"
+  }
+}

--- a/tests/qc_golden/test_realtime_golden.py
+++ b/tests/qc_golden/test_realtime_golden.py
@@ -9,6 +9,8 @@ on any call (ScriptedModel with no rules), so a regression that reintroduces
 an LLM call fails here immediately. Regenerate with QC_GOLDEN_UPDATE=1.
 """
 
+import json
+
 import numpy as np
 
 from .fixtures import write_gaussian_spectrum
@@ -223,6 +225,73 @@ def test_realtime_cold_start_broken_candidate_skipped(tmp_path, monkeypatch):
     assert cs.get("n_auditioned") == 2, cs
     assert (result.get("reuse_validity") or {}).get("source") == \
         f"script_bank:{good_id}"
+
+
+def test_degenerate_data_check_unit():
+    """The pre-flight gate is conservative: glitch shapes fail, real and
+    partially-corrupted spectra pass (the correction path salvages those)."""
+    from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+        _degenerate_data_check,
+    )
+    x = np.linspace(0, 100, 500)
+    y = 5 * np.exp(-(x - 50) ** 2 / 9) + np.random.RandomState(0).normal(0, 0.05, 500)
+
+    assert _degenerate_data_check(np.vstack([x, y])) is None  # real spectrum
+    y_nan = y.copy()
+    y_nan[::3] = np.nan  # a third corrupted — recoverable, must pass
+    assert _degenerate_data_check(np.vstack([x, y_nan])) is None
+
+    assert "dynamic range" in _degenerate_data_check(
+        np.vstack([x, np.zeros_like(x)]))          # all-zero
+    assert "finite" in _degenerate_data_check(
+        np.vstack([x[:10], y[:10]]))                # runt
+    assert "finite" in _degenerate_data_check(
+        np.vstack([x, np.full_like(x, np.nan)]))    # all-NaN
+    assert "dynamic range" in _degenerate_data_check(
+        np.vstack([x, np.full_like(x, 7.3)]))       # constant
+
+
+def test_realtime_glitch_frame_gated_zero_llm(tmp_path):
+    """An all-zeros frame under realtime fails in the pre-flight gate:
+    zero LLM calls, no script execution attempts, honest error."""
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+
+    data_dir = tmp_path / "data"
+    prior_dir = tmp_path / "prior"
+    data_dir.mkdir()
+    spectrum = write_gaussian_spectrum(data_dir / "gaussian_peak.csv")
+
+    prior_agent = CurveFittingAgent(
+        output_dir=str(prior_dir), enable_human_feedback=False,
+        use_literature=False,
+    )
+    prior_agent.model = ScriptedModel(curve_rules("happy"))
+    assert prior_agent.analyze(str(spectrum))["status"] == "success"
+
+    x = np.linspace(0, 100, 500)
+    glitch = data_dir / "glitch_zeros.csv"
+    np.savetxt(glitch, np.column_stack([x, np.zeros_like(x)]),
+               delimiter=",", header="x,y", comments="")
+
+    agent = CurveFittingAgent(
+        output_dir=str(tmp_path / "out"), enable_human_feedback=False,
+        use_literature=False,
+    )
+    model = ScriptedModel([])  # fail-loud: ANY LLM call raises
+    agent.model = model
+    result = agent.analyze(
+        str(glitch),
+        profile="realtime",
+        prior_analysis_paths=[str(prior_dir)],
+        reuse_locked_script=True,
+    )
+    assert model.calls == [], f"gated frame made LLM calls: {model.calls}"
+    sr = json.loads(
+        (tmp_path / "out" / "series_fit_results.json").read_text())
+    frame = sr["results"][0]
+    assert frame["success"] is False
+    assert "Pre-flight degenerate-data gate" in frame["error"]
+    assert frame.get("script") is None  # nothing was executed or corrected
 
 
 def test_realtime_drift_flags_changed_data(tmp_path):

--- a/tests/qc_golden/test_realtime_golden.py
+++ b/tests/qc_golden/test_realtime_golden.py
@@ -96,6 +96,135 @@ def test_realtime_requires_locked_recipe(tmp_path):
         agent.analyze(str(spectrum), profile="realtime")
 
 
+def _enable_bank(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCILINK_HOME", str(tmp_path / "scilink_home"))
+    monkeypatch.setenv("SCILINK_SCRIPT_BANK", "1")
+
+
+def test_realtime_cold_start_zero_llm(tmp_path, monkeypatch):
+    """Verbatim cold start (#346 step 4): a realtime run with NO prior
+    auditions bank candidates against the frame; the winner becomes the
+    locked recipe — still zero LLM calls — with source=script_bank:<id>,
+    cold_start surfaced, and the record's cross-session stats bumped once."""
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+    from scilink.skills._shared import _script_bank as sb
+
+    _enable_bank(tmp_path, monkeypatch)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    spectrum = write_gaussian_spectrum(data_dir / "gaussian_peak.csv")
+
+    # Seed the bank via a normal thorough run (write hook does the banking).
+    seed_agent = CurveFittingAgent(
+        output_dir=str(tmp_path / "seed"), enable_human_feedback=False,
+        use_literature=False,
+    )
+    seed_agent.model = ScriptedModel(curve_rules("happy"))
+    seed_result = seed_agent.analyze(str(spectrum))
+    assert seed_result["status"] == "success"
+    assert seed_result.get("banked_scripts"), "seed run must bank its script"
+    rid = seed_result["banked_scripts"][0]
+    assert sb.get_record("curve_fitting", rid)["stats"]["n_successes"] == 1
+
+    # Cold start — no prior, fail-loud model.
+    agent = CurveFittingAgent(
+        output_dir=str(tmp_path / "out"), enable_human_feedback=False,
+        use_literature=False,
+    )
+    model = ScriptedModel([])
+    agent.model = model
+    result = agent.analyze(str(spectrum), profile="realtime")
+
+    assert result["status"] == "success", result.get("error")
+    assert model.calls == [], f"cold start made LLM calls: {model.calls}"
+    assert result.get("profile") == "realtime"
+    rv = result.get("reuse_validity") or {}
+    assert rv.get("reused") is True and rv.get("verdict") == "good", rv
+    assert rv.get("source") == f"script_bank:{rid}", rv
+    assert rv.get("drift") == "none", rv  # same data as the record's origin
+    cs = result.get("cold_start") or {}
+    assert cs.get("id") == rid and cs.get("n_auditioned") == 1, cs
+    # One cross-session success recorded for the winner; the realtime run
+    # itself banked nothing.
+    rec = sb.get_record("curve_fitting", rid)
+    assert rec["stats"]["n_successes"] == 2
+    assert len(sb.list_records("curve_fitting")) == 1
+
+
+def test_realtime_cold_start_no_match_demotes_to_thorough(tmp_path, monkeypatch):
+    """Empty bank → the cold start finds nothing and the run loudly falls
+    back to a thorough anchor (LLM calls happen; no realtime provenance)."""
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+
+    _enable_bank(tmp_path, monkeypatch)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    spectrum = write_gaussian_spectrum(data_dir / "gaussian_peak.csv")
+
+    agent = CurveFittingAgent(
+        output_dir=str(tmp_path / "out"), enable_human_feedback=False,
+        use_literature=False,
+    )
+    model = ScriptedModel(curve_rules("happy"))
+    agent.model = model
+    result = agent.analyze(str(spectrum), profile="realtime")
+
+    assert result["status"] == "success", result.get("error")
+    assert result.get("profile") != "realtime"
+    assert model.calls, "thorough fallback must run the normal LLM pipeline"
+    assert "reuse_validity" not in result
+
+
+def test_realtime_cold_start_broken_candidate_skipped(tmp_path, monkeypatch):
+    """A higher-ranked candidate whose script fails the audition is skipped;
+    the next candidate wins (n_auditioned=2)."""
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+    from scilink.skills._shared import _script_bank as sb
+
+    _enable_bank(tmp_path, monkeypatch)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    spectrum = write_gaussian_spectrum(data_dir / "gaussian_peak.csv")
+
+    # Seed a WORKING record via a thorough run.
+    seed_agent = CurveFittingAgent(
+        output_dir=str(tmp_path / "seed"), enable_human_feedback=False,
+        use_literature=False,
+    )
+    seed_agent.model = ScriptedModel(curve_rules("happy"))
+    seed_result = seed_agent.analyze(str(spectrum))
+    good_id = seed_result["banked_scripts"][0]
+    good_rec = sb.get_record("curve_fitting", good_id)
+
+    # Seed a BROKEN record with the same fingerprint and a usage bonus that
+    # ranks it FIRST (find_exemplar sorts by score).
+    sb.add_record("curve_fitting", {
+        "working_script": "raise RuntimeError('rotted script')",
+        "data_fingerprint": good_rec["data_fingerprint"],
+        "measurement_context": good_rec.get("measurement_context") or {},
+        "technique_signals": good_rec.get("technique_signals") or {},
+        "outcome": {}, "provenance": {"session": "old"},
+    })
+    broken_id = [r["id"] for r in sb.list_records("curve_fitting")
+                 if r["id"] != good_id][0]
+    for s in ("s2", "s3", "s4", "s5"):
+        sb.record_success("curve_fitting", broken_id, session=s)
+
+    agent = CurveFittingAgent(
+        output_dir=str(tmp_path / "out"), enable_human_feedback=False,
+        use_literature=False,
+    )
+    agent.model = ScriptedModel([])
+    result = agent.analyze(str(spectrum), profile="realtime")
+
+    assert result["status"] == "success", result.get("error")
+    cs = result.get("cold_start") or {}
+    assert cs.get("id") == good_id, cs
+    assert cs.get("n_auditioned") == 2, cs
+    assert (result.get("reuse_validity") or {}).get("source") == \
+        f"script_bank:{good_id}"
+
+
 def test_realtime_drift_flags_changed_data(tmp_path):
     """A realtime frame whose data no longer resembles the anchor must flag
     drift='suspected' even when the reused script still fits (the R² gate

--- a/tests/qc_golden/test_realtime_golden.py
+++ b/tests/qc_golden/test_realtime_golden.py
@@ -1,0 +1,141 @@
+"""Golden pin for the realtime profile (#346 step 3).
+
+The contract this pins: a curve frame analyzed under ``profile="realtime"``
+with a reusable prior makes **ZERO LLM calls** — every pipeline stage around
+the reuse fast path (skill suggestion, planning, plan validation, literature,
+verification, synthesis) is skipped — and the result carries the provenance
+stamp plus the fingerprint-drift channel. The model object would fail loudly
+on any call (ScriptedModel with no rules), so a regression that reintroduces
+an LLM call fails here immediately. Regenerate with QC_GOLDEN_UPDATE=1.
+"""
+
+import numpy as np
+
+from .fixtures import write_gaussian_spectrum
+from .harness import (
+    ScriptedModel,
+    check_golden,
+    make_normalizer,
+    normalize_obj,
+)
+from .scenarios import curve_rules
+
+
+def test_curve_realtime_zero_llm_golden(tmp_path):
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+
+    data_dir = tmp_path / "data"
+    prior_dir = tmp_path / "prior"
+    out_dir = tmp_path / "out"
+    data_dir.mkdir()
+    spectrum = write_gaussian_spectrum(data_dir / "gaussian_peak.csv")
+
+    norm = make_normalizer({
+        str(out_dir): "<OUTDIR>", str(prior_dir): "<PRIORDIR>",
+        str(data_dir): "<DATADIR>",
+    })
+
+    # Anchor — one thorough run producing the locked recipe.
+    prior_agent = CurveFittingAgent(
+        output_dir=str(prior_dir), enable_human_feedback=False,
+        use_literature=False,
+    )
+    prior_agent.model = ScriptedModel(curve_rules("happy"), normalizer=norm)
+    prior_result = prior_agent.analyze(str(spectrum))
+    assert prior_result["status"] == "success"
+
+    # Frame — realtime: the model has NO rules, so ANY LLM call fails loudly.
+    agent = CurveFittingAgent(
+        output_dir=str(out_dir), enable_human_feedback=False,
+        use_literature=False,
+    )
+    model = ScriptedModel([], normalizer=norm)
+    agent.model = model
+    result = agent.analyze(
+        str(spectrum),
+        profile="realtime",
+        prior_analysis_paths=[str(prior_dir)],
+        reuse_locked_script=True,
+    )
+
+    assert result["status"] == "success", result.get("error")
+    assert model.calls == [], f"realtime frame made LLM calls: {model.calls}"
+    assert result.get("profile") == "realtime"
+    rv = result.get("reuse_validity")
+    assert rv and rv["reused"] is True and rv["verdict"] == "good", rv
+    # Drift channel present. The anchor run had the bank disabled (no
+    # persisted fingerprint), so the lazy fallback re-reads the anchor's
+    # data file — same file here, so similarity is exactly 1.0.
+    assert rv.get("drift") == "none", rv
+    assert rv.get("fingerprint_similarity") == 1.0, rv
+    # Provenance reaches quality_history for the post-hoc sweep.
+    assert (result.get("quality_history") or {}).get(
+        "produced_under_profile") == "realtime"
+
+    payload = {
+        "llm_calls": [c["rule"] for c in model.calls],  # pinned empty
+        "result": normalize_obj(result, norm),
+        "reuse_validity": normalize_obj(rv, norm),
+    }
+    check_golden("curve_realtime_reuse", payload)
+
+
+def test_realtime_requires_locked_recipe(tmp_path):
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    spectrum = write_gaussian_spectrum(data_dir / "gaussian_peak.csv")
+    agent = CurveFittingAgent(
+        output_dir=str(tmp_path / "out"), enable_human_feedback=False,
+        use_literature=False,
+    )
+    agent.model = ScriptedModel([])
+    import pytest
+    with pytest.raises(ValueError, match="realtime"):
+        agent.analyze(str(spectrum), profile="realtime")
+
+
+def test_realtime_drift_flags_changed_data(tmp_path):
+    """A realtime frame whose data no longer resembles the anchor must flag
+    drift='suspected' even when the reused script still fits (the R² gate
+    alone is blind to this — live-proven on the dehydration series)."""
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+
+    data_dir = tmp_path / "data"
+    prior_dir = tmp_path / "prior"
+    data_dir.mkdir()
+    spectrum = write_gaussian_spectrum(data_dir / "gaussian_peak.csv")
+
+    prior_agent = CurveFittingAgent(
+        output_dir=str(prior_dir), enable_human_feedback=False,
+        use_literature=False,
+    )
+    prior_agent.model = ScriptedModel(curve_rules("happy"))
+    assert prior_agent.analyze(str(spectrum))["status"] == "success"
+
+    # New phase: different peak set in the same window (three peaks vs one).
+    x = np.linspace(0, 100, 500)
+    y = (3.0 * np.exp(-(x - 20) ** 2 / 8)
+         + 2.0 * np.exp(-(x - 65) ** 2 / 12)
+         + 1.5 * np.exp(-(x - 85) ** 2 / 6)
+         + np.random.RandomState(0).normal(0, 0.02, x.size))
+    new_frame = data_dir / "new_phase.csv"
+    np.savetxt(new_frame, np.column_stack([x, y]), delimiter=",",
+               header="x,y", comments="")
+
+    agent = CurveFittingAgent(
+        output_dir=str(tmp_path / "out"), enable_human_feedback=False,
+        use_literature=False,
+    )
+    agent.model = ScriptedModel([])
+    result = agent.analyze(
+        str(new_frame),
+        profile="realtime",
+        prior_analysis_paths=[str(prior_dir)],
+        reuse_locked_script=True,
+    )
+    assert result["status"] == "success", result.get("error")
+    rv = result.get("reuse_validity") or {}
+    assert rv.get("drift") == "suspected", rv
+    assert rv.get("fingerprint_similarity") < 0.92, rv

--- a/tests/test_script_bank.py
+++ b/tests/test_script_bank.py
@@ -176,6 +176,105 @@ class TestBankCRUD:
         assert sb.list_records("curve_fitting") == []
 
 
+class TestRetrieval:
+    def _raman(self, seed=0, shift=0.0, amp=1.0):
+        x = np.linspace(90, 1300, 2400)
+        y = (5 * amp * np.exp(-(x - (142 + shift)) ** 2 / 30)
+             + 3 * np.exp(-(x - (395 + shift)) ** 2 / 120)
+             + 2 * np.exp(-(x - (513 + shift)) ** 2 / 130)
+             + np.random.RandomState(seed).normal(0, 0.05, x.size))
+        return x, y
+
+    def _seed_bank(self):
+        x, y = self._raman(0)
+        sb.add_record("curve_fitting", {
+            "working_script": "# raman exemplar",
+            "data_fingerprint": sb.curve_fingerprint(x, y),
+            "measurement_context": {"technique": "Raman"},
+            "technique_signals": {"model_type": "pseudo-Voigt sum"},
+            "outcome": {"metric": {"name": "r_squared", "value": 0.99}},
+            "provenance": {"session": "s1"},
+        })
+
+    def test_same_family_hits_unrelated_misses(self):
+        self._seed_bank()
+        x, y = self._raman(seed=7, shift=3.0, amp=0.6)  # same bands, new run
+        hit = sb.find_exemplar("curve_fitting", sb.curve_fingerprint(x, y),
+                               {"technique": "Raman"})
+        assert hit and hit[0]["record"]["working_script"] == "# raman exemplar"
+        assert hit[0]["fingerprint_score"] > 0.9
+
+        xd = np.linspace(0, 100, 1500)  # unrelated decay curve
+        yd = 10 * np.exp(-xd / 20) + np.random.RandomState(6).normal(0, 0.02, xd.size)
+        assert sb.find_exemplar("curve_fitting", sb.curve_fingerprint(xd, yd),
+                                {"technique": "TRPL"}) == []
+
+    def test_units_hard_filter(self):
+        self._seed_bank()
+        rec = sb.list_records("curve_fitting")[0]
+        # Give the stored record explicit units; a query in DIFFERENT units
+        # must be filtered out even with a perfect fingerprint.
+        x, y = self._raman(0)
+        fp_ev = sb.curve_fingerprint(x, y, x_units="eV")
+        fp_cm = sb.curve_fingerprint(x, y, x_units="cm-1")
+        rec["data_fingerprint"]["x_units"] = "cm-1"
+        (sb._domain_dir("curve_fitting") / f"{rec['id']}.json").write_text(
+            __import__("json").dumps(rec))
+        assert sb.find_exemplar("curve_fitting", fp_ev) == []
+        assert sb.find_exemplar("curve_fitting", fp_cm)
+
+    def test_usage_stats_break_ties(self):
+        x, y = self._raman(0)
+        fp = sb.curve_fingerprint(x, y)
+        base = {"data_fingerprint": fp, "measurement_context": {"technique": "Raman"},
+                "outcome": {}, "provenance": {"session": "s1"}}
+        fresh = sb.add_record("curve_fitting", {**base, "working_script": "# once"})
+        vet = sb.add_record("curve_fitting", {**base, "working_script": "# veteran"})
+        for s in ("s2", "s3", "s4"):
+            sb.add_record("curve_fitting", {**base, "working_script": "# veteran",
+                                            "provenance": {"session": s}})
+        top = sb.find_exemplar("curve_fitting", fp)[0]
+        assert top["record"]["id"] == vet["id"]
+        assert fresh["id"] != vet["id"]
+
+    def test_mark_retrieved_and_no_fingerprint(self):
+        self._seed_bank()
+        rid = sb.list_records("curve_fitting")[0]["id"]
+        sb.mark_retrieved("curve_fitting", rid)
+        sb.mark_retrieved("curve_fitting", rid)
+        assert sb.get_record("curve_fitting", rid)["stats"]["n_retrievals"] == 2
+        assert sb.find_exemplar("curve_fitting", None) == []
+        assert sb.find_exemplar("curve_fitting", {"kind": "unknown"}) == []
+
+    def test_render_exemplar_block(self):
+        self._seed_bank()
+        match = sb.find_exemplar("curve_fitting",
+                                 sb.curve_fingerprint(*self._raman(3)))[0]
+        block = sb.render_exemplar_block(match)
+        assert "# raman exemplar" in block
+        assert "STARTING POINT" in block
+        assert "r_squared = 0.99" in block
+
+    def test_hs_similarity_routes_by_band_profile(self):
+        axis = np.linspace(400, 600, 256)
+        edge = 1 / (1 + np.exp(-(axis - 500) / 3))
+        cube_a = edge[None, None, :] * np.ones((4, 4, 256))
+        fp_a = sb.hyperspectral_fingerprint(cube_a, axis, "eV")
+        sb.add_record("hyperspectral", {
+            "working_script": "# edge script", "data_fingerprint": fp_a,
+            "measurement_context": {}, "outcome": {},
+            "provenance": {"session": "h1"}})
+        # Same edge cube, slightly noisy → hit
+        noisy = cube_a * (1 + np.random.RandomState(0).normal(0, 0.05, cube_a.shape))
+        assert sb.find_exemplar(
+            "hyperspectral", sb.hyperspectral_fingerprint(noisy, axis, "eV"))
+        # Different axis window entirely → miss
+        axis2 = np.linspace(1000, 2000, 256)
+        assert sb.find_exemplar(
+            "hyperspectral",
+            sb.hyperspectral_fingerprint(cube_a, axis2, "eV")) == []
+
+
 class TestBankEnabled:
     def test_follows_memory_switch(self, monkeypatch):
         assert sb.bank_enabled() is True          # SCILINK_MEMORY=1 (fixture)

--- a/tests/test_script_bank.py
+++ b/tests/test_script_bank.py
@@ -1,0 +1,359 @@
+"""Tests for the script bank (issue #346, step 1: write hook + fingerprints).
+
+Covers:
+  - the deterministic data fingerprints (curve peak census, image
+    texture/periodicity, hyperspectral band summary) on synthetic data;
+  - bank CRUD with script-hash dedup and usage-stat accumulation;
+  - the enable gate (follows the persistent-memory master switch;
+    ``SCILINK_SCRIPT_BANK`` overrides in both directions);
+  - the three agents' write hooks (approved-only, once-per-run dedup,
+    failure isolation, inert when disabled).
+
+No LLM calls anywhere — the write path is deterministic by design.
+"""
+
+import logging
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from scilink.skills._shared import _script_bank as sb
+
+
+@pytest.fixture(autouse=True)
+def _isolated_bank(tmp_path, monkeypatch):
+    """Isolate the store and enable the master switch (bank follows it)."""
+    monkeypatch.setenv("SCILINK_HOME", str(tmp_path))
+    monkeypatch.setenv("SCILINK_MEMORY", "1")
+    monkeypatch.delenv("SCILINK_SCRIPT_BANK", raising=False)
+
+
+# ──────────────────────────────────────────────────────────────
+# Fingerprints
+# ──────────────────────────────────────────────────────────────
+
+class TestCurveFingerprint:
+    def _three_gaussians(self, noise=0.05, seed=0):
+        rs = np.random.RandomState(seed)
+        x = np.linspace(0, 100, 2000)
+        y = (0.02 * x
+             + 5.0 * np.exp(-(x - 20) ** 2 / 4)
+             + 3.0 * np.exp(-(x - 50) ** 2 / 9)
+             + 1.5 * np.exp(-(x - 80) ** 2 / 2)
+             + rs.normal(0, noise, x.size))
+        return x, y
+
+    def test_peak_census_exact(self):
+        x, y = self._three_gaussians()
+        fp = sb.curve_fingerprint(x, y, x_units="eV")
+        assert fp["kind"] == "curve"
+        assert fp["n_points"] == 2000
+        assert fp["x_units"] == "eV"
+        assert fp["x_range"] == [0.0, 100.0]
+        assert fp["peaks"]["count"] == 3
+        positions = sorted(p["position"] for p in fp["peaks"]["top"])
+        for found, true in zip(positions, [20, 50, 80]):
+            assert abs(found - true) < 1.0
+        assert fp["snr"] > 20
+        assert fp["baseline"]["drift"] > 0.1  # the ramp
+
+    def test_peak_census_noisy(self):
+        x, y = self._three_gaussians(noise=0.3)
+        assert sb.curve_fingerprint(x, y)["peaks"]["count"] == 3
+
+    def test_weak_shoulder_recovered(self):
+        rs = np.random.RandomState(0)
+        x = np.linspace(0, 100, 2000)
+        y = (5.0 * np.exp(-(x - 50) ** 2 / 9)
+             + 0.6 * np.exp(-(x - 58) ** 2 / 4)
+             + rs.normal(0, 0.05, x.size))
+        assert sb.curve_fingerprint(x, y)["peaks"]["count"] == 2
+
+    def test_degenerate_inputs(self):
+        assert sb.curve_fingerprint([], [])["n_points"] == 0
+        flat = sb.curve_fingerprint(np.arange(100), np.ones(100))
+        assert flat["peaks"]["count"] == 0
+        with_nans = sb.curve_fingerprint(
+            np.arange(50, dtype=float), np.full(50, np.nan))
+        assert with_nans["peaks"]["count"] == 0  # no crash
+
+
+class TestImageFingerprint:
+    def test_lattice_vs_noise_periodicity(self):
+        rs = np.random.RandomState(0)
+        xx, yy = np.meshgrid(np.arange(256), np.arange(256))
+        lattice = np.sin(xx * 0.5) * np.sin(yy * 0.5) + rs.normal(0, 0.1, (256, 256))
+        noise = rs.normal(0, 1, (256, 256))
+        fp_lat = sb.image_fingerprint(lattice, pixel_size_nm=0.1)
+        fp_noise = sb.image_fingerprint(noise)
+        assert fp_lat["shape"] == [256, 256]
+        assert fp_lat["pixel_size_nm"] == 0.1
+        assert fp_lat["fft_periodicity"] > 50
+        assert fp_noise["fft_periodicity"] < 5
+
+    def test_rgb_collapsed_and_degenerate(self):
+        rgb = np.zeros((32, 32, 3))
+        assert sb.image_fingerprint(rgb)["shape"] == [32, 32]
+        assert sb.image_fingerprint(np.zeros((0, 0)))["shape"] == [0, 0]
+
+
+class TestHyperspectralFingerprint:
+    def test_edge_cube(self):
+        rs = np.random.RandomState(0)
+        axis = np.linspace(400, 600, 300)
+        spec = (1 / (1 + np.exp(-(axis - 500) / 3))
+                + 0.3 * np.exp(-(axis - 550) ** 2 / 20))
+        cube = spec[None, None, :] * (1 + rs.normal(0, 0.05, (8, 8, 300)))
+        fp = sb.hyperspectral_fingerprint(cube, axis, "eV")
+        assert fp["shape"] == [8, 8, 300]
+        assert fp["axis"] == {"units": "eV", "start": 400.0, "end": 600.0,
+                              "n_channels": 300}
+        assert len(fp["band_means"]) == 16
+        assert fp["band_means"][0] < 0.1      # pre-edge ~0
+        assert fp["band_means"][-1] > 0.5     # post-edge high
+        assert fp["peaks"]["count"] >= 1
+
+    def test_channels_fallback(self):
+        cube = np.ones((2, 2, 64))
+        fp = sb.hyperspectral_fingerprint(cube)
+        assert fp["axis"]["units"] == "channels"
+        assert fp["axis"]["end"] == 63.0
+
+
+# ──────────────────────────────────────────────────────────────
+# CRUD + dedup
+# ──────────────────────────────────────────────────────────────
+
+def _record(script="import numpy as np\nprint(1)\n", session="run_A", r2=0.98):
+    return {
+        "working_script": script,
+        "measurement_context": {"technique": "XRD"},
+        "data_fingerprint": {"kind": "curve", "n_points": 100},
+        "outcome": {"model_type": "pseudo_voigt",
+                    "metric": {"name": "r_squared", "value": r2}},
+        "provenance": {"session": session},
+    }
+
+
+class TestBankCRUD:
+    def test_create_then_dedup_update(self):
+        r1 = sb.add_record("curve_fitting", _record(session="run_A", r2=0.98))
+        assert r1["action"] == "created"
+        # Same script up to trailing whitespace → update, not duplicate.
+        r2 = sb.add_record("curve_fitting", _record(
+            script="import numpy as np  \nprint(1)\n", session="run_B", r2=0.99))
+        assert r2 == {"id": r1["id"], "action": "updated"}
+
+        recs = sb.list_records("curve_fitting")
+        assert len(recs) == 1
+        rec = recs[0]
+        assert rec["stats"]["n_successes"] == 2
+        assert rec["sessions"] == ["run_A", "run_B"]
+        assert rec["outcome"]["best_metric"]["value"] == 0.99
+        assert rec["outcome"]["metric"]["value"] == 0.98  # original preserved
+
+    def test_distinct_script_new_record(self):
+        sb.add_record("curve_fitting", _record())
+        r = sb.add_record("curve_fitting", _record(script="totally different"))
+        assert r["action"] == "created"
+        assert len(sb.list_records("curve_fitting")) == 2
+
+    def test_get_remove_and_domain_filter(self):
+        rid = sb.add_record("curve_fitting", _record())["id"]
+        sb.add_record("image_analysis", _record(script="img script"))
+        assert sb.get_record("curve_fitting", rid)["id"] == rid
+        assert len(sb.list_records()) == 2
+        assert len(sb.list_records("image_analysis")) == 1
+        assert sb.remove_records("curve_fitting", [rid]) == 1
+        assert sb.list_records("curve_fitting") == []
+
+    def test_no_script_skipped(self):
+        rec = _record()
+        rec["working_script"] = "   "
+        assert sb.add_record("curve_fitting", rec)["action"] == "skipped_no_script"
+        assert sb.list_records("curve_fitting") == []
+
+
+class TestBankEnabled:
+    def test_follows_memory_switch(self, monkeypatch):
+        assert sb.bank_enabled() is True          # SCILINK_MEMORY=1 (fixture)
+        monkeypatch.setenv("SCILINK_MEMORY", "0")
+        assert sb.bank_enabled() is False
+
+    def test_flag_overrides_both_ways(self, monkeypatch):
+        monkeypatch.setenv("SCILINK_SCRIPT_BANK", "0")
+        assert sb.bank_enabled() is False         # off even with memory on
+        monkeypatch.setenv("SCILINK_MEMORY", "0")
+        monkeypatch.setenv("SCILINK_SCRIPT_BANK", "1")
+        assert sb.bank_enabled() is True          # on even with memory off
+
+
+# ──────────────────────────────────────────────────────────────
+# Agent write hooks (unbound calls on fake agents — no LLM anywhere)
+# ──────────────────────────────────────────────────────────────
+
+def _fake_agent(home):
+    a = types.SimpleNamespace()
+    a.logger = logging.getLogger("banktest")
+    a.output_dir = Path(home) / "sess"
+    a.output_dir.mkdir(parents=True, exist_ok=True)
+    return a
+
+
+def _curve_state(n_results=2, shared_script=True):
+    rs = np.random.RandomState(0)
+    x = np.linspace(0, 100, 500)
+    y = 5 * np.exp(-(x - 50) ** 2 / 9) + rs.normal(0, 0.05, x.size)
+    stack = np.stack([np.vstack([x, y])] * max(1, n_results))
+    results = []
+    for i in range(n_results):
+        script = ("import numpy as np\n# SHARED\n" if shared_script
+                  else f"import numpy as np\n# S{i}\n")
+        results.append({
+            "index": i, "name": f"s{i}", "success": True,
+            "model_type": "1 Gaussian",
+            "fit_quality": {"r_squared": 0.99},
+            "script": script,
+            "quality_history": {"approved": True, "verification_iterations": []},
+        })
+    return {
+        "locked_fitting_config": {"physical_model": "1 Gaussian",
+                                  "analysis_approach": "single peak fit"},
+        "skills_loaded": [],
+        "system_info": {"technique": "PL", "x_units": "nm"},
+        "data_path": "/data/spectrum.csv",
+        "spectrum_stack": stack,
+        "series_results": results,
+    }
+
+
+class TestCurveBankHook:
+    def _run(self, tmp_path, state):
+        from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+        return CurveFittingAgent._maybe_bank_scripts(_fake_agent(tmp_path), state)
+
+    def test_banks_approved_scripts_once_per_run(self, tmp_path):
+        banked = self._run(tmp_path, _curve_state(n_results=2, shared_script=True))
+        assert len(banked) == 1  # locked-recipe series: one distinct script
+        rec = sb.list_records("curve_fitting")[0]
+        assert rec["stats"]["n_successes"] == 1
+        assert rec["data_fingerprint"]["peaks"]["count"] == 1
+        assert rec["data_fingerprint"]["x_units"] == "nm"
+        assert rec["measurement_context"]["technique"] == "PL"
+        assert rec["outcome"]["metric"]["value"] == 0.99
+        assert rec["provenance"]["data_file"] == "spectrum.csv"
+        assert "# SHARED" in rec["working_script"]
+
+    def test_distinct_scripts_bank_separately(self, tmp_path):
+        banked = self._run(tmp_path, _curve_state(n_results=2, shared_script=False))
+        assert len(banked) == 2
+
+    def test_second_run_updates_stats(self, tmp_path):
+        self._run(tmp_path, _curve_state())
+        agent2 = _fake_agent(tmp_path)
+        agent2.output_dir = Path(tmp_path) / "sess2"
+        agent2.output_dir.mkdir(exist_ok=True)
+        from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+        CurveFittingAgent._maybe_bank_scripts(agent2, _curve_state())
+        rec = sb.list_records("curve_fitting")[0]
+        assert rec["stats"]["n_successes"] == 2
+        assert len(rec["sessions"]) == 2
+
+    def test_unapproved_and_failed_skipped(self, tmp_path):
+        state = _curve_state(n_results=2, shared_script=False)
+        state["series_results"][0]["quality_history"]["approved"] = False
+        state["series_results"][1]["success"] = False
+        assert self._run(tmp_path, state) == []
+        assert sb.list_records("curve_fitting") == []
+
+    def test_inert_when_disabled(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SCILINK_MEMORY", "0")
+        assert self._run(tmp_path, _curve_state()) == []
+        assert not sb.bank_dir().exists()
+
+    def test_failure_isolated(self, tmp_path):
+        state = _curve_state()
+        state["series_results"] = "not a list"  # forces an internal error
+        assert self._run(tmp_path, state) == []
+
+
+class TestImageBankHook:
+    def test_banks_with_image_fingerprint(self, tmp_path):
+        from scilink.agents.exp_agents.image_analysis_agent import ImageAnalysisAgent
+        rs = np.random.RandomState(0)
+        state = {
+            "analysis_approach": "grain segmentation",
+            "skills_loaded": [],
+            "system_info": {"instrument": "SEM"},
+            "image_paths": ["/data/frame.tif"],
+            "image_stack": [rs.normal(0, 1, (64, 64))],
+            "series_results": [{
+                "index": 0, "name": "frame", "success": True,
+                "analysis_type": "segmentation",
+                "script": "import numpy as np\n# IMG\n",
+                "quality_history": {"approved": True, "final_score": 0.9},
+            }],
+        }
+        banked = ImageAnalysisAgent._maybe_bank_scripts(_fake_agent(tmp_path), state)
+        assert len(banked) == 1
+        rec = sb.list_records("image_analysis")[0]
+        assert rec["data_fingerprint"]["kind"] == "image"
+        assert rec["data_fingerprint"]["shape"] == [64, 64]
+        assert rec["outcome"]["metric"] == {"name": "quality_score", "value": 0.9}
+        assert rec["provenance"]["data_file"] == "frame.tif"
+
+
+class TestHyperspectralBankHook:
+    def test_banks_with_cube_fingerprint(self, tmp_path):
+        from scilink.agents.exp_agents.hyperspectral_analysis_agent import (
+            HyperspectralAnalysisAgent,
+        )
+        rs = np.random.RandomState(0)
+        cube = rs.random((4, 4, 128)) + np.linspace(0, 1, 128)
+        agent = _fake_agent(tmp_path)
+        agent._handle_system_info = lambda si: si or {}
+        agent._load_hyperspectral_data = lambda p: cube
+        records = [{
+            "target": "thickness map",
+            "required_outputs": ["map"],
+            "script": "import numpy as np\n# HS\n",
+            "quality_history": {"approved": True, "final_passed_fraction": 1.0},
+        }, {
+            "target": "rejected map",
+            "script": "import numpy as np\n# BAD\n",
+            "quality_history": {"approved": False},
+        }]
+        banked = HyperspectralAnalysisAgent._maybe_bank_scripts(
+            agent, records, {"skills_loaded": []}, "/data/cube.npy",
+            {"technique": "EELS",
+             "energy_range": {"start": 400, "end": 600, "units": "eV"}},
+        )
+        assert len(banked) == 1
+        rec = sb.list_records("hyperspectral")[0]
+        assert rec["data_fingerprint"]["kind"] == "hyperspectral"
+        assert rec["data_fingerprint"]["shape"] == [4, 4, 128]
+        assert rec["outcome"]["metric"] == {"name": "passed_fraction", "value": 1.0}
+        assert rec["technique_signals"]["analysis_target"] == "thickness map"
+        assert rec["provenance"]["data_file"] == "cube.npy"
+
+    def test_cube_load_failure_still_banks(self, tmp_path):
+        from scilink.agents.exp_agents.hyperspectral_analysis_agent import (
+            HyperspectralAnalysisAgent,
+        )
+        agent = _fake_agent(tmp_path)
+        agent._handle_system_info = lambda si: si or {}
+
+        def _boom(_):
+            raise RuntimeError("no such file")
+
+        agent._load_hyperspectral_data = _boom
+        records = [{
+            "target": "map", "script": "import numpy as np\n# HS2\n",
+            "quality_history": {"approved": True},
+        }]
+        banked = HyperspectralAnalysisAgent._maybe_bank_scripts(
+            agent, records, {}, "/gone.npy", {})
+        assert len(banked) == 1
+        assert sb.list_records("hyperspectral")[0]["data_fingerprint"] is None

--- a/tests/test_script_bank.py
+++ b/tests/test_script_bank.py
@@ -250,6 +250,33 @@ class TestCurveBankHook:
         banked = self._run(tmp_path, _curve_state(n_results=2, shared_script=False))
         assert len(banked) == 2
 
+    def test_reuse_verdict_good_banks_without_quality_history(self, tmp_path):
+        # The #172 reuse fast path carries reuse_validity instead of
+        # quality_history.approved — its gate pass must count as a success.
+        state = _curve_state(n_results=1)
+        r = state["series_results"][0]
+        del r["quality_history"]
+        r["reuse_validity"] = {"reused": True, "verdict": "good"}
+        assert len(self._run(tmp_path, state)) == 1
+
+    def test_reuse_verdict_poor_not_banked(self, tmp_path):
+        state = _curve_state(n_results=1)
+        r = state["series_results"][0]
+        del r["quality_history"]
+        r["reuse_validity"] = {"reused": True, "verdict": "poor"}
+        assert self._run(tmp_path, state) == []
+
+    def test_stamped_fingerprint_preferred(self, tmp_path):
+        # File inputs never put per-spectrum arrays in the outer state; the
+        # controller stamps _bank_fingerprint on the result instead.
+        state = _curve_state(n_results=1)
+        state["spectrum_stack"] = None
+        state["series_results"][0]["_bank_fingerprint"] = {
+            "kind": "curve", "n_points": 777}
+        self._run(tmp_path, state)
+        rec = sb.list_records("curve_fitting")[0]
+        assert rec["data_fingerprint"]["n_points"] == 777
+
     def test_second_run_updates_stats(self, tmp_path):
         self._run(tmp_path, _curve_state())
         agent2 = _fake_agent(tmp_path)


### PR DESCRIPTION
Implements issue #346 end to end: a **script bank** (episodic memory of successful analysis scripts) and a **real-time analysis mode** built on top of it. Stacked on #345 (the shared QC engine); six commits, each live-validated on Bedrock before the next was started.

## What a user gets

**1. The agents stop re-implementing what already worked.** Every approved analysis already produces a working script; until now that history was inert unless you hand-pointed `prior_analysis_paths` at a specific run. Now every approved result is automatically banked (`~/.scilink/script_bank/<domain>/`) with three tiers of matching signal — the measurement context from your metadata, a numeric fingerprint of the data the script actually solved (peak positions/widths, axis range, SNR, band profiles, image texture), and the outcome (script, model, quality metric). On a later analysis, the closest proven script is retrieved and offered to the model as a *starting point to adapt* — dataset-specific values re-derived, the locked plan staying authoritative, the normal verification loop unchanged. Re-banking an identical script updates its usage statistics instead of duplicating, so "which scripts keep succeeding across sessions" accumulates as an honest, evidence-based signal.

**2. A real-time mode for in-situ streams: `analyze(profile="realtime")`.** Anchor a series with one thorough run (or let the bank cold-start it — see below), then each frame executes the locked script with **zero LLM calls**: ~4 s/frame instead of ~5–9 min. Each frame reports a two-channel health check: the usual quality gate (R²) *plus* a fingerprint-distance drift signal against the anchor — because live testing proved the R² gate alone is blind to phase transitions when the locked script auto-detects peaks. Every frame is provenance-stamped for a post-experiment thorough sweep ("cheap now, rigorous later").

**3. Cold start from the bank.** `profile="realtime"` with no anchor auditions the top banked scripts against the first frame — numerics only — and the first to pass the gate becomes the locked recipe. No match → the run loudly falls back to a thorough anchor, which itself gets banked, so the next campaign of that kind cold-starts. Detector-glitch frames (all-zero, runt, all-NaN) are rejected by a pre-flight gate in milliseconds; partially corrupted frames still reach the existing correction path, which demonstrably salvages them.

## Live validation highlights (bedrock opus-4-8)

- **38-frame in-situ XRD dehydration replay**: 37/37 realtime frames at median 4.0 s (3.4 min for the whole series), zero LLM traffic; drift flagged on exactly the frames from the known 45.8 °C transition onset while all R² verdicts stayed `good` — the two-channel detector working as designed.
- **Cold start**: a campaign started from nothing in 20.4 s, zero LLM calls; retrieval is phase-aware (post-transition frames lock the post-transition record); the drift check reads distance from the *winning script's* proven territory.
- **The canonical drift workflow end to end**: realtime → drift flagged → thorough re-anchor (old anchor as reference, bank correctly silent under precedence) → realtime resumes drift-free.
- **Adapt-mode across all three modalities**, including an adversarial case: a TEM particle-sizing exemplar offered for an AFM mica image produced an honest Fourier lattice analysis — the plan is locked before codegen ever sees the exemplar, so a bad retrieval cannot redirect the analysis. Cross-sample transfer worked (Au K-edge thickness script adapted to a Bi coupon: edge energy and element swapped, vetted tools retained).
- **Glitch triad**: all-zeros 232.6 s → 4.7 s and 10-point runt 205.8 s → 0.1 s after the pre-flight gate (both zero-LLM, honestly flagged); the NaN-laced frame still recovers via one correction (R² 0.999).

Known limits, stated up front: the arithmetic gate is not a physics-identity check (hence the fingerprint drift channel, and conservative verbatim candidate selection); banked scripts are dataset-specific (hence adapt-as-exemplar under full verification, never trust); within one technique the growing bank trends toward always-offering *some* exemplar — intended technique-level transfer, with cross-technique/-window/-units retrieval firmly filtered. Realtime is wired for the curve agent in v1 (image lacks a deterministic per-frame gate metric; HS per-frame cost is numerics-dominated); image/HS accept the `profile` parameter and warn.

---

## Technical details (for AI reviewers)

**Store & fingerprints — `scilink/skills/_shared/_script_bank.py` (new).** Mirrors `_staging.py`: records at `scilink_home()/script_bank/<domain>/<id>.json`; `add_record` dedups by whitespace-insensitive SHA1 `script_hash` → updates `stats.n_successes` (counts runs, not series items), `sessions` (cap 20), `best_metric` (strictly-better only), and backfills empty fingerprint/context tiers; `bank_enabled()` follows `memory_enabled()` with `SCILINK_SCRIPT_BANK` overriding both ways. Fingerprints are deterministic (no LLM): curve = peak census (uniform smoothing window `n//400`, prominence `max(0.05, 12·noise/√window)` — exact counts across 20 noise seeds on 3-peak clean/noisy, 12-peak crowded, and weak-shoulder synthetics) + x-range + SNR + baseline character; image = intensity percentiles, edge density, FFT radial periodicity (lattice ≈1078 vs noise ≈1.05); hyperspectral = cube shape + axis + 16-band mean-spectrum profile + peak census. Retrieval `find_exemplar`: hard filters (fingerprint `kind`, axis units when both declared) → score `0.8·fp_sim + 0.2·context-token-Jaccard + usage bonus (≤0.05)`, floor 0.45, top-1; HS similarity is damped by range agreement `(0.4+0.6·r)` to kill profile-matches-in-disjoint-window (test-caught). `mark_retrieved` / `record_success` bump usage stats; concurrent writers are lossy-but-never-corrupt (read-modify-write, local store).

**Write hooks.** `_maybe_bank_scripts` beside `_maybe_stage_t2_solutions` in all three agents; gate = `quality_history.approved OR reuse_validity.verdict=="good"`; once per distinct script per run; failure-isolated. Per-item fingerprints are stamped where the data is in scope (`_fit_single_spectrum` / `_process_single_image` → `result["_bank_fingerprint"]`) because file inputs never surface per-item arrays to the outer state — a first-live-pass finding (commit 838c38d). The HS hook lazily reloads the cube and rebuilds the axis via `resolve_axis_spec`. Realtime frames never bank (a 500-frame campaign is one success, not 500); cold-start wins get one `record_success` per campaign.

**Adapt-mode injection.** `_offer_bank_exemplar` in curve/image `qc_run_initial` stashes the top match; `_generate_fitting_script` / `_generate_analysis_script` append `render_exemplar_block` only when `prior_script is None AND _annealing_level == 0` — refinements and the hot script-drop's from-scratch regeneration stay exemplar-free, so verifier pressure erases a bad exemplar's lineage. HS appends to `ctx.current_prompt` only (retries rebuild from the clean `base_prompt`). `prior_analysis_paths` always outranks the bank. The planner never sees the exemplar (retrieval runs after config lock), and plan conformance applies to exemplar-adapted scripts as fresh generations — the adversarial live case rests on both properties.

**Realtime profile.** `analyze(profile=...)` resolves via the previously-unconsumed `QCProfile` (`_qc_profile.py`); `create_unified_curve_fitting_pipeline(profile="realtime")` swaps in a 5-step pipeline (AnalyzeData → UnifiedSeriesProcessing with `max_verification_iterations=0`, `conformance_instructions=None`, `replanner=None` → Store → reports); locked config seeded from the anchor's `series_fit_results.json`; fallback (prior script cannot execute) = bounded single generation, no verification loop. Drift: `_attach_drift_signal` adds `fingerprint_similarity` + `drift ∈ {none, suspected, unavailable}` to `reuse_validity`; `DRIFT_SIMILARITY_THRESHOLD = 0.92` calibrated on the dehydration series (same-phase 1.000 / transition onset 0.900 / post-transition 0.787; 0/30 false positives on noisy re-measurements up to 8× anchor noise); anchor fingerprint from the persisted stamp, else lazily re-read from the anchor's `data_path`, else honestly `unavailable`. Provenance: `result.profile`, per-item `quality_history.produced_under_profile`, deterministic one-line summary replacing the skipped synthesis. Orchestrator `run_analysis` gains a `profile` enum whose description teaches the drift-escalation policy (verified live: the orchestrator assembled realtime args from task wording alone).

**Cold start.** `_bank_cold_start_audition` (curve agent): `find_exemplar(k=3, min_score=0.55)` — floor deliberately above adapt's 0.45 — then `stage_and_run` each candidate verbatim, parse `FIT_RESULTS_JSON` R² vs the gate; winner threads into the series controller's reuse resolution as `state["_cold_start_reuse"]` (same #172 path: validity gate, correction retry, drift vs the record's own fingerprint), `reuse_validity.source = script_bank:<id>`, `result.cold_start = {id, score, audition_r2, n_auditioned}`. No candidate → loud demotion to thorough. Degenerate first frame → stays realtime and fails fast (no thorough LLM spend on garbage).

**Pre-flight gate.** `_degenerate_data_check` (< 32 finite points, or zero dynamic range over finite values) at the single `_fit_single_spectrum` choke point, realtime-only; the engine's terminal failure record now carries the last attempt's own error so the gate reason reaches `series_fit_results.json`.

**Tests & no-regression.** 26 tests in `tests/test_script_bank.py` (fingerprint exactness, dedup/stats, retrieval hit/miss/units/ties, hook gating incl. reuse-verdict and stamped-fingerprint paths); 8 in `tests/qc_golden/test_realtime_golden.py` incl. the `curve_realtime_reuse` golden pinning **zero** LLM calls with a fail-loud `ScriptedModel([])`, drift-flags-changed-data, cold-start win/demotion/rotted-candidate, and the gated glitch frame. All pre-existing goldens pass unregenerated (bank off ⇒ prompt builders byte-identical; the two `test_persistent_memory` failures in combined runs are pre-existing env leakage from `qc_golden/conftest.py`, reproduced on the base branch). Live drivers and logs under `tests/_script_bank_live_runs/` (untracked).

**Deferred (recorded in the issue/memory):** quality-metric term in retrieval ranking (multi-session veteran currently outranks a higher-R² newcomer on the same fingerprint); deterministic image gate metric (unlocks image realtime + verbatim); fingerprint-drift channel for the plain non-realtime reuse path (needs reuse-golden regeneration); retrieval index if banks grow ≫5k records (47 ms/call at 500); a `scilink memory`-style CLI surface for inspecting/pruning bank records.

Closes #346.
