### PR TITLE
Failure-path hardening: honest total-failure status, partial passthrough, adaptive timeouts

### DIFF
--- a/scilink/agents/exp_agents/_locked_exec.py
+++ b/scilink/agents/exp_agents/_locked_exec.py
@@ -23,10 +23,13 @@ was actually duplicated and fragile.
 """
 
 import json
+import logging
 import os
 from pathlib import Path
 
 import numpy as np
+
+_LOG = logging.getLogger(__name__)
 
 DATA_NAME = "data.npy"
 VIZ_NAME = "visualization.png"
@@ -70,7 +73,8 @@ def script_uses_canonical_input(script: str, data_name: str = DATA_NAME) -> bool
 def stage_and_run(executor, script, primary_array, item_dir, *,
                   data_name: str = DATA_NAME, viz_name: str = VIZ_NAME,
                   aux: dict = None, metadata: dict = None,
-                  meta_name: str = META_NAME) -> dict:
+                  meta_name: str = META_NAME,
+                  timeout: int | None = None) -> dict:
     """Stage ``primary_array`` as ``data_name`` in ``item_dir`` and run ``script``
     VERBATIM there (working_dir=item_dir), then collect the canonical viz.
 
@@ -100,7 +104,8 @@ def stage_and_run(executor, script, primary_array, item_dir, *,
     viz = item_dir / viz_name
     viz.unlink(missing_ok=True)   # clear any stale viz before the run
 
-    exec_res = executor.execute_script(script, working_dir=str(item_dir))
+    exec_res = executor.execute_script(script, working_dir=str(item_dir),
+                                       timeout=timeout)
 
     has_viz = viz.exists()
     return {
@@ -112,3 +117,51 @@ def stage_and_run(executor, script, primary_array, item_dir, *,
         "visualization_bytes": viz.read_bytes() if has_viz else None,
         "item_dir": str(item_dir),
     }
+
+
+# Adaptive-timeout policy for the per-item attempt loops. A subprocess that
+# times out is rarely "broken code" — usually the fit just needs longer.
+# Re-running the SAME script with 2× the timeout, up to a hard cap, avoids
+# burning LLM tokens on a correction pass "fixing" code that wasn't wrong.
+TIMEOUT_ESCALATIONS = 2
+TIMEOUT_GROWTH = 2.0
+TIMEOUT_HARD_CAP_S = 1800
+
+
+def stage_and_run_adaptive(executor, script, primary_array, item_dir, *,
+                           aux: dict = None, metadata: dict = None,
+                           logger=None) -> dict:
+    """`stage_and_run` with adaptive timeout escalation.
+
+    Starts at the executor's configured timeout; on a timeout, retries the
+    SAME script with a doubled timeout, up to ``TIMEOUT_ESCALATIONS`` retries
+    bounded by ``TIMEOUT_HARD_CAP_S``. Non-timeout failures are returned
+    as-is so the caller's script-correction loop handles them. The final
+    (still timed-out) result is returned unchanged, so the correction LLM
+    sees the standard "timed out" message.
+    """
+    log = logger or _LOG
+    current = int(executor.timeout)
+    run = None
+    for esc in range(TIMEOUT_ESCALATIONS + 1):
+        run = stage_and_run(executor, script, primary_array, item_dir,
+                            aux=aux, metadata=metadata, timeout=current)
+        if run["status"] == "success":
+            return run
+        msg = (run["exec"].get("message") or "").lower()
+        if "timed out" not in msg:
+            return run  # genuine script error — the correction loop's job
+        next_timeout = min(int(current * TIMEOUT_GROWTH), TIMEOUT_HARD_CAP_S)
+        if next_timeout <= current or esc >= TIMEOUT_ESCALATIONS:
+            log.warning(
+                f"    ⏱  Timed out at {current}s; escalation budget exhausted "
+                f"({TIMEOUT_ESCALATIONS} retries, {TIMEOUT_HARD_CAP_S}s cap) "
+                f"— handing the timeout to the correction loop."
+            )
+            return run
+        log.warning(
+            f"    ⏱  Script timed out at {current}s — retrying same script "
+            f"with {next_timeout}s (escalation {esc + 1}/{TIMEOUT_ESCALATIONS})"
+        )
+        current = next_timeout
+    return run

--- a/scilink/agents/exp_agents/_locked_exec.py
+++ b/scilink/agents/exp_agents/_locked_exec.py
@@ -119,6 +119,43 @@ def stage_and_run(executor, script, primary_array, item_dir, *,
     }
 
 
+def is_timeout_error(err) -> bool:
+    """True when an attempt error is the executor's timeout message."""
+    return "timed out" in str(err or "").lower()
+
+
+def trailing_timeout_failures(attempts: list) -> int:
+    """Count consecutive TRAILING attempts that failed on execution timeout.
+
+    Used to tell a refit/rewrite that the recent failures were budget
+    failures, not quality failures — a different-but-equally-slow approach
+    would fail the same way.
+    """
+    n = 0
+    for a in reversed(attempts or []):
+        r = a.get("result") or {}
+        if r.get("success") is False and is_timeout_error(r.get("error")):
+            n += 1
+        else:
+            break
+    return n
+
+
+def should_escalate_timeout_model(base_script, attempt: int,
+                                  max_attempts: int,
+                                  consecutive_timeouts: int) -> bool:
+    """Last-resort model escalation predicate (shared by curve + image).
+
+    Fires ONLY on the final TWO corrections of a fresh fit (base_script
+    None — locked-reuse items must never restructure) whose recent failures
+    are >= 2 consecutive timeouts. Two chances, not one: a restructured
+    script sometimes carries an introduced bug, and a crash resets the
+    consecutive-timeout counter, so the very next correction naturally takes
+    the plain debug path and can fix it (observed live)."""
+    return (base_script is None and attempt >= max_attempts - 1
+            and consecutive_timeouts >= 2)
+
+
 # Adaptive-timeout policy for the per-item attempt loops. A subprocess that
 # times out is rarely "broken code" — usually the fit just needs longer.
 # Re-running the SAME script with 2× the timeout, up to a hard cap, avoids

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1161,20 +1161,25 @@ class AnalysisOrchestratorAgent:
             )
             return data_path
 
-    def create_agent_for_analysis(self, agent_id: int, output_dir: str) -> Any:
+    def create_agent_for_analysis(self, agent_id: int, output_dir: str,
+                                  executor_timeout: int = None) -> Any:
         """
         Create an agent instance configured for a specific analysis run.
-        
+
         Each analysis run gets a fresh agent instance with its own output
         directory, ensuring outputs from different analyses don't collide.
-        
+
         Args:
             agent_id: The agent type ID (0-2)
             output_dir: Unique output directory for this analysis run
-            
+            executor_timeout: Optional per-run script-execution timeout in
+                seconds (the adaptive-escalation ladder starts from this
+                value). None keeps the agent's default. Filtered out by the
+                signature check below for agents that don't accept it.
+
         Returns:
             Configured agent instance
-            
+
         Raises:
             ValueError: If agent_id is invalid
         """
@@ -1196,6 +1201,8 @@ class AnalysisOrchestratorAgent:
             # (hyperspectral, FFT, SAM, atomistic) — passing it would raise.
             "analysis_depth": self.image_analysis_depth,
         }
+        if executor_timeout is not None:
+            common_kwargs["executor_timeout"] = int(executor_timeout)
 
         # Lazy-load built-in agents; custom agents already carry their class.
         cls = entry.get("class")

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2821,7 +2821,12 @@ class AnalysisOrchestratorTools:
                 self.orch.analysis_results.append(analysis_record)
                 
                 # === Format response ===
-                if result.get("status") == "success":
+                # "partial" is hyperspectral's salvage outcome (approximate /
+                # withheld maps with honest caveats) — a usable, degraded
+                # result. It gets the full success-shaped payload with its
+                # caveats attached, NOT the error branch (which used to
+                # surface it as an error with an empty error object).
+                if result.get("status") in ("success", "partial"):
                     # Find main visualization
                     viz_path = None
                     for candidate in analysis_output_dir.rglob("*_analysis.png"):
@@ -2838,7 +2843,7 @@ class AnalysisOrchestratorTools:
                                 break
 
                     response = {
-                        "status": "success",
+                        "status": result.get("status"),
                         "analysis_id": analysis_id,
                         "agent_used": self.AGENT_NAMES.get(agent_id),
                         "output_directory": str(analysis_output_dir),
@@ -2848,6 +2853,17 @@ class AnalysisOrchestratorTools:
                         "note": f"All outputs saved to: {analysis_output_dir}",
                         "next_steps": "Use assess_novelty to check literature for these claims, or get_recommendations for follow-up experiments.",
                     }
+                    if result.get("status") == "partial":
+                        response["confidence"] = result.get("confidence")
+                        response["warnings"] = result.get("warnings") or []
+                        if result.get("degraded_outputs"):
+                            response["degraded_outputs"] = result[
+                                "degraded_outputs"]
+                        response["note"] = (
+                            "PARTIAL result: some outputs are approximate or "
+                            "were withheld (see warnings). "
+                            + response["note"]
+                        )
                     if viz_path:
                         response["visualization_path"] = viz_path
                     if result.get("tier2_results"):

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2190,6 +2190,7 @@ class AnalysisOrchestratorTools:
             max_verification_iterations: int = None,
             starting_annealing_level: int = None,
             n_candidates: int = None,
