### PR TITLE
Large-data hardening: wall-clock budgets (#358) + decomposition-first gate (#359)

### DIFF
--- a/scilink/agents/exp_agents/_qc_engine.py
+++ b/scilink/agents/exp_agents/_qc_engine.py
@@ -185,9 +185,25 @@ class CodegenQCEngine:
 
         host.qc_loop_setup(ctx)
 
+        # Cumulative wall-clock budget for the whole verification loop
+        # (#358). OPT-IN via a host attribute — hosts that don't set it get
+        # byte-identical behavior. Attempt counts alone don't bound time:
+        # each iteration regenerates + re-executes code, so N cheap-but-
+        # failing attempts can run for hours without a ceiling.
+        import time as _time
+        _budget = getattr(host, "qc_time_budget_s", None)
+        _loop_t0 = _time.monotonic()
+
         max_iters = host.max_verification_iterations
         for verification_iter in range(max_iters):
             ctx.iteration = verification_iter
+            if _budget and _time.monotonic() - _loop_t0 > _budget:
+                logger.warning(
+                    f"   Verification loop wall-clock budget exceeded "
+                    f"({int(_budget)}s) after {verification_iter} "
+                    "iteration(s) — stopping with the best result so far.")
+                host.qc_final_verify(ctx)
+                return
             logger.info(
                 f"   Verification {verification_iter + 1}/{max_iters} "
                 f"(annealing level {ctx.annealing_level})..."

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -27,6 +27,7 @@ from ..instruct import (
     SPECTROSCOPY_PHYSICS_SANITY_INSTRUCTIONS,
     SPECTROSCOPY_RESULT_REVIEW_INSTRUCTIONS,
     SPECTROSCOPY_SALVAGE_JUDGE_INSTRUCTIONS,
+    NOT_MEASURABLE_JUDGE_INSTRUCTIONS,
 )
 
 from ....skills.hyperspectral.eels.eels import AGENT_METADATA_KEYS_TO_STRIP
@@ -701,6 +702,20 @@ This is the RAW cube — no smoothing/clipping/despiking has been applied for yo
 noise/spike/negative handling you judge necessary for a stable per-pixel fit —
 the goal is fittable spectra — but do NOT erase the feature you are measuring.
 If performing derivative-based operations (like `find_peaks` or `curve_fit`) on noisy data, apply appropriate smoothing to ensure convergence.
+
+### MEASURABILITY GATE — the honest null
+BEFORE mapping any per-pixel feature, TEST that it is measurable: examine the
+field-mean (or masked-mean) spectrum and require the feature's prominence to
+exceed a noise-derived threshold (several times the per-channel noise sigma).
+If it is NOT measurable, return
+{{"maps": {{}}, "not_measurable": {{"feature": "<what was requested>",
+"evidence": "<the NUMBERS: prominence vs noise sigma, and where you looked>",
+"description": "<one-line determination>"}}}}
+instead of estimator outputs — centroid/moment values computed on flat noise
+look plausible and are worse than an honest null. A judge reviews every
+not_measurable declaration against the deterministic band-flux evidence:
+declaring it without numeric evidence, or to dodge a hard but real fit, is
+rejected and retried.
 {reconstruction_section}{auxiliary_section}{fit_mask_section}{hints_section}
 ### REQUIRED RETURN FORMAT
 {{
@@ -2568,6 +2583,18 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                 state.setdefault("dynamic_analysis_records", []).append(record)
 
         # --- FINAL AGGREGATION ---
+        _null_meta = [m for m in all_valid_meta
+                      if isinstance(m, dict) and m.get("determination")]
+        if not all_valid_maps and _null_meta:
+            # Every task resolved to a judged honest null — that is a
+            # COMPLETED determination, not a failure. Commit the metadata so
+            # the synthesis reports the absence.
+            self.logger.warning(
+                "∅ Dynamic analysis completed with NULL determinations only "
+                f"({len(_null_meta)}): the requested feature(s) are not "
+                "measurable in this dataset.")
+            state["custom_analysis_metadata_list"] = all_valid_meta
+            return state
         if not all_valid_maps:
             self.logger.warning("⚠️ All dynamic analysis tasks failed.")
             state["dynamic_analysis_failed"] = True
@@ -2773,8 +2800,10 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
             # which the numeric fraction alone cannot — overwrite
             # (curve's verifier-approved path does the same).
             _hist["approved"] = bool(task_success)
+            _nm_rec = getattr(ctx, "not_measurable", None)
             return {
                 "target": ctx.item_name,
+                **({"not_measurable": _nm_rec} if _nm_rec else {}),
                 "required_outputs": ctx.required_outputs,
                 "task_success": bool(task_success),
                 "salvaged": (not task_success) and ctx.best_attempt["valid_count"] > 0,
@@ -2869,6 +2898,43 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
 
             # Validation
             if not isinstance(result_dict, dict): raise ValueError("Function return must be a dict.")
+
+            # Honest-null path (#358 follow-up): the generated code may
+            # DECLARE the requested feature not measurable, with numeric
+            # evidence. A judge reviews the declaration against the
+            # deterministic flux table; an accepted null TERMINATES the task
+            # as a completed determination (retrying an unmeasurable fit is
+            # exactly the churn the wall-clock budget otherwise has to kill).
+            # A rejected declaration raises -> the normal retry feedback path.
+            _nm = result_dict.get("not_measurable")
+            if isinstance(_nm, dict) and not result_dict.get("maps"):
+                ok, critique = self._judge_not_measurable(_nm, ctx)
+                if ok:
+                    self.logger.warning(
+                        f"    ∅ Task {i}: NOT-MEASURABLE determination "
+                        f"accepted by the judge — {_nm.get('description')} "
+                        f"(evidence: {str(_nm.get('evidence'))[:200]})")
+                    ctx.not_measurable = dict(_nm)
+                    ctx.attempt_entries.append({
+                        "attempt": retries + 1,
+                        "not_measurable": True,
+                        "evidence": str(_nm.get("evidence"))[:400],
+                    })
+                    # Surface the determination to the downstream synthesis.
+                    ctx.session["all_valid_meta"].append({
+                        "feature_name": str(_nm.get("feature") or target_desc),
+                        "determination": "not measurable in this dataset "
+                                         "(judged honest null)",
+                        "evidence": str(_nm.get("evidence"))[:400],
+                        "description": str(_nm.get("description"))[:300],
+                    })
+                    ctx.retries = retries + 1
+                    return {"success": True, "task_success": True,
+                            "not_measurable": dict(_nm)}
+                raise ValueError(
+                    f"not_measurable declaration rejected by the judge: "
+                    f"{critique}")
+
             maps_dict = result_dict.get("maps")
             if not maps_dict or not isinstance(maps_dict, dict):
                 raise ValueError("Return dict must contain a 'maps' key.")
@@ -3242,6 +3308,35 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
             if reject_votes + remaining < self.SANITY_REJECT_MAJORITY:
                 return True, ""
         return True, ""
+
+    def _judge_not_measurable(self, nm: dict, ctx) -> tuple:
+        """Judge a generated code's NOT-MEASURABLE declaration (#358 follow-
+        up) against the deterministic band-flux table (and the mean-spectrum
+        figure when available). Returns (defensible: bool, critique: str).
+        Fails CLOSED (reject on any judge error): a wrongly-rejected null
+        costs one retry; a wrongly-accepted null hides a real feature."""
+        try:
+            prompt = [NOT_MEASURABLE_JUDGE_INSTRUCTIONS,
+                      "\n--- DECLARATION ---\n"
+                      + json.dumps(nm, default=str)[:1500]]
+            if ctx.session.get("flux_table"):
+                prompt.append("\n--- DETERMINISTIC MEASURED FLUX BY BAND ---\n"
+                              + ctx.session["flux_table"])
+            if ctx.mean_spec_bytes:
+                prompt.append("\nField-mean spectrum:")
+                prompt.append({"mime_type": "image/jpeg",
+                               "data": ctx.mean_spec_bytes})
+            resp = self.model.generate_content(
+                prompt, generation_config=self.generation_config,
+                safety_settings=self.safety_settings)
+            verdict, _ = self._parse_llm_response(resp)
+            if not isinstance(verdict, dict) or "defensible" not in verdict:
+                return False, "judge returned no usable verdict"
+            return (bool(verdict.get("defensible")),
+                    str(verdict.get("critique") or ""))
+        except Exception as e:  # noqa: BLE001 - fail closed
+            self.logger.warning(f"    not-measurable judge crashed: {e}")
+            return False, f"judge unavailable ({e}); retry with maps"
 
     def _judge_salvage(self, dashboard_bytes, code_str, mean_spec_bytes,
                        system_info, objective, tool_descriptions, result_summary):

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -2167,7 +2167,8 @@ class RunDynamicAnalysisController:
         return self.MAX_RETRIES - 1
 
     def __init__(self, model, logger, generation_config, safety_settings, parse_fn,
-                 executor_timeout: int = 600):
+                 executor_timeout: int = 600,
+                 qc_time_budget_s: float = 1800.0):
         self.model = model
         self.logger = logger
         self.generation_config = generation_config
@@ -2177,6 +2178,12 @@ class RunDynamicAnalysisController:
         # executor_timeout kwarg so the user's chosen limit is honored
         # and the log line below reports the actual value.
         self.executor_timeout = executor_timeout
+        # Cumulative wall-clock budget for the QC verification loop (#358):
+        # the attempt cap alone doesn't bound time (each attempt can run up
+        # to executor_timeout). Consumed by CodegenQCEngine's verification
+        # loop; falsy disables. Hyperspectral is the only host that sets
+        # this — curve/image behavior is byte-identical.
+        self.qc_time_budget_s = qc_time_budget_s
         self._parse_llm_response = parse_fn
 
     def execute(self, state: dict) -> dict:

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -531,6 +531,7 @@ def build_code_generation_prompt(
     skill_implementation: str | None = None,
     reconstruction_available: bool = False,
     auxiliary_operands: dict | None = None,
+    fit_mask_pixels: tuple | None = None,
 ) -> str:
     skill_section = ""
     if skill_implementation:
@@ -586,7 +587,24 @@ Prioritize this guidance in your analysis, but also capture any other significan
         _sig_extra.append("reconstruction=None")
     if auxiliary_operands:
         _sig_extra.append("auxiliary=None")
+    if fit_mask_pixels:
+        _sig_extra.append("fit_mask=None")
     signature = "analyze_feature(data, axis" + "".join(f", {p}" for p in _sig_extra) + ")"
+
+    fit_mask_section = ""
+    if fit_mask_pixels:
+        _n_true, _n_total, _comp = fit_mask_pixels
+        fit_mask_section = f"""
+
+### FIT MASK — MANDATORY SCOPE (`fit_mask`)
+Your function is handed `fit_mask`: a boolean ({h}, {w}) array marking the
+{_n_true} pixels ({_n_true / max(_n_total, 1):.1%} of the frame) your fit is
+scoped to — the dilated high-abundance region of decomposition component
+{_comp}. This is the LARGE-DATA GATE: fit ONLY where `fit_mask` is True
+(e.g. iterate over `np.argwhere(fit_mask)` or index with `data[fit_mask]`),
+and fill every returned map with `np.nan` outside the mask. Do NOT fit the
+full frame — that is exactly the cost this mask exists to avoid.
+"""
 
     auxiliary_section = ""
     if auxiliary_operands:
@@ -683,7 +701,7 @@ This is the RAW cube — no smoothing/clipping/despiking has been applied for yo
 noise/spike/negative handling you judge necessary for a stable per-pixel fit —
 the goal is fittable spectra — but do NOT erase the feature you are measuring.
 If performing derivative-based operations (like `find_peaks` or `curve_fit`) on noisy data, apply appropriate smoothing to ensure convergence.
-{reconstruction_section}{auxiliary_section}{hints_section}
+{reconstruction_section}{auxiliary_section}{fit_mask_section}{hints_section}
 ### REQUIRED RETURN FORMAT
 {{
     "maps": {{
@@ -717,24 +735,76 @@ def _sanitize_filename(text: str) -> str:
     return safe_text
 
 
-def _invoke_analyze_feature(func, data, axis, reconstruction=None, *, auxiliary=None):
-    """Call the generated ``analyze_feature``, passing the optional operands
-    (``reconstruction``, ``auxiliary``) only when the function declares them.
+def _build_fit_mask(abundance_maps, comp_idx, shape, logger,
+                    dilate_frac: float = 0.04):
+    """Build a DILATED fitting mask from one component's abundance map
+    (#359 fit_scope="component_mask").
 
-    Both are *options*, not a contract: a function that keeps the legacy
+    Threshold at HALF-MAX of the abundance range, then binary-
+    dilate by ~``dilate_frac`` of the smaller spatial dimension (min 3 px)
+    so mask-boundary physics (interfaces, transition zones) stays inside
+    the fitted region. Returns a bool (h, w) array, or None when the maps /
+    index are unusable (the caller falls back to full-frame)."""
+    try:
+        if abundance_maps is None or comp_idx is None:
+            return None
+        maps = np.asarray(abundance_maps)
+        idx = int(comp_idx)
+        if maps.ndim != 3 or not (0 <= idx < maps.shape[0]):
+            return None
+        amap = maps[idx]
+        if amap.shape != tuple(shape):
+            return None
+        amap = np.asarray(amap, float)
+        lo, hi = float(np.nanmin(amap)), float(np.nanmax(amap))
+        if not np.isfinite(lo) or not np.isfinite(hi) or hi <= lo:
+            return None
+        # Half-max threshold: the mask tracks the component's actual
+        # footprint rather than a fixed fraction of the frame.
+        mask = amap >= (lo + 0.5 * (hi - lo))
+        if not mask.any() or mask.all():
+            return None
+        from scipy.ndimage import binary_dilation
+        n_iter = max(3, int(dilate_frac * min(shape)))
+        mask = binary_dilation(mask, iterations=n_iter)
+        if mask.mean() > 0.5:
+            # The component covers most of the frame — masking buys nothing;
+            # fall back to full-frame.
+            return None
+        logger.info(
+            f"    Fit mask from component {idx}: half-max abundance "
+            f"threshold + {n_iter}px dilation -> {int(mask.sum())} of "
+            f"{mask.size} pixels ({mask.mean():.1%}).")
+        return mask
+    except Exception as e:  # noqa: BLE001 - mask is an optimization, never fatal
+        logger.warning(f"    Fit-mask construction failed: {e}")
+        return None
+
+
+def _invoke_analyze_feature(func, data, axis, reconstruction=None, *,
+                            auxiliary=None, fit_mask=None):
+    """Call the generated ``analyze_feature``, passing the optional operands
+    (``reconstruction``, ``auxiliary``, ``fit_mask``) only when the function
+    declares them.
+
+    All are *options*, not a contract: a function that keeps the legacy
     two-argument signature is valid and simply fits the raw ``data`` (issue
-    #219 for ``reconstruction``; #226 for ``auxiliary``). We never force an
-    extra argument on a function that doesn't accept it — that would raise
-    ``TypeError`` and break a perfectly good fit.
+    #219 for ``reconstruction``; #226 for ``auxiliary``; #359 for
+    ``fit_mask``). We never force an extra argument on a function that
+    doesn't accept it — that would raise ``TypeError`` and break a
+    perfectly good fit.
 
     ``auxiliary`` is a ``{label: array}`` dict of shape-aligned companion
     operands (e.g. a reference spectrum to divide by); passed by keyword only.
+    ``fit_mask`` is a bool (h, w) array scoping the per-pixel fit.
     """
     optional = {}
     if reconstruction is not None:
         optional["reconstruction"] = reconstruction
     if auxiliary:  # non-empty dict
         optional["auxiliary"] = auxiliary
+    if fit_mask is not None:
+        optional["fit_mask"] = fit_mask
     if not optional:
         return func(data, axis)
 
@@ -1619,6 +1689,21 @@ class SelectRefinementTargetController:
         prompt_parts = [self.instructions]
         prompt_parts.append(f"\n\n--- Current Analysis: {state.get('iteration_title', 'Analysis')} ---")
 
+        # Data size for the LARGE-DATA GATE (#359): the gate's verdicts
+        # (masked fit / global-first / decomposition-only) apply above
+        # ~50k pixels; below that the decision is unconstrained.
+        try:
+            _h, _w, _e = state["hspy_data"].shape
+            prompt_parts.append(
+                f"\n\nDATA SIZE: {_h}x{_w} = {_h * _w} pixels x {_e} bands"
+                + (" — the LARGE-DATA GATE applies: commit each decision to "
+                   "one of its four verdicts."
+                   if _h * _w > 50_000 else
+                   " — small data; the LARGE-DATA GATE does not constrain "
+                   "this decision."))
+        except Exception:  # noqa: BLE001 - size line is advisory
+            pass
+
         if skip_mode:
             prompt_parts.append("""
 
@@ -2344,6 +2429,20 @@ class RunDynamicAnalysisController:
             else:
                 self.logger.info(f"👉 Task {i}/{len(custom_targets)}: {target_desc}")
 
+            # LARGE-DATA GATE (#359): a target may scope its fit to the
+            # dilated high-abundance region of a decomposition component.
+            # A failed mask construction falls back to full-frame (logged) —
+            # the mask is an optimization, never a gate on correctness.
+            fit_mask = None
+            if str(target.get("fit_scope") or "full_frame") == "component_mask":
+                fit_mask = _build_fit_mask(
+                    state.get("final_abundance_maps"),
+                    target.get("mask_component_index"), (h, w), self.logger)
+                if fit_mask is None:
+                    self.logger.warning(
+                        "    fit_scope=component_mask requested but no usable "
+                        "abundance mask — falling back to full_frame.")
+
             # 1. Define Prompt for this specific task
             base_prompt = build_code_generation_prompt(
                 target_desc=target_desc,
@@ -2362,6 +2461,9 @@ class RunDynamicAnalysisController:
                 skill_implementation=_render_skill_block(state, "implementation"),
                 reconstruction_available=reconstruction is not None,
                 auxiliary_operands={k: v.shape for k, v in auxiliary_operands.items()},
+                fit_mask_pixels=((int(fit_mask.sum()), int(fit_mask.size),
+                                  int(target.get("mask_component_index")))
+                                 if fit_mask is not None else None),
             )
 
             # Registered tools from the _shared registry (this agent + active
@@ -2453,6 +2555,7 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                 "optimal_data": optimal_data,
                 "reconstruction": reconstruction,
                 "auxiliary_operands": auxiliary_operands,
+                "fit_mask": fit_mask,
                 "processing_note": processing_note,
                 "all_valid_maps": all_valid_maps,
                 "all_valid_meta": all_valid_meta,
@@ -2704,6 +2807,7 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
         optimal_data = ctx.session["optimal_data"]
         reconstruction = ctx.session["reconstruction"]
         auxiliary_operands = ctx.session["auxiliary_operands"]
+        fit_mask = ctx.session.get("fit_mask")
         processing_note = ctx.session["processing_note"]
         retries = ctx.retries
 
@@ -2760,7 +2864,7 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                 func = local_scope["analyze_feature"]
                 result_dict = _invoke_analyze_feature(
                     func, optimal_data, state["energy_axis"], reconstruction,
-                    auxiliary=auxiliary_operands,
+                    auxiliary=auxiliary_operands, fit_mask=fit_mask,
                 )
 
             # Validation
@@ -2844,6 +2948,14 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                             f"{float(np.nanmean(result_map)):.4g} {current_unit}; "
                             f"valid coverage {_cov:.1f}% "
                             f"({int(_real.sum())} of {result_map.size} pixels finite & non-zero)")
+                        if fit_mask is not None:
+                            summary += (
+                                f" NOTE: the fit was SCOPED to a "
+                                f"{int(fit_mask.sum())}-pixel mask "
+                                f"({fit_mask.mean():.1%} of the frame; "
+                                "large-data gate) — NaN outside the masked "
+                                "region is BY DESIGN, so judge coverage and "
+                                "structure WITHIN the mask only.")
                         if ctx.session.get("flux_table"):
                             summary += "\n\n" + ctx.session["flux_table"]
                         tool_descriptions = _used_tool_descriptions(state, code_str)
@@ -2862,8 +2974,14 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                         # Diagnostic (non-required) map: lighter single
                         # visual QC — no method/physics gate needed.
                         self.logger.info(f"    👀 Performing Visual QC on {feature_name}...")
+                        _mask_note = (
+                            "" if fit_mask is None else
+                            f" [fit scoped to a {int(fit_mask.sum())}-pixel "
+                            "mask; NaN outside it is by design — judge "
+                            "within the mask only]")
                         is_valid, critique = self._check_result_visually(
-                            dashboard_bytes, f"{target_desc} ({feature_name})")
+                            dashboard_bytes,
+                            f"{target_desc} ({feature_name}){_mask_note}")
 
                     if is_valid:
                         # STAGE DATA (Do not commit to state yet)

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -704,10 +704,24 @@ the goal is fittable spectra — but do NOT erase the feature you are measuring.
 If performing derivative-based operations (like `find_peaks` or `curve_fit`) on noisy data, apply appropriate smoothing to ensure convergence.
 
 ### MEASURABILITY GATE — the honest null
-BEFORE mapping any per-pixel feature, TEST that it is measurable: examine the
-field-mean (or masked-mean) spectrum and require the feature's prominence to
-exceed a noise-derived threshold (several times the per-channel noise sigma).
-If it is NOT measurable, return
+BEFORE mapping any per-pixel feature, TEST that it is measurable. Do the
+statistics correctly:
+- Compare the feature's prominence in an AVERAGED spectrum against the noise
+  OF THAT AVERAGE: averaging N spectra reduces noise by sqrt(N), so the
+  threshold is several times sigma_pixel/sqrt(N) — NOT the per-pixel sigma.
+  (A prominence of 0.2 with sigma_pixel=0.4 over 10,000 averaged spectra is
+  a ~50-sigma detection, not a null.)
+- Test BRIGHT-REGION means as well as the field mean: a feature localized to
+  a small region is diluted ~(region/frame) in the field mean but fully
+  present in the mean over the brightest pixels (e.g. top 1-5% by integrated
+  intensity). Declare not_measurable ONLY if it fails in BOTH.
+- Measurability is RESOLUTION-DEPENDENT: a feature detectable in the mean
+  but with per-pixel SNR below threshold is not mappable at native
+  resolution — spatially BIN until the binned per-pixel SNR clears the bar
+  (binning k x k cuts noise by k) and return the coarse map, stating the
+  effective resolution in the description. Reserve not_measurable for
+  features that fail even in aggregate.
+If it is genuinely NOT measurable, return
 {{"maps": {{}}, "not_measurable": {{"feature": "<what was requested>",
 "evidence": "<the NUMBERS: prominence vs noise sigma, and where you looked>",
 "description": "<one-line determination>"}}}}

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -1656,6 +1656,28 @@ Return a JSON object:
 """
 
 
+NOT_MEASURABLE_JUDGE_INSTRUCTIONS = """You are a skeptical spectroscopist judging a NULL DETERMINATION. Generated \
+analysis code declined to map a per-pixel feature, declaring it NOT \
+MEASURABLE in this dataset, with the evidence below. Decide whether the \
+declaration is scientifically defensible or an evasion of a hard but real fit.
+
+ACCEPT only when the evidence is NUMERIC and decisive (e.g. feature \
+prominence in the field-mean/masked-mean spectrum below a few times the \
+noise sigma) AND the deterministic MEASURED FLUX BY BAND table is consistent \
+with the claimed absence (no band stands out where the feature was expected).
+REJECT when the evidence is vague, non-numeric, contradicted by the flux \
+table, or when the feature could plausibly be recovered by a better method \
+(masking, denoising, narrower window) — rejection sends the task back for \
+another attempt.
+
+Respond in valid JSON with EXACTLY these keys:
+{
+  "defensible": true | false,
+  "critique": "<if false: what the evidence misses / what to try instead; else a one-line confirmation>"
+}
+"""
+
+
 SPECTROSCOPY_SALVAGE_JUDGE_INSTRUCTIONS = """
 You are a senior scientist making a FINAL salvage decision. Automated extraction
 did NOT fully pass verification after all retries. You are shown the BEST partial

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -1661,14 +1661,25 @@ analysis code declined to map a per-pixel feature, declaring it NOT \
 MEASURABLE in this dataset, with the evidence below. Decide whether the \
 declaration is scientifically defensible or an evasion of a hard but real fit.
 
-ACCEPT only when the evidence is NUMERIC and decisive (e.g. feature \
-prominence in the field-mean/masked-mean spectrum below a few times the \
-noise sigma) AND the deterministic MEASURED FLUX BY BAND table is consistent \
-with the claimed absence (no band stands out where the feature was expected).
-REJECT when the evidence is vague, non-numeric, contradicted by the flux \
-table, or when the feature could plausibly be recovered by a better method \
-(masking, denoising, narrower window) — rejection sends the task back for \
-another attempt.
+ACCEPT only when the evidence is NUMERIC and decisive AND survives these \
+checks:
+1. ARITHMETIC CONSISTENCY — recompute the claim from its own numbers. The \
+correct noise reference for an N-spectrum average is sigma_pixel/sqrt(N), \
+NOT the per-pixel sigma; if the declaration's own figures imply a detection \
+(e.g. it states a mean-spectrum SNR at or above its own threshold, or its \
+prominence exceeds a few times sigma_pixel/sqrt(N)), REJECT — the code \
+applied the wrong statistics.
+2. LOCALIZATION — a feature confined to a small region is diluted \
+~(region/frame) in the field mean AND in the field-integrated flux table; \
+the declaration must show the feature also fails in a BRIGHT-REGION mean \
+(top few % of pixels by intensity). A field-mean-only null on possibly \
+localized data is not decisive: REJECT.
+3. FLUX TABLE — the deterministic MEASURED FLUX BY BAND must be consistent \
+with the claimed absence for spatially extended features (remembering it \
+cannot rule out localized ones — see check 2).
+REJECT also when the evidence is vague, non-numeric, or the feature could \
+plausibly be recovered by a better method (masking, denoising, narrower \
+window) — rejection sends the task back for another attempt.
 
 Respond in valid JSON with EXACTLY these keys:
 {

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -1274,6 +1274,14 @@ Depending on the analysis method used in the current iteration, you will receive
    * *Tip:* The custom code sandbox provides `lmfit` in addition to `numpy`/`scipy`/`sklearn`. Use `lmfit` for multi-peak or complex fitting scenarios — it offers built-in models (GaussianModel, LorentzianModel, VoigtModel), parameter constraints, and composite models via the `+` operator. For simple single-peak fits on large datasets, raw `curve_fit` is faster due to lower per-pixel overhead.
    * *SIZE GUARD — scale every target to the pixel count:* the sandbox is single-process, so a per-pixel iterative fit (~2-5 ms each) over a full frame costs ~4-40 minutes per 100k pixels and can exceed the execution timeout. State in the target's description WHICH pixels the fit touches. Above ~50k pixels, the target must specify a reduction: restrict fitting to the scientifically relevant mask/region, or go coarse-to-fine (fit a spatially binned map first, refine only where structure appears), or use a vectorized/linearized estimator instead of per-pixel iterative fits.
 
+4. **LARGE-DATA GATE — decomposition-first staging (above ~50k pixels):**
+   Commit each decision to ONE of four verdicts, using the decomposition evidence in front of you:
+   * **fit-within-dilated-mask** — the signal of interest is spatially LOCALIZED in a component's abundance map: set `"fit_scope": "component_mask"` and `"mask_component_index": <0-based component index>` on the target. The pipeline builds the mask from that component's high-abundance region WITH a dilation halo (mask-boundary physics lives at the edges) and scopes the generated code to it.
+   * **fit-global-then-decide** — a WEAK feature may be present everywhere (uniform signals give decomposition no spatial contrast to separate): describe a target whose code fits the MEAN spectrum first (one cheap fit) and maps per-pixel only where that detection justifies it.
+   * **fit-everywhere** — only when the objective genuinely needs full-frame per-pixel parameters; then apply the size-guard tactics (vectorize, coarse-to-fine).
+   * **decomposition-only (STOP)** — permitted ONLY when the components are clean AND the residuals are unstructured AND the objective names no per-pixel quantity. A STRUCTURED residual (derivative shapes, coherent spatial patterns, high residual autocorrelation) is the signature of continuous parameter variation or a weak everywhere-signal — physics decomposition CANNOT model — and mandates a fitting target even when every component looks clean.
+   The gate is ASYMMETRIC: use decomposition evidence freely to ADD scope (nominate a component, a mask, a global-first plan), but RESTRICT scope or STOP only under the residual-certified conditions above. A user objective explicitly requesting per-pixel quantities ALWAYS overrides the gate.
+
 ---
 
 **Output Format:**
@@ -1282,6 +1290,7 @@ You MUST output a valid JSON object.
 **STRICT TYPE RULES:**
 * All refinement targets have `"type": "custom_code"`.
 * For `custom_code` targets: `value = null` (the description field is what matters).
+* Optional scoping fields on a `custom_code` target (the LARGE-DATA GATE): `"fit_scope"`: `"full_frame"` (default) or `"component_mask"`; when `"component_mask"`, also set `"mask_component_index"` (0-based index of the decomposition component whose high-abundance region defines the fitting mask).
 * Targets of other types (e.g. legacy `"spatial"` or `"spectral"`) are NOT supported and will be ignored by the downstream pipeline. Do not emit them.
 
 **Required outputs (objective-aware QC enforcement):**

--- a/scilink/agents/exp_agents/preprocess.py
+++ b/scilink/agents/exp_agents/preprocess.py
@@ -47,6 +47,9 @@ class HyperspectralPreprocessingAgent(BaseUtilityAgent):
     """
 
     MAX_SCRIPT_ATTEMPTS = 3
+    # Cumulative wall-clock budget for the custom-script retry
+    # loop (#358); falsy disables.
+    SCRIPT_LOOP_TIME_BUDGET_S = 900.0
 
     def __init__(self, *args,
                  output_dir: str = "preprocessing_output",
@@ -395,7 +398,20 @@ class HyperspectralPreprocessingAgent(BaseUtilityAgent):
         last_error = "No script generated yet."
         custom_script = None
 
+        # Cumulative wall-clock budget across ALL attempts (#358): each
+        # attempt can run up to the executor timeout, so the attempt cap
+        # alone does not bound total time.
+        import time as _time
+        _t0 = _time.monotonic()
+
         for attempt in range(1, self.MAX_SCRIPT_ATTEMPTS + 1):
+            if (attempt > 1 and self.SCRIPT_LOOP_TIME_BUDGET_S
+                    and _time.monotonic() - _t0 > self.SCRIPT_LOOP_TIME_BUDGET_S):
+                last_error = (f"custom-script wall-clock budget exceeded "
+                              f"({int(self.SCRIPT_LOOP_TIME_BUDGET_S)}s) "
+                              f"after {attempt - 1} attempt(s)")
+                self.logger.warning(last_error)
+                break
             try:
                 if attempt == 1:
                     self.logger.info(f"Attempt {attempt}/{self.MAX_SCRIPT_ATTEMPTS}: Generating initial script...")
@@ -515,6 +531,9 @@ class CurvePreprocessingAgent(BaseUtilityAgent):
     """
     
     MAX_SCRIPT_ATTEMPTS = 5
+    # Cumulative wall-clock budget for the custom-script retry
+    # loop (#358); falsy disables.
+    SCRIPT_LOOP_TIME_BUDGET_S = 900.0
     MAX_MODEL_ATTEMPTS = 5
 
     def __init__(self, *args,
@@ -826,7 +845,20 @@ class CurvePreprocessingAgent(BaseUtilityAgent):
         last_error = "No script generated yet."
         custom_script = None
 
+        # Cumulative wall-clock budget across ALL attempts (#358): each
+        # attempt can run up to the executor timeout, so the attempt cap
+        # alone does not bound total time.
+        import time as _time
+        _t0 = _time.monotonic()
+
         for attempt in range(1, self.MAX_SCRIPT_ATTEMPTS + 1):
+            if (attempt > 1 and self.SCRIPT_LOOP_TIME_BUDGET_S
+                    and _time.monotonic() - _t0 > self.SCRIPT_LOOP_TIME_BUDGET_S):
+                last_error = (f"custom-script wall-clock budget exceeded "
+                              f"({int(self.SCRIPT_LOOP_TIME_BUDGET_S)}s) "
+                              f"after {attempt - 1} attempt(s)")
+                self.logger.warning(last_error)
+                break
             try:
                 if attempt == 1:
                     custom_script = self._generate_custom_script_1d(stats, instruction, input_filename)

--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -56,6 +56,12 @@ _FANOUT_POLL_S = 5              # how often to check for finished branches
 _FANOUT_HEARTBEAT_S = 60        # min gap between "still running" ticks
 FANOUT_SOFT_CAP = 5             # warn / confirm beyond this many fused branches
 FANOUT_HARD_CAP = 8             # refuse beyond this — cost/quality cliff
+# Per-branch wall-clock budget (#358). A stuck branch (e.g. an analysis
+# retry loop that keeps failing QC) must not hold the whole fan-out: on
+# expiry the branch is recorded degraded and ABANDONED (its subprocesses are
+# killed; the thread itself cannot be killed safely and may finish late,
+# which is recorded for audit without changing the verdict). <= 0 disables.
+FANOUT_BRANCH_TIME_BUDGET_S = 3600.0
 # In AUTONOMOUS mode there is no human to confirm, so the verdict IS the gate:
 # proceed only on a confident 'complementary' read.
 AUTONOMOUS_CONFIDENCE_THRESHOLD = 0.6
@@ -630,10 +636,20 @@ def _run_one_branch(orch, branch: dict, companions: List[dict],
     Each worker touches ONLY its own ``entry`` dict, so there is no shared
     mutation across threads. Never raises — failures are captured into the
     ledger slot like ``_delegate`` does.
+
+    Records its start time and thread id on the entry so ``run_fanout``'s
+    wait loop can enforce the branch wall-clock budget (#358): an abandoned
+    branch has ``timed_out`` set on its entry, in which case a late
+    completion must NOT clobber the timeout verdict (fusion already ran
+    without it) — the late outcome is recorded under ``late_result`` for
+    audit instead.
     """
+    import threading
     index = entry["index"]
     slug = _slug(branch.get("label") or Path(branch["data_path"]).stem)
     base_dir = orch.fanout_dir / f"{index:02d}_{slug}"
+    entry["_started_at"] = time.monotonic()
+    entry["_branch_tid"] = threading.get_ident()
     try:
         from ..exp_agents.analysis_orchestrator import AnalysisMode
         child = _make_ephemeral_analysis_child(orch, base_dir)
@@ -647,10 +663,21 @@ def _run_one_branch(orch, branch: dict, companions: List[dict],
         result = {"status": "error", "error": str(e), "summary": "",
                   "key_findings": [], "files_produced": [],
                   "suggested_followups": [], "warnings": []}
+    if entry.get("timed_out"):
+        logger.warning(
+            f"fan-out branch {index} finished AFTER its wall-clock budget "
+            f"expired (late status: {result.get('status')}); the timeout "
+            "verdict stands — late outcome recorded for audit only.")
+        entry["late_result"] = {
+            "status": result.get("status"),
+            "summary_head": (result.get("summary") or "")[:300],
+            "n_files": len(result.get("files_produced") or [])}
+        return
     orch._close_delegation(entry, result)
 
 
-def run_fanout(orch, branches: List[dict]) -> str:
+def run_fanout(orch, branches: List[dict],
+               branch_time_budget_s: Optional[float] = None) -> str:
     """Gate → confirm → run branches concurrently. Returns JSON.
 
     `branches` is a list of ``{"data_path", "task", "label", "metadata"?,
@@ -660,6 +687,11 @@ def run_fanout(orch, branches: List[dict]) -> str:
     prunes to the complementary subset; only that subset runs. Branches run
     independently unless the gate classifies the set co-registered (operand
     mesh) — see ``_operand_mesh`` — and/or a branch opts into steering.
+
+    ``branch_time_budget_s`` caps each branch's wall clock (#358; default
+    ``FANOUT_BRANCH_TIME_BUDGET_S``, <= 0 disables): an overdue branch is
+    recorded degraded and abandoned so the fan-out completes and fusion runs
+    over the productive branches.
     """
     # --- normalize input ---
     norm: List[dict] = []
@@ -853,12 +885,19 @@ def run_fanout(orch, branches: List[dict]) -> str:
 
     max_workers = min(len(run_branches), FANOUT_MAX_WORKERS)
     n_total = len(run_branches)
-    with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        fut_label = {}
+    budget = (FANOUT_BRANCH_TIME_BUDGET_S if branch_time_budget_s is None
+              else float(branch_time_budget_s))
+    # No context manager: an abandoned (timed-out) branch thread cannot be
+    # killed, and `with` would join it — the pool is shut down without
+    # waiting instead (#358).
+    pool = ThreadPoolExecutor(max_workers=max_workers)
+    try:
+        fut_label, fut_entry = {}, {}
         for i in range(n_total):
             fut = pool.submit(_run_one_branch, orch, run_branches[i],
                               branch_companions[i], entries[i])
             fut_label[fut] = run_branches[i]["label"]
+            fut_entry[fut] = entries[i]
         # Wait with a periodic heartbeat so the user can see the parallel run is
         # alive (a slow branch can otherwise look like a hang). Each branch is
         # announced as it finishes; the rest get a "still running" tick.
@@ -880,11 +919,49 @@ def run_fanout(orch, branches: List[dict]) -> str:
                 print(f"  ✅ analysis branch finished: {fut_label[f]}  "
                       f"({n_total - len(pending)}/{n_total} done)")
                 since_tick = 0.0  # a completion already shows the run is alive
+            # Branch wall-clock budget (#358): abandon a branch that has run
+            # past its deadline — record it degraded (the existing
+            # degraded-branch machinery excludes it from fusion), kill its
+            # registered subprocesses, and stop waiting for its thread.
+            if budget > 0:
+                overdue = [f for f in pending
+                           if fut_entry[f].get("_started_at") is not None
+                           and fut_entry[f].get("status") == "running"
+                           and (time.monotonic() - fut_entry[f]["_started_at"]
+                                > budget)]
+                for f in overdue:
+                    e = fut_entry[f]
+                    e["timed_out"] = True
+                    print(f"  ⏱️  analysis branch '{fut_label[f]}' exceeded "
+                          f"its wall-clock budget ({int(budget)}s) — "
+                          "abandoning it (degraded, excluded from fusion).")
+                    logger.warning(
+                        f"fan-out branch {e['index']} ('{fut_label[f]}') "
+                        f"abandoned after {int(budget)}s wall-clock budget")
+                    tid = e.get("_branch_tid")
+                    if tid:
+                        try:
+                            from ...executors import kill_subprocesses_for_thread
+                            kill_subprocesses_for_thread(tid)
+                        except Exception:  # noqa: BLE001 - best-effort cleanup
+                            pass
+                    orch._close_delegation(e, {
+                        "status": "error",
+                        "error": (f"branch wall-clock budget exceeded "
+                                  f"({int(budget)}s); branch abandoned"),
+                        "summary": "", "key_findings": [],
+                        "files_produced": [], "suggested_followups": [],
+                        "warnings": [f"abandoned after {int(budget)}s "
+                                     "wall-clock budget (#358)"],
+                    })
+                    pending.discard(f)
             if pending and since_tick >= _FANOUT_HEARTBEAT_S:
                 since_tick = 0.0
                 elapsed = int(time.monotonic() - start)
                 print(f"  ⏳ {len(pending)} of {n_total} parallel analyses still "
                       f"running ... (~{elapsed}s elapsed)")
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
 
     def _productive(e):
         # A branch that reports success but yields neither findings nor files
@@ -928,12 +1005,18 @@ def run_fanout(orch, branches: List[dict]) -> str:
     }
     if degraded:
         n_err = sum(1 for r in degraded if r["status"] != "success")
+        n_timeout = sum(1 for e in entries if e.get("timed_out"))
         out["warning"] = (
             f"{len(degraded)} branch(es) produced no usable output "
-            f"({n_err} errored, {len(degraded) - n_err} succeeded-but-empty, "
+            f"({n_err} errored"
+            + (f", of which {n_timeout} abandoned on the "
+               f"branch wall-clock budget" if n_timeout else "")
+            + f", {len(degraded) - n_err} succeeded-but-empty, "
             "e.g. analysis code could not execute). Do not treat these as "
             "completed analyses or fuse them; report the gap to the user."
         )
+        if n_timeout:
+            out["branches_timed_out"] = n_timeout
     return json.dumps(out, indent=2, default=str)
 
 

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1178,10 +1178,12 @@ class MetaOrchestratorAgent:
         return json.dumps(assess_complementarity(self, datasets),
                           indent=2, default=str)
 
-    def _run_fanout(self, branches: list) -> str:
-        """Gate, confirm, then run analysis branches concurrently (full mesh)."""
+    def _run_fanout(self, branches: list,
+                    branch_time_budget_s: Optional[float] = None) -> str:
+        """Gate, confirm, then run analysis branches concurrently."""
         from .fanout import run_fanout
-        return run_fanout(self, branches)
+        return run_fanout(self, branches,
+                          branch_time_budget_s=branch_time_budget_s)
 
     def _fuse_delegations(self, indices: list, focus: Optional[str] = None) -> str:
         """Reconcile finished complementary branch findings into one narrative."""

--- a/tests/test_decomp_gate.py
+++ b/tests/test_decomp_gate.py
@@ -1,0 +1,122 @@
+"""Offline tests for the decomposition-first large-data gate (#359).
+
+The gate is ASYMMETRIC (decomposition evidence may ADD scope freely, but may
+RESTRICT it only under residual-certified conditions): four verdicts —
+fit-everywhere / fit-within-dilated-mask / fit-global-then-decide /
+decomposition-only. These tests cover the mechanical layer: the prompt
+contracts, the dilated-mask builder, the sandbox plumbing, and QC
+mask-awareness inputs.
+
+  conda run -n scilink python tests/test_decomp_gate.py
+"""
+import os
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+
+import numpy as np
+
+from scilink.agents.exp_agents.controllers.hyperspectral_controllers import (
+    _build_fit_mask, _invoke_analyze_feature, build_code_generation_prompt)
+from scilink.agents.exp_agents.instruct import (
+    SPECTROSCOPY_REFINEMENT_INSTRUCTIONS)
+
+import logging
+
+results = {}
+LOG = logging.getLogger("gate_test")
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+def main():
+    # 1) Prompt contracts.
+    print("1) prompt contracts:")
+    t = SPECTROSCOPY_REFINEMENT_INSTRUCTIONS
+    check("gate block present with all four verdicts",
+          "LARGE-DATA GATE" in t
+          and all(s in t for s in ("fit-within-dilated-mask",
+                                   "fit-global-then-decide",
+                                   "fit-everywhere", "decomposition-only")))
+    check("decomposition-only is residual-certified",
+          "residual" in t.split("decomposition-only (STOP)")[1][:600].lower())
+    check("asymmetry + objective override stated",
+          "ASYMMETRIC" in t and "ALWAYS overrides" in t)
+    check("target schema documents the scoping fields",
+          '"fit_scope"' in t and '"mask_component_index"' in t)
+    p = build_code_generation_prompt(
+        "t", 96, 96, 180, "nm", 400.0, 900.0, "raw",
+        fit_mask_pixels=(1200, 9216, 2))
+    check("codegen prompt renders the mandatory-scope mask section",
+          "FIT MASK — MANDATORY SCOPE" in p and "1200 pixels" in p
+          and "component\n2" in p or ("component" in p and "1200" in p))
+    check("mask arg in the generated signature", "fit_mask=None" in p)
+    p0 = build_code_generation_prompt("t", 96, 96, 180, "nm", 400.0, 900.0,
+                                      "raw")
+    check("no mask -> no mask section (unchanged default)",
+          "FIT MASK" not in p0 and "fit_mask" not in p0)
+
+    # 2) Dilated-mask builder with planted truth.
+    print("2) mask builder:")
+    h = w = 100
+    yy, xx = np.mgrid[0:h, 0:w]
+    blob = ((xx - 30) ** 2 + (yy - 40) ** 2) < 8 ** 2      # ~200 px blob
+    amaps = np.stack([np.random.rand(h, w) * 0.05,
+                      blob * 1.0 + np.random.rand(h, w) * 0.05])
+    m = _build_fit_mask(amaps, 1, (h, w), LOG)
+    check("mask covers the blob", m is not None and bool(m[blob].all()))
+    ring = ((xx - 30) ** 2 + (yy - 40) ** 2 < 11 ** 2) & ~blob
+    check("mask is DILATED beyond the blob (boundary halo kept)",
+          m is not None and m[ring].mean() > 0.9)
+    check("mask stays a small fraction of the frame",
+          m is not None and m.mean() < 0.25)
+    print("3) mask builder fallbacks:")
+    check("bad component index -> None", _build_fit_mask(amaps, 7, (h, w), LOG) is None)
+    check("no maps -> None", _build_fit_mask(None, 0, (h, w), LOG) is None)
+    check("shape mismatch -> None",
+          _build_fit_mask(amaps, 1, (50, 50), LOG) is None)
+    flat = np.ones((2, h, w))
+    check("degenerate (all-equal) abundance -> None",
+          _build_fit_mask(flat, 0, (h, w), LOG) is None)
+
+    # 4) Sandbox plumbing: fit_mask passed only when accepted.
+    print("4) invoke plumbing:")
+    data = np.random.rand(4, 4, 5)
+    axis = np.arange(5.0)
+    mask = np.zeros((4, 4), bool); mask[1, 1] = True
+    got = {}
+
+    def modern(d, a, fit_mask=None):
+        got["mask"] = fit_mask
+        return {"maps": {}}
+    _invoke_analyze_feature(modern, data, axis, fit_mask=mask)
+    check("mask reaches a function that declares it",
+          got.get("mask") is mask)
+
+    def legacy(d, a):
+        got["legacy"] = True
+        return {"maps": {}}
+    _invoke_analyze_feature(legacy, data, axis, fit_mask=mask)
+    check("legacy 2-arg function still works (mask not forced)",
+          got.get("legacy") is True)
+
+    def kwargs_fn(d, a, **kw):
+        got["kw"] = kw
+        return {"maps": {}}
+    _invoke_analyze_feature(kwargs_fn, data, axis, fit_mask=mask)
+    check("**kwargs function receives the mask",
+          got.get("kw", {}).get("fit_mask") is mask)
+
+    print("\n" + "=" * 50)
+    npass = sum(results.values())
+    print(f"DECOMP GATE: {npass}/{len(results)} checks passed")
+    for k, v in results.items():
+        if not v:
+            print("  FAILED:", k)
+    raise SystemExit(0 if npass == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_decomp_gate.py
+++ b/tests/test_decomp_gate.py
@@ -109,6 +109,59 @@ def main():
     check("**kwargs function receives the mask",
           got.get("kw", {}).get("fit_mask") is mask)
 
+    # 5) Honest-null contract (#358 follow-up): prompt + judged declaration.
+    print("5) measurability gate / honest null:")
+    p = build_code_generation_prompt("t", 96, 96, 180, "nm", 400.0, 900.0,
+                                     "raw")
+    check("codegen prompt carries the MEASURABILITY GATE contract",
+          "MEASURABILITY GATE" in p and "not_measurable" in p
+          and "evidence" in p)
+    from scilink.agents.exp_agents.controllers.hyperspectral_controllers import (
+        RunDynamicAnalysisController)
+
+    class _Resp:
+        def __init__(self, obj): self._o = obj
+        text = ""
+
+    class _Model:
+        def __init__(self, verdict): self.verdict = verdict
+        def generate_content(self, prompt, generation_config=None,
+                             safety_settings=None):
+            if isinstance(self.verdict, Exception):
+                raise self.verdict
+            return _Resp(self.verdict)
+
+    def _parse(resp):
+        return resp._o, None
+
+    class _Ctx:
+        session = {"flux_table": "band | flux\n400-500 | 100.0"}
+        mean_spec_bytes = None
+
+    def _mk(verdict):
+        c = object.__new__(RunDynamicAnalysisController)
+        c.model = _Model(verdict)
+        c.logger = LOG
+        c.generation_config = None
+        c.safety_settings = None
+        c._parse_llm_response = _parse
+        return c
+
+    nm = {"feature": "two peaks", "evidence": "prominence 0.08 vs sigma 0.4",
+          "description": "flat field"}
+    ok, _ = _mk({"defensible": True, "critique": "confirmed"})\
+        ._judge_not_measurable(nm, _Ctx())
+    check("defensible null accepted", ok is True)
+    ok, crit = _mk({"defensible": False, "critique": "flux table shows a band"})\
+        ._judge_not_measurable(nm, _Ctx())
+    check("indefensible null rejected with critique",
+          ok is False and "band" in crit)
+    ok, crit = _mk(RuntimeError("api down"))._judge_not_measurable(nm, _Ctx())
+    check("judge crash fails CLOSED (reject, retry)",
+          ok is False and "unavailable" in crit)
+    ok, _ = _mk({"something": "else"})._judge_not_measurable(nm, _Ctx())
+    check("unusable verdict fails CLOSED", ok is False)
+
     print("\n" + "=" * 50)
     npass = sum(results.values())
     print(f"DECOMP GATE: {npass}/{len(results)} checks passed")

--- a/tests/test_decomp_gate_live.py
+++ b/tests/test_decomp_gate_live.py
@@ -154,8 +154,35 @@ def scenario_shift():
     check("shift: bounded (< 35 min)", dt < 2100)
 
 
+def scenario_null_demand():
+    """Pure noise + DEMANDED per-pixel peak outputs — previously this burned
+    the full QC retry ladder until a budget killed the branch. With the
+    measurability gate, the generated code should DECLARE the feature not
+    measurable (judged against the flux table) and the task should complete
+    fast as an honest null determination."""
+    h = w = 256
+    cube = RNG.normal(100, 5, (h, w, WL.size))
+    p = _save_cube(cube, "nulldemand", "survey acquisition")
+    res, summary, dt, base = _run(
+        p, f"Analyze the hyperspectral image at {p} (256x256x160; "
+           f"wavelengths in the metadata JSON). Extract PER-PIXEL maps of "
+           "the two emission peaks: report Peak1_Position, Peak1_FWHM, "
+           "Peak2_Position, Peak2_FWHM at every pixel.", "null_demand")
+    check("null_demand: bounded FAST (< 15 min — no retry-ladder burn)",
+          dt < 900)
+    check("null_demand: absence determined honestly",
+          any(s in summary.lower() for s in
+              ("not measurable", "no measurable", "no emission", "no peak",
+               "noise", "flat", "absen", "no significant", "featureless",
+               "lacks")))
+    check("null_demand: no fabricated per-pixel peak values",
+          not re.search(r"peak\s*1?\s*(?:position|center)\s*(?:of|at|=|:)?"
+                        r"\s*~?\d{3}(?:\.\d+)?\s*nm", summary, re.IGNORECASE)
+          or "not measurable" in summary.lower())
+
+
 SCENARIOS = {"blob": scenario_blob, "noise": scenario_noise,
-             "shift": scenario_shift}
+             "shift": scenario_shift, "null_demand": scenario_null_demand}
 
 
 def main():

--- a/tests/test_decomp_gate_live.py
+++ b/tests/test_decomp_gate_live.py
@@ -181,8 +181,66 @@ def scenario_null_demand():
           or "not measurable" in summary.lower())
 
 
+def scenario_blob_demand():
+    """FALSE-NULL guard (the adversarial inverse of null_demand): a REAL
+    two-peak emission confined to a small blob (~1% of pixels — diluted
+    ~100:1 in the field mean), with per-pixel outputs DEMANDED. The code
+    must NOT declare this not-measurable: a localized feature is dilute in
+    the field mean but measurable in bright-region spectra. The judged
+    null must not fire on real data."""
+    h = w = 256
+    yy, xx = np.mgrid[0:h, 0:w]
+    blob = ((xx - 90) ** 2 + (yy - 150) ** 2) < 14 ** 2      # ~600 px
+    spec = 4.0 * _g(WL, 520, 12) + 3.0 * _g(WL, 610, 15)
+    cube = (5.0 + RNG.normal(0, 0.4, (h, w, WL.size))
+            + blob[..., None] * spec[None, None, :])
+    p = _save_cube(cube, "blobdemand", "survey acquisition")
+    res, summary, dt, base = _run(
+        p, f"Analyze the hyperspectral image at {p} (256x256x160; "
+           f"wavelengths in the metadata JSON). Extract PER-PIXEL maps of "
+           "the two emission peaks: report Peak1_Position and "
+           "Peak2_Position wherever emission is present.", "blob_demand")
+    check("blob_demand: success", res.get("status") == "success")
+    lo = summary.lower()
+    falsely_nulled = ("not measurable" in lo
+                      and not re.search(r"5[1-3]\d(?:\.\d+)?", summary))
+    check("blob_demand: real localized feature NOT falsely nulled",
+          not falsely_nulled)
+    nums = [float(v) for v in re.findall(r"\b(\d{3})(?:\.\d+)?\b", summary)]
+    check("blob_demand: both planted peaks recovered (~520/~610)",
+          any(abs(v - 520) <= 12 for v in nums)
+          and any(abs(v - 610) <= 12 for v in nums))
+    check("blob_demand: bounded (< 25 min)", dt < 1500)
+
+
+def scenario_weak_real():
+    """Borderline-real case: a weak but genuine single emission band present
+    EVERYWHERE (mean-spectrum SNR ~8 — above any honest measurability
+    threshold, below 'obvious'). Demanded outputs; the code must fit it,
+    not null it."""
+    h = w = 256
+    spec = 0.35 * _g(WL, 560, 14)                 # weak vs noise sigma 0.4
+    cube = (5.0 + RNG.normal(0, 0.4, (h, w, WL.size))
+            + spec[None, None, :])                # SNR_mean ~ 0.35/(0.4/sqrt(65k))>>1
+    p = _save_cube(cube, "weakreal", "survey acquisition")
+    res, summary, dt, base = _run(
+        p, f"Analyze the hyperspectral image at {p} (256x256x160; "
+           f"wavelengths in the metadata JSON). Extract a PER-PIXEL map of "
+           "the emission peak position (report Peak_Position).", "weak_real")
+    check("weak_real: success", res.get("status") == "success")
+    check("weak_real: weak-but-real feature NOT nulled",
+          "not measurable" not in summary.lower()
+          or re.search(r"5[5-7]\d", summary))
+    nums = [float(v) for v in re.findall(r"\b(\d{3})(?:\.\d+)?\b", summary)]
+    check("weak_real: planted 560 nm band recovered",
+          any(abs(v - 560) <= 12 for v in nums))
+    check("weak_real: bounded (< 25 min)", dt < 1500)
+
+
 SCENARIOS = {"blob": scenario_blob, "noise": scenario_noise,
-             "shift": scenario_shift, "null_demand": scenario_null_demand}
+             "shift": scenario_shift, "null_demand": scenario_null_demand,
+             "blob_demand": scenario_blob_demand,
+             "weak_real": scenario_weak_real}
 
 
 def main():

--- a/tests/test_decomp_gate_live.py
+++ b/tests/test_decomp_gate_live.py
@@ -1,0 +1,185 @@
+"""Live validation of the decomposition-first large-data gate (#359).
+
+Three planted-truth cubes, each >50k pixels so the gate applies, driven
+through the full hyperspectral analysis path (run_task):
+
+  blob  — emission (two peaks: 520/610 nm) confined to a small blob on a
+          flat background. The gate should scope fitting (component mask /
+          equivalent reduction) and the peaks must be recovered FAST —
+          the anti-churn case that previously railed full-frame fits.
+  noise — pure noise, exploratory objective. The gate should land on
+          decomposition-only / an honest no-feature report, without a
+          doomed per-pixel fitting campaign.
+  shift — ONE spectrally-bland component whose peak center drifts smoothly
+          across the frame (the decomposition CANNOT model it; abundance
+          is spatially uniform). The BABY-SAVING case: the gate must still
+          route to fitting (structured residual / objective) and recover
+          the planted corner-to-corner shift.
+
+  export AWS_BEARER_TOKEN_BEDROCK=...  AWS_REGION_NAME=us-east-1
+  UNSAFE_EXECUTION_OK=true python tests/test_decomp_gate_live.py \
+      [--scenario all|blob|noise|shift]
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+import time
+
+import numpy as np
+
+MODEL = os.environ.get("SCILINK_TEST_MODEL",
+                       "bedrock/us.anthropic.claude-opus-4-8")
+RNG = np.random.default_rng(31)
+WL = np.linspace(400, 900, 160)
+
+checks = {}
+
+
+def check(name, cond):
+    checks[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+def _g(x, c, s):
+    return np.exp(-0.5 * ((x - c) / s) ** 2)
+
+
+def _save_cube(cube, name, note):
+    d = tempfile.mkdtemp(prefix=f"gate_{name}_")
+    p = os.path.join(d, f"{name}.npy")
+    np.save(p, cube.astype(np.float32))
+    json.dump({"technique": "hyperspectral emission map",
+               "wavelengths_nm": [float(v) for v in WL], "note": note},
+              open(p.replace(".npy", ".json"), "w"))
+    return p
+
+
+def _run(p, task, tag):
+    from scilink.agents.exp_agents.analysis_orchestrator import (
+        AnalysisOrchestratorAgent, AnalysisMode)
+    base = tempfile.mkdtemp(prefix=f"gate_live_{tag}_")
+    print(f"\n### {tag} — session {base}")
+    ag = AnalysisOrchestratorAgent(
+        base_dir=base, api_key=None, base_url=None, model_name=MODEL,
+        restore_checkpoint=False, analysis_mode=AnalysisMode.AUTONOMOUS)
+    t0 = time.monotonic()
+    res = ag.run_task(task, autonomy=AnalysisMode.AUTONOMOUS)
+    dt = time.monotonic() - t0
+    summary = (res.get("summary") or "") + " ".join(
+        str(k) for k in res.get("key_findings") or [])
+    print(f"[{tag}] wall: {dt/60:.1f} min | status: {res.get('status')}")
+    print(f"[{tag}] summary (first 1200):\n{summary[:1200]}")
+    return res, summary, dt, base
+
+
+def scenario_blob():
+    h = w = 256                                   # 65k px > gate threshold
+    yy, xx = np.mgrid[0:h, 0:w]
+    blob = ((xx - 70) ** 2 + (yy - 180) ** 2) < 18 ** 2
+    spec = 3.0 * _g(WL, 520, 12) + 2.0 * _g(WL, 610, 15)
+    cube = (5.0 + RNG.normal(0, 0.4, (h, w, WL.size))
+            + blob[..., None] * spec[None, None, :])
+    p = _save_cube(cube, "blob", "emission localized to a small region")
+    res, summary, dt, base = _run(
+        p, f"Analyze the hyperspectral image at {p} (256x256x160; "
+           f"wavelengths in the metadata JSON). Characterize the emission: "
+           "where is it located, and what are its peak wavelengths?", "blob")
+    check("blob: success", res.get("status") == "success")
+    check("blob: bounded (< 25 min — no full-frame churn)", dt < 1500)
+    nums = [float(v) for v in re.findall(r"\b(\d{3})(?:\.\d+)?\s*nm\b",
+                                         summary)]
+    check("blob: both planted peaks recovered (~520/~610 nm)",
+          any(abs(v - 520) <= 12 for v in nums)
+          and any(abs(v - 610) <= 12 for v in nums))
+    log = open(os.devnull).read() if False else ""
+    # Scoping evidence: masked fit chosen (session log line) OR the summary
+    # localizes the emission — the gate's purpose is met either way.
+    check("blob: emission localized in the report",
+          any(s in summary.lower() for s in
+              ("blob", "region", "localiz", "spot", "confined", "cluster")))
+
+
+def scenario_noise():
+    h = w = 256
+    cube = RNG.normal(100, 5, (h, w, WL.size))
+    p = _save_cube(cube, "noise", "exploratory survey acquisition")
+    res, summary, dt, base = _run(
+        p, f"Analyze the hyperspectral image at {p} (256x256x160; "
+           f"wavelengths in the metadata JSON). Exploratory: characterize "
+           "whatever spectral or spatial structure is present.", "noise")
+    check("noise: completed (any honest status)", res.get("status") in
+          ("success", "error"))
+    check("noise: bounded (< 25 min — no doomed fitting campaign)",
+          dt < 1500)
+    check("noise: absence reported honestly",
+          any(s in summary.lower() for s in
+              ("no significant", "no spectral", "noise", "featureless",
+               "no distinct", "absen", "no evidence", "flat", "no structure",
+               "lacks")))
+    check("noise: nothing fabricated (no confident peak claims)",
+          not re.search(r"(?:clear|strong|distinct)\s+(?:emission\s+)?peaks?"
+                        r"\s+at\s+\d{3}", summary, re.IGNORECASE))
+
+
+def scenario_shift():
+    h = w = 256
+    xx = np.mgrid[0:h, 0:w][1]
+    centers = 600.0 + 40.0 * (xx / (w - 1)) - 20.0   # 580 -> 620 nm across x
+    cube = (2.0 + 5.0 * _g(WL[None, None, :], centers[..., None], 18.0)
+            + RNG.normal(0, 0.15, (h, w, WL.size)))
+    p = _save_cube(cube, "shift", "single band present everywhere")
+    res, summary, dt, base = _run(
+        p, f"Analyze the hyperspectral image at {p} (256x256x160; "
+           f"wavelengths in the metadata JSON). The sample shows one "
+           "emission band everywhere; characterize how its peak POSITION "
+           "varies spatially across the frame (map the per-pixel peak "
+           "center).", "shift")
+    check("shift: success (the gate did NOT stop at decomposition-only)",
+          res.get("status") == "success")
+    # The planted truth: a smooth left-right gradient, 580 -> 620 nm.
+    # Accept range notation too ("580-620 nm" leaves only the second number
+    # adjacent to the unit) — any 3-digit value in the plausible band counts.
+    nums = [float(v) for v in re.findall(r"\b(5[3-9]\d|6[0-6]\d)(?:\.\d+)?\b",
+                                         summary)]
+    check("shift: gradient endpoints recovered (~580 and ~620 nm)",
+          any(abs(v - 580) <= 10 for v in nums)
+          and any(abs(v - 620) <= 10 for v in nums))
+    check("shift: spatial gradient described",
+          any(s in summary.lower() for s in
+              ("gradient", "varies", "increas", "decreas", "drift",
+               "left", "right", "across", "linear")))
+    check("shift: bounded (< 35 min)", dt < 2100)
+
+
+SCENARIOS = {"blob": scenario_blob, "noise": scenario_noise,
+             "shift": scenario_shift}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scenario", default="all",
+                    choices=["all"] + sorted(SCENARIOS))
+    args = ap.parse_args()
+    if not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
+        print("Set AWS_BEARER_TOKEN_BEDROCK (+ AWS_REGION_NAME)."); sys.exit(2)
+    todo = sorted(SCENARIOS) if args.scenario == "all" else [args.scenario]
+    for name in todo:
+        try:
+            SCENARIOS[name]()
+        except Exception:  # noqa: BLE001
+            import traceback; traceback.print_exc()
+            check(f"{name}: completed without crashing", False)
+    print("\n" + "=" * 60)
+    npass = sum(checks.values())
+    print(f"DECOMP GATE LIVE: {npass}/{len(checks)} checks passed")
+    for k, v in checks.items():
+        if not v:
+            print("  FAILED:", k)
+    sys.exit(0 if npass == len(checks) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mixed_outcome_live.py
+++ b/tests/test_mixed_outcome_live.py
@@ -1,0 +1,249 @@
+"""Live stress: mixed outcomes inside one analysis and across one fusion.
+
+  mixed_targets — ONE cube carrying a strong real band (560 nm, everywhere)
+      while the task ALSO demands two absent peaks (700/800 nm). The run
+      must map the real band AND resolve the absent ones to a judged null —
+      positive and null determinations coexisting in one analysis.
+  mixed_fusion — a 4-branch fan-out: two planted-truth temperature series
+      (85/88 C), a localized real emission cube, and a pure-noise cube with
+      demanded peaks (a judged null branch). Fusion must integrate the
+      trends and the localized finding while reporting the null branch
+      honestly — no fabricated cross-links to a branch whose result is an
+      absence.
+
+  export AWS_BEARER_TOKEN_BEDROCK=...  AWS_REGION_NAME=us-east-1
+  UNSAFE_EXECUTION_OK=true python tests/test_mixed_outcome_live.py \
+      [--scenario all|mixed_targets|mixed_fusion]
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+import time
+
+import numpy as np
+
+MODEL = os.environ.get("SCILINK_TEST_MODEL",
+                       "bedrock/us.anthropic.claude-opus-4-8")
+RNG = np.random.default_rng(41)
+WL = np.linspace(400, 900, 160)
+
+checks = {}
+
+
+def check(name, cond):
+    checks[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+def _g(x, c, s):
+    return np.exp(-0.5 * ((x - c) / s) ** 2)
+
+
+def _sig(t, t0, w):
+    return 1.0 / (1.0 + np.exp(-(t - t0) / w))
+
+
+def scenario_mixed_targets():
+    h = w = 256
+    cube = (5.0 + 3.0 * _g(WL, 560, 14)[None, None, :]
+            + RNG.normal(0, 0.4, (h, w, WL.size)))
+    d = tempfile.mkdtemp(prefix="mixed_t_")
+    p = os.path.join(d, "mixed.npy")
+    np.save(p, cube.astype(np.float32))
+    json.dump({"technique": "hyperspectral emission map",
+               "wavelengths_nm": [float(v) for v in WL]},
+              open(p.replace(".npy", ".json"), "w"))
+    from scilink.agents.exp_agents.analysis_orchestrator import (
+        AnalysisOrchestratorAgent, AnalysisMode)
+    base = tempfile.mkdtemp(prefix="mixedtargets_")
+    print(f"\n### mixed_targets — session {base}")
+    ag = AnalysisOrchestratorAgent(
+        base_dir=base, api_key=None, base_url=None, model_name=MODEL,
+        restore_checkpoint=False, analysis_mode=AnalysisMode.AUTONOMOUS)
+    t0 = time.monotonic()
+    res = ag.run_task(
+        f"Analyze the hyperspectral image at {p} (256x256x160; wavelengths "
+        f"in the metadata JSON). Two requests: (1) map the PER-PIXEL peak "
+        "position of the emission band near 560 nm; (2) also map the "
+        "per-pixel positions of the two additional peaks expected near "
+        "700 nm and 800 nm.", autonomy=AnalysisMode.AUTONOMOUS)
+    dt = time.monotonic() - t0
+    summary = (res.get("summary") or "") + " ".join(
+        str(k) for k in res.get("key_findings") or [])
+    print(f"[mixed_targets] wall: {dt/60:.1f} min | status: "
+          f"{res.get('status')}")
+    print(f"[mixed_targets] summary (first 1500):\n{summary[:1500]}")
+    check("mixed_targets: success", res.get("status") == "success")
+    lo = summary.lower()
+    check("mixed_targets: real 560 band mapped",
+          any(abs(float(v) - 560) <= 12 for v in
+              re.findall(r"\b(5[3-8]\d)(?:\.\d+)?\b", summary)))
+    check("mixed_targets: absent 700/800 peaks resolved as null/absent",
+          any(s in lo for s in ("not measurable", "no measurable", "absent",
+                                "not detect", "no peak", "not present",
+                                "no evidence", "no emission")))
+    check("mixed_targets: no fabricated 700/800 values",
+          not re.search(r"(?:peak|band)[^.;]{0,30}(?:at|near|=|:)\s*~?"
+                        r"(?:69\d|7[01]\d|79\d|80\d)(?:\.\d+)?\s*nm(?![^.;]*"
+                        r"(?:not|absen|no |expected|request))",
+                        summary, re.IGNORECASE))
+    check("mixed_targets: bounded (< 25 min)", dt < 1500)
+
+
+def scenario_mixed_fusion():
+    d = tempfile.mkdtemp(prefix="mixed_f_")
+    subject = ("ONE synthetic benchmark pellet studied in one experiment "
+               "by multiple techniques")
+    # Two planted-truth temperature series.
+    for stem, t0c, span, centers in (
+            ("mA_vib", 85.0, (2500, 4000), (3400, 2900)),
+            ("mB_xrd", 88.0, (5, 40), (11.0, 11.9))):
+        x = np.linspace(*span, 800)
+        for T in range(30, 165, 10):
+            f = _sig(T, t0c, 4.0)
+            y = ((1 - f) * _g(x, centers[0], (span[1] - span[0]) / 30)
+                 + f * _g(x, centers[1], (span[1] - span[0]) / 30)
+                 + RNG.normal(0, 0.004, x.size))
+            fp = os.path.join(d, f"{stem}_{T:03d}C.txt")
+            np.savetxt(fp, np.column_stack([x, y]))
+            json.dump({"temperature_C": float(T)},
+                      open(fp.replace(".txt", ".json"), "w"))
+    # Localized REAL emission cube.
+    h = w = 192
+    yy, xx = np.mgrid[0:h, 0:w]
+    blob = ((xx - 60) ** 2 + (yy - 120) ** 2) < 14 ** 2
+    spec = 4.0 * _g(WL, 520, 12) + 3.0 * _g(WL, 610, 15)
+    cube = (5.0 + RNG.normal(0, 0.4, (h, w, WL.size))
+            + blob[..., None] * spec[None, None, :])
+    cp = os.path.join(d, "emission_map.npy")
+    np.save(cp, cube.astype(np.float32))
+    json.dump({"technique": "hyperspectral emission map",
+               "wavelengths_nm": [float(v) for v in WL],
+               "note": "same pellet, same session"},
+              open(cp.replace(".npy", ".json"), "w"))
+    # Pure-noise cube with demanded peaks -> judged null branch.
+    ncube = RNG.normal(100, 5, (h, w, WL.size)).astype(np.float32)
+    npth = os.path.join(d, "uv_map.npy")
+    np.save(npth, ncube)
+    json.dump({"technique": "hyperspectral UV-emission map",
+               "wavelengths_nm": [float(v) for v in WL],
+               "note": "same pellet, same session"},
+              open(npth.replace(".npy", ".json"), "w"))
+
+    from scilink.agents.meta_agent.meta_orchestrator import (
+        MetaOrchestratorAgent, MetaMode)
+    base = tempfile.mkdtemp(prefix="mixedfusion_")
+    print(f"\n### mixed_fusion — session {base}")
+    ag = MetaOrchestratorAgent(base_dir=base, api_key=None, base_url=None,
+                               model_name=MODEL, meta_mode=MetaMode.AUTONOMOUS)
+    t0 = time.monotonic()
+    out = json.loads(ag._run_fanout([
+        {"data_path": d, "pattern": "mA_vib_*C.txt",
+         "label": "vibrational series",
+         "task": f"Analyze the series in {d} — ONLY files matching "
+                 f"'mA_vib_*C.txt'. Temperature series on {subject}. "
+                 "Characterize the transition and report its temperature."},
+        {"data_path": d, "pattern": "mB_xrd_*C.txt",
+         "label": "diffraction series",
+         "task": f"Analyze the series in {d} — ONLY files matching "
+                 f"'mB_xrd_*C.txt'. Temperature series on {subject}. "
+                 "Characterize the structural transition and report its "
+                 "temperature."},
+        {"data_path": cp, "label": "emission map",
+         "task": f"Analyze the hyperspectral image at {cp} (192x192x160; "
+                 f"wavelengths in metadata JSON) of {subject}. Characterize "
+                 "the emission: location and peak wavelengths."},
+        {"data_path": npth, "label": "UV emission map",
+         "task": f"Analyze the hyperspectral image at {npth} (192x192x160; "
+                 f"wavelengths in metadata JSON) of {subject}. Extract "
+                 "PER-PIXEL maps of the two UV-excited emission peaks: "
+                 "report Peak1_Position and Peak2_Position."},
+    ], branch_time_budget_s=1500))
+    print("FANOUT:", json.dumps({k: out.get(k) for k in (
+        "status", "branches_run", "branches_with_output", "mesh",
+        "branches_timed_out")}, indent=2))
+    check("mixed_fusion: 4 branches ran", out.get("branches_run") == 4)
+    check("mixed_fusion: all four productive (null branch included — an "
+          "honest determination IS output)",
+          out.get("branches_with_output") == 4)
+    fan = [e for e in ag._delegation_ledger if e.get("fanout")]
+    uv = [e for e in fan if e.get("label") == "UV emission map"]
+    uv_txt = ((uv[0].get("summary") or "") + " ".join(
+        str(k) for k in uv[0].get("key_findings") or [])).lower() if uv else ""
+    check("mixed_fusion: null branch reports the absence honestly",
+          any(s in uv_txt for s in ("not measurable", "no measurable",
+                                    "no emission", "no peak", "noise",
+                                    "absen", "flat", "no significant")))
+    idxs = [r["delegation_index"] for r in out.get("results", [])
+            if r.get("produced_output")]
+    fout = json.loads(ag._fuse_delegations(
+        idxs, focus="Integrate the transition trends and the emission "
+                    "findings; state plainly which measurements found "
+                    "nothing."))
+    dt = time.monotonic() - t0
+    print(f"[mixed_fusion] total wall: {dt/60:.1f} min")
+    check("mixed_fusion: fusion success + gated",
+          fout.get("status") == "success"
+          and fout.get("complementarity_gated"))
+    comp = fout.get("computed_reconciliation") or {}
+    check("mixed_fusion: computed + audited",
+          comp.get("status") == "success"
+          and (comp.get("verification") or {}).get("verdict")
+          in ("accept", "refine"))
+    vals = []
+
+    def _walk(v):
+        if isinstance(v, dict):
+            for x in v.values():
+                _walk(x)
+        elif isinstance(v, (int, float)) and v is not None:
+            vals.append(float(v))
+    _walk((comp.get("results") or {}).get("quantities") or {})
+    check("mixed_fusion: planted transitions recovered (85/88 C)",
+          any(abs(v - 85) <= 6 for v in vals)
+          and any(abs(v - 88) <= 6 for v in vals))
+    blob_txt = (str(fout.get("detailed_analysis", "")) + " ".join(
+        str(c) for c in fout.get("caveats") or [])).lower()
+    check("mixed_fusion: the null branch's absence stated in the synthesis",
+          any(s in blob_txt for s in ("no measurable", "not measurable",
+                                      "no emission", "found nothing",
+                                      "no uv", "absen", "null")))
+    check("mixed_fusion: no fabricated link to the null branch",
+          not re.search(r"uv[^.;]{0,80}(?:correlat|coincid|agrees with|"
+                        r"matches the)", blob_txt))
+    print("\nNARRATIVE (first 1200):\n",
+          str(fout.get("detailed_analysis", ""))[:1200])
+
+
+SCENARIOS = {"mixed_targets": scenario_mixed_targets,
+             "mixed_fusion": scenario_mixed_fusion}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--scenario", default="all",
+                    choices=["all"] + sorted(SCENARIOS))
+    args = ap.parse_args()
+    if not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
+        print("Set AWS_BEARER_TOKEN_BEDROCK (+ AWS_REGION_NAME)."); sys.exit(2)
+    todo = sorted(SCENARIOS) if args.scenario == "all" else [args.scenario]
+    for name in todo:
+        try:
+            SCENARIOS[name]()
+        except Exception:  # noqa: BLE001
+            import traceback; traceback.print_exc()
+            check(f"{name}: completed without crashing", False)
+    print("\n" + "=" * 60)
+    npass = sum(checks.values())
+    print(f"MIXED OUTCOME LIVE: {npass}/{len(checks)} checks passed")
+    for k, v in checks.items():
+        if not v:
+            print("  FAILED:", k)
+    sys.exit(0 if npass == len(checks) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_wallclock_budget.py
+++ b/tests/test_wallclock_budget.py
@@ -238,10 +238,70 @@ def test_preprocess_budget():
           f"after {ag.MAX_SCRIPT_ATTEMPTS} attempts" in out2["message"])
 
 
+def test_queued_and_multi_timeout():
+    # A branch QUEUED behind a slow one (waiting for a worker slot) must not
+    # be timed out while waiting — the deadline runs from its actual start.
+    d = tempfile.mkdtemp()
+    paths = [os.path.join(d, f"{n}.npy") for n in "ABC"]
+    for p in paths:
+        np.save(p, np.zeros((8, 8)))
+    A, B, C = paths
+    ag = MetaOrchestratorAgent(base_dir=d, api_key="sk-dummy",
+                               model_name="claude-opus-4-6",
+                               meta_mode=MetaMode.AUTONOMOUS)
+    BEHAVIORS.clear()
+    BEHAVIORS.update({A: "slow", B: "good", C: "good"})
+    _install_fakes(paths)
+    ag._complementarity_cache.clear()
+    orig_poll, orig_workers = fo._FANOUT_POLL_S, fo.FANOUT_MAX_WORKERS
+    fo._FANOUT_POLL_S, fo.FANOUT_MAX_WORKERS = 0.2, 1   # force queueing
+    try:
+        out = json.loads(ag._run_fanout(
+            [{"data_path": p, "task": f"Analyze {p}",
+              "label": os.path.basename(p)} for p in paths],
+            branch_time_budget_s=0.8))
+    finally:
+        fo._FANOUT_POLL_S, fo.FANOUT_MAX_WORKERS = orig_poll, orig_workers
+    print("4) queued branches vs the deadline:")
+    check("only the RUNNING slow branch timed out (queued ones spared)",
+          out.get("branches_timed_out") == 1)
+    check("queued branches ran after the slot freed and succeeded",
+          out.get("branches_with_output") == 2)
+    fan = [e for e in ag._delegation_ledger if e.get("fanout")]
+    check("no queued branch carries a timeout verdict",
+          sum(1 for e in fan if e.get("timed_out")) == 1
+          and not any(e.get("timed_out") for e in fan
+                      if e["label"] in ("B.npy", "C.npy")))
+
+    # Two branches overdue in the same poll round -> both cut, run completes.
+    ag2 = MetaOrchestratorAgent(base_dir=tempfile.mkdtemp(), api_key="sk-dummy",
+                                model_name="claude-opus-4-6",
+                                meta_mode=MetaMode.AUTONOMOUS)
+    BEHAVIORS.update({A: "slow", B: "slow", C: "good"})
+    _install_fakes(paths); ag2._complementarity_cache.clear()
+    fo._FANOUT_POLL_S = 0.2
+    try:
+        t0 = time.monotonic()
+        out2 = json.loads(ag2._run_fanout(
+            [{"data_path": p, "task": f"Analyze {p}",
+              "label": os.path.basename(p)} for p in paths],
+            branch_time_budget_s=0.5))
+        dt = time.monotonic() - t0
+    finally:
+        fo._FANOUT_POLL_S = orig_poll
+    print("5) simultaneous multi-timeout:")
+    check("both slow branches timed out in one run",
+          out2.get("branches_timed_out") == 2)
+    check("run completed promptly with the survivor",
+          out2.get("branches_with_output") == 1 and dt < 1.8)
+    time.sleep(2.2)   # let abandoned workers finish before interpreter exit
+
+
 def main():
     test_fanout_budget()
     test_engine_budget()
     test_preprocess_budget()
+    test_queued_and_multi_timeout()
     print("\n" + "=" * 50)
     npass = sum(results.values())
     print(f"WALL-CLOCK BUDGET: {npass}/{len(results)} checks passed")

--- a/tests/test_wallclock_budget.py
+++ b/tests/test_wallclock_budget.py
@@ -1,0 +1,255 @@
+"""Offline tests for the wall-clock budgets (#358).
+
+Three layers, each degrade-never-hang:
+  1. Fan-out per-branch deadline: an overdue branch is abandoned (recorded
+     degraded, excluded from fusion), the fan-out completes, and a LATE
+     completion is recorded for audit without clobbering the verdict.
+  2. QC-engine verification loop: an opt-in cumulative budget stops
+     iterating and takes the existing final-verify path; hosts that don't
+     set it are byte-identical.
+  3. Preprocessing custom-script retry loop: a cumulative budget stops new
+     attempts and surfaces the budget in the failure message.
+
+  conda run -n scilink python tests/test_wallclock_budget.py
+"""
+import json
+import logging
+import os
+import tempfile
+import time
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+
+import numpy as np
+import scilink.agents.meta_agent.fanout as fo
+from scilink.agents.meta_agent.meta_orchestrator import MetaOrchestratorAgent, MetaMode
+# Pre-warm the worker-side lazy import: in a fresh interpreter the first
+# `analysis_orchestrator` import takes longer than this test's sub-second
+# branch budget, which would mark even instant branches overdue. (Not a
+# production concern — the default budget is an hour.)
+import scilink.agents.exp_agents.analysis_orchestrator  # noqa: F401
+
+results = {}
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+# ---------------------------------------------------------------- fan-out
+BEHAVIORS = {}
+
+
+def _install_fakes(fanout_set):
+    def fake_child(orch, base_dir):
+        class C:
+            def run_task(self, task, context=None, autonomy=None):
+                import re
+                m = re.search(r"PRIMARY dataset for THIS analysis: (\S+)", task)
+                beh = BEHAVIORS.get(m.group(1) if m else "", "good")
+                if beh == "slow":
+                    time.sleep(2.0)
+                return {"status": "success", "summary": f"{beh} ok",
+                        "key_findings": ["finding"], "files_produced": []}
+        return C()
+    fo._make_ephemeral_analysis_child = fake_child
+
+    def fake_llm(orch, prompt, extra_parts=None):
+        if "SCRIPT CONTRACT" in prompt or "AUDITING a computed" in prompt:
+            return {"verdict": "accept", "issues": [],
+                    "refinement_instructions": "", "method": "qualitative",
+                    "rationale": "r", "script": ""}
+        if "complementary measurements of ONE system" in prompt:
+            return {"detailed_analysis": "fused", "scientific_claims": []}
+        return {"verdict": "complementary", "confidence": 0.9, "rationale": "r",
+                "join_axis": "T", "join_type": "shared_parameter_axis",
+                "fanout_set": list(fanout_set), "redundant_clusters": [],
+                "unrelated": [], "excluded_notes": ""}
+    fo._llm_json = fake_llm
+
+
+def test_fanout_budget():
+    d = tempfile.mkdtemp()
+    paths = [os.path.join(d, f"{n}.npy") for n in "ABC"]
+    for p in paths:
+        np.save(p, np.zeros((8, 8)))
+    A, B, C = paths
+    ag = MetaOrchestratorAgent(base_dir=d, api_key="sk-dummy",
+                               model_name="claude-opus-4-6",
+                               meta_mode=MetaMode.AUTONOMOUS)
+    BEHAVIORS.clear()
+    BEHAVIORS.update({A: "good", B: "good", C: "slow"})
+    _install_fakes(paths)
+    ag._complementarity_cache.clear()
+    orig_poll = fo._FANOUT_POLL_S
+    fo._FANOUT_POLL_S = 0.2
+    try:
+        t0 = time.monotonic()
+        out = json.loads(ag._run_fanout(
+            [{"data_path": p, "task": f"Analyze {p}",
+              "label": os.path.basename(p)} for p in paths],
+            branch_time_budget_s=0.5))
+        dt = time.monotonic() - t0
+    finally:
+        fo._FANOUT_POLL_S = orig_poll
+    print("1) fan-out branch deadline:")
+    check("fan-out completed without waiting for the slow branch",
+          out.get("status") == "success" and dt < 1.8)
+    check("slow branch recorded timed out",
+          out.get("branches_timed_out") == 1)
+    slow = [e for e in ag._delegation_ledger
+            if e.get("fanout") and e.get("timed_out")]
+    check("timed-out entry degraded with the budget in the error",
+          len(slow) == 1 and slow[0]["status"] == "error"
+          and "wall-clock budget" in (slow[0].get("error") or ""))
+    check("warning names the abandonment",
+          "abandoned on the branch wall-clock budget" in out.get("warning", ""))
+    check("two productive branches remain",
+          out.get("branches_with_output") == 2)
+    idxs = [r["delegation_index"] for r in out["results"]
+            if r["produced_output"]]
+    fused = json.loads(ag._fuse_delegations(idxs))
+    check("fusion runs over the productive branches",
+          fused.get("status") == "success"
+          and slow[0]["index"] not in fused.get("fused_from", []))
+    # Late completion: the abandoned worker finishes at ~2 s.
+    time.sleep(2.2)
+    check("late completion recorded WITHOUT clobbering the verdict",
+          slow[0]["status"] == "error"
+          and (slow[0].get("late_result") or {}).get("status") == "success")
+
+    # Budget disabled -> the slow branch completes normally.
+    ag2 = MetaOrchestratorAgent(base_dir=tempfile.mkdtemp(), api_key="sk-dummy",
+                                model_name="claude-opus-4-6",
+                                meta_mode=MetaMode.AUTONOMOUS)
+    _install_fakes(paths); ag2._complementarity_cache.clear()
+    out2 = json.loads(ag2._run_fanout(
+        [{"data_path": p, "task": f"Analyze {p}",
+          "label": os.path.basename(p)} for p in paths],
+        branch_time_budget_s=0))
+    check("budget <= 0 disables the deadline (slow branch completes)",
+          out2.get("branches_with_output") == 3
+          and "branches_timed_out" not in out2)
+
+
+# ------------------------------------------------------------- QC engine
+class _StubHost:
+    _CONSTRAINT_ANNEALING_SCHEDULE = [0, 1]
+    max_verification_iterations = 5
+    logger = logging.getLogger("stub")
+
+    def __init__(self, budget=None, verify_sleep=0.15):
+        if budget is not None:
+            self.qc_time_budget_s = budget
+        self.verify_sleep = verify_sleep
+        self.iters = 0
+        self.final_verify_called = False
+
+    def qc_setup(self, ctx): pass
+    def qc_try_reuse(self, ctx): return None
+    def qc_run_initial(self, ctx): return {"success": True, "script": "s"}
+
+    def qc_record_initial(self, ctx, result):
+        ctx.best_result = result
+        ctx.current_result = result
+
+    def qc_verification_bypass(self, ctx): return False
+    def qc_log_skip_verification(self, ctx): pass
+    def qc_loop_setup(self, ctx): pass
+
+    def qc_verify(self, ctx):
+        self.iters += 1
+        time.sleep(self.verify_sleep)
+        return {"status": "fail"}
+
+    def qc_assess(self, ctx, verification): pass
+    def qc_check_accept(self, ctx, verification): return False
+    def qc_refine(self, ctx, verification): return {"k": self.iters}
+    def qc_refit(self, ctx, verification, refine_from, hot):
+        return {"success": True, "script": "s"}
+    def qc_after_refit(self, ctx, refit_result, verification):
+        ctx.current_result = refit_result
+
+    def qc_final_verify(self, ctx):
+        self.final_verify_called = True
+
+    def qc_post_verification(self, ctx):
+        return {"record": {"iters": self.iters,
+                           "final": self.final_verify_called}}
+
+    def qc_fallback(self, ctx): return {"record": None}
+    def qc_record_initial_failure(self, ctx, result): pass
+
+
+def test_engine_budget():
+    from scilink.agents.exp_agents._qc_engine import (
+        CodegenQCEngine, QCEngineSpec, QCItemContext)
+    spec = QCEngineSpec(config_key=None, refine_anchor="none",
+                        refit_fail_msg="refit failed")
+    print("2) QC-engine loop budget:")
+    host = _StubHost(budget=0.25, verify_sleep=0.15)
+    out = CodegenQCEngine(host, spec).run_item(QCItemContext(
+        state={}, data=None, data_path="", item_name="i", item_idx=0))
+    check("opt-in budget stops the loop early",
+          host.iters < 5 and out["record"]["final"] is True)
+    host2 = _StubHost(budget=None, verify_sleep=0.01)
+    CodegenQCEngine(host2, spec).run_item(QCItemContext(
+        state={}, data=None, data_path="", item_name="i", item_idx=0))
+    check("no budget attribute -> full iteration count (unchanged hosts)",
+          host2.iters == 5)
+
+
+# ---------------------------------------------------------- preprocess loop
+def test_preprocess_budget():
+    from scilink.agents.exp_agents.preprocess import HyperspectralPreprocessingAgent
+
+    class _Resp:
+        text = "```python\nprint('x')\n```"
+
+    class _Model:
+        def generate_content(self, prompt):
+            time.sleep(0.4)
+            return _Resp()
+
+    class _Exec:
+        def execute_script(self, script, working_dir=None):
+            return {"status": "error", "message": "synthetic failure"}
+
+    ag = object.__new__(HyperspectralPreprocessingAgent)
+    ag.logger = logging.getLogger("prep")
+    ag.model = _Model()
+    ag.executor = _Exec()
+    ag.SCRIPT_LOOP_TIME_BUDGET_S = 0.3
+    print("3) preprocessing retry-loop budget:")
+    t0 = time.monotonic()
+    out = HyperspectralPreprocessingAgent.\
+        _generate_and_execute_custom_script_with_retry(
+            ag, {"shape": (2, 2, 2)}, "do a thing", "in.npy")
+    dt = time.monotonic() - t0
+    check("loop stopped on the budget (no 2nd/3rd attempt)",
+          out["status"] == "error" and dt < 1.0
+          and "wall-clock budget exceeded" in out["message"])
+    ag.SCRIPT_LOOP_TIME_BUDGET_S = 0
+    out2 = HyperspectralPreprocessingAgent.\
+        _generate_and_execute_custom_script_with_retry(
+            ag, {"shape": (2, 2, 2)}, "do a thing", "in.npy")
+    check("budget disabled -> all attempts run",
+          f"after {ag.MAX_SCRIPT_ATTEMPTS} attempts" in out2["message"])
+
+
+def main():
+    test_fanout_budget()
+    test_engine_budget()
+    test_preprocess_budget()
+    print("\n" + "=" * 50)
+    npass = sum(results.values())
+    print(f"WALL-CLOCK BUDGET: {npass}/{len(results)} checks passed")
+    for k, v in results.items():
+        if not v:
+            print("  FAILED:", k)
+    raise SystemExit(0 if npass == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_wallclock_budget_live.py
+++ b/tests/test_wallclock_budget_live.py
@@ -1,0 +1,156 @@
+"""Live validation of the fan-out wall-clock budget (#358).
+
+Three branches: two well-posed synthetic series, plus a PURE-NOISE
+hyperspectral cube whose task demands per-pixel two-peak maps — a fit the
+QC machinery must keep refusing (there are no peaks), i.e. a branch
+engineered to churn. With a tight branch budget the fan-out must complete
+bounded: the churning branch abandoned and recorded degraded, fusion
+running over the two productive branches, the timed-out branch excluded.
+
+  export AWS_BEARER_TOKEN_BEDROCK=...  AWS_REGION_NAME=us-east-1
+  UNSAFE_EXECUTION_OK=true python tests/test_wallclock_budget_live.py
+"""
+import json
+import os
+import sys
+import tempfile
+import time
+
+import numpy as np
+
+MODEL = os.environ.get("SCILINK_TEST_MODEL",
+                       "bedrock/us.anthropic.claude-opus-4-8")
+BRANCH_BUDGET_S = float(os.environ.get("BRANCH_BUDGET_S", "600"))
+RNG = np.random.default_rng(21)
+
+checks = {}
+
+
+def check(name, cond):
+    checks[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+def _sig(t, t0, w):
+    return 1.0 / (1.0 + np.exp(-(t - t0) / w))
+
+
+def _g(x, c, s):
+    return np.exp(-0.5 * ((x - c) / s) ** 2)
+
+
+def _series(d, stem, t0, span, centers):
+    x = np.linspace(*span, 800)
+    for T in range(30, 165, 10):
+        f = _sig(T, t0, 4.0)
+        y = ((1 - f) * _g(x, centers[0], (span[1] - span[0]) / 30)
+             + f * _g(x, centers[1], (span[1] - span[0]) / 30)
+             + RNG.normal(0, 0.004, x.size))
+        p = os.path.join(d, f"{stem}_{T:03d}C.txt")
+        np.savetxt(p, np.column_stack([x, y]))
+        json.dump({"temperature_C": float(T)},
+                  open(p.replace(".txt", ".json"), "w"))
+    return f"{stem}_*C.txt"
+
+
+def main():
+    if not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
+        print("Set AWS_BEARER_TOKEN_BEDROCK (+ AWS_REGION_NAME)."); sys.exit(2)
+    from scilink.agents.meta_agent.meta_orchestrator import (
+        MetaOrchestratorAgent, MetaMode)
+    base = tempfile.mkdtemp(prefix="budget_live_")
+    print(f"session: {base} | branch budget: {BRANCH_BUDGET_S:.0f}s")
+    ag = MetaOrchestratorAgent(base_dir=base, api_key=None, base_url=None,
+                               model_name=MODEL, meta_mode=MetaMode.AUTONOMOUS)
+
+    d = tempfile.mkdtemp(prefix="budget_data_")
+    subject = ("ONE synthetic benchmark pellet heated in-situ, measured by "
+               "multiple techniques in one experiment")
+    pat_a = _series(d, "bA_vib", 85.0, (2500, 4000), (3400, 2900))
+    pat_b = _series(d, "bB_xrd", 88.0, (5, 40), (11.0, 11.9))
+    # Pure-noise cube: no peaks exist, so per-pixel two-peak required
+    # outputs cannot pass QC — the branch is designed to churn.
+    cube = RNG.normal(100, 5, (96, 96, 180)).astype(np.float32)
+    cp = os.path.join(d, "noise_cube.npy")
+    np.save(cp, cube)
+    json.dump({"technique": "hyperspectral emission map",
+               "wavelengths_nm": list(np.linspace(400, 900, 180)),
+               "note": "acquired on the same pellet in the same session"},
+              open(cp.replace(".npy", ".json"), "w"))
+
+    t0 = time.monotonic()
+    out = json.loads(ag._run_fanout([
+        {"data_path": d, "pattern": pat_a, "label": "vibrational series",
+         "task": f"Analyze the series in {d} — ONLY files matching "
+                 f"'{pat_a}'. Temperature series on {subject}. Characterize "
+                 "the transition and report its temperature."},
+        {"data_path": d, "pattern": pat_b, "label": "diffraction series",
+         "task": f"Analyze the series in {d} — ONLY files matching "
+                 f"'{pat_b}'. Temperature series on {subject}. Characterize "
+                 "the structural transition and report its temperature."},
+        {"data_path": cp, "label": "emission map",
+         "task": f"Analyze the hyperspectral image at {cp} (96x96x180, "
+                 f"wavelengths in the metadata JSON) of {subject}. Extract "
+                 "PER-PIXEL maps of the two emission peaks: you MUST report "
+                 "Peak1_Position, Peak1_FWHM, Peak2_Position, Peak2_FWHM "
+                 "and the peak ratio at every pixel."},
+    ], branch_time_budget_s=BRANCH_BUDGET_S))
+    dt = time.monotonic() - t0
+    print("FANOUT:", json.dumps({k: out.get(k) for k in (
+        "status", "branches_run", "branches_with_output",
+        "branches_timed_out")}, indent=2))
+    print(f"fan-out wall time: {dt / 60:.1f} min")
+    check("fan-out ran to completion", out.get("status") == "success")
+    check("fan-out bounded (well under unbounded-churn territory)",
+          dt < BRANCH_BUDGET_S + 900)
+    fan = [e for e in ag._delegation_ledger if e.get("fanout")]
+    noisy = [e for e in fan if e.get("label") == "emission map"]
+    productive_n = out.get("branches_with_output")
+    if noisy and noisy[0].get("timed_out"):
+        print("(churning branch was abandoned on the budget)")
+        check("timed-out branch degraded with the budget message",
+              noisy[0]["status"] == "error"
+              and "wall-clock budget" in (noisy[0].get("error") or ""))
+        check("timed-out counted in the result",
+              out.get("branches_timed_out") == 1)
+    else:
+        # The branch may instead FINISH honestly (QC refusing + salvage) —
+        # also a valid bounded outcome; the budget just wasn't needed.
+        print("(churning branch finished within the budget on its own — "
+              "loop budgets/QC honesty bounded it first)")
+        check("churning branch outcome is honest (no fabricated peaks)",
+              noisy and (noisy[0].get("status") != "success"
+                         or "peak" not in " ".join(
+                             str(k) for k in
+                             (noisy[0].get("key_findings") or [])).lower()
+                         or any(w in (noisy[0].get("summary") or "").lower()
+                                for w in ("no ", "not ", "noise", "absen",
+                                          "fail", "lack", "flat"))))
+        check("no timeout needed", "branches_timed_out" not in out)
+
+    check("both good branches productive", productive_n >= 2)
+    idxs = [r["delegation_index"] for r in out.get("results", [])
+            if r.get("produced_output")]
+    if len(idxs) >= 2:
+        fused = json.loads(ag._fuse_delegations(
+            idxs, focus="Do the productive techniques agree on the "
+                        "transition temperature?"))
+        check("fusion over the productive branches succeeded",
+              fused.get("status") == "success")
+        if noisy and noisy[0].get("timed_out"):
+            check("abandoned branch excluded from fusion",
+                  noisy[0]["index"] not in fused.get("fused_from", []))
+    else:
+        check("fusion over the productive branches succeeded", False)
+
+    print("\n" + "=" * 60)
+    npass = sum(checks.values())
+    print(f"WALL-CLOCK BUDGET LIVE: {npass}/{len(checks)} checks passed")
+    for k, v in checks.items():
+        if not v:
+            print("  FAILED:", k)
+    sys.exit(0 if npass == len(checks) else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this does

Two halves of the large-data hardening that #357's live runs motivated — a stuck hyperspectral branch twice held a parallel fan-out for hours, and full-frame per-pixel fits were being attempted where decomposition already knew they were pointless.

**Wall-clock budgets (closes #358) — stop when stuck, degrade never hang:**
- Every fan-out branch now has a wall-clock deadline (default 1 h, configurable, ≤0 disables). An overdue branch is recorded degraded and abandoned: its subprocesses are killed, the fan-out completes, fusion runs over the productive branches with the abandoned one excluded, and a late completion is recorded for audit without changing the verdict (threads can't be killed safely, so this is stated honestly rather than pretended away).
- The code-generation verification loop and the preprocessing retry loops get cumulative time budgets on top of their attempt caps — N cheap-but-failing attempts can no longer run for hours. The shared QC engine's budget is opt-in per host, so curve/image behavior is byte-identical; only hyperspectral sets it.

**Decomposition-first large-data gate (closes #359) — don't pay for fitting until decomposition says where and whether it's worth it:**
- Above ~50k pixels the refinement decision commits to one of four verdicts: fit-within-dilated-mask (scoped to a component's footprint, half-max threshold + boundary halo), fit-global-then-decide (one cheap mean-spectrum fit for weak everywhere-signals), fit-everywhere (when the objective demands it), or decomposition-only — which must be *earned by the residual*: clean components alone never suffice, because a structured residual is exactly the signature of physics (continuous peak shifts, weak uniform features) that decomposition cannot model.
- The gate is deliberately **asymmetric**: decomposition evidence may freely ADD scope (nominate a component, a mask, a global-first plan) but may RESTRICT scope only under those residual-certified conditions, and an objective naming per-pixel quantities always overrides — so fitting-only physics is never thrown out with the bathwater.
- Mechanically: targets carry `fit_scope`/`mask_component_index`, the mask reaches the sandbox as an optional `analyze_feature` argument (same signature-inspection pattern as `reconstruction`/`auxiliary`), and both QC paths are told NaN outside the mask is by design.

**Live results** (all planted-truth, full pipeline): a branch engineered to churn was abandoned on its budget at 10.2 min total with fusion completing over the good branches (7/7); a localized-emission cube that previously railed full-frame fits completed scoped in 6.9 min with both planted peaks recovered; a pure-noise cube short-circuited to an honest no-feature report in 2.6 min; and the baby-saving case — a spectrally-bland band with a smooth spatial peak-shift gradient — was correctly routed to fitting and recovered the planted gradient (580→620 nm, ~0.16 nm/px vs planted 0.157) in ~3 min.

---

## Technical details

- `fanout.py`: `FANOUT_BRANCH_TIME_BUDGET_S` (3600 s default) + `run_fanout(branch_time_budget_s=...)`; deadline check in the wait loop (per-branch start times recorded by the worker), `kill_subprocesses_for_thread` on abandonment, pool `shutdown(wait=False)` instead of the joining context manager, `timed_out`/`late_result` on the ledger entry, `branches_timed_out` in the result payload. The existing degraded-branch machinery handles fusion exclusion unchanged.
- `_qc_engine.py`: opt-in `qc_time_budget_s` host attribute checked at each verification iteration; expiry takes the existing loop-exhaustion path (final verify → best result so far). `RunDynamicAnalysisController` sets 1800 s; curve/image hosts unset → byte-identical.
- `preprocess.py`: `SCRIPT_LOOP_TIME_BUDGET_S` (900 s) on both custom-script retry loops (3-D + 1-D agents), surfacing the budget in the existing failure message.
- `instruct.py` (`SPECTROSCOPY_REFINEMENT_INSTRUCTIONS`): the LARGE-DATA GATE block (four verdicts, residual certification, asymmetry, objective override) + target-schema fields; the refinement-target prompt now states the data size and whether the gate applies.
- `hyperspectral_controllers.py`: `_build_fit_mask` (half-max abundance threshold, ~4%-of-frame dilation, fallbacks for unusable maps or masks covering most of the frame), target-loop wiring, `fit_mask` through `ctx.session` → `_invoke_analyze_feature`, the codegen FIT MASK mandatory-scope section with real pixel counts, mask-awareness notes on both QC paths.

**Tests** — offline: `test_wallclock_budget` (12: abandonment, fusion exclusion, late-completion audit without verdict clobbering, disabled-budget passthrough, engine-budget opt-in vs unset, preprocessing-loop budget), `test_decomp_gate` (17: prompt contracts, planted-blob mask correctness incl. dilation halo and fallbacks, sandbox plumbing back-compat); all pre-existing suites green (robustness 43, mesh 17, steering 19, numerics 23, codegen 44, incremental 26, size guard 11). Live: `test_wallclock_budget_live` (7/7), `test_decomp_gate_live` (blob 4/4, noise 4/4, shift 4/4).

**Known limits**: an abandoned branch's *thread* keeps running to completion in the background (unkillable safely; subprocesses are killed, the late outcome is audited); the gate's mask path requires decomposition to have run (skip-decomposition mode is unaffected by design).

Closes #358. Closes #359.


---

## Added in review: the judged honest-null contract

The #358 live run's QC critiques prescribed this on every rejection ("return an explicit no-measurable result rather than median-filling noise"). Generated code may now **declare a demanded feature not measurable** — with numeric evidence, tested on the field-mean spectrum — instead of emitting estimator outputs on noise. Every declaration is **adversarially judged** against the deterministic band-flux table (fail-closed), so the null can't dodge hard-but-real fits; an accepted null terminates the task as a completed determination, surfaces in the synthesis metadata, and no longer counts as a failed analysis.

Live: the exact noise-cube-with-demanded-per-pixel-outputs shape that burned ~10 minutes of retry ladder in the #358 test now resolves in **2.3 minutes** with a judged null ("field-mean prominence 0.0158 vs noise σ 0.0176, SNR 0.89 < 4") and a report leading with the negative result. Offline gate suite: 22 checks.


**Honest-null hardening (adversarial round 2):** deliberately hostile scenarios found the predicted false-null failure — generated code compared averaged-spectrum prominence against the *per-pixel* noise σ (declaring a null whose own evidence read "SNR=73.85"), and the judge rubber-stamped it. Fixed at both layers: the contract now states the statistics (σ_pixel/√N for averages; bright-region means required — a localized feature is ~region/frame diluted in the field mean; a resolution ladder for mean-detectable-but-per-pixel-noisy features → binned maps with stated effective resolution), and the judge got explicit arithmetic-consistency and localization checks (a declaration whose own numbers imply detection is auto-rejected; field-mean-only nulls on possibly-localized data are not decisive). Post-fix: the localized-real case recovers both planted peaks in 3.7 min; the weak-uniform case reports the band at ~559 nm with an honestly-uniform map (the planted truth); true nulls remain correctly accepted (n=2).


**Stress round 3 (mixed outcomes + concurrency edges):** offline — a branch queued behind a slow one is not falsely timed out while waiting for a worker slot, and simultaneous multi-timeouts both cut cleanly (budget suite now 17 checks). Live — `mixed_targets` (5/5): one analysis simultaneously mapped a real 560 nm band and resolved two demanded-but-absent peaks to a judged null with nothing fabricated; `mixed_fusion` (8/8): a 4-branch fan-out where the noise branch's first wrong-statistics null declaration was **rejected by the hardened judge with the arithmetic critique** and the corrected retry accepted — then fusion integrated two planted trends and a localized emission, recovered both transitions, stated the null branch's absence plainly, and fabricated no links to the branch that found nothing.
