### PR TITLE
Connect directly to remote MCP servers (streamable HTTP + auth headers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ Connect external MCP servers to extend SciLink with additional tools:
 ```bash
 # Python MCP server (e.g., arXiv paper search)
 scilink analyze --mcp stdio:arxiv:python,-m,arxiv_mcp_server,--storage-path,/tmp/papers
+
+# Remote streamable-HTTP server (e.g., a hosted lab platform with token auth)
+scilink analyze --mcp mcp_config.json   # {"url": "...", "transport": "http", "headers": {...}}
 ```
 
 Programmatically:
@@ -189,9 +192,17 @@ tool_count = orchestrator.connect_mcp_server(
     server_name="arxiv",
     command=["python", "-m", "arxiv_mcp_server", "--storage-path", "/tmp/papers"]
 )
+
+# or a remote server over streamable HTTP with bearer-token auth
+tool_count = orchestrator.connect_mcp_server(
+    server_name="lab-platform",
+    url="https://mcp.example.com/mcp",
+    transport="http",
+    headers={"Authorization": f"Bearer {os.environ['LAB_PLATFORM_API_KEY']}"},
+)
 ```
 
-In the **web UI**, go to the **Tools** tab > **MCP Servers** section, select a transport (stdio/SSE), enter the server name and command, and click **Connect**.
+In the **web UI**, go to the **Tools** tab > **MCP Servers** section, select a transport (stdio/SSE/HTTP), enter the server name and command or URL (plus optional headers for authenticated servers), and click **Connect**.
 
 See [docs/mcp_client_integration.md](docs/mcp_client_integration.md) for the full MCP guide.
 

--- a/docs/mcp_client_integration.md
+++ b/docs/mcp_client_integration.md
@@ -24,6 +24,9 @@ scilink analyze --mcp stdio:arxiv:python,-m,arxiv_mcp_server,--storage-path,/tmp
 # SSE transport (connects to a running server)
 scilink analyze --mcp sse:myserver:http://localhost:8000/sse
 
+# Streamable HTTP transport (remote/hosted servers)
+scilink analyze --mcp http:myserver:https://host/mcp
+
 # JSON config file
 scilink analyze --mcp /path/to/mcp_config.json
 
@@ -34,6 +37,7 @@ scilink analyze --mcp stdio:arxiv:python,-m,arxiv_mcp_server stdio:fs:npx,-y,@mo
 **Shorthand format:**
 - stdio: `stdio:<name>:<command>,<arg1>,<arg2>`
 - SSE: `sse:<name>:<url>`
+- Streamable HTTP: `http:<name>:<url>`
 
 **JSON config file format:**
 ```json
@@ -52,14 +56,27 @@ Or for SSE:
 }
 ```
 
+Or for streamable HTTP with authentication (the shape most hosted platform
+APIs use — `${VAR}` in header values is expanded from the environment, so the
+token never lands in the JSON file):
+```json
+{
+  "name": "lab-platform",
+  "url": "https://mcp.example.com/mcp",
+  "transport": "http",
+  "headers": {"Authorization": "Bearer ${LAB_PLATFORM_API_KEY}"}
+}
+```
+
 ### 2. UI (Tools & Agents tab)
 
 In the Streamlit UI, go to the **Tools & Agents** tab and find the **MCP Servers** section:
 
-1. Select transport type (**stdio** or **sse**)
+1. Select transport type (**stdio**, **sse**, or **http** — streamable HTTP, for remote/hosted servers)
 2. Enter a **server name** (any label you choose)
-3. Enter the **command** (for stdio) or **URL** (for SSE)
-4. Click **Connect**
+3. Enter the **command** (for stdio) or **URL** (for sse/http)
+4. For sse/http, optionally enter **Headers** as a JSON object, e.g. `{"Authorization": "Bearer ${MY_API_KEY}"}` — `${VAR}` is expanded from the environment
+5. Click **Connect**
 
 Connected servers and their tool counts appear below. Click **Disconnect** to remove a server.
 
@@ -80,6 +97,14 @@ count = orch.connect_mcp_server(
 count = orch.connect_mcp_server(
     "myserver",
     url="http://localhost:8000/sse",
+)
+
+# Streamable HTTP transport with bearer-token auth (remote/hosted servers)
+count = orch.connect_mcp_server(
+    "lab-platform",
+    url="https://mcp.example.com/mcp",
+    transport="http",
+    headers={"Authorization": f"Bearer {os.environ['LAB_PLATFORM_API_KEY']}"},
 )
 
 # With environment variables (stdio only)
@@ -123,7 +148,7 @@ The LLM will use the arXiv MCP tools to search and retrieve papers, then use Sci
 
 ## Example: OpentronsAI protocol generation
 
-Connect to the OpentronsAI MCP server (hosted on Hugging Face) to generate Opentrons protocols:
+Connect to the OpentronsAI MCP server (hosted on Hugging Face) to generate Opentrons protocols. (This example predates native streamable-HTTP support and bridges through `npx mcp-remote`; for servers speaking streamable HTTP, connect directly with the `http` transport instead — no Node.js required.)
 
 ```bash
 # CLI

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1000,6 +1000,8 @@ class AnalysisOrchestratorAgent:
         command: list = None,
         url: str = None,
         env: dict = None,