+            executor_timeout: int = None,
         ) -> str:
             """
             Execute analysis with the selected or specified agent.
@@ -2640,7 +2641,9 @@ class AnalysisOrchestratorTools:
                 # NOTE: Code-executing agents may prompt the user
                 # for sandbox approval and raise RuntimeError if declined.
                 try:
-                    agent = self.orch.create_agent_for_analysis(agent_id, str(analysis_output_dir))
+                    agent = self.orch.create_agent_for_analysis(
+                        agent_id, str(analysis_output_dir),
+                        executor_timeout=executor_timeout)
                 except RuntimeError as e:
                     # Handle sandbox rejection or other init failures
                     error_msg = str(e)
@@ -3167,6 +3170,20 @@ class AnalysisOrchestratorTools:
                         "skill's R² gate (a warning is logged on conflict), but it "
                         "will NOT replace a skill that scores by a non-R² metric. "
                         "Leave unset for standard analyses."
+                    )
+                },
+                "executor_timeout": {
+                    "type": "integer",
+                    "description": (
+                        "All analysis agents. Per-run script-execution timeout "
+                        "in seconds (default 600; the adaptive escalation "
+                        "ladder retries a timed-out script at 2x up to 1800 s "
+                        "before any LLM correction). RAISE it when a previous "
+                        "run of the same data failed with 'Script execution "
+                        "timed out' or when the dataset is very large and a "
+                        "single fit legitimately needs longer; LOWER it (e.g. "
+                        "30-60) for real-time/quick-look turnaround where a "
+                        "slow fit should fail fast. Leave unset otherwise."
                     )
                 },
                 "max_verification_iterations": {

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -2669,26 +2669,12 @@ def _write_series_fit_results(output_dir, state, series_results, quality_setting
 # Backwards-compatible alias (pre-rename import path).
 HumanFeedbackRefinementController = CurveFittingPlanningController
 
-def _is_timeout_error(err) -> bool:
-    """True when an attempt error is the executor's timeout message."""
-    return "timed out" in str(err or "").lower()
-
-
-def _trailing_timeout_failures(attempts: list) -> int:
-    """Count consecutive TRAILING attempts that failed on execution timeout.
-
-    Used to tell a refit/rewrite that the recent failures were budget
-    failures, not fit-quality failures — a different-but-equally-slow
-    approach would fail the same way.
-    """
-    n = 0
-    for a in reversed(attempts or []):
-        r = a.get("result") or {}
-        if r.get("success") is False and _is_timeout_error(r.get("error")):
-            n += 1
-        else:
-            break
-    return n
+# Shared timeout-failure helpers (one copy for curve + image) — re-exported
+# under the historical underscore names so existing imports keep working.
+from .._locked_exec import (  # noqa: E402
+    is_timeout_error as _is_timeout_error,
+    trailing_timeout_failures as _trailing_timeout_failures,
+)
 
 
 class UnifiedSeriesProcessingController:
@@ -3109,15 +3095,11 @@ Your guidance: '''
     def _should_escalate_timeout_model(base_script, attempt: int,
                                        max_attempts: int,
                                        consecutive_timeouts: int) -> bool:
-        """Fire the last-resort model escalation ONLY on the final TWO
-        corrections of a fresh fit (base_script None — locked-reuse fits must
-        never restructure) whose recent failures are >= 2 consecutive
-        timeouts. Two chances, not one: a restructured script sometimes
-        carries an introduced bug, and a crash resets the consecutive-timeout
-        counter, so the very next correction naturally takes the plain
-        debug path and can fix it (observed live)."""
-        return (base_script is None and attempt >= max_attempts - 1
-                and consecutive_timeouts >= 2)
+        """See :func:`_locked_exec.should_escalate_timeout_model` (shared
+        with image analysis)."""
+        from .._locked_exec import should_escalate_timeout_model
+        return should_escalate_timeout_model(
+            base_script, attempt, max_attempts, consecutive_timeouts)
 
     def _correct_script_with_timeout_escalation(
             self, state: dict, script: str, error_msg: str) -> tuple[str, str]:
@@ -3436,7 +3418,13 @@ Your guidance: '''
                     else:
                         script, diagnosis = self._correct_script(
                             state, script, last_error)
-                    script_errors.append({"error": last_error, "diagnosis": diagnosis})
+                    entry = {"error": last_error, "diagnosis": diagnosis}
+                    if _is_timeout_error(last_error):
+                        # Structured failure-mode tag: lets the fallback
+                        # judge / post-hoc sweeps filter timeouts without
+                        # string-matching the message.
+                        entry["kind"] = "timeout"
+                    script_errors.append(entry)
 
                 state["_verify_working_dir"] = str(item_dir)
                 # Adaptive timeout: a slow-but-correct script is retried
@@ -3485,7 +3473,7 @@ Your guidance: '''
               and run["visualization_path"] is not None
               and "FIT_RESULTS_JSON:" in run["stdout"])
         if not ok:
-            return {
+            failure = {
                 "index": spectrum_idx,
                 "name": spectrum_name,
                 "success": False,
@@ -3495,6 +3483,9 @@ Your guidance: '''
                 "script": script,
                 "script_errors": script_errors,
             }
+            if _is_timeout_error(last_error):
+                failure["kind"] = "timeout"
+            return failure
 
         fit_results = _parse_script_markers(run["stdout"])
 
@@ -5149,18 +5140,29 @@ Return JSON with:
         else:
             # Surface the last attempt's own error (e.g. the realtime
             # pre-flight gate's reason) instead of only the generic summary.
