### PR TITLE
Scalarizer: pass through already-scalarized tables instead of re-deriving (#366)

### DIFF
--- a/scilink/agents/planning_agents/scalarizer_agent.py
+++ b/scilink/agents/planning_agents/scalarizer_agent.py
@@ -20,6 +20,14 @@ from ._deprecation import normalize_params
 from .base_agent import BaseAgent
 
 
+def _np_is_numeric(series) -> bool:
+    try:
+        import pandas as pd
+        return bool(pd.api.types.is_numeric_dtype(series))
+    except Exception:  # noqa: BLE001
+        return False
+
+
 class ScalarizerAgent(BaseAgent):
     """
     Agent for converting raw experimental data into scalar descriptors
@@ -249,6 +257,156 @@ class ScalarizerAgent(BaseAgent):
             logging.warning(f"Reflection failed: {e}")
             return {"status": "pass", "reasoning": "Auto-reflection unavailable."}
 
+    # ------------------------------------------------------------------
+    # Pass-through for already-scalarized tables (#366)
+    # ------------------------------------------------------------------
+    _DERIVATION_TERMS = ("ratio", "divide", "normaliz", "per ", "difference",
+                         "slope", "fit", "integrat", "selectivity", "yield",
+                         "convert", "subtract", "sum of", "average over",
+                         "rate", "efficiency")
+
+    @staticmethod
+    def _norm_tokens(name) -> set:
+        import re as _re
+        toks = set(t for t in _re.split(r"[^a-z0-9]+", str(name).lower()) if t)
+        # unit / statistics suffixes don't carry identity
+        return toks - {"nm", "ev", "cm", "kev", "c", "k", "s", "a", "u",
+                       "px", "deg", "mean", "err", "std"}
+
+    def _load_flat_table(self, data_path):
+        """Best-effort flat-table read. Returns a DataFrame or None (never
+        raises) — anything that isn't a clean headered table (raw spectra,
+        multi-block instrument exports) returns None and takes the normal
+        codegen path."""
+        try:
+            import pandas as pd
+            path = Path(data_path)
+            if path.suffix.lower() in (".xlsx", ".xls"):
+                df = pd.read_excel(path)
+            else:
+                df = pd.read_csv(path)
+            if df.shape[1] < 2 or df.shape[0] < 1:
+                return None
+            # A real header row: column names mostly non-numeric strings.
+            numeric_names = sum(str(c).replace(".", "").replace("-", "")
+                                .isdigit() for c in df.columns)
+            if numeric_names > 0:
+                return None
+            return df
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _try_table_passthrough(self, df, objective_query,
+                               experiment_context, column_role_hints):
+        """When the requested quantities are literally columns of an
+        already-scalarized table, READ them — do not generate code to
+        re-derive them. Live failure modes this prevents: a one-row feature
+        table failing five codegen retries ("No numeric columns found"), and
+        worse, a plausible wrong number (the ROW COUNT returned as a
+        requested count metric). Returns a result dict, or None to proceed
+        with normal codegen (any unmatched/derived quantity falls through).
+        """
+        if df is None:
+            return None
+        cols = list(df.columns)
+        col_tokens = {c: self._norm_tokens(c) for c in cols}
+
+        requested = []
+        schema = (experiment_context or {}).get("_schema_requirements") or {}
+        for key in ("input_columns", "target_columns"):
+            requested += [str(x) for x in (schema.get(key) or [])]
+        if column_role_hints:
+            requested += [str(x) for x in
+                          (column_role_hints.get("inputs") or [])]
+            requested += [str(x) for x in
+                          (column_role_hints.get("targets") or [])]
+
+        explicit = bool(requested)
+        if not explicit:
+            # Goal-derived matching, conservative: only for tables that are
+            # recognizably ALREADY-EXTRACTED feature rows (a features.csv /
+            # 'unit' identity column), and only when the goal demands no
+            # derivation beyond the matched columns.
+            is_feature_table = ("unit" in [str(c).lower() for c in cols])
+            goal = str(objective_query or "").lower()
+            if not is_feature_table:
+                return None
+            if any(t in goal for t in self._DERIVATION_TERMS):
+                return None
+            goal_toks = self._norm_tokens(goal)
+            requested = [c for c in cols
+                         if col_tokens[c] and col_tokens[c] <= goal_toks]
+            if not requested:
+                return None
+
+        # Every requested quantity must match a column (token-subset either
+        # direction); one miss means a genuine derivation — codegen's job.
+        matched = {}
+        for req in requested:
+            rt = self._norm_tokens(req)
+            if not rt:
+                return None
+            hit = next((c for c in cols
+                        if rt <= col_tokens[c] or col_tokens[c] <= rt), None)
+            if hit is None or not _np_is_numeric(df[hit]):
+                return None
+            matched[req] = hit
+
+        import numpy as _np
+        metrics = {}
+        for req, c in matched.items():
+            vals = df[c].tolist()
+            metrics[req] = (float(vals[0]) if len(vals) == 1
+                            else [None if (isinstance(v, float)
+                                           and _np.isnan(v)) else v
+                                  for v in vals])
+        roles = {}
+        if schema:
+            roles = {"inputs": schema.get("input_columns") or [],
+                     "targets": schema.get("target_columns") or []}
+        elif column_role_hints:
+            roles = {"inputs": column_role_hints.get("inputs") or [],
+                     "targets": column_role_hints.get("targets") or []}
+        print(f"  📋 Pass-through: requested quantities are existing table "
+              f"columns ({ {r: c for r, c in matched.items()} }); reading "
+              "values directly — no extraction code generated.")
+        self.state["column_roles"] = roles
+        result = {"status": "success", "metrics": metrics,
+                  "source_script": None, "column_roles": roles,
+                  "passthrough": True, "error": None}
+        self._log_action(
+            action="table_passthrough",
+            input_ctx={"requested": requested},
+            result=result,
+            rationale="Requested quantities matched existing columns; read "
+                      "directly instead of re-deriving (issue #366).")
+        return result
+
+    @staticmethod
+    def _rowcount_suspects(metrics, df) -> list:
+        """Names of scalar metrics equal to the table's ROW COUNT while a
+        same-named column holds different values — the signature of code
+        that counted rows instead of reading the requested column."""
+        if df is None or not isinstance(metrics, dict):
+            return []
+        n = float(len(df))
+        out = []
+        for name, val in metrics.items():
+            if not isinstance(val, (int, float)) or float(val) != n:
+                continue
+            rt = ScalarizerAgent._norm_tokens(name)
+            for c in df.columns:
+                if (rt and (rt <= ScalarizerAgent._norm_tokens(c)
+                            or ScalarizerAgent._norm_tokens(c) <= rt)):
+                    try:
+                        col_vals = set(float(v) for v in df[c].dropna())
+                        if col_vals and col_vals != {n}:
+                            out.append(name)
+                    except Exception:  # noqa: BLE001
+                        pass
+                    break
+        return out
+
     def scalarize(self,
                  data_path: str,
                  objective_query: str = "",
@@ -339,6 +497,14 @@ class ScalarizerAgent(BaseAgent):
             
             return result
         
+        # Path 1.5 (#366): already-scalarized tables — when the requested
+        # quantities are existing columns, read them; never re-derive.
+        _flat_df = self._load_flat_table(data_path)
+        _pt = self._try_table_passthrough(
+            _flat_df, objective_query, experiment_context, column_role_hints)
+        if _pt is not None:
+            return _pt
+
         # Path 2: Generate new script
         file_context = self._read_file_head(data_path)
         
@@ -443,6 +609,21 @@ class ScalarizerAgent(BaseAgent):
                 current_prompt = base_prompt + f"\n\n**RUNTIME ERROR:**\n{err_msg}\nFix the code."
                 continue
                 
+            # Row-count trap (#366): a metric equal to the table's row
+            # count while a same-named column holds different values means
+            # the code counted rows instead of reading the column — a
+            # plausible wrong number that must not pass silently.
+            _suspects = self._rowcount_suspects(exec_res.get("metrics"), _flat_df)
+            if _suspects:
+                print(f"    ❌ Row-count trap: {_suspects} equal the table's "
+                      "row count; the matching column holds different values.")
+                current_prompt = base_prompt + (
+                    "\n\n**AUTO-CRITIQUE:** The metric(s) "
+                    f"{_suspects} equal the number of table rows — the code "
+                    "counted rows instead of READING the same-named column's "
+                    "values. Read the column directly.")
+                continue
+
             schema_for_verification = None
             if experiment_context and "_schema_requirements" in experiment_context:
                 schema_for_verification = experiment_context["_schema_requirements"]

--- a/tests/test_scalarizer_passthrough.py
+++ b/tests/test_scalarizer_passthrough.py
@@ -1,0 +1,125 @@
+"""Offline tests for the scalarizer table pass-through + row-count trap
+(#366): requested quantities that are already table columns are READ, not
+re-derived; genuine derivations still take the codegen path; a metric equal
+to the row count while a same-named column disagrees is caught.
+
+  conda run -n scilink python tests/test_scalarizer_passthrough.py
+"""
+import os
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+
+import pandas as pd
+
+from scilink.agents.planning_agents.scalarizer_agent import ScalarizerAgent
+
+results = {}
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+class _Host:
+    state: dict
+    def __init__(self):
+        self.state = {}
+    def _log_action(self, **kw):
+        self.state.setdefault("log", []).append(kw["action"])
+    _norm_tokens = staticmethod(ScalarizerAgent._norm_tokens)
+    _DERIVATION_TERMS = ScalarizerAgent._DERIVATION_TERMS
+    _load_flat_table = ScalarizerAgent._load_flat_table
+    _try_table_passthrough = ScalarizerAgent._try_table_passthrough
+    _rowcount_suspects = staticmethod(ScalarizerAgent._rowcount_suspects)
+
+
+def _csv(d, name, text):
+    p = Path(d) / name
+    p.write_text(text)
+    return str(p)
+
+
+def main():
+    h = _Host()
+    d = tempfile.mkdtemp(prefix="scalpt_")
+
+    hs = _csv(d, "features.csv",
+              "unit,Peak_Position_mean_nm,Peak_FWHM_mean\n"
+              "emission_map,620.05,35.5\n")
+    img = _csv(d, "img_features.csv",
+               "unit,particle_count,diameter_mean_nm\nimage_0000,8,11.75\n")
+    tidy = _csv(d, "tidy.csv",
+                "temperature_C,pH,product_area,byproduct_area\n"
+                "15.18,2.38,7.12,21.10\n15.45,4.11,11.91,22.97\n")
+
+    print("1) loader:")
+    check("features table parses", h._load_flat_table(hs) is not None)
+    raw = _csv(d, "spectrum.csv", "400.0,0.11\n400.5,0.12\n401.0,0.13\n")
+    check("headerless raw spectrum -> None (codegen path)",
+          h._load_flat_table(raw) is None)
+    check("missing file -> None", h._load_flat_table("/nope.csv") is None)
+
+    print("2) explicit-schema pass-through:")
+    ctx = {"_schema_requirements": {"input_columns": ["temperature_C", "pH"],
+                                    "target_columns": ["product_area"]}}
+    r = h._try_table_passthrough(h._load_flat_table(tidy), "optimize", ctx, None)
+    check("all schema columns present -> pass-through, values read",
+          r is not None and r["passthrough"]
+          and r["metrics"]["product_area"] == [7.12, 11.91]
+          and r["metrics"]["temperature_C"] == [15.18, 15.45])
+    check("column_roles carried from schema",
+          r["column_roles"]["targets"] == ["product_area"])
+    ctx2 = {"_schema_requirements": {"input_columns": ["temperature_C", "pH"],
+                                     "target_columns": ["selectivity"]}}
+    check("derived target (no matching column) -> codegen path",
+          h._try_table_passthrough(h._load_flat_table(tidy),
+                                   "maximize selectivity", ctx2, None) is None)
+
+    print("3) goal-derived pass-through (feature tables only):")
+    r = h._try_table_passthrough(
+        h._load_flat_table(img),
+        "Extract the particle count and mean diameter as scalar metrics.",
+        None, None)
+    check("one-row image table: column VALUES returned (not the row count)",
+          r is not None and r["metrics"]["particle_count"] == 8.0
+          and r["metrics"]["diameter_mean_nm"] == 11.75)
+    r = h._try_table_passthrough(
+        h._load_flat_table(hs),
+        "Extract the emission peak position as a scalar metric.", None, None)
+    check("one-row HS table: peak position read directly",
+          r is not None and r["metrics"]["Peak_Position_mean_nm"] == 620.05)
+    check("no 'unit' identity column -> goal matching stays off",
+          h._try_table_passthrough(h._load_flat_table(tidy),
+                                   "extract the product area", None, None)
+          is None)
+    check("derivation language blocks goal pass-through",
+          h._try_table_passthrough(h._load_flat_table(img),
+                                   "ratio of particle count to area",
+                                   None, None) is None)
+
+    print("4) row-count trap:")
+    df1 = h._load_flat_table(img)
+    check("row-count metric flagged when the column disagrees",
+          h._rowcount_suspects({"Particle_Count": 1.0}, df1)
+          == ["Particle_Count"])
+    check("correct value not flagged",
+          h._rowcount_suspects({"Particle_Count": 8.0}, df1) == [])
+    check("unrelated metric not flagged",
+          h._rowcount_suspects({"Selectivity": 1.0}, df1) == [])
+    check("no table -> no false alarms",
+          h._rowcount_suspects({"x": 1.0}, None) == [])
+
+    print("\n" + "=" * 50)
+    npass = sum(results.values())
+    print(f"SCALARIZER PASSTHROUGH: {npass}/{len(results)} checks passed")
+    for k, v in results.items():
+        if not v:
+            print("  FAILED:", k)
+    raise SystemExit(0 if npass == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Asking the planning stack to "optimize on the results of that analysis" routes the analysis's feature table into the scalarizer — which treated it as raw data to reduce, generating extraction code for quantities that are *already columns*. One failure shape burned five retries and failed honestly; the other silently returned the **row count** as a requested count metric, a plausible wrong number that script-locking would then have baked into every subsequent point of a BO campaign. Since #365, a one-row feature table is the natural first step of every analyze→optimize workflow, so this sat directly on that on-ramp.

The fix is deterministic on both ends and leaves genuine derivations exactly as they were: quantities that match existing columns are **read**; quantities that don't (e.g. `selectivity = product/byproduct`) still go through code generation.

## Technical details

- **Pass-through pre-step** (`_try_table_passthrough`, before codegen): engages when every requested quantity token-matches an existing numeric column. Requested quantities come from the BO `_schema_requirements`, `column_role_hints`, or — conservatively, only for recognized feature tables (a `unit` identity column) with no derivation language in the goal — the goal text. Values are read per row (scalar for one row, lists for many), `column_roles` carried from the schema/hints, no LLM call, no sandbox. Any miss falls through to the unchanged codegen path.
- **Row-count trap** (`_rowcount_suspects`, post-execution): a scalar metric equal to the table's row count while a fuzzy-matching column holds different values triggers a correction retry that names the column to read — the exact silent-wrong signature observed live.
- **Tests**: offline `tests/test_scalarizer_passthrough.py` 14/14 (loader tolerance incl. headerless spectra → codegen; schema/hint/goal matching; derived-target fall-through; derivation-language and no-`unit` blocks; trap true/false positives). Live: both #366 repro shapes now return correct values instantly (previously 5 failed retries / silent row count); 38-row real XRD table with explicit BO schema passes through completely; a raw techfest spectrum still codegens (positive areas); full meta-mode closed loop on the techfest tidy campaign derives selectivity via codegen — correctly **not** passed through — and returns an in-range BO recommendation (40.7 °C / pH 5.42) in 2.0 min.
- **Known limits**: goal-text matching is deliberately narrow (explicit schema/hints are the robust path); multi-block/Excel-exotic tables fall back to codegen via the tolerant loader returning `None`; the trap can't flag a wrong value that isn't the row count — that class stays with the auto-reflection layer.

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)