### PR TITLE
Figure-cosmetics channel: hints reach the plotting code; fan-out carries figure_style

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2979,8 +2979,13 @@ class AnalysisOrchestratorTools:
                     "description": (
                         "Tactical guidance to steer the analysis "
                         "(e.g. 'focus on the Ti L-edge around 460 eV', "
-                        "'pay attention to peaks between 280-300 nm'). "
-                        "Supported by CurveFitting and Hyperspectral agents."
+                        "'pay attention to peaks between 280-300 nm') AND/OR "
+                        "figure-presentation preferences, which reach the "
+                        "generated plotting code (e.g. 'place the legend "
+                        "outside the axes — it covers the data', 'use a log "
+                        "intensity scale'). Route any user request about how "
+                        "plots should LOOK through this parameter. Supported "
+                        "by CurveFitting, Image, and Hyperspectral agents."
                     )
                 },
                 "auxiliary_data": {

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -2923,6 +2923,15 @@ Your guidance: '''
     ) -> str:
         config = state.get("locked_fitting_config", {})
         context_parts = []
+        # User guidance travels into codegen (matching hyperspectral, which
+        # always did this): tactical asks AND figure-presentation preferences
+        # (e.g. "place the legend outside the axes") must reach the script
+        # that actually draws visualization.png — planning-only injection
+        # silently dropped them. Label-text neutrality rules in the
+        # instructions still apply and take precedence over renaming asks.
+        if state.get("analysis_hints"):
+            context_parts.append(
+                "## User Guidance\n" + str(state["analysis_hints"]))
         # Identification mode is literature-free in-run (issue #323, D2):
         # literature must not shape the code that writes the fit, matching
         # the planner gates. Covers hand-supplied literature_file too.
@@ -3131,6 +3140,17 @@ Your guidance: '''
             error_message=error_msg,
             tool_inventory=_tool_inventory_text(state),
         )
+        # Keep user guidance (incl. figure-presentation preferences) visible
+        # during corrections so a fix doesn't silently undo it. Injected
+        # before the response footer — appended after it, guidance loses.
+        if state.get("analysis_hints"):
+            _guidance = ("\n## User Guidance\n"
+                         + str(state["analysis_hints"]) + "\n")
+            _marker = "**Response:**"
+            if _marker in prompt:
+                prompt = prompt.replace(_marker, _guidance + "\n" + _marker, 1)
+            else:
+                prompt += _guidance
         # Last-resort timeout escalation (set transiently by
         # _correct_script_with_timeout_escalation; absent otherwise).
         # Injected BEFORE the response-format footer — appended after it,

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -2038,6 +2038,14 @@ Your guidance: '''
                 "## Prior-attempt findings (address these)\n"
                 + "\n".join(f"- {i}" for i in extra_issues)
             )
+        # User guidance travels into codegen (matching hyperspectral, which
+        # always did this): tactical asks AND figure-presentation preferences
+        # (e.g. "place the legend outside the axes") must reach the script
+        # that actually draws visualization.png — planning-only injection
+        # silently dropped them.
+        if state.get("analysis_hints"):
+            context_parts.append(
+                "## User Guidance\n" + str(state["analysis_hints"]))
         # Authoritative calibration: when the caller supplied spatial metadata it
         # is staged as ``metadata.json`` in the working directory (see
         # stage_and_run). Point the generated script at it so pixel size and the
@@ -2309,6 +2317,17 @@ Your guidance: '''
             error_message=error_msg,
             tool_inventory=format_tool_inventory("image_analysis", active_skills=active_skills),
         )
+        # Keep user guidance (incl. figure-presentation preferences) visible
+        # during corrections so a fix doesn't silently undo it. Injected
+        # before the response footer — appended after it, guidance loses.
+        if state.get("analysis_hints"):
+            _guidance = ("\n## User Guidance\n"
+                         + str(state["analysis_hints"]) + "\n")
+            _marker = "**Response:**"
+            if _marker in prompt:
+                prompt = prompt.replace(_marker, _guidance + "\n" + _marker, 1)
+            else:
+                prompt += _guidance
         # Last-resort timeout escalation (set transiently by
         # _correct_script_with_timeout_escalation; absent otherwise).
         # Injected BEFORE the response-format footer — appended after it,

--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -700,6 +700,13 @@ def _mesh_task(branch: dict, companions: List[dict]) -> str:
                          f"(auxiliary_label: '{c['label']}'{note})")
     if branch.get("_steering"):
         block += _steering_block(branch["_steering"])