-            last_err = next(
-                (e for e in ((a.get("result") or {}).get("error")
-                             for a in reversed(ctx.all_attempts)) if e),
-                None,
+            last_result = next(
+                (r for r in ((a.get("result") or {})
+                             for a in reversed(ctx.all_attempts))
+                 if r.get("error")),
+                {},
             )
-            return {
+            last_err = last_result.get("error")
+            failure = {
                 "index": ctx.item_idx, "name": ctx.item_name, "success": False,
                 "error": ("All fitting attempts failed"
                           + (f": {last_err}" if last_err else "")),
                 "attempts": len(ctx.all_attempts),
                 "parameters": {}, "fit_quality": {},
             }
+            # Carry the structured failure-mode tag and the per-attempt
+            # audit trail from the underlying attempt result — without this,
+            # the anchor's fallback dict lost the kind=timeout tag that
+            # _fit_single_spectrum set (observed live).
+            if last_result.get("kind"):
+                failure["kind"] = last_result["kind"]
+            if last_result.get("script_errors"):
+                failure["script_errors"] = last_result["script_errors"]
+            return failure
 
     def _fit_with_quality_control_best_of_n(
         self,

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -34,8 +34,8 @@ from typing import Callable, Optional, Any, Dict, List
 import numpy as np
 
 from .._locked_exec import (
-    stage_and_run, script_uses_canonical_input, DATA_NAME, CANDIDATES_DIR_NAME,
-    atomic_np_save,
+    stage_and_run, stage_and_run_adaptive, script_uses_canonical_input,
+    DATA_NAME, CANDIDATES_DIR_NAME, atomic_np_save,
 )
 from .._qc_engine import CodegenQCEngine, QCEngineSpec, QCItemContext
 from ....utils.codegen_parse import parse_codegen_response
@@ -3339,8 +3339,12 @@ Your guidance: '''
                     script_errors.append({"error": last_error, "diagnosis": diagnosis})
 
                 state["_verify_working_dir"] = str(item_dir)
-                run = stage_and_run(self.executor, script, curve_data, item_dir,
-                                    aux=extra_operands)
+                # Adaptive timeout: a slow-but-correct script is retried
+                # verbatim with doubled timeouts before the correction LLM
+                # ever sees a "timed out" error.
+                run = stage_and_run_adaptive(self.executor, script, curve_data,
+                                             item_dir, aux=extra_operands,
+                                             logger=self.logger)
                 exec_result = run["exec"]
 
                 if run["status"] == "success":

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -2669,6 +2669,28 @@ def _write_series_fit_results(output_dir, state, series_results, quality_setting
 # Backwards-compatible alias (pre-rename import path).
 HumanFeedbackRefinementController = CurveFittingPlanningController
 
+def _is_timeout_error(err) -> bool:
+    """True when an attempt error is the executor's timeout message."""
+    return "timed out" in str(err or "").lower()
+
+
+def _trailing_timeout_failures(attempts: list) -> int:
+    """Count consecutive TRAILING attempts that failed on execution timeout.
+
+    Used to tell a refit/rewrite that the recent failures were budget
+    failures, not fit-quality failures — a different-but-equally-slow
+    approach would fail the same way.
+    """
+    n = 0
+    for a in reversed(attempts or []):
+        r = a.get("result") or {}
+        if r.get("success") is False and _is_timeout_error(r.get("error")):
+            n += 1
+        else:
+            break
+    return n
+
+
 class UnifiedSeriesProcessingController:
     """
     Processes ALL spectra using the locked fitting model.
@@ -3063,6 +3085,60 @@ Your guidance: '''
 
         return result["script"]
 
+    # Last-resort model escalation for persistent execution timeouts. The
+    # locked-model rule (and its narrow computational-strategy carve-out)
+    # is the norm; this clause fires only when even carve-out corrections
+    # kept timing out on a FRESH (non-locked-reuse) fit — meaning the
+    # locked model itself is infeasible within the execution budget.
+    _TIMEOUT_MODEL_ESCALATION_CLAUSE = (
+        "\n**TIMEOUT ESCALATION — LAST RESORT. This clause SUPERSEDES the "
+        "CRITICAL rule and the timeout exception above for this single "
+        "correction:** computational-strategy fixes were already attempted "
+        "in earlier corrections and the script STILL exceeds the execution "
+        "budget — efficiency alone has failed, so the locked model itself "
+        "is computationally infeasible. RESTRUCTURE the model into a "
+        "computationally feasible alternative that preserves the plan's "
+        "scientific intent (fewer components, a cheaper lineshape, an "
+        "analytic approximation). Do not return another implementation of "
+        "the same infeasible model. The fit window and the data remain "
+        "untouchable: full window, ALL of the data. State exactly what you "
+        "changed and why in `diagnosis`.\n"
+    )
+
+    @staticmethod
+    def _should_escalate_timeout_model(base_script, attempt: int,
+                                       max_attempts: int,
+                                       consecutive_timeouts: int) -> bool:
+        """Fire the last-resort model escalation ONLY on the final TWO
+        corrections of a fresh fit (base_script None — locked-reuse fits must
+        never restructure) whose recent failures are >= 2 consecutive
+        timeouts. Two chances, not one: a restructured script sometimes
+        carries an introduced bug, and a crash resets the consecutive-timeout
+        counter, so the very next correction naturally takes the plain
+        debug path and can fix it (observed live)."""
+        return (base_script is None and attempt >= max_attempts - 1
+                and consecutive_timeouts >= 2)
+
+    def _correct_script_with_timeout_escalation(
+            self, state: dict, script: str, error_msg: str) -> tuple[str, str]:
+        """`_correct_script` under the last-resort timeout escalation: the
+        escalation clause is injected and the annealing level is raised to
+        hot for this ONE call (skill strictness relaxes in lockstep), then
+        both are restored so no later stage sees the elevated state."""
+        saved_level = state.get("_annealing_level", 0)
+        state["_timeout_model_escalation"] = True
+        state["_annealing_level"] = max(saved_level, self._hot_annealing_level)
+        self.logger.warning(
+            "    🔥 Last-resort timeout escalation: allowing model "
+            "restructure on the final correction (consecutive execution "
+            "timeouts persisted after computational fixes)."
+        )
+        try:
+            return self._correct_script(state, script, error_msg)
+        finally:
+            state["_annealing_level"] = saved_level
+            state.pop("_timeout_model_escalation", None)
+
     def _correct_script(self, state: dict, script: str, error_msg: str) -> tuple[str, str]:
         """Return ``(corrected_script, diagnosis)``."""
         config = state.get("locked_fitting_config", {})
@@ -3073,6 +3149,19 @@ Your guidance: '''
             error_message=error_msg,
             tool_inventory=_tool_inventory_text(state),
         )
+        # Last-resort timeout escalation (set transiently by
+        # _correct_script_with_timeout_escalation; absent otherwise).
+        # Injected BEFORE the response-format footer — appended after it,
+        # the clause loses to the two locked-model prohibitions above
+        # (observed live: the LLM kept an infeasible 40-component model).
+        if state.get("_timeout_model_escalation"):
+            marker = "**Response:**"
+            if marker in prompt:
+                prompt = prompt.replace(
+                    marker,
+                    self._TIMEOUT_MODEL_ESCALATION_CLAUSE + "\n" + marker, 1)
+            else:
+                prompt += self._TIMEOUT_MODEL_ESCALATION_CLAUSE
         # Codegen recipe from ALL co-active skills (see _generate_fitting_script).
         recipes = _collect_codegen_recipe(state)
         if recipes:
@@ -3291,6 +3380,8 @@ Your guidance: '''
         last_error = ""
         run = None
         script_errors: list[dict] = []
+        consecutive_timeouts = 0
+        used_timeout_escalation = False
 
         for attempt in range(1, self.MAX_ATTEMPTS + 1):
             try:
@@ -3335,7 +3426,16 @@ Your guidance: '''
                             "; ".join(conformance["justified_deviations"]),
                         )
                 else:
-                    script, diagnosis = self._correct_script(state, script, last_error)
+                    if self._should_escalate_timeout_model(
+                            base_script, attempt, self.MAX_ATTEMPTS,
+                            consecutive_timeouts):
+                        script, diagnosis = (
+                            self._correct_script_with_timeout_escalation(
+                                state, script, last_error))
+                        used_timeout_escalation = True
+                    else:
+                        script, diagnosis = self._correct_script(
+                            state, script, last_error)
                     script_errors.append({"error": last_error, "diagnosis": diagnosis})
 
                 state["_verify_working_dir"] = str(item_dir)
@@ -3366,11 +3466,16 @@ Your guidance: '''
                             f"'visualization.png' in the working directory."
                         )
                         self.logger.warning(f"    ⚠️ Attempt {attempt}: Script ran but missing outputs: {', '.join(missing)}")
+                        consecutive_timeouts = 0
                 else:
                     last_error = exec_result.get("message", "Unknown error")
+                    consecutive_timeouts = (
+                        consecutive_timeouts + 1
+                        if _is_timeout_error(last_error) else 0)
                     self.logger.warning(f"    ⚠️ Attempt {attempt} failed: {last_error[:100]}")
             except Exception as e:
                 last_error = str(e)
+                consecutive_timeouts = 0
                 self.logger.error(f"    ❌ Attempt {attempt} error: {e}")
 
         # Success iff the final run produced BOTH the marker and the viz (matches
@@ -3500,6 +3605,11 @@ Your guidance: '''
             "script": script,
             "script_errors": script_errors,
         }
+        if used_timeout_escalation:
+            # Provenance: this fit came from the last-resort model
+            # restructure after persistent timeouts — the executed script,
+            # not the locked plan prose, is authoritative for the model.
+            result["timeout_model_escalation"] = True
         # Fingerprint of the data this script solved (script bank, #346) —
         # stamped here because per-spectrum arrays for file inputs never reach
         # the outer state the bank write hook reads. No-op unless the bank is
@@ -4684,13 +4794,30 @@ Return JSON with:
         else:
             self.logger.info(f"   Refitting with verification feedback...")
 
+        # Timeout-aware refit context: when the trailing refit attempt(s)
+        # died on execution timeouts, say so explicitly — the stall counter
+        # that drives annealing is cause-blind, and without this a hot
+        # rewrite has model freedom but no signal that COST is the problem
+        # (it could regenerate another equally slow approach). No trailing
+        # timeouts -> identical issues list, no behavior change.
+        issues = list(verification.get("issues_found", []))
+        n_timeouts = _trailing_timeout_failures(ctx.all_attempts)
+        if n_timeouts:
+            issues.append(
+                f"EXECUTION BUDGET: the previous {n_timeouts} attempt(s) "
+                f"failed by execution TIMEOUT, not by fit quality. The next "
+                f"approach must be computationally cheaper (vectorized, "
+                f"efficient optimizer, fewer expensive components) — a "
+                f"different but equally slow approach will fail the same way."
+            )
+
         return self._fit_single_spectrum(
             state=ctx.state, curve_data=ctx.data, data_path=ctx.data_path,
             spectrum_name=ctx.item_name, spectrum_idx=ctx.item_idx,
             base_script=None,
             refine_from_script=refine_from,
             refine_from_r2=ctx.best_score,
-            refine_from_issues=verification.get("issues_found", []),
+            refine_from_issues=issues,
         )
 
     def qc_after_refit(self, ctx: QCItemContext, verified_result: dict,

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -36,6 +36,7 @@ import numpy as np
 
 from .._locked_exec import (
     stage_and_run, stage_and_run_adaptive, script_uses_canonical_input,
+    is_timeout_error, trailing_timeout_failures, should_escalate_timeout_model,
     DATA_NAME, VIZ_NAME, CANDIDATES_DIR_NAME, atomic_np_save,
 )
 from .._qc_engine import CodegenQCEngine, QCEngineSpec, QCItemContext
@@ -2017,6 +2018,7 @@ Your guidance: '''
         data_path: str,
         stats: dict,
         base_script: str | None = None,
+        extra_issues: list | None = None,
     ) -> str:
         """Generate an image analysis script using the locked config.
 
@@ -2024,9 +2026,18 @@ Your guidance: '''
         prompt to adapt the previous attempt's script to the refined plan
         rather than regenerating from scratch. When ``None`` or empty,
         falls back to fresh generation via ``self.script_instructions``.
+
+        ``extra_issues`` (optional) — findings from prior attempts the new
+        script must address (e.g. the qc_refit EXECUTION BUDGET note when
+        trailing attempts failed by timeout). None/empty is a no-op.
         """
         config = state.get("locked_analysis_config", {})
         context_parts = []
+        if extra_issues:
+            context_parts.append(
+                "## Prior-attempt findings (address these)\n"
+                + "\n".join(f"- {i}" for i in extra_issues)
+            )
         # Authoritative calibration: when the caller supplied spatial metadata it
         # is staged as ``metadata.json`` in the working directory (see
         # stage_and_run). Point the generated script at it so pixel size and the
@@ -2237,6 +2248,47 @@ Your guidance: '''
 
         return result["script"]
 
+    # Last-resort pipeline escalation for persistent execution timeouts —
+    # the image twin of the curve controller's clause. Fires only when even
+    # carve-out corrections kept timing out on a FRESH (non-locked-reuse)
+    # analysis, meaning the locked pipeline itself is infeasible within the
+    # execution budget.
+    _TIMEOUT_MODEL_ESCALATION_CLAUSE = (
+        "\n**TIMEOUT ESCALATION — LAST RESORT. This clause SUPERSEDES the "
+        "CRITICAL rule and the timeout exception above for this single "
+        "correction:** computational-strategy fixes were already attempted "
+        "in earlier corrections and the script STILL exceeds the execution "
+        "budget — efficiency alone has failed, so the locked pipeline "
+        "itself is computationally infeasible. RESTRUCTURE the pipeline "
+        "into a computationally feasible alternative that preserves the "
+        "plan's scientific intent and still extracts the planned features "
+        "(a cheaper segmentation/detection method, coarser internal search, "
+        "fewer expensive stages). Do not return another implementation of "
+        "the same infeasible pipeline. The full image extent remains "
+        "untouchable. State exactly what you changed and why in "
+        "`diagnosis`.\n"
+    )
+
+    def _correct_script_with_timeout_escalation(
+            self, state: dict, script: str, error_msg: str) -> tuple:
+        """`_correct_script` under the last-resort timeout escalation: the
+        escalation clause is injected and the annealing level is raised to
+        hot for this ONE call (skill strictness relaxes in lockstep), then
+        both are restored so no later stage sees the elevated state."""
+        saved_level = state.get("_annealing_level", 0)
+        state["_timeout_model_escalation"] = True
+        state["_annealing_level"] = max(saved_level, self._hot_annealing_level)
+        self.logger.warning(
+            "    🔥 Last-resort timeout escalation: allowing pipeline "
+            "restructure on this correction (consecutive execution "
+            "timeouts persisted after computational fixes)."
+        )
+        try:
+            return self._correct_script(state, script, error_msg)
+        finally:
+            state["_annealing_level"] = saved_level
+            state.pop("_timeout_model_escalation", None)
+
     def _correct_script(
         self, state: dict, script: str, error_msg: str
     ) -> tuple:
@@ -2257,6 +2309,18 @@ Your guidance: '''
             error_message=error_msg,
             tool_inventory=format_tool_inventory("image_analysis", active_skills=active_skills),
         )
