### PR TITLE
Curve-series scout: full-series change detection beside the visual overlay

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -2051,17 +2051,8 @@ class CurveFittingPlanningController:
         """
         from ..instruct import CURVE_FITTING_PLAN_VALIDATION_PROMPT
 
-        regime_section = ""
-        series_plan = state.get("series_analysis_plan")
-        if series_plan and series_plan.get("regimes"):
-            lines = ["\n**Regimes:**"]
-            for regime in series_plan["regimes"]:
-                lines.append(
-                    f"- {regime.get('name', 'Unnamed')}: "
-                    f"model={regime.get('physical_model', 'N/A')}, "
-                    f"params={', '.join(regime.get('parameters_to_extract', []))}"
-                )
-            regime_section = "\n".join(lines)
+        regime_section = self._build_regime_section(
+            state.get("series_analysis_plan"))
 
         prompt_text = CURVE_FITTING_PLAN_VALIDATION_PROMPT.format(
             analysis_approach=state.get("analysis_approach", "N/A"),
@@ -2086,6 +2077,19 @@ class CurveFittingPlanningController:
         data_plot = state.get("scout_overlay_plot") or state.get("original_plot_bytes")
         if data_plot:
             prompt_parts.append("\n**Data:**")
+            # The overlay is a SUBSAMPLE — without saying so, the validator
+            # reads its legend as the whole series and "corrects" valid
+            # regime spectrum_indices down to the scouted count (seen live).
+            if state.get("scout_overlay_plot") and not state.get(
+                    "is_single_spectrum", True):
+                num_spectra = state.get("num_spectra", 1)
+                n_scouts = len(state.get("scout_data") or [])
+                prompt_parts.append(
+                    f"The overlay shows {n_scouts} representative spectra "
+                    f"scouted from the full series of {num_spectra}. Regime "
+                    f"spectrum_indices refer to the full series "
+                    f"(0..{num_spectra - 1}), not to the overlay curves."
+                )
             prompt_parts.append({"mime_type": "image/png", "data": data_plot})
         # Same fit-free zoom into hard-to-resolve regions so the validator can
         # catch unresolved structure the plan mischaracterized (no-op for series
@@ -2125,6 +2129,49 @@ class CurveFittingPlanningController:
             self.logger.warning(f"  Plan validation failed: {e}, keeping plan")
 
         return state
+
+    @staticmethod
+    def _format_spectrum_indices(indices) -> str:
+        """Compact range rendering of an index list: '0-11, 13, 15-20'."""
+        idx = sorted({int(i) for i in (indices or [])})
+        if not idx:
+            return ""
+        parts, start, prev = [], idx[0], idx[0]
+        for i in idx[1:]:
+            if i == prev + 1:
+                prev = i
+                continue
+            parts.append(f"{start}-{prev}" if prev > start else f"{start}")
+            start = prev = i
+        parts.append(f"{start}-{prev}" if prev > start else f"{start}")
+        return ", ".join(parts)
+
+    @classmethod
+    def _build_regime_section(cls, series_plan) -> str:
+        """Regime block for the plan-validation prompt.
+
+        Shows each regime's spectrum_indices — the validator cannot preserve
+        an assignment it never saw — and states the omission semantics that
+        `_extract_series_plan` implements on the way back.
+        """
+        if not (series_plan and series_plan.get("regimes")):
+            return ""
+        lines = ["\n**Regimes:**"]
+        for regime in series_plan["regimes"]:
+            spectra = cls._format_spectrum_indices(
+                regime.get("spectrum_indices", []))
+            lines.append(
+                f"- {regime.get('name', 'Unnamed')}: "
+                f"spectra=[{spectra}], "
+                f"model={regime.get('physical_model', 'N/A')}, "
+                f"params={', '.join(regime.get('parameters_to_extract', []))}"
+            )
+        lines.append(
+            "If you revise the series plan, return spectrum_indices for each "
+            "regime; a regime returned without them inherits its current "
+            "assignment shown above."
+        )
+        return "\n".join(lines)
 
     def _append_scout_context(self, prompt: list, state: dict, scout_data: list) -> None:
         """Append scout spectrum plots and series regime planning instructions."""
@@ -2253,6 +2300,34 @@ class CurveFittingPlanningController:
         if not regimes:
             state["series_analysis_plan"] = None
             return
+
+        # A validation/refinement revision may return regimes without
+        # spectrum_indices — omission means "assignment unchanged", not
+        # "unassign". Inherit from the plan being revised (by regime name,
+        # else by position when the regime count is unchanged); otherwise
+        # the missing-index fallback below assigns every spectrum to
+        # regime 1 and drops the rest as empty, silently collapsing a
+        # multi-regime plan whenever the revision was about something else.
+        prior_regimes = (state.get("series_analysis_plan") or {}).get("regimes") or []
+        if prior_regimes:
+            prior_by_name = {
+                r.get("name"): r for r in prior_regimes if r.get("name")
+            }
+            same_count = len(regimes) == len(prior_regimes)
+            for pos, regime in enumerate(regimes):
+                if regime.get("spectrum_indices"):
+                    continue
+                source = prior_by_name.get(regime.get("name"))
+                if source is None and same_count:
+                    source = prior_regimes[pos]
+                inherited = (source or {}).get("spectrum_indices")
+                if inherited:
+                    regime["spectrum_indices"] = list(inherited)
+                    self.logger.info(
+                        f"  Regime '{regime.get('name', 'unnamed')}' returned "
+                        f"without spectrum_indices — inherited "
+                        f"{len(inherited)} from the plan being revised"
+                    )
 
         # Validate index coverage
         all_indices = set()

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1307,6 +1307,71 @@ class SeriesScoutController:
                 return np.load(data_path)
             return np.loadtxt(data_path, delimiter=',')
 
+    # The visual scout is capped at 7 spectra; the SVD reduction runs on the
+    # full series so a transition the subsample straddles is still located.
+    # This cap only bounds file-loading cost on very long series.
+    _REDUCTION_MAX_SPECTRA = 256
+
+    def _run_series_reduction(self, state: dict, num_spectra: int) -> None:
+        """Full-series unsupervised change detection (mean-centered SVD).
+
+        Stores the `reduce_curves` result under `state["series_reduction"]`
+        (None on any failure — never blocks the scout). Control axis comes
+        from `series_metadata` values when they are numeric and per-spectrum,
+        else spectrum index.
+        """
+        from ....skills._shared.series_reduction import reduce_curves
+
+        try:
+            indices = list(range(num_spectra))
+            if num_spectra > self._REDUCTION_MAX_SPECTRA:
+                step = (num_spectra - 1) / (self._REDUCTION_MAX_SPECTRA - 1)
+                indices = sorted({round(i * step)
+                                  for i in range(self._REDUCTION_MAX_SPECTRA)})
+            series_metadata = state.get("series_metadata", {})
+            values = series_metadata.get("values", [])
+            curves, controls = [], []
+            for idx in indices:
+                try:
+                    x, y = self._extract_xy(self._load_spectrum(idx, state))
+                except Exception:
+                    continue
+                cv = None
+                if idx < len(values):
+                    try:
+                        cv = float(values[idx])
+                    except (TypeError, ValueError):
+                        cv = None
+                curves.append((x, y))
+                controls.append(cv)
+
+            if curves and all(c is not None for c in controls):
+                ctrl = controls
+                control_source = series_metadata.get("variable") or "index"
+            else:
+                ctrl, control_source = None, "index"
+
+            result = reduce_curves(
+                curves, controls=ctrl, control_source=control_source,
+                label="series", return_figure=True,
+            )
+            if result.get("status") != "success":
+                self.logger.info(
+                    f"  Change detection skipped: {result.get('error')}")
+                state["series_reduction"] = None
+                return
+            if len(curves) < num_spectra:
+                result["subsampled"] = f"{len(curves)} of {num_spectra} spectra"
+            state["series_reduction"] = result
+            self.logger.info(
+                f"  Change detection (all {result['n_points']} spectra): "
+                f"change point ≈ {result['change_point']:g} "
+                f"({control_source}), sharpness {result['change_sharpness']}"
+            )
+        except Exception as e:
+            self.logger.warning(f"  Series change detection failed: {e}")
+            state["series_reduction"] = None
+
     def execute(self, state: dict) -> dict:
         if state.get("error_dict") or state.get("is_single_spectrum", True):
             return state
@@ -1368,6 +1433,11 @@ class SeriesScoutController:
                 state["scout_overlay_plot"] = None
         else:
             state["scout_overlay_plot"] = None
+
+        # Full-series change detection (additive: the scouts above remain the
+        # visual evidence; this locates WHERE the series changes using every
+        # spectrum, which the <=7-spectrum subsample cannot).
+        self._run_series_reduction(state, num_spectra)
 
         state["scout_data"] = scout_data
         self.logger.info(f"  Scouted {len(scout_data)} of {num_spectra} spectra")
@@ -2108,6 +2178,47 @@ class CurveFittingPlanningController:
                 "mime_type": "image/png",
                 "data": overlay,
             })
+
+        # Full-series SVD change detection (computed on every spectrum, not
+        # just the scouts — a transition between scout indices still shows).
+        reduction = state.get("series_reduction")
+        if reduction:
+            unit = series_metadata.get("unit", "")
+            axis = reduction.get("control_variable", {}).get("source", "index")
+            flags = reduction.get("flags", {})
+            flag_names = [k for k in ("shift_dominated", "intensity_drift",
+                                      "resampled_to_common_grid")
+                          if flags.get(k)]
+            coverage = reduction.get("subsampled") or (
+                f"all {reduction['n_points']} spectra")
+            lines = [
+                "\n### Full-Series Change Detection (computed)",
+                f"Unsupervised SVD change detection ran on {coverage} — "
+                "unlike the scout plots above, it sees between the scouted "
+                "indices.",
+                f"- Change point: {axis} ≈ {reduction['change_point']:g} "
+                f"{unit}".rstrip(),
+                f"- Change sharpness: {reduction['change_sharpness']} "
+                "(steepest single step as a fraction of the score range; "
+                "near 1 = abrupt transition, small = gradual evolution)",
+                f"- Variance explained by first two components: "
+                f"{reduction['variance_explained']}",
+            ]
+            if flag_names:
+                lines.append(f"- Flags: {', '.join(flag_names)}")
+            if reduction.get("caution"):
+                lines.append(f"- Caution: {reduction['caution']}")
+            lines.append(
+                "Use this to place regime boundaries and to judge whether "
+                "the scouts straddle a transition; the plots remain the "
+                "evidence for WHAT changes."
+            )
+            prompt.append("\n".join(lines))
+            if reduction.get("score_curve_png"):
+                prompt.append({
+                    "mime_type": "image/png",
+                    "data": reduction["score_curve_png"],
+                })
 
         prompt.append("\n### Individual Scout Spectra")
         for scout in scout_data:

--- a/scilink/skills/_shared/series_reduction.py
+++ b/scilink/skills/_shared/series_reduction.py
@@ -1,10 +1,11 @@
-"""Cheap unsupervised reduction of a measurement series (fan-out steering).
+"""Cheap unsupervised reduction of a measurement series.
 
-The #296 phase-(d) steering payload: answer only "WHERE along the control
-variable does this series change, and how sharply?" via mean-centered SVD —
-a change DETECTOR, not a re-derivation (no fitting, no peak model, no phase
-assumptions). Available at branch-launch time, when the companion branch's
-own proper analysis does not exist yet.
+Answers only "WHERE along the control variable does this series change, and
+how sharply?" via mean-centered SVD — a change DETECTOR, not a re-derivation
+(no fitting, no peak model, no phase assumptions). Two consumers: fan-out
+branch steering (the #296 phase-(d) payload, file-based `reduce_series`) and
+the curve-series scout (in-memory `reduce_curves` over the full series, which
+the <=7-spectrum visual scout cannot see).
 
 The known artifacts are OWNED here (computed flags, not prompt prose):
 
@@ -112,11 +113,46 @@ def reduce_series(files: List[str], out_dir: Optional[str] = None,
             controls.append(cv)
             sources.append(src)
         if any(c is None for c in controls):
-            controls = list(range(len(files)))
-            source = "index"
+            controls, source = None, "index"
         else:
             source = next(s for s in sources if s)
+        return reduce_curves(curves, controls=controls, control_source=source,
+                             label=label, n_grid=n_grid, out_dir=out_dir)
+    except Exception as e:  # noqa: BLE001 - steering must never break a fan-out
+        logger.warning(f"series reduction failed for {label}: {e}")
+        return {"status": "error", "error": str(e)}
+
+
+def reduce_curves(curves: list, controls=None, control_source: str = "index",
+                  label: str = "series", n_grid: int = _N_GRID,
+                  out_dir: Optional[str] = None,
+                  return_figure: bool = False) -> dict:
+    """In-memory core of :func:`reduce_series`.
+
+    ``curves`` is a list of ``(x, y)`` array pairs; ``controls`` an optional
+    per-curve control value (falls back to index order), ``control_source``
+    the name/provenance of that axis. With ``return_figure=True`` the score
+    curve is also returned as PNG bytes under ``score_curve_png`` (for
+    callers that embed it in a prompt rather than write artifacts). Same
+    return contract as :func:`reduce_series`; never raises."""
+    try:
+        curves = [(np.asarray(x, dtype=float), np.asarray(y, dtype=float))
+                  for x, y in (curves or [])]
+        if len(curves) < 4:
+            return {"status": "error",
+                    "error": f"need >= 4 series points, got {len(curves)}"}
+        for i, (x, _) in enumerate(curves):
+            if x.size < 8:
+                return {"status": "error",
+                        "error": f"curve {i}: too few channels"}
+        if controls is None:
+            controls, control_source = list(range(len(curves))), "index"
         controls = np.asarray(controls, dtype=float)
+        if controls.size != len(curves):
+            return {"status": "error",
+                    "error": f"{controls.size} control values for "
+                             f"{len(curves)} curves"}
+        source = control_source
 
         # Common grid: intersection of x-ranges (flags a resample if the
         # grids differ at all).
@@ -172,7 +208,7 @@ def reduce_series(files: List[str], out_dir: Optional[str] = None,
         out = {
             "status": "success",
             "label": label,
-            "n_points": int(len(files)),
+            "n_points": int(len(curves)),
             "n_channels": int(grid.size),
             "control_variable": {
                 "source": source,
@@ -193,7 +229,9 @@ def reduce_series(files: List[str], out_dir: Optional[str] = None,
                 json.dump({**out, "score1": score1.tolist(),
                            "controls": controls.tolist()}, fh, indent=2)
             out["reduction_json_path"] = jpath
+        if out_dir or return_figure:
             try:
+                import io
                 import matplotlib
                 matplotlib.use("Agg")
                 import matplotlib.pyplot as plt
@@ -209,13 +247,20 @@ def reduce_series(files: List[str], out_dir: Optional[str] = None,
                              f"(PC1 {var_explained[0]:.0%} of variance)")
                 ax.legend(fontsize=8)
                 fig.tight_layout()
-                fpath = os.path.join(out_dir, "score_curve.png")
-                fig.savefig(fpath, dpi=110)
+                buf = io.BytesIO()
+                fig.savefig(buf, format="png", dpi=110)
                 plt.close(fig)
-                out["score_curve_path"] = fpath
+                png = buf.getvalue()
+                if out_dir:
+                    fpath = os.path.join(out_dir, "score_curve.png")
+                    with open(fpath, "wb") as fh:
+                        fh.write(png)
+                    out["score_curve_path"] = fpath
+                if return_figure:
+                    out["score_curve_png"] = png
             except Exception as e:  # noqa: BLE001 - figure is best-effort
                 logger.warning(f"series reduction: could not plot: {e}")
         return out
-    except Exception as e:  # noqa: BLE001 - steering must never break a fan-out
+    except Exception as e:  # noqa: BLE001 - reduction must never break a caller
         logger.warning(f"series reduction failed for {label}: {e}")
         return {"status": "error", "error": str(e)}

--- a/tests/test_scout_reduction_live.py
+++ b/tests/test_scout_reduction_live.py
@@ -1,0 +1,152 @@
+"""Live validation: full-series change detection reaches the series planner.
+
+16-spectrum synthetic temperature series (300-450 K, 10 K steps). A sharp
+composition switch (peak at 900 dies, peak at 1300 grows) is planted at
+405 K — between indices 10 and 11, strictly BETWEEN the visual scout
+indices {0, 4, 8, 12, 15} (nearest scouts: 380 K and 420 K). The planner
+can only place a regime boundary at index 10/11 by reading the computed
+change point; the scouts alone bound it no tighter than (8, 12).
+
+Checks:
+  - scout log reports change detection on all 16 spectra, change point
+    within one series step of 405 K;
+  - the series plan has >= 2 regimes;
+  - the boundary between regime 1 and regime 2 falls at index 10 or 11.
+
+  export AWS_BEARER_TOKEN_BEDROCK=...  AWS_REGION_NAME=us-east-1
+  UNSAFE_EXECUTION_OK=true python tests/test_scout_reduction_live.py [model]
+"""
+import io
+import logging
+import os
+import re
+import sys
+import tempfile
+
+import numpy as np
+
+MODEL = os.environ.get("SCILINK_TEST_MODEL",
+                       "bedrock/us.anthropic.claude-opus-4-8")
+RNG = np.random.default_rng(11)
+
+checks = {}
+
+
+def check(name, cond):
+    checks[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+def _g(x, c, s):
+    return np.exp(-0.5 * ((x - c) / s) ** 2)
+
+
+def _make_stack(temps, t0=405.0, width=1.5):
+    x = np.linspace(400, 1800, 700)
+    frames = []
+    for T in temps:
+        w = 1 / (1 + np.exp(-(T - t0) / width))
+        y = ((1 - w) * _g(x, 900, 40) + w * _g(x, 1300, 40)
+             + RNG.normal(0, 0.004, x.size))
+        frames.append(np.column_stack([x, y]))
+    return np.stack(frames)
+
+
+class _Tee(io.TextIOBase):
+    def __init__(self, *streams):
+        self.streams = streams
+
+    def write(self, s):
+        for st in self.streams:
+            st.write(s)
+        return len(s)
+
+    def flush(self):
+        for st in self.streams:
+            st.flush()
+
+
+def main() -> int:
+    model_name = sys.argv[1] if len(sys.argv) > 1 else MODEL
+
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+
+    temps = [300.0 + 10.0 * i for i in range(16)]
+    stack = _make_stack(temps)
+    out = tempfile.mkdtemp(prefix="scout_reduction_live_")
+    print(f"output dir: {out}")
+
+    agent = CurveFittingAgent(
+        api_key=None, model_name=model_name, output_dir=out,
+        enable_human_feedback=False, use_literature=False,
+        max_verification_iterations=0,
+    )
+
+    capture = io.StringIO()
+    handler = logging.StreamHandler(capture)
+    handler.setLevel(logging.INFO)
+    logging.getLogger().addHandler(handler)
+    old_stdout = sys.stdout
+    sys.stdout = _Tee(old_stdout, capture)
+    try:
+        result = agent.analyze(
+            stack,
+            system_info={
+                "technique": "in-situ optical spectroscopy during heating",
+                "sample": "thin film, temperature ramp",
+                "x_axis": "wavenumber (cm-1)",
+                "y_axis": "intensity (a.u.)",
+            },
+            series_metadata={"variable": "temperature", "unit": "K",
+                             "values": temps},
+            objective=("Fit the spectral peaks across the temperature series "
+                       "and track their evolution; report any transition "
+                       "temperature you find."),
+        )
+    finally:
+        sys.stdout = old_stdout
+        logging.getLogger().removeHandler(handler)
+    log = capture.getvalue()
+
+    print("\nchecks:")
+    m = re.search(
+        r"Change detection \(all 16 spectra\): change point ≈ ([\d.]+)", log)
+    check("change detection ran on all 16 spectra", m is not None)
+    cp = float(m.group(1)) if m else float("nan")
+    print(f"    detected change point: {cp}")
+    check("change point within one step of planted 405 K",
+          m is not None and abs(cp - 405.0) <= 10.0)
+
+    # Planner log format ("<name>: indices [...], model: ..."), falling back
+    # to the regime banner ("Spectra: indices [...]").
+    groups = re.findall(r": indices \[([^\]]*)\], model:", log)
+    if not groups:
+        groups = re.findall(r"Spectra: indices \[([^\]]*)\]", log)
+    regime_indices = [
+        sorted(int(v) for v in re.findall(r"\d+", g)) for g in groups
+    ]
+    print(f"    regimes (spectrum indices): {regime_indices}")
+    check("series plan has >= 2 regimes", len(regime_indices) >= 2)
+    boundary_ok = False
+    if len(regime_indices) >= 2:
+        splits = sorted(r[0] for r in regime_indices[1:])
+        boundary_ok = any(s in (10, 11) for s in splits)
+        print(f"    regime split point(s): {splits} (planted: 11)")
+    check("regime boundary at index 10/11 (sub-scout resolution)", boundary_ok)
+
+    status = (result or {}).get("status", "no result")
+    print(f"    analyze status: {status}")
+    check("analyze completed", isinstance(result, dict)
+          and status not in ("error", "no result"))
+
+    print("\n" + "=" * 50)
+    npass = sum(checks.values())
+    print(f"SCOUT REDUCTION LIVE: {npass}/{len(checks)} checks passed")
+    for k, v in checks.items():
+        if not v:
+            print("  FAILED:", k)
+    return 0 if npass == len(checks) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_scout_reduction_live.py
+++ b/tests/test_scout_reduction_live.py
@@ -117,22 +117,28 @@ def main() -> int:
     check("change point within one step of planted 405 K",
           m is not None and abs(cp - 405.0) <= 10.0)
 
-    # Planner log format ("<name>: indices [...], model: ..."), falling back
-    # to the regime banner ("Spectra: indices [...]").
-    groups = re.findall(r": indices \[([^\]]*)\], model:", log)
-    if not groups:
-        groups = re.findall(r"Spectra: indices \[([^\]]*)\]", log)
-    regime_indices = [
-        sorted(int(v) for v in re.findall(r"\d+", g)) for g in groups
-    ]
-    print(f"    regimes (spectrum indices): {regime_indices}")
-    check("series plan has >= 2 regimes", len(regime_indices) >= 2)
-    boundary_ok = False
-    if len(regime_indices) >= 2:
+    # The locked-configuration banner is authoritative — the plan can be
+    # logged twice (initial + post-validation revision). Fall back to the
+    # plan-log / regime-banner formats.
+    n_regimes, splits = 0, []
+    locked = re.search(r"First-in-regime spectra \(full QC\): \[([^\]]*)\]",
+                       log)
+    if locked:
+        firsts = [int(v) for v in re.findall(r"\d+", locked.group(1))]
+        n_regimes, splits = len(firsts), sorted(firsts[1:])
+    else:
+        groups = (re.findall(r": indices \[([^\]]*)\], model:", log)
+                  or re.findall(r"Spectra: indices \[([^\]]*)\]", log))
+        regime_indices = [
+            sorted(int(v) for v in re.findall(r"\d+", g)) for g in groups
+        ]
+        n_regimes = len(regime_indices)
         splits = sorted(r[0] for r in regime_indices[1:])
-        boundary_ok = any(s in (10, 11) for s in splits)
-        print(f"    regime split point(s): {splits} (planted: 11)")
-    check("regime boundary at index 10/11 (sub-scout resolution)", boundary_ok)
+    print(f"    locked regimes: {n_regimes}, split point(s): {splits} "
+          "(planted: 11)")
+    check("series plan has >= 2 regimes", n_regimes >= 2)
+    check("regime boundary at index 10/11 (sub-scout resolution)",
+          any(s in (10, 11) for s in splits))
 
     status = (result or {}).get("status", "no result")
     print(f"    analyze status: {status}")

--- a/tests/test_scout_series_reduction.py
+++ b/tests/test_scout_series_reduction.py
@@ -1,0 +1,204 @@
+"""Offline tests for full-series change detection in the curve-series scout.
+
+The scout's visual subsample is capped at 7 spectra; the added
+`reduce_curves` pass runs on the FULL series and feeds the planner a
+computed change point next to the overlay. Synthetic series with planted
+ground truth: a transition placed BETWEEN scout indices (invisible to the
+subsample), control axis from series_metadata, fallbacks, failure
+isolation, and the prompt injection.
+
+  conda run -n scilink python tests/test_scout_series_reduction.py
+"""
+import logging
+import os
+import tempfile
+
+import numpy as np
+
+from scilink.skills._shared.series_reduction import reduce_curves
+from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+    CurveFittingPlanningController,
+    SeriesScoutController,
+)
+
+RNG = np.random.default_rng(7)
+results = {}
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("scout-reduction-test")
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+def _g(x, c, s):
+    return np.exp(-0.5 * ((x - c) / s) ** 2)
+
+
+def _make_series(temps, t0=85.0, width=2.0, n_channels=600):
+    """Composition switch at t0: peak at 900 dies, peak at 1300 grows."""
+    x = np.linspace(400, 1800, n_channels)
+    curves = []
+    for T in temps:
+        w = 1 / (1 + np.exp(-(T - t0) / width))
+        y = ((1 - w) * _g(x, 900, 40) + w * _g(x, 1300, 40)
+             + RNG.normal(0, 0.004, x.size))
+        curves.append(np.column_stack([x, y]))
+    return curves
+
+
+def _stub_plot_fn(curve_data, system_info, title_suffix=""):
+    return b"\x89PNG-stub"
+
+
+def _scout_state(num, stack=None, paths=None, values=None,
+                 variable="temperature", unit="C"):
+    state = {
+        "is_single_spectrum": False,
+        "num_spectra": num,
+        "system_info": {},
+        "series_metadata": {"variable": variable, "unit": unit,
+                            "values": values if values is not None else []},
+    }
+    if stack is not None:
+        state["spectrum_stack"] = stack
+    if paths is not None:
+        state["spectrum_paths"] = paths
+    return state
+
+
+def main():
+    # 1) reduce_curves core: explicit controls, named axis, figure bytes.
+    temps = list(range(30, 170, 10))
+    curves = [(c[:, 0], c[:, 1]) for c in _make_series(temps)]
+    out = reduce_curves(curves, controls=temps, control_source="temperature",
+                        return_figure=True)
+    print("1) reduce_curves core (planted change at 85):")
+    check("success", out["status"] == "success")
+    check("change point within half a step of 85",
+          abs(out["change_point"] - 85.0) <= 5.0)
+    check("control source passed through",
+          out["control_variable"]["source"] == "temperature")
+    check("figure returned as PNG bytes",
+          out.get("score_curve_png", b"")[:4] == b"\x89PNG")
+    check("no artifact paths without out_dir",
+          "score_curve_path" not in out and "reduction_json_path" not in out)
+
+    out = reduce_curves(curves)
+    check("index fallback when controls omitted",
+          out["status"] == "success"
+          and out["control_variable"]["source"] == "index")
+    check("no figure unless requested", "score_curve_png" not in out)
+
+    print("2) reduce_curves failure paths:")
+    check("too few curves -> error",
+          reduce_curves(curves[:3])["status"] == "error")
+    check("control-length mismatch -> error",
+          reduce_curves(curves, controls=temps[:-2])["status"] == "error")
+
+    # 3) Controller on an in-memory stack: transition planted BETWEEN scout
+    #    indices. n=40 scouts {0,7,13,20,26,33,39}; transition at index 23.
+    temps = [20.0 + 2.5 * i for i in range(40)]  # 20 .. 117.5
+    t0 = temps[23] + 1.0  # between scout indices 20 and 26
+    stack = np.stack(_make_series(temps, t0=t0, width=0.8))
+    scout = SeriesScoutController(logger=logger, plot_fn=_stub_plot_fn)
+    state = scout.execute(_scout_state(40, stack=stack, values=temps))
+    red = state.get("series_reduction")
+    print("3) scout controller, stack path (transition between scouts):")
+    check("reduction present and successful",
+          isinstance(red, dict) and red["status"] == "success")
+    check("ran on the full series, not the 7 scouts", red["n_points"] == 40)
+    check("change point within one step of planted t0",
+          abs(red["change_point"] - t0) <= 2.5)
+    check("control axis from series_metadata",
+          red["control_variable"]["source"] == "temperature")
+    check("score curve figure attached",
+          red.get("score_curve_png", b"")[:4] == b"\x89PNG")
+    check("additive: scout_data intact", len(state["scout_data"]) == 7)
+    check("additive: overlay intact", bool(state.get("scout_overlay_plot")))
+
+    # 4) Controller on a file-path series (no stack).
+    d = tempfile.mkdtemp()
+    paths = []
+    for i, c in enumerate(_make_series(temps, t0=t0, width=0.8)):
+        p = os.path.join(d, f"spec_{i:03d}.txt")
+        np.savetxt(p, c, delimiter=",")
+        paths.append(p)
+    state = scout.execute(_scout_state(40, paths=paths, values=temps))
+    red = state.get("series_reduction")
+    print("4) scout controller, file-path series:")
+    check("paths: reduction successful",
+          isinstance(red, dict) and red["status"] == "success")
+    check("paths: change point located", abs(red["change_point"] - t0) <= 2.5)
+
+    # 5) Non-numeric series values -> index axis fallback.
+    state = scout.execute(_scout_state(
+        40, stack=stack, values=[f"run_{i}" for i in range(40)]))
+    red = state.get("series_reduction")
+    print("5) non-numeric control values:")
+    check("index fallback", isinstance(red, dict)
+          and red["control_variable"]["source"] == "index")
+
+    # 6) No-op and failure isolation.
+    print("6) no-op + failure isolation:")
+    state = scout.execute({"is_single_spectrum": True})
+    check("single spectrum: scout untouched", "series_reduction" not in state)
+    state = scout.execute(_scout_state(
+        6, paths=[os.path.join(d, f"missing_{i}.txt") for i in range(6)],
+        values=list(range(6))))
+    check("all loads fail: reduction None, no raise",
+          state.get("series_reduction") is None)
+
+    # 7) Long-series cap: reduction subsampled, marker set.
+    temps_long = [float(i) for i in range(300)]
+    stack_long = np.stack(_make_series(temps_long, t0=150.0, width=2.0,
+                                       n_channels=200))
+    state = scout.execute(_scout_state(300, stack=stack_long,
+                                       values=temps_long))
+    red = state.get("series_reduction")
+    print("7) long-series cap:")
+    check("capped at 256 rows", isinstance(red, dict)
+          and red["n_points"] <= 256 and "of 300 spectra" in
+          red.get("subsampled", ""))
+    check("capped run still locates change",
+          abs(red["change_point"] - 150.0) <= 3.0)
+
+    # 8) Prompt injection next to the overlay (method uses no self state).
+    stack = np.stack(_make_series(temps, t0=t0, width=0.8))
+    state = scout.execute(_scout_state(40, stack=stack, values=temps))
+    prompt = []
+    CurveFittingPlanningController._append_scout_context(
+        None, prompt, state, state["scout_data"])
+    text = "\n".join(p for p in prompt if isinstance(p, str))
+    images = [p for p in prompt if isinstance(p, dict)]
+    print("8) planning-prompt injection:")
+    check("change-detection block present",
+          "Full-Series Change Detection" in text)
+    check("change point stated with axis name",
+          "temperature" in text and f"{state['series_reduction']['change_point']:g}" in text)
+    check("score curve embedded as image",
+          any(p.get("data") == state["series_reduction"]["score_curve_png"]
+              for p in images))
+    check("existing scout images still present",
+          sum(1 for p in images if p.get("data") == b"\x89PNG-stub") == 7)
+    # Reduction absent -> block absent (backcompat with pre-existing states).
+    state.pop("series_reduction")
+    prompt = []
+    CurveFittingPlanningController._append_scout_context(
+        None, prompt, state, state["scout_data"])
+    text = "\n".join(p for p in prompt if isinstance(p, str))
+    check("no block when reduction missing",
+          "Full-Series Change Detection" not in text)
+
+    print("\n" + "=" * 50)
+    npass = sum(results.values())
+    print(f"SCOUT SERIES REDUCTION: {npass}/{len(results)} checks passed")
+    for k, v in results.items():
+        if not v:
+            print("  FAILED:", k)
+    raise SystemExit(0 if npass == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_series_plan_revision.py
+++ b/tests/test_series_plan_revision.py
@@ -1,0 +1,177 @@
+"""Offline tests for series-plan revision index inheritance.
+
+A plan-validation (or refinement) revision that returns regimes without
+spectrum_indices used to collapse a multi-regime plan: the missing-index
+fallback assigned every spectrum to regime 1 and dropped the rest as empty.
+Observed live (ibuprofen in-situ XRD, 2026-07-16): the validator revised for
+air-scatter handling, renamed the regimes slightly, omitted the indices, and
+a 2-regime plan silently became 1 regime. The fix inherits omitted indices
+from the plan being revised (by name, else by position when the regime count
+is unchanged) and shows the indices to the validator in the first place.
+
+  conda run -n scilink python tests/test_series_plan_revision.py
+"""
+import logging
+import types
+
+from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+    CurveFittingPlanningController,
+)
+
+results = {}
+logging.basicConfig(level=logging.WARNING)
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+def _ctrl():
+    return types.SimpleNamespace(
+        logger=logging.getLogger("revision-test"),
+        _extract_series_plan=None,  # unused; unbound call below
+    )
+
+
+def _extract(state, result):
+    CurveFittingPlanningController._extract_series_plan(_ctrl(), state, result)
+
+
+def _state(prior_regimes=None, num=38):
+    state = {"is_single_spectrum": False, "num_spectra": num}
+    if prior_regimes is not None:
+        state["series_analysis_plan"] = {"regimes": prior_regimes}
+    return state
+
+
+def _plan(*regimes):
+    return {"series_analysis_plan": {"regimes": list(regimes)}}
+
+
+def main():
+    # 1) The live collapse, replayed: revision renames regimes (name match
+    #    fails), omits indices, count unchanged -> positional inheritance.
+    state = _state([
+        {"name": "Dihydrate phase (below transition)",
+         "spectrum_indices": list(range(0, 12)), "physical_model": "PV"},
+        {"name": "Dehydrated phase (above transition)",
+         "spectrum_indices": list(range(12, 38)), "physical_model": "PV"},
+    ])
+    _extract(state, _plan(
+        {"name": "Dihydrate phase (below transition, T < ~47 C)",
+         "physical_model": "PV revised"},
+        {"name": "Dehydrated phase (above transition, T > ~47 C)",
+         "physical_model": "PV revised"},
+    ))
+    plan = state["series_analysis_plan"]
+    print("1) live collapse scenario (renamed regimes, no indices):")
+    check("plan keeps 2 regimes", plan is not None and len(plan["regimes"]) == 2)
+    check("regime 1 indices inherited positionally",
+          plan["regimes"][0]["spectrum_indices"] == list(range(0, 12)))
+    check("regime 2 indices inherited positionally",
+          plan["regimes"][1]["spectrum_indices"] == list(range(12, 38)))
+    check("revised models kept",
+          plan["regimes"][0]["physical_model"] == "PV revised")
+
+    # 2) Name match wins over position (regimes reordered in the revision).
+    state = _state([
+        {"name": "A", "spectrum_indices": [0, 1, 2]},
+        {"name": "B", "spectrum_indices": [3, 4, 5]},
+    ], num=6)
+    _extract(state, _plan({"name": "B"}, {"name": "A"}))
+    plan = state["series_analysis_plan"]
+    print("2) reordered revision, names stable:")
+    check("B keeps its own indices despite position 0",
+          plan["regimes"][0]["name"] == "B"
+          and plan["regimes"][0]["spectrum_indices"] == [3, 4, 5])
+    check("A keeps its own indices despite position 1",
+          plan["regimes"][1]["spectrum_indices"] == [0, 1, 2])
+
+    # 3) Explicit indices from the revision always win over inheritance.
+    state = _state([
+        {"name": "A", "spectrum_indices": [0, 1, 2]},
+        {"name": "B", "spectrum_indices": [3, 4, 5]},
+    ], num=6)
+    _extract(state, _plan(
+        {"name": "A", "spectrum_indices": [0, 1]},
+        {"name": "B", "spectrum_indices": [2, 3, 4, 5]},
+    ))
+    plan = state["series_analysis_plan"]
+    print("3) explicit revised indices:")
+    check("revised assignment respected",
+          plan["regimes"][0]["spectrum_indices"] == [0, 1]
+          and plan["regimes"][1]["spectrum_indices"] == [2, 3, 4, 5])
+
+    # 4) Partial omission: only the omitting regime inherits.
+    state = _state([
+        {"name": "A", "spectrum_indices": [0, 1, 2]},
+        {"name": "B", "spectrum_indices": [3, 4, 5]},
+    ], num=6)
+    _extract(state, _plan(
+        {"name": "A", "spectrum_indices": [0, 1, 2, 3]},
+        {"name": "B"},
+    ))
+    plan = state["series_analysis_plan"]
+    print("4) partial omission:")
+    check("explicit regime kept, omitted regime inherited",
+          plan["regimes"][0]["spectrum_indices"] == [0, 1, 2, 3]
+          and plan["regimes"][1]["spectrum_indices"] == [3, 4, 5])
+
+    # 5) No prior plan (initial planning): behavior unchanged — missing
+    #    indices fall back to regime 1, empty second regime is dropped.
+    state = _state(num=6)
+    _extract(state, _plan({"name": "A"}, {"name": "B"}))
+    plan = state["series_analysis_plan"]
+    print("5) initial planning without indices (pre-existing fallback):")
+    check("collapses to 1 regime as before",
+          plan is not None and len(plan["regimes"]) == 1
+          and plan["regimes"][0]["spectrum_indices"] == [0, 1, 2, 3, 4, 5])
+
+    # 6) Count changed AND names changed: no safe match -> fallback as before
+    #    (a deliberate restructure is not second-guessed).
+    state = _state([
+        {"name": "A", "spectrum_indices": [0, 1, 2]},
+        {"name": "B", "spectrum_indices": [3, 4, 5]},
+    ], num=6)
+    _extract(state, _plan({"name": "X"}, {"name": "Y"}, {"name": "Z"}))
+    plan = state["series_analysis_plan"]
+    print("6) restructured revision (3 new names, no indices):")
+    check("no positional guess across counts; fallback applies",
+          plan is not None and len(plan["regimes"]) == 1
+          and plan["regimes"][0]["name"] == "X")
+
+    # 7) Compact index formatting for the validation prompt.
+    fmt = CurveFittingPlanningController._format_spectrum_indices
+    print("7) index formatting:")
+    check("ranges", fmt(list(range(0, 12))) == "0-11")
+    check("mixed", fmt([0, 1, 2, 5, 7, 8]) == "0-2, 5, 7-8")
+    check("single", fmt([4]) == "4")
+    check("empty", fmt([]) == "")
+
+    # 8) Validation-prompt regime section carries the indices + semantics.
+    section = CurveFittingPlanningController._build_regime_section(
+        {"regimes": [
+            {"name": "A", "spectrum_indices": list(range(0, 12)),
+             "physical_model": "PV", "parameters_to_extract": ["center"]},
+            {"name": "B", "spectrum_indices": list(range(12, 38)),
+             "physical_model": "PV", "parameters_to_extract": ["center"]},
+        ]})
+    print("8) validation regime section:")
+    check("shows indices", "spectra=[0-11]" in section
+          and "spectra=[12-37]" in section)
+    check("states omission semantics", "inherits" in section)
+    check("empty plan -> empty section",
+          CurveFittingPlanningController._build_regime_section(None) == "")
+
+    print("\n" + "=" * 50)
+    npass = sum(results.values())
+    print(f"SERIES PLAN REVISION: {npass}/{len(results)} checks passed")
+    for k, v in results.items():
+        if not v:
+            print("  FAILED:", k)
+    raise SystemExit(0 if npass == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

When the curve-fitting agent scouts a spectral series before planning, it previews at most 7 evenly-spaced spectra. A transition that falls *between* those scouted frames is invisible, and an overlay of many similar curves is hard to read — so the planner could only bound a regime boundary to the gap between two scouts.

This PR adds a cheap, deterministic **full-series change detection** step to the scout: a mean-centered SVD over *every* spectrum in the series (the same `reduce_series` machinery already proven in fan-out steering), reported to the planner next to the existing overlay as a computed change point, a sharpness score, artifact flags, and a score-vs-temperature figure. The visual scout is unchanged and remains the evidence for *what* changes; the computed signal says *where* to look.

On real data this works at sub-scout resolution: on a 38-frame ibuprofen dehydration XRD series the detector reported 47 °C (independent frame-correlation truth: 48–51 °C) and the planner placed the dihydrate/dehydrated boundary at frame 11 — finer than the scout spacing could justify. On a 53-frame IMAuCl4 transformation series it reported 71.3 °C against a 70.4–72.1 °C truth window.

The detector is honest about its limits, as computed flags rather than prose: a drift-only series is flagged `intensity_drift` and a continuously shifting band `shift_dominated` (with a caution that loadings must not be read as component spectra) — and in live tests the planner correctly kept **single-regime** plans for both, fabricating no transitions.

Live testing also exposed and fixed a pre-existing bug: a plan-validation revision that returned regimes without `spectrum_indices` silently collapsed a multi-regime plan into one regime. Revisions now preserve the assignment (shown to the validator, inherited when omitted), and the validator is told the overlay is a subsample so it doesn't mistake 7 overlay curves for the whole series.

---

**Technical details**

*Feature (`d020cf71`)*
- `scilink/skills/_shared/series_reduction.py` — in-memory `reduce_curves(curves, controls, control_source, …, return_figure)` core extracted from `reduce_series`; the file-based wrapper keeps its control-variable discovery and exact return contract (existing suite 17/17 unchanged). `return_figure=True` returns the score-curve PNG as bytes for prompt embedding.
- `SeriesScoutController._run_series_reduction` — runs after the visual scout; control axis from `series_metadata.values` (numeric, per-spectrum) else frame index; evenly-subsampled 256-row cap on very long series (marked in the output); result under `state["series_reduction"]`, `None` on any failure — never blocks the scout.
- `CurveFittingPlanningController._append_scout_context` — appends the change-detection block (change point, sharpness, variance explained, flags, caution) + score-curve image after the overlay; absent key → absent block. Reused by the refinement path.

*Revision fix (`376ad571`)*
- `_validate_plan` regime section (extracted as `_build_regime_section`) now shows each regime's `spectrum_indices` in compact ranges with stated omission semantics; the Data figure carries an n-of-N subsample note (pre-fix, the validator read the overlay legend as the whole series and "corrected" valid indices down to the scouted count — observed live twice).
- `_extract_series_plan` inherits omitted indices from the plan being revised: name match first, positional only when the regime count is unchanged; explicit indices always win; count-and-names restructures deliberately fall through to the previous fallback.

*Validation*
- Offline: `tests/test_scout_series_reduction.py` (28 checks, incl. a transition planted between scout indices), `tests/test_series_plan_revision.py` (17 checks, incl. an exact replay of the live collapse), existing `test_series_reduction.py` 17/17.
- Live (Bedrock Opus 4.8, 8 scenarios, all green): ibuprofen 38-frame XRD 6/6; IMAuCl4 53-frame XRD 6/6 pre-fix baseline + 6/6 post-fix with revision; synthetic planted-truth 5/5; phantom-transition hint 5/5 (planner tested and validator rejected a claimed transition the data lacks); honest-null drift 5/5 (single regime); shift-dominated 5/5 (single regime, caution fired); edge single/n=3/n=5 8/8 (scout bypass, graceful <4-point skip, minimal-series boundary). `tests/test_scout_reduction_live.py` is the committed synthetic harness.

*Known limits*
- The change point is a single steepest-step estimate; a multi-stage transformation reports only the dominant step (the IMAuCl4 planner still resolved three regimes from the visual evidence).
- Change-point-steered scout *frame selection* (bracketing the detected transition instead of even spacing) is a deliberate follow-up, not in this PR.