### PR TITLE
Fix the component-mask path (axis/index/binning/shapes) + principle-based fusion figures

### DIFF
--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -781,36 +781,97 @@ def _build_fit_mask(abundance_maps, comp_idx, shape, logger,
     so mask-boundary physics (interfaces, transition zones) stays inside
     the fitted region. Returns a bool (h, w) array, or None when the maps /
     index are unusable (the caller falls back to full-frame)."""
+    def _no(reason):
+        logger.info(f"    Fit-mask not built: {reason}")
+        return None
+
     try:
-        if abundance_maps is None or comp_idx is None:
-            return None
+        if abundance_maps is None:
+            return _no("no abundance maps in state (decomposition skipped "
+                       "or failed)")
+        if comp_idx is None:
+            return _no("target carries no mask_component_index")
         maps = np.asarray(abundance_maps)
         idx = int(comp_idx)
-        if maps.ndim != 3 or not (0 <= idx < maps.shape[0]):
-            return None
-        amap = maps[idx]
-        if amap.shape != tuple(shape):
-            return None
+        if maps.ndim != 3:
+            return _no(f"abundance maps have unusable shape {maps.shape}")
+
+        # The package convention is component-LAST — (H, W, n), the shape
+        # ``run_spectral_unmixing`` returns and ``reconstruct_cube``
+        # documents. (This builder originally indexed component-FIRST and
+        # silently sliced rows off every real decomposition.) Resolve the
+        # component axis by which spatial grid actually aligns with the raw
+        # frame — same-scale or an integer-factor binning of it; accept a
+        # component-first stack defensively.
+        def _grid_scale(hw):
+            fy, ry = divmod(int(shape[0]), hw[0])
+            fx, rx = divmod(int(shape[1]), hw[1])
+            return None if (ry or rx or fy < 1 or fx < 1) else (fy, fx)
+
+        last_ok = _grid_scale(maps.shape[:2]) is not None
+        first_ok = _grid_scale(maps.shape[1:]) is not None
+        if last_ok and first_ok:
+            # Both readings align with the frame (divisibility accident) —
+            # the component axis is the SMALL one (n is <=8 in practice,
+            # spatial dims are tens to hundreds).
+            last_ok = maps.shape[2] <= maps.shape[0]
+            first_ok = not last_ok
+        if last_ok:
+            n_comp = maps.shape[2]
+            comp_slice = lambda k: maps[:, :, k]     # noqa: E731
+        elif first_ok:
+            n_comp = maps.shape[0]
+            comp_slice = lambda k: maps[k]           # noqa: E731
+        else:
+            return _no(f"abundance grid {maps.shape} does not align with "
+                       f"the raw frame {tuple(shape)} (same scale or "
+                       "integer-factor binning)")
+
+        # The index contract is the 1-BASED "Component N" label used in
+        # every decomposition plot the planner sees (a 0-based schema note
+        # lost to that visual context live). Tolerate the 0-based habit:
+        # 0 also means the first component.
+        if 1 <= idx <= n_comp:
+            idx -= 1
+        elif idx != 0:
+            return _no(f"component index {idx} out of range (1..{n_comp})")
+        amap = comp_slice(idx)
+        # A preprocessing spatial_bin_factor shrinks the decomposition's
+        # spatial grid while codegen fits the RAW cube. When the raw frame
+        # is an integer multiple of the abundance grid, the mask is valid
+        # at the binned scale — build it there and upsample by pixel
+        # repetition at the end.
+        scale = _grid_scale(amap.shape)
+        if scale == (1, 1):
+            scale = None
         amap = np.asarray(amap, float)
         lo, hi = float(np.nanmin(amap)), float(np.nanmax(amap))
         if not np.isfinite(lo) or not np.isfinite(hi) or hi <= lo:
-            return None
+            return _no("abundance map is degenerate (flat or non-finite)")
         # Half-max threshold: the mask tracks the component's actual
         # footprint rather than a fixed fraction of the frame.
         mask = amap >= (lo + 0.5 * (hi - lo))
         if not mask.any() or mask.all():
-            return None
+            return _no("half-max threshold yields an empty or whole-frame mask")
         from scipy.ndimage import binary_dilation
-        n_iter = max(3, int(dilate_frac * min(shape)))
+        # Dilate at the scale the mask was built at, so the physical halo
+        # is ~dilate_frac of the frame regardless of binning.
+        n_iter = max(3, int(dilate_frac * min(mask.shape)))
         mask = binary_dilation(mask, iterations=n_iter)
         if mask.mean() > 0.5:
             # The component covers most of the frame — masking buys nothing;
             # fall back to full-frame.
-            return None
+            return _no(f"component footprint covers {mask.mean():.0%} of the frame — masking buys nothing")
+        if scale is not None:
+            mask = np.repeat(np.repeat(mask, scale[0], axis=0),
+                             scale[1], axis=1)
         logger.info(
-            f"    Fit mask from component {idx}: half-max abundance "
-            f"threshold + {n_iter}px dilation -> {int(mask.sum())} of "
-            f"{mask.size} pixels ({mask.mean():.1%}).")
+            f"    Fit mask from Component {idx + 1}: half-max abundance "
+            f"threshold + {n_iter}px dilation"
+            + (f" + {scale[0]}x{scale[1]} upsample (binned decomposition)"
+               if scale else "")
+            + f" -> {int(mask.sum())} of {mask.size} pixels "
+              f"({mask.mean():.1%}).")
         return mask
     except Exception as e:  # noqa: BLE001 - mask is an optimization, never fatal
         logger.warning(f"    Fit-mask construction failed: {e}")
@@ -2347,7 +2408,13 @@ class RunDynamicAnalysisController:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 
         # --- PREPARE DATA CONTEXT ---
-        h, w, e = state["hspy_data"].shape
+        # Shapes must describe the cube the generated code actually receives:
+        # the RAW cube (original_hspy_data -> optimal_data below). When a
+        # preprocessing spatial_bin_factor shrank hspy_data, using the binned
+        # shape here misstated the size in the codegen prompt and — worse —
+        # made the (h, w) commit check below reject every returned raw-scale
+        # map as a "shape mismatch".
+        h, w, e = state["original_hspy_data"].shape
 
         # Axis & Unit Detection — reads through resolve_axis_spec so non-energy
         # axes (time, voltage, frequency, ...) work the same as the legacy

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -1276,7 +1276,7 @@ Depending on the analysis method used in the current iteration, you will receive
 
 4. **LARGE-DATA GATE — decomposition-first staging (above ~50k pixels):**
    Commit each decision to ONE of four verdicts, using the decomposition evidence in front of you:
-   * **fit-within-dilated-mask** — the signal of interest is spatially LOCALIZED in a component's abundance map: set `"fit_scope": "component_mask"` and `"mask_component_index": <0-based component index>` on the target. The pipeline builds the mask from that component's high-abundance region WITH a dilation halo (mask-boundary physics lives at the edges) and scopes the generated code to it.
+   * **fit-within-dilated-mask** — the signal of interest is spatially LOCALIZED in a component's abundance map: set `"fit_scope": "component_mask"` and `"mask_component_index": <component NUMBER as labeled in the decomposition plots — "Component 2" means 2>` on the target. The pipeline builds the mask from that component's high-abundance region WITH a dilation halo (mask-boundary physics lives at the edges) and scopes the generated code to it.
    * **fit-global-then-decide** — a WEAK feature may be present everywhere (uniform signals give decomposition no spatial contrast to separate): describe a target whose code fits the MEAN spectrum first (one cheap fit) and maps per-pixel only where that detection justifies it.
    * **fit-everywhere** — only when the objective genuinely needs full-frame per-pixel parameters; then apply the size-guard tactics (vectorize, coarse-to-fine).
    * **decomposition-only (STOP)** — permitted ONLY when the components are clean AND the residuals are unstructured AND the objective names no per-pixel quantity. A STRUCTURED residual (derivative shapes, coherent spatial patterns, high residual autocorrelation) is the signature of continuous parameter variation or a weak everywhere-signal — physics decomposition CANNOT model — and mandates a fitting target even when every component looks clean.
@@ -1290,7 +1290,7 @@ You MUST output a valid JSON object.
 **STRICT TYPE RULES:**
 * All refinement targets have `"type": "custom_code"`.
 * For `custom_code` targets: `value = null` (the description field is what matters).
-* Optional scoping fields on a `custom_code` target (the LARGE-DATA GATE): `"fit_scope"`: `"full_frame"` (default) or `"component_mask"`; when `"component_mask"`, also set `"mask_component_index"` (0-based index of the decomposition component whose high-abundance region defines the fitting mask).
+* Optional scoping fields on a `custom_code` target (the LARGE-DATA GATE): `"fit_scope"`: `"full_frame"` (default) or `"component_mask"`; when `"component_mask"`, also set `"mask_component_index"` (the component NUMBER as labeled in the decomposition plots, i.e. "Component N" -> N; its high-abundance region defines the fitting mask).
 * Targets of other types (e.g. legacy `"spatial"` or `"spectral"`) are NOT supported and will be ignored by the downstream pipeline. Do not emit them.
 
 **Required outputs (objective-aware QC enforcement):**

--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -1293,8 +1293,17 @@ absolute paths given below.
 with units>}, "notes": [<what was skipped or degraded, and why>]}. Every \
 number in it must be computed by this script. Plain floats only; write \
 NaN/inf as null.
-- Strongly preferred: write ./fusion_figure.png — the aligned overlay of \
-the branch trends on the shared axis, with the located transitions marked.
+- Strongly preferred: write ./fusion_figure.png. Design the figure YOURSELF \
+for what these particular results need — there is no fixed template, and the \
+right form (overlay, difference plot, timeline, small multiples, ...) follows \
+from the join type and the finding. The only requirements: it shows the \
+RECONCILIATION itself (the cross-branch relationship, not a re-plot of one \
+branch); every plotted number comes from this script's computation; \
+uncertainties are drawn when available; the SCALE is chosen so the finding \
+is actually visible (an effect small against the absolute values needs a \
+difference/zoomed view, not full-range axes); and known confounds/flags are \
+annotated on the figure. A reader should be able to judge the headline \
+claim from the figure alone.
 - Print a short (<= 20 lines) plain-text summary to stdout.
 - Be robust: a missing column or unreadable file must degrade (recorded in \
 "notes"), not crash.

--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -1031,14 +1031,20 @@ _FUSION_FIG_MAX_DIM = 1536   # enough to read spatial structure; keeps payload s
 def _branch_key_figure(entry: dict) -> Optional[str]:
     """Pick one representative figure from a branch's produced files.
 
-    Prefers known representative names (segmentation overlay, NMF/PCA summary
-    grid, fit-review plot); falls back to the first image. Returns a path or None.
+    Priority order encodes evidence SCALE: a series branch's story is its
+    cross-series trend (parameter_trends.png), not any single unit's fit —
+    fusion reconciles trends, so the trend plot is what both the report
+    reader and the fusion LLM should see. Single-measurement branches
+    produce no trend figure and fall through to the representative
+    per-unit names (summary grid, overlay, fit plot); last resort is the
+    first image. Returns a path or None.
     """
     imgs = [str(f) for f in (entry.get("files_produced") or [])
             if Path(str(f)).suffix.lower() in _FIGURE_EXTS and Path(str(f)).exists()]
     if not imgs:
         return None
-    for pat in ("summary_grid", "visualization", "overlay", "review", "fit", "map"):
+    for pat in ("trend", "summary_grid", "visualization", "overlay",
+                "review", "fit", "map"):
         for f in imgs:
             if pat in Path(f).name.lower():
                 return f

--- a/tests/test_decomp_gate.py
+++ b/tests/test_decomp_gate.py
@@ -63,9 +63,13 @@ def main():
     h = w = 100
     yy, xx = np.mgrid[0:h, 0:w]
     blob = ((xx - 30) ** 2 + (yy - 40) ** 2) < 8 ** 2      # ~200 px blob
+    # Component-LAST (H, W, n) — the package convention
+    # (run_spectral_unmixing output / reconstruct_cube contract).
     amaps = np.stack([np.random.rand(h, w) * 0.05,
-                      blob * 1.0 + np.random.rand(h, w) * 0.05])
-    m = _build_fit_mask(amaps, 1, (h, w), LOG)
+                      blob * 1.0 + np.random.rand(h, w) * 0.05], axis=-1)
+    # Index contract is the 1-based "Component N" plot label: the blob
+    # lives in the second map -> "Component 2".
+    m = _build_fit_mask(amaps, 2, (h, w), LOG)
     check("mask covers the blob", m is not None and bool(m[blob].all()))
     ring = ((xx - 30) ** 2 + (yy - 40) ** 2 < 11 ** 2) & ~blob
     check("mask is DILATED beyond the blob (boundary halo kept)",
@@ -75,11 +79,52 @@ def main():
     print("3) mask builder fallbacks:")
     check("bad component index -> None", _build_fit_mask(amaps, 7, (h, w), LOG) is None)
     check("no maps -> None", _build_fit_mask(None, 0, (h, w), LOG) is None)
-    check("shape mismatch -> None",
-          _build_fit_mask(amaps, 1, (50, 50), LOG) is None)
-    flat = np.ones((2, h, w))
+    check("non-integer shape mismatch -> None",
+          _build_fit_mask(amaps, 2, (150, 130), LOG) is None)
+    check("raw smaller than the abundance grid -> None",
+          _build_fit_mask(amaps, 2, (50, 50), LOG) is None)
+
+    # Binned-decomposition upsampling: abundance maps at (h, w) from a
+    # spatial_bin_factor=2 preprocessing, raw cube at (2h, 2w). The mask
+    # must come back at RAW scale, still covering the (scaled) blob.
+    print("3b) binned-decomposition mask upsampling:")
+    m2 = _build_fit_mask(amaps, 2, (2 * h, 2 * w), LOG)
+    check("integer-factor mismatch upsamples instead of bailing",
+          m2 is not None and m2.shape == (2 * h, 2 * w))
+    blob_up = np.repeat(np.repeat(blob, 2, axis=0), 2, axis=1)
+    check("upsampled mask covers the blob at raw scale",
+          m2 is not None and bool(m2[blob_up].all()))
+    check("upsampled mask keeps the dilation halo (strictly wider than "
+          "the blob)", m2 is not None and m2.sum() > blob_up.sum())
+    check("upsampled mask stays a small fraction of the frame",
+          m2 is not None and m2.mean() < 0.25)
+    m1 = _build_fit_mask(amaps, 2, (h, w), LOG)
+    check("same-scale coverage fraction preserved by upsampling",
+          m1 is not None and m2 is not None
+          and abs(m1.mean() - m2.mean()) < 1e-9)
+    m3 = _build_fit_mask(amaps, 2, (3 * h, 3 * w), LOG)
+    check("factor-3 binning also upsamples",
+          m3 is not None and m3.shape == (3 * h, 3 * w))
+    flat = np.ones((h, w, 2))
     check("degenerate (all-equal) abundance -> None",
-          _build_fit_mask(flat, 0, (h, w), LOG) is None)
+          _build_fit_mask(flat, 1, (h, w), LOG) is None)
+    amaps_cf = np.moveaxis(amaps, -1, 0)          # (n, H, W) legacy stack
+    m_cf = _build_fit_mask(amaps_cf, 2, (h, w), LOG)
+    check("component-FIRST stack accepted defensively (same mask)",
+          m_cf is not None and np.array_equal(m_cf, m))
+
+    print("3c) component-index convention (1-based plot labels):")
+    m_lbl = _build_fit_mask(amaps, 2, (h, w), LOG)
+    check("'Component 2' label selects the second map (blob found)",
+          m_lbl is not None and bool(m_lbl[blob].all()))
+    m_first = _build_fit_mask(amaps, 1, (h, w), LOG)
+    check("'Component 1' selects the flat first map -> None (no footprint)",
+          m_first is None)
+    m_zero = _build_fit_mask(amaps, 0, (h, w), LOG)
+    check("0 tolerated as the first component (0-based habit)",
+          (m_zero is None) == (m_first is None))
+    check("one past the last component -> None",
+          _build_fit_mask(amaps, 3, (h, w), LOG) is None)
 
     # 4) Sandbox plumbing: fit_mask passed only when accepted.
     print("4) invoke plumbing:")


### PR DESCRIPTION
## Summary

A clean end-to-end re-run of two real multimodal studies surfaced that the decomposition-guided fitting mask (the `fit-within-dilated-mask` verdict from the large-data gate) **has never actually worked on real data** — every request silently fell back to full-frame fitting. The failure was invisible because the fallback is deliberately graceful and the generated code usually compensated with its own masking. This PR fixes the whole chain, adds reason logging so a silent fallback can't hide again, and — separately — replaces the fusion figure's fixed template with principle-based requirements.

With the fixes, the intended flow works live end to end: the planner names "Component 2", the mask is built from that component's actual footprint (3,233 of 122,500 pixels — the emitter plus a dilation halo), and the per-pixel fit runs only there.

## Technical details

Four stacked defects, isolated live by adding a reason log to every mask bail-out (`hyperspectral_controllers.py`):

1. **Wrong component axis (the root cause).** `_build_fit_mask` indexed the abundance array as `(n, H, W)`, but the package convention — `run_spectral_unmixing`'s output, `reconstruct_cube`'s documented contract — is component-last `(H, W, n)`. `maps[idx]` therefore sliced spatial rows, never a component, and the shape checks rejected the slice. The builder now resolves the component axis by which spatial grid aligns with the raw frame (same scale or integer-factor binning), with the component count as the tiebreak on divisibility accidents; component-first stacks are still accepted defensively.
2. **Index-base mismatch.** The schema said 0-based `mask_component_index` while every decomposition plot the planner sees is labeled "Component N" — live, "Component 2" of 2 arrived as index 2 and fell out of bounds. The contract is now the 1-based plot label (0 tolerated as a 0-based habit); schema text updated at both mentions.
3. **Binned decomposition vs raw codegen.** A preprocessing `spatial_bin_factor` leaves abundance maps at the binned scale while codegen fits the raw cube; the mask is now built at the binned scale and upsampled by the integer bin factor instead of being discarded.
4. **Shape source split in `RunDynamicAnalysisController`.** `h, w, e` came from the binned `hspy_data` while codegen received the raw cube — misstating the cube size in the codegen prompt and, worse, rejecting **every** returned raw-scale map at the commit check as a "shape mismatch" (observed live: a binned branch lost all its per-pixel maps to this). Shapes now come from the cube codegen actually receives.

**Fusion figure (second commit, `fanout.py`).** The reconciliation-script contract mandated "the aligned overlay of branch trends on the shared axis" — right for axis-joined series (it produced the clean three-technique dehydration overlay), wrong for scalar regimes (a live fusion drew two indistinguishable ~1052 cm⁻¹ bars whose finding, Δ = −0.02 unresolved, was invisible at full-range scale). The spec now states requirements — show the reconciliation itself, plot only script-computed numbers, draw uncertainties, pick a scale on which the finding is visible, annotate confounds — and leaves the plot form entirely to the codegen.

- **Tests**: `tests/test_decomp_gate.py` 34/34 (component-last fixtures, axis tiebreak, 1-based index contract incl. 0-tolerance and out-of-range, binned upsampling at factors 2/3 with coverage preservation, defensive component-first); `tests/test_fusion_codegen.py` 44/44; QC goldens 17/17 byte-identical (no prompt-trace change on the golden paths).
- **Live**: the same scenario that fell back to full-frame in three consecutive pre-fix runs now builds the mask from the named component and completes the masked `fit_per_pixel` analysis in 4.4 min.
- **Known limits**: the rank-k reconstruction offer is still withheld when decomposition ran binned (upsampling a full cube is memory-heavy, unlike a bool mask — the offer is optional context, not scope); axis disambiguation on pathological square/divisible shapes relies on the small-component-count tiebreak, acceptable for an optimization that is never a correctness gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)