### PR TITLE
Hyperspectral results feed the quantitative fusion (and BO) via features.csv

### DIFF
--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -3,6 +3,7 @@ Hyperspectral Analysis Agent
 """
 
 
+import json
 import os
 import numpy as np
 import cv2
@@ -467,19 +468,80 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         if staged:
             response["staged_solutions"] = staged
 
+        # Persist the numeric results to <output_dir>/analysis_results.json
+        # so the shared feature-table writer (feature_table.py, generic
+        # extracted_features adapter) can emit features.csv — the file the
+        # orchestrator's run_task collects into `feature_tables` and the
+        # meta fusion's numerics bundle reads. Without this, hyperspectral
+        # branches can never feed the computed reconciliation.
+        self._write_results_file(response)
+
         self._log_action(
             action="analyze",
             input_ctx={"data": data_path},
             result=response,
             rationale="Hyperspectral analysis completed."
         )
-        
+
         self.logger.info(f"\n{'='*80}")
         self.logger.info(f"✅ ANALYSIS COMPLETE")
         self.logger.info(f"   Output: {self.output_dir}")
         self.logger.info(f"{'='*80}\n")
         
         return response
+
+    def _write_results_file(self, response: dict) -> str | None:
+        """Persist a compact ``analysis_results.json`` with a FLAT
+        ``extracted_features`` dict, feature-table ready.
+
+        The dynamic-analysis features live in ``response`` as a LIST of
+        per-map records ({name, units, description, stats:{min,max,mean}})
+        — the shape the synthesis prompts consume — but the shared feature
+        -table adapter (``feature_table._extracted_feature_rows``) needs a
+        dict of scalars. Flatten each committed map's stats into
+        ``<Map_Name>_<stat>[_<units>]`` columns. Judged honest-null
+        determinations are recorded as ``<feature>_not_measurable = 1`` so
+        an absence survives into the table as data, not as a missing row.
+        Failure-isolated: never breaks the analysis.
+        """
+        try:
+            feats: dict = {}
+            for m in response.get("extracted_features") or []:
+                if not isinstance(m, dict):
+                    continue
+                nm = m.get("not_measurable")
+                if isinstance(nm, dict) and nm.get("feature"):
+                    base = str(nm["feature"]).strip().replace(" ", "_")[:60]
+                    feats[f"{base}_not_measurable"] = 1
+                    continue
+                stats = m.get("stats")
+                if not isinstance(stats, dict):
+                    continue
+                base = str(m.get("name") or "feature").strip().replace(" ", "_")
+                units = str(m.get("units") or "").strip()
+                suffix = ("_" + units.replace(" ", "").replace("/", "per")
+                          if units and units.lower() not in ("a.u.", "au", "")
+                          else "")
+                for k, v in stats.items():
+                    if isinstance(v, (int, float)) and np.isfinite(v):
+                        feats[f"{base}_{k}{suffix}"] = float(v)
+            if not feats:
+                return None
+            payload = {
+                "agent_type": "hyperspectral",
+                "status": response.get("status"),
+                "extracted_features": feats,
+            }
+            path = self.output_dir / "analysis_results.json"
+            with open(path, "w") as fh:
+                json.dump(payload, fh, indent=2, default=str)
+            self.logger.info(
+                f"   📄 Numeric features persisted for downstream fusion: "
+                f"{path.name} ({len(feats)} scalars)")
+            return str(path)
+        except Exception as e:  # noqa: BLE001 - table emit must never break analyze
+            self.logger.warning(f"Could not write analysis_results.json: {e}")
+            return None
 
     def _maybe_stage_t2_solutions(self, records: list, skill_state: dict) -> list:
         """Stage novel hot-retry successes for later, review-gated distillation.