+        transport: str = None,
+        headers: dict = None,
     ) -> int:
         """Connect to an MCP server and register its tools.
 
@@ -1007,8 +1009,12 @@ class AnalysisOrchestratorAgent:
             server_name: Human-readable label for this server.
             command: Command + args for stdio transport,
                 e.g. ``["npx", "-y", "@mcp/server-filesystem", "/tmp"]``.
-            url: URL for SSE transport.
+            url: URL for a network transport (SSE or streamable HTTP).
             env: Optional environment variables for the subprocess.
+            transport: Transport for ``url`` — ``"sse"`` (default) or
+                ``"http"`` (streamable HTTP).
+            headers: Optional HTTP headers for the ``url`` transports,
+                e.g. ``{"Authorization": "Bearer <token>"}``.
 
         Returns:
             Number of tools registered from this server.
@@ -1022,7 +1028,10 @@ class AnalysisOrchestratorAgent:
             )
             return 0
 
-        conn = MCPConnection(server_name, command=command, url=url, env=env)
+        conn = MCPConnection(
+            server_name, command=command, url=url, env=env,
+            transport=transport, headers=headers,
+        )
         schemas = conn.connect()
 
         existing_names = {t["name"] for t in self._external_tools}

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -619,6 +619,8 @@ class MetaOrchestratorAgent:
         command: list = None,
         url: str = None,
         env: dict = None,
+        transport: str = None,
+        headers: dict = None,
     ) -> int:
         """Connect to an MCP server and register its tools on the meta and
         every specialist child.
@@ -633,8 +635,12 @@ class MetaOrchestratorAgent:
             server_name: Human-readable label for this server.
             command: Command + args for stdio transport,
                 e.g. ``["npx", "-y", "@mcp/server-filesystem", "/tmp"]``.
-            url: URL for SSE transport.
+            url: URL for a network transport (SSE or streamable HTTP).
             env: Optional environment variables for the subprocess.
+            transport: Transport for ``url`` — ``"sse"`` (default) or
+                ``"http"`` (streamable HTTP).
+            headers: Optional HTTP headers for the ``url`` transports,
+                e.g. ``{"Authorization": "Bearer <token>"}``.
 
         Returns:
             Number of tools registered on the meta from this server.
@@ -648,7 +654,10 @@ class MetaOrchestratorAgent:
             )
             return 0
 
-        conn = MCPConnection(server_name, command=command, url=url, env=env)
+        conn = MCPConnection(
+            server_name, command=command, url=url, env=env,
+            transport=transport, headers=headers,
+        )
         schemas = conn.connect()
 
         existing_names = {t["name"] for t in self._external_tools}
@@ -697,6 +706,7 @@ class MetaOrchestratorAgent:
         self._register_shared_extension({
             "kind": "mcp", "server_name": server_name,
             "command": command, "url": url, "env": env,
+            "transport": transport, "headers": headers,
         })
         return registered
 
@@ -825,6 +835,8 @@ class MetaOrchestratorAgent:
                     command=ext.get("command"),
                     url=ext.get("url"),
                     env=ext.get("env"),