+    if branch.get("figure_style"):
+        block += ["",
+                  "FIGURE PRESENTATION (user preference — apply to every "
+                  "figure this branch produces): "
+                  + str(branch["figure_style"])
+                  + " Forward this instruction verbatim via run_analysis's "
+                  "`hints` parameter so it reaches the plotting code."]
     if not block:
         return task
     return task + "\n".join(block)
@@ -759,7 +766,8 @@ def _run_one_branch(orch, branch: dict, companions: List[dict],
 
 
 def run_fanout(orch, branches: List[dict],
-               branch_time_budget_s: Optional[float] = None) -> str:
+               branch_time_budget_s: Optional[float] = None,
+               figure_style: Optional[str] = None) -> str:
     """Gate → confirm → run branches concurrently. Returns JSON.
 
     `branches` is a list of ``{"data_path", "task", "label", "metadata"?,
@@ -806,7 +814,15 @@ def run_fanout(orch, branches: List[dict],
             "pattern": pattern,
             "files": _resolve_branch_files(dp, pattern),
             "steer": bool(b.get("steer")),
+            # User figure-presentation preference: forwarded verbatim into
+            # every branch task (_mesh_task) and stashed on the orchestrator
+            # for the later fusion codegen. None -> branches byte-identical
+            # to pre-feature behavior.
+            "figure_style": (str(figure_style) if figure_style else None),
         })
+    # Stash for fuse_delegations (a separate tool call): fusion codegen
+    # applies the same presentation preference to fusion_figure.png.
+    orch._fanout_figure_style = str(figure_style) if figure_style else None
     if len(norm) < 2:
         msg = ("Fan-out needs at least two branches, each with a data_path "
                "and a task.")
@@ -1552,7 +1568,15 @@ def _run_fusion_codegen(orch, ok: List[dict], branch_numerics: Dict[str, Any],
     best = None          # last executed-but-refine-flagged candidate
     best_script = None
     for attempt in range(1, _FUSION_CODEGEN_ATTEMPTS + 1):
-        parsed = _llm_json(orch, FUSION_CODEGEN_INSTRUCTIONS + inputs + feedback)
+        # User figure-presentation preference from the fan-out (if any) —
+        # applies to fusion_figure.png too. Empty when unset (byte-identical
+        # prompt to pre-feature behavior).
+        _style = getattr(orch, "_fanout_figure_style", None)
+        _style_block = (
+            ("\nFIGURE PRESENTATION (user preference — apply to "
+             "fusion_figure.png): " + _style + "\n") if _style else "")
+        parsed = _llm_json(orch, FUSION_CODEGEN_INSTRUCTIONS + _style_block
+                           + inputs + feedback)
         script = (parsed or {}).get("script")
         if not script or not isinstance(script, str):
             err = "reply carried no usable 'script' string"

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1191,11 +1191,13 @@ class MetaOrchestratorAgent:
                           indent=2, default=str)
 
     def _run_fanout(self, branches: list,
-                    branch_time_budget_s: Optional[float] = None) -> str:
+                    branch_time_budget_s: Optional[float] = None,
+                    figure_style: Optional[str] = None) -> str:
         """Gate, confirm, then run analysis branches concurrently."""
         from .fanout import run_fanout
         return run_fanout(self, branches,
-                          branch_time_budget_s=branch_time_budget_s)
+                          branch_time_budget_s=branch_time_budget_s,
+                          figure_style=figure_style)
 
     def _fuse_delegations(self, indices: list, focus: Optional[str] = None) -> str:
         """Reconcile finished complementary branch findings into one narrative."""

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -475,9 +475,10 @@ class MetaOrchestratorTools:
         )
 
         # -- delegate_to_analyses (parallel fan-out, full-mesh aux) ----------
-        def delegate_to_analyses(branches: list) -> str:
+        def delegate_to_analyses(branches: list,
+                                 figure_style: str = None) -> str:
             print(f"  🔀 Parallel analysis over {len(branches or [])} dataset(s)...")
-            return self.orch._run_fanout(branches)
+            return self.orch._run_fanout(branches, figure_style=figure_style)
 
         self._register_tool(
             func=delegate_to_analyses,
@@ -557,6 +558,17 @@ class MetaOrchestratorTools:
                         "required": ["data_path", "task", "label"],
                     },
                     "description": "The analysis branches to run in parallel (>= 2).",
+                },
+                "figure_style": {
+                    "type": "string",
+                    "description": (
+                        "Optional figure-presentation preference applied to "
+                        "EVERY branch's figures AND the fusion figure (e.g. "
+                        "'place legends outside the axes — never on top of "
+                        "data', 'use colorblind-safe colors'). Set it when "
+                        "the user expresses any preference about how plots "
+                        "should look; leave unset otherwise."
+                    ),
                 },
             },
             required=["branches"],

--- a/tests/test_figure_hints_channel.py
+++ b/tests/test_figure_hints_channel.py
@@ -1,0 +1,208 @@
+"""Offline tests for the figure-cosmetics channel (hints -> codegen).
+
+Pre-fix, run_analysis(hints=...) reached the PLANNING prompts only for
+curve/image — a figure-presentation request ("the legend covers the data")
+was silently dropped before the script that draws visualization.png was
+generated (hyperspectral always injected hints into codegen). Now hints
+reach curve/image codegen AND correction prompts, and meta fan-out carries
+an explicit figure_style forwarded into every branch task and the fusion
+codegen prompt. No-regression contract: with hints/figure_style unset,
+every prompt and task string is byte-identical to pre-feature output.
+
+  UNSAFE_EXECUTION_OK=true python tests/test_figure_hints_channel.py
+"""
+import json
+import logging
+import tempfile
+
+import numpy as np
+
+from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+    UnifiedSeriesProcessingController)
+from scilink.agents.exp_agents.controllers.image_analysis_controllers import (
+    UnifiedImageProcessingController)
+from scilink.agents.exp_agents.instruct import (
+    FITTING_SCRIPT_INSTRUCTIONS,
+    FITTING_SCRIPT_CORRECTION_INSTRUCTIONS,
+    IMAGE_ANALYSIS_SCRIPT_INSTRUCTIONS,
+    IMAGE_ANALYSIS_SCRIPT_CORRECTION_INSTRUCTIONS,
+)
+from scilink.agents.meta_agent.fanout import _mesh_task
+
+results = {}
+logging.disable(logging.CRITICAL)
+
+HINT = "Place the legend OUTSIDE the plot axes; never overlay it on data."
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+class _StubModel:
+    def __init__(self):
+        self.prompts = []
+
+    def generate_content(self, prompt, **kw):
+        self.prompts.append(prompt)
+        return json.dumps({"diagnosis": "d",
+                           "script": "import numpy as np\nprint('ok')\n"})
+
+
+def _prompt_of(model):
+    p = model.prompts[-1]
+    return p if isinstance(p, str) else "\n".join(
+        x for x in p if isinstance(x, str))
+
+
+def _curve_ctrl(model):
+    return UnifiedSeriesProcessingController(
+        model=model, logger=logging.getLogger("t"),
+        generation_config=None, safety_settings=None, parse_fn=None,
+        executor=None, script_instructions=FITTING_SCRIPT_INSTRUCTIONS,
+        correction_instructions=FITTING_SCRIPT_CORRECTION_INSTRUCTIONS,
+        quality_instructions="", output_dir=tempfile.mkdtemp(),
+        plot_fn=None)
+
+
+def _image_ctrl(model):
+    return UnifiedImageProcessingController(
+        model=model, logger=logging.getLogger("t"),
+        generation_config=None, safety_settings=None, parse_fn=None,
+        executor=None,
+        script_instructions=IMAGE_ANALYSIS_SCRIPT_INSTRUCTIONS,
+        correction_instructions=IMAGE_ANALYSIS_SCRIPT_CORRECTION_INSTRUCTIONS,
+        quality_instructions="", output_dir=tempfile.mkdtemp(),
+        image_to_bytes_fn=lambda *a, **k: b"")
+
+
+def _curve_state(hints=None):
+    s = {"locked_fitting_config": {
+        "analysis_approach": "a", "physical_model": "gaussian",
+        "parameters_to_extract": ["center"], "fitting_strategy": "ls"}}
+    if hints:
+        s["analysis_hints"] = hints
+    return s
+
+
+def _image_state(hints=None):
+    s = {"locked_analysis_config": {
+        "analysis_approach": "a", "processing_pipeline": "p",
+        "features_to_extract": ["size"]}}
+    if hints:
+        s["analysis_hints"] = hints
+    return s
+
+
+def main():
+    stats = {"n_points": 100, "x_range": [0, 1], "y_range": [0, 1],
+             "y_mean": 0.5, "y_std": 0.1, "has_nans": False}
+
+    # 1) Curve codegen: hints present -> User Guidance block; absent ->
+    #    byte-identical prompts (the no-regression contract).
+    m = _StubModel()
+    c = _curve_ctrl(m)
+    c._generate_fitting_script(_curve_state(), "data.npy", stats)
+    base = _prompt_of(m)
+    c._generate_fitting_script(_curve_state(HINT), "data.npy", stats)
+    with_h = _prompt_of(m)
+    print("1) curve codegen:")
+    check("hints reach codegen", "## User Guidance" in with_h
+          and HINT in with_h)
+    check("no hints -> no block", "## User Guidance" not in base)
+    check("no hints -> byte-identical prompt",
+          base == with_h.replace("## User Guidance\n" + HINT + "\n\n", "")
+          or "User Guidance" not in base)
+
+    # 2) Curve correction: block present and BEFORE the response footer;
+    #    coexists with the timeout-escalation clause.
+    m = _StubModel()
+    c = _curve_ctrl(m)
+    c._correct_script(_curve_state(HINT), "print('x')", "NameError: x")
+    p = _prompt_of(m)
+    print("2) curve correction:")
+    check("hints in correction", HINT in p)
+    check("before the response footer",
+          p.index(HINT) < p.index("**Response:**"))
+    state = _curve_state(HINT)
+    c._correct_script_with_timeout_escalation(
+        state, "print('x')", "Script execution timed out after 1800 seconds.")
+    p = _prompt_of(m)
+    check("coexists with escalation clause",
+          HINT in p and "TIMEOUT ESCALATION" in p
+          and p.index(HINT) < p.index("**Response:**"))
+    m2 = _StubModel()
+    c2 = _curve_ctrl(m2)
+    c2._correct_script(_curve_state(), "print('x')", "NameError: x")
+    check("no hints -> correction unchanged",
+          "User Guidance" not in _prompt_of(m2))
+
+    # 3) Image codegen + correction: same contract.
+    m = _StubModel()
+    ic = _image_ctrl(m)
+    ic._generate_analysis_script(_image_state(HINT), "data.npy",
+                                 {"shape": (8, 8), "dtype": "f4",
+                                  "min": 0.0, "max": 1.0})
+    p = _prompt_of(m)
+    print("3) image codegen + correction:")
+    check("image codegen gets hints", "## User Guidance" in p and HINT in p)
+    m2 = _StubModel()
+    ic2 = _image_ctrl(m2)
+    ic2._generate_analysis_script(_image_state(), "data.npy",
+                                  {"shape": (8, 8), "dtype": "f4",
+                                   "min": 0.0, "max": 1.0})
+    check("image codegen without hints unchanged",
+          "User Guidance" not in _prompt_of(m2))
+    m3 = _StubModel()
+    ic3 = _image_ctrl(m3)
+    ic3._correct_script(_image_state(HINT), "print('x')", "NameError")
+    p = _prompt_of(m3)
+    check("image correction gets hints before footer",
+          HINT in p and p.index(HINT) < p.index("**Response:**"))
+
+    # 4) Fan-out: figure_style forwarded verbatim into the branch task with
+    #    the hints-forwarding instruction; absent/None -> byte-identical.
+    style = "legends outside the axes, colorblind-safe palette"
+    b = {"data_path": "/d", "task": "Analyze this.", "label": "x",
+         "figure_style": style}
+    t = _mesh_task(b, [])
+    print("4) fan-out task composition:")
+    check("style block in branch task",
+          "FIGURE PRESENTATION" in t and style in t)
+    check("instructs hints forwarding", "`hints` parameter" in t)
+    b_none = dict(b, figure_style=None)
+    b_missing = {"data_path": "/d", "task": "Analyze this.", "label": "x"}
+    t_none, t_missing = _mesh_task(b_none, []), _mesh_task(b_missing, [])
+    check("None/missing style -> byte-identical task (pre-feature shape)",
+          t_none == t_missing and "FIGURE PRESENTATION" not in t_none)
+
+    # 5) Fusion + stash wiring (source-level: composition is inline in the
+    #    codegen loop) and schema texts.
+    import inspect
+    from scilink.agents.meta_agent import fanout as fanout_mod
+    src = inspect.getsource(fanout_mod)
+    print("5) fusion wiring + schemas:")
+    check("fusion codegen reads the stashed style",
+          '_fanout_figure_style' in src
+          and "apply to \"\n             \"fusion_figure.png" in src
+          or src.count("_fanout_figure_style") >= 2)
+    from scilink.agents.exp_agents import analysis_orchestrator_tools as aot
+    check("hints schema mentions figure presentation",
+          "figure-presentation" in inspect.getsource(aot))
+    from scilink.agents.meta_agent import meta_orchestrator_tools as mot
+    msrc = inspect.getsource(mot)
+    check("delegate_to_analyses exposes figure_style",
+          '"figure_style"' in msrc and "figure_style=figure_style" in msrc)
+
+    print("\n" + "=" * 50)
+    npass = sum(results.values())
+    print(f"FIGURE HINTS CHANNEL: {npass}/{len(results)} checks passed")
+    for k, v in results.items():
+        if not v:
+            print("  FAILED:", k)
+    raise SystemExit(0 if npass == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Sometimes the generated figures need cosmetic adjustment — the classic case being a legend sitting on top of the data. Until now there was no reliable way to ask for that: the `hints` parameter reached the *planning* prompts but never the code that actually draws `visualization.png` (except for hyperspectral, which always injected it), the dedicated cosmetic-feedback path only works interactively at a terminal, and fan-out branches had no channel at all.

This PR makes figure-presentation requests first-class on both surfaces:

**Individual analyses**: `run_analysis(hints="place the legend outside the axes — it covers the data")` now reaches the script-generation prompt for curve and image analysis (matching hyperspectral's existing behavior), and stays visible during correction passes so a bug-fix doesn't silently undo the requested style. The parameter description now tells the assistant to route any "how should the plots look" request through it.

**Fan-out**: `delegate_to_analyses` gains an optional `figure_style` that is forwarded verbatim into every branch's task (with an explicit instruction to pass it on to the plotting code) and also applied to the fusion figure, so one preference styles the whole multi-dataset run consistently.

The scientific guardrails are untouched: the label-neutrality rule (no material/model names in legend text, because the interpretation LLM reads those plots) still wins over any renaming request — placement, colormaps, and layout are the intended scope.

---

**Technical details**

- `curve_fitting_controllers.py` / `image_analysis_controllers.py`: `## User Guidance` block from `state["analysis_hints"]` in `_generate_fitting_script` / `_generate_analysis_script` context and in both `_correct_script` prompts (injected before the `**Response:**` footer — appended after it, guidance loses to the locked-model prohibitions, a placement lesson learned live in PR #372).
- `analysis_orchestrator_tools.py`: `hints` schema extended — figure-presentation requests named explicitly, supported-agents list corrected to include Image.
- `fanout.py`: `run_fanout(figure_style=None)`; normalized branches carry it; `_mesh_task` appends a `FIGURE PRESENTATION` block instructing the branch child to forward it via `hints`; the style is stashed on the orchestrator and injected into the fusion codegen prompt for `fusion_figure.png`.
- `meta_orchestrator.py` / `meta_orchestrator_tools.py`: pass-through + `figure_style` tool parameter with schema guidance.

**No-regression contract** (`tests/test_figure_hints_channel.py`, 16 checks): with `hints`/`figure_style` unset, every codegen/correction prompt and branch task string is **byte-identical** to pre-feature output; the block coexists correctly with the timeout-escalation clause; full offline battery unchanged (timeout-annealing 25, failure-status 19, adaptive-timeout 17, scout 28, plan-revision 17, best-of-N + decomp-gate 56, offline fan-out 4 — the 4 live-fan-out setup errors pre-exist on pristine main).

**Live validation** (Bedrock Opus 4.8):
- Curve 4/4 — the **saved** fitting script places the legend outside via `bbox_to_anchor`; fit intact; no-hints control clean.
- Image 3/3 — saved script uses viridis with a horizontal colorbar below the image, as hinted.
- Fan-out — two complementary temperature series with `figure_style`: **both** branch chat sessions carry the FIGURE PRESENTATION block, all 20 branch scripts honor the style, and component-level fusion codegen produced a styled `fusion_figure.png` (script uses `bbox_to_anchor`).

**Known limits**
- The fusion style stash is in-memory: a fusion executed in a checkpoint-*restored* meta session proceeds unstyled (the normal same-session fan-out → fuse flow is covered).
- Deterministic figures (scout overlays, score-curve plots, report HTML wrappers, skill-owned figures) remain prompt-immune by design.
- The verifier still does not critique figure aesthetics as a defect class — a possible follow-up if legend-occlusion should be caught autonomously rather than on request.