### PR TITLE
Persist hook fields in curve results + global test store isolation

### DIFF
--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -969,13 +969,6 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # Compile results
         final_results = self._compile_results(state)
 
-        # Save final results
-        results_path = self.output_dir / "analysis_results.json"
-        with open(results_path, 'w') as f:
-            # Make serializable
-            serializable = self._make_serializable(final_results)
-            json.dump(serializable, f, indent=2, default=str)
-
         # Save fitting scripts for reproducibility
         self._save_fitting_scripts(state)
 
@@ -998,6 +991,15 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         banked = self._maybe_bank_scripts(state)
         if banked:
             final_results["banked_scripts"] = banked
+
+        # Save final results AFTER the memory hooks so the persisted JSON
+        # carries staged_solutions / banked_scripts, matching the returned
+        # dict (they were previously written before the hooks and silently
+        # missing from the file).
+        results_path = self.output_dir / "analysis_results.json"
+        with open(results_path, 'w') as f:
+            serializable = self._make_serializable(final_results)
+            json.dump(serializable, f, indent=2, default=str)
 
         self.logger.info("")
         self.logger.info("✅ ANALYSIS COMPLETE")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Global test isolation for SciLink's persistent store.
+
+Every test gets a throwaway ``SCILINK_HOME`` (and a clean slate for the
+memory/bank env switches). Without this, a developer machine where
+persistent memory is ENABLED in ``~/.scilink/config.json`` leaks in both
+directions: agent-running tests write fixture scripts into the developer's
+REAL script bank / staging buffer, and the bank's retrieval hooks inject
+exemplar blocks into golden-pinned prompts (observed live: 7 golden
+mismatches + fixture records in the real store the first time the suite ran
+on a memory-enabled machine).
+
+Tests that exercise the memory features opt back in explicitly with their
+own ``monkeypatch.setenv`` calls, which run after this autouse fixture and
+override it.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_scilink_home(tmp_path_factory, monkeypatch):
+    home = tmp_path_factory.mktemp("scilink_home")
+    monkeypatch.setenv("SCILINK_HOME", str(home))
+    monkeypatch.delenv("SCILINK_MEMORY", raising=False)
+    monkeypatch.delenv("SCILINK_SCRIPT_BANK", raising=False)

--- a/tests/qc_golden/test_realtime_golden.py
+++ b/tests/qc_golden/test_realtime_golden.py
@@ -126,6 +126,10 @@ def test_realtime_cold_start_zero_llm(tmp_path, monkeypatch):
     assert seed_result["status"] == "success"
     assert seed_result.get("banked_scripts"), "seed run must bank its script"
     rid = seed_result["banked_scripts"][0]
+    # The persisted results file must carry the hook fields too (it used to
+    # be written BEFORE the staging/banking hooks and silently lacked them).
+    saved = json.loads((tmp_path / "seed" / "analysis_results.json").read_text())
+    assert saved.get("banked_scripts") == seed_result["banked_scripts"]
     assert sb.get_record("curve_fitting", rid)["stats"]["n_successes"] == 1
 
     # Cold start — no prior, fail-loud model.


### PR DESCRIPTION
Two small fixes surfaced by inspecting real UI sessions after the #349 merge.

## What a user gets

**Saved results now tell the truth about memory.** The curve agent wrote `analysis_results.json` before the staging/banking hooks ran, so `banked_scripts` / `staged_solutions` were in the returned dict but silently missing from the file on disk — making successful banking look like a failure when inspecting a run directory. (The two sessions that surfaced this actually demonstrated the full bank flywheel working: the first banked its D/G carbon fit, the second retrieved it at score 0.932, adapted it, and banked the variant.) The file is now written after the hooks.

**Running the test suite can no longer touch your real memory store.** On a machine with persistent memory enabled in `~/.scilink/config.json`, the suite leaked both ways: agent-running tests banked fixture scripts into the developer's real `~/.scilink/script_bank`, and bank retrieval injected exemplar blocks into golden-pinned prompts (observed: 7 golden mismatches + 3 fixture records in the real store). A new global `tests/conftest.py` gives every test a throwaway `SCILINK_HOME` with the memory/bank switches cleared; memory-feature tests opt back in explicitly.

---

## Technical details (for AI reviewers)

- `curve_fitting_agent.py`: the `analysis_results.json` dump moved from before `_save_fitting_scripts` to after `_maybe_bank_scripts` (same serialization, same path; nothing between reads the file). Image/HS agents already saved after their hooks — curve was the outlier.
- `tests/conftest.py` (new): autouse fixture — `SCILINK_HOME` → per-test tmp via `tmp_path_factory`, `SCILINK_MEMORY`/`SCILINK_SCRIPT_BANK` deleted. Test-local `monkeypatch.setenv` calls run later and override, so the memory/bank/panel suites keep their explicit opt-ins unchanged.
- `test_realtime_golden.py`: the cold-start test additionally asserts the persisted seed `analysis_results.json` carries `banked_scripts` equal to the returned value.
- Verified on a memory-enabled machine: 75/75 across qc_golden + script-bank + memory-panel + persistent-memory + human-feedback + HS-records suites, goldens unregenerated, and the real `~/.scilink` store untouched by the run.