+                    transport=ext.get("transport"),
+                    headers=ext.get("headers"),
                 )
         except Exception as e:  # noqa: BLE001
             self.logger.warning(

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -1030,14 +1030,20 @@ class PlanningOrchestratorAgent:
         command: list = None,
         url: str = None,
         env: dict = None,
+        transport: str = None,
+        headers: dict = None,
     ) -> int:
         """Connect to an MCP server and register its tools.
 
         Args:
             server_name: Human-readable label for this server.
             command: Command + args for stdio transport.
-            url: URL for SSE transport.
+            url: URL for a network transport (SSE or streamable HTTP).
             env: Optional environment variables for the subprocess.
+            transport: Transport for ``url`` — ``"sse"`` (default) or
+                ``"http"`` (streamable HTTP).
+            headers: Optional HTTP headers for the ``url`` transports,
+                e.g. ``{"Authorization": "Bearer <token>"}``.
 
         Returns:
             Number of tools registered from this server.
@@ -1051,7 +1057,10 @@ class PlanningOrchestratorAgent:
             )
             return 0
 
-        conn = MCPConnection(server_name, command=command, url=url, env=env)
+        conn = MCPConnection(
+            server_name, command=command, url=url, env=env,
+            transport=transport, headers=headers,
+        )
         schemas = conn.connect()
 
         existing_names = {t["name"] for t in self._external_tools}

--- a/scilink/cli/analyze.py
+++ b/scilink/cli/analyze.py
@@ -178,9 +178,12 @@ Metadata Options:
         metavar='MCP_CONFIG',
         help=(
             'MCP server configurations. Each entry can be:\n'
-            '  - A JSON config file ({"name":"...", "command":["..."], "env":{}})\n'
+            '  - A JSON config file ({"name":"...", "command":["..."], "url":"...", '
+            '"transport":"sse|http", "headers":{...}, "env":{}}; ${VAR} in header '
+            'values is expanded from the environment)\n'
             '  - stdio shorthand:  stdio:name:command,arg1,arg2\n'
             '  - SSE shorthand:    sse:name:http://host:port/sse\n'
+            '  - Streamable HTTP shorthand: http:name:https://host/mcp\n'
             'Example: scilink analyze --mcp stdio:fs:npx,-y,@modelcontextprotocol/server-filesystem,/tmp'
         )
     )
@@ -701,18 +704,40 @@ Supported data types:
                     count = self.agent.connect_mcp_server(name, url=url)
                     print(f"   ✅ Registered {count} tool(s) from '{name}'")
 
+                elif entry.startswith("http:"):
+                    # http:name:https://host/mcp  (streamable HTTP)
+                    parts = entry[len("http:"):].split(":", 1)
+                    name = parts[0]
+                    url = parts[1] if len(parts) > 1 else ""
+                    print(f"\n🔌 Connecting to MCP server '{name}' "
+                          "(streamable HTTP)...")
+                    count = self.agent.connect_mcp_server(
+                        name, url=url, transport="http"
+                    )
+                    print(f"   ✅ Registered {count} tool(s) from '{name}'")
+
                 else:
                     # JSON config file
                     path = Path(entry).resolve()
                     with open(path) as f:
                         cfg = _json.load(f)
                     name = cfg.get("name", path.stem)
+                    headers = cfg.get("headers")
+                    if headers:
+                        # ${VAR} in header values is expanded so tokens stay
+                        # in the environment, not in the JSON file.
+                        headers = {
+                            k: os.path.expandvars(v)
+                            for k, v in headers.items()
+                        }
                     print(f"\n🔌 Connecting to MCP server '{name}'...")
                     count = self.agent.connect_mcp_server(
                         name,
                         command=cfg.get("command"),
                         url=cfg.get("url"),
                         env=cfg.get("env"),
+                        transport=cfg.get("transport"),
+                        headers=headers,
                     )
                     print(f"   ✅ Registered {count} tool(s) from '{name}'")
 

--- a/scilink/cli/meta.py
+++ b/scilink/cli/meta.py
@@ -144,9 +144,12 @@ Environment Variables:
         metavar='MCP_CONFIG',
         help=(
             'MCP server configurations. Each entry can be:\n'
-            '  - A JSON config file ({"name":"...", "command":["..."], "env":{}})\n'
+            '  - A JSON config file ({"name":"...", "command":["..."], "url":"...", '
+            '"transport":"sse|http", "headers":{...}, "env":{}}; ${VAR} in header '
+            'values is expanded from the environment)\n'
             '  - stdio shorthand:  stdio:name:command,arg1,arg2\n'
             '  - SSE shorthand:    sse:name:http://host:port/sse\n'
+            '  - Streamable HTTP shorthand: http:name:https://host/mcp\n'
             'Each server is shared with every specialist. Example: '
             'scilink explore --mcp stdio:fs:npx,-y,@modelcontextprotocol/server-filesystem,/tmp'
         )
@@ -489,18 +492,40 @@ a nested child sub-session under this meta session.
                     count = self.agent.connect_mcp_server(name, url=url)
                     print(f"   ✅ Registered {count} tool(s) from '{name}'")
 
+                elif entry.startswith("http:"):
+                    # http:name:https://host/mcp  (streamable HTTP)
+                    parts = entry[len("http:"):].split(":", 1)
+                    name = parts[0]
+                    url = parts[1] if len(parts) > 1 else ""
+                    print(f"\n🔌 Connecting to MCP server '{name}' "
+                          "(streamable HTTP)...")
+                    count = self.agent.connect_mcp_server(
+                        name, url=url, transport="http"
+                    )
+                    print(f"   ✅ Registered {count} tool(s) from '{name}'")
+
                 else:
                     # JSON config file
                     path = Path(entry).resolve()
                     with open(path) as f:
                         cfg = _json.load(f)
                     name = cfg.get("name", path.stem)
+                    headers = cfg.get("headers")
+                    if headers:
+                        # ${VAR} in header values is expanded so tokens stay
+                        # in the environment, not in the JSON file.
+                        headers = {
+                            k: os.path.expandvars(v)
+                            for k, v in headers.items()
+                        }
                     print(f"\n🔌 Connecting to MCP server '{name}'...")
                     count = self.agent.connect_mcp_server(
                         name,
                         command=cfg.get("command"),
                         url=cfg.get("url"),
                         env=cfg.get("env"),
+                        transport=cfg.get("transport"),
+                        headers=headers,
                     )
                     print(f"   ✅ Registered {count} tool(s) from '{name}'")
 

--- a/scilink/cli/plan.py
+++ b/scilink/cli/plan.py
@@ -152,9 +152,12 @@ Supported Models:
         metavar='MCP_CONFIG',
         help=(
             'MCP server configurations. Each entry can be:\n'
-            '  - A JSON config file ({"name":"...", "command":["..."], "env":{}})\n'
+            '  - A JSON config file ({"name":"...", "command":["..."], "url":"...", '
+            '"transport":"sse|http", "headers":{...}, "env":{}}; ${VAR} in header '
+            'values is expanded from the environment)\n'
             '  - stdio shorthand:  stdio:name:command,arg1,arg2\n'
             '  - SSE shorthand:    sse:name:http://host:port/sse\n'
+            '  - Streamable HTTP shorthand: http:name:https://host/mcp\n'
             'Example: scilink plan --mcp stdio:fs:npx,-y,@modelcontextprotocol/server-filesystem,/tmp'
         )
     )
@@ -585,17 +588,38 @@ class OrchestratorPlayground:
                     count = self.agent.connect_mcp_server(name, url=url)
                     print(f"   ✅ Registered {count} tool(s) from '{name}'")
 
+                elif entry.startswith("http:"):
+                    parts = entry[len("http:"):].split(":", 1)
+                    name = parts[0]
+                    url = parts[1] if len(parts) > 1 else ""
+                    print(f"\n🔌 Connecting to MCP server '{name}' "
+                          "(streamable HTTP)...")
+                    count = self.agent.connect_mcp_server(
+                        name, url=url, transport="http"
+                    )
+                    print(f"   ✅ Registered {count} tool(s) from '{name}'")
+
                 else:
                     path = Path(entry).resolve()
                     with open(path) as f:
                         cfg = _json.load(f)
                     name = cfg.get("name", path.stem)
+                    headers = cfg.get("headers")
+                    if headers:
+                        # ${VAR} in header values is expanded so tokens stay
+                        # in the environment, not in the JSON file.
+                        headers = {
+                            k: os.path.expandvars(v)
+                            for k, v in headers.items()
+                        }
                     print(f"\n🔌 Connecting to MCP server '{name}'...")
                     count = self.agent.connect_mcp_server(
                         name,
                         command=cfg.get("command"),
                         url=cfg.get("url"),
                         env=cfg.get("env"),
+                        transport=cfg.get("transport"),
+                        headers=headers,
                     )
                     print(f"   ✅ Registered {count} tool(s) from '{name}'")
 

--- a/scilink/mcp_client.py
+++ b/scilink/mcp_client.py
@@ -2,7 +2,7 @@
 
 Provides a thin synchronous wrapper around the async MCP Python SDK so that
 the analysis orchestrator can discover and call tools exposed by any
-MCP-compatible server over stdio or SSE transports.
+MCP-compatible server over stdio, SSE, or streamable HTTP transports.
 
 The ``mcp`` package is installed by default with SciLink.
 """