+        # Last-resort timeout escalation (set transiently by
+        # _correct_script_with_timeout_escalation; absent otherwise).
+        # Injected BEFORE the response-format footer — appended after it,
+        # the clause loses to the locked-pipeline prohibitions above.
+        if state.get("_timeout_model_escalation"):
+            marker = "**Response:**"
+            if marker in prompt:
+                prompt = prompt.replace(
+                    marker,
+                    self._TIMEOUT_MODEL_ESCALATION_CLAUSE + "\n" + marker, 1)
+            else:
+                prompt += self._TIMEOUT_MODEL_ESCALATION_CLAUSE
         # Codegen recipe from ALL co-active skills (see the generate-script path).
         recipes = _collect_codegen_recipe(state)
         if recipes:
@@ -2354,6 +2418,7 @@ Your guidance: '''
         image_idx: int,
         base_script: Optional[str] = None,
         refine_from_script: Optional[str] = None,
+        refine_from_issues: Optional[list] = None,
     ) -> dict:
         """Execute analysis pipeline on a single image with retry logic.
 
@@ -2393,6 +2458,8 @@ Your guidance: '''
         run = None
         script_errors = []
         last_diagnosis = None
+        consecutive_timeouts = 0
+        used_timeout_escalation = False
 
         for attempt in range(1, self.MAX_ATTEMPTS + 1):
             try:
@@ -2404,6 +2471,7 @@ Your guidance: '''
                         DATA_NAME,
                         stats,
                         base_script=refine_from_script,
+                        extra_issues=refine_from_issues,
                     )
                     if not script_uses_canonical_input(script):
                         last_error = (
@@ -2436,9 +2504,17 @@ Your guidance: '''
                             "; ".join(conformance["justified_deviations"]),
                         )
                 else:
-                    script, last_diagnosis = self._correct_script(
-                        state, script, last_error
-                    )
+                    if should_escalate_timeout_model(
+                            base_script, attempt, self.MAX_ATTEMPTS,
+                            consecutive_timeouts):
+                        script, last_diagnosis = (
+                            self._correct_script_with_timeout_escalation(
+                                state, script, last_error))
+                        used_timeout_escalation = True
+                    else:
+                        script, last_diagnosis = self._correct_script(
+                            state, script, last_error
+                        )
 
                 # Sanitize the script
                 script = self._sanitize_script(script)
@@ -2480,19 +2556,28 @@ Your guidance: '''
                             "fix": (last_diagnosis or "")[:300] or None,
                         })
                         last_diagnosis = None
+                        consecutive_timeouts = 0
                 else:
                     last_error = exec_result.get("message", "Unknown error")
                     self.logger.warning(
                         f"    Attempt {attempt} failed: {last_error[:100]}"
                     )
-                    script_errors.append({
+                    entry = {
                         "attempt": attempt,
                         "error": last_error[:300],
                         "fix": (last_diagnosis or "")[:300] or None,
-                    })
+                    }
+                    if is_timeout_error(last_error):
+                        # Structured failure-mode tag (matches curve).
+                        entry["kind"] = "timeout"
+                        consecutive_timeouts += 1
+                    else:
+                        consecutive_timeouts = 0
+                    script_errors.append(entry)
                     last_diagnosis = None
             except Exception as e:
                 last_error = str(e)
+                consecutive_timeouts = 0
                 self.logger.error(f"    Attempt {attempt} error: {e}")
                 script_errors.append({
                     "attempt": attempt,
@@ -2506,7 +2591,7 @@ Your guidance: '''
               and run["visualization_path"] is not None
               and "IMAGE_ANALYSIS_RESULTS_JSON:" in run["stdout"])
         if not ok:
