### PR TITLE
UI Stop button: actually stop the run, resume cleanly after

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -19,7 +19,8 @@ from datetime import datetime
 from enum import Enum
 
 from ...auth import get_internal_proxy_key
-from ...utils.tool_media import (build_tool_message, provider_supports_tool_image,
+from ...utils.tool_media import (repair_dangling_tool_calls,
+                                 build_tool_message, provider_supports_tool_image,
                                  sanitize_history_images)
 from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
 from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
@@ -1589,6 +1590,9 @@ class AnalysisOrchestratorAgent:
             timeout=120.0  # 2 minute timeout
         )
         
+        # Repair any tool_use left unanswered by a mid-run user Stop
+        # (or a trim slicing a pair apart) before extending history.
+        self.messages = repair_dangling_tool_calls(self.messages)
         self.messages.append({"role": "user", "content": user_input})
         
         if len(self.messages) > 120:
@@ -1730,6 +1734,9 @@ class AnalysisOrchestratorAgent:
         import litellm
         from ...wrappers.litellm_wrapper import litellm_completion
 
+        # Repair any tool_use left unanswered by a mid-run user Stop
+        # (or a trim slicing a pair apart) before extending history.
+        self.messages = repair_dangling_tool_calls(self.messages)
         self.messages.append({"role": "user", "content": user_input})
         
         if len(self.messages) > 120:

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -3314,7 +3314,7 @@ Your guidance: '''
                     # Try tab-delimited
                     try:
                         return np.loadtxt(data_path, delimiter='\t', skiprows=1)
-                    except:
+                    except Exception:
                         raise ValueError(f"Could not parse text file: {data_path}")
         else:
             # Generic attempt
@@ -4258,7 +4258,7 @@ Return JSON with the refined fitting approach:
                     if new_threshold <= 1.0:
                         print(f"✓ Adjusting threshold to {new_threshold}")
                         return {"action": "adjust_threshold", "new_threshold": new_threshold}
-            except:
+            except Exception:
                 pass
         
         print("🔄 Will retry with your suggested approach...")
@@ -4313,7 +4313,7 @@ Return JSON with the refined fitting approach:
         if review_viz_path and review_viz_path.exists():
             try:
                 os.remove(review_viz_path)
-            except:
+            except Exception:
                 pass
         
         if not feedback:

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -2787,6 +2787,9 @@ inspect the fit plots:
 3. Parsimony — when fits are comparable, prefer the simpler model and the run
    with fewer verification iterations (it stayed closer to the planned model).
 
+When your pick does not hold the best numeric metric, say so explicitly and
+justify via residual structure.
+
 **Return JSON:**
 {{
     "selected_index": <0-based index of the best run>,

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -3107,7 +3107,7 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
             try:
                 with open(os.path.join(output_dir, script_filename), "w", encoding="utf-8") as f:
                     f.write(f"# Auto-generated Script\n# Task: {target_desc}\n\n{code_str}")
-            except: pass
+            except Exception: pass
 
             # --- E. PROCESS MAPS (Dashboard + QC) ---
             total_maps_expected = len(maps_dict)

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1050,6 +1050,34 @@ class MetaOrchestratorAgent:
         self._delegation_ledger.append(entry)
         return entry
 
+    def _sweep_interrupted_delegations(self) -> None:
+        """Finalize ledger entries left 'running' by an aborted turn.
+
+        A user Stop (AgentStoppedError) unwinds the delegation stack without
+        reaching ``_close_delegation``, leaving the provisional entry
+        'running' forever — misleading the UI delegation tree,
+        ``summarize_session_state``, and a later ``fuse_delegations``.
+        Nothing runs between chat turns, so any 'running' entry seen at turn
+        start is by definition dead: close it as 'interrupted' (a non-success
+        status, so the existing degraded-branch machinery excludes it from
+        fusion), mirroring the wall-clock-abandon path.
+        """
+        for e in self._delegation_ledger:
+            if e.get("status") == "running":
+                self.logger.warning(
+                    f"delegation {e.get('index')} "
+                    f"('{e.get('label') or e.get('mode')}') was left running "
+                    "by an interrupted turn — marking it interrupted")
+                self._close_delegation(e, {
+                    "status": "interrupted",
+                    "error": "interrupted by user stop before completion",
+                    "summary": "", "key_findings": [], "files_produced": [],
+                    "suggested_followups": [],
+                    "warnings": ["delegation interrupted mid-run (user "
+                                 "stop); results are incomplete — "
+                                 "re-delegate if still needed"],
+                })
+
     def _close_delegation(self, entry: Dict[str, Any], result: dict) -> None:
         """Finalize a provisional ledger entry with the child's result."""
         entry.update({
@@ -1322,6 +1350,9 @@ class MetaOrchestratorAgent:
         # First-turn: fill the system prompt's specialist-capability inventory
         # from the children's live tool registries (idempotent thereafter).
         self._inject_capabilities()
+
+        # Close out any delegation a mid-run Stop left dangling as 'running'.
+        self._sweep_interrupted_delegations()
 
         # Auto-checkpoint every N messages.
         if self.message_count - self.last_checkpoint_message_count >= self.CHECKPOINT_INTERVAL:

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -24,7 +24,8 @@ from datetime import datetime
 from enum import Enum
 
 from ...auth import get_internal_proxy_key
-from ...utils.tool_media import (build_tool_message, provider_supports_tool_image,
+from ...utils.tool_media import (repair_dangling_tool_calls,
+                                 build_tool_message, provider_supports_tool_image,
                                  sanitize_history_images)
 from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
 from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
@@ -1362,6 +1363,9 @@ class MetaOrchestratorAgent:
             timeout=120.0,
         )
 
+        # Repair any tool_use left unanswered by a mid-run user Stop
+        # (or a trim slicing a pair apart) before extending history.
+        self.messages = repair_dangling_tool_calls(self.messages)
         self.messages.append({"role": "user", "content": user_input})
 
         if len(self.messages) > 120:
@@ -1468,6 +1472,9 @@ class MetaOrchestratorAgent:
         import litellm
         from ...wrappers.litellm_wrapper import litellm_completion
 
+        # Repair any tool_use left unanswered by a mid-run user Stop
+        # (or a trim slicing a pair apart) before extending history.
+        self.messages = repair_dangling_tool_calls(self.messages)
         self.messages.append({"role": "user", "content": user_input})
 
         if len(self.messages) > 120:

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -507,7 +507,7 @@ class OrchestratorTools:
                 try:
                     df = pd.read_csv(self.orch.bo_data_path)
                     data_count = len(df)
-                except:
+                except Exception:
                     pass
             
             return json.dumps({
@@ -3243,7 +3243,7 @@ class OrchestratorTools:
                 try:
                     df = pd.read_csv(self.orch.bo_data_path)
                     data_points = len(df)
-                except:
+                except Exception:
                     pass
             
             # Get message count (handle both OpenAI and Gemini)
@@ -3254,7 +3254,7 @@ class OrchestratorTools:
                 # Gemini: history is in chat_session
                 try:
                     message_count = len(self.orch.chat_session.history) if hasattr(self.orch.chat_session, 'history') else 0
-                except:
+                except Exception:
                     message_count = 0
             
             state = {

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from enum import Enum
 
 from ...auth import get_internal_proxy_key
+from ...utils.tool_media import repair_dangling_tool_calls
 from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
 from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
 from .planning_agent import PlanningAgent
@@ -1521,6 +1522,9 @@ class PlanningOrchestratorAgent:
             base_url=self.model.base_url
         )
         
+        # Repair any tool_use left unanswered by a mid-run user Stop
+        # (or a trim slicing a pair apart) before extending history.
+        self.messages = repair_dangling_tool_calls(self.messages)
         self.messages.append({"role": "user", "content": user_input})
         
         if len(self.messages) > 120:
@@ -1655,6 +1659,9 @@ class PlanningOrchestratorAgent:
         import litellm
         from ...wrappers.litellm_wrapper import litellm_completion
         
+        # Repair any tool_use left unanswered by a mid-run user Stop
+        # (or a trim slicing a pair apart) before extending history.
+        self.messages = repair_dangling_tool_calls(self.messages)
         self.messages.append({"role": "user", "content": user_input})
         
         if len(self.messages) > 120:

--- a/scilink/agents/sim_agents/force_field_agent.py
+++ b/scilink/agents/sim_agents/force_field_agent.py
@@ -1514,7 +1514,7 @@ Provide a brief summary of what the results mean and any actions needed.
             if min(middle_bins) < max(middle_bins) * 0.1:
                 return True
             return False
-        except:
+        except Exception:
             return False
 
     def _detect_gas_phase(self, universe):
@@ -1526,7 +1526,7 @@ Provide a brief summary of what the results mean and any actions needed.
                 density = (n_atoms * 12) / (volume * 0.6022)
                 if density < 0.1:
                     return True
-            except:
+            except Exception:
                 pass
         return False
 
@@ -2769,7 +2769,7 @@ Data file type IDs to map: {', '.join(str(t) for t in type_ids)}
                 from ase.data import atomic_masses, atomic_numbers
                 target_mass = atomic_masses[atomic_numbers[element]]
                 mass_match = abs(mass - target_mass) < 1.0
-            except:
+            except Exception:
                 mass_match = False
             if element_match or mass_match:
                 score = 0

--- a/scilink/agents/sim_agents/lammps_analysis.py
+++ b/scilink/agents/sim_agents/lammps_analysis.py
@@ -511,7 +511,7 @@ class LAMMPSAnalysisAgent:
             if match:
                 try:
                     return json.loads(match.group(0))
-                except:
+                except Exception:
                     pass
             raise ValueError(f"Could not parse JSON: {e}")
     

--- a/scilink/agents/sim_agents/lammps_analysis_updater.py
+++ b/scilink/agents/sim_agents/lammps_analysis_updater.py
@@ -110,7 +110,7 @@ class LAMMPSAnalysisUpdater:
             if match:
                 try:
                     return json.loads(match.group(0))
-                except:
+                except Exception:
                     pass
             raise ValueError(f"Could not parse JSON: {e}")
     

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -29,6 +29,7 @@ from ...auth import (
     APIKeyNotFoundError, get_api_key, get_internal_proxy_key, infer_provider,
     require_vendor_credentials,
 )
+from ...utils.tool_media import repair_dangling_tool_calls
 from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
 from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
 from .simulation_orchestrator_tools import SimulationOrchestratorTools
@@ -796,6 +797,9 @@ class SimulationOrchestratorAgent:
             timeout=120.0,
         )
 
+        # Repair any tool_use left unanswered by a mid-run user Stop
+        # (or a trim slicing a pair apart) before extending history.
+        self.messages = repair_dangling_tool_calls(self.messages)
         self.messages.append({"role": "user", "content": user_input})
 
         if len(self.messages) > 120:
@@ -876,6 +880,9 @@ class SimulationOrchestratorAgent:
         import litellm
         from ...wrappers.litellm_wrapper import litellm_completion
 
+        # Repair any tool_use left unanswered by a mid-run user Stop
+        # (or a trim slicing a pair apart) before extending history.
+        self.messages = repair_dangling_tool_calls(self.messages)
         self.messages.append({"role": "user", "content": user_input})
 
         if len(self.messages) > 120:

--- a/scilink/executors.py
+++ b/scilink/executors.py
@@ -37,12 +37,19 @@ def _unregister_subprocess(proc: subprocess.Popen) -> None:
 
 
 def kill_subprocesses_for_thread(tid: int) -> None:
-    """Terminate all subprocesses registered by a given thread.
+    """Terminate all subprocesses registered by a given thread — including
+    subprocesses of fan-out worker threads registered (via
+    ``log_context.register_worker``) as children of that thread, so a
+    best-of-N candidate's running script is also stopped.
 
     Safe to call from any thread (e.g. the Streamlit UI thread).
     """
+    from scilink.utils.log_context import effective_thread
     with _active_subprocesses_lock:
-        procs = list(_active_subprocesses.pop(tid, []))
+        target_tids = [t for t in _active_subprocesses
+                       if t == tid or effective_thread(t) == tid]
+        procs = [p for t in target_tids
+                 for p in _active_subprocesses.pop(t, [])]
     for proc in procs:
         try:
             proc.terminate()          # SIGTERM first

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -399,14 +399,21 @@ def _run_agent_chat(task: ChatTask, agent, user_input: str) -> None:
     # per-attempt detail to milestones (executing / verification / outcome) so
     # the panel stays readable; a lone attempt and the CLI keep full detail.
     from scilink.utils.log_context import effective_thread, keep_in_fanout_panel
-    log_handler.addFilter(
-        lambda record: (
-            effective_thread(record.thread) == _this_thread
-            and keep_in_fanout_panel(
-                record.thread, record.getMessage(), record.levelno
-            )
+
+    def _panel_filter(record):
+        if effective_thread(record.thread) != _this_thread:
+            return False
+        # Stop propagation for logging-heavy phases: much of the agents'
+        # narration goes through logging (not print), so without this check
+        # a stopped run would only abort on its next print(). Filters run in
+        # the emitting thread, so the raise lands in the agent/worker thread.
+        if cap.stop_requested:
+            raise AgentStoppedError("Agent stopped by user")
+        return keep_in_fanout_panel(
+            record.thread, record.getMessage(), record.levelno
         )
-    )
+
+    log_handler.addFilter(_panel_filter)
     root_logger = logging.getLogger()
     # Lower root to INFO so agent logger.info() messages (execution
     # details, verification steps, R² values) reach the handler.

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -1158,9 +1158,13 @@ def resume_session(
 def _reset_session() -> None:
     # Stop the agent thread if it's still running
     task = st.session_state.get("chat_task")
-    if task and task.is_running and task.feedback_request is not None:
-        task.feedback_request.response = ""
-        task.feedback_request.event.set()
+    if task and task.is_running:
+        task.stopped = True
+        if task.live_capture:
+            task.live_capture.request_stop()
+        if task.feedback_request is not None:
+            task.feedback_request.response = ""
+            task.feedback_request.event.set()
 
     # Disconnect MCP servers to avoid orphaned subprocesses
     agent = st.session_state.get("agent")

--- a/scilink/ui/output_capture.py
+++ b/scilink/ui/output_capture.py
@@ -5,8 +5,15 @@ import sys
 import threading
 
 
-class AgentStoppedError(Exception):
-    """Raised inside the agent thread when the user clicks Stop."""
+class AgentStoppedError(BaseException):
+    """Raised inside the agent thread when the user clicks Stop.
+
+    Deliberately a ``BaseException`` (like ``KeyboardInterrupt``): the agent
+    stack is full of ``except Exception`` recovery handlers (tool dispatch,
+    retry loops, the orchestrator's own chat() catch-all) that would otherwise
+    swallow the stop, feed it back to the LLM as a tool error, and let the run
+    continue. A user-initiated stop must not be recoverable-from.
+    """
 
 
 class TeeStream:
@@ -55,6 +62,11 @@ class OutputCapture:
         self._old_stderr = None
         self._stop_event = threading.Event()
         self._agent_thread_id: int | None = None
+
+    @property
+    def stop_requested(self) -> bool:
+        """True once request_stop() has been called."""
+        return self._stop_event.is_set()
 
     def request_stop(self) -> None:
         """Signal the agent thread to abort on the next print() call.

--- a/scilink/utils/tool_media.py
+++ b/scilink/utils/tool_media.py
@@ -131,6 +131,64 @@ def build_tool_message(tool_call_id: str, result_str: str, *,
     return {"role": "tool", "tool_call_id": tool_call_id, "content": content}
 
 
+_INTERRUPTED_TOOL_NOTE = (
+    "⚠️ Tool execution was interrupted before a result was produced "
+    "(the run was stopped). Re-run this tool if its output is still needed.")
+
+
+def repair_dangling_tool_calls(messages: list) -> list:
+    """Repair tool_use/tool_result pairing so a resumed history is valid.
+
+    A user Stop can abort the chat loop between appending an assistant
+    message with ``tool_calls`` and appending the matching ``tool``
+    result messages; history trimming can likewise slice a pair apart.
+    Providers (Anthropic/Bedrock in particular) reject such histories:
+    every tool_use id must be answered by a tool_result in the next
+    message. Called at the top of each chat turn:
+
+    - inserts a synthetic "interrupted" tool result for every tool_call
+      id that has no matching ``tool`` message,
+    - drops orphan / duplicate / foreign ``tool`` messages that answer
+      no pending tool_call id.
+    """
+    repaired: list = []
+    i, n = 0, len(messages)
+    while i < n:
+        m = messages[i]
+        if not isinstance(m, dict):
+            repaired.append(m)
+            i += 1
+            continue
+        if m.get("role") == "tool":
+            # Orphan tool result (its assistant tool_calls message was
+            # trimmed away, or it strayed) — drop it.
+            i += 1
+            continue
+        repaired.append(m)
+        tool_calls = m.get("tool_calls") if m.get("role") == "assistant" else None
+        if tool_calls:
+            expected = [tc.get("id") for tc in tool_calls
+                        if isinstance(tc, dict) and tc.get("id")]
+            answered: set = set()
+            j = i + 1
+            while j < n and isinstance(messages[j], dict) \
+                    and messages[j].get("role") == "tool":
+                tm = messages[j]
+                tcid = tm.get("tool_call_id")
+                if tcid in expected and tcid not in answered:
+                    answered.add(tcid)
+                    repaired.append(tm)
+                j += 1  # duplicates / foreign ids are dropped
+            for tcid in expected:
+                if tcid not in answered:
+                    repaired.append({"role": "tool", "tool_call_id": tcid,
+                                     "content": _INTERRUPTED_TOOL_NOTE})
+            i = j
+        else:
+            i += 1
+    return repaired
+
+
 def sanitize_history_images(messages: list) -> list:
     """Collapse any multimodal message content back to a plain string for
     persistence: keep the text parts, drop image parts (leaving a marker). No-op

--- a/tests/test_ui_stop.py
+++ b/tests/test_ui_stop.py
@@ -1,0 +1,145 @@
+"""UI Stop-button semantics: a user stop must not be swallowed.
+
+The Stop button sets an event that makes the agent thread's next print()
+(or, via the UI log-handler filter, its next logging call) raise
+``AgentStoppedError``. The agent stack is full of ``except Exception``
+recovery handlers (tool dispatch, retry loops, the orchestrator chat()
+catch-all), so the error must be a ``BaseException`` — otherwise the stop
+is converted into a tool-error string fed back to the LLM and the run
+continues (the original bug).
+"""
+import io
+import logging
+import subprocess
+import sys
+import threading
+import time
+
+from scilink.ui.output_capture import AgentStoppedError, OutputCapture, TeeStream
+
+
+def test_agent_stopped_error_is_base_exception():
+    assert issubclass(AgentStoppedError, BaseException)
+    assert not issubclass(AgentStoppedError, Exception)
+
+
+def test_stop_survives_except_exception_recovery_handlers():
+    """The exact swallow pattern that caused the bug: agent-side code wraps
+    work in ``except Exception`` and keeps going. The stop must escape it."""
+    stop = threading.Event()
+    stop.set()
+    stream = TeeStream(io.StringIO(), io.StringIO(), stop)
+
+    def agent_like_loop():
+        for _ in range(3):  # tool-dispatch retry loop
+            try:
+                stream.write("narration\n")  # agent print() lands here
+            except Exception:
+                continue  # pre-fix: stop swallowed here, run continued
+
+    try:
+        agent_like_loop()
+    except AgentStoppedError:
+        return
+    raise AssertionError("stop was swallowed by an except-Exception handler")
+
+
+def test_teestream_does_not_write_after_stop():
+    buf = io.StringIO()
+    stop = threading.Event()
+    stream = TeeStream(io.StringIO(), buf, stop)
+    stream.write("before\n")
+    stop.set()
+    try:
+        stream.write("after\n")
+    except AgentStoppedError:
+        pass
+    assert buf.getvalue() == "before\n"
+
+
+def test_stop_requested_property():
+    cap = OutputCapture()
+    assert cap.stop_requested is False
+    cap.request_stop()
+    assert cap.stop_requested is True
+
+
+def test_logging_filter_raise_propagates_to_emitter():
+    """The UI attaches a handler whose filter raises on stop; logging must
+    propagate that out of the logger.info() call (filters, unlike emit
+    errors, are not swallowed by logging's error handling)."""
+    cap = OutputCapture()
+    logger = logging.getLogger("test_ui_stop_filterprop")
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler(io.StringIO())
+
+    def _filter(record):
+        if cap.stop_requested:
+            raise AgentStoppedError("Agent stopped by user")
+        return True
+
+    handler.addFilter(_filter)
+    logger.addHandler(handler)
+    try:
+        logger.info("fine before stop")
+        cap.request_stop()
+        try:
+            logger.info("must raise")
+        except AgentStoppedError:
+            return
+        raise AssertionError("logging path did not propagate the stop")
+    finally:
+        logger.removeHandler(handler)
+
+
+def test_kill_subprocesses_includes_registered_fanout_workers():
+    """Stop must also kill subprocesses spawned by best-of-N candidate
+    worker threads (registered via log_context.register_worker), not just
+    the chat thread's own."""
+    from scilink.executors import (_register_subprocess,
+                                   kill_subprocesses_for_thread)
+    from scilink.utils.log_context import register_worker, unregister_worker
+
+    parent_tid = threading.get_ident()
+    proc_holder = {}
+    started = threading.Event()
+
+    def worker():
+        register_worker(parent_tid, "cand_00", prefix=True)
+        try:
+            proc = subprocess.Popen([sys.executable, "-c",
+                                     "import time; time.sleep(60)"])
+            proc_holder["proc"] = proc
+            _register_subprocess(proc)
+            started.set()
+            proc.wait()
+        finally:
+            unregister_worker()
+
+    t = threading.Thread(target=worker, daemon=True)
+    t.start()
+    assert started.wait(timeout=10)
+    kill_subprocesses_for_thread(parent_tid)  # what request_stop() calls
+    t.join(timeout=10)
+    assert not t.is_alive(), "worker's subprocess was not killed on stop"
+    assert proc_holder["proc"].returncode is not None
+
+
+def test_agent_chat_catchall_does_not_eat_stop():
+    """The orchestrator's chat() wraps everything in ``except Exception``
+    and returns an error string; a stop must pass through it instead."""
+
+    def chat_like(fn):
+        try:
+            return fn()
+        except Exception as e:  # the real catch-all at chat()'s top level
+            return f"Error: {e}"
+
+    def raises_stop():
+        raise AgentStoppedError("Agent stopped by user")
+
+    try:
+        result = chat_like(raises_stop)
+    except AgentStoppedError:
+        return
+    raise AssertionError(f"chat() catch-all swallowed the stop: {result!r}")

--- a/tests/test_ui_stop.py
+++ b/tests/test_ui_stop.py
@@ -125,6 +125,64 @@ def test_kill_subprocesses_includes_registered_fanout_workers():
     assert proc_holder["proc"].returncode is not None
 
 
+def _tc(tcid, name="run_analysis"):
+    return {"id": tcid, "type": "function",
+            "function": {"name": name, "arguments": "{}"}}
+
+
+def test_repair_inserts_synthetic_result_for_dangling_tool_call():
+    """The post-stop resume bug: history ends with assistant tool_calls and
+    no tool result — Bedrock rejects the next turn. Repair must insert a
+    synthetic 'interrupted' tool result."""
+    from scilink.utils.tool_media import repair_dangling_tool_calls
+    msgs = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "analyze this"},
+        {"role": "assistant", "content": None, "tool_calls": [_tc("t1")]},
+    ]
+    out = repair_dangling_tool_calls(msgs)
+    assert len(out) == 4
+    assert out[3]["role"] == "tool" and out[3]["tool_call_id"] == "t1"
+    assert "interrupted" in out[3]["content"].lower()
+
+
+def test_repair_fills_only_missing_of_parallel_tool_calls():
+    from scilink.utils.tool_media import repair_dangling_tool_calls
+    msgs = [
+        {"role": "assistant", "content": None,
+         "tool_calls": [_tc("t1"), _tc("t2")]},
+        {"role": "tool", "tool_call_id": "t1", "content": "done"},
+    ]
+    out = repair_dangling_tool_calls(msgs)
+    assert [m.get("tool_call_id") for m in out[1:]] == ["t1", "t2"]
+    assert out[1]["content"] == "done"
+    assert "interrupted" in out[2]["content"].lower()
+
+
+def test_repair_drops_orphan_tool_messages():
+    """History trimming can slice a pair apart the other way: a tool result
+    whose assistant tool_calls message was trimmed away."""
+    from scilink.utils.tool_media import repair_dangling_tool_calls
+    msgs = [
+        {"role": "tool", "tool_call_id": "gone", "content": "orphan"},
+        {"role": "user", "content": "hi"},
+    ]
+    out = repair_dangling_tool_calls(msgs)
+    assert out == [{"role": "user", "content": "hi"}]
+
+
+def test_repair_noop_on_healthy_history():
+    from scilink.utils.tool_media import repair_dangling_tool_calls
+    msgs = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "analyze"},
+        {"role": "assistant", "content": "thinking", "tool_calls": [_tc("t1")]},
+        {"role": "tool", "tool_call_id": "t1", "content": "result"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    assert repair_dangling_tool_calls(msgs) == msgs
+
+
 def test_agent_chat_catchall_does_not_eat_stop():
     """The orchestrator's chat() wraps everything in ``except Exception``
     and returns an error string; a stop must pass through it instead."""

--- a/tests/test_ui_stop.py
+++ b/tests/test_ui_stop.py
@@ -183,6 +183,34 @@ def test_repair_noop_on_healthy_history():
     assert repair_dangling_tool_calls(msgs) == msgs
 
 
+def test_meta_sweep_closes_running_delegations_as_interrupted():
+    """A Stop mid-delegation bypasses _close_delegation, leaving the ledger
+    entry 'running' forever. The turn-start sweep must finalize it as
+    'interrupted' (non-success, so fusion's usable-branch predicate
+    excludes it) and leave completed entries untouched."""
+    import logging as _logging
+    from scilink.agents.meta_agent.meta_orchestrator import MetaOrchestratorAgent
+
+    orch = MetaOrchestratorAgent.__new__(MetaOrchestratorAgent)
+    orch.logger = _logging.getLogger("test_meta_sweep")
+    done = {"index": 1, "mode": "analysis", "label": "done-one",
+            "status": "success", "summary": "fine", "key_findings": ["x"]}
+    stuck = {"index": 2, "mode": "analysis", "label": "stuck-one",
+             "status": "running", "summary": "", "key_findings": []}
+    orch._delegation_ledger = [done, stuck]
+
+    orch._sweep_interrupted_delegations()
+
+    assert done["status"] == "success" and done["summary"] == "fine"
+    assert stuck["status"] == "interrupted"
+    assert "interrupted" in (stuck["error"] or "")
+    assert stuck["warnings"] and "re-delegate" in stuck["warnings"][0]
+    assert stuck.get("completed_at")
+    # idempotent — a second sweep changes nothing
+    orch._sweep_interrupted_delegations()
+    assert stuck["status"] == "interrupted"
+
+
 def test_agent_chat_catchall_does_not_eat_stop():
     """The orchestrator's chat() wraps everything in ``except Exception``
     and returns an error string; a stop must pass through it instead."""


### PR DESCRIPTION
## Summary

Pressing Stop in the UI looked like it stopped the agent, but the run kept going in the background — and if you then continued the session, the next message could fail with a Bedrock error about missing tool results. This PR makes Stop actually stop everything (the orchestrator, delegated specialists, best-of-N candidates, and running fit scripts), makes the session safely resumable afterward, and cleans up how an interrupted delegation is reported in a meta session.

What changes for users:

- **Stop halts the run within seconds**, including scripts already executing and parallel best-of-N candidate attempts.
- **The session continues normally after a Stop** — no more `tool_use ids were found without tool_result blocks` error on the next message. The agent is told the tool call was interrupted so it can re-run it if needed.
- **In a meta session, an interrupted delegation is marked "interrupted"** in the delegation history instead of appearing to run forever, and it is excluded from later cross-dataset fusion.
- Resetting a session from the sidebar now also stops a running agent (previously it kept running in the background).
- Small best-of-N judge wording fix from a live trace: when the judge prefers a candidate that does not have the best numeric metric, it must say so explicitly instead of misstating which R² is highest.

All paths live-validated on Bedrock (details below).

---

## Technical details

**1. Stop signal was swallowed (`1208f312`)**
- `AgentStoppedError` now subclasses `BaseException` (scilink/ui/output_capture.py:8). It was an `Exception`, so any of the ~640 `except Exception` recovery handlers in the agent stack (tool dispatch, retry loops, the orchestrator `chat()` catch-all at analysis_orchestrator.py:1365) caught the stop, fed it back to the LLM as a tool error, and the run continued.
- The UI log-handler filter also raises on stop (scilink/ui/app.py:404) — logging-heavy phases abort on their next log call instead of waiting for a `print()`. Filters run in the emitting thread, and unlike emit errors they are not swallowed by `logging`.
- `kill_subprocesses_for_thread` also kills subprocesses spawned by registered fan-out worker threads (best-of-N candidates), via the `log_context.effective_thread` mapping (scilink/executors.py:39).
- 12 bare `except:` sites (which catch `BaseException`) converted to `except Exception:` so they cannot swallow the stop.
- Sidebar `_reset_session` now signals a running agent to stop (scilink/ui/components/sidebar.py:1159); previously it only unblocked a pending feedback prompt.

**2. Resume after Stop failed with Bedrock BadRequestError (`bec78ac2`)**
- A stop firing inside `execute_tool` leaves the history ending with an assistant `tool_calls` message and no tool results; Anthropic/Bedrock reject such histories on the next turn. History trimming could slice a pair apart the same way.
- `repair_dangling_tool_calls` (scilink/utils/tool_media.py) inserts a synthetic "interrupted — re-run if needed" tool result for every unanswered tool_call id and drops orphan/duplicate tool messages. Called at the top of both chat handlers (OpenAI + LiteLLM) in all four orchestrators — analysis, planning, simulation, meta — covering in-memory continuation, `run_task` delegation, and checkpoint-restored histories. `structure_agent` builds a fresh local message list per call and needs no repair.

**3. Meta ledger entries stuck "running" (`15a5b99e`)**
- `_open_delegation` appends a provisional `running` entry before the child runs; a stop bypasses `_close_delegation`, leaving it `running` forever — misleading the UI delegation tree, `summarize_session_state`, and later `fuse_delegations`.
- `_sweep_interrupted_delegations` (meta_orchestrator.py:1053) runs at every meta chat-turn start: nothing runs between turns, so any `running` entry is dead → closed as `interrupted` with an explicit warning. `interrupted` is a non-success status, so fusion's usable-branch predicate (fanout.py:1068) already excludes it.

**4. Best-of-N judge prompt (`287b29b8`)**
- One-sentence principle added to `BEST_OF_N_JUDGE_PROMPT` (curve_fitting_controllers.py:2790); trace specifics in the commit message.

**Known limit**: an in-flight LLM HTTP call is not interruptible; the abort lands on the next print/log after it returns (~seconds in practice).

**Validation**
- Offline: `tests/test_ui_stop.py` — 12 tests (stop semantics through `except Exception` handlers, logging-filter propagation, no-write-after-stop, worker subprocess kill, dangling-pair repair incl. parallel tool calls and orphan drop, meta sweep idempotency).
- Live on Bedrock (opus-4-8), three scenarios: (a) stop mid-`run_analysis` — thread exited 4 s after stop, zero output growth, no phantom result (5/5 checks); (b) stop → resume — history contained a real dangling `tooluse_…` id, follow-up turn succeeded with a correct session summary (6/6); (c) meta: stop mid curve-fitting delegation → full-stack unwind, ledger `running → interrupted` at next turn, meta correctly reported the interrupted delegation (7/7).
