### PR TITLE
Script-bank management surface + graduation signal (follow-up to #347)

### DIFF
--- a/scilink/cli/memory.py
+++ b/scilink/cli/memory.py
@@ -22,6 +22,14 @@ Staged T=2 solutions (distill_staging) subcommands:
   consolidate  Distill all staged solutions of a technique into a NEW skill
   prune-staged Delete staged solution(s)
 
+Script bank (script_bank — episodic memory of successful scripts) subcommands:
+  bank         List banked scripts with cross-session usage stats
+               (★ proven = graduation candidates)
+  bank-show    Print a bank record including its script
+  bank-promote Send a proven record into distill staging — it then flows
+               through the same review-gated upgrade/consolidate path
+  bank-prune   Delete a bank record
+
 `upgrade`/`consolidate` call an LLM; configure with --model / --base-url / --api-key.
 """
 
@@ -302,6 +310,89 @@ def _cmd_prune_staged(args) -> int:
     return 0 if n else 1
 
 
+def _cmd_bank(args) -> int:
+    """`scilink memory bank` — list script-bank records (episodic memory)."""
+    from scilink.skills._shared import _script_bank
+    rows = _script_bank.bank_summary(args.domain)
+    if args.proven_only:
+        rows = [r for r in rows if r["proven"]]
+    if not rows:
+        print("No banked scripts." + (" (proven-only filter)" if args.proven_only else ""))
+        return 0
+    threshold = _script_bank.proven_n()
+    by_domain = {}
+    for r in rows:
+        by_domain.setdefault(r["domain"], []).append(r)
+    n_proven = 0
+    for dom, recs in sorted(by_domain.items()):
+        print(f"{dom}: {len(recs)} banked script(s)")
+        for r in recs:
+            metric = r["metric"]
+            mtxt = (f"  {metric['name']}={metric['value']}"
+                    if isinstance(metric, dict) and metric.get("value") is not None else "")
+            marks = ""
+            if r["proven"]:
+                marks += "  ★ proven"
+                n_proven += 1
+            if r["promoted_to_staging"]:
+                marks += f"  ✓ promoted (staged {r['promoted_to_staging']})"
+            print(f"    · id={r['id']}  successes={r['n_successes']} "
+                  f"retrievals={r['n_retrievals']}{mtxt}{marks}")
+            print(f"      {r['label'][:100]}")
+    print(f"\n{len(rows)} record(s); ★ = succeeded in ≥{threshold} sessions "
+          f"(a graduation candidate). Inspect with `bank-show <domain>/<id>`; "
+          f"send a proven one into the review-gated skill path with "
+          f"`bank-promote <domain>/<id>`.")
+    if n_proven and not args.proven_only:
+        print(f"{n_proven} proven record(s) — see them alone with `bank --proven-only`.")
+    return 0
+
+
+def _cmd_bank_show(args) -> int:
+    from scilink.skills._shared import _script_bank
+    domain, rid = _split_ref(args.ref)
+    rec = _script_bank.get_record(domain, rid)
+    if rec is None:
+        print(f"❌ No bank record {domain}/{rid}.")
+        return 1
+    import json as _json
+    script = rec.pop("working_script", "")
+    print(_json.dumps(rec, indent=2, default=str))
+    print("\n--- working_script " + "-" * 50)
+    print(script)
+    return 0
+
+
+def _cmd_bank_promote(args) -> int:
+    """Send a bank record into distill staging (the graduation path)."""
+    _warn_memory_off()
+    from scilink.skills._shared import _script_bank
+    domain, rid = _split_ref(args.ref)
+    out = _script_bank.promote_to_staging(domain, rid, technique=args.technique)
+    if out.get("status") != "success":
+        print(f"❌ {out.get('message')}")
+        return 1
+    print(f"🧠 Promoted bank record {rid} → staged {out['staged_id']} "
+          f"[{out['technique']}].")
+    print("   Review with `scilink memory staged`, then `upgrade` it into an "
+          "existing skill or `consolidate` once enough of the technique "
+          "accumulates. The bank record is kept (marked ✓ promoted).")
+    return 0
+
+
+def _cmd_bank_prune(args) -> int:
+    from scilink.skills._shared import _script_bank
+    domain, rid = _split_ref(args.ref)
+    if not args.yes:
+        resp = input(f"Delete bank record {domain}/{rid}? [y/N] ").strip().lower()
+        if resp not in ("y", "yes"):
+            print("Aborted.")
+            return 1
+    n = _script_bank.remove_records(domain, [rid])
+    print(f"🗑️  Removed {n} bank record(s).")
+    return 0 if n else 1
+
+
 def main():
     """Entry point for 'scilink memory'."""
     parser = argparse.ArgumentParser(
@@ -362,6 +453,32 @@ def main():
     p_ps.add_argument("ref", help="Staged solution ref '<domain>/<id>'")
     p_ps.add_argument("--yes", action="store_true", help="Skip the confirmation prompt")
     p_ps.set_defaults(func=_cmd_prune_staged)
+
+    # --- script bank (episodic memory of successful scripts) ---
+    p_bank = sub.add_parser(
+        "bank", help="List banked scripts (episodic memory) with usage stats")
+    p_bank.add_argument("--domain", help="Restrict to one domain")
+    p_bank.add_argument("--proven-only", action="store_true",
+                        help="Show only records proven across sessions "
+                             "(graduation candidates)")
+    p_bank.set_defaults(func=_cmd_bank)
+
+    p_bs = sub.add_parser("bank-show", help="Print a bank record incl. its script")
+    p_bs.add_argument("ref", help="Bank record ref '<domain>/<id>'")
+    p_bs.set_defaults(func=_cmd_bank_show)
+
+    p_bp = sub.add_parser(
+        "bank-promote",
+        help="Send a proven bank record into distill staging (review-gated skill path)")
+    p_bp.add_argument("ref", help="Bank record ref '<domain>/<id>'")
+    p_bp.add_argument("--technique", default=None,
+                      help="Staging technique label (default: derived from the record)")
+    p_bp.set_defaults(func=_cmd_bank_promote)
+
+    p_br = sub.add_parser("bank-prune", help="Delete a bank record")
+    p_br.add_argument("ref", help="Bank record ref '<domain>/<id>'")
+    p_br.add_argument("--yes", action="store_true", help="Skip the confirmation prompt")
+    p_br.set_defaults(func=_cmd_bank_prune)
 
     args = parser.parse_args()
     if not getattr(args, "func", None):

--- a/scilink/skills/_shared/_script_bank.py
+++ b/scilink/skills/_shared/_script_bank.py
@@ -658,6 +658,137 @@ def record_success(domain: str, rid: str, session: Optional[str] = None,
         pass
 
 
+# ──────────────────────────────────────────────────────────────
+# Management surface + graduation signal
+#
+# The bank is episodic memory; skill graduation is semantic memory. The
+# bridge: records that keep succeeding across sessions ("proven") are the
+# evidence-based graduation candidates — promotion copies one into the
+# distill-staging buffer, where the EXISTING review-gated upgrade /
+# consolidate ceremony applies. The bank record itself is kept (episodic
+# history is not consumed by distillation).
+# ──────────────────────────────────────────────────────────────
+
+#: Cross-session successes at which a record counts as "proven" — the
+#: evidence-based replacement for "climbed to hot once" as a graduation
+#: signal. Overridable via $SCILINK_BANK_PROVEN_N.
+_DEFAULT_PROVEN_N = 3
+
+
+def proven_n() -> int:
+    raw = os.environ.get("SCILINK_BANK_PROVEN_N", "").strip()
+    if raw:
+        try:
+            return max(2, int(raw))
+        except ValueError:
+            pass
+    return _DEFAULT_PROVEN_N
+
+
+def record_label(rec: Dict[str, Any]) -> str:
+    """One-line 'what this script does' for lists (CLI / UI)."""
+    signals = rec.get("technique_signals") or {}
+    outcome = rec.get("outcome") or {}
+    what = (signals.get("model_type") or signals.get("analysis_type")
+            or signals.get("analysis_target") or outcome.get("model_type")
+            or outcome.get("analysis_type") or "(unlabeled script)")
+    return str(what)
+
+
+def bank_summary(domain: Optional[str] = None, *,
+                 root: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Compact display rows for the management surfaces, proven-first."""
+    threshold = proven_n()
+    rows = []
+    for rec in list_records(domain, root=root):
+        stats = rec.get("stats") or {}
+        metric = (rec.get("outcome") or {}).get("best_metric") \
+            or (rec.get("outcome") or {}).get("metric")
+        rows.append({
+            "domain": rec.get("domain"),
+            "id": rec.get("id"),
+            "label": record_label(rec)[:120],
+            "n_successes": int(stats.get("n_successes", 1) or 1),
+            "n_retrievals": int(stats.get("n_retrievals", 0) or 0),
+            "sessions": rec.get("sessions") or [],
+            "metric": metric,
+            "created_at": rec.get("created_at"),
+            "proven": int(stats.get("n_successes", 1) or 1) >= threshold,
+            "promoted_to_staging": rec.get("promoted_to_staging"),
+        })
+    rows.sort(key=lambda r: (-r["n_successes"], -r["n_retrievals"], r["id"] or ""))
+    return rows
+
+
+def _derive_technique_label(rec: Dict[str, Any]) -> str:
+    import re
+    label = re.sub(r"[^a-z0-9]+", "_", record_label(rec).lower()).strip("_")
+    if len(label) > 48:  # cut at a word boundary, not mid-word
+        label = label[:48].rsplit("_", 1)[0]
+    return label or "uncategorized"
+
+
+def promote_to_staging(domain: str, rid: str, technique: Optional[str] = None,
+                       *, root: Optional[Path] = None,
+                       staging_root: Optional[Path] = None) -> Dict[str, Any]:
+    """Copy a bank record into the distill-staging buffer (graduation path).
+
+    The staged record enters the existing review-gated ceremony (upgrade an
+    existing skill, or consolidate N of a technique into a new one) with
+    provenance ``bank_proven`` and the cross-session evidence attached. The
+    bank record is kept and marked ``promoted_to_staging`` so surfaces show
+    it and repeat promotions are flagged. ``technique`` defaults to a
+    deterministic label derived from the record (no LLM).
+    """
+    from . import _staging
+
+    rec = get_record(domain, rid, root=root)
+    if rec is None:
+        return {"status": "error", "message": f"No bank record {domain}/{rid}."}
+    if rec.get("promoted_to_staging"):
+        return {"status": "error",
+                "message": (f"Record {rid} was already promoted "
+                            f"(staged id {rec['promoted_to_staging']}). "
+                            f"Review it with `scilink memory staged`.")}
+    script = (rec.get("working_script") or "").strip()
+    if not script:
+        return {"status": "error", "message": f"Record {rid} has no script."}
+
+    stats = rec.get("stats") or {}
+    outcome = rec.get("outcome") or {}
+    metric = outcome.get("best_metric") or outcome.get("metric")
+    staged_record: Dict[str, Any] = {
+        "provenance": "bank_proven",
+        "model": record_label(rec),
+        "deviation_from_plan": (
+            f"Proven in the script bank: succeeded in "
+            f"{stats.get('n_successes', 1)} session(s), retrieved "
+            f"{stats.get('n_retrievals', 0)} time(s) "
+            f"(sessions: {', '.join(rec.get('sessions') or [])[:200]})."
+        ),
+        "plan_summary": outcome.get("plan_summary"),
+        "measurement_context": rec.get("measurement_context"),
+        "working_script": script,
+        "session": (rec.get("sessions") or ["?"])[-1],
+        "bank_id": rid,
+    }
+    if isinstance(metric, dict) and metric.get("name") == "r_squared":
+        staged_record["r_squared"] = metric.get("value")
+    elif isinstance(metric, dict) and metric.get("value") is not None:
+        staged_record["quality_score"] = metric.get("value")
+
+    label = technique or _derive_technique_label(rec)
+    sid = _staging.stage_solution(domain, label, staged_record,
+                                  root=staging_root)
+
+    rec["promoted_to_staging"] = sid
+    rec["updated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    (_domain_dir(domain, root=root) / f"{rid}.json").write_text(
+        json.dumps(rec, indent=2, default=str))
+    return {"status": "success", "staged_id": sid, "technique": label,
+            "domain": domain, "bank_id": rid}
+
+
 def render_exemplar_block(match: Dict[str, Any]) -> str:
     """LLM-facing prompt block offering a retrieved script as an exemplar.
 

--- a/scilink/skills/_shared/_script_bank.py
+++ b/scilink/skills/_shared/_script_bank.py
@@ -697,13 +697,24 @@ def record_label(rec: Dict[str, Any]) -> str:
 
 def bank_summary(domain: Optional[str] = None, *,
                  root: Optional[Path] = None) -> List[Dict[str, Any]]:
-    """Compact display rows for the management surfaces, proven-first."""
+    """Compact display rows for the management surfaces, proven-first.
+
+    ``promoted_to_staging`` is reported only while the staged copy still
+    exists (awaiting review) — once it was consumed by upgrade/consolidate
+    or pruned, the record shows as promotable again, matching
+    :func:`promote_to_staging`'s refusal rule.
+    """
+    from . import _staging
+
     threshold = proven_n()
     rows = []
     for rec in list_records(domain, root=root):
         stats = rec.get("stats") or {}
         metric = (rec.get("outcome") or {}).get("best_metric") \
             or (rec.get("outcome") or {}).get("metric")
+        sid = rec.get("promoted_to_staging")
+        if sid and _staging.get_staged(rec.get("domain") or "", sid) is None:
+            sid = None  # dangling — the staged copy was consumed or pruned
         rows.append({
             "domain": rec.get("domain"),
             "id": rec.get("id"),
@@ -714,7 +725,7 @@ def bank_summary(domain: Optional[str] = None, *,
             "metric": metric,
             "created_at": rec.get("created_at"),
             "proven": int(stats.get("n_successes", 1) or 1) >= threshold,
-            "promoted_to_staging": rec.get("promoted_to_staging"),
+            "promoted_to_staging": sid,
         })
     rows.sort(key=lambda r: (-r["n_successes"], -r["n_retrievals"], r["id"] or ""))
     return rows
@@ -745,11 +756,16 @@ def promote_to_staging(domain: str, rid: str, technique: Optional[str] = None,
     rec = get_record(domain, rid, root=root)
     if rec is None:
         return {"status": "error", "message": f"No bank record {domain}/{rid}."}
-    if rec.get("promoted_to_staging"):
-        return {"status": "error",
-                "message": (f"Record {rid} was already promoted "
-                            f"(staged id {rec['promoted_to_staging']}). "
-                            f"Review it with `scilink memory staged`.")}
+    prior_sid = rec.get("promoted_to_staging")
+    if prior_sid:
+        # Refuse only while the staged copy is still awaiting review. Once it
+        # was consumed (upgrade/consolidate remove staged records) or pruned,
+        # the mark is dangling and re-promotion is legitimate.
+        if _staging.get_staged(domain, prior_sid, root=staging_root) is not None:
+            return {"status": "error",
+                    "message": (f"Record {rid} is already staged for review "
+                                f"(staged id {prior_sid}). Review it with "
+                                f"`scilink memory staged`.")}
     script = (rec.get("working_script") or "").strip()
     if not script:
         return {"status": "error", "message": f"Record {rid} has no script."}

--- a/scilink/ui/components/skills.py
+++ b/scilink/ui/components/skills.py
@@ -162,11 +162,11 @@ def _render_memory_section() -> None:
 
     if provisional:
         st.markdown(f"**Provisional — awaiting review ({len(provisional)})**")
-        for r in provisional:
+        for r in _paged(provisional, "provpage"):
             _render_memory_row(_memory, r, provisional=True)
     if promoted:
         st.markdown(f"**Promoted ({len(promoted)})**")
-        for r in promoted:
+        for r in _paged(promoted, "prompage"):
             _render_memory_row(_memory, r, provisional=False)
     if not rows:
         st.caption("No persisted skills yet.")
@@ -207,7 +207,7 @@ def _render_staged_section() -> None:
 
     for (domain, technique), recs in sorted(groups.items()):
         with st.expander(f"`{domain}/{technique}` — {len(recs)} staged", expanded=False):
-            for r in recs:
+            for r in _paged(recs, f"stagedpage::{domain}/{technique}"):
                 metric = r.get("r_squared") or r.get("quality_score")
                 prov = _staging.PROVENANCE_LABELS.get(r.get("provenance", "t2_solution"), r.get("provenance", ""))
                 meta_col, view_col = st.columns([3, 1])
@@ -216,7 +216,8 @@ def _render_staged_section() -> None:
                     + (f" · {_staging.metric_label(r)}" if _staging.metric_label(r) else "")
                 )
                 with view_col.popover("View", width="stretch"):
-                    _render_staged_record(r)
+                    _lazy_content(f"stagedlazy::{r['id']}",
+                                  lambda r=r: _render_staged_record(r))
             if model is None:
                 st.info("Start a session to enable upgrade/consolidate (needs a model).")
                 continue
@@ -317,6 +318,48 @@ def _render_staged_section() -> None:
                     st.caption(f"Accumulating {len(recs)}/{need} examples before a new skill.")
 
 
+# Streamlit renders popover/expander CONTENT eagerly on every rerun, open or
+# not — with many memory records that meant re-reading every file and
+# re-highlighting every script per chat interaction (the observed panel
+# slowdown). Heavy content therefore loads only behind an explicit tick, and
+# long lists paginate.
+_PANEL_PAGE = 15
+_SCRIPT_PREVIEW_CHARS = 8000
+
+
+def _lazy_content(key: str, render_fn) -> None:
+    """Render heavy content only when the user asks for it."""
+    if st.checkbox("Load full content", key=key):
+        render_fn()
+    else:
+        st.caption("Tick to load — kept lazy so a large store doesn't slow the panel.")
+
+
+def _paged(items: list, key: str) -> list:
+    """First page of a long list, with a 'Show all' toggle."""
+    if len(items) <= _PANEL_PAGE:
+        return items
+    if st.session_state.get(key):
+        return items
+    if st.button(f"Show all {len(items)} (first {_PANEL_PAGE} shown)", key=f"btn::{key}"):
+        st.session_state[key] = True
+        st.rerun()
+    return items[:_PANEL_PAGE]
+
+
+def _script_block(script: str, full_hint: str) -> None:
+    script = (script or "").strip()
+    if not script:
+        return
+    st.markdown("**working script:**")
+    if len(script) > _SCRIPT_PREVIEW_CHARS:
+        st.code(script[:_SCRIPT_PREVIEW_CHARS]
+                + f"\n# … truncated — full script via {full_hint}",
+                language="python")
+    else:
+        st.code(script, language="python")
+
+
 def _render_bank_section() -> None:
     """Script bank — episodic memory of successful analysis scripts.
 
@@ -356,7 +399,7 @@ def _render_bank_section() -> None:
         n_proven = sum(1 for r in recs if r["proven"])
         star = f", ★ {n_proven} proven" if n_proven else ""
         with st.expander(f"`{domain}` — {len(recs)} banked{star}", expanded=False):
-            for r in recs:
+            for r in _paged(recs, f"bankpage::{domain}"):
                 metric = r["metric"]
                 mtxt = (f" · {metric['name']}={metric['value']}"
                         if isinstance(metric, dict) and metric.get("value") is not None
@@ -371,11 +414,13 @@ def _render_bank_section() -> None:
                     f"{r['label'][:110]}"
                 )
                 with view_col.popover("View", width="stretch"):
-                    rec = _script_bank.get_record(domain, r["id"])
-                    if rec:
-                        _render_bank_record(rec)
-                    else:
-                        st.error("Record unreadable.")
+                    def _load(domain=domain, rid=r["id"]):
+                        rec = _script_bank.get_record(domain, rid)
+                        if rec:
+                            _render_bank_record(rec)
+                        else:
+                            st.error("Record unreadable.")
+                    _lazy_content(f"banklazy::{domain}/{r['id']}", _load)
                 with act_col.popover("···", width="stretch"):
                     if st.button(
                         "Promote → staged knowledge",
@@ -409,10 +454,8 @@ def _render_bank_record(rec: dict) -> None:
         if k in _BANK_HIDDEN_KEYS or v in (None, "", [], {}):
             continue
         st.markdown(f"**{k.replace('_', ' ')}:** {v}")
-    script = (rec.get("working_script") or "").strip()
-    if script:
-        st.markdown("**working script:**")
-        st.code(script, language="python")
+    _script_block(rec.get("working_script"),
+                  f"`scilink memory bank-show {rec.get('domain')}/{rec.get('id')}`")
 
 
 # Bookkeeping keys not worth showing in the per-record viewer.
@@ -427,10 +470,8 @@ def _render_staged_record(r: dict) -> None:
         if k in _STAGED_HIDDEN_KEYS or v in (None, "", [], {}):
             continue
         st.markdown(f"**{k.replace('_', ' ')}:** {v}")
-    script = (r.get("working_script") or r.get("script") or "").strip()
-    if script:
-        st.markdown("**working script:**")
-        st.code(script, language="python")
+    _script_block(r.get("working_script") or r.get("script"),
+                  "the staging record file")
 
 
 def _render_memory_row(_memory, r, *, provisional: bool) -> None:
@@ -445,10 +486,13 @@ def _render_memory_row(_memory, r, *, provisional: bool) -> None:
         if r.get("provenance"):
             st.caption(f"provenance: {r['provenance']}"
                        + (f" · session: {r['session']}" if r.get("session") else ""))
-        try:
-            st.markdown(_memory.show_memory(r["domain"], r["name"]))
-        except Exception as e:
-            st.warning(f"Could not render skill: {e}")
+
+        def _load_md(domain=r["domain"], name=r["name"]):
+            try:
+                st.markdown(_memory.show_memory(domain, name))
+            except Exception as e:  # noqa: BLE001
+                st.warning(f"Could not render skill: {e}")
+        _lazy_content(f"skilllazy::{ref}", _load_md)
 
         from scilink.skills import loader
         mem_on = loader.memory_enabled()

--- a/scilink/ui/components/skills.py
+++ b/scilink/ui/components/skills.py
@@ -172,6 +172,7 @@ def _render_memory_section() -> None:
         st.caption("No persisted skills yet.")
 
     _render_staged_section()
+    _render_bank_section()
 
 
 def _render_staged_section() -> None:
@@ -314,6 +315,104 @@ def _render_staged_section() -> None:
                     st.rerun()
                 if not ready:
                     st.caption(f"Accumulating {len(recs)}/{need} examples before a new skill.")
+
+
+def _render_bank_section() -> None:
+    """Script bank — episodic memory of successful analysis scripts.
+
+    Lists banked scripts with their cross-session usage stats; a record
+    proven across sessions (★) can be promoted into distill staging, where
+    the existing review-gated upgrade/consolidate ceremony turns it into a
+    skill. Inspection and pruning are always available.
+    """
+    from scilink.skills._shared import _script_bank
+
+    st.markdown("---")
+    st.markdown("**Script bank** — proven analysis scripts, retrieved & adapted on new data")
+    st.caption(
+        "Every approved analysis banks its working script with a fingerprint "
+        "of the data it solved; later runs retrieve the closest match as a "
+        "starting point, and real-time mode can cold-start a campaign from "
+        "one. Records that keep succeeding across sessions (★) are "
+        "evidence-backed skill candidates — promote one to send it into the "
+        "staged-knowledge review path above."
+    )
+
+    try:
+        rows = _script_bank.bank_summary()
+    except Exception as e:  # noqa: BLE001
+        st.error(f"Could not read the script bank: {e}")
+        return
+    if not rows:
+        st.caption("No banked scripts yet — they accumulate as analyses succeed.")
+        return
+
+    threshold = _script_bank.proven_n()
+    by_domain: dict = {}
+    for r in rows:
+        by_domain.setdefault(r["domain"], []).append(r)
+
+    for domain, recs in sorted(by_domain.items()):
+        n_proven = sum(1 for r in recs if r["proven"])
+        star = f", ★ {n_proven} proven" if n_proven else ""
+        with st.expander(f"`{domain}` — {len(recs)} banked{star}", expanded=False):
+            for r in recs:
+                metric = r["metric"]
+                mtxt = (f" · {metric['name']}={metric['value']}"
+                        if isinstance(metric, dict) and metric.get("value") is not None
+                        else "")
+                badge = "★ proven" if r["proven"] else \
+                    f"{r['n_successes']}/{threshold} sessions"
+                if r["promoted_to_staging"]:
+                    badge += " · ✓ promoted"
+                meta_col, view_col, act_col = st.columns([4, 1, 1])
+                meta_col.caption(
+                    f"id={r['id']} · {badge} · retrieved {r['n_retrievals']}×{mtxt}\n\n"
+                    f"{r['label'][:110]}"
+                )
+                with view_col.popover("View", width="stretch"):
+                    rec = _script_bank.get_record(domain, r["id"])
+                    if rec:
+                        _render_bank_record(rec)
+                    else:
+                        st.error("Record unreadable.")
+                with act_col.popover("···", width="stretch"):
+                    if st.button(
+                        "Promote → staged knowledge",
+                        key=f"bankprom::{domain}/{r['id']}",
+                        disabled=bool(r["promoted_to_staging"]),
+                        help=("Already promoted." if r["promoted_to_staging"] else
+                              "Copies this script into the staged-knowledge "
+                              "buffer above for the review-gated skill path. "
+                              "The bank record is kept."),
+                    ):
+                        out = _script_bank.promote_to_staging(domain, r["id"])
+                        if out.get("status") == "success":
+                            st.success(f"Staged as {out['staged_id']} "
+                                       f"[{out['technique']}] — review above.")
+                        else:
+                            st.error(out.get("message", "Promotion failed."))
+                        st.rerun()
+                    if st.button("Delete record",
+                                 key=f"bankdel::{domain}/{r['id']}"):
+                        _script_bank.remove_records(domain, [r["id"]])
+                        st.rerun()
+
+
+# Bank bookkeeping keys not worth echoing in the per-record viewer.
+_BANK_HIDDEN_KEYS = {"id", "domain", "script_hash", "working_script"}
+
+
+def _render_bank_record(rec: dict) -> None:
+    """Show one bank record's matching tiers, stats, and script."""
+    for k, v in rec.items():
+        if k in _BANK_HIDDEN_KEYS or v in (None, "", [], {}):
+            continue
+        st.markdown(f"**{k.replace('_', ' ')}:** {v}")
+    script = (rec.get("working_script") or "").strip()
+    if script:
+        st.markdown("**working script:**")
+        st.code(script, language="python")
 
 
 # Bookkeeping keys not worth showing in the per-record viewer.

--- a/tests/test_memory_panel.py
+++ b/tests/test_memory_panel.py
@@ -63,6 +63,62 @@ def test_lazy_tick_loads_one_record(heavy_store):
     assert len(at.code) == 1  # exactly the ticked record's script
 
 
+def test_panel_survives_hostile_and_degenerate_records(tmp_path, monkeypatch):
+    """Markdown/HTML in labels, missing tiers, plain-float metrics, and a
+    corrupt JSON file alongside must not break the panel."""
+    monkeypatch.setenv("SCILINK_HOME", str(tmp_path))
+    monkeypatch.setenv("SCILINK_MEMORY", "1")
+    from scilink.skills._shared import _script_bank as sb
+
+    sb.add_record("curve_fitting", {
+        "working_script": "# s", "data_fingerprint": {"kind": "curve"},
+        "measurement_context": {},
+        "technique_signals": {"model_type": "**bold** <script>x</script> `tick`"},
+        "outcome": {"metric": 0.97}, "provenance": {"session": "s"}})
+    sb.add_record("curve_fitting", {
+        "working_script": "# s2", "data_fingerprint": None,
+        "measurement_context": None, "technique_signals": None,
+        "outcome": None, "provenance": {"session": "s"}})
+    (sb._domain_dir("curve_fitting") / "corrupt.json").write_text("{broken")
+
+    at = AppTest.from_string(PANEL_SCRIPT, default_timeout=60)
+    at.run()
+    assert not at.exception, at.exception
+
+
+def test_promote_button_flow_and_dangling_reenable(tmp_path, monkeypatch):
+    """Clicking Promote stages the record and disables the button; once the
+    staged copy is consumed/pruned, the button re-enables."""
+    monkeypatch.setenv("SCILINK_HOME", str(tmp_path))
+    monkeypatch.setenv("SCILINK_MEMORY", "1")
+    from scilink.skills._shared import _script_bank as sb, _staging
+
+    rid = sb.add_record("curve_fitting", {
+        "working_script": "# promoteme", "data_fingerprint": {"kind": "curve"},
+        "measurement_context": {}, "technique_signals": {"model_type": "voigt sum"},
+        "outcome": {"metric": {"name": "r_squared", "value": 0.99}},
+        "provenance": {"session": "s"}})["id"]
+    for s in ("s2", "s3"):
+        sb.record_success("curve_fitting", rid, session=s)
+    key = f"bankprom::curve_fitting/{rid}"
+
+    at = AppTest.from_string(PANEL_SCRIPT, default_timeout=60)
+    at.run()
+    btn = next(b for b in at.button if b.key == key)
+    assert not btn.disabled
+    btn.click().run()
+    assert not at.exception, at.exception
+    staged = _staging.list_staged("curve_fitting")
+    assert len(staged) == 1 and staged[0]["bank_id"] == rid
+
+    at.run()  # fresh render: button now disabled
+    assert next(b for b in at.button if b.key == key).disabled
+
+    _staging.remove_staged("curve_fitting", [staged[0]["id"]])
+    at.run()  # staged copy gone: promotable again
+    assert not next(b for b in at.button if b.key == key).disabled
+
+
 def test_long_lists_paginate(heavy_store):
     at = AppTest.from_string(PANEL_SCRIPT, default_timeout=60)
     at.run()

--- a/tests/test_memory_panel.py
+++ b/tests/test_memory_panel.py
@@ -1,0 +1,71 @@
+"""Headless render tests for the UI memory panel (skills.py).
+
+Guards the panel's performance contract: Streamlit renders popover/expander
+content eagerly on every rerun, so with many memory records the panel used to
+re-read every file and re-highlight every script per chat interaction (the
+observed slowdown). Heavy content must load only behind the explicit
+'Load full content' tick, and long lists must paginate.
+
+Uses streamlit.testing.v1.AppTest (no browser); skipped when streamlit is
+not installed.
+"""
+
+import pytest
+
+st = pytest.importorskip("streamlit")
+from streamlit.testing.v1 import AppTest  # noqa: E402
+
+PANEL_SCRIPT = """
+from scilink.ui.components.skills import _render_memory_section
+_render_memory_section()
+"""
+
+
+@pytest.fixture()
+def heavy_store(tmp_path, monkeypatch):
+    """A store with enough records to expose eager-render regressions."""
+    monkeypatch.setenv("SCILINK_HOME", str(tmp_path))
+    monkeypatch.setenv("SCILINK_MEMORY", "1")
+    from scilink.skills._shared import _script_bank as sb, _staging
+
+    big_script = "\n".join(f"# line {i}" for i in range(200))
+    for i in range(40):
+        sb.add_record("curve_fitting", {
+            "working_script": big_script + f"\n# uniq {i}",
+            "data_fingerprint": {"kind": "curve", "n_points": 1000 + i},
+            "measurement_context": {"technique": "Raman"},
+            "technique_signals": {"model_type": f"model variant {i}"},
+            "outcome": {"metric": {"name": "r_squared", "value": 0.99}},
+            "provenance": {"session": f"run{i}"}})
+    for i in range(30):
+        _staging.stage_solution("curve_fitting", f"tech_{i % 5}", {
+            "provenance": "t2_solution", "model": f"m{i}",
+            "working_script": big_script, "session": f"run{i}",
+            "r_squared": 0.99})
+    return tmp_path
+
+
+def test_panel_renders_lazily(heavy_store):
+    at = AppTest.from_string(PANEL_SCRIPT, default_timeout=60)
+    at.run()
+    assert not at.exception, at.exception
+    # NO script is syntax-highlighted until a viewer is explicitly loaded.
+    assert len(at.code) == 0
+    # Lazy viewers exist for the paged rows.
+    assert len(at.checkbox) > 0
+
+
+def test_lazy_tick_loads_one_record(heavy_store):
+    at = AppTest.from_string(PANEL_SCRIPT, default_timeout=60)
+    at.run()
+    at.checkbox[0].check().run()
+    assert not at.exception, at.exception
+    assert len(at.code) == 1  # exactly the ticked record's script
+
+
+def test_long_lists_paginate(heavy_store):
+    at = AppTest.from_string(PANEL_SCRIPT, default_timeout=60)
+    at.run()
+    # 40 bank records in one domain -> a 'Show all' button caps the page.
+    labels = " ".join(b.label for b in at.button)
+    assert "Show all 40" in labels

--- a/tests/test_script_bank.py
+++ b/tests/test_script_bank.py
@@ -324,7 +324,25 @@ class TestManagementSurface:
         rec = sb.get_record("curve_fitting", rid)
         assert rec["promoted_to_staging"] == out["staged_id"]
         again = sb.promote_to_staging("curve_fitting", rid)
-        assert again["status"] == "error" and "already promoted" in again["message"]
+        assert again["status"] == "error" and "already staged" in again["message"]
+
+    def test_repromotion_allowed_after_staged_copy_gone(self):
+        """upgrade/consolidate CONSUME staged records (and a user may prune
+        one) — a dangling promotion mark must not block re-promotion, and
+        the summary must stop showing the promoted badge."""
+        from scilink.skills._shared import _staging
+        rid = self._seed(n_sessions=3)
+        first = sb.promote_to_staging("curve_fitting", rid)
+        # Blocked while the staged copy awaits review...
+        assert sb.promote_to_staging("curve_fitting", rid)["status"] == "error"
+        assert sb.bank_summary("curve_fitting")[0]["promoted_to_staging"] == \
+            first["staged_id"]
+        # ...but free again once it was consumed/pruned.
+        _staging.remove_staged("curve_fitting", [first["staged_id"]])
+        assert sb.bank_summary("curve_fitting")[0]["promoted_to_staging"] is None
+        second = sb.promote_to_staging("curve_fitting", rid)
+        assert second["status"] == "success"
+        assert second["staged_id"] != first["staged_id"]
 
     def test_promote_explicit_technique_and_missing(self):
         rid = self._seed()

--- a/tests/test_script_bank.py
+++ b/tests/test_script_bank.py
@@ -275,6 +275,64 @@ class TestRetrieval:
             sb.hyperspectral_fingerprint(cube_a, axis2, "eV")) == []
 
 
+class TestManagementSurface:
+    def _seed(self, n_sessions=1, script="import numpy as np\n# proven\n"):
+        rid = sb.add_record("curve_fitting", {
+            "working_script": script,
+            "data_fingerprint": {"kind": "curve", "n_points": 100},
+            "measurement_context": {"technique": "Raman"},
+            "technique_signals": {"model_type": "Sum of 3 pseudo-Voigt peaks"},
+            "outcome": {"metric": {"name": "r_squared", "value": 0.99},
+                        "plan_summary": "fit three bands"},
+            "provenance": {"session": "s1"},
+        })["id"]
+        for i in range(1, n_sessions):
+            sb.record_success("curve_fitting", rid, session=f"s{i + 1}")
+        return rid
+
+    def test_bank_summary_shape_and_proven(self):
+        vet = self._seed(n_sessions=3)
+        fresh = self._seed(n_sessions=1, script="# other\n")
+        rows = sb.bank_summary("curve_fitting")
+        assert [r["id"] for r in rows][0] == vet  # proven-first ordering
+        top = rows[0]
+        assert top["proven"] is True and top["n_successes"] == 3
+        assert top["label"].startswith("Sum of 3 pseudo-Voigt")
+        assert top["metric"]["value"] == 0.99
+        assert rows[1]["id"] == fresh and rows[1]["proven"] is False
+
+    def test_proven_n_env_override(self, monkeypatch):
+        rid = self._seed(n_sessions=2)
+        assert sb.bank_summary("curve_fitting")[0]["proven"] is False
+        monkeypatch.setenv("SCILINK_BANK_PROVEN_N", "2")
+        assert sb.bank_summary("curve_fitting")[0]["proven"] is True
+        assert sb.get_record("curve_fitting", rid) is not None
+
+    def test_promote_to_staging_round_trip(self):
+        from scilink.skills._shared import _staging
+        rid = self._seed(n_sessions=3)
+        out = sb.promote_to_staging("curve_fitting", rid)
+        assert out["status"] == "success"
+        assert out["technique"] == "sum_of_3_pseudo_voigt_peaks"
+        staged = _staging.get_staged("curve_fitting", out["staged_id"])
+        assert staged["provenance"] == "bank_proven"
+        assert staged["r_squared"] == 0.99
+        assert "# proven" in staged["working_script"]
+        assert "3 session(s)" in staged["deviation_from_plan"]
+        assert staged["bank_id"] == rid
+        # Bank record kept and marked; repeat promotion refuses.
+        rec = sb.get_record("curve_fitting", rid)
+        assert rec["promoted_to_staging"] == out["staged_id"]
+        again = sb.promote_to_staging("curve_fitting", rid)
+        assert again["status"] == "error" and "already promoted" in again["message"]
+
+    def test_promote_explicit_technique_and_missing(self):
+        rid = self._seed()
+        out = sb.promote_to_staging("curve_fitting", rid, technique="raman_bands")
+        assert out["technique"] == "raman_bands"
+        assert sb.promote_to_staging("curve_fitting", "nope1234")["status"] == "error"
+
+
 class TestBankEnabled:
     def test_follows_memory_switch(self, monkeypatch):
         assert sb.bank_enabled() is True          # SCILINK_MEMORY=1 (fixture)


### PR DESCRIPTION
Follow-up to #347 (stacked on its branch): the script bank's **user surface** and its **bridge to skill graduation** — items 1 and 5 from that PR's deferred list.

## What a user gets

**See and manage what the agent remembers.** Bank records were previously inspectable only as JSON files under `~/.scilink/script_bank/`. Now:

- `scilink memory bank` lists banked scripts per domain with their cross-session stats — how many sessions each script has succeeded in, how often it was retrieved, its quality metric. Records proven across ≥3 sessions are starred as graduation candidates (`--proven-only` filters to them). `bank-show` prints a full record including the script; `bank-prune` deletes one.
- The UI memory panel gains a matching **Script bank** section beside the staged-knowledge section: per-domain expanders, usage badges, a record viewer, and promote/delete actions.

**An evidence-based path from episodic memory to skills.** `scilink memory bank-promote <domain>/<id>` (or the UI button) copies a proven record into the distill-staging buffer, where the *existing* review-gated ceremony applies unchanged — upgrade it into an existing skill, or consolidate it with others of its technique into a new one. This completes the memory story from issue #346: the bank gives immediate breadth (every success, zero ceremony), graduation gives curated depth, and "succeeded repeatedly across sessions" replaces "climbed to hot once" as the promotion evidence. The bank record itself is kept (episodic history is not consumed) and marked so surfaces show the promotion and repeats refuse.

Smoke-tested against the real store produced by #347's live-validation runs (11 curve + 3 hyperspectral records): the listing stars the two genuinely proven records (4 and 3 sessions), and promoting one staged it under a derived technique label, immediately visible to `scilink memory staged` with its metric and provenance.

---

## Technical details (for AI reviewers)

- `scilink/skills/_shared/_script_bank.py`: `proven_n()` (default 3, `$SCILINK_BANK_PROVEN_N`, floor 2), `record_label(rec)` (model_type → analysis_type → analysis_target fallback chain), `bank_summary(domain)` (display rows sorted by `(-n_successes, -n_retrievals, id)`), `promote_to_staging(domain, rid, technique=None, *, root, staging_root)` → stages `{provenance: "bank_proven", model, deviation_from_plan: <cross-session evidence>, plan_summary, measurement_context, working_script, session, bank_id, r_squared|quality_score}` via the existing `_staging.stage_solution`; refuses when `promoted_to_staging` is already set or the script is empty; deterministic technique label = snake-cased `record_label` cut at a word boundary ≤48 chars (no LLM — the staging vocabulary accepts any label, and the existing LLM labeler remains available upstream for T=2 staging).
- `scilink/cli/memory.py`: four flat subcommands (`bank`, `bank-show`, `bank-promote`, `bank-prune`) mirroring the staged-solutions command shapes, including the `_warn_memory_off` nudge on promote and `--yes` on prune. Module docstring updated.
- `scilink/ui/components/skills.py`: `_render_bank_section()` + `_render_bank_record()` appended after the staged section; thin rendering over the module helpers (no logic in Streamlit code); promote button disabled once promoted; delete via the per-record `···` popover.
- Tests: +5 in `tests/test_script_bank.py` (36 total) — summary shape/ordering/proven flag, `SCILINK_BANK_PROVEN_N` override, full promote round-trip asserting the staged record's provenance/metric/evidence and the refuse-on-repeat, explicit-technique and missing-record errors. Goldens pass unregenerated (no agent-path changes in this PR).
- Performance (second commit): Streamlit renders popover/expander content eagerly on every rerun — the cause of the panel slowdown with many memory records. All heavy content (skill markdown, staged/bank record views incl. `st.code` script highlighting) now loads only behind an explicit "Load full content" tick; long lists paginate (15 + Show all); oversized scripts truncate with a CLI pointer. Headless `AppTest` regression tests (`tests/test_memory_panel.py`): a 70-record store renders in ~0.08 s with zero eager code blocks. This also fixes the pre-existing eager renders in the provisional-skills and staged-knowledge sections.
- Known limits: promotion metadata maps `r_squared`/generic metrics onto the staging record's existing fields.