-            return {
+            failure = {
                 "index": image_idx,
                 "name": image_name,
                 "success": False,
@@ -2516,6 +2601,9 @@ Your guidance: '''
                 "script": script,
                 "script_errors": script_errors,
             }
+            if is_timeout_error(last_error):
+                failure["kind"] = "timeout"
+            return failure
 
         # Parse results from stdout
         analysis_results = {}
@@ -2546,6 +2634,11 @@ Your guidance: '''
             "script": script,
             "script_errors": script_errors,
         }
+        if used_timeout_escalation:
+            # Provenance: this analysis came from the last-resort pipeline
+            # restructure after persistent timeouts — the executed script,
+            # not the locked plan prose, is authoritative for the pipeline.
+            result["timeout_model_escalation"] = True
         # Fingerprint of the image this script solved (script bank, #346) —
         # stamped here because per-image arrays for file inputs never reach
         # the outer state the bank write hook reads. No-op unless the bank is
@@ -3666,11 +3759,27 @@ Return JSON with:
         self.logger.info(
             "   Re-analyzing with verification feedback..."
         )
+        # Timeout-aware refit context (matches curve): the stall counter
+        # that drives annealing is cause-blind, so a hot rewrite needs to be
+        # TOLD when the trailing failures were budget failures. No trailing
+        # timeouts -> no issues passed, no behavior change.
+        issues = None
+        n_timeouts = trailing_timeout_failures(ctx.all_attempts)
+        if n_timeouts:
+            issues = [
+                f"EXECUTION BUDGET: the previous {n_timeouts} attempt(s) "
+                f"failed by execution TIMEOUT, not by analysis quality. The "
+                f"next approach must be computationally cheaper (vectorized, "
+                f"cheaper segmentation/detection, fewer expensive stages) — "
+                f"a different but equally slow approach will fail the same "
+                f"way."
+            ]
         return self._process_single_image(
             state=ctx.state, image_data=ctx.data,
             data_path=ctx.data_path, image_name=ctx.item_name,
             image_idx=ctx.item_idx, base_script=None,
             refine_from_script=refine_from,
+            refine_from_issues=issues,
         )
 
     def qc_after_refit(self, ctx: QCItemContext, verified_result: dict,
@@ -3963,15 +4072,32 @@ Return JSON with:
             )
             return ctx.best_result
         else:
-            return {
+            # Carry error detail, the structured failure-mode tag, and the
+            # per-attempt audit trail from the underlying attempt result
+            # (matches curve; without this the anchor's fallback dict lost
+            # the kind=timeout tag that _process_single_image set).
+            last_result = next(
+                (r for r in ((a.get("result") or {})
+                             for a in reversed(ctx.all_attempts))
+                 if r.get("error")),
+                {},
+            )
+            last_err = last_result.get("error")
+            failure = {
                 "index": ctx.item_idx,
                 "name": ctx.item_name,
                 "success": False,
-                "error": "All analysis attempts failed",
+                "error": ("All analysis attempts failed"
+                          + (f": {last_err}" if last_err else "")),
                 "attempts": len(ctx.all_attempts),
                 "extracted_features": {},
                 "quality_metrics": {},
             }
+            if last_result.get("kind"):
+                failure["kind"] = last_result["kind"]
+            if last_result.get("script_errors"):
+                failure["script_errors"] = last_result["script_errors"]
+            return failure
 
     # Total image-byte budget for the best-of-N judge call (original image +
     # N candidate visualizations); per-image cap is derived from it.

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -35,7 +35,7 @@ from typing import Callable, Optional, Any, Dict, List
 import numpy as np
 
 from .._locked_exec import (
-    stage_and_run, script_uses_canonical_input,
+    stage_and_run, stage_and_run_adaptive, script_uses_canonical_input,
     DATA_NAME, VIZ_NAME, CANDIDATES_DIR_NAME, atomic_np_save,
 )
 from .._qc_engine import CodegenQCEngine, QCEngineSpec, QCItemContext
@@ -2443,8 +2443,13 @@ Your guidance: '''
                 # Sanitize the script
                 script = self._sanitize_script(script)
 
-                run = stage_and_run(self.executor, script, image_data, working_dir,
-                                    metadata=state.get("system_info"))
+                # Adaptive timeout: a slow-but-correct script is retried
+                # verbatim with doubled timeouts before the correction LLM
+                # ever sees a "timed out" error.
+                run = stage_and_run_adaptive(self.executor, script, image_data,
+                                             working_dir,
+                                             metadata=state.get("system_info"),
+                                             logger=self.logger)
                 exec_result = run["exec"]
 
                 if run["status"] == "success":

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -1795,6 +1795,14 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                     "fit_quality": r.get("fit_quality", {}),
                     "visualization_path": r.get("visualization_path"),
                     "error": r.get("error"),
+                    # Structured failure-mode tag ("timeout" today); absent
+                    # on successes and untagged failures. script_errors is
+                    # the per-attempt audit trail ({error, diagnosis, kind}
+                    # entries — no scripts), surfaced so callers can filter
+                    # failure modes without string-matching messages.
+                    **({"kind": r["kind"]} if r.get("kind") else {}),
+                    **({"script_errors": r["script_errors"]}
+                       if r.get("script_errors") else {}),
                     "flagged": r.get("flagged", False),
                     "flag_reason": r.get("flag_reason"),
                     "flag_recommendation": r.get("flag_recommendation"),

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -1675,6 +1675,22 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "task_mode": state.get("task_mode", "fitting"),
         }
 
+        # Zero-success guard: if every spectrum failed every attempt (a
+        # per-item condition, so no controller set error_dict), the run must
+        # not report top-level success — a caller checking only `status`
+        # would be misled. Salvaged best-available fits carry success=True
+        # (with quality_warning) and are unaffected.
+        if series_results and all(
+                isinstance(r, dict) and r.get("success") is False
+                for r in series_results):
+            item_errors = [r.get("error") for r in series_results
+                           if r.get("error")]
+            results["status"] = "error"
+            results["error"] = {
+                "error": f"All {len(series_results)} spectrum fit(s) failed",
+                "details": item_errors[-1] if item_errors else "",
+            }
+
         # Realtime provenance (#346 / plan §7.3): stamp the profile on the
         # top-level result AND each per-item quality_history so a post-hoc
         # sweep can select realtime frames for thorough re-analysis. Also

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -179,6 +179,18 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
     # PRIMARY ENTRY POINT
     # =========================================================================
 
+    @staticmethod
+    def _plain_total_dynamic_failure(records) -> bool:
+        """True when EVERY dynamic-analysis target failed PLAINLY — no
+        success, nothing salvaged, and no honest not-measurable resolution
+        (which is a legitimate answered outcome, not a silent failure)."""
+        records = records or []
+        if not records or any(r.get("task_success") for r in records):
+            return False
+        plain = [r for r in records
+                 if not r.get("salvaged") and not r.get("not_measurable")]
+        return bool(plain)
+
     def analyze(
         self,
         data: AnalysisInput,
@@ -446,6 +458,25 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             response["confidence"] = worst.get("confidence", "low")
             response["warnings"] = [d["caveat"] for d in degradation if d.get("caveat")]
             response["degraded_outputs"] = degradation
+
+        # Total dynamic-analysis failure with nothing salvageable used to
+        # slip through as a bare "success" with empty features: degradation
+        # notes exist only when some maps passed QC (valid_count > 0), so a
+        # zero-valid total failure recorded nothing. Downgrade honestly —
+        # unless every failed target was resolved through the honest
+        # not-measurable channel, which is a legitimate answered outcome.
+        if (response.get("status") != "partial"
+                and self._plain_total_dynamic_failure(
+                    result_json.get("dynamic_analysis_records"))):
+            records = result_json.get("dynamic_analysis_records") or []
+            response["status"] = "partial"
+            response["confidence"] = "none"
+            response.setdefault("warnings", []).append(
+                f"Dynamic analysis failed for all {len(records)} "
+                f"target(s): no requested output passed verification "
+                f"and nothing was salvageable. Decomposition-level "
+                f"outputs and the descriptive analysis (if any) are "
+                f"unaffected.")
 
 
         # Stage novel hot-annealing successes (method-family abandoned and a

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -1499,6 +1499,21 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "output_directory": str(self.output_dir),
         }
 
+        # Zero-success guard: if every image failed every attempt (a
+        # per-item condition, so no controller set error_dict), the run must
+        # not report top-level success. Salvaged best-available results carry
+        # success=True (with quality_warning) and are unaffected.
+        if series_results and all(
+                isinstance(r, dict) and r.get("success") is False
+                for r in series_results):
+            item_errors = [r.get("error") for r in series_results
+                           if r.get("error")]
+            results["status"] = "error"
+            results["error"] = {
+                "error": f"All {len(series_results)} image analysis(es) failed",
+                "details": item_errors[-1] if item_errors else "",
+            }
+
         if is_single:
             # Single image: compact structure
             analysis_result = state.get("analysis_result", {})

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -1585,6 +1585,11 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                     "analysis_type": r.get("analysis_type"),
                     "visualization_path": r.get("visualization_path"),
                     "error": r.get("error"),
+                    # Structured failure-mode tag + per-attempt audit trail
+                    # (matches curve; absent on successes/untagged failures).
+                    **({"kind": r["kind"]} if r.get("kind") else {}),
+                    **({"script_errors": r["script_errors"]}
+                       if r.get("script_errors") else {}),
                     "flagged": r.get("flagged", False),
                     "flag_reason": r.get("flag_reason"),
                     "adaptively_refitted": r.get("adaptively_refitted", False),

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2572,6 +2572,7 @@ never as missing keys.
 *(NumPy 2.x: aliases removed in NumPy 2.0 raise `AttributeError` — use `np.trapezoid` not `np.trapz`; prefer `scipy.integrate.trapezoid` for integration.)*
 
 **CRITICAL:** Fix only the execution error. Do NOT change the fitting model, its parameters, the fit domain/window, or the overall analysis approach — and never narrow the window or truncate the data to raise R². The model is locked for series consistency.
+**Narrow exception — timeout errors ONLY:** if the error says the script timed out, the script is too slow, not wrong. You may change the COMPUTATIONAL strategy — vectorize loops, reduce optimizer restarts/iterations, replace brute-force search with an efficient optimizer — but every rule above still holds: same model, same parameters, same fit domain/window, and ALL of the data.
 
 **I/O contract (do not deviate):** the data is `data.npy` in the current working directory — load it with `np.load` (do NOT look for .csv/.txt/.dat or glob for other files); save the plot to `visualization.png`; print one line `FIT_RESULTS_JSON:{{...}}` with the fit results. Missing any of these fails the run. Also keep saving `fit.npy` (1-D fitted curve at the `data.npy` x-points, length N) if the script you are fixing already did — it feeds the reviewer's residual diagnostics.
 
@@ -3859,6 +3860,10 @@ IMAGE_ANALYSIS_SCRIPT_CORRECTION_INSTRUCTIONS = """Fix this failed image analysi
 
 **CRITICAL:** Fix only the execution error. Do NOT change the analysis pipeline, feature \
 extraction approach, or the overall analysis strategy. The approach is locked for series consistency.
+**Narrow exception — timeout errors ONLY:** if the error says the script timed out, the script is \
+too slow, not wrong. You may change the COMPUTATIONAL strategy — vectorize loops, reduce iteration \
+counts, use coarser internal search grids — but the pipeline, the extracted features, and the full \
+image extent must not change.
 
 **Response:** Return only `{{"diagnosis": "...", "script": "..."}}`
 """

--- a/scilink/executors.py
+++ b/scilink/executors.py
@@ -285,14 +285,25 @@ class ScriptExecutor:
         
         logging.info(f"ScriptExecutor initialized (timeout: {self.timeout}s)")
 
-    def execute_script(self, script_content: str, working_dir: str = None) -> dict:
+    def execute_script(self, script_content: str, working_dir: str = None,
+                       timeout: int | None = None) -> dict:
         """Execute a Python script.
 
         Thread-safe: the subprocess's CWD is set via ``Popen(cwd=...)`` and the
         caller's process CWD is never mutated, so concurrent calls from
         different threads do not race on a shared global.
+
+        Args:
+            script_content: Python source to execute.
+            working_dir: Directory to use as the subprocess's CWD (and where
+                the temp script file is written). Defaults to current CWD.
+            timeout: Per-call timeout in seconds. When ``None`` (the default),
+                uses ``self.timeout`` from construction. Callers that need an
+                adaptive-timeout escalation pattern pass the override here
+                without mutating shared executor state.
         """
-        logging.info("   Executing Python script...")
+        effective_timeout = self.timeout if timeout is None else timeout
+        logging.info(f"   Executing Python script (timeout: {effective_timeout}s)...")
 
         if working_dir:
             os.makedirs(working_dir, exist_ok=True)
@@ -318,11 +329,11 @@ class ScriptExecutor:
             # Register so OutputCapture.kill_subprocesses() can terminate it.
             _register_subprocess(proc)
             try:
-                stdout, stderr = proc.communicate(timeout=self.timeout)
+                stdout, stderr = proc.communicate(timeout=effective_timeout)
             except subprocess.TimeoutExpired:
                 proc.kill()
                 proc.wait()
-                return {"status": "error", "message": f"Script execution timed out after {self.timeout} seconds."}
+                return {"status": "error", "message": f"Script execution timed out after {effective_timeout} seconds."}
             finally:
                 _unregister_subprocess(proc)
 

--- a/tests/test_adaptive_timeout.py
+++ b/tests/test_adaptive_timeout.py
@@ -1,0 +1,171 @@
+"""Offline tests for adaptive timeout escalation (slow != broken).
+
+A subprocess that times out is rarely broken code — usually the fit just
+needs longer. `stage_and_run_adaptive` retries the SAME script with doubled
+timeouts (2 escalations, 1800 s hard cap) before the correction LLM ever
+sees a "timed out" error; genuine script errors pass straight through to
+the correction loop. Plus: the correction prompts carry a NARROW timeout
+exception (computational strategy only — model/window/data untouchable).
+
+  UNSAFE_EXECUTION_OK=true python tests/test_adaptive_timeout.py
+"""
+import io
+import logging
+import tempfile
+import time
+
+from scilink.executors import ScriptExecutor
+from scilink.agents.exp_agents._locked_exec import (
+    stage_and_run_adaptive, TIMEOUT_ESCALATIONS, TIMEOUT_HARD_CAP_S,
+)
+
+import numpy as np
+
+results = {}
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+SLOW_OK = """
+import time, numpy as np
+time.sleep(3)
+np.load("data.npy")
+open("visualization.png", "wb").write(b"png")
+print("done")
+"""
+
+BROKEN = """
+raise RuntimeError("genuinely broken script")
+"""
+
+NEVER_ENDS = """
+import time
+time.sleep(60)
+"""
+
+
+class _CountingExecutor(ScriptExecutor):
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self.calls = []
+
+    def execute_script(self, script_content, working_dir=None, timeout=None):
+        self.calls.append(timeout if timeout is not None else self.timeout)
+        return super().execute_script(script_content, working_dir, timeout)
+
+
+class _FakeTimeoutExecutor:
+    """Always times out; records requested timeouts (no real sleeping)."""
+
+    def __init__(self, timeout):
+        self.timeout = timeout
+        self.calls = []
+
+    def execute_script(self, script_content, working_dir=None, timeout=None):
+        t = timeout if timeout is not None else self.timeout
+        self.calls.append(t)
+        return {"status": "error",
+                "message": f"Script execution timed out after {t} seconds."}
+
+
+def _capture_log():
+    buf = io.StringIO()
+    h = logging.StreamHandler(buf)
+    h.setLevel(logging.WARNING)
+    logging.getLogger().addHandler(h)
+    return buf, h
+
+
+def main():
+    data = np.column_stack([np.linspace(0, 1, 50), np.zeros(50)])
+
+    # 1) Slow-but-correct script: escalates 1s -> 2s -> 4s, succeeds, no
+    #    correction ever involved.
+    ex = _CountingExecutor(timeout=1)
+    buf, h = _capture_log()
+    t0 = time.monotonic()
+    run = stage_and_run_adaptive(ex, SLOW_OK, data, tempfile.mkdtemp())
+    dt = time.monotonic() - t0
+    logging.getLogger().removeHandler(h)
+    log = buf.getvalue()
+    print("1) slow-but-correct script (sleep 3, timeout 1):")
+    check("succeeds after escalation", run["status"] == "success")
+    check("timeout ladder 1 -> 2 -> 4", ex.calls == [1, 2, 4])
+    check("escalation logged",
+          "retrying same script with 2s" in log
+          and "retrying same script with 4s" in log)
+    check("bounded wall clock (~3+overhead, not 5x600)", dt < 30)
+
+    # 2) Genuinely broken script: returned as-is on the FIRST call — the
+    #    correction loop's job, no timeout escalation.
+    ex = _CountingExecutor(timeout=5)
+    run = stage_and_run_adaptive(ex, BROKEN, data, tempfile.mkdtemp())
+    print("2) genuinely broken script:")
+    check("error passed through", run["status"] == "error"
+          and "genuinely broken" in run["exec"].get("message", ""))
+    check("no escalation for non-timeout errors", ex.calls == [5])
+
+    # 3) Never-ending script: escalation budget exhausted, final result is
+    #    the standard timed-out error (what the correction LLM then sees).
+    ex = _CountingExecutor(timeout=1)
+    buf, h = _capture_log()
+    run = stage_and_run_adaptive(ex, NEVER_ENDS, data, tempfile.mkdtemp())
+    logging.getLogger().removeHandler(h)
+    print("3) never-ending script:")
+    check("returns timed-out error after budget",
+          run["status"] == "error"
+          and "timed out" in run["exec"]["message"])
+    check("exactly 1 + ESCALATIONS calls",
+          len(ex.calls) == 1 + TIMEOUT_ESCALATIONS)
+    check("budget-exhausted handoff logged",
+          "escalation budget exhausted" in buf.getvalue())
+
+    # 4) Hard cap: base 1500 -> 1800 (cap) -> stop (next would not grow).
+    fake = _FakeTimeoutExecutor(timeout=1500)
+    run = stage_and_run_adaptive(fake, "x", data, tempfile.mkdtemp())
+    print("4) hard cap:")
+    check("caps at TIMEOUT_HARD_CAP_S then stops",
+          fake.calls == [1500, TIMEOUT_HARD_CAP_S])
+
+    # 5) executor timeout kwarg: default falls back to construction value.
+    ex = ScriptExecutor(timeout=60)
+    out = ex.execute_script("print('hi')")
+    check("5) default timeout path still works", out["status"] == "success")
+    out = ex.execute_script("import time; time.sleep(3)", timeout=1)
+    check("per-call override honored in message",
+          out["status"] == "error" and "after 1 seconds" in out["message"])
+
+    # 6) Correction prompts: narrow timeout exception present, locked-model
+    #    rule intact.
+    from scilink.agents.exp_agents.instruct import (
+        FITTING_SCRIPT_CORRECTION_INSTRUCTIONS,
+        IMAGE_ANALYSIS_SCRIPT_CORRECTION_INSTRUCTIONS,
+    )
+    print("6) correction-prompt carve-outs:")
+    for name, tpl, keep in (
+        ("curve", FITTING_SCRIPT_CORRECTION_INSTRUCTIONS,
+         "never narrow the window or truncate the data"),
+        ("image", IMAGE_ANALYSIS_SCRIPT_CORRECTION_INSTRUCTIONS,
+         "Do NOT change the analysis pipeline"),
+    ):
+        check(f"{name}: locked rule intact", keep in tpl)
+        check(f"{name}: timeout exception present",
+              "timeout errors ONLY" in tpl and "too slow, not wrong" in tpl)
+    check("curve: exception preserves model/window/data",
+          "same model, same parameters, same fit domain/window, and ALL of "
+          "the data" in FITTING_SCRIPT_CORRECTION_INSTRUCTIONS)
+
+    print("\n" + "=" * 50)
+    npass = sum(results.values())
+    print(f"ADAPTIVE TIMEOUT: {npass}/{len(results)} checks passed")
+    for k, v in results.items():
+        if not v:
+            print("  FAILED:", k)
+    raise SystemExit(0 if npass == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_failure_status_propagation.py
+++ b/tests/test_failure_status_propagation.py
@@ -1,0 +1,126 @@
+"""Offline tests for total-failure status propagation (zero-success guard).
+
+Pre-fix, a run where EVERY spectrum/image failed every attempt (a per-item
+condition, so no controller set error_dict) still returned top-level
+status "success" from _compile_results — a caller checking only `status`
+was misled. The guard flips it to "error" with an error dict matching the
+error_dict shape; anything with at least one success (including salvaged
+best-available results, which carry success=True + quality_warning) is
+untouched, and exotic items missing the `success` key never trip it.
+
+  conda run -n scilink python tests/test_failure_status_propagation.py
+"""
+import logging
+
+from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+from scilink.agents.exp_agents.image_analysis_agent import ImageAnalysisAgent
+
+results = {}
+logging.disable(logging.CRITICAL)
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+def _fail(i, err="exec failed"):
+    return {"index": i, "name": f"item_{i}", "success": False, "error": err}
+
+
+def _ok(i, warn=None):
+    r = {"index": i, "name": f"item_{i}", "success": True,
+         "parameters": {"a": 1.0}, "fit_quality": {"r_squared": 0.99}}
+    if warn:
+        r["quality_warning"] = warn
+    return r
+
+
+def _curve_state(series_results, **kw):
+    state = {"is_single_spectrum": len(series_results) <= 1,
+             "num_spectra": max(len(series_results), 1),
+             "series_results": series_results,
+             "synthesis_result": {}, "flagged_spectra": []}
+    state.update(kw)
+    return state
+
+
+def _image_state(series_results, **kw):
+    state = {"is_single_image": len(series_results) <= 1,
+             "num_images": max(len(series_results), 1),
+             "series_results": series_results,
+             "synthesis_result": {}, "flagged_images": [],
+             "analysis_result": {}}
+    state.update(kw)
+    return state
+
+
+def main():
+    curve = CurveFittingAgent()
+    image = ImageAnalysisAgent()
+
+    # 1) All failed -> error with error_dict-shaped payload.
+    print("1) all items failed:")
+    out = curve._compile_results(_curve_state(
+        [_fail(0), _fail(1, "timeout"), _fail(2)]))
+    check("curve: status error", out["status"] == "error")
+    check("curve: error names the count",
+          "All 3 spectrum fit(s) failed" in out["error"]["error"])
+    check("curve: details carry last item error",
+          out["error"]["details"] == "timeout" or out["error"]["details"])
+    out = image._compile_results(_image_state([_fail(0), _fail(1)]))
+    check("image: status error", out["status"] == "error")
+    check("image: error names the count",
+          "All 2 image analysis(es) failed" in out["error"]["error"])
+
+    # 2) Single-item total failure (single spectrum = series of 1).
+    print("2) single item failed:")
+    out = curve._compile_results(_curve_state([_fail(0)]))
+    check("curve single: status error", out["status"] == "error")
+    out = image._compile_results(_image_state([_fail(0)]))
+    check("image single: status error", out["status"] == "error")
+
+    # 3) Mixed success/failure -> success (per-item failures stay per-item).
+    print("3) mixed outcomes:")
+    out = curve._compile_results(_curve_state([_fail(0), _ok(1), _fail(2)]))
+    check("curve mixed: status success", out["status"] == "success")
+    out = image._compile_results(_image_state([_ok(0), _fail(1)]))
+    check("image mixed: status success", out["status"] == "success")
+
+    # 4) Salvaged best-available (success=True + quality_warning) -> success.
+    print("4) salvaged best-available:")
+    out = curve._compile_results(_curve_state(
+        [_ok(0, warn="R² below threshold")]))
+    check("curve salvaged: status success", out["status"] == "success")
+
+    # 5) Empty series_results (no fitting ran) -> unchanged success.
+    print("5) empty series_results:")
+    out = curve._compile_results(_curve_state([]))
+    check("curve empty: status success", out["status"] == "success")
+
+    # (A series item without a `success` key is impossible on this path —
+    # _compile_results itself indexes r["success"] when building
+    # individual_results — so the guard's explicit `is False` requirement
+    # is purely defensive and has no reachable counterexample to test.)
+
+    # 6) Orchestrator formatting branch accepts partial (source-level check:
+    #    the closure is not unit-instantiable, live test covers behavior).
+    import inspect
+    from scilink.agents.exp_agents import analysis_orchestrator_tools as aot
+    src = inspect.getsource(aot)
+    check("run_analysis success branch admits 'partial'",
+          'in ("success", "partial")' in src)
+    check("partial branch surfaces confidence/warnings",
+          'response["confidence"]' in src and 'response["warnings"]' in src)
+
+    print("\n" + "=" * 50)
+    npass = sum(results.values())
+    print(f"FAILURE STATUS PROPAGATION: {npass}/{len(results)} checks passed")
+    for k, v in results.items():
+        if not v:
+            print("  FAILED:", k)
+    raise SystemExit(0 if npass == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_failure_status_propagation.py
+++ b/tests/test_failure_status_propagation.py
@@ -103,7 +103,27 @@ def main():
     # individual_results — so the guard's explicit `is False` requirement
     # is purely defensive and has no reachable counterexample to test.)
 
-    # 6) Orchestrator formatting branch accepts partial (source-level check:
+    # 6) HS plain-total-failure predicate: fires only when every target
+    #    failed with no salvage AND no honest not-measurable resolution.
+    from scilink.agents.exp_agents.hyperspectral_analysis_agent import (
+        HyperspectralAnalysisAgent as HS)
+    plain = HS._plain_total_dynamic_failure
+    print("6) HS plain-total-failure predicate:")
+    check("all plain failures -> fires",
+          plain([{"task_success": False}, {"task_success": False}]))
+    check("mixed plain + not_measurable -> fires (plain part unresolved)",
+          plain([{"task_success": False, "not_measurable": {"why": "x"}},
+                 {"task_success": False}]))
+    check("all not_measurable -> honest null, does NOT fire",
+          not plain([{"task_success": False,
+                      "not_measurable": {"why": "x"}}]))
+    check("salvaged failure -> handled by degradation notes, does NOT fire",
+          not plain([{"task_success": False, "salvaged": True}]))
+    check("any success -> does NOT fire",
+          not plain([{"task_success": True}, {"task_success": False}]))
+    check("no records -> does NOT fire", not plain([]) and not plain(None))
+
+    # 7) Orchestrator formatting branch accepts partial (source-level check:
     #    the closure is not unit-instantiable, live test covers behavior).
     import inspect
     from scilink.agents.exp_agents import analysis_orchestrator_tools as aot

--- a/tests/test_timeout_annealing.py
+++ b/tests/test_timeout_annealing.py
@@ -1,0 +1,161 @@
+"""Offline tests for timeout-aware annealing (last-resort model escalation).
+
+Two additions, both pure additions on paths that previously ended in
+failure: (1) qc_refit tells the (possibly hot) rewrite when trailing
+attempts died on execution timeouts — the stall counter that drives
+annealing is cause-blind; (2) the final correction of a fresh fit whose
+failures are >= 2 consecutive timeouts gets a LAST-RESORT clause allowing
+model restructure (window/data still untouchable), with the annealing
+level raised to hot for that one call and restored afterwards.
+
+  conda run -n scilink python tests/test_timeout_annealing.py
+"""
+import json
+import logging
+import tempfile
+
+from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+    UnifiedSeriesProcessingController,
+    _is_timeout_error,
+    _trailing_timeout_failures,
+)
+from scilink.agents.exp_agents.instruct import (
+    FITTING_SCRIPT_CORRECTION_INSTRUCTIONS,
+)
+
+results = {}
+logging.disable(logging.CRITICAL)
+
+TIMEOUT_MSG = "Script execution timed out after 1800 seconds."
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+def _attempt(success, error=None):
+    return {"result": {"success": success, "error": error}}
+
+
+class _StubModel:
+    def __init__(self, raise_error=False):
+        self.prompts = []
+        self.raise_error = raise_error
+
+    def generate_content(self, prompt, **kw):
+        self.prompts.append(prompt)
+        if self.raise_error:
+            raise RuntimeError("stub LLM failure")
+        return json.dumps({"diagnosis": "stub diagnosis",
+                           "script": "import numpy as np\nprint('ok')\n"})
+
+
+def _controller(model):
+    return UnifiedSeriesProcessingController(
+        model=model, logger=logging.getLogger("t"),
+        generation_config=None, safety_settings=None, parse_fn=None,
+        executor=None, script_instructions="",
+        correction_instructions=FITTING_SCRIPT_CORRECTION_INSTRUCTIONS,
+        quality_instructions="", output_dir=tempfile.mkdtemp(),
+        plot_fn=None,
+    )
+
+
+def main():
+    # 1) Timeout-error detection + trailing-failure counting.
+    print("1) helpers:")
+    check("timeout message detected", _is_timeout_error(TIMEOUT_MSG))
+    check("other errors not timeout",
+          not _is_timeout_error("NameError: x") and not _is_timeout_error(None))
+    check("trailing count stops at non-timeout",
+          _trailing_timeout_failures([
+              _attempt(False, "NameError"),
+              _attempt(False, TIMEOUT_MSG),
+              _attempt(False, TIMEOUT_MSG)]) == 2)
+    check("success breaks the trail",
+          _trailing_timeout_failures([
+              _attempt(False, TIMEOUT_MSG),
+              _attempt(True),
+              _attempt(False, TIMEOUT_MSG)]) == 1)
+    check("empty/None attempts -> 0",
+          _trailing_timeout_failures([]) == 0
+          and _trailing_timeout_failures(None) == 0)
+
+    # 2) Escalation trigger matrix — final correction of a FRESH fit with
+    #    >= 2 consecutive timeouts, and nothing else.
+    should = UnifiedSeriesProcessingController._should_escalate_timeout_model
+    print("2) trigger matrix:")
+    check("fires: fresh fit, final attempt, 2 timeouts",
+          should(None, 5, 5, 2))
+    check("fires on the penultimate attempt too (debug-chance design)",
+          should(None, 4, 5, 2))
+    check("locked-reuse fit never escalates",
+          not should("locked script", 5, 5, 5))
+    check("not on earlier attempts", not should(None, 3, 5, 3))
+    check("not on a single timeout", not should(None, 5, 5, 1))
+    check("not on non-timeout failures", not should(None, 5, 5, 0))
+
+    # 3) Escalated correction: clause injected, hot annealing for that one
+    #    call, state fully restored afterwards.
+    model = _StubModel()
+    ctrl = _controller(model)
+    state = {"locked_fitting_config": {"analysis_approach": "a",
+                                       "physical_model": "gaussian"},
+             "_annealing_level": 0}
+    script, diagnosis = ctrl._correct_script_with_timeout_escalation(
+        state, "print('slow')", TIMEOUT_MSG)
+    prompt = model.prompts[-1]
+    print("3) escalated correction:")
+    check("script returned", bool(script))
+    check("LAST RESORT clause in prompt", "TIMEOUT ESCALATION" in prompt
+          and "RESTRUCTURE the model" in prompt)
+    check("clause declares precedence", "SUPERSEDES" in prompt)
+    check("clause injected before the response footer",
+          prompt.index("TIMEOUT ESCALATION") < prompt.index("**Response:**"))
+    check("window/data still fenced in the clause",
+          "full window, ALL of" in prompt)
+    check("locked-model CRITICAL rule still present",
+          "never narrow the window or truncate the data" in prompt)
+    check("standard carve-out still present",
+          "timeout errors ONLY" in prompt)
+    check("annealing level restored", state.get("_annealing_level") == 0)
+    check("escalation flag cleared",
+          "_timeout_model_escalation" not in state)
+
+    # 4) State restored even when the LLM call raises.
+    ctrl = _controller(_StubModel(raise_error=True))
+    state = {"locked_fitting_config": {}, "_annealing_level": 1}
+    try:
+        ctrl._correct_script_with_timeout_escalation(state, "x", TIMEOUT_MSG)
+        raised = False
+    except RuntimeError:
+        raised = True
+    print("4) exception safety:")
+    check("stub error propagated", raised)
+    check("level restored on exception", state.get("_annealing_level") == 1)
+    check("flag cleared on exception",
+          "_timeout_model_escalation" not in state)
+
+    # 5) No-regression: a PLAIN correction never carries the clause.
+    model = _StubModel()
+    ctrl = _controller(model)
+    state = {"locked_fitting_config": {}}
+    ctrl._correct_script(state, "print('x')", "NameError: x")
+    print("5) plain correction unchanged:")
+    check("no escalation clause without the flag",
+          "TIMEOUT ESCALATION" not in model.prompts[-1])
+    check("locked rule present as always",
+          "never narrow the window" in model.prompts[-1])
+
+    print("\n" + "=" * 50)
+    npass = sum(results.values())
+    print(f"TIMEOUT ANNEALING: {npass}/{len(results)} checks passed")
+    for k, v in results.items():
+        if not v:
+            print("  FAILED:", k)
+    raise SystemExit(0 if npass == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR hardens how the analysis agents behave when generated code fails or runs slow, across four commits. The through-line: **the reported outcome always matches what actually happened, and slow-but-correct work gets recovered instead of discarded.**

**1. A run where every fit failed no longer reports success.** If every spectrum/image failed all attempts, the result now says `status: "error"` with the count and the underlying error. Runs with at least one usable result — including salvaged below-threshold fits — are unchanged.

**2. Hyperspectral's honest "partial" verdict survives to the orchestrator.** Salvage outcomes (approximate/withheld maps with caveats) used to reach the assistant as an error with an empty error object; they now arrive as a success-shaped payload with the partial status, confidence, warnings, and degraded-output details. A new last-ditch net also covers total dynamic-analysis failure with nothing salvageable — previously a bare success with empty features — while honest not-measurable determinations (a legitimate answered outcome, with statistical evidence) stay successes.

**3. Slow is not broken: timeouts escalate before the LLM "fixes" working code.** A timed-out script is re-run **verbatim** at doubled timeouts (two escalations, 30-min cap) before any correction. If it still times out, the correction LLM sees it under a deliberately narrow exception: computational-strategy changes only — same model, same parameters, same fit window, all of the data. If even that fails, the final two corrections of a fresh fit may **restructure the model** under a clause that supersedes the locked-model rule for that single correction (window/data still untouchable); locked-reuse series items can never restructure, and the annealing schedule, struggle gate, and T=2 consolidation stamps are provably untouched.

**4. Timeouts are now observable and steerable.** `run_analysis` gains an `executor_timeout` knob (raise it for big data or after a timed-out run; lower it for real-time fail-fast). Failure records carry a structured `kind: "timeout"` tag plus the per-attempt audit trail, projected into `individual_results` — no more string-matching error messages. The verification loop's refits are told when prior failures were budget failures rather than quality failures, and image analysis has full parity with curve for all of the above.

---

**Technical details**

*Commit `b83d3555` — total-failure honesty*
- Zero-success guard in curve/image `_compile_results` (explicit `success: False` on every item → error_dict-shaped error; `individual_results` preserved).
- `run_analysis` success branch admits `("success", "partial")`; partial carries `confidence`/`warnings`/`degraded_outputs` + PARTIAL note.

*Commit `d2d9b2d3` — adaptive timeouts (revives unmerged `b5ca517a`, generalized to image)*
- `executors.py` per-call `timeout` override; shared `stage_and_run_adaptive` in `_locked_exec` (2 escalations × 2.0, 1800 s cap, same-script retry; non-timeout errors pass through). Wired into both attempt loops; reuse-audition and mask-patch sites stay quick-fail.
- Narrow timeout-only exception in both correction templates; the original locked-model sentence untouched. HS excluded (its in-process `ExecutionTimeout` already hints vectorize).

*Commit `d53457b2` — timeout-aware annealing*
- `qc_refit` appends an EXECUTION BUDGET line when `_trailing_timeout_failures > 0` (the stall counter driving annealing is cause-blind).
- Last-resort model escalation on the final TWO corrections of a fresh fit with ≥2 consecutive timeouts; SUPERSEDES clause injected **before** the response footer (after it, the LLM kept an infeasible model — observed live); hot annealing bump restored in a `finally` on return and exception. Two chances by design: a restructure bug crashes, the crash resets the timeout counter, the next correction naturally debugs it (observed live).
- Annealing read-points verified: `_candidate_climbed_to_hot` and `_produced_at_level` read only the engine's per-iteration records; a cost-driven rescue can't fake best-of-N "struggled to hot" and is never staged for T=2 consolidation. Success results carry `timeout_model_escalation: True` provenance.

*Commit `7ddd6781` — observability, image parity, HS last-ditch honesty*
- `executor_timeout` on `run_analysis`, threaded via `create_agent_for_analysis` (signature-filtered, `None` = agent default) with directional schema guidance.
- `kind: "timeout"` on `script_errors` entries and failure dicts **including the `qc_fallback` hard dict** (the anchor's dict dropped the tag the attempt loop set — caught live); `kind` + `script_errors` projected into `individual_results`.
- Image parity: `refine_from_issues` channel (`_process_single_image` → `_generate_analysis_script extra_issues`) for the budget note; shared `should_escalate_timeout_model` predicate in `_locked_exec`; image escalation clause (pipeline wording, full-image-extent fence).
- HS `_plain_total_dynamic_failure`: every target failed with nothing salvaged and no honest not-measurable resolution → `partial` with a warning.

**Validation**

*Offline*: `test_failure_status_propagation.py` 19, `test_adaptive_timeout.py` 17, `test_timeout_annealing.py` 25; prior suites unaffected (scout 28/28, plan-revision 17/17, best-of-N + decomp-gate 56).

*Component live tests (Bedrock Opus 4.8)*: exec-boundary total failure → honest error 5/5; HS salvage → partial through the tool 5/5; escalation ladder e2e 4/4 (3/3 scripts rescued verbatim, zero corrections); carve-out 9/9 (brute-force grid → `curve_fit`, window/model preserved, 0.8 s, R² 0.9997); refit budget note 4/4; last-resort rescue 7/7 (LLM restructured an infeasible 161-parameter fit into fixed-grid centers + analytic NNLS amplitudes — all 40 planned components still reported, full window, all data, 2.4 s, R² 0.9998); knob 5/5; tagging 5/5; image parity 8/8.

*Extensive synthetic suite* (committed at `benchmarking_for_paper2/failure_hardening_suite/`, seeded, rerunnable, all through the real `run_analysis` tool):
- Wave 1 (19/20): change point 405 K exact + regime splits [10,11]; knob+ladder rescued with 5 escalations and zero corrections; adversarial 25-component demand defused by planner judgment (the one miss was a harness check under-crediting that recovery level — corrected); HS partial passthrough; pure-noise cube resolved via NOT-MEASURABLE with 5σ evidence.
- Wave 2, different data families incl. series (18/18 in substance): double transition — planner resolved BOTH planted boundaries [7,18] though the SVD reduction reports only the dominant step; XRD-like heating series — change point 247.5 °C vs 240 planted, regime split exactly at index 14; kinetics decays — honestly single-regime, no fabricated transition; image morphology-switch series narrated; ladder escalation on a heavy 4×1500² image series under the knob; two-phase cube — Peak_Center 519.97/609.98 nm vs planted 520/610 with spatial localization.

**Known limits**
- HS timeout handling deliberately unchanged (in-process `ExecutionTimeout` already delivers a vectorize hint; escalating an in-process wall is riskier).
- Escalation ladder worst case with the default 600 s executor timeout is 600+1200+1800 s per attempt before correction — bounded, zero LLM calls per rung; the `executor_timeout` knob lets the orchestrator lower it for fail-fast contexts.
- The HS plain-total-failure downgrade is a last-ditch net: live probing shows the honest-null and withheld-salvage nets catch realistic cases upstream (both observed live), so the new path is offline-proven (all five record combinations) rather than live-triggered.