### PR TITLE
Retrieval quality tie-breaker + variant-group promotion into skill consolidation

### DIFF
--- a/scilink/cli/memory.py
+++ b/scilink/cli/memory.py
@@ -378,19 +378,73 @@ def _cmd_bank_show(args) -> int:
 
 
 def _cmd_bank_promote(args) -> int:
-    """Send a bank record into distill staging (the graduation path)."""
+    """Send bank record(s) into distill staging (the graduation path).
+
+    Several refs promote as a GROUP under one shared technique label, so
+    `consolidate` later reviews the variants together."""
     _warn_memory_off()
     from scilink.skills._shared import _script_bank
-    domain, rid = _split_ref(args.ref)
-    out = _script_bank.promote_to_staging(domain, rid, technique=args.technique)
-    if out.get("status") != "success":
-        print(f"❌ {out.get('message')}")
+    refs = [_split_ref(r) for r in args.refs]
+    domain = refs[0][0]
+    if any(d != domain for d, _ in refs):
+        print("❌ Group promotion takes records from ONE domain.")
         return 1
-    print(f"🧠 Promoted bank record {rid} → staged {out['staged_id']} "
-          f"[{out['technique']}].")
-    print("   Review with `scilink memory staged`, then `upgrade` it into an "
-          "existing skill or `consolidate` once enough of the technique "
-          "accumulates. The bank record is kept (marked ✓ promoted).")
+    if len(refs) == 1:
+        out = _script_bank.promote_to_staging(domain, refs[0][1],
+                                              technique=args.technique)
+        if out.get("status") != "success":
+            print(f"❌ {out.get('message')}")
+            return 1
+        print(f"🧠 Promoted bank record {refs[0][1]} → staged {out['staged_id']} "
+              f"[{out['technique']}].")
+    else:
+        out = _script_bank.promote_group_to_staging(
+            domain, [rid for _, rid in refs], technique=args.technique)
+        if out.get("status") != "success":
+            print(f"❌ {out.get('message')}")
+            return 1
+        print(f"🧠 Promoted {len(out['staged_ids'])} record(s) as one technique "
+              f"[{out['technique']}] → staged {', '.join(out['staged_ids'])}.")
+        for s in out.get("skipped", []):
+            print(f"   (skipped {s['id']}: {s['reason']})")
+        if out.get("ready_to_consolidate"):
+            print(f"   ✅ {out['n_staged_total']} staged for this technique — "
+                  f"ready: `scilink memory consolidate {domain}/{out['technique']}`")
+        else:
+            print(f"   Accumulating {out['n_staged_total']}/"
+                  f"{_staging.consolidate_min_n()} for consolidation "
+                  f"(`consolidate` can force it now).")
+    print("   Review with `scilink memory staged`; bank records are kept "
+          "(marked ✓ promoted).")
+    return 0
+
+
+def _cmd_bank_groups(args) -> int:
+    """`scilink memory bank-groups` — same-system variant clusters."""
+    from scilink.skills._shared import _script_bank
+    domains = ([args.domain] if args.domain else
+               sorted({r["domain"] for r in _script_bank.bank_summary()}))
+    total = 0
+    for dom in domains:
+        thr = (args.threshold if args.threshold is not None
+               else _script_bank.VARIANT_GROUP_THRESHOLD)
+        for g in _script_bank.find_variant_groups(dom, threshold=thr):
+            total += 1
+            print(f"{dom}: {len(g['ids'])} variants of one system "
+                  f"(min pairwise similarity {g['min_similarity']})")
+            for r in g["records"]:
+                m = r["metric"]
+                mtxt = (f"  {m['name']}={m['value']}"
+                        if isinstance(m, dict) and m.get("value") is not None else "")
+                mark = " ✓ promoted" if r["promoted_to_staging"] else ""
+                print(f"    · {r['id']}  successes={r['n_successes']}{mtxt}{mark}")
+                print(f"      {r['label'][:90]}")
+            refs = " ".join(f"{dom}/{i}" for i in g["ids"])
+            print(f"    → promote together: `scilink memory bank-promote {refs} "
+                  f"--technique {g['suggested_technique']}`")
+    if not total:
+        print("No variant groups found (need ≥2 records of the same system "
+              "in a domain).")
     return 0
 
 