@@ -26,6 +26,12 @@ try:
 except ImportError:
     HAS_SSE = False
 
+try:
+    from mcp.client.streamable_http import streamablehttp_client
+    HAS_STREAMABLE_HTTP = True
+except ImportError:
+    HAS_STREAMABLE_HTTP = False
+
 
 def _require_mcp():
     if not HAS_MCP:
@@ -46,9 +52,17 @@ class MCPConnection:
         Command + arguments for stdio transport,
         e.g. ``["npx", "-y", "@modelcontextprotocol/server-filesystem", "/tmp"]``.
     url : str | None
-        URL for SSE transport, e.g. ``"http://localhost:8080/sse"``.
+        URL for a network transport, e.g. ``"http://localhost:8080/sse"``
+        (SSE) or ``"https://host/mcp"`` (streamable HTTP).
     env : dict | None
         Extra environment variables passed to the stdio subprocess.
+    transport : str | None
+        Which transport to use for ``url``: ``"sse"`` (default, matches
+        historical behavior) or ``"http"`` (streamable HTTP). Ignored for
+        ``command`` connections, which are always stdio.
+    headers : dict | None
+        HTTP headers sent with every request on the ``url`` transports —
+        e.g. ``{"Authorization": "Bearer <token>"}``.
     """
 
     def __init__(
@@ -57,15 +71,25 @@ class MCPConnection:
         command: Optional[List[str]] = None,
         url: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
+        transport: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
     ):
         _require_mcp()
         if not command and not url:
-            raise ValueError("Provide either 'command' (stdio) or 'url' (SSE).")
+            raise ValueError(
+                "Provide either 'command' (stdio) or 'url' (SSE / streamable HTTP)."
+            )
+        if transport is not None and transport not in ("sse", "http"):
+            raise ValueError(
+                f"Unknown transport '{transport}': expected 'sse' or 'http'."
+            )
 
         self.server_name = server_name
         self.command = command
         self.url = url
         self.env = env
+        self.transport = transport or "sse"
+        self.headers = headers
 
         self._tool_schemas: List[dict] = []
         self._connected = False
@@ -121,18 +145,27 @@ class MCPConnection:
                 env=self.env,
             )
             transport_ctx = stdio_client(params)
+        elif self.url and self.transport == "http":
+            if not HAS_STREAMABLE_HTTP:
+                raise ImportError(
+                    "Streamable HTTP transport requires a recent 'mcp' package. "
+                    "Install with: pip install -U mcp"
+                )
+            transport_ctx = streamablehttp_client(self.url, headers=self.headers)
         elif self.url:
             if not HAS_SSE:
                 raise ImportError(
                     "SSE transport requires 'mcp[sse]'. "
                     "Install with: pip install mcp[sse]"
                 )
-            transport_ctx = sse_client(self.url)
+            transport_ctx = sse_client(self.url, headers=self.headers)
         else:
             raise ValueError("No transport configured.")
 
         # Enter the transport context manager manually so it stays open.
-        read_stream, write_stream = await transport_ctx.__aenter__()
+        # stdio/SSE yield (read, write); streamable HTTP yields
+        # (read, write, get_session_id) — the star soaks up the extra.
+        read_stream, write_stream, *_ = await transport_ctx.__aenter__()
         self._cleanup_coros.append(transport_ctx.__aexit__)
 
         session_ctx = ClientSession(read_stream, write_stream)

--- a/scilink/ui/components/tools_agents.py
+++ b/scilink/ui/components/tools_agents.py
@@ -2,6 +2,8 @@
 
 import importlib.util
 import inspect
+import json
+import os
 import sys
 from pathlib import Path
 
@@ -171,7 +173,10 @@ def _render_mcp_section(agent) -> None:
 
     # Connection form
     transport = st.radio(
-        "Transport", ["stdio", "sse"], horizontal=True, key="mcp_transport"
+        "Transport", ["stdio", "sse", "http"], horizontal=True,
+        key="mcp_transport",
+        help="'http' is streamable HTTP — the standard transport for "
+             "remote/hosted MCP servers (e.g. platform APIs with token auth).",
     )
     col_name, col_addr = st.columns([1, 2])
     with col_name:
@@ -183,21 +188,50 @@ def _render_mcp_section(agent) -> None:
                 placeholder="npx -y @modelcontextprotocol/server-name /path",
                 key="mcp_addr",
             )
-        else:
+        elif transport == "sse":
             mcp_addr = st.text_input(
                 "URL",
                 placeholder="http://localhost:8080/sse",
                 key="mcp_addr",
             )
+        else:
+            mcp_addr = st.text_input(
+                "URL",
+                placeholder="https://host/mcp",
+                key="mcp_addr",
+            )
+
+    mcp_headers_raw = ""
+    if transport in ("sse", "http"):
+        mcp_headers_raw = st.text_input(
+            "Headers (JSON, optional)",
+            placeholder='{"Authorization": "Bearer ${MY_API_KEY}"}',
+            key="mcp_headers",
+            help="Sent with every request. ${VAR} in values is expanded "
+                 "from the environment, so tokens can stay out of the form.",
+        )
 
     col_connect, _ = st.columns([1, 2])
     with col_connect:
         connect_clicked = st.button("Connect", key="mcp_connect_btn", type="primary", width="stretch")
     if connect_clicked:
+        headers = None
+        headers_error = None
+        if mcp_headers_raw.strip():
+            try:
+                headers = {
+                    k: os.path.expandvars(v)
+                    for k, v in json.loads(mcp_headers_raw).items()
+                }
+            except (ValueError, AttributeError) as e:
+                headers_error = f"Headers must be a JSON object: {e}"
+
         if not mcp_name or not mcp_addr:
             st.warning("Provide both a server name and a command/URL.")
         elif mcp_name in mcp_connections:
             st.warning(f"'{mcp_name}' is already connected.")
+        elif headers_error:
+            st.error(headers_error)
         else:
             try:
                 with st.spinner(f"Connecting to '{mcp_name}'..."):
@@ -207,7 +241,8 @@ def _render_mcp_section(agent) -> None:
                         )
                     else:
                         count = agent.connect_mcp_server(
-                            mcp_name, url=mcp_addr
+                            mcp_name, url=mcp_addr,
+                            transport=transport, headers=headers,
                         )
                 st.success(f"Connected to '{mcp_name}': {count} tool(s)")
                 st.rerun()
@@ -221,8 +256,12 @@ def _render_mcp_section(agent) -> None:
                 tool_count = len(conn.tool_schemas) if hasattr(conn, "tool_schemas") else 0
                 col_info, col_btn = st.columns([5, 1])
                 with col_info:
+                    conn_transport = (
+                        "stdio" if conn.command
+                        else getattr(conn, "transport", "sse")
+                    )
                     st.caption(
-                        f"Transport: {'stdio' if conn.command else 'sse'} · "
+                        f"Transport: {conn_transport} · "
                         f"{tool_count} tool(s)"
                     )
                 with col_btn:

--- a/tests/test_mcp_streamable_http.py
+++ b/tests/test_mcp_streamable_http.py
@@ -1,0 +1,108 @@
+"""Offline tests for MCPConnection's streamable HTTP transport.
+
+Spins up a real in-process MCP server (FastMCP + uvicorn) behind a
+bearer-token middleware, then connects through ``MCPConnection`` — so the
+tests exercise the actual wire path, including that ``headers`` reach the
+server on every request.
+"""
+
+import socket
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("uvicorn")
+pytest.importorskip("mcp.server.fastmcp")
+
+from scilink.mcp_client import MCPConnection
+
+TOKEN = "test-token-123"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def http_server_url():
+    """A streamable-HTTP MCP server that rejects requests without the token."""
+    import uvicorn
+    from mcp.server.fastmcp import FastMCP
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.responses import JSONResponse
+
+    server = FastMCP("test-lab", stateless_http=True)
+
+    @server.tool()
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    app = server.streamable_http_app()
+
+    class RequireBearer(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            if request.headers.get("authorization") != f"Bearer {TOKEN}":
+                return JSONResponse({"error": "unauthorized"}, status_code=401)
+            return await call_next(request)
+
+    app.add_middleware(RequireBearer)
+
+    port = _free_port()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    uv = uvicorn.Server(config)
+    thread = threading.Thread(target=uv.run, daemon=True)
+    thread.start()
+    deadline = time.time() + 15
+    while not uv.started:
+        if time.time() > deadline:
+            raise RuntimeError("uvicorn did not start within 15s")
+        time.sleep(0.05)
+
+    yield f"http://127.0.0.1:{port}/mcp"
+
+    uv.should_exit = True
+    thread.join(timeout=5)
+
+
+def test_connect_list_and_call_with_headers(http_server_url):
+    conn = MCPConnection(
+        "lab",
+        url=http_server_url,
+        transport="http",
+        headers={"Authorization": f"Bearer {TOKEN}"},
+    )
+    try:
+        schemas = conn.connect()
+        names = {s["function"]["name"] for s in schemas}
+        assert "add" in names
+        assert conn.connected
+
+        result = conn.call_tool("add", {"a": 2, "b": 3})
+        assert "5" in result
+    finally:
+        conn.disconnect()
+
+
+def test_connect_without_headers_is_rejected(http_server_url):
+    conn = MCPConnection("lab-noauth", url=http_server_url, transport="http")
+    try:
+        with pytest.raises(Exception):
+            conn.connect()
+        assert not conn.connected
+    finally:
+        conn.disconnect()
+
+
+def test_url_defaults_to_sse_transport():
+    conn = MCPConnection("legacy", url="http://localhost:9/sse")
+    assert conn.transport == "sse"
+    conn.disconnect()
+
+
+def test_unknown_transport_rejected():
+    with pytest.raises(ValueError, match="Unknown transport"):
+        MCPConnection("bad", url="http://localhost:9/mcp", transport="grpc")


### PR DESCRIPTION
## Summary

SciLink can now connect directly to remote, hosted MCP servers — the kind cloud lab platforms and instrument APIs expose — including ones that require an API token. Point any orchestrator (analyze, plan, or explore) at the server's URL, supply the token as a header, and its tools register like any other SciLink tools. Previously this required running a local proxy process to bridge transports and inject credentials; now it is a one-line config:

```json
{
  "name": "lab-platform",
  "url": "https://mcp.example.com/mcp",
  "transport": "http",
  "headers": {"Authorization": "Bearer ${LAB_PLATFORM_API_KEY}"}
}
```

```bash
scilink analyze --mcp lab_platform.json
```

`${VAR}` in header values is expanded from the environment, so tokens never sit in config files. The web UI's MCP section gains the same capability (http transport option + optional headers field), and unauthenticated servers get a CLI shorthand: `--mcp http:name:https://host/mcp`.

Nothing changes for existing setups: stdio configs are untouched, and a bare `url` still means SSE.

---

**Technical details**

- `scilink/mcp_client.py`: `MCPConnection` gains `transport` (`"sse"` default | `"http"`) and `headers` params. The http branch uses the `mcp` SDK's `streamablehttp_client(url, headers=...)` — already a base dependency, so no new install requirements. Its context manager yields a 3-tuple (read, write, get_session_id) vs 2 for stdio/SSE; handled with starred unpacking. Bonus fix: `headers` is now also forwarded to `sse_client`, which always accepted it but was never passed.
  - Note: the SDK deprecates `streamablehttp_client` in favor of `streamable_http_client(url, http_client=...)`, but the replacement drops the `headers` param for an injected `httpx.AsyncClient`. Kept the stable headers-first shim; migrating later is a one-line change in `_connect`.
- `connect_mcp_server` threads `transport`/`headers` through on all three orchestrators (analysis, planning, meta). The meta's shared-extension record and child replay (`_register_shared_extension` / `_apply_extension_to_child`) carry the new fields so lazily-created specialist children reconnect with credentials.
- CLI (`analyze`/`plan`/`meta`): new `http:` shorthand branch; JSON config accepts `transport` and `headers` with `os.path.expandvars` on header values. The three copies stay copies per the no-base-class convention.
- UI (`tools_agents.py`): third transport radio option, headers JSON field (shown for sse/http, same `${VAR}` expansion), and the connected-server caption now reports the actual transport instead of inferring stdio-vs-sse.
- Tests (`tests/test_mcp_streamable_http.py`, offline): spins up a real in-process FastMCP streamable-HTTP server behind a bearer-token middleware and exercises the actual wire path through `MCPConnection` — connect/list/call with credentials, connection rejection without them, SSE-default backcompat, and transport validation. 4/4 green; also verified end-to-end at the orchestrator level (connect → tool call round-trip → disconnect unregisters).

**Known limits**: headers are static for the connection's lifetime (no token-refresh/OAuth flows); the UI headers field accepts a JSON object only.