### PR TITLE
Fork built-in skills (copy-on-write) with structurally additive upgrades

### DIFF
--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2998,14 +2998,19 @@ Update an existing skill with new knowledge while preserving what is already cor
    (`error_lessons` error→fix pairs) → validation pitfalls/sanity-checks and analysis cautions; \
    `user_correction` (`user_feedback`) → planning constraints/preferences and validation \
    acceptance criteria (treat human corrections as high-priority ground truth).
-4. Do NOT remove existing content unless the new knowledge explicitly contradicts it.
+4. Be ADDITIVE: the existing skill already routes real analyses, and every existing rule, \
+   constraint, and section is load-bearing — removing or weakening one regresses working \
+   behavior. Remove or weaken existing guidance ONLY when the new knowledge explicitly \
+   contradicts it.
 5. When there is a conflict, prefer the newer knowledge but note the discrepancy briefly.
 6. If the new knowledge materially changes the skill's purpose, update the description; \
    otherwise leave it intact.
 7. Keep prose tight. The skill is read into LLM context every time.
 
-Return a JSON object with the SAME keys as the existing skill (description, overview, planning, \
-analysis, interpretation, validation) reflecting the merged skill content.
+Return a JSON object with the SAME keys as the existing skill — description plus EVERY section \
+key the existing skill has (any of: overview, planning, analysis, implementation, interpretation, \
+validation) — reflecting the merged skill content. Omitting a key the existing skill has would \
+DELETE that section.
 
 Output ONLY the JSON object. Do not wrap in code blocks. Do not include any prose outside the JSON."""
 

--- a/scilink/cli/memory.py
+++ b/scilink/cli/memory.py
@@ -16,6 +16,10 @@ Skills (graduated_skills) subcommands:
   promote   Clear a skill's provisional flag so it routes normally
   demote    Set a promoted skill back to provisional (out of auto-routing)
   prune     Delete a skill bundle
+  fork      Copy a BUILT-IN skill into the persistent store (shadows it;
+            makes it upgradable) — copy-on-write for shipped skills
+  diff-builtin  Diff a forked skill against its shipped original (for
+            contributing improvements back as a package PR)
 
 Staged T=2 solutions (distill_staging) subcommands:
   staged       List staged raw T=2 solutions, grouped by technique
@@ -165,6 +169,47 @@ def _cmd_demote(args) -> int:
     return 0
 
 
+def _cmd_fork(args) -> int:
+    """`scilink memory fork` — copy a built-in skill into the persistent store."""
+    _warn_memory_off()  # a fork only SHADOWS while persistent memory is on
+    from scilink.skills._shared._memory import fork_builtin
+    domain, name = _split_ref(args.ref)
+    try:
+        out = fork_builtin(domain, name)
+    except FileNotFoundError as e:
+        print(f"❌ {e}")
+        return 1
+    if out.get("status") != "success":
+        print(f"❌ {out.get('message')}")
+        return 1
+    print(f"🍴 Forked built-in {domain}/{name} → {out['path']}")
+    print("   The fork SHADOWS the shipped skill immediately (loader precedence)"
+          " and is now a valid `upgrade --into` target.")
+    if out.get("has_sibling_tools"):
+        print(f"   Note: the built-in bundle also ships tools "
+              f"({', '.join(out['sibling_tools'])}) — those stay with the "
+              f"package and keep registering for this skill; only the "
+              f"markdown was forked.")
+    print(f"   Contribute back later: `scilink memory diff-builtin {domain}/{name}`; "
+          f"prune the fork once merged upstream.")
+    return 0
+
+
+def _cmd_diff_builtin(args) -> int:
+    from scilink.skills._shared._memory import diff_builtin
+    domain, name = _split_ref(args.ref)
+    try:
+        out = diff_builtin(domain, name)
+    except FileNotFoundError as e:
+        print(f"❌ {e}")
+        return 1
+    if out["identical"]:
+        print(f"Fork of {domain}/{name} is identical to the built-in.")
+    else:
+        print(out["diff"])
+    return 0
+
+
 def _cmd_prune(args) -> int:
     domain, name = _split_ref(args.ref)
     if not args.yes:
@@ -252,6 +297,9 @@ def _cmd_upgrade(args) -> int:
     if prop.get("status") != "success":
         print(f"❌ {prop.get('message', prop)}")
         return 1
+
+    for w in prop.get("regression_warnings") or []:
+        print(f"⚠️  ADDITIVITY: {w}")
 
     # 2) show the diff for review (upgrade mutates an existing skill in place)
     if not args.yes:
@@ -444,6 +492,17 @@ def main():
         "demote", help="Set a skill back to provisional (out of auto-routing)")
     p_demote.add_argument("ref", help="Skill reference '<domain>/<name>'")
     p_demote.set_defaults(func=_cmd_demote)
+
+    p_fork = sub.add_parser(
+        "fork", help="Copy a built-in skill into the persistent store "
+                     "(shadows it; enables upgrade)")
+    p_fork.add_argument("ref", help="Built-in skill ref '<domain>/<name>'")
+    p_fork.set_defaults(func=_cmd_fork)
+
+    p_db = sub.add_parser(
+        "diff-builtin", help="Diff a forked skill against the shipped built-in")
+    p_db.add_argument("ref", help="Skill ref '<domain>/<name>'")
+    p_db.set_defaults(func=_cmd_diff_builtin)
 
     p_prune = sub.add_parser("prune", help="Delete a skill bundle")
     p_prune.add_argument("ref", help="Skill reference '<domain>/<name>'")

--- a/scilink/skills/_shared/_memory.py
+++ b/scilink/skills/_shared/_memory.py
@@ -221,6 +221,69 @@ def demote_memory(domain: str, name: str, *, root: Optional[Path] = None) -> Dic
     }
 
 
+def fork_builtin(domain: str, name: str, *, root: Optional[Path] = None) -> Dict[str, Any]:
+    """Copy a built-in (package) skill into the persistent store.
+
+    The copy-on-write path for improving a shipped skill: package skills are
+    immutable to the runtime machinery, but the loader's precedence (user
+    roots > persistent store > built-in) means the forked copy SHADOWS the
+    shipped one immediately — and the review-gated upgrade machinery can
+    then evolve it. Contribute the divergence back with a package PR (see
+    ``scilink memory diff-builtin``) and prune the fork afterwards.
+
+    The markdown is copied byte-identical (so diff-builtin starts clean).
+    Sibling ``.py`` tool files are NOT copied: TOOL_SPEC discovery walks the
+    installed package by skill name, so the shipped tools keep registering
+    for the forked skill unchanged.
+    """
+    from ..loader import _SKILLS_DIR
+
+    src_md = _SKILLS_DIR / domain / name / f"{name}.md"
+    if not src_md.is_file():
+        raise FileNotFoundError(f"No built-in skill: {domain}/{name}")
+    root = root or graduated_skills_dir()
+    dest_dir = root / domain / name
+    dest_md = dest_dir / f"{name}.md"
+    if dest_md.exists():
+        return {"status": "error",
+                "message": (f"{domain}/{name} is already forked "
+                            f"({dest_md}); upgrade or prune that copy.")}
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    (dest_dir / "__init__.py").touch()
+    dest_md.write_text(src_md.read_text())
+    sibling_tools = sorted(
+        f.name for f in src_md.parent.glob("*.py") if f.name != "__init__.py")
+    return {
+        "status": "success",
+        "domain": domain,
+        "name": name,
+        "path": str(dest_md),
+        "builtin_path": str(src_md),
+        "has_sibling_tools": bool(sibling_tools),
+        "sibling_tools": sibling_tools,
+    }
+
+
+def diff_builtin(domain: str, name: str, *, root: Optional[Path] = None) -> Dict[str, Any]:
+    """Unified diff of a forked skill against its shipped built-in original."""
+    import difflib
+    from ..loader import _SKILLS_DIR
+
+    src_md = _SKILLS_DIR / domain / name / f"{name}.md"
+    fork_md = (root or graduated_skills_dir()) / domain / name / f"{name}.md"
+    if not src_md.is_file():
+        raise FileNotFoundError(f"No built-in skill: {domain}/{name}")
+    if not fork_md.is_file():
+        raise FileNotFoundError(f"No forked copy of {domain}/{name} "
+                                f"(run `scilink memory fork {domain}/{name}`).")
+    diff = "\n".join(difflib.unified_diff(
+        src_md.read_text().splitlines(), fork_md.read_text().splitlines(),
+        fromfile=f"built-in/{name}.md", tofile=f"fork/{name}.md", lineterm=""))
+    return {"status": "success", "diff": diff,
+            "identical": not diff, "builtin_path": str(src_md),
+            "fork_path": str(fork_md)}
+
+
 def prune_memory(domain: str, name: str, *, root: Optional[Path] = None) -> Dict[str, Any]:
     """Delete a persisted skill bundle directory."""
     root = root or graduated_skills_dir()

--- a/scilink/skills/_shared/_staging.py
+++ b/scilink/skills/_shared/_staging.py
@@ -339,6 +339,104 @@ def _missing_target_error(target_domain: str, target_name: str) -> Dict[str, Any
                         f"consolidate to create a new skill.")}
 
 
+_FM_RE = __import__("re").compile(r"\A---\n(.*?)\n---\n", __import__("re").DOTALL)
+
+
+def _preserve_structure(existing: str, proposed: str) -> str:
+    """Structural additivity: reinstate what the JSON round-trip loses.
+
+    The upgrade LLM works on a fixed-vocabulary JSON view of the skill, so
+    its re-rendered markdown drops everything outside that vocabulary —
+    observed live on a forked built-in: the ``technique:`` routing
+    frontmatter (breaks skill auto-selection), the H1 title, the original
+    heading casing, and an injected empty section. This deterministic pass
+    restores the original frontmatter (the LLM may refresh only
+    ``description``), the title, and heading case, and drops empty sections
+    the original didn't have. Prose merging stays the LLM's job; structure
+    is not up for negotiation.
+    """
+    import re
+    import yaml
+
+    m_old, m_new = _FM_RE.match(existing), _FM_RE.match(proposed)
+    old_meta = yaml.safe_load(m_old.group(1)) if m_old else {}
+    new_meta = yaml.safe_load(m_new.group(1)) if m_new else {}
+    old_meta = old_meta if isinstance(old_meta, dict) else {}
+    new_meta = new_meta if isinstance(new_meta, dict) else {}
+    merged = dict(old_meta)
+    if new_meta.get("description"):
+        merged["description"] = new_meta["description"]
+
+    body = proposed[m_new.end():] if m_new else proposed
+    old_body = existing[m_old.end():] if m_old else existing
+
+    # Restore original heading casing (case-insensitive match).
+    old_heads = {h.lower(): h
+                 for h in re.findall(r"^##\s+(.+?)\s*$", old_body, re.M)}
+    body = re.sub(
+        r"^(##\s+)(.+?)\s*$",
+        lambda m: m.group(1) + old_heads.get(m.group(2).lower(), m.group(2)),
+        body, flags=re.M)
+
+    # Drop EMPTY sections the original didn't have (round-trip artifacts).
+    parts = re.split(r"(?m)^(##\s+.+)$", body)
+    rebuilt = [parts[0]]
+    for i in range(1, len(parts), 2):
+        head, section_body = parts[i], (parts[i + 1] if i + 1 < len(parts) else "")
+        name = head.lstrip("# ").strip().lower()
+        if not section_body.strip() and name not in old_heads:
+            continue
+        rebuilt.append(head + section_body)
+    body = "".join(rebuilt) if len(rebuilt) > 1 else body
+
+    # Reinstate whole sections the proposal dropped — additivity by
+    # construction: an omitted section reappears verbatim from the original
+    # (appended in original order), so an LLM omission can no longer delete
+    # curated content. The reviewer still sees it via the diff.
+    new_heads = {h.lower()
+                 for h in re.findall(r"^##\s+(.+?)\s*$", body, re.M)}
+    old_parts = re.split(r"(?m)^(##\s+.+)$", old_body)
+    for i in range(1, len(old_parts), 2):
+        head = old_parts[i]
+        name = head.lstrip("# ").strip().lower()
+        if name not in new_heads:
+            section_body = old_parts[i + 1] if i + 1 < len(old_parts) else ""
+            body = body.rstrip("\n") + "\n\n" + head + section_body
+
+    # Restore a lost H1 title.
+    m_title = re.match(r"\s*(#\s+[^#\n][^\n]*)", old_body)
+    if m_title and not re.search(r"^#\s+[^#]", body, re.M):
+        body = m_title.group(1) + "\n\n" + body.lstrip("\n")
+
+    if merged:
+        fm = yaml.safe_dump(merged, default_flow_style=False, sort_keys=False,
+                            allow_unicode=True, width=10_000).strip()
+        return f"---\n{fm}\n---\n{body}"
+    return body
+
+
+def _regression_warnings(existing: str, proposed: str) -> List[str]:
+    """Deterministic additivity check on an upgrade proposal.
+
+    Upgrades must not regress a skill that already routes real analyses:
+    flag dropped ``##`` sections and large content shrinkage so the human
+    reviewer sees structural loss before approving. Advisory — the reviewer
+    decides; a deliberate trim can still be applied.
+    """
+    import re
+    old_secs = re.findall(r"^##\s+(.+?)\s*$", existing, re.M)
+    new_secs = {s.lower() for s in re.findall(r"^##\s+(.+?)\s*$", proposed, re.M)}
+    warns = [f"existing section '## {s}' is missing from the proposal"
+             for s in old_secs if s.lower() not in new_secs]
+    n_old, n_new = len(existing.split()), len(proposed.split())
+    if n_old and n_new < 0.8 * n_old:
+        warns.append(
+            f"proposal is {100 - round(100 * n_new / n_old)}% shorter than the "
+            f"current skill ({n_new} vs {n_old} words) — check that existing "
+            f"guidance was not dropped")
+    return warns
+
+
 def propose_skill_upgrade(
     domain: str,
     staged_ids: List[str],
@@ -378,11 +476,15 @@ def propose_skill_upgrade(
     )
     if result.get("status") != "success":
         return result
+    existing_content = target_md.read_text()
+    proposed_content = _preserve_structure(existing_content, result["content"])
     return {
         "status": "success",
         "action": "proposed",
-        "proposed_content": result["content"],
-        "existing_content": target_md.read_text(),
+        "proposed_content": proposed_content,
+        "existing_content": existing_content,
+        "regression_warnings": _regression_warnings(
+            existing_content, proposed_content),
         "skill_path": str(target_md),
         "target_domain": target_domain,
         "target_name": target_name,

--- a/scilink/ui/components/skills.py
+++ b/scilink/ui/components/skills.py
@@ -232,7 +232,16 @@ def _render_staged_section() -> None:
             # Keep the action buttons in narrow columns + a trailing spacer so
             # they land at a modest size (like the sidebar's Reset/Quit) rather
             # than stretching across the full-width memory panel.
-            targets = [f"{s['domain']}/{s['name']}" for s in _memory.list_memory(domain=domain)]
+            persistent = {s["name"] for s in _memory.list_memory(domain=domain)}
+            targets = [f"{domain}/{n}" for n in sorted(persistent)]
+            # Built-ins are valid targets via copy-on-write: selecting one
+            # forks it into the persistent store first (shadowing the shipped
+            # copy), then the normal review-gated upgrade applies to the fork.
+            from scilink.skills import loader as _loader
+            builtin_only = [n for n in _loader.list_skills(domain)
+                            if n not in persistent]
+            targets += [f"{domain}/{n} (built-in — forks on upgrade)"
+                        for n in sorted(builtin_only)]
             c1, c2, _ = st.columns([2, 2, 4])
             prop_key = f"upgprop::{domain}/{technique}"
             with c1:
@@ -249,6 +258,15 @@ def _render_staged_section() -> None:
                         from scilink.agents.exp_agents.instruct import (
                             KNOWLEDGE_TO_SKILL_INSTRUCTIONS, SKILL_UPDATE_INSTRUCTIONS)
                         td, tn = tgt.split("/", 1)
+                        if tn.endswith(" (built-in — forks on upgrade)"):
+                            tn = tn.split(" (built-in", 1)[0]
+                            fout = _memory.fork_builtin(td, tn)
+                            if fout.get("status") != "success":
+                                st.error(fout.get("message", "Fork failed."))
+                                st.rerun()
+                            st.info(f"Forked built-in {td}/{tn} — the fork now "
+                                    f"shadows the shipped skill and receives "
+                                    f"this upgrade.")
                         prop = _staging.propose_skill_upgrade(
                             domain, [sid], target_domain=td, target_name=tn,
                             llm_call=_llm_call,
@@ -298,6 +316,8 @@ def _render_staged_section() -> None:
                     f"**Review upgrade → `{prop['target_domain']}/{prop['target_name']}`** "
                     "— applies in place; the current version is backed up to `.md.bak`."
                 )
+                for w in prop.get("regression_warnings") or []:
+                    st.warning(f"Additivity check: {w}")
                 diff = "\n".join(difflib.unified_diff(
                     prop["existing_content"].splitlines(),
                     prop["proposed_content"].splitlines(),

--- a/tests/test_persistent_memory.py
+++ b/tests/test_persistent_memory.py
@@ -37,3 +37,106 @@ class TestDemote:
         import pytest as _pytest
         with _pytest.raises(FileNotFoundError):
             _memory.demote_memory("curve_fitting", "nope")
+
+
+# ──────────────────────────────────────────────────────────────
+# Fork built-in skills (copy-on-write) + additivity guard
+# ──────────────────────────────────────────────────────────────
+
+class TestForkBuiltin:
+    def test_fork_shadows_and_upgradable(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SCILINK_HOME", str(tmp_path))
+        # Shadowing requires the persistent store to be ACTIVE — with memory
+        # off the graduated root is not on the skill search path at all.
+        monkeypatch.setenv("SCILINK_MEMORY", "1")
+        from scilink.skills import loader
+        from scilink.skills._shared import _memory
+
+        builtin_text = (loader._SKILLS_DIR / "curve_fitting" / "raman"
+                        / "raman.md").read_text()
+        out = _memory.fork_builtin("curve_fitting", "raman")
+        assert out["status"] == "success"
+        assert out["has_sibling_tools"] is False
+        # Byte-identical copy -> diff-builtin starts clean.
+        d = _memory.diff_builtin("curve_fitting", "raman")
+        assert d["identical"] is True
+        # The fork appears in the persistent store (upgrade target)…
+        assert any(r["name"] == "raman" for r in _memory.list_memory())
+        # …and SHADOWS the built-in: edit the fork, loader serves the edit.
+        fork_md = tmp_path / "graduated_skills" / "curve_fitting" / "raman" / "raman.md"
+        fork_md.write_text(builtin_text + "\nFORK_SENTINEL_LINE\n")
+        loaded = loader.load_skill("raman", domain="curve_fitting")
+        assert "FORK_SENTINEL_LINE" in str(loaded)
+        d = _memory.diff_builtin("curve_fitting", "raman")
+        assert d["identical"] is False and "FORK_SENTINEL_LINE" in d["diff"]
+
+    def test_double_fork_refused_and_missing_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SCILINK_HOME", str(tmp_path))
+        from scilink.skills._shared import _memory
+        assert _memory.fork_builtin("curve_fitting", "raman")["status"] == "success"
+        again = _memory.fork_builtin("curve_fitting", "raman")
+        assert again["status"] == "error" and "already forked" in again["message"]
+        import pytest as _pytest
+        with _pytest.raises(FileNotFoundError):
+            _memory.fork_builtin("curve_fitting", "no_such_skill")
+        with _pytest.raises(FileNotFoundError):
+            _memory.diff_builtin("curve_fitting", "xps")  # not forked
+
+    def test_sibling_tools_flagged(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SCILINK_HOME", str(tmp_path))
+        from scilink.skills._shared import _memory
+        out = _memory.fork_builtin("curve_fitting", "xrd_profile")
+        assert out["status"] == "success"
+        assert out["has_sibling_tools"] is True
+        assert "fit_pattern.py" in out["sibling_tools"]
+
+
+class TestAdditivityGuard:
+    def test_regression_warnings(self):
+        from scilink.skills._shared._staging import _regression_warnings
+        existing = ("## overview\nlong text " + "word " * 100
+                    + "\n## planning\nrules\n## validation\nchecks\n")
+        clean = existing + "\nnew lesson appended\n"
+        assert _regression_warnings(existing, clean) == []
+        dropped = "## overview\n" + "word " * 100
+        warns = _regression_warnings(existing, dropped)
+        assert any("planning" in w for w in warns)
+        assert any("validation" in w for w in warns)
+        shrunk = "## overview\nshort\n## planning\nx\n## validation\ny\n"
+        assert any("shorter" in w for w in _regression_warnings(existing, shrunk))
+
+    def test_preserve_structure_round_trip(self):
+        from scilink.skills._shared._staging import _preserve_structure
+        existing = (
+            "---\ndescription: old desc\n"
+            "technique: [Raman, micro-Raman]\n---\n"
+            "# Raman Spectroscopy\n\n"
+            "## Overview\nbody A\n\n## Planning\nbody B\n")
+        proposed = (  # what the JSON round-trip typically emits
+            "---\ndescription: refreshed desc\n---\n"
+            "## overview\nbody A plus new lesson\n\n"
+            "## analysis\n\n"           # empty artifact section
+            "## planning\nbody B\n")
+        out = _preserve_structure(existing, proposed)
+        assert "technique:" in out and "micro-Raman" in out   # routing meta kept
+        assert "refreshed desc" in out                        # LLM description honored
+        assert "# Raman Spectroscopy" in out                  # title restored
+        assert "## Overview" in out and "## overview" not in out  # casing restored
+        assert "## analysis" not in out                       # empty artifact dropped
+        assert "new lesson" in out                            # LLM merge kept
+        from scilink.skills._shared._staging import _regression_warnings
+        assert _regression_warnings(existing, out) == []
+
+    def test_preserve_structure_reinstates_dropped_section(self):
+        from scilink.skills._shared._staging import (
+            _preserve_structure, _regression_warnings)
+        existing = ("---\ndescription: d\n---\n"
+                    "## Overview\nA\n\n## Implementation\nCRITICAL RECIPE\n\n"
+                    "## Validation\nchecks\n")
+        proposed = ("---\ndescription: d\n---\n"
+                    "## overview\nA plus lesson\n\n## validation\nchecks\n")
+        out = _preserve_structure(existing, proposed)
+        assert "## Implementation" in out and "CRITICAL RECIPE" in out
+        # reinstated content sits after the surviving sections
+        assert out.index("CRITICAL RECIPE") > out.index("A plus lesson")
+        assert _regression_warnings(existing, out) == []


### PR DESCRIPTION
Answers the workflow question: *what if we find deficiencies in a built-in skill and want to upgrade it?* — and bakes in the requirement that upgrades must be additive and never regress working behavior.

## What a user gets

**`scilink memory fork curve_fitting/raman`** copies the shipped skill into the persistent store, where the loader's existing precedence makes it shadow the built-in immediately (while persistent memory is on — warned otherwise). The fork is then a normal target for the review-gated upgrade machinery: staged lessons merge into it with a diff review, backups, and demote/prune as escape hatches. `scilink memory diff-builtin` produces the divergence for contributing improvements back upstream as a package PR, after which the fork can be pruned. In the UI, built-in skills now appear directly in the staged-knowledge “Upgrade into” dropdown, marked *(built-in — forks on upgrade)*, and fork automatically on first use. Bundles that ship `.py` tools keep them registered from the package — only the markdown forks (stated explicitly by the command).

**Upgrades are additive by construction, not by prompt-hope.** The first live fork-upgrade exposed real regressions from the JSON round-trip: the `technique:` routing frontmatter vanished (breaking skill auto-selection), the title and heading casing were lost, and the whole `## Implementation` section was deleted because the update template's key enumeration omitted it. Three layers now guarantee additivity: the template states the additive principle and enumerates every section key; a deterministic post-pass (`_preserve_structure`) reinstates original frontmatter (the LLM may refresh only the description), heading casing, the H1 title, and **any section the proposal dropped — verbatim**; and advisory regression warnings (dropped sections, >20% shrinkage) surface in the CLI and the UI review block before anything is applied.

Live progression on a forked `raman` with real staged lessons (Bedrock opus-4-8): before the guards — 5 additivity warnings, routing metadata and an entire section lost; after — zero warnings, all five sections plus `technique:` and title intact, 162 lines added / 11 removed, and the residual `diff-builtin` deltas are YAML re-rendering and line reflow only.

---

## Technical details (for AI reviewers)

- `_memory.fork_builtin(domain, name)`: source `loader._SKILLS_DIR/<domain>/<name>/<name>.md`; dest `graduated_skills_dir()`; byte-identical copy (so `diff_builtin` starts clean); refuses double-fork; reports `sibling_tools`. `diff_builtin` = unified diff builtin→fork.
- `_staging._preserve_structure(existing, proposed)`: frontmatter merge (original keys win; `description` may update), heading-case restoration via case-insensitive map, empty-section artifact removal (sections absent from the original), verbatim reinstatement of omitted sections (appended in original order), H1 restoration. Applied in `propose_skill_upgrade` before `_regression_warnings` (now case-insensitive).
- `SKILL_UPDATE_INSTRUCTIONS`: additive principle (one sentence, per the prompt-patch convention) + key enumeration now includes `implementation` with an explicit “omitting a key deletes that section” warning.
- CLI: `fork`, `diff-builtin`, additivity warnings printed before the upgrade diff. UI: built-in targets with auto-fork on preview; `st.warning` per regression warning in the review block.
- Tests: +5 in `test_persistent_memory.py` — fork/shadow round trip (including the memory-off nuance: the persistent root is only on the search path when memory is enabled), double-fork/missing errors, sibling-tools flag (`xrd_profile`), `_preserve_structure` round trip, dropped-section reinstatement. 68 green across memory suites; goldens unregenerated.
- Known limits: reinstated sections append at the end (original inter-section order is not fully re-sorted — content-complete, order-approximate); `diff-builtin` shows YAML restyling of frontmatter as changes (semantically identical).