@@ -488,11 +542,24 @@ def main():
 
     p_bp = sub.add_parser(
         "bank-promote",
-        help="Send a proven bank record into distill staging (review-gated skill path)")
-    p_bp.add_argument("ref", help="Bank record ref '<domain>/<id>'")
+        help="Send bank record(s) into distill staging; several refs promote "
+             "as a group under one shared technique label")
+    p_bp.add_argument("refs", nargs="+",
+                      help="Bank record ref(s) '<domain>/<id>' (same domain)")
     p_bp.add_argument("--technique", default=None,
-                      help="Staging technique label (default: derived from the record)")
+                      help="Staging technique label (default: derived from the "
+                           "best record)")
     p_bp.set_defaults(func=_cmd_bank_promote)
+
+    p_bg = sub.add_parser(
+        "bank-groups",
+        help="Show same-system variant clusters (candidates for group "
+             "promotion + consolidation)")
+    p_bg.add_argument("--domain", help="Restrict to one domain")
+    p_bg.add_argument("--threshold", type=float, default=None,
+                      help="Fingerprint-similarity grouping threshold "
+                           "(default 0.85)")
+    p_bg.set_defaults(func=_cmd_bank_groups)
 
     p_br = sub.add_parser("bank-prune", help="Delete a bank record")
     p_br.add_argument("ref", help="Bank record ref '<domain>/<id>'")

--- a/scilink/skills/_shared/_script_bank.py
+++ b/scilink/skills/_shared/_script_bank.py
@@ -612,7 +612,16 @@ def find_exemplar(domain: str, fingerprint: Optional[Dict[str, Any]],
         s_ctx = _context_similarity(query_tokens, rec)
         n_succ = (rec.get("stats") or {}).get("n_successes", 1) or 1
         usage = min(0.05, 0.01 * (int(n_succ) - 1))
-        score = 0.8 * s_fp + 0.2 * s_ctx + usage
+        # Quality tie-breaker: a small term from the record's gate metric so
+        # near-ties (same-system variants with equal fingerprints and usage)
+        # resolve toward the better-quality script instead of record-id order.
+        # Deliberately subordinate: one cross-session success (+0.01 usage)
+        # outweighs any realistic metric gap (max term 0.02) — "proven
+        # repeatedly" still beats "better once".
+        outcome = rec.get("outcome") or {}
+        mv = _metric_value(outcome.get("best_metric") or outcome.get("metric"))
+        quality = 0.02 * min(max(mv, 0.0), 1.0) if mv is not None else 0.0
+        score = 0.8 * s_fp + 0.2 * s_ctx + usage + quality
         if score >= min_score:
             scored.append((score, s_fp, rec))
     scored.sort(key=lambda t: (-t[0], t[2].get("id", "")))
@@ -727,7 +736,8 @@ def bank_summary(domain: Optional[str] = None, *,
             "proven": int(stats.get("n_successes", 1) or 1) >= threshold,
             "promoted_to_staging": sid,
         })
-    rows.sort(key=lambda r: (-r["n_successes"], -r["n_retrievals"], r["id"] or ""))
+    rows.sort(key=lambda r: (-r["n_successes"], -r["n_retrievals"],
+                             -(_metric_value(r["metric"]) or 0.0), r["id"] or ""))
     return rows
 
 
@@ -803,6 +813,131 @@ def promote_to_staging(domain: str, rid: str, technique: Optional[str] = None,
         json.dumps(rec, indent=2, default=str))
     return {"status": "success", "staged_id": sid, "technique": label,
             "domain": domain, "bank_id": rid}
+
+
+#: Minimum pairwise fingerprint similarity for two records to count as
+#: variants of the same system. Calibrated on real data: same-system pairs
+#: score ~1.0, a phase transition drops to ~0.79 (in-situ XRD), transition
+#: onset ~0.90 — 0.85 groups true variants without merging changed systems.
+VARIANT_GROUP_THRESHOLD = 0.85
+
+
+def find_variant_groups(domain: str, *, min_size: int = 2,
+                        threshold: float = VARIANT_GROUP_THRESHOLD,
+                        root: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Cluster a domain's records into same-system variant groups.
+
+    Single-linkage over pairwise fingerprint similarity (same kind only).
+    These groups are the natural units for skill consolidation: N different
+    successful treatments of one system are exactly what the distillation
+    LLM needs to generalize from. Returns, per group of >= ``min_size``:
+    ``ids`` (proven-first), ``min_similarity`` (worst pair inside the
+    group), ``suggested_technique`` (derived from the best member), and
+    ``n_unpromoted`` (members whose staged copy does not currently exist).
+    """
+    recs = [r for r in list_records(domain, root=root)
+            if (r.get("data_fingerprint") or {}).get("kind")
+            and (r.get("working_script") or "").strip()]
+    if len(recs) < min_size:
+        return []
+    sims: Dict[tuple, float] = {}
+    parent = list(range(len(recs)))
+
+    def find(i):
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    for i in range(len(recs)):
+        fp_i = recs[i]["data_fingerprint"]
+        simfn = _SIMILARITY_FNS.get(fp_i.get("kind"))
+        if simfn is None:
+            continue
+        for j in range(i + 1, len(recs)):
+            fp_j = recs[j]["data_fingerprint"]
+            if fp_j.get("kind") != fp_i.get("kind"):
+                continue
+            s = simfn(fp_i, fp_j)
+            sims[(i, j)] = s
+            if s >= threshold:
+                parent[find(i)] = find(j)
+
+    clusters: Dict[int, list] = {}
+    for i in range(len(recs)):
+        clusters.setdefault(find(i), []).append(i)
+
+    summary_by_id = {r["id"]: r for r in bank_summary(domain, root=root)}
+    groups = []
+    for members in clusters.values():
+        if len(members) < min_size:
+            continue
+        rows = sorted(
+            (summary_by_id[recs[i]["id"]] for i in members
+             if recs[i]["id"] in summary_by_id),
+            key=lambda r: (-r["n_successes"],
+                           -(_metric_value(r["metric"]) or 0.0), r["id"] or ""))
+        if len(rows) < min_size:
+            continue
+        pair_sims = [sims.get((min(i, j), max(i, j)), 1.0)
+                     for a, i in enumerate(members) for j in members[a + 1:]]
+        best = get_record(domain, rows[0]["id"], root=root) or {}
+        groups.append({
+            "domain": domain,
+            "ids": [r["id"] for r in rows],
+            "records": rows,
+            "min_similarity": round(min(pair_sims), 3) if pair_sims else 1.0,
+            "suggested_technique": _derive_technique_label(best),
+            "n_unpromoted": sum(1 for r in rows if not r["promoted_to_staging"]),
+        })
+    groups.sort(key=lambda g: (-len(g["ids"]), g["ids"][0]))
+    return groups
+
+
+def promote_group_to_staging(domain: str, ids: List[str],
+                             technique: Optional[str] = None, *,
+                             root: Optional[Path] = None,
+                             staging_root: Optional[Path] = None) -> Dict[str, Any]:
+    """Promote several same-system records under ONE shared technique label.
+
+    The shared label is what lets ``consolidate`` receive the variants
+    together — per-record derived labels would scatter them across
+    techniques and they would never be reviewed jointly. Records whose
+    staged copy already exists are skipped (not an error). Label defaults
+    to the best member's derived label.
+    """
+    from . import _staging
+
+    recs = [(rid, get_record(domain, rid, root=root)) for rid in ids]
+    missing = [rid for rid, rec in recs if rec is None]
+    if missing:
+        return {"status": "error",
+                "message": f"No bank record(s): {', '.join(missing)}."}
+    if technique is None:
+        best = max((rec for _, rec in recs),
+                   key=lambda r: ((r.get("stats") or {}).get("n_successes", 1),
+                                  _metric_value((r.get("outcome") or {}).get("best_metric")
+                                                or (r.get("outcome") or {}).get("metric")) or 0.0))
+        technique = _derive_technique_label(best)
+
+    staged_ids, skipped = [], []
+    for rid, _rec in recs:
+        out = promote_to_staging(domain, rid, technique=technique,
+                                 root=root, staging_root=staging_root)
+        if out.get("status") == "success":
+            staged_ids.append(out["staged_id"])
+        else:
+            skipped.append({"id": rid, "reason": out.get("message")})
+    if not staged_ids and skipped:
+        return {"status": "error", "technique": technique, "skipped": skipped,
+                "message": "Nothing promoted: " + skipped[0]["reason"]}
+
+    n_staged_total = len(_staging.group_by_technique(
+        domain, root=staging_root).get(technique, []))
+    return {"status": "success", "technique": technique,
+            "staged_ids": staged_ids, "skipped": skipped,
+            "n_staged_total": n_staged_total,
+            "ready_to_consolidate": n_staged_total >= _staging.consolidate_min_n()}
 
 
 def render_exemplar_block(match: Dict[str, Any]) -> str:

--- a/scilink/ui/components/skills.py
+++ b/scilink/ui/components/skills.py
@@ -406,6 +406,7 @@ def _render_bank_section() -> None:
         n_proven = sum(1 for r in recs if r["proven"])
         star = f", ★ {n_proven} proven" if n_proven else ""
         with st.expander(f"`{domain}` — {len(recs)} banked{star}", expanded=False):
+            _render_variant_group_suggestions(domain)
             for r in _paged(recs, f"bankpage::{domain}"):
                 metric = r["metric"]
                 mtxt = (f" · {metric['name']}={metric['value']}"
@@ -449,6 +450,62 @@ def _render_bank_section() -> None:
                                  key=f"bankdel::{domain}/{r['id']}"):
                         _script_bank.remove_records(domain, [r["id"]])
                         st.rerun()
+
+
+def _render_variant_group_suggestions(domain: str) -> None:
+    """Surface same-system variant clusters as one-click group promotions.
+
+    N different successful treatments of one system are exactly what skill
+    consolidation needs to generalize from — but only if they reach the
+    staging buffer under ONE technique label. This suggestion does the
+    grouping (by fingerprint similarity) and the shared label for the user.
+    """
+    from scilink.skills._shared import _script_bank
+
+    try:
+        groups = [g for g in _script_bank.find_variant_groups(domain)
+                  if g["n_unpromoted"] > 0]
+    except Exception:  # noqa: BLE001 - suggestions must never break the panel
+        return
+    for g in groups:
+        ids = g["ids"]
+        with st.container(border=True):
+            st.markdown(
+                f"💡 **{len(ids)} records look like the same system** "
+                f"(min pairwise similarity {g['min_similarity']}): "
+                + ", ".join(f"`{i}`" for i in ids)
+            )
+            st.caption(
+                "Promote them together under one technique label so the "
+                "review-gated consolidation can distill a general skill "
+                "from all variants at once."
+            )
+            gkey = "::".join([domain] + ids)
+            label = st.text_input(
+                "Technique label", value=g["suggested_technique"],
+                key=f"bankgrouplabel::{gkey}")
+            if st.button(f"Promote {len(ids)} as one technique",
+                         key=f"bankgroup::{gkey}"):
+                out = _script_bank.promote_group_to_staging(
+                    domain, ids, technique=label or None)
+                if out.get("status") == "success":
+                    msg = (f"Staged {len(out['staged_ids'])} under "
+                           f"[{out['technique']}].")
+                    if out.get("ready_to_consolidate"):
+                        msg += " Ready to consolidate in Staged knowledge above."
+                    else:
+                        msg += (f" {out['n_staged_total']} staged so far — "
+                                f"consolidation is suggested at "
+                                f"{_consolidate_min_n_ui()}.")
+                    st.success(msg)
+                else:
+                    st.error(out.get("message", "Group promotion failed."))
+                st.rerun()
+
+
+def _consolidate_min_n_ui() -> int:
+    from scilink.skills._shared import _staging
+    return _staging.consolidate_min_n()
 
 
 # Bank bookkeeping keys not worth echoing in the per-record viewer.

--- a/tests/test_memory_panel.py
+++ b/tests/test_memory_panel.py
@@ -157,3 +157,35 @@ def test_demote_and_destage_buttons(tmp_path, monkeypatch):
     destage.click().run()
     assert not at.exception, at.exception
     assert _staging.list_staged("curve_fitting") == []
+
+
+def test_variant_group_suggestion_and_group_promote(tmp_path, monkeypatch):
+    """The bank panel suggests same-system variant groups and promotes them
+    under one shared technique label; the suggestion clears afterwards."""
+    monkeypatch.setenv("SCILINK_HOME", str(tmp_path))
+    monkeypatch.setenv("SCILINK_MEMORY", "1")
+    from scilink.skills._shared import _script_bank as sb, _staging
+
+    fp = {"kind": "curve", "n_points": 500, "x_range": [0.0, 100.0],
+          "peaks": {"count": 2, "top": [
+              {"position": 30.0, "fwhm": 5.0, "prominence": 1.0},
+              {"position": 70.0, "fwhm": 5.0, "prominence": 0.5}]}}
+    ids = [sb.add_record("curve_fitting", {
+        "working_script": f"# v{i}", "data_fingerprint": fp,
+        "measurement_context": {"technique": "Raman"},
+        "technique_signals": {"model_type": "two voigt carbon"},
+        "outcome": {"metric": {"name": "r_squared", "value": 0.99 - i * 0.01}},
+        "provenance": {"session": f"s{i}"}})["id"] for i in range(2)]
+
+    at = AppTest.from_string(PANEL_SCRIPT, default_timeout=60)
+    at.run()
+    gkey = "::".join(["curve_fitting"] + sorted(ids, key=lambda x: x))
+    btns = [b for b in at.button if b.key and b.key.startswith("bankgroup::")]
+    assert btns, "group-promote suggestion button missing"
+    btns[0].click().run()
+    assert not at.exception, at.exception
+    staged = _staging.group_by_technique("curve_fitting")
+    assert len(staged) == 1 and len(next(iter(staged.values()))) == 2
+
+    at.run()  # suggestion gone once all members are promoted
+    assert not [b for b in at.button if b.key and b.key.startswith("bankgroup::")]

--- a/tests/test_script_bank.py
+++ b/tests/test_script_bank.py
@@ -559,3 +559,102 @@ class TestHyperspectralBankHook:
             agent, records, {}, "/gone.npy", {})
         assert len(banked) == 1
         assert sb.list_records("hyperspectral")[0]["data_fingerprint"] is None
+
+
+class TestMetricTieBreaker:
+    def _rec(self, script, r2, sessions=1):
+        rid = sb.add_record("curve_fitting", {
+            "working_script": script,
+            "data_fingerprint": {"kind": "curve", "n_points": 500,
+                                 "x_range": [0.0, 100.0],
+                                 "peaks": {"count": 2, "top": [
+                                     {"position": 30.0, "fwhm": 5.0, "prominence": 1.0},
+                                     {"position": 70.0, "fwhm": 5.0, "prominence": 0.5}]}},
+            "measurement_context": {"technique": "Raman"},
+            "technique_signals": {"model_type": "two peaks"},
+            "outcome": {"metric": {"name": "r_squared", "value": r2}},
+            "provenance": {"session": "s1"}})["id"]
+        for i in range(1, sessions):
+            sb.record_success("curve_fitting", rid, session=f"s{i+1}")
+        return rid
+
+    def _query_fp(self):
+        return {"kind": "curve", "n_points": 500, "x_range": [0.0, 100.0],
+                "peaks": {"count": 2, "top": [
+                    {"position": 30.0, "fwhm": 5.0, "prominence": 1.0},
+                    {"position": 70.0, "fwhm": 5.0, "prominence": 0.5}]}}
+
+    def test_metric_breaks_exact_tie(self):
+        low = self._rec("# low", 0.9838)   # lower id would win the old sort
+        high = self._rec("# high", 0.9905)
+        top = sb.find_exemplar("curve_fitting", self._query_fp())[0]
+        assert top["record"]["id"] == high
+        assert low != high
+
+    def test_proven_still_beats_better_metric(self):
+        veteran = self._rec("# vet", 0.9838, sessions=3)   # +0.02 usage
+        self._rec("# newcomer", 0.9999)                     # metric edge ~0.0003
+        top = sb.find_exemplar("curve_fitting", self._query_fp())[0]
+        assert top["record"]["id"] == veteran
+
+
+class TestVariantGroups:
+    def _seed_pair_plus_outlier(self):
+        fp_same = {"kind": "curve", "n_points": 500, "x_range": [0.0, 100.0],
+                   "peaks": {"count": 2, "top": [
+                       {"position": 30.0, "fwhm": 5.0, "prominence": 1.0},
+                       {"position": 70.0, "fwhm": 5.0, "prominence": 0.5}]}}
+        fp_far = {"kind": "curve", "n_points": 800, "x_range": [1000.0, 2000.0],
+                  "peaks": {"count": 5, "top": [
+                      {"position": 1500.0, "fwhm": 20.0, "prominence": 1.0}]}}
+        ids = []
+        for i, (fp, r2) in enumerate([(fp_same, 0.9905), (fp_same, 0.9838),
+                                      (fp_far, 0.99)]):
+            ids.append(sb.add_record("curve_fitting", {
+                "working_script": f"# variant {i}",
+                "data_fingerprint": fp,
+                "measurement_context": {"technique": "Raman"},
+                "technique_signals": {"model_type": "Two Voigt D G carbon"},
+                "outcome": {"metric": {"name": "r_squared", "value": r2}},
+                "provenance": {"session": f"s{i}"}})["id"])
+        return ids
+
+    def test_groups_cluster_same_system_only(self):
+        a, b, far = self._seed_pair_plus_outlier()
+        groups = sb.find_variant_groups("curve_fitting")
+        assert len(groups) == 1
+        g = groups[0]
+        assert sorted(g["ids"]) == sorted([a, b])
+        assert far not in g["ids"]
+        assert g["min_similarity"] >= sb.VARIANT_GROUP_THRESHOLD
+        assert g["ids"][0] == a  # higher metric ranks first inside the group
+        assert g["n_unpromoted"] == 2
+        assert g["suggested_technique"].startswith("two_voigt")
+
+    def test_group_promotion_shared_label_and_consolidate_flow(self, monkeypatch):
+        from scilink.skills._shared import _staging
+        a, b, _ = self._seed_pair_plus_outlier()
+        out = sb.promote_group_to_staging("curve_fitting", [a, b])
+        assert out["status"] == "success"
+        assert len(out["staged_ids"]) == 2 and not out["skipped"]
+        groups = _staging.group_by_technique("curve_fitting")
+        assert set(groups.keys()) == {out["technique"]}  # ONE shared label
+        assert len(groups[out["technique"]]) == 2
+        # readiness reflects consolidate_min_n
+        assert out["ready_to_consolidate"] is False
+        monkeypatch.setenv("SCILINK_CONSOLIDATE_N", "2")
+        out2 = sb.promote_group_to_staging("curve_fitting", [a, b])
+        assert out2["status"] == "error"  # both already staged -> nothing new
+        # suggestion disappears once everyone is promoted
+        assert sb.find_variant_groups("curve_fitting")[0]["n_unpromoted"] == 0
+
+    def test_group_promotion_skips_staged_member(self):
+        a, b, _ = self._seed_pair_plus_outlier()
+        sb.promote_to_staging("curve_fitting", a, technique="early")
+        out = sb.promote_group_to_staging("curve_fitting", [a, b],
+                                          technique="carbon_dg")
+        assert out["status"] == "success"
+        assert len(out["staged_ids"]) == 1
+        assert out["skipped"][0]["id"] == a
+        assert sb.promote_group_to_staging(
+            "curve_fitting", ["nope0000"])["status"] == "error"


### PR DESCRIPTION
Two additions driven by the first real same-system variant pair in a user's bank (two successful treatments of the same carbon D/G spectrum: Voigt-on-spline R²=0.9905 vs ALS-baseline R²=0.9838, pairwise fingerprint similarity 1.0).

## What a user gets

**1. Ties in script retrieval now resolve toward the better script.** Same-system variants tie on fingerprint and usage; the winner was previously decided by record-id order (which happened to favor the lower-R² variant in the real pair). A small quality term (weighted below one cross-session success, so *proven repeatedly* still beats *better once*) breaks the tie. Live-verified: identical retrieval scores to three decimals, and a full Bedrock session now gets offered the higher-R² record — and adapted it to R²=0.9969, the family's best fit yet.

**2. Variant groups flow into skill consolidation together.** `scilink memory bank-groups` (and a suggestion box in the UI bank panel) detects same-system variant clusters by fingerprint similarity and promotes them under **one shared technique label** — the missing bridge to `consolidate`, which reviews **all** variants of a system jointly and distills a general skill. Per-record derived labels used to scatter variants across techniques so they could never be reviewed together. Live-validated end to end on a copy of the real store: the carbon pair was detected (similarity 1.0), group-promoted via CLI, and Bedrock consolidation produced a genuinely generalized skill — **both** baseline strategies with explicit selection criteria ("ALS preferred default; spline when the continuum has structured shoulders"), shared parameter bounds, the low-wavenumber exclusion lesson, and validation targets quoting the real examples' R² range.

Grouping threshold 0.85, calibrated on real data: same-system pairs score ~1.0, a phase-transition onset 0.90, a changed phase 0.79.

---

## Technical details (for AI reviewers)

- `_script_bank.find_exemplar`: score gains `+0.02·clamp(metric,0,1)` from `outcome.best_metric|metric` via `_metric_value`; max term (0.02) and realistic deltas (~1e-4) both sit below one usage step (0.01/success). `bank_summary` ordering adds `-metric` before id.
- `find_variant_groups(domain, min_size=2, threshold=VARIANT_GROUP_THRESHOLD)`: union-find single-linkage over pairwise same-kind fingerprint similarity; returns ids (proven-then-metric ordered), group `min_similarity`, `suggested_technique` (derived from best member), `n_unpromoted` (liveness-aware). `promote_group_to_staging(domain, ids, technique=None)`: shared label defaulting to best member's derivation; skips members whose staged copy exists; reports `ready_to_consolidate` vs `consolidate_min_n()`.
- CLI: `bank-promote` takes `refs nargs='+'` (single-ref behavior unchanged; multi = group path); new `bank-groups [--domain] [--threshold]` prints clusters with a copy-pasteable promote command. UI: `_render_variant_group_suggestions` inside each domain expander — bordered suggestion with prefilled label input and one-click group promote; hidden once all members are staged; failure-isolated.
- Tests: +7 (`TestMetricTieBreaker`: exact-tie flip + veteran-beats-metric; `TestVariantGroups`: cluster membership/threshold/ordering, shared-label staging + readiness, skip-already-staged, missing-id error; AppTest: suggestion renders, button stages both under one label, suggestion clears). 66 green across the memory suites; goldens unregenerated.
- Live artifacts (store-copy, not committed): ranking flip on the real pair; CLI bank-groups/bank-promote transcript; consolidated skill `auto_carbon_dg_fluorescence_fit`; full Bedrock adapt session offering the metric winner.