### PR TITLE
Drop the gsas extra: PyPI forbids direct-URL dependencies

### DIFF
--- a/docs/xrd_identification_setup.md
+++ b/docs/xrd_identification_setup.md
@@ -7,7 +7,7 @@ anything.
 ```
 Tier 1  pip install scilink[structure-matching]     search/simulate/score + fingerprint tools
 Tier 2  scilink fetch-xrd-library                   one-time reference-library download
-Tier 3  pip install scilink[gsas]  (needs Fortran)  GSAS-II: profiles, indexing, Le Bail, Rietveld
+Tier 3  pip install "GSAS-II @ git+..."  (needs Fortran)  GSAS-II: profiles, indexing, Le Bail, Rietveld
 ```
 
 ## Tool → dependency matrix
@@ -112,8 +112,8 @@ exist first. The verified recipe (conda supplies the compilers):
 conda create -n scilink python=3.12
 conda activate scilink
 conda install -c conda-forge fortran-compiler meson ninja
-pip install "scilink[structure-matching]"   # BEFORE gsas: settles the numpy ABI
-pip install "scilink[gsas]"
+pip install "scilink[structure-matching]"   # BEFORE GSAS-II: settles the numpy ABI
+pip install "GSAS-II @ git+https://github.com/AdvancedPhotonSource/GSAS-II.git"
 ```
 
 Verify:
@@ -128,13 +128,14 @@ python -c "from GSASII import GSASIIscriptable; print('GSAS-II OK')"
 |---|---|
 | `ERROR: Compiler gfortran cannot compile programs` during pip install | The conda compiler activation scripts did not run (`CONDA_BUILD_SYSROOT` unset). Happens with bare `conda run -n env pip install ...`. Fix: `conda activate` the env in a shell (or `source .../etc/profile.d/conda.sh && conda activate env`), then pip install. |
 | `Unknown compiler(s): gfortran` | No Fortran toolchain at all — run the `conda install -c conda-forge fortran-compiler meson ninja` step. |
-| numpy ABI errors importing GSAS-II | GSAS-II was compiled against a different numpy than the one now installed. Fix: install scilink (which pins the scientific stack) **before** the `gsas` extra; reinstall the extra after major numpy changes. |
+| numpy ABI errors importing GSAS-II | GSAS-II was compiled against a different numpy than the one now installed. Fix: install scilink (which pins the scientific stack) **before** GSAS-II; reinstall GSAS-II after major numpy changes. |
 | `ModuleNotFoundError: GSASII` but tools "registered" | Expected degradation: the Tier-3 tools stay importable and registry-visible without GSAS-II and raise an actionable error naming this recipe only when actually called. |
 | GSAS-II console noise (`config.ini does not exist`, refinement logs) | Harmless; the tools capture or tolerate it. |
 
-`[gsas]` is deliberately **excluded from `scilink[all]`**: a from-source
-Fortran build would break `pip install scilink[all]` on machines without a
-compiler.
+GSAS-II is deliberately **not a scilink extra**: it is not on PyPI, and PyPI
+rejects package metadata that carries a direct URL dependency (so a `[gsas]`
+extra would block publishing scilink itself). It must be installed manually
+with the command above.
 
 ## Maintainers — refreshing the prebuilt artifact
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,14 +69,12 @@ structure-matching = [
     "pulp>=2.7.0",
     "pyarrow>=14.0",
 ]
-gsas = [
-    # GSAS-II full-profile XRD simulation engine (optional 'gsas' backend of
-    # simulate_xrd_pattern). Built from source, so it needs a Fortran compiler
-    # available at install time (e.g. `conda install -c conda-forge
-    # fortran-compiler meson ninja`). Deliberately NOT in [all]: the from-source
-    # build would break `pip install scilink[all]` on machines without a compiler.
-    "GSAS-II @ git+https://github.com/AdvancedPhotonSource/GSAS-II.git",
-]
+# NOTE: GSAS-II (the optional 'gsas' backend of simulate_xrd_pattern) cannot be
+# an extra: it is not on PyPI, and PyPI rejects uploads whose metadata carries a
+# direct URL dependency ("Can't have direct dependency"). Install it manually —
+# it builds from source, so a Fortran compiler must be present (e.g.
+# `conda install -c conda-forge fortran-compiler meson ninja`):
+#   pip install "GSAS-II @ git+https://github.com/AdvancedPhotonSource/GSAS-II.git"
 all = [
     "scilink[sim]",
     "scilink[ui]",

--- a/scilink/skills/structure_matching/xrd/_gsas_engine.py
+++ b/scilink/skills/structure_matching/xrd/_gsas_engine.py
@@ -28,10 +28,10 @@ toolchain):
     conda create -n <env> python=3.12
     conda activate <env>
     conda install -c conda-forge fortran-compiler meson ninja
-    pip install "scilink[gsas]"        # or: pip install -e ".[gsas]" from a checkout
+    pip install "GSAS-II @ git+https://github.com/AdvancedPhotonSource/GSAS-II.git"
 