--- a/tests/test_hs_fusion_numerics.py
+++ b/tests/test_hs_fusion_numerics.py
@@ -1,0 +1,118 @@
+"""Offline tests for the hyperspectral features-to-fusion chain.
+
+Hyperspectral branches previously could never feed the quantitative fusion:
+the agent kept its numeric results in memory only, so the shared feature-
+table writer found nothing, run_task collected no feature_tables, and the
+fusion numerics bundle saw the branch as table-less. These tests cover the
+new link end to end: _write_results_file flattening -> analysis_results.json
+-> write_feature_table -> features.csv -> _branch_numerics preview.
+
+  conda run -n scilink python tests/test_hs_fusion_numerics.py
+"""
+import csv
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+
+results = {}
+LOG = logging.getLogger("hs_fusion_test")
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+class _Host:
+    """Just enough of the agent for _write_results_file."""
+
+    def __init__(self, out):
+        self.output_dir = Path(out)
+        self.logger = LOG
+
+
+def _write(response, out):
+    from scilink.agents.exp_agents.hyperspectral_analysis_agent import (
+        HyperspectralAnalysisAgent)
+    return HyperspectralAnalysisAgent._write_results_file(
+        _Host(out), response)
+
+
+RESPONSE = {
+    "status": "success",
+    "extracted_features": [
+        {"name": "Peak_Position", "units": "nm",
+         "description": "per-pixel emission center",
+         "stats": {"min": 601.2, "max": 638.9, "mean": 620.05}},
+        {"name": "Peak_FWHM", "units": "a.u.",
+         "stats": {"min": 30.0, "max": 42.0, "mean": 35.5}},
+        {"not_measurable": {"feature": "second UV peak",
+                            "evidence": "prominence 0.01 vs sigma 0.4"}},
+        {"name": "weird", "stats": {"mean": float("nan")}},   # non-finite
+        "not-a-dict",                                          # junk entry
+    ],
+}
+
+
+def main():
+    print("1) _write_results_file flattening:")
+    d = tempfile.mkdtemp(prefix="hsft_")
+    p = _write(RESPONSE, d)
+    check("file written", p is not None and Path(p).name == "analysis_results.json")
+    data = json.loads(Path(p).read_text())
+    feats = data["extracted_features"]
+    check("stats flattened with units in the column",
+          feats.get("Peak_Position_mean_nm") == 620.05
+          and feats.get("Peak_Position_min_nm") == 601.2)
+    check("a.u. units omitted from the column name",
+          feats.get("Peak_FWHM_mean") == 35.5)
+    check("judged null recorded as data, not dropped",
+          feats.get("second_UV_peak_not_measurable") == 1)
+    check("non-finite and junk entries skipped",
+          not any(k.startswith("weird") for k in feats))
+
+    d2 = tempfile.mkdtemp(prefix="hsft_empty_")
+    check("no numeric features -> no file (no empty tables downstream)",
+          _write({"status": "success", "extracted_features": []}, d2) is None
+          and not (Path(d2) / "analysis_results.json").exists())
+
+    print("2) shared feature-table writer picks it up:")
+    from scilink.agents.exp_agents.feature_table import write_feature_table
+    ft = write_feature_table(d)
+    check("features.csv emitted from the HS results file",
+          ft is not None and Path(ft).name == "features.csv")
+    with open(ft) as fh:
+        rows = list(csv.DictReader(fh))
+    check("one row with the flattened columns",
+          len(rows) == 1 and rows[0]["Peak_Position_mean_nm"] == "620.05"
+          and rows[0]["second_UV_peak_not_measurable"] == "1")
+
+    print("3) fusion numerics bundle reads the table:")
+    from scilink.agents.meta_agent.fanout import _branch_numerics
+    entry = {"label": "emission map", "feature_tables": [ft],
+             "files_produced": [str(Path(d) / "analysis_results.json")]}
+    num = _branch_numerics(entry, join_axis=None)
+    check("branch registers numerics",
+          isinstance(num, dict) and num.get("feature_tables"))
+    prev = json.dumps(num, default=str)
+    check("preview carries the physical columns",
+          "Peak_Position_mean_nm" in prev)
+
+    check("table-less branch still degrades to None (guardrail intact)",
+          _branch_numerics({"label": "x", "files_produced": []}, None) is None)
+
+    print("\n" + "=" * 50)
+    npass = sum(results.values())
+    print(f"HS FUSION NUMERICS: {npass}/{len(results)} checks passed")
+    for k, v in results.items():
+        if not v:
+            print("  FAILED:", k)
+    raise SystemExit(0 if npass == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hs_fusion_numerics_live.py
+++ b/tests/test_hs_fusion_numerics_live.py
@@ -1,0 +1,121 @@
+"""Live acceptance for hyperspectral features reaching the quantitative
+fusion: a 2-branch fan-out (emission cube + planted temperature series) on
+ONE synthetic sample. Pre-fix, the cube branch never registered numeric
+tables, so computed reconciliation needed the OTHER branches alone to cross
+its >=2-numerics guard; here it can only run if the cube contributes.
+
+  export AWS_BEARER_TOKEN_BEDROCK=...  AWS_REGION_NAME=us-east-1
+  UNSAFE_EXECUTION_OK=true python tests/test_hs_fusion_numerics_live.py
+"""
+import json
+import os
+import sys
+import tempfile
+import time
+
+import numpy as np
+
+MODEL = os.environ.get("SCILINK_TEST_MODEL",
+                       "bedrock/us.anthropic.claude-opus-4-8")
+RNG = np.random.default_rng(37)
+
+checks = {}
+
+
+def check(name, cond):
+    checks[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+def main():
+    if not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
+        print("Set AWS_BEARER_TOKEN_BEDROCK (+ AWS_REGION_NAME)."); sys.exit(2)
+
+    d = tempfile.mkdtemp(prefix="hsfn_live_")
+    subject = "ONE synthetic phosphor pellet studied in one session"
+
+    # Branch 1: emission cube, band centered at 620 nm (the planted truth
+    # the reconciliation should be able to quote from the cube's table).
+    wl = np.linspace(450, 850, 140)
+    h = w = 96
+    spec = 4.0 * np.exp(-0.5 * ((wl - 620.0) / 16.0) ** 2)
+    cube = (5.0 + spec[None, None, :]
+            + RNG.normal(0, 0.3, (h, w, wl.size))).astype(np.float32)
+    cp = os.path.join(d, "emission.npy")
+    np.save(cp, cube)
+    json.dump({"technique": "hyperspectral emission map",
+               "energy_range": {"start": 450.0, "end": 850.0, "units": "nm"},
+               "note": "same pellet, same session"},
+              open(cp.replace(".npy", ".json"), "w"))
+
+    # Branch 2: temperature series with a transition at 85 C.
+    x = np.linspace(500, 700, 600)
+    for T in range(30, 165, 10):
+        f = 1.0 / (1.0 + np.exp(-(T - 85.0) / 4.0))
+        y = ((1 - f) * np.exp(-0.5 * ((x - 620) / 8) ** 2)
+             + f * np.exp(-0.5 * ((x - 640) / 8) ** 2)
+             + RNG.normal(0, 0.004, x.size))
+        fp = os.path.join(d, f"pl_{T:03d}C.txt")
+        np.savetxt(fp, np.column_stack([x, y]))
+        json.dump({"temperature_C": float(T)},
+                  open(fp.replace(".txt", ".json"), "w"))
+
+    from scilink.agents.meta_agent.meta_orchestrator import (
+        MetaOrchestratorAgent, MetaMode)
+    base = tempfile.mkdtemp(prefix="hsfn_sess_")
+    print(f"session: {base}")
+    ag = MetaOrchestratorAgent(base_dir=base, api_key=None, base_url=None,
+                               model_name=MODEL, meta_mode=MetaMode.AUTONOMOUS)
+    t0 = time.monotonic()
+    out = json.loads(ag._run_fanout([
+        {"data_path": cp, "label": "emission map",
+         "task": f"Analyze the hyperspectral image at {cp} (96x96x140, "
+                 f"wavelengths in the metadata JSON) of {subject}. "
+                 "Characterize the emission band: its center wavelength "
+                 "and width."},
+        {"data_path": d, "pattern": "pl_*C.txt", "label": "PL series",
+         "task": f"Analyze the series in {d} — ONLY files matching "
+                 f"'pl_*C.txt'. Temperature series on {subject}. "
+                 "Characterize the transition and report its temperature."},
+    ]))
+    check("fan-out succeeded", out.get("status") == "success"
+          and out.get("branches_with_output") == 2)
+
+    # The cube branch must now carry a feature table into the ledger.
+    fan = [e for e in ag._delegation_ledger if e.get("fanout")]
+    em = [e for e in fan if e.get("label") == "emission map"]
+    tables = (em[0].get("feature_tables") or []) if em else []
+    check("cube branch registered a feature table (the fixed gap)",
+          any(str(t).endswith("features.csv") for t in tables))
+
+    idxs = [r["delegation_index"] for r in out.get("results", [])
+            if r.get("produced_output")]
+    fout = json.loads(ag._fuse_delegations(
+        idxs, focus="Relate the emission band to the temperature-driven "
+                    "transition; reconcile numerically where possible."))
+    dt = time.monotonic() - t0
+    print(f"wall: {dt/60:.1f} min")
+    check("fusion gated + succeeded",
+          fout.get("status") == "success" and fout.get("complementarity_gated"))
+    comp = fout.get("computed_reconciliation") or {}
+    check("computed reconciliation RAN (>=2 numeric branches incl. the cube)",
+          comp.get("status") == "success")
+    check("audit verdict recorded",
+          (comp.get("verification") or {}).get("verdict") in ("accept",
+                                                              "refine"))
+    blob = json.dumps(comp.get("results") or {}, default=str)
+    check("cube-side quantity present in the computed numerics "
+          "(620 nm band reachable)",
+          any(s in blob for s in ("619", "620", "621", "Peak_Position")))
+
+    print("\n" + "=" * 60)
+    npass = sum(checks.values())
+    print(f"HS FUSION NUMERICS LIVE: {npass}/{len(checks)} checks passed")
+    for k, v in checks.items():
+        if not v:
+            print("  FAILED:", k)
+    sys.exit(0 if npass == len(checks) else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Hyperspectral was the only analysis agent whose numbers could never reach the quantitative fusion or the planning/BO pipeline. Curve-fitting and image analyses persist their results to a per-run file that the shared feature-table writer turns into `features.csv` — the flat table the fusion's reconciliation engine and the planning orchestrator's `analyze_file`/scalarizer/BO chain both consume. The hyperspectral agent kept its results in memory only, so on a real multimodal study the two datacube branches contributed nothing to the computed reconciliation (which then couldn't run at all — it requires two numeric branches), and a cube-derived quantity could never become a BO target without being re-typed by hand.

This PR closes that gap following the existing convention exactly: the hyperspectral agent now persists its per-map results to a results file, and everything downstream — the table writer, `run_task`'s `feature_tables` collection, the fusion numerics bundle, the meta's "pass the table path to planning/BO" contract — lights up with **zero consumer changes**.

Honest nulls survive as data: a judged not-measurable determination lands in the table as `<feature>_not_measurable = 1`, so a fusion or a downstream consumer sees the absence as a recorded result rather than a missing row.

## Technical details

- `HyperspectralAnalysisAgent._write_results_file` (called at the end of `analyze()`, failure-isolated): flattens the dynamic-analysis per-map records (`{name, units, stats:{min,max,mean}}`) into scalar columns `<Map_Name>_<stat>[_<units>]` (units folded into the column name per the fusion contract's "keys named with units"; `a.u.` omitted; non-finite values and malformed entries skipped) and writes `<output_dir>/analysis_results.json` with a top-level `extracted_features` dict — the exact shape `feature_table._extracted_feature_rows` (the pre-existing generic adapter) already consumes. No file is emitted when a run produced no numeric features, so no empty tables appear downstream.
- No changes to `feature_table.py`, the orchestrator, the meta, or the fusion — the chain `analysis_results.json → write_feature_table → features.csv → run_task.feature_tables → _branch_numerics` already existed for the other two agents.
- **Tests**: offline `tests/test_hs_fusion_numerics.py` (11/11) covers the flattening rules, the null-as-data column, adapter pickup into `features.csv`, the fusion-side preview, and that table-less branches still degrade to `None` (the #296 guardrail). Live `tests/test_hs_fusion_numerics_live.py` (6/6) is a designed acceptance: a 2-branch fan-out (emission cube + planted temperature series) where the computed reconciliation can only cross its ≥2-numerics guard **if the cube contributes** — post-fix the cube registers its table, "Computing quantitative reconciliation (2 branches with numerics)" fires, the audit records a verdict, and the cube's planted 620 nm band appears in the computed quantities (6.9 min end to end on Bedrock Opus).
- **Also verified**: the scalarizer/BO path over current tables — a live `scalarize()` over a real 48-row in-situ XRD `features.csv` from this week's runs works unchanged. A separate pre-existing limitation was found while testing (the scalarizer's verification loop struggles on ONE-row tables of any provenance — it predates this PR and applies equally to single-image tables); tracked separately.
- **Known limits**: a single cube analysis yields one table row (flattened map statistics), like a single-image analysis — many-row HS tables accrue across runs of a campaign, not within one delegation. Per-pixel distributions are summarized (min/max/mean), not exported; if fusion ever needs raw per-pixel joins, that's the co-registered-operands path, not the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)