-The ``gsas`` extra pulls GSAS-II from its git repository
-(``git+https://github.com/AdvancedPhotonSource/GSAS-II.git``) and compiles its
+(GSAS-II is not on PyPI and PyPI forbids direct-URL dependencies in package
+metadata, so this cannot be a ``scilink[gsas]`` extra.) The install compiles its
 Fortran extensions against the environment's numpy. Install scilink/pymatgen
 *before* GSAS-II so the compile links against the final numpy ABI. Note: the
 compiler activation only happens inside an activated conda env — building via a
@@ -152,10 +152,10 @@ def _load_g2sc():
     except Exception as exc:  # pragma: no cover - env-dependent
         raise RuntimeError(
             "The 'gsas' XRD engine requires GSAS-II (GSASIIscriptable), which is "
-            "not importable in this environment. Install the optional extra: "
-            "pip install 'scilink[gsas]' (builds GSAS-II from source; needs a "
-            "Fortran compiler, e.g. `conda install -c conda-forge fortran-compiler "
-            "meson ninja`)."
+            "not importable in this environment. Install it with: pip install "
+            "\"GSAS-II @ git+https://github.com/AdvancedPhotonSource/GSAS-II.git\" "
+            "(builds from source; needs a Fortran compiler, e.g. `conda install "
+            "-c conda-forge fortran-compiler meson ninja`)."
         ) from exc
 
 
@@ -854,9 +854,9 @@ def index_pattern(
         from GSASII import GSASIIindex as G2indx
     except Exception as exc:  # pragma: no cover - env-dependent
         raise RuntimeError(
-            "index_pattern requires GSAS-II (GSASIIindex). Install the optional "
-            "extra: pip install 'scilink[gsas]' (see module docstring for the "
-            "Fortran-compiler recipe)."
+            "index_pattern requires GSAS-II (GSASIIindex). Install it with: "
+            "pip install \"GSAS-II @ git+https://github.com/AdvancedPhotonSource/"
+            "GSAS-II.git\" (see module docstring for the Fortran-compiler recipe)."
         ) from exc
 
     lam = _resolve_wavelength(wavelength)

--- a/scilink/skills/structure_matching/xrd/xrd.md
+++ b/scilink/skills/structure_matching/xrd/xrd.md
@@ -185,7 +185,8 @@ The skill ships five tools the analysis script chains together:
 
 Install dependencies: `pip install scilink[structure-matching]` (pymatgen
 with the XRD analysis module, mp-api, pulp). Rietveld refinement
-additionally needs `pip install scilink[gsas]` (GSAS-II, built from source
+additionally needs GSAS-II, which is not on PyPI: `pip install "GSAS-II @
+git+https://github.com/AdvancedPhotonSource/GSAS-II.git"` (built from source
 — see the `simulate_xrd_pattern` `gsas` engine docs for the recipe).
 
 **Extending the backend list.** Materials Project, local CIF, and COD

--- a/tests/test_gsas_engine.py
+++ b/tests/test_gsas_engine.py
@@ -146,7 +146,7 @@ def test_actionable_error_without_gsas():
     with pytest.raises(RuntimeError) as exc:
         sx.simulate_xrd_pattern("x.cif", engine="gsas")
     msg = str(exc.value)
-    assert "scilink[gsas]" in msg and "Fortran" in msg
+    assert "GSAS-II @ git+" in msg and "Fortran" in msg
 
 
 @pytest.mark.skipif(not _pymatgen_available(), reason="pymatgen not installed")


### PR DESCRIPTION
## Summary

Installing GSAS-II support through `pip install scilink[gsas]` is gone — that extra blocked publishing scilink to PyPI. GSAS-II is not on PyPI, so the extra pointed at its git repository, and PyPI rejects any package whose metadata carries a direct URL dependency ("Can't have direct dependency"). GSAS-II is now installed manually instead:

```bash
conda install -c conda-forge fortran-compiler meson ninja   # Fortran toolchain first
pip install "GSAS-II @ git+https://github.com/AdvancedPhotonSource/GSAS-II.git"
```

Nothing changes for users who don't need Rietveld/Le Bail/indexing: the Tier-3 tools still degrade gracefully, staying importable and raising an actionable error with the recipe above only when actually called.

Every place that taught the old command is updated: the install docs, the XRD skill text, the engine module docstring, and both runtime error messages.

---

**Technical details**

- `pyproject.toml` — the `[project.optional-dependencies] gsas` extra removed, replaced by a NOTE comment carrying the manual install command and the PyPI rationale. `[all]` never included it, so `[all]` is unchanged.
- `scilink/skills/structure_matching/xrd/_gsas_engine.py` — module-docstring recipe and the two actionable errors (`_load_g2sc`, `index_pattern`) now give the direct `pip install "GSAS-II @ git+…"` command.
- `scilink/skills/structure_matching/xrd/xrd.md` — Rietveld dependency note updated.
- `docs/xrd_identification_setup.md` — Tier-3 table row, install recipe, numpy-ABI pitfall row, and the former "excluded from `[all]`" note (now explains the PyPI direct-URL restriction).
- `tests/test_gsas_engine.py` — `test_actionable_error_without_gsas` asserts on `"GSAS-II @ git+"` instead of `"scilink[gsas]"`. Verified to genuinely run (not skip) and pass in an env without GSAS-II: 12 passed / 13 gsas-dependent skips.
- Known limit: users on old instructions running `pip install scilink[gsas]` get a pip warning about an unknown extra and base scilink — same graceful degradation as never having installed GSAS-II.