### PR TITLE
Hypothesis generation: best-of-N candidates, lab/ideation modes, and cross-domain cross-pollination (#377)

### DIFF
--- a/scilink/agents/lit_agents/literature_agent.py
+++ b/scilink/agents/lit_agents/literature_agent.py
@@ -373,6 +373,36 @@ class LiteratureSearchAgent:
         )
         return self._execute_crow_task(formatted_query, task_type="Hypothesis")
 
+    def search_for_cross_domain(self, objective: str) -> Dict[str, Any]:
+        """
+        Formats a query for INSPIRATION retrieval: mechanisms and design
+        principles from adjacent or unrelated fields that could TRANSFER to
+        this problem.
+
+        Deliberately not a topical review. ``search_for_hypothesis_context``
+        retrieves the problem's own subfield — which grounds a plan but also
+        anchors it to established approaches. This one asks for analogies
+        whose mechanism might carry over, which is where a genuinely new
+        mechanistic idea usually comes from.
+
+        Intended for ideation. Benchmarking showed cross-domain context
+        raises idea novelty and non-obviousness, but degrades adherence to
+        hard equipment/process constraints — so pair it with grounding
+        retrieval, and prefer grounding alone when a plan must satisfy
+        stated constraints.
+        """
+        formatted_query = (
+            "Survey mechanisms and design principles from ADJACENT and "
+            "UNRELATED domains that could TRANSFER to the problem below. Do "
+            "NOT provide a topical review of the problem's own subfield "
+            "methods. For each analogous system (a different chemistry, "
+            "biology, or engineering field achieving a similar function), "
+            "describe the underlying mechanism and explain why it might "
+            "transfer. Emphasize unconventional and emerging approaches.\n\n"
+            f"PROBLEM: {objective}"
+        )
+        return self._execute_crow_task(formatted_query, task_type="CrossDomain")
+
     def search_for_fitting_models(self, objective: str) -> Dict[str, Any]:
         """
         Formats a query specifically for finding mathematical equations.

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -397,7 +397,15 @@ class MetaOrchestratorTools:
                 "with no interactive user and returns a structured JSON result "
                 "(status, summary, key_findings, files_produced, "
                 "suggested_followups, warnings, delegation_index). `task` must "
-                "be a complete, self-contained instruction."
+                "be a complete, self-contained instruction. The specialist "
+                "supports best-of-N plan generation (an LLM judge picks among "
+                "distinct candidate strategies): when the user asks for "
+                "alternatives or the design goal is open-ended, add the "
+                "instruction 'use n_candidates=N on generate_initial_plan' "
+                "(N up to 4) to the task — but keep the scientific goal "
+                "itself SINGULAR (never phrase the objective as 'propose N "
+                "strategies'; the tool parameter provides the multiplicity). "
+                "Omit for narrow or follow-up tasks."
             ),
             parameters={
                 "task": {

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -405,7 +405,10 @@ class MetaOrchestratorTools:
                 "when the user wants a specific width — including N=1 for a "
                 "single plan. Keep the scientific goal itself SINGULAR "
                 "(never phrase the objective as 'propose N strategies'; the "
-                "tool parameter provides the multiplicity)."
+                "tool parameter provides the multiplicity). When the user is "
+                "brainstorming/ideating rather than planning an executable "
+                "run, add 'use selection_profile=discovery' to the task so "
+                "the candidate judge weights novelty over feasibility."
             ),
             parameters={
                 "task": {

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -399,13 +399,13 @@ class MetaOrchestratorTools:
                 "suggested_followups, warnings, delegation_index). `task` must "
                 "be a complete, self-contained instruction. The specialist "
                 "supports best-of-N plan generation (an LLM judge picks among "
-                "distinct candidate strategies): when the user asks for "
-                "alternatives or the design goal is open-ended, add the "
-                "instruction 'use n_candidates=N on generate_initial_plan' "
-                "(N up to 4) to the task — but keep the scientific goal "
-                "itself SINGULAR (never phrase the objective as 'propose N "
-                "strategies'; the tool parameter provides the multiplicity). "
-                "Omit for narrow or follow-up tasks."
+                "distinct candidate strategies) and DEFAULTS to best-of-3 for "
+                "a campaign's first plan. Only add an explicit "
+                "'use n_candidates=N on generate_initial_plan' instruction "
+                "when the user wants a specific width — including N=1 for a "
+                "single plan. Keep the scientific goal itself SINGULAR "
+                "(never phrase the objective as 'propose N strategies'; the "
+                "tool parameter provides the multiplicity)."
             ),
             parameters={
                 "task": {

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -407,7 +407,7 @@ class MetaOrchestratorTools:
                 "(never phrase the objective as 'propose N strategies'; the "
                 "tool parameter provides the multiplicity). When the user is "
                 "brainstorming/ideating rather than planning an executable "
-                "run, add 'use selection_profile=discovery' to the task so "
+                "run, add 'use selection_profile=ideation' to the task so "
                 "the candidate judge weights novelty over feasibility."
             ),
             parameters={

--- a/scilink/agents/planning_agents/html_generator.py
+++ b/scilink/agents/planning_agents/html_generator.py
@@ -247,6 +247,32 @@ class HTMLReportGenerator:
         </div>
         """
 
+    def generate_single_plan(self, plan: Dict[str, Any], output_path: str,
+                             title: str = "Candidate Plan"):
+        """Render ONE plan dict (not the session history) to a standalone HTML
+        report — used for best-of-N candidate reports, where each candidate
+        gets its own persisted page under ``plan_candidates/``."""
+        content_html = "".join(
+            self._render_experiment(exp, x + 1)
+            for x, exp in enumerate(plan.get('proposed_experiments', []))
+        )
+        html_content = f"""
+        <!DOCTYPE html><html><head><meta charset="UTF-8"><title>{html.escape(title)}</title>{self._get_css()}</head>
+        <body><div class="container">
+            <header>
+                <h1>🔭 {html.escape(title)}</h1>
+                <div class="objective"><strong>Objective:</strong> {html.escape(self.state.get('objective', '') or '')}</div>
+            </header>
+            <div class="step">
+                <div class="step-header"><span class="badge plan">EXPERIMENTAL STRATEGY</span></div>
+                {content_html}
+            </div>
+            <footer>{self.generated_by}</footer>
+        </div></body></html>
+        """
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write(html_content)
+
     def generate(self, output_path: str):
         date_str = self.state.get('start_time', datetime.now().isoformat())
         

--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -185,8 +185,8 @@ Respond with a single JSON object:
 """
 
 
-DISCOVERY_AUTHOR_OVERRIDE = """
-## DISCOVERY MODE — GROUNDING LATITUDE (overrides the Safety Rule above)
+IDEATION_AUTHOR_OVERRIDE = """
+## IDEATION MODE — GROUNDING LATITUDE (overrides the Safety Rule above)
 This run is research ideation. The provided context may deliberately lack
 the key inspiration. Instead of declining for insufficient context: ground
 your plan in the context where possible, and where the decisive mechanism
@@ -207,8 +207,8 @@ Prefer the candidate most likely to produce a clean, interpretable result
 on the stated platform."""
 
 
-BESTOFN_SELECTION_PROFILE_DISCOVERY = """
-## SELECTION WEIGHTING — DISCOVERY PROFILE
+BESTOFN_SELECTION_PROFILE_IDEATION = """
+## SELECTION WEIGHTING — IDEATION PROFILE
 This is research ideation: the goal is the most scientifically valuable
 hypothesis, not tomorrow's protocol. Weight information_gain and
 mechanistic novelty most heavily when selecting: prefer the candidate
@@ -957,7 +957,7 @@ SAMPLE FILENAMES (first 20): {filenames}
 
 QUESTION: {query}
 
-The script below provides imports, file discovery, and reader functions.
+The script below provides imports, file ideation, and reader functions.
 Complete ONLY the TODO section (query logic).
 
 ```
@@ -991,7 +991,7 @@ SAMPLE FILENAMES (first 20): {filenames}
 QUERY: {query}
 TOP-K to retain: {top_k}
 
-The script below provides imports, file discovery, and reader functions.
+The script below provides imports, file ideation, and reader functions.
 Complete ONLY the TODO section.
 
 ```

--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -133,6 +133,16 @@ You MUST respond with a single JSON object containing a key "proposed_experiment
 """
 
 
+HYPOTHESIS_BESTOFN_AUTHOR_NOTE = """## ⚠️ BEST-OF-N AUTHORING NOTE
+You are authoring ONE candidate in a multi-candidate (best-of-N) process:
+alternative strategies are handled by SEPARATE candidate plans and compared
+by a judge afterwards. If the objective asks to explore multiple distinct
+strategies or alternatives, that request is satisfied by the process — NOT by
+this plan. Propose exactly ONE strategy: a single coherent experiment plan
+built around one mechanistic approach. Do NOT pack multiple alternative
+strategies into this plan."""
+
+
 HYPOTHESIS_DISTINCTNESS_CONDITIONING = """## ⚠️ PRIOR CANDIDATE HYPOTHESES (already proposed for this objective)
 {prior_hypotheses}
 

--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -133,6 +133,48 @@ You MUST respond with a single JSON object containing a key "proposed_experiment
 """
 
 
+HYPOTHESIS_DISTINCTNESS_CONDITIONING = """## ⚠️ PRIOR CANDIDATE HYPOTHESES (already proposed for this objective)
+{prior_hypotheses}
+
+You MUST propose a plan that tests a DIFFERENT mechanistic hypothesis or
+strategic approach from every hypothesis listed above. Standard practice
+(equipment, safety, characterization steps) may repeat; the scientific claim
+and the strategy that tests it must not. If the provided evidence cannot
+support another distinct, well-grounded approach, respond with the error JSON
+(e.g. {{"error": "Insufficient context: no additional distinct approach is supported by the provided evidence."}})
+instead of inventing one."""
+
+
+HYPOTHESIS_BEST_OF_N_SELECTION_INSTRUCTIONS = """
+You are an expert research strategist selecting the best of several candidate
+experimental plans for the same objective. The candidates were authored
+against the SAME evidence (provided below), so differences between them
+reflect strategy, not information. Judge them comparatively.
+
+Score EACH candidate 1-5 on:
+- "groundedness": every load-bearing claim is traceable to the provided evidence.
+- "testability": the hypothesis is falsifiable by the stated expected_outcome.
+- "actionability": steps are executable without placeholders; optimization
+  parameters are well-bounded.
+- "feasibility": equipment/technique demands match what the evidence says is
+  available.
+- "information_gain": how much the result advances the objective whichever way
+  it falls.
+
+Then select ONE candidate. You are a selector, not an editor: do not rewrite,
+merge, or extend any plan. If your selection does NOT have the top score on
+some criterion, you MUST state that tradeoff plainly in your reasoning rather
+than smoothing it over.
+
+Respond with a single JSON object:
+{"scores": [{"candidate": <1-based int>, "groundedness": <1-5>, "testability": <1-5>,
+             "actionability": <1-5>, "feasibility": <1-5>, "information_gain": <1-5>,
+             "comment": "<one sentence>"}],
+ "selected_candidate": <1-based int>,
+ "reasoning": "<short paragraph explaining the comparative pick, naming any criterion where the pick is not the top scorer>"}
+"""
+
+
 TEA_INSTRUCTIONS_FALLBACK = """
 You are an expert technoeconomic analyst.
 

--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -185,6 +185,18 @@ Respond with a single JSON object:
 """
 
 
+DISCOVERY_AUTHOR_OVERRIDE = """
+## DISCOVERY MODE — GROUNDING LATITUDE (overrides the Safety Rule above)
+This run is research ideation. The provided context may deliberately lack
+the key inspiration. Instead of declining for insufficient context: ground
+your plan in the context where possible, and where the decisive mechanism
+is not in the context you MAY introduce one from general scientific
+knowledge — choose the boldest hypothesis you can rigorously defend, and
+mark context-external elements as (speculative) in the justification.
+Never fabricate specific numeric claims or attribute them to unnamed
+sources."""
+
+
 BESTOFN_SELECTION_PROFILE_LAB = """
 ## SELECTION WEIGHTING — LAB PROFILE
 This campaign is headed for actual execution. Weight feasibility and

--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -185,6 +185,27 @@ Respond with a single JSON object:
 """
 
 
+BESTOFN_SELECTION_PROFILE_LAB = """
+## SELECTION WEIGHTING — LAB PROFILE
+This campaign is headed for actual execution. Weight feasibility and
+actionability most heavily when selecting: a plan that cannot run on the
+available equipment, or whose steps are not directly executable, cannot
+generate any information regardless of how interesting its hypothesis is.
+Prefer the candidate most likely to produce a clean, interpretable result
+on the stated platform."""
+
+
+BESTOFN_SELECTION_PROFILE_DISCOVERY = """
+## SELECTION WEIGHTING — DISCOVERY PROFILE
+This is research ideation: the goal is the most scientifically valuable
+hypothesis, not tomorrow's protocol. Weight information_gain and
+mechanistic novelty most heavily when selecting: prefer the candidate
+whose result would advance understanding most — whichever way it falls —
+even if it is operationally more demanding. Feasibility is a tiebreaker,
+not a veto; only rule a candidate out on feasibility if it is
+fundamentally unexecutable, and say so plainly."""
+
+
 TEA_INSTRUCTIONS_FALLBACK = """
 You are an expert technoeconomic analyst.
 

--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -957,7 +957,7 @@ SAMPLE FILENAMES (first 20): {filenames}
 
 QUESTION: {query}
 
-The script below provides imports, file ideation, and reader functions.
+The script below provides imports, file discovery, and reader functions.
 Complete ONLY the TODO section (query logic).
 
 ```
@@ -991,7 +991,7 @@ SAMPLE FILENAMES (first 20): {filenames}
 QUERY: {query}
 TOP-K to retain: {top_k}
 
-The script below provides imports, file ideation, and reader functions.
+The script below provides imports, file discovery, and reader functions.
 Complete ONLY the TODO section.
 
 ```

--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -185,6 +185,14 @@ Respond with a single JSON object:
 """
 
 
+CONSTRAINT_COVERAGE_NOTE = """
+## MANDATORY CONSTRAINT COVERAGE
+Every hard constraint stated above must be addressed by a named experimental
+step that says which constraint it satisfies. An unaddressed constraint is a
+failed plan, however scientifically interesting the rest of it is.
+"""
+
+
 IDEATION_AUTHOR_OVERRIDE = """
 ## IDEATION MODE — GROUNDING LATITUDE (overrides the Safety Rule above)
 This run is research ideation. The provided context may deliberately lack

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -925,7 +925,11 @@ class OrchestratorTools:
                         "iterations, thin evidence, or narrowly-specified "
                         "objectives. A cap, not a quota: generation stops "
                         "early when the evidence supports no further "
-                        "distinct approach."
+                        "distinct approach. When raising it, keep "
+                        "specific_objective about ONE scientific goal — do "
+                        "NOT ask for multiple plans/strategies in the "
+                        "objective text; this parameter provides the "
+                        "multiplicity."
                     ),
                 },
             },

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -559,47 +559,89 @@ class OrchestratorTools:
                     "message": "Literature search not available (no FutureHouse API key configured)"
                 })
 
-            valid_types = ("hypothesis_context", "economic_data", "fitting_models")
-            if search_type not in valid_types:
+            search_methods = {
+                "hypothesis_context": self.orch.lit_agent.search_for_hypothesis_context,
+                "cross_domain": self.orch.lit_agent.search_for_cross_domain,
+                "economic_data": self.orch.lit_agent.search_for_economic_data,
+                "fitting_models": self.orch.lit_agent.search_for_fitting_models,
+            }
+            # Multiple types run CONCURRENTLY: each Edison call is minutes of
+            # waiting, so a serial pair doubles the user's wait for no reason.
+            types = [t.strip() for t in str(search_type).split(",") if t.strip()]
+            bad = [t for t in types if t not in search_methods]
+            if bad or not types:
                 return json.dumps({
                     "status": "error",
-                    "message": f"Invalid search_type '{search_type}'. Must be one of: {', '.join(valid_types)}"
+                    "message": (f"Invalid search_type '{search_type}'. Use one or more "
+                                f"(comma-separated) of: {', '.join(search_methods)}")
                 })
 
-            print(f"  ⚡ Tool: Searching literature ({search_type}) for '{objective[:80]}...'")
+            label = "+".join(types)
+            print(f"  ⚡ Tool: Searching literature ({label}) for '{objective[:80]}...'"
+                  + (" [parallel]" if len(types) > 1 else ""))
 
             try:
                 clean_query = optimize_search_query(
                     objective=objective, model=self.orch.planner.model
                 )
 
-                search_methods = {
-                    "hypothesis_context": self.orch.lit_agent.search_for_hypothesis_context,
-                    "economic_data": self.orch.lit_agent.search_for_economic_data,
-                    "fitting_models": self.orch.lit_agent.search_for_fitting_models,
-                }
-                lit_res = search_methods[search_type](clean_query)
+                if len(types) == 1:
+                    results = {types[0]: search_methods[types[0]](clean_query)}
+                else:
+                    from concurrent.futures import ThreadPoolExecutor
+                    with ThreadPoolExecutor(max_workers=len(types)) as ex:
+                        futures = {t: ex.submit(search_methods[t], clean_query)
+                                   for t in types}
+                        results = {t: f.result() for t, f in futures.items()}
 
-                if lit_res['status'] != 'success':
+                ok = {t: r for t, r in results.items() if r.get("status") == "success"}
+                if not ok:
+                    first = next(iter(results.values()))
                     return json.dumps({
-                        "status": lit_res['status'],
-                        "message": lit_res.get('message', 'Literature search did not succeed')
+                        "status": first.get("status", "error"),
+                        "message": first.get("message", "Literature search did not succeed")
                     })
 
-                # Save to file (distinct per search_type to avoid overwrites)
-                lit_path = self._output_dir() / f"literature_search_{search_type}.md"
+                # Sections are LABELLED, not concatenated: candidates must be
+                # able to tell established results in this field (usable as
+                # constraints) from cross-domain analogies (usable as
+                # mechanism inspiration, but not established here).
+                SECTION = {
+                    "hypothesis_context": "## ESTABLISHED IN THIS FIELD (known methods, "
+                                          "parameter ranges, failure modes)",
+                    "cross_domain": "## TRANSFERABLE MECHANISMS FROM OTHER DOMAINS "
+                                    "(analogies — NOT established results in this field)",
+                    "economic_data": "## ECONOMIC CONTEXT",
+                    "fitting_models": "## MODELS AND EQUATIONS",
+                }
+                parts = [f"{SECTION.get(t, '## ' + t.upper())}\n{ok[t]['content']}"
+                         for t in types if t in ok]
+                content = "\n\n".join(parts)
+
+                lit_path = self._output_dir() / f"literature_search_{label}.md"
                 with open(lit_path, 'w') as f:
-                    f.write(f"# Literature Search Results ({search_type})\n\n")
-                    f.write(lit_res['content'])
+                    f.write(f"# Literature Search Results ({label})\n\n")
+                    f.write(content)
 
-                print(f"  ✅ Literature search completed. Saved to {lit_path.name}")
+                failed = [t for t in types if t not in ok]
+                print(f"  ✅ Literature search completed ({len(ok)}/{len(types)}). "
+                      f"Saved to {lit_path.name}")
 
-                return json.dumps({
+                out = {
                     "status": "success",
+                    "searches_run": list(ok),
                     "file_path": str(lit_path),
-                    "content_preview": lit_res['content'][:500] + "..." if len(lit_res['content']) > 500 else lit_res['content'],
-                    "hint": "Pass file_path as literature_context to generate_initial_plan()"
-                })
+                    "content_preview": content[:500] + "..." if len(content) > 500 else content,
+                    "hint": "Pass file_path as literature_context to generate_initial_plan()",
+                }
+                if failed:
+                    out["failed_searches"] = failed
+                if "cross_domain" in ok:
+                    out["caveat"] = ("Cross-domain context raises idea novelty but was "
+                                     "measured to degrade adherence to hard constraints. "
+                                     "Prefer hypothesis_context alone when the plan must "
+                                     "satisfy stated equipment/process constraints.")
+                return json.dumps(out)
 
             except Exception as e:
                 logging.error(f"Literature search error: {e}", exc_info=True)
@@ -611,14 +653,28 @@ class OrchestratorTools:
             description=(
                 "Searches scientific literature via FutureHouse Edison API. "
                 "Call BEFORE generate_initial_plan() to enrich the plan with external context. "
-                "Pass the returned file_path as literature_context to generate_initial_plan()."
+                "Pass the returned file_path as literature_context to generate_initial_plan(). "
+                "Several search types can be requested at once as a comma-separated "
+                "list — they run CONCURRENTLY and are merged into one labelled "
+                "document, so two searches cost roughly the wait of one."
             ),
             parameters={
                 "objective": {"type": "string", "description": "Research objective or question to search for"},
                 "search_type": {
                     "type": "string",
-                    "description": "Type of search: 'hypothesis_context' (default, for planning), 'economic_data' (for TEA), or 'fitting_models' (for curve fitting)",
-                    "enum": ["hypothesis_context", "economic_data", "fitting_models"]
+                    "description": (
+                        "One type, or several comma-separated (run in parallel). "
+                        "'hypothesis_context' (default): established methods, "
+                        "parameter ranges and pitfalls in the problem's own field — "
+                        "the grounding a runnable plan needs. "
+                        "'cross_domain': mechanisms from ADJACENT/UNRELATED fields "
+                        "that could transfer — use for IDEATION (pair it with "
+                        "hypothesis_context: 'hypothesis_context,cross_domain'), and "
+                        "AVOID it when the plan must honour hard equipment or process "
+                        "constraints, where it was measured to reduce constraint "
+                        "compliance. 'economic_data' (TEA); 'fitting_models' "
+                        "(curve fitting)."
+                    ),
                 }
             },
             required=["objective"]

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -676,7 +676,8 @@ class OrchestratorTools:
             additional_context: str = None,
             skill: str = None,
             literature_context: str = None,
-            molecule_context: str = None
+            molecule_context: str = None,
+            n_candidates: int = 1
         ):
             """
             Generates experimental plan (science strategy only, no code).
@@ -794,6 +795,10 @@ class OrchestratorTools:
             ext_ctx = "\n\n".join(external_context_parts) if external_context_parts else None
 
             try:
+                try:
+                    n_cand = max(1, min(int(n_candidates or 1), 4))
+                except (TypeError, ValueError):
+                    n_cand = 1
                 plan = self.orch.planner.generate_plan(
                     objective=obj,
                     knowledge_paths=knowledge_list,
@@ -802,7 +807,10 @@ class OrchestratorTools:
                     enable_human_feedback=self._get_human_feedback_enabled(),
                     reset_state=False,
                     skill=effective_skill,
-                    external_context=ext_ctx
+                    external_context=ext_ctx,
+                    n_candidates=n_cand,
+                    candidate_report_dir=(str(self._output_dir() / "plan_candidates")
+                                          if n_cand > 1 else None)
                 )
 
                 # Store skill on orchestrator for downstream tools
@@ -853,6 +861,17 @@ class OrchestratorTools:
                 }
                 if saved_extras:
                     result["external_results_files"] = saved_extras
+                pc = (self.orch.planner.state or {}).get("plan_candidates")
+                if n_cand > 1 and pc:
+                    result["best_of_n"] = {
+                        "requested": n_cand,
+                        "produced": len(pc.get("candidates", [])),
+                        "selected_candidate": pc.get("selected_index"),
+                        "human_override": pc.get("human_override", False),
+                        "tier": pc.get("tier"),
+                        "judge_reasoning": (pc.get("judge") or {}).get("reasoning", ""),
+                        "candidate_reports": pc.get("reports", []),
+                    }
                 return json.dumps(result)
                 
             except Exception as e:
@@ -893,7 +912,22 @@ class OrchestratorTools:
                     ),
                 },
                 "literature_context": {"type": "string", "description": "File path or text from search_literature() tool. Provides external scientific literature context."},
-                "molecule_context": {"type": "string", "description": "File path or text from query_molecules() tool. Provides molecular design / synthesis context."}
+                "molecule_context": {"type": "string", "description": "File path or text from query_molecules() tool. Provides molecular design / synthesis context."},
+                "n_candidates": {
+                    "type": "integer",
+                    "description": (
+                        "Best-of-N width (1-4, default 1 = single plan, "
+                        "unchanged behavior). RAISE to explore multiple "
+                        "DISTINCT strategic approaches when the objective is "
+                        "open-ended, the evidence is rich, or the user asks "
+                        "for alternatives — an LLM judge picks the best and "
+                        "the human can override. Keep at 1 for follow-up "
+                        "iterations, thin evidence, or narrowly-specified "
+                        "objectives. A cap, not a quota: generation stops "
+                        "early when the evidence supports no further "
+                        "distinct approach."
+                    ),
+                },
             },
             required=[]
         )

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -103,6 +103,27 @@ def _build_optimization_skill_description() -> str:
     return " ".join(parts)
 
 
+def resolve_n_candidates(requested, planner_state) -> int:
+    """
+    Best-of-N default policy for ``generate_initial_plan`` (issue #377).
+
+    An explicit request always wins (clamped 1-4; pass 1 for a single plan).
+    When the caller omits it, a campaign's FIRST plan defaults to best-of-3 —
+    two rounds of live meta testing showed the opt-in default never fired
+    because upstream routing narrows the objective before delegating, so
+    "raise N when open-ended" prompt guidance never triggered. Any later
+    plan in the campaign defaults to 1: follow-ups iterate on a committed
+    strategy, and the runner-up fallback already covers plan replacement.
+    """
+    if requested is not None:
+        try:
+            return max(1, min(int(requested), 4))
+        except (TypeError, ValueError):
+            return 1
+    is_first_plan = not (planner_state or {}).get("current_plan")
+    return 3 if is_first_plan else 1
+
+
 class OrchestratorTools:
     """
     Manages tool definitions, schemas, and execution for the OrchestratorAgent.
@@ -677,7 +698,7 @@ class OrchestratorTools:
             skill: str = None,
             literature_context: str = None,
             molecule_context: str = None,
-            n_candidates: int = 1
+            n_candidates: int = None
         ):
             """
             Generates experimental plan (science strategy only, no code).
@@ -795,10 +816,11 @@ class OrchestratorTools:
             ext_ctx = "\n\n".join(external_context_parts) if external_context_parts else None
 
             try:
-                try:
-                    n_cand = max(1, min(int(n_candidates or 1), 4))
-                except (TypeError, ValueError):
-                    n_cand = 1
+                n_cand = resolve_n_candidates(
+                    n_candidates, self.orch.planner.state)
+                if n_candidates is None and n_cand > 1:
+                    print(f"    🧭 New campaign — defaulting to best-of-{n_cand} "
+                          "candidate plans (pass n_candidates=1 for a single plan).")
                 plan = self.orch.planner.generate_plan(
                     objective=obj,
                     knowledge_paths=knowledge_list,
@@ -916,20 +938,17 @@ class OrchestratorTools:
                 "n_candidates": {
                     "type": "integer",
                     "description": (
-                        "Best-of-N width (1-4, default 1 = single plan, "
-                        "unchanged behavior). RAISE to explore multiple "
-                        "DISTINCT strategic approaches when the objective is "
-                        "open-ended, the evidence is rich, or the user asks "
-                        "for alternatives — an LLM judge picks the best and "
-                        "the human can override. Keep at 1 for follow-up "
-                        "iterations, thin evidence, or narrowly-specified "
-                        "objectives. A cap, not a quota: generation stops "
-                        "early when the evidence supports no further "
-                        "distinct approach. When raising it, keep "
-                        "specific_objective about ONE scientific goal — do "
-                        "NOT ask for multiple plans/strategies in the "
-                        "objective text; this parameter provides the "
-                        "multiplicity."
+                        "Best-of-N width (1-4). OMITTED: a campaign's FIRST "
+                        "plan defaults to best-of-3 (distinct candidate "
+                        "strategies, LLM judge picks, human can override); "
+                        "later plans default to 1. Pass 1 explicitly when "
+                        "the user wants a single plan; pass 2-4 to set the "
+                        "width. A cap, not a quota: generation stops early "
+                        "when the evidence supports no further distinct "
+                        "approach. Keep specific_objective about ONE "
+                        "scientific goal — do NOT ask for multiple "
+                        "plans/strategies in the objective text; this "
+                        "parameter provides the multiplicity."
                     ),
                 },
             },

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -686,7 +686,7 @@ class OrchestratorTools:
             Queries the FutureHouse Molecules agent for molecular design,
             synthesis planning, or cheminformatics tasks.
             Call this BEFORE generate_initial_plan() when the objective
-            involves molecular design or ideation.
+            involves molecular design or discovery.
             """
             if not self.orch.mol_agent:
                 return json.dumps({
@@ -737,7 +737,7 @@ class OrchestratorTools:
             description=(
                 "Queries the FutureHouse Molecules agent for molecular design, synthesis planning, "
                 "or cheminformatics. Call BEFORE generate_initial_plan() when the objective involves "
-                "molecule design or ideation. Pass the returned file_path as molecule_context."
+                "molecule design or discovery. Pass the returned file_path as molecule_context."
             ),
             parameters={
                 "objective": {"type": "string", "description": "Molecular design or synthesis objective"}
@@ -3976,7 +3976,7 @@ class OrchestratorTools:
             from difflib import get_close_matches
 
             # Direct path: an existing file/directory given by path is used
-            # as-is, without requiring knowledge-directory ideation.
+            # as-is, without requiring knowledge-directory discovery.
             p = Path(file_name).expanduser()
             if p.is_file() and p.suffix.lower() in QUERYABLE_EXTENSIONS:
                 return str(p.resolve()), None
@@ -4238,7 +4238,7 @@ class OrchestratorTools:
 
             # 1. Discover queryable files / directory databases. Informational
             #    only — an explicit `file_name` path is resolved directly below,
-            #    so ideation being empty is not an error when a path is given.
+            #    so discovery being empty is not an error when a path is given.
             queryable = _discover_queryable_files()
 
             # 2. Resolve target
@@ -4250,7 +4250,7 @@ class OrchestratorTools:
                 return json.dumps({
                     "status": "error",
                     "message": "No queryable data files or directories found by "
-                               "ideation. Pass the file's absolute path as `file_name`."
+                               "discovery. Pass the file's absolute path as `file_name`."
                 })
             elif len(queryable) == 1:
                 target = queryable[0]
@@ -4478,7 +4478,7 @@ class OrchestratorTools:
                 return json.dumps({"status": "error",
                                    "message": "Sandbox approval denied — screening cannot run."})
 
-            # Resolve to an absolute directory path (direct → fallback ideation).
+            # Resolve to an absolute directory path (direct → fallback discovery).
             direct = Path(database_path).expanduser()
             if direct.is_dir():
                 dir_path, dir_name = str(direct.resolve()), direct.name

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -630,7 +630,7 @@ class OrchestratorTools:
             Queries the FutureHouse Molecules agent for molecular design,
             synthesis planning, or cheminformatics tasks.
             Call this BEFORE generate_initial_plan() when the objective
-            involves molecular design or discovery.
+            involves molecular design or ideation.
             """
             if not self.orch.mol_agent:
                 return json.dumps({
@@ -681,7 +681,7 @@ class OrchestratorTools:
             description=(
                 "Queries the FutureHouse Molecules agent for molecular design, synthesis planning, "
                 "or cheminformatics. Call BEFORE generate_initial_plan() when the objective involves "
-                "molecule design or discovery. Pass the returned file_path as molecule_context."
+                "molecule design or ideation. Pass the returned file_path as molecule_context."
             ),
             parameters={
                 "objective": {"type": "string", "description": "Molecular design or synthesis objective"}
@@ -835,7 +835,7 @@ class OrchestratorTools:
                     candidate_report_dir=(str(self._output_dir() / "plan_candidates")
                                           if n_cand > 1 else None),
                     selection_profile=(selection_profile
-                                       if selection_profile in ("lab", "discovery")
+                                       if selection_profile in ("lab", "ideation")
                                        else "lab")
                 )
 
@@ -957,12 +957,12 @@ class OrchestratorTools:
                 },
                 "selection_profile": {
                     "type": "string",
-                    "enum": ["lab", "discovery"],
+                    "enum": ["lab", "ideation"],
                     "description": (
                         "How the best-of-N judge weights its pick. 'lab' "
                         "(default): feasibility/actionability first — use "
                         "when the plan will actually be executed on stated "
-                        "equipment. 'discovery': information gain and "
+                        "equipment. 'ideation': information gain and "
                         "mechanistic novelty first, feasibility only as a "
                         "tiebreaker — SWITCH to this when the user is "
                         "brainstorming, ideating, or asking for the most "
@@ -3915,7 +3915,7 @@ class OrchestratorTools:
             from difflib import get_close_matches
 
             # Direct path: an existing file/directory given by path is used
-            # as-is, without requiring knowledge-directory discovery.
+            # as-is, without requiring knowledge-directory ideation.
             p = Path(file_name).expanduser()
             if p.is_file() and p.suffix.lower() in QUERYABLE_EXTENSIONS:
                 return str(p.resolve()), None
@@ -4177,7 +4177,7 @@ class OrchestratorTools:
 
             # 1. Discover queryable files / directory databases. Informational
             #    only — an explicit `file_name` path is resolved directly below,
-            #    so discovery being empty is not an error when a path is given.
+            #    so ideation being empty is not an error when a path is given.
             queryable = _discover_queryable_files()
 
             # 2. Resolve target
@@ -4189,7 +4189,7 @@ class OrchestratorTools:
                 return json.dumps({
                     "status": "error",
                     "message": "No queryable data files or directories found by "
-                               "discovery. Pass the file's absolute path as `file_name`."
+                               "ideation. Pass the file's absolute path as `file_name`."
                 })
             elif len(queryable) == 1:
                 target = queryable[0]
@@ -4417,7 +4417,7 @@ class OrchestratorTools:
                 return json.dumps({"status": "error",
                                    "message": "Sandbox approval denied — screening cannot run."})
 
-            # Resolve to an absolute directory path (direct → fallback discovery).
+            # Resolve to an absolute directory path (direct → fallback ideation).
             direct = Path(database_path).expanduser()
             if direct.is_dir():
                 dir_path, dir_name = str(direct.resolve()), direct.name

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -636,11 +636,14 @@ class OrchestratorTools:
                 }
                 if failed:
                     out["failed_searches"] = failed
-                if "cross_domain" in ok:
-                    out["caveat"] = ("Cross-domain context raises idea novelty but was "
-                                     "measured to degrade adherence to hard constraints. "
-                                     "Prefer hypothesis_context alone when the plan must "
-                                     "satisfy stated equipment/process constraints.")
+                if ok:
+                    out["caveat"] = ("Literature context of any type was measured to "
+                                     "reduce constraint COVERAGE — plans stay on-topic "
+                                     "but silently omit individual requirements. When "
+                                     "the objective carries hard equipment/process "
+                                     "constraints, pass them as additional_context so "
+                                     "each is mapped to a named step; do not withhold "
+                                     "the literature.")
                 return json.dumps(out)
 
             except Exception as e:
@@ -669,10 +672,8 @@ class OrchestratorTools:
                         "the grounding a runnable plan needs. "
                         "'cross_domain': mechanisms from ADJACENT/UNRELATED fields "
                         "that could transfer — use for IDEATION (pair it with "
-                        "hypothesis_context: 'hypothesis_context,cross_domain'), and "
-                        "AVOID it when the plan must honour hard equipment or process "
-                        "constraints, where it was measured to reduce constraint "
-                        "compliance. 'economic_data' (TEA); 'fitting_models' "
+                        "hypothesis_context: 'hypothesis_context,cross_domain'). "
+                        "'economic_data' (TEA); 'fitting_models' "
                         "(curve fitting)."
                     ),
                 }

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -698,7 +698,8 @@ class OrchestratorTools:
             skill: str = None,
             literature_context: str = None,
             molecule_context: str = None,
-            n_candidates: int = None
+            n_candidates: int = None,
+            selection_profile: str = "lab"
         ):
             """
             Generates experimental plan (science strategy only, no code).
@@ -832,7 +833,10 @@ class OrchestratorTools:
                     external_context=ext_ctx,
                     n_candidates=n_cand,
                     candidate_report_dir=(str(self._output_dir() / "plan_candidates")
-                                          if n_cand > 1 else None)
+                                          if n_cand > 1 else None),
+                    selection_profile=(selection_profile
+                                       if selection_profile in ("lab", "discovery")
+                                       else "lab")
                 )
 
                 # Store skill on orchestrator for downstream tools
@@ -949,6 +953,23 @@ class OrchestratorTools:
                         "scientific goal — do NOT ask for multiple "
                         "plans/strategies in the objective text; this "
                         "parameter provides the multiplicity."
+                    ),
+                },
+                "selection_profile": {
+                    "type": "string",
+                    "enum": ["lab", "discovery"],
+                    "description": (
+                        "How the best-of-N judge weights its pick. 'lab' "
+                        "(default): feasibility/actionability first — use "
+                        "when the plan will actually be executed on stated "
+                        "equipment. 'discovery': information gain and "
+                        "mechanistic novelty first, feasibility only as a "
+                        "tiebreaker — SWITCH to this when the user is "
+                        "brainstorming, ideating, or asking for the most "
+                        "scientifically interesting direction rather than "
+                        "tomorrow's runnable protocol. Same candidates and "
+                        "scores either way; only the pick's weighting "
+                        "changes, and the human can still override."
                     ),
                 },
             },

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -968,8 +968,13 @@ class OrchestratorTools:
                         "brainstorming, ideating, or asking for the most "
                         "scientifically interesting direction rather than "
                         "tomorrow's runnable protocol. Same candidates and "
-                        "scores either way; only the pick's weighting "
-                        "changes, and the human can still override."
+                        "scores either way; only the authoring latitude and "
+                        "the pick's weighting change, and the human can "
+                        "still override. NOTE: ideation requires "
+                        "n_candidates >= 2 — with a single plan there is "
+                        "nothing to select and the profile has no effect, "
+                        "so never pass n_candidates=1 together with "
+                        "ideation."
                     ),
                 },
             },

--- a/scilink/agents/planning_agents/planning_agent.py
+++ b/scilink/agents/planning_agents/planning_agent.py
@@ -584,6 +584,7 @@ class PlanningAgent(BaseAgent):
                     primary_data=author_context.get("primary_data"),
                     images=all_image_paths or None,
                     image_descriptions=image_descriptions,
+                    additional_context=ctx_string,
                     skill_context=skill_planning_context,
                     fallback_tier=(tier == "fallback"),
                 )

--- a/scilink/agents/planning_agents/planning_agent.py
+++ b/scilink/agents/planning_agents/planning_agent.py
@@ -458,9 +458,12 @@ class PlanningAgent(BaseAgent):
                 mechanistic approach — an LLM judge picks one, and (in
                 interactive modes) the human may override before the usual
                 plan review. A cap, not a quota: generation stops early when
-                the evidence supports no further distinct approach. RAISE for
-                breadth on open-ended objectives; keep 1 for follow-up
-                iterations and thin evidence.
+                the evidence supports no further distinct approach. Note that
+                even a narrowly-specified objective usually admits multiple
+                strategies — the meaningful reason to stay at 1 is a strategy
+                already being committed (follow-up iterations), not objective
+                specificity. (The orchestrator tool layer applies exactly that
+                policy: campaign-first plans default to 3.)
             candidate_report_dir: Directory for per-candidate HTML reports
                 (persisted; referenced from the selection cards). Only used
                 when n_candidates > 1.

--- a/scilink/agents/planning_agents/planning_agent.py
+++ b/scilink/agents/planning_agents/planning_agent.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import copy
 import json
 import logging
 import shutil
@@ -40,14 +41,22 @@ from .planning_rag import (
     refine_plan_with_feedback,
     refine_code_with_feedback,
     verify_plan_relevance,
-    critique_plan
+    critique_plan,
+    generate_plan_candidates,
+    judge_plan_candidates
 )
 
 from ...skills.loader import load_skill
 
 from scilink.parsers import ingest_files, extract_images
 
-from .user_interface import display_plan_summary, get_user_feedback
+from .user_interface import (
+    display_plan_summary,
+    get_user_feedback,
+    display_plan_candidates,
+    get_candidate_selection,
+    format_caveats
+)
 
 from .html_generator import HTMLReportGenerator
 
@@ -409,7 +418,9 @@ class PlanningAgent(BaseAgent):
                     enable_human_feedback: bool = True,
                     reset_state: bool = False,
                     skill: Optional[str] = None,
-                    external_context: Optional[str] = None) -> Dict[str, Any]:
+                    external_context: Optional[str] = None,
+                    n_candidates: int = 1,
+                    candidate_report_dir: Optional[str] = None) -> Dict[str, Any]:
         """
         Generate experimental plan (science only, no implementation code/protocol).
 
@@ -441,6 +452,18 @@ class PlanningAgent(BaseAgent):
             external_context: Pre-fetched external context (e.g. from
                 orchestrator's search_literature/query_molecules tools).
                 When provided, skips internal literature search.
+            n_candidates: Best-of-N width (clamped 1-4). At 1 (default) the
+                single-plan path runs unchanged. Above 1, candidates are
+                generated sequentially — each conditioned to test a DIFFERENT
+                mechanistic approach — an LLM judge picks one, and (in
+                interactive modes) the human may override before the usual
+                plan review. A cap, not a quota: generation stops early when
+                the evidence supports no further distinct approach. RAISE for
+                breadth on open-ended objectives; keep 1 for follow-up
+                iterations and thin evidence.
+            candidate_report_dir: Directory for per-candidate HTML reports
+                (persisted; referenced from the selection cards). Only used
+                when n_candidates > 1.
 
         Returns:
             Dict containing the experimental plan with keys:
@@ -531,32 +554,98 @@ class PlanningAgent(BaseAgent):
 
         # RAG for science plan
         print(f"\n--- Generating Experimental Strategy ---")
-        res, author_context = perform_science_rag(
-            objective=objective,
-            instructions=HYPOTHESIS_GENERATION_INSTRUCTIONS,
-            task_name="Experimental Plan",
-            kb_docs=self.kb_docs,
-            model=self.model,
-            generation_config=self.generation_config,
-            primary_data_set=primary_data_set,
-            image_paths=all_image_paths,
-            image_descriptions=image_descriptions,
-            additional_context=ctx_string,
-            external_context=external_context,
-            skill_context=skill_planning_context,
-            return_context=True
-        )
+        n_candidates = max(1, min(int(n_candidates or 1), 4))
+        bestofn_candidates = None
+        bestofn_judge = None
+        bestofn_selected = None
+        bestofn_reports = []
+        if n_candidates > 1:
+            candidates, author_context, tier = generate_plan_candidates(
+                objective=objective,
+                kb_docs=self.kb_docs,
+                model=self.model,
+                generation_config=self.generation_config,
+                n_candidates=n_candidates,
+                primary_data_set=primary_data_set,
+                image_paths=all_image_paths,
+                image_descriptions=image_descriptions,
+                additional_context=ctx_string,
+                external_context=external_context,
+                skill_context=skill_planning_context,
+            )
+            if len(candidates) > 1:
+                print(f"\n--- Judging {len(candidates)} Candidate Plans ---")
+                bestofn_judge = judge_plan_candidates(
+                    objective=objective,
+                    candidates=candidates,
+                    model=self.model,
+                    generation_config=self.generation_config,
+                    retrieved_context=author_context.get("retrieved_context"),
+                    primary_data=author_context.get("primary_data"),
+                    images=all_image_paths or None,
+                    image_descriptions=image_descriptions,
+                    skill_context=skill_planning_context,
+                    fallback_tier=(tier == "fallback"),
+                )
+                bestofn_selected = bestofn_judge["selected_candidate"]
+                print(f"  - 🧑‍⚖️ Judge pick: Candidate {bestofn_selected}")
+                # Persisted per-candidate reports (referenced from the
+                # selection cards; kept for runner-up fallback and audit).
+                if candidate_report_dir:
+                    Path(candidate_report_dir).mkdir(parents=True, exist_ok=True)
+                    for ci, cand in enumerate(candidates, 1):
+                        rp = Path(candidate_report_dir) / f"candidate_{ci}.html"
+                        try:
+                            HTMLReportGenerator(self.state).generate_single_plan(
+                                cand, str(rp), title=f"Plan Candidate {ci}")
+                            bestofn_reports.append(str(rp))
+                        except Exception as e:
+                            logging.warning(f"Candidate report {ci} failed: {e}")
+            else:
+                print("  - ℹ️  Only one distinct candidate produced — "
+                      "proceeding as a single-plan run.")
+            bestofn_candidates = candidates
+            res = copy.deepcopy(candidates[(bestofn_selected or 1) - 1])
+            self.state["plan_candidates"] = {
+                "candidates": bestofn_candidates,
+                "judge": bestofn_judge,
+                "selected_index": bestofn_selected or 1,
+                "human_override": False,
+                "tier": tier,
+                "reports": bestofn_reports,
+            }
+        else:
+            res, author_context = perform_science_rag(
+                objective=objective,
+                instructions=HYPOTHESIS_GENERATION_INSTRUCTIONS,
+                task_name="Experimental Plan",
+                kb_docs=self.kb_docs,
+                model=self.model,
+                generation_config=self.generation_config,
+                primary_data_set=primary_data_set,
+                image_paths=all_image_paths,
+                image_descriptions=image_descriptions,
+                additional_context=ctx_string,
+                external_context=external_context,
+                skill_context=skill_planning_context,
+                return_context=True
+            )
 
         if external_context:
             res["literature_search"] = external_context
 
         self._log_action(
-            action="perform_science_rag",
+            action=("generate_plan_candidates" if n_candidates > 1
+                    else "perform_science_rag"),
             input_ctx={
                 "objective": objective,
                 "knowledge_paths": knowledge_paths,
                 "has_primary_data": primary_data_set is not None,
-                "has_external_context": bool(external_context)
+                "has_external_context": bool(external_context),
+                **({"n_candidates": n_candidates,
+                    "n_produced": len(bestofn_candidates),
+                    "judge_pick": bestofn_selected}
+                   if n_candidates > 1 else {})
             },
             result=res,
             rationale=res.get("proposed_experiments", [{}])[0].get("justification") if res.get("proposed_experiments") else None
@@ -568,74 +657,115 @@ class PlanningAgent(BaseAgent):
         self.state["plan_history"].append(res.copy())
         self.state["current_plan"] = res
         
-        # 1) Objective-conformance check (enforcing). A non-conforming plan is
-        # automatically adjusted — the proven self-correction loop, unchanged.
-        if not res.get("error"):
-            is_relevant, critique = verify_plan_relevance(objective, res, self.model, self.generation_config)
+        def _conform_and_critique(res):
+            # 1) Objective-conformance check (enforcing). A non-conforming plan is
+            # automatically adjusted — the proven self-correction loop, unchanged.
+            if not res.get("error"):
+                is_relevant, critique = verify_plan_relevance(objective, res, self.model, self.generation_config)
 
-            if not is_relevant:
-                print(f"\n🔄 Self-correction triggered: {critique}")
-                res = refine_plan_with_feedback(
-                    original_result=res,
-                    feedback=f"CRITICAL: {critique}",
-                    objective=objective,
-                    model=self.model,
-                    generation_config=self.generation_config,
-                    skill_context=skill_planning_context
+                if not is_relevant:
+                    print(f"\n🔄 Self-correction triggered: {critique}")
+                    res = refine_plan_with_feedback(
+                        original_result=res,
+                        feedback=f"CRITICAL: {critique}",
+                        objective=objective,
+                        model=self.model,
+                        generation_config=self.generation_config,
+                        skill_context=skill_planning_context
+                    )
+
+                    res["iteration"] = current_iter
+                    res["stage"] = "Auto-Corrected"
+                    self.state["plan_history"].append(res.copy())
+                    self.state["current_plan"] = res
+
+                    self._log_action(
+                        action="self_correction",
+                        input_ctx={"critique": critique},
+                        result=res,
+                        rationale=f"Auto-corrected due to: {critique}"
+                    )
+
+            # 2) Advisory critic (separate call, AFTER conformance + any adjustment).
+            # Checks PHYSICAL REALISM and INTERNAL CONSISTENCY of the final plan and
+            # records caveats — it NEVER rewrites the plan. Findings surface as
+            # "Caveats & Potential Limitations" for the human (CO_PILOT / AUTOPILOT)
+            # at the feedback prompt, or as run_task `warnings` (AUTONOMOUS / meta).
+            # Auto-applying critic findings was shown to rescope plans unreliably, so
+            # acting on them is left to an explicit human/consumer decision.
+            if not res.get("error"):
+                verdict = critique_plan(
+                    objective, res, self.model, self.generation_config,
+                    retrieved_context=author_context.get("retrieved_context"),
+                    primary_data=author_context.get("primary_data"),
+                    images=all_image_paths or None,
+                    image_descriptions=image_descriptions,
+                    additional_context=ctx_string,
+                    skill_context=skill_planning_context,
                 )
+                findings = verdict.get("findings", [])
+                if findings:
+                    # Order critical-first so the caveats list and warnings lead with
+                    # the most material concerns. Record on the plan (no rewrite).
+                    _order = {"critical": 0, "minor": 1}
+                    findings = sorted(findings, key=lambda f: _order.get(f.get("severity"), 1))
+                    res["critic_findings"] = findings
+                    self.state["current_plan"] = res
+                    # Stamp onto the latest history snapshot too so the HTML report
+                    # (which renders plan_history, not current_plan) shows the caveats.
+                    if self.state.get("plan_history"):
+                        self.state["plan_history"][-1]["critic_findings"] = findings
+                    n_crit = sum(1 for f in findings if f.get("severity") == "critical")
+                    print(f"\n⚠️  Critic noted {len(findings)} caveat(s)"
+                          f"{f' ({n_crit} significant)' if n_crit else ''} "
+                          "— recorded under Caveats & Potential Limitations (plan unchanged).")
+                    self._log_action(
+                        action="critic_review",
+                        input_ctx={"findings": findings},
+                        result=res,
+                        rationale="Advisory caveats recorded; plan not modified."
+                    )
+            return res
 
+        res = _conform_and_critique(res)
+
+        # Stage-1 best-of-N selection: candidate cards + judge pick + the
+        # pick's caveats, then accept-or-override. Selection only — free-text
+        # refinement stays with the stage-2 prompt below, on whichever
+        # candidate wins here. The critic stays advisory throughout: caveats
+        # are DISPLAYED at this prompt, never acted on automatically, and a
+        # critical finding never auto-switches the selection.
+        if (bestofn_candidates and len(bestofn_candidates) > 1
+                and enable_human_feedback and not res.get("error")):
+            display_plan_candidates(
+                bestofn_candidates, bestofn_judge or {}, bestofn_selected,
+                report_paths=bestofn_reports,
+                pick_caveats=format_caveats(res.get("critic_findings")),
+            )
+            choice = get_candidate_selection(len(bestofn_candidates), bestofn_selected)
+            if choice != bestofn_selected:
+                print(f"  - 👤 Human override: Candidate {choice} "
+                      f"(judge picked {bestofn_selected}).")
+                self.state["plan_candidates"]["selected_index"] = choice
+                self.state["plan_candidates"]["human_override"] = True
+                res = copy.deepcopy(bestofn_candidates[choice - 1])
+                if external_context:
+                    res["literature_search"] = external_context
                 res["iteration"] = current_iter
-                res["stage"] = "Auto-Corrected"
+                res["stage"] = "Science Draft (human-selected candidate)"
                 self.state["plan_history"].append(res.copy())
                 self.state["current_plan"] = res
-
                 self._log_action(
-                    action="self_correction",
-                    input_ctx={"critique": critique},
+                    action="bestofn_human_override",
+                    input_ctx={"judge_pick": bestofn_selected, "human_pick": choice},
                     result=res,
-                    rationale=f"Auto-corrected due to: {critique}"
+                    rationale="Human overrode the judge's candidate selection."
                 )
+                bestofn_selected = choice
+                # Lazy-critique invariant: every plan that becomes
+                # current_plan has been conformance-checked and critiqued.
+                res = _conform_and_critique(res)
 
-        # 2) Advisory critic (separate call, AFTER conformance + any adjustment).
-        # Checks PHYSICAL REALISM and INTERNAL CONSISTENCY of the final plan and
-        # records caveats — it NEVER rewrites the plan. Findings surface as
-        # "Caveats & Potential Limitations" for the human (CO_PILOT / AUTOPILOT)
-        # at the feedback prompt, or as run_task `warnings` (AUTONOMOUS / meta).
-        # Auto-applying critic findings was shown to rescope plans unreliably, so
-        # acting on them is left to an explicit human/consumer decision.
-        if not res.get("error"):
-            verdict = critique_plan(
-                objective, res, self.model, self.generation_config,
-                retrieved_context=author_context.get("retrieved_context"),
-                primary_data=author_context.get("primary_data"),
-                images=all_image_paths or None,
-                image_descriptions=image_descriptions,
-                additional_context=ctx_string,
-                skill_context=skill_planning_context,
-            )
-            findings = verdict.get("findings", [])
-            if findings:
-                # Order critical-first so the caveats list and warnings lead with
-                # the most material concerns. Record on the plan (no rewrite).
-                _order = {"critical": 0, "minor": 1}
-                findings = sorted(findings, key=lambda f: _order.get(f.get("severity"), 1))
-                res["critic_findings"] = findings
-                self.state["current_plan"] = res
-                # Stamp onto the latest history snapshot too so the HTML report
-                # (which renders plan_history, not current_plan) shows the caveats.
-                if self.state.get("plan_history"):
-                    self.state["plan_history"][-1]["critic_findings"] = findings
-                n_crit = sum(1 for f in findings if f.get("severity") == "critical")
-                print(f"\n⚠️  Critic noted {len(findings)} caveat(s)"
-                      f"{f' ({n_crit} significant)' if n_crit else ''} "
-                      "— recorded under Caveats & Potential Limitations (plan unchanged).")
-                self._log_action(
-                    action="critic_review",
-                    input_ctx={"findings": findings},
-                    result=res,
-                    rationale="Advisory caveats recorded; plan not modified."
-                )
-        
         # Human feedback on strategy
         human_feedback = None
         if enable_human_feedback and res.get("proposed_experiments") and not res.get("error"):

--- a/scilink/agents/planning_agents/planning_agent.py
+++ b/scilink/agents/planning_agents/planning_agent.py
@@ -1131,6 +1131,62 @@ class PlanningAgent(BaseAgent):
         
         return self.state
     
+    def _recritique_revision(self,
+                             new_plan: Dict[str, Any],
+                             prior_plan: Dict[str, Any],
+                             revision_request: str,
+                             skill_context: Optional[str] = None,
+                             images: Optional[List[Any]] = None) -> Dict[str, Any]:
+        """
+        Resolution-check re-critique after a plan revision, so the recorded
+        caveats describe the CURRENT plan — the refinement LLM echoes the old
+        ``critic_findings`` into the revised JSON, which otherwise persists
+        stale (possibly already-fixed) caveats into reports and warnings.
+
+        Pops the echoed caveats, then re-runs the advisory critic with the
+        before/request/after picture (drop resolved, keep unresolved, flag
+        new). Annotation only — never modifies the plan and never triggers
+        further action, so the advisory-only contract is untouched. Fails
+        open like the critic itself. Evidence here is the revision context
+        (prior plan + findings + request); the original retrieval context is
+        not persisted across calls.
+        """
+        if new_plan.get("error") or not new_plan.get("proposed_experiments"):
+            return new_plan
+
+        prior_findings = prior_plan.get("critic_findings")
+        new_plan.pop("critic_findings", None)  # discard echoed-stale caveats
+
+        try:
+            verdict = critique_plan(
+                self.state["objective"], new_plan, self.model,
+                self.generation_config,
+                images=images,
+                skill_context=skill_context,
+                prior_plan=prior_plan,
+                prior_findings=prior_findings,
+                human_feedback=revision_request,
+            )
+        except Exception as e:
+            # critique_plan fails open internally; this guard keeps the
+            # revision alive even if the call itself dies.
+            logging.error(f"Revision re-critique failed open: {e}")
+            verdict = {"findings": []}
+        findings = verdict.get("findings", [])
+        if findings:
+            _order = {"critical": 0, "minor": 1}
+            findings = sorted(findings,
+                              key=lambda f: _order.get(f.get("severity"), 1))
+            new_plan["critic_findings"] = findings
+            if self.state.get("plan_history"):
+                self.state["plan_history"][-1]["critic_findings"] = findings
+        elif self.state.get("plan_history"):
+            # the snapshot appended before this call carries the echoed copy
+            self.state["plan_history"][-1].pop("critic_findings", None)
+
+        self.state["current_plan"] = new_plan
+        return new_plan
+
     def refine_plan(self,
                     results: Any,
                     enable_human_feedback: bool = True,
@@ -1268,6 +1324,15 @@ Select the most appropriate strategy:
         self.state["plan_history"].append(new_plan.copy())
         self.state["current_plan"] = new_plan
 
+        # Resolution-check re-critique so caveats describe the revised plan.
+        new_plan = self._recritique_revision(
+            new_plan, prior_plan=current_plan,
+            revision_request=("Plan revised in response to experimental "
+                             f"results:\n{consolidated_feedback[:2000]}"),
+            skill_context=skill_refine_context,
+            images=loaded_images or None,
+        )
+
         self._log_action(
             action="refine_plan_reasoning",
             input_ctx={
@@ -1295,6 +1360,7 @@ Select the most appropriate strategy:
                     "phase": "science_iteration", 
                     "feedback": human_feedback
                 })
+                prior_plan = new_plan
                 new_plan = refine_plan_with_feedback(
                     original_result=new_plan,
                     feedback=human_feedback,
@@ -1308,6 +1374,11 @@ Select the most appropriate strategy:
                 new_plan["stage"] = "Human Refined (Science)"
                 self.state["plan_history"].append(new_plan.copy())
                 self.state["current_plan"] = new_plan
+                new_plan = self._recritique_revision(
+                    new_plan, prior_plan=prior_plan,
+                    revision_request=human_feedback,
+                    skill_context=skill_refine_context,
+                )
                 print("✅ Strategic revision updated.")
 
         self._log_action(
@@ -1396,6 +1467,14 @@ Select the most appropriate strategy:
         self.state["plan_history"].append(new_plan.copy())
         self.state["current_plan"] = new_plan
 
+        # Resolution-check re-critique: a constraint adjustment often resolves
+        # a recorded caveat — the caveat channel must reflect the CURRENT plan.
+        new_plan = self._recritique_revision(
+            new_plan, prior_plan=current_plan,
+            revision_request=constraint_description,
+            skill_context=skill_constraint_context,
+        )
+
         self._log_action(
             action="adjust_plan_for_constraints",
             input_ctx={"constraint": constraint_description[:200]},
@@ -1419,6 +1498,7 @@ Select the most appropriate strategy:
                     "phase": "constraint_adjustment",
                     "feedback": human_feedback
                 })
+                prior_plan = new_plan
                 new_plan = refine_plan_with_feedback(
                     original_result=new_plan,
                     feedback=human_feedback,
@@ -1431,6 +1511,11 @@ Select the most appropriate strategy:
                 new_plan["stage"] = "Human Refined (Constraint)"
                 self.state["plan_history"].append(new_plan.copy())
                 self.state["current_plan"] = new_plan
+                new_plan = self._recritique_revision(
+                    new_plan, prior_plan=prior_plan,
+                    revision_request=human_feedback,
+                    skill_context=skill_constraint_context,
+                )
                 print("✅ Constraint adjustment updated.")
 
         self.state["status"] = "constraint_adjusted"

--- a/scilink/agents/planning_agents/planning_agent.py
+++ b/scilink/agents/planning_agents/planning_agent.py
@@ -582,6 +582,7 @@ class PlanningAgent(BaseAgent):
                 additional_context=ctx_string,
                 external_context=external_context,
                 skill_context=skill_planning_context,
+                selection_profile=selection_profile,
             )
             if len(candidates) > 1:
                 print(f"\n--- Judging {len(candidates)} Candidate Plans ---")

--- a/scilink/agents/planning_agents/planning_agent.py
+++ b/scilink/agents/planning_agents/planning_agent.py
@@ -472,8 +472,12 @@ class PlanningAgent(BaseAgent):
                 (criteria and scores are identical either way). "lab"
                 (default): feasibility/actionability first — the plan must
                 run on the available platform. "ideation": information
-                gain/novelty first, feasibility as tiebreaker — for research
-                ideation rather than executable campaign planning.
+                gain/novelty first, feasibility as tiebreaker, plus
+                author-side grounding latitude — for research ideation
+                rather than executable campaign planning. Applies only when
+                n_candidates >= 2: the single-plan path ignores the profile
+                entirely (documented behavior — ideation is a property of
+                the multi-candidate process).
 
         Returns:
             Dict containing the experimental plan with keys:

--- a/scilink/agents/planning_agents/planning_agent.py
+++ b/scilink/agents/planning_agents/planning_agent.py
@@ -420,7 +420,8 @@ class PlanningAgent(BaseAgent):
                     skill: Optional[str] = None,
                     external_context: Optional[str] = None,
                     n_candidates: int = 1,
-                    candidate_report_dir: Optional[str] = None) -> Dict[str, Any]:
+                    candidate_report_dir: Optional[str] = None,
+                    selection_profile: str = "lab") -> Dict[str, Any]:
         """
         Generate experimental plan (science only, no implementation code/protocol).
 
@@ -467,6 +468,12 @@ class PlanningAgent(BaseAgent):
             candidate_report_dir: Directory for per-candidate HTML reports
                 (persisted; referenced from the selection cards). Only used
                 when n_candidates > 1.
+            selection_profile: How the best-of-N judge WEIGHTS its pick
+                (criteria and scores are identical either way). "lab"
+                (default): feasibility/actionability first — the plan must
+                run on the available platform. "discovery": information
+                gain/novelty first, feasibility as tiebreaker — for research
+                ideation rather than executable campaign planning.
 
         Returns:
             Dict containing the experimental plan with keys:
@@ -590,6 +597,7 @@ class PlanningAgent(BaseAgent):
                     additional_context=ctx_string,
                     skill_context=skill_planning_context,
                     fallback_tier=(tier == "fallback"),
+                    selection_profile=selection_profile,
                 )
                 bestofn_selected = bestofn_judge["selected_candidate"]
                 print(f"  - 🧑‍⚖️ Judge pick: Candidate {bestofn_selected}")
@@ -616,6 +624,7 @@ class PlanningAgent(BaseAgent):
                 "selected_index": bestofn_selected or 1,
                 "human_override": False,
                 "tier": tier,
+                "profile": selection_profile,
                 "reports": bestofn_reports,
             }
         else:

--- a/scilink/agents/planning_agents/planning_agent.py
+++ b/scilink/agents/planning_agents/planning_agent.py
@@ -471,7 +471,7 @@ class PlanningAgent(BaseAgent):
             selection_profile: How the best-of-N judge WEIGHTS its pick
                 (criteria and scores are identical either way). "lab"
                 (default): feasibility/actionability first — the plan must
-                run on the available platform. "discovery": information
+                run on the available platform. "ideation": information
                 gain/novelty first, feasibility as tiebreaker — for research
                 ideation rather than executable campaign planning.
 

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -229,6 +229,15 @@ for each:
   search_literature(objective="...", search_type="hypothesis_context") → plan_lit_path
   generate_initial_plan(..., literature_context=plan_lit_path)
 
+Several search types can be requested at once (comma-separated) and run in
+parallel, costing roughly the wait of a single search. For IDEATION sessions
+— brainstorming, exploring approaches, "what are interesting directions" —
+pair grounding with cross-domain retrieval and select the ideation profile:
+  search_literature(objective="...", search_type="hypothesis_context,cross_domain")
+  generate_initial_plan(..., literature_context=..., selection_profile="ideation")
+Do NOT add cross_domain when the plan must satisfy hard equipment or process
+constraints: it raises novelty but measurably reduces constraint compliance.
+
 For refinement, reuse existing literature or run a new search as needed.
 
 **MOLECULAR DESIGN WORKFLOW:**

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -235,8 +235,10 @@ parallel, costing roughly the wait of a single search. For IDEATION sessions
 pair grounding with cross-domain retrieval and select the ideation profile:
   search_literature(objective="...", search_type="hypothesis_context,cross_domain")
   generate_initial_plan(..., literature_context=..., selection_profile="ideation")
-Do NOT add cross_domain when the plan must satisfy hard equipment or process
-constraints: it raises novelty but measurably reduces constraint compliance.
+Literature of any type reduces constraint COVERAGE — plans stay on-topic but
+omit individual requirements. When the objective carries hard equipment or
+process constraints, pass them as additional_context (each is then mapped to a
+named step) rather than withholding the literature.
 
 For refinement, reuse existing literature or run a new search as needed.
 

--- a/scilink/agents/planning_agents/planning_rag.py
+++ b/scilink/agents/planning_agents/planning_rag.py
@@ -17,7 +17,9 @@ from .instruct import (
     TEA_INSTRUCTIONS_FALLBACK,
     HYPOTHESIS_DISTINCTNESS_CONDITIONING,
     HYPOTHESIS_BEST_OF_N_SELECTION_INSTRUCTIONS,
-    HYPOTHESIS_BESTOFN_AUTHOR_NOTE
+    HYPOTHESIS_BESTOFN_AUTHOR_NOTE,
+    BESTOFN_SELECTION_PROFILE_LAB,
+    BESTOFN_SELECTION_PROFILE_DISCOVERY
 )
 
 
@@ -505,7 +507,8 @@ def judge_plan_candidates(objective: str,
                           image_descriptions: Optional[List[str]] = None,
                           additional_context: Optional[str] = None,
                           skill_context: Optional[str] = None,
-                          fallback_tier: bool = False) -> Dict[str, Any]:
+                          fallback_tier: bool = False,
+                          selection_profile: str = "lab") -> Dict[str, Any]:
     """
     Comparative LLM judge over best-of-N plan candidates.
 
@@ -570,8 +573,17 @@ def judge_plan_candidates(objective: str,
             "do not penalize candidates for the missing knowledge base.\n"
         )
 
+    # Selection profile: same criteria and scores either way (the human sees
+    # an identical card format); only the WEIGHTING of the pick changes.
+    # "lab" codifies the execution-first behavior; "discovery" weights
+    # information gain first — benchmark evidence showed the lab weighting
+    # leaves the boldest (most rediscovery-shaped) candidate unpicked.
+    profile_note = (BESTOFN_SELECTION_PROFILE_DISCOVERY
+                    if selection_profile == "discovery"
+                    else BESTOFN_SELECTION_PROFILE_LAB)
+
     prompt = (
-        f"{HYPOTHESIS_BEST_OF_N_SELECTION_INSTRUCTIONS}\n"
+        f"{HYPOTHESIS_BEST_OF_N_SELECTION_INSTRUCTIONS}\n{profile_note}\n"
         f"## OBJECTIVE:\n{objective}\n{tier_note}\n"
         f"## EVIDENCE ALL CANDIDATES WERE AUTHORED AGAINST:\n"
         + ("\n\n".join(evidence_parts) if evidence_parts

--- a/scilink/agents/planning_agents/planning_rag.py
+++ b/scilink/agents/planning_agents/planning_rag.py
@@ -14,7 +14,9 @@ from .instruct import (
     HYPOTHESIS_GENERATION_INSTRUCTIONS,
     TEA_INSTRUCTIONS,
     HYPOTHESIS_GENERATION_INSTRUCTIONS_FALLBACK,
-    TEA_INSTRUCTIONS_FALLBACK
+    TEA_INSTRUCTIONS_FALLBACK,
+    HYPOTHESIS_DISTINCTNESS_CONDITIONING,
+    HYPOTHESIS_BEST_OF_N_SELECTION_INSTRUCTIONS
 )
 
 
@@ -323,7 +325,8 @@ def perform_science_rag(objective: str,
                         additional_context: Optional[str] = None,
                         external_context: Optional[str] = None,
                         skill_context: Optional[str] = None,
-                        return_context: bool = False) -> Any:
+                        return_context: bool = False,
+                        mode_key: Optional[str] = None) -> Any:
     """
     Executes the Scientific/TEA RAG loop over the Docs KnowledgeBase.
 
@@ -376,6 +379,7 @@ def perform_science_rag(objective: str,
         fallback_instructions=fallback_instructions,
         task_name=task_name,
         return_context=return_context,
+        mode_key=mode_key,
     )
 
     if return_context:
@@ -383,6 +387,201 @@ def perform_science_rag(objective: str,
         return result, {"retrieved_context": retrieved_context,
                         "primary_data": primary_data_str}
     return rag_out
+
+
+def generate_plan_candidates(objective: str,
+                             kb_docs: Any,
+                             model: Any,
+                             generation_config: Any,
+                             n_candidates: int,
+                             primary_data_set: Optional[Dict[str, str]] = None,
+                             image_paths: Optional[List[str]] = None,
+                             image_descriptions: Optional[List[str]] = None,
+                             additional_context: Optional[str] = None,
+                             external_context: Optional[str] = None,
+                             skill_context: Optional[str] = None
+                             ) -> Tuple[List[Dict[str, Any]], Dict[str, Any], str]:
+    """
+    Sequential, diversity-conditioned best-of-N candidate generation.
+
+    Candidate 1 runs the normal science RAG (with its fallback swap); its
+    instruction tier — "strict" or "fallback" — is then pinned for the whole
+    run, so a fallback run authors ALL candidates under the fallback
+    instructions and a strict run never silently mixes in general-knowledge
+    plans. Each later candidate sees the prior candidates' hypothesis
+    sentences plus the distinctness conditioning, and may DECLINE (error JSON)
+    when the evidence supports no further distinct approach — so
+    ``n_candidates`` is a cap, not a quota.
+
+    Returns ``(candidates, author_context, tier)`` where ``candidates`` holds
+    only successful (non-declined) plans, in generation order, and
+    ``author_context`` is the shared grounding evidence
+    (``{"retrieved_context", "primary_data"}``) all candidates were authored
+    against.
+    """
+    first, author_context = perform_science_rag(
+        objective=objective,
+        instructions=HYPOTHESIS_GENERATION_INSTRUCTIONS,
+        task_name="Candidate Plan 1",
+        kb_docs=kb_docs,
+        model=model,
+        generation_config=generation_config,
+        primary_data_set=primary_data_set,
+        image_paths=image_paths,
+        image_descriptions=image_descriptions,
+        additional_context=additional_context,
+        external_context=external_context,
+        skill_context=skill_context,
+        return_context=True,
+        mode_key="_rag_mode",
+    )
+    tier = first.pop("_rag_mode", "strict") if isinstance(first, dict) else "strict"
+    candidates = [first]
+    if first.get("error") or not first.get("proposed_experiments"):
+        return candidates, author_context, tier
+
+    if tier == "fallback":
+        print("  - ℹ️  Fallback tier pinned for all candidates in this run.")
+
+    instructions = (HYPOTHESIS_GENERATION_INSTRUCTIONS if tier == "strict"
+                    else HYPOTHESIS_GENERATION_INSTRUCTIONS_FALLBACK)
+
+    for k in range(2, n_candidates + 1):
+        prior = "\n".join(
+            f"{i}. {c['proposed_experiments'][0].get('hypothesis', 'N/A')}"
+            for i, c in enumerate(candidates, 1)
+        )
+        conditioning = HYPOTHESIS_DISTINCTNESS_CONDITIONING.format(
+            prior_hypotheses=prior
+        )
+        add_ctx = (f"{additional_context}\n\n{conditioning}"
+                   if additional_context else conditioning)
+        # No fallback_instructions here: within the pinned tier, a decline is
+        # a decline — the early stop, not a trigger to change tiers mid-run.
+        res = run_rag(
+            query=objective,
+            instructions=instructions,
+            kb=kb_docs,
+            model=model,
+            generation_config=generation_config,
+            images=image_paths,
+            image_descriptions=image_descriptions,
+            external_context=external_context,
+            additional_context=add_ctx,
+            primary_data_str=author_context.get("primary_data"),
+            skill_context=skill_context,
+            fallback_instructions=None,
+            task_name=f"Candidate Plan {k}",
+        )
+        if not isinstance(res, dict) or res.get("error") or not res.get("proposed_experiments"):
+            reason = (res or {}).get("error", "no experiments returned") \
+                if isinstance(res, dict) else "unparseable response"
+            print(f"  - 🛑 Candidate {k} declined ({reason}) — "
+                  f"stopping at {len(candidates)} distinct candidate(s).")
+            break
+        candidates.append(res)
+
+    return candidates, author_context, tier
+
+
+def judge_plan_candidates(objective: str,
+                          candidates: List[Dict[str, Any]],
+                          model: Any,
+                          generation_config: Any,
+                          retrieved_context: Optional[str] = None,
+                          primary_data: Optional[str] = None,
+                          images: Optional[List[Any]] = None,
+                          image_descriptions: Optional[List[str]] = None,
+                          skill_context: Optional[str] = None,
+                          fallback_tier: bool = False) -> Dict[str, Any]:
+    """
+    Comparative LLM judge over best-of-N plan candidates.
+
+    A selector, not an editor: scores each candidate on five criteria against
+    the SAME evidence the authors saw and picks one; it emits no caveats (the
+    advisory critic owns that channel) and never modifies a plan. Fails open
+    to candidate 1 — a judge crash must not block planning — with the failure
+    recorded in the returned dict.
+
+    Returns ``{"scores": [...], "selected_candidate": <1-based>,
+    "reasoning": str}`` (+ ``"error"`` if the judge failed).
+    """
+    fail_open = {"scores": [], "selected_candidate": 1,
+                 "reasoning": "Judge unavailable — defaulted to candidate 1."}
+    if len(candidates) < 2:
+        return {"scores": [], "selected_candidate": 1,
+                "reasoning": "Single candidate — no comparison needed."}
+
+    cand_blocks = []
+    for i, cand in enumerate(candidates, 1):
+        cand_blocks.append(
+            f"### CANDIDATE {i}\n"
+            + json.dumps({"proposed_experiments":
+                          cand.get("proposed_experiments", [])}, indent=2)
+        )
+
+    evidence_parts = []
+    if primary_data:
+        evidence_parts.append(f"## 📊 Primary Experimental Data:\n{primary_data}")
+    if retrieved_context:
+        evidence_parts.append(f"## Retrieved Context (KB + literature):\n{retrieved_context}")
+    if skill_context:
+        evidence_parts.append(skill_context)
+
+    loaded_images = []
+    if images and _PIL_Image:
+        for img in images:
+            if isinstance(img, str):
+                try:
+                    loaded_images.append(_PIL_Image.open(img))
+                except Exception as e:
+                    print(f"    - ⚠️ Judge could not load image {img}: {e}")
+            else:
+                loaded_images.append(img)
+    if loaded_images:
+        note = "## Provided Images: (See attached)"
+        if image_descriptions:
+            note += f"\n## Image Descriptions:\n{json.dumps(image_descriptions, indent=2)}"
+        evidence_parts.append(note)
+
+    tier_note = ""
+    if fallback_tier:
+        tier_note = (
+            "\nNOTE: ALL candidates were authored in fallback mode (general "
+            "scientific knowledge; the local knowledge base lacked specific "
+            "context). Judge groundedness against the evidence that IS "
+            "provided (data, literature, images) and general plausibility — "
+            "do not penalize candidates for the missing knowledge base.\n"
+        )
+
+    prompt = (
+        f"{HYPOTHESIS_BEST_OF_N_SELECTION_INSTRUCTIONS}\n"
+        f"## OBJECTIVE:\n{objective}\n{tier_note}\n"
+        f"## EVIDENCE ALL CANDIDATES WERE AUTHORED AGAINST:\n"
+        + ("\n\n".join(evidence_parts) if evidence_parts
+           else "(no shared evidence beyond the objective)")
+        + "\n\n## THE CANDIDATES:\n" + "\n\n".join(cand_blocks)
+    )
+
+    try:
+        prompt_parts = [prompt]
+        prompt_parts.extend(loaded_images)
+        response = model.generate_content(prompt_parts,
+                                          generation_config=generation_config)
+        verdict, err = parse_json_from_response(response)
+        if err or not isinstance(verdict, dict):
+            logging.error(f"Best-of-N judge parse failure: {err}")
+            return {**fail_open, "error": str(err)}
+        sel = verdict.get("selected_candidate")
+        if not isinstance(sel, int) or not (1 <= sel <= len(candidates)):
+            logging.error(f"Best-of-N judge returned invalid selection: {sel}")
+            return {**fail_open, "error": f"invalid selected_candidate: {sel}"}
+        return {"scores": verdict.get("scores", []),
+                "selected_candidate": sel,
+                "reasoning": verdict.get("reasoning", "")}
+    except Exception as e:
+        logging.error(f"Best-of-N judge failed: {e}")
+        return {**fail_open, "error": str(e)}
 
 
 def normalize_code(code: str) -> str:

--- a/scilink/agents/planning_agents/planning_rag.py
+++ b/scilink/agents/planning_agents/planning_rag.py
@@ -20,7 +20,8 @@ from .instruct import (
     HYPOTHESIS_BESTOFN_AUTHOR_NOTE,
     BESTOFN_SELECTION_PROFILE_LAB,
     BESTOFN_SELECTION_PROFILE_IDEATION,
-    IDEATION_AUTHOR_OVERRIDE
+    IDEATION_AUTHOR_OVERRIDE,
+    CONSTRAINT_COVERAGE_NOTE
 )
 
 
@@ -361,6 +362,15 @@ def perform_science_rag(objective: str,
         except Exception as e:
             print(f"  - ⚠️ Warning: Failed to parse primary data set: {e}")
 
+    # Literature context crowds out the less glamorous constraints: plans stay
+    # on-topic but silently drop individual requirements, and the misses are
+    # omissions rather than violations. Demanding an explicit constraint->step
+    # mapping restores coverage at no measurable cost to plan quality. Scoped
+    # to the condition it was measured in — constraints AND literature both
+    # present; a constraints-only run already complies.
+    if additional_context and external_context:
+        additional_context = f"{additional_context}\n{CONSTRAINT_COVERAGE_NOTE}"
+
     # --- Select the fallback instruction set matching the planning task ---
     fallback_instructions = None
     if instructions == HYPOTHESIS_GENERATION_INSTRUCTIONS:
@@ -417,6 +427,12 @@ def generate_plan_candidates(objective: str,
     sentences plus the distinctness conditioning, and may DECLINE (error JSON)
     when the evidence supports no further distinct approach — so
     ``n_candidates`` is a cap, not a quota.
+
+    ``selection_profile="ideation"`` has author-side effect only in STRICT
+    runs: a fallback run swaps in the fallback instructions for every
+    candidate, which already license general knowledge, so
+    ``IDEATION_AUTHOR_OVERRIDE`` does not apply there and only the judge
+    weighting differs.
 
     Returns ``(candidates, author_context, tier)`` where ``candidates`` holds
     only successful (non-declined) plans, in generation order, and

--- a/scilink/agents/planning_agents/planning_rag.py
+++ b/scilink/agents/planning_agents/planning_rag.py
@@ -19,7 +19,8 @@ from .instruct import (
     HYPOTHESIS_BEST_OF_N_SELECTION_INSTRUCTIONS,
     HYPOTHESIS_BESTOFN_AUTHOR_NOTE,
     BESTOFN_SELECTION_PROFILE_LAB,
-    BESTOFN_SELECTION_PROFILE_DISCOVERY
+    BESTOFN_SELECTION_PROFILE_DISCOVERY,
+    DISCOVERY_AUTHOR_OVERRIDE
 )
 
 
@@ -402,7 +403,8 @@ def generate_plan_candidates(objective: str,
                              image_descriptions: Optional[List[str]] = None,
                              additional_context: Optional[str] = None,
                              external_context: Optional[str] = None,
-                             skill_context: Optional[str] = None
+                             skill_context: Optional[str] = None,
+                             selection_profile: str = "lab"
                              ) -> Tuple[List[Dict[str, Any]], Dict[str, Any], str]:
     """
     Sequential, diversity-conditioned best-of-N candidate generation.
@@ -431,9 +433,19 @@ def generate_plan_candidates(objective: str,
                   if additional_context else HYPOTHESIS_BESTOFN_AUTHOR_NOTE) \
         if n_candidates > 1 else additional_context
 
+    # Discovery profile relaxes the derivability rule at AUTHORING time: the
+    # override rides the instruction block itself (adjacent to the safety
+    # rule it supersedes). Lab profile authors exactly as before — the
+    # benchmark showed the strict derivability discipline structurally caps
+    # rediscovery when the key inspiration is absent from the context.
+    author_instructions = HYPOTHESIS_GENERATION_INSTRUCTIONS
+    if selection_profile == "discovery":
+        author_instructions = (HYPOTHESIS_GENERATION_INSTRUCTIONS
+                               + DISCOVERY_AUTHOR_OVERRIDE)
+
     first, author_context = perform_science_rag(
         objective=objective,
-        instructions=HYPOTHESIS_GENERATION_INSTRUCTIONS,
+        instructions=author_instructions,
         task_name="Candidate Plan 1",
         kb_docs=kb_docs,
         model=model,
@@ -455,7 +467,7 @@ def generate_plan_candidates(objective: str,
     if tier == "fallback":
         print("  - ℹ️  Fallback tier pinned for all candidates in this run.")
 
-    instructions = (HYPOTHESIS_GENERATION_INSTRUCTIONS if tier == "strict"
+    instructions = (author_instructions if tier == "strict"
                     else HYPOTHESIS_GENERATION_INSTRUCTIONS_FALLBACK)
 
     for k in range(2, n_candidates + 1):

--- a/scilink/agents/planning_agents/planning_rag.py
+++ b/scilink/agents/planning_agents/planning_rag.py
@@ -492,6 +492,7 @@ def judge_plan_candidates(objective: str,
                           primary_data: Optional[str] = None,
                           images: Optional[List[Any]] = None,
                           image_descriptions: Optional[List[str]] = None,
+                          additional_context: Optional[str] = None,
                           skill_context: Optional[str] = None,
                           fallback_tier: bool = False) -> Dict[str, Any]:
     """
@@ -523,6 +524,10 @@ def judge_plan_candidates(objective: str,
     evidence_parts = []
     if primary_data:
         evidence_parts.append(f"## 📊 Primary Experimental Data:\n{primary_data}")
+    if additional_context:
+        # Lab constraints / equipment live here — feasibility is judged
+        # against this, so it must reach the judge, not just the authors.
+        evidence_parts.append(f"## Additional Context:\n{additional_context}")
     if retrieved_context:
         evidence_parts.append(f"## Retrieved Context (KB + literature):\n{retrieved_context}")
     if skill_context:

--- a/scilink/agents/planning_agents/planning_rag.py
+++ b/scilink/agents/planning_agents/planning_rag.py
@@ -16,7 +16,8 @@ from .instruct import (
     HYPOTHESIS_GENERATION_INSTRUCTIONS_FALLBACK,
     TEA_INSTRUCTIONS_FALLBACK,
     HYPOTHESIS_DISTINCTNESS_CONDITIONING,
-    HYPOTHESIS_BEST_OF_N_SELECTION_INSTRUCTIONS
+    HYPOTHESIS_BEST_OF_N_SELECTION_INSTRUCTIONS,
+    HYPOTHESIS_BESTOFN_AUTHOR_NOTE
 )
 
 
@@ -419,6 +420,15 @@ def generate_plan_candidates(objective: str,
     (``{"retrieved_context", "primary_data"}``) all candidates were authored
     against.
     """
+    # Every author — candidate 1 included — is told it is writing ONE of N.
+    # Without this, an objective phrased as "explore several alternatives"
+    # makes the (otherwise unconditioned) first author pack all the
+    # alternative strategies into a single plan, which then wins at the
+    # judge on scope-matching (observed live via the meta delegation path).
+    author_ctx = (f"{additional_context}\n\n{HYPOTHESIS_BESTOFN_AUTHOR_NOTE}"
+                  if additional_context else HYPOTHESIS_BESTOFN_AUTHOR_NOTE) \
+        if n_candidates > 1 else additional_context
+
     first, author_context = perform_science_rag(
         objective=objective,
         instructions=HYPOTHESIS_GENERATION_INSTRUCTIONS,
@@ -429,7 +439,7 @@ def generate_plan_candidates(objective: str,
         primary_data_set=primary_data_set,
         image_paths=image_paths,
         image_descriptions=image_descriptions,
-        additional_context=additional_context,
+        additional_context=author_ctx,
         external_context=external_context,
         skill_context=skill_context,
         return_context=True,
@@ -454,8 +464,9 @@ def generate_plan_candidates(objective: str,
         conditioning = HYPOTHESIS_DISTINCTNESS_CONDITIONING.format(
             prior_hypotheses=prior
         )
-        add_ctx = (f"{additional_context}\n\n{conditioning}"
-                   if additional_context else conditioning)
+        note_and_conditioning = f"{HYPOTHESIS_BESTOFN_AUTHOR_NOTE}\n\n{conditioning}"
+        add_ctx = (f"{additional_context}\n\n{note_and_conditioning}"
+                   if additional_context else note_and_conditioning)
         # No fallback_instructions here: within the pinned tier, a decline is
         # a decline — the early stop, not a trigger to change tiers mid-run.
         res = run_rag(

--- a/scilink/agents/planning_agents/planning_rag.py
+++ b/scilink/agents/planning_agents/planning_rag.py
@@ -19,8 +19,8 @@ from .instruct import (
     HYPOTHESIS_BEST_OF_N_SELECTION_INSTRUCTIONS,
     HYPOTHESIS_BESTOFN_AUTHOR_NOTE,
     BESTOFN_SELECTION_PROFILE_LAB,
-    BESTOFN_SELECTION_PROFILE_DISCOVERY,
-    DISCOVERY_AUTHOR_OVERRIDE
+    BESTOFN_SELECTION_PROFILE_IDEATION,
+    IDEATION_AUTHOR_OVERRIDE
 )
 
 
@@ -433,15 +433,15 @@ def generate_plan_candidates(objective: str,
                   if additional_context else HYPOTHESIS_BESTOFN_AUTHOR_NOTE) \
         if n_candidates > 1 else additional_context
 
-    # Discovery profile relaxes the derivability rule at AUTHORING time: the
+    # Ideation profile relaxes the derivability rule at AUTHORING time: the
     # override rides the instruction block itself (adjacent to the safety
     # rule it supersedes). Lab profile authors exactly as before — the
     # benchmark showed the strict derivability discipline structurally caps
     # rediscovery when the key inspiration is absent from the context.
     author_instructions = HYPOTHESIS_GENERATION_INSTRUCTIONS
-    if selection_profile == "discovery":
+    if selection_profile == "ideation":
         author_instructions = (HYPOTHESIS_GENERATION_INSTRUCTIONS
-                               + DISCOVERY_AUTHOR_OVERRIDE)
+                               + IDEATION_AUTHOR_OVERRIDE)
 
     first, author_context = perform_science_rag(
         objective=objective,
@@ -587,11 +587,11 @@ def judge_plan_candidates(objective: str,
 
     # Selection profile: same criteria and scores either way (the human sees
     # an identical card format); only the WEIGHTING of the pick changes.
-    # "lab" codifies the execution-first behavior; "discovery" weights
+    # "lab" codifies the execution-first behavior; "ideation" weights
     # information gain first — benchmark evidence showed the lab weighting
     # leaves the boldest (most rediscovery-shaped) candidate unpicked.
-    profile_note = (BESTOFN_SELECTION_PROFILE_DISCOVERY
-                    if selection_profile == "discovery"
+    profile_note = (BESTOFN_SELECTION_PROFILE_IDEATION
+                    if selection_profile == "ideation"
                     else BESTOFN_SELECTION_PROFILE_LAB)
 
     prompt = (

--- a/scilink/agents/planning_agents/planning_rag.py
+++ b/scilink/agents/planning_agents/planning_rag.py
@@ -241,7 +241,7 @@ def critique_plan(objective: str,
         if pl:
             revision_parts.append("CAVEATS PREVIOUSLY RAISED on the prior plan:\n" + pl)
     if human_feedback:
-        revision_parts.append(f'HUMAN REVISION REQUEST:\n"{human_feedback}"')
+        revision_parts.append(f'REVISION REQUEST:\n"{human_feedback}"')
 
     if revision_parts:
         prior_section = (

--- a/scilink/agents/planning_agents/user_interface.py
+++ b/scilink/agents/planning_agents/user_interface.py
@@ -108,6 +108,87 @@ def display_plan_summary(result: Dict[str, Any]) -> None:
     print("\n" + "="*80)
 
 
+def display_plan_candidates(candidates: List[Dict[str, Any]],
+                            judge: Dict[str, Any],
+                            selected: int,
+                            report_paths: Optional[List[str]] = None,
+                            pick_caveats: Optional[List[str]] = None) -> None:
+    """
+    Print the best-of-N candidate summary cards for human review.
+
+    Extractive by design: every line comes verbatim from fields the plan JSON
+    already carries (name / hypothesis / expected_outcome / justification) plus
+    the judge's scores — no extra LLM call, so a card cannot drift from the
+    plan it describes. This ONE stdout block serves both surfaces: the CLI
+    user reads it directly, and the UI parser splits it into cards + a radio
+    (gated on the "PLAN CANDIDATES" header and the card markers below — keep
+    them stable).
+    """
+    scores_by_idx = {s.get("candidate"): s for s in judge.get("scores", [])
+                     if isinstance(s, dict)}
+
+    print("\n" + "=" * 80)
+    print(f"🧭 PLAN CANDIDATES — {len(candidates)} distinct strategies "
+          f"(judge pick: Candidate {selected})")
+    print("=" * 80)
+
+    for i, cand in enumerate(candidates, 1):
+        exp = (cand.get("proposed_experiments") or [{}])[0]
+        marker = "  ← judge pick" if i == selected else ""
+        print(f"\n── Candidate {i}: {exp.get('experiment_name', 'Unnamed')} ──{marker}")
+        print(f"🎯 Hypothesis: {exp.get('hypothesis', 'N/A')}")
+        print(f"📈 Expected outcome: {exp.get('expected_outcome', 'N/A')}")
+        print(f"💡 Justification: {exp.get('justification', 'N/A')}")
+        s = scores_by_idx.get(i)
+        if s:
+            print("🧑‍⚖️ Judge: "
+                  f"groundedness {s.get('groundedness', '?')}/5 · "
+                  f"testability {s.get('testability', '?')}/5 · "
+                  f"actionability {s.get('actionability', '?')}/5 · "
+                  f"feasibility {s.get('feasibility', '?')}/5 · "
+                  f"info-gain {s.get('information_gain', '?')}/5")
+            if s.get("comment"):
+                print(f"   {s['comment']}")
+        if report_paths and i <= len(report_paths):
+            print(f"📄 Full plan: {report_paths[i - 1]}")
+
+    if judge.get("reasoning"):
+        print(f"\n🧑‍⚖️ JUDGE REASONING:\n  {judge['reasoning']}")
+    if pick_caveats:
+        print(f"\n⚠️  Caveats on the pick (Candidate {selected}):")
+        for c in pick_caveats:
+            print(f"  • {c}")
+    print("\n" + "=" * 80)
+
+
+def get_candidate_selection(n_candidates: int, judge_pick: int) -> int:
+    """
+    Stage-1 selection prompt: accept the judge's pick (ENTER) or override by
+    index. Selection only — free-text refinement belongs to the existing
+    stage-2 plan-approval prompt, which runs on whichever candidate wins here.
+
+    The prompt string carries the "accept plan candidate <pick>" marker the UI
+    parser gates on; the reply contract is the analysis best-of-N one (bare
+    digit, or empty for the pick). Anything unparseable falls back to the
+    judge's pick — never blocks.
+    """
+    print("\n" + "-" * 60)
+    print("📝 SELECT A PLAN CANDIDATE")
+    print("-" * 60)
+    print(f"• Press [ENTER] to accept the judge's pick (Candidate {judge_pick}).")
+    print(f"• Or type a candidate number (1-{n_candidates}) to choose a "
+          "different plan.")
+
+    reply = input(f"\n> Selection (ENTER to accept plan candidate {judge_pick}): ").strip()
+
+    if reply.isdigit() and 1 <= int(reply) <= n_candidates:
+        return int(reply)
+    if reply:
+        print(f"  - ℹ️  '{reply}' is not a candidate number — keeping the "
+              f"judge's pick (Candidate {judge_pick}).")
+    return judge_pick
+
+
 def get_user_feedback() -> Optional[str]:
     """
     Pauses execution to get user input via the CLI. 

--- a/scilink/knowledge/rag_engine.py
+++ b/scilink/knowledge/rag_engine.py
@@ -172,7 +172,8 @@ def run_rag(query: str,
             skill_context: Optional[str] = None,
             fallback_instructions: Optional[str] = None,
             task_name: str = "RAG",
-            return_context: bool = False) -> Any:
+            return_context: bool = False,
+            mode_key: Optional[str] = None) -> Any:
     """Generic RAG generation loop.
 
     Retrieves context for ``query`` from ``kb``, builds a multimodal prompt
@@ -200,6 +201,10 @@ def run_rag(query: str,
             so callers can reuse the exact grounding evidence the generation
             saw (e.g. a downstream critic). Default False preserves the
             original ``result``-only return for all existing callers.
+        mode_key: When set, stamp the returned dict with
+            ``result[mode_key] = "fallback" | "strict"`` so the caller can
+            tell which instruction tier actually produced the plan. Off by
+            default — existing callers' results are untouched.
 
     Returns:
         The parsed JSON dict (or ``{"error": ...}`` on failure). When
@@ -271,6 +276,7 @@ def run_rag(query: str,
             result.get("error") and "Insufficient" in str(result.get("error"))
         )
 
+        used_fallback = False
         if needs_fallback:
             print(f"    - ⚠️ Strict generation failed: {result.get('error')}")
             if not fallback_instructions:
@@ -285,7 +291,10 @@ def run_rag(query: str,
             if error_msg_fb:
                 return _ret({"error": f"Fallback JSON Parsing Error: {error_msg_fb}"})
             print("    - ✅ Fallback generation successful.")
+            used_fallback = True
 
+        if mode_key and isinstance(result, dict):
+            result[mode_key] = "fallback" if used_fallback else "strict"
         return _ret(result)
 
     except Exception as e:

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -288,7 +288,14 @@ def _find_code_review_files() -> list[tuple[str, str]]:
 
 
 def _find_new_html_reports() -> list[str]:
-    """Return HTML report paths in the session dir not yet shown."""
+    """Return HTML report paths in the session dir not yet shown.
+
+    Best-of-N candidate reports (``plan_candidates/``) are deliberately
+    excluded from the chat message: they are side artifacts reviewed at the
+    selection prompt and browsable in the File Explorer, and stacking N of
+    them next to the winner's ``plan.html`` buries the actual deliverable.
+    They are still marked known so they never leak into a later message.
+    """
     session_dir = st.session_state.session_dir
     if session_dir is None:
         return []
@@ -297,6 +304,8 @@ def _find_new_html_reports() -> list[str]:
         s = str(p)
         if s not in st.session_state.known_images:  # reuse the same set
             st.session_state.known_images.add(s)
+            if p.parent.name == "plan_candidates":
+                continue
             new.append(s)
     return new
 

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -346,6 +346,46 @@ def _parse_bestofn_review(context: str, prompt: str):
     return ordered, pick
 
 
+def _parse_plan_candidate_review(context: str, prompt: str):
+    """Parse the best-of-N PLAN candidate review from captured stdout.
+
+    Sibling of ``_parse_bestofn_review`` for plan mode: gated on its own
+    marker strings ("accept plan candidate" in the prompt, "PLAN CANDIDATES"
+    in the buffer) so neither parser can hijack the other's review, and with
+    its own card grammar — plan candidates carry judge scores, not the
+    ``metric=value`` scalar the analysis regex expects. Returns
+    ``(candidates, judge_pick)`` with ``candidates`` a list of
+    ``{"idx": int, "label": str}``, or ``None`` to fall back to the generic
+    text box (graceful degradation on any parse miss). The full summary cards
+    themselves render via the existing context box; this parser only powers
+    the radio selector. Reply contract matches ``get_candidate_selection``:
+    bare digit to override, "" to accept the judge's pick.
+    """
+    if not prompt or "accept plan candidate" not in prompt:
+        return None
+    if not context or "PLAN CANDIDATES" not in context:
+        return None
+    import re
+    block = context[context.rfind("PLAN CANDIDATES"):]
+    cands: dict[int, str] = {}
+    pick = None
+    for m in re.finditer(r"── Candidate (\d+): (.+?) ──(.*)", block):
+        idx = int(m.group(1))
+        name = m.group(2).strip()
+        if len(name) > 60:
+            name = name[:57] + "…"
+        cands[idx] = f"Candidate {idx} — {name}"
+        if "judge pick" in m.group(3).lower():
+            pick = idx
+    if not cands:
+        return None
+    if pick is None:
+        pm = re.search(r"accept plan candidate (\d+)", prompt)
+        pick = int(pm.group(1)) if pm else min(cands)
+    ordered = [{"idx": i, "label": cands[i]} for i in sorted(cands)]
+    return ordered, pick
+
+
 def _run_agent_chat(task: ChatTask, agent, user_input: str) -> None:
     """Target for the background thread."""
     import logging
@@ -831,6 +871,8 @@ else:
                 # render a radio selector (scales to any N, unlike one button
                 # per candidate). None -> falls through to the generic text box.
                 _bestofn_data = _parse_bestofn_review(req.context or "", _prompt)
+                # Plan-mode best-of-N: same radio UX, its own parser/markers.
+                _plan_cand_data = _parse_plan_candidate_review(req.context or "", _prompt)
                 # (_is_fanout_confirm computed above, before the context render)
                 if "Context" in _prompt or "MISSING METADATA" in _ctx_tail:
                     _input_label = "Describe your data (optional):"
@@ -929,6 +971,44 @@ else:
                     with col_pick:
                         if st.button(f"Accept judge's pick (Candidate {_pick})",
                                      type="secondary", width="stretch"):
+                            req.response = ""
+                            req.event.set()
+                            st.session_state.pop("_feedback_preview_images", None)
+                            st.session_state.pop("_code_review_files", None)
+                            st.rerun(scope="app")
+                # Plan best-of-N selection: radio over candidate plans. The
+                # summary cards are already visible in the context box above;
+                # full per-candidate HTML reports live in plan_candidates/.
+                # Sends a bare digit (override) or "" (accept judge's pick) —
+                # the get_candidate_selection contract.
+                elif _plan_cand_data:
+                    _pcands, _ppick = _plan_cand_data
+                    _popts = [c["idx"] for c in _pcands]
+                    _plabels = {c["idx"]: c["label"] for c in _pcands}
+                    _pdefault = _popts.index(_ppick) if _ppick in _popts else 0
+                    _pchoice = st.radio(
+                        "Select the plan candidate to proceed with:",
+                        _popts, index=_pdefault,
+                        format_func=lambda i: _plabels.get(i, f"Candidate {i}"),
+                        key="plan_cand_choice",
+                    )
+                    st.markdown(
+                        '<span class="bestofn-actions-anchor"></span>',
+                        unsafe_allow_html=True,
+                    )
+                    col_puse, col_ppick = st.columns(2)
+                    with col_puse:
+                        if st.button("Use selected plan", type="primary",
+                                     width="stretch"):
+                            req.response = str(_pchoice)
+                            req.event.set()
+                            st.session_state.pop("_feedback_preview_images", None)
+                            st.session_state.pop("_code_review_files", None)
+                            st.rerun(scope="app")
+                    with col_ppick:
+                        if st.button(f"Accept judge's pick (Candidate {_ppick})",
+                                     type="secondary", width="stretch",
+                                     key="plan_cand_accept"):
                             req.response = ""
                             req.event.set()
                             st.session_state.pop("_feedback_preview_images", None)

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -372,8 +372,10 @@ def _parse_plan_candidate_review(context: str, prompt: str):
     for m in re.finditer(r"── Candidate (\d+): (.+?) ──(.*)", block):
         idx = int(m.group(1))
         name = m.group(2).strip()
-        if len(name) > 60:
-            name = name[:57] + "…"
+        # Generous cap: experiment names are the radio's primary signal and
+        # the row has the full content width — clip only pathological ones.
+        if len(name) > 120:
+            name = name[:117] + "…"
         cands[idx] = f"Candidate {idx} — {name}"
         if "judge pick" in m.group(3).lower():
             pick = idx

--- a/scilink/ui/state.py
+++ b/scilink/ui/state.py
@@ -47,8 +47,13 @@ def init_session_state() -> None:
         "pending_auto_load_metadata": None,
         "cfg_consent": False,
         "selected_preview_file": None,
-        # Mode selection (None until chosen on welcome screen)
-        "app_mode": None,
+        # Mode selection. Initialized to the real default ("meta" — mission
+        # control) rather than None: the sidebar renders BEFORE the main
+        # body's None->meta assignment, so a None here made the first page
+        # load hide the mode-gated sidebar sections (embedding model/API key
+        # for plan+meta, the meta's two-level autonomy list) and point
+        # resume-session discovery at the analyze fallback.
+        "app_mode": "meta",
         # Planning mode state
         "planning_objective": "",
         # Meta mode state

--- a/tests/test_best_of_n_planning.py
+++ b/tests/test_best_of_n_planning.py
@@ -451,3 +451,50 @@ def test_stale_buffer_takes_latest_block(capsys):
     cands, pick = parse(buffer, "accept plan candidate 3")
     assert len(cands) == 3 and pick == 3
     assert cands[0]["label"] == "Candidate 1 — New 1"
+
+
+# --------------------------------------------------- constraint coverage
+
+def _capture_ctx(monkeypatch):
+    """Capture the additional_context that reaches the RAG engine."""
+    from scilink.agents.planning_agents import planning_rag as pr
+    seen = {}
+
+    def fake_run_rag(**kw):
+        seen["additional_context"] = kw.get("additional_context")
+        return {"plan": "x"}
+
+    monkeypatch.setattr(pr, "run_rag", fake_run_rag)
+    return pr, seen
+
+
+def test_coverage_note_injected_only_with_literature_and_constraints(monkeypatch):
+    """Literature degrades constraint COVERAGE (omissions, not violations), so
+    the constraint->step mapping demand rides along whenever both are present —
+    and stays out of the prompt otherwise, which is the condition it was
+    measured in."""
+    pr, seen = _capture_ctx(monkeypatch)
+    cases = {
+        ("constraints", "lit"): True,
+        ("constraints", None): False,
+        (None, "lit"): False,
+        (None, None): False,
+    }
+    for (add, ext), expected in cases.items():
+        seen.clear()
+        pr.perform_science_rag(
+            objective="o", instructions="i", task_name="t", kb_docs=None,
+            model=None, generation_config=None,
+            additional_context=add, external_context=ext)
+        got = pr.CONSTRAINT_COVERAGE_NOTE in (seen["additional_context"] or "")
+        assert got is expected, f"add={add!r} ext={ext!r}: coverage note {got}"
+
+
+def test_coverage_note_preserves_the_original_context(monkeypatch):
+    """The note is additive — the caller's constraints must survive verbatim."""
+    pr, seen = _capture_ctx(monkeypatch)
+    pr.perform_science_rag(
+        objective="o", instructions="i", task_name="t", kb_docs=None,
+        model=None, generation_config=None,
+        additional_context="max 2 mL/well, aqueous only", external_context="lit")
+    assert "max 2 mL/well, aqueous only" in seen["additional_context"]

--- a/tests/test_best_of_n_planning.py
+++ b/tests/test_best_of_n_planning.py
@@ -262,6 +262,19 @@ def test_candidate_html_reports_written(tmp_path, no_verify_no_critic):
         str(report_dir / "candidate_1.html"), str(report_dir / "candidate_2.html")]
 
 
+def test_resolve_n_candidates_default_policy():
+    """First plan of a campaign defaults to best-of-3; follow-ups to 1;
+    explicit values always win (clamped); junk degrades to 1."""
+    from scilink.agents.planning_agents.orchestrator_tools import resolve_n_candidates
+    assert resolve_n_candidates(None, {}) == 3
+    assert resolve_n_candidates(None, None) == 3
+    assert resolve_n_candidates(None, {"current_plan": {"stage": "x"}}) == 1
+    assert resolve_n_candidates(1, {}) == 1          # explicit single plan wins
+    assert resolve_n_candidates(4, {"current_plan": {}}) == 4
+    assert resolve_n_candidates(7, {}) == 4          # clamp
+    assert resolve_n_candidates("junk", {}) == 1     # degrade, never crash
+
+
 def test_all_authors_get_one_of_n_note(tmp_path, no_verify_no_critic):
     """EVERY author (candidate 1 included) is told it writes ONE of N —
     otherwise an objective phrased 'explore several alternatives' makes the

--- a/tests/test_best_of_n_planning.py
+++ b/tests/test_best_of_n_planning.py
@@ -264,7 +264,7 @@ def test_candidate_html_reports_written(tmp_path, no_verify_no_critic):
 
 def test_selection_profile_reaches_judge(tmp_path, no_verify_no_critic):
     """The judge prompt carries the LAB weighting by default and the
-    DISCOVERY weighting when requested; candidates/authors are unaffected
+    IDEATION weighting when requested; candidates/authors are unaffected
     (profile changes the pick's weighting, not generation)."""
     def responses():
         return [plan_json("P1", "H1"), plan_json("P2", "H2"), judge_json(1, 2)]
@@ -274,18 +274,18 @@ def test_selection_profile_reaches_judge(tmp_path, no_verify_no_critic):
     agent.generate_plan("obj", enable_human_feedback=False, n_candidates=2)
     judge_prompt = model.calls[-1]
     assert "SELECTION WEIGHTING — LAB PROFILE" in judge_prompt
-    assert "DISCOVERY PROFILE" not in judge_prompt
+    assert "IDEATION PROFILE" not in judge_prompt
     assert all("SELECTION WEIGHTING" not in c for c in model.calls[:-1])
 
     model2 = ScriptedModel(responses())
     agent2 = make_agent(tmp_path / "disc", model2)
     agent2.generate_plan("obj", enable_human_feedback=False, n_candidates=2,
-                         selection_profile="discovery")
-    assert "SELECTION WEIGHTING — DISCOVERY PROFILE" in model2.calls[-1]
-    assert agent2.state["plan_candidates"]["profile"] == "discovery"
-    # discovery also relaxes AUTHOR-side derivability — every author prompt
+                         selection_profile="ideation")
+    assert "SELECTION WEIGHTING — IDEATION PROFILE" in model2.calls[-1]
+    assert agent2.state["plan_candidates"]["profile"] == "ideation"
+    # ideation also relaxes AUTHOR-side derivability — every author prompt
     # carries the grounding-latitude override; lab authors never see it
-    assert all("DISCOVERY MODE — GROUNDING LATITUDE" in c
+    assert all("IDEATION MODE — GROUNDING LATITUDE" in c
                for c in model2.calls[:-1])
     assert all("GROUNDING LATITUDE" not in c for c in model.calls)
 

--- a/tests/test_best_of_n_planning.py
+++ b/tests/test_best_of_n_planning.py
@@ -1,0 +1,316 @@
+"""Offline tests for best-of-N hypothesis generation in plan mode.
+
+Covers the contract pinned in issue #377:
+- n_candidates=1 is a no-op (single-plan path, no candidate state);
+- sequential candidates are diversity-conditioned on prior hypotheses;
+- retrieval evidence is shared (same retrieved-context block in every prompt);
+- N is a cap: a decline (error JSON) stops generation early and skips judging;
+- fallback parity: the tier is decided at candidate 1 and pinned for the run;
+- the judge selects; invalid/broken judge output fails open to candidate 1;
+- human override switches the selection and re-runs the (advisory) critic —
+  the lazy-critique invariant;
+- the critic is never acted on automatically (no auto-refine, no auto-switch);
+- state["plan_candidates"] is JSON-serializable (checkpoint rides along);
+- the CLI candidate block round-trips through the UI parser (CLI→UI contract).
+
+All LLM traffic is a scripted mock; no network.
+"""
+
+import ast
+import builtins
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scilink.agents.planning_agents.planning_agent import PlanningAgent
+from scilink.agents.planning_agents.base_agent import BaseAgent
+from scilink.agents.planning_agents import planning_agent as pa_mod
+from scilink.agents.planning_agents.user_interface import display_plan_candidates
+
+
+# ---------------------------------------------------------------- helpers
+
+def plan_json(name, hypothesis):
+    return json.dumps({
+        "proposed_experiments": [{
+            "hypothesis": hypothesis,
+            "experiment_name": name,
+            "experimental_steps": ["Step 1: do the thing", "Step 2: measure"],
+            "required_equipment": ["Instrument A"],
+            "optimization_params": [
+                {"parameter_name": "Temperature", "parameter_type": "continuous",
+                 "min_value": 20.0, "max_value": 80.0, "rationale": "range"}],
+            "expected_outcome": f"Outcome supporting {name}",
+            "justification": f"Justified by evidence for {name}",
+            "source_documents": ["doc1.pdf"],
+        }]
+    })
+
+
+def judge_json(pick, n):
+    return json.dumps({
+        "scores": [
+            {"candidate": i, "groundedness": 4, "testability": 4,
+             "actionability": 4, "feasibility": 4, "information_gain": 3 + (i == pick),
+             "comment": f"Candidate {i} comment."}
+            for i in range(1, n + 1)
+        ],
+        "selected_candidate": pick,
+        "reasoning": f"Candidate {pick} best balances the criteria.",
+    })
+
+
+DECLINE = json.dumps({"error": "Insufficient context: no additional distinct "
+                               "approach is supported by the provided evidence."})
+
+
+class ScriptedModel:
+    """Returns canned responses in order; records every prompt it saw."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def generate_content(self, prompt_parts, generation_config=None):
+        if isinstance(prompt_parts, str):
+            prompt_parts = [prompt_parts]
+        self.calls.append("\n".join(p for p in prompt_parts if isinstance(p, str)))
+        if not self.responses:
+            raise AssertionError("ScriptedModel exhausted — unexpected extra LLM call")
+        return SimpleNamespace(text=self.responses.pop(0))
+
+
+def make_agent(tmp_path, model):
+    agent = PlanningAgent.__new__(PlanningAgent)
+    BaseAgent.__init__(agent, str(tmp_path))
+    agent.agent_type = "planning"
+    agent.model = model
+    agent.generation_config = None
+    agent.kb_docs = None
+    agent.kb_code = None
+    agent.lit_agent = None
+    agent._ensure_kb_is_ready = lambda *a, **k: False
+    return agent
+
+
+@pytest.fixture
+def no_verify_no_critic(monkeypatch):
+    """Patch conformance + critic to spies so the ScriptedModel only serves
+    generation and judge calls. Returns (verify_calls, critic_calls) lists."""
+    verify_calls, critic_calls = [], []
+    monkeypatch.setattr(pa_mod, "verify_plan_relevance",
+                        lambda *a, **k: (verify_calls.append(a), (True, ""))[1])
+    monkeypatch.setattr(pa_mod, "critique_plan",
+                        lambda *a, **k: (critic_calls.append(a), {"findings": []})[1])
+    return verify_calls, critic_calls
+
+
+# ---------------------------------------------------------------- tests
+
+def test_n1_is_single_plan_noop(tmp_path, no_verify_no_critic):
+    model = ScriptedModel([plan_json("Solo", "H-solo")])
+    agent = make_agent(tmp_path, model)
+    res = agent.generate_plan("obj", enable_human_feedback=False)
+    assert res["proposed_experiments"][0]["experiment_name"] == "Solo"
+    assert len(model.calls) == 1
+    assert "plan_candidates" not in agent.state
+    assert "PRIOR CANDIDATE HYPOTHESES" not in model.calls[0]
+
+
+def test_sequential_conditioning_and_shared_evidence(tmp_path, no_verify_no_critic):
+    model = ScriptedModel([
+        plan_json("P1", "H1: mechanism alpha"),
+        plan_json("P2", "H2: mechanism beta"),
+        plan_json("P3", "H3: mechanism gamma"),
+        judge_json(2, 3),
+    ])
+    agent = make_agent(tmp_path, model)
+    res = agent.generate_plan("obj", enable_human_feedback=False, n_candidates=3)
+
+    gen1, gen2, gen3, judge = model.calls
+    # candidate 1 is unconditioned; 2 and 3 see all prior hypotheses
+    assert "PRIOR CANDIDATE HYPOTHESES" not in gen1
+    assert "PRIOR CANDIDATE HYPOTHESES" in gen2 and "H1: mechanism alpha" in gen2
+    assert "H1: mechanism alpha" in gen3 and "H2: mechanism beta" in gen3
+    assert "DIFFERENT mechanistic hypothesis" in gen3
+    # shared evidence: identical retrieved-context block in every author prompt
+    marker = "No specific documents found in Knowledge Base."
+    assert all(marker in g for g in (gen1, gen2, gen3))
+    # judge saw all three candidates and the pick won
+    assert "CANDIDATE 3" in judge and "selector, not an editor" in judge
+    assert res["proposed_experiments"][0]["experiment_name"] == "P2"
+
+    pc = agent.state["plan_candidates"]
+    assert pc["selected_index"] == 2
+    assert pc["human_override"] is False
+    assert pc["tier"] == "strict"
+    assert len(pc["candidates"]) == 3
+    json.dumps(pc)  # checkpoint rides planner_state — must serialize
+
+
+def test_decline_stops_early_and_skips_judge(tmp_path, no_verify_no_critic):
+    model = ScriptedModel([
+        plan_json("P1", "H1"),
+        DECLINE,  # candidate 2 declines -> stop; judge never called
+    ])
+    agent = make_agent(tmp_path, model)
+    res = agent.generate_plan("obj", enable_human_feedback=False, n_candidates=4)
+    assert len(model.calls) == 2
+    assert res["proposed_experiments"][0]["experiment_name"] == "P1"
+    pc = agent.state["plan_candidates"]
+    assert len(pc["candidates"]) == 1 and pc["selected_index"] == 1
+    assert pc["judge"] is None
+
+
+def test_fallback_tier_pinned_for_whole_run(tmp_path, no_verify_no_critic):
+    model = ScriptedModel([
+        json.dumps({"error": "Insufficient context for a specific plan."}),
+        plan_json("F1", "H1-fallback"),   # candidate 1 fallback retry
+        plan_json("F2", "H2-fallback"),   # candidate 2, authored in fallback tier
+        judge_json(1, 2),
+    ])
+    agent = make_agent(tmp_path, model)
+    agent.generate_plan("obj", enable_human_feedback=False, n_candidates=2)
+
+    strict1, fb1, gen2, judge = model.calls
+    assert "FALLBACK MODE ACTIVATED" not in strict1
+    assert "FALLBACK MODE ACTIVATED" in fb1
+    # tier pinned: candidate 2 authored directly under fallback instructions,
+    # with the distinctness conditioning on top
+    assert "FALLBACK MODE ACTIVATED" in gen2
+    assert "PRIOR CANDIDATE HYPOTHESES" in gen2 and "H1-fallback" in gen2
+    assert agent.state["plan_candidates"]["tier"] == "fallback"
+    # judge told to compare within the fallback tier
+    assert "fallback mode" in judge
+
+
+def test_judge_invalid_selection_fails_open(tmp_path, no_verify_no_critic):
+    model = ScriptedModel([
+        plan_json("P1", "H1"),
+        plan_json("P2", "H2"),
+        json.dumps({"scores": [], "selected_candidate": 7, "reasoning": "bad"}),
+    ])
+    agent = make_agent(tmp_path, model)
+    res = agent.generate_plan("obj", enable_human_feedback=False, n_candidates=2)
+    pc = agent.state["plan_candidates"]
+    assert pc["selected_index"] == 1
+    assert "error" in pc["judge"]
+    assert res["proposed_experiments"][0]["experiment_name"] == "P1"
+
+
+def test_human_override_switches_and_recritiques(tmp_path, monkeypatch,
+                                                 no_verify_no_critic):
+    verify_calls, critic_calls = no_verify_no_critic
+    model = ScriptedModel([
+        plan_json("P1", "H1"),
+        plan_json("P2", "H2"),
+        plan_json("P3", "H3"),
+        judge_json(1, 3),
+    ])
+    agent = make_agent(tmp_path, model)
+    replies = iter(["3", ""])  # stage 1: override to 3; stage 2: approve as-is
+    monkeypatch.setattr(builtins, "input", lambda *a: next(replies))
+
+    res = agent.generate_plan("obj", enable_human_feedback=True, n_candidates=3)
+
+    pc = agent.state["plan_candidates"]
+    assert pc["selected_index"] == 3 and pc["human_override"] is True
+    assert res["proposed_experiments"][0]["experiment_name"] == "P3"
+    assert agent.state["current_plan"]["proposed_experiments"][0]["experiment_name"] == "P3"
+    # lazy-critique invariant: judge's pick AND the overridden choice were
+    # each conformance-checked and critiqued; nothing else was
+    assert len(verify_calls) == 2 and len(critic_calls) == 2
+    # advisory-only: no extra generation happened in response to criticism
+    assert len(model.calls) == 4
+
+
+def test_enter_accepts_judge_pick(tmp_path, monkeypatch, no_verify_no_critic):
+    verify_calls, critic_calls = no_verify_no_critic
+    model = ScriptedModel([
+        plan_json("P1", "H1"),
+        plan_json("P2", "H2"),
+        judge_json(2, 2),
+    ])
+    agent = make_agent(tmp_path, model)
+    replies = iter(["", ""])  # accept pick; approve plan
+    monkeypatch.setattr(builtins, "input", lambda *a: next(replies))
+
+    res = agent.generate_plan("obj", enable_human_feedback=True, n_candidates=2)
+    pc = agent.state["plan_candidates"]
+    assert pc["selected_index"] == 2 and pc["human_override"] is False
+    assert res["proposed_experiments"][0]["experiment_name"] == "P2"
+    assert len(verify_calls) == 1 and len(critic_calls) == 1
+
+
+def test_candidate_html_reports_written(tmp_path, no_verify_no_critic):
+    model = ScriptedModel([
+        plan_json("P1", "H1"),
+        plan_json("P2", "H2"),
+        judge_json(1, 2),
+    ])
+    agent = make_agent(tmp_path, model)
+    report_dir = tmp_path / "plan_candidates"
+    agent.generate_plan("obj", enable_human_feedback=False, n_candidates=2,
+                        candidate_report_dir=str(report_dir))
+    files = sorted(p.name for p in report_dir.glob("*.html"))
+    assert files == ["candidate_1.html", "candidate_2.html"]
+    html = (report_dir / "candidate_2.html").read_text()
+    assert "H2" in html and "P2" in html
+    assert agent.state["plan_candidates"]["reports"] == [
+        str(report_dir / "candidate_1.html"), str(report_dir / "candidate_2.html")]
+
+
+# ------------------------------------------------- CLI -> UI parser contract
+
+def _load_ui_parser():
+    """Extract _parse_plan_candidate_review from app.py without importing
+    streamlit (app.py has top-level st.* calls)."""
+    src = Path(__file__).resolve().parents[1] / "scilink" / "ui" / "app.py"
+    tree = ast.parse(src.read_text())
+    fn = next(n for n in tree.body
+              if isinstance(n, ast.FunctionDef)
+              and n.name == "_parse_plan_candidate_review")
+    ns = {}
+    exec(compile(ast.Module(body=[fn], type_ignores=[]), str(src), "exec"), ns)
+    return ns["_parse_plan_candidate_review"]
+
+
+def test_cli_block_roundtrips_through_ui_parser(capsys):
+    candidates = [json.loads(plan_json(f"Plan {i}", f"H{i}")) for i in (1, 2, 3)]
+    judge = json.loads(judge_json(2, 3))
+    judge = {"scores": judge["scores"], "selected_candidate": 2,
+             "reasoning": judge["reasoning"]}
+    display_plan_candidates(candidates, judge, selected=2,
+                            report_paths=["a.html", "b.html", "c.html"],
+                            pick_caveats=["[physics] minor caveat"])
+    block = capsys.readouterr().out
+
+    parse = _load_ui_parser()
+    prompt = "\n> Selection (ENTER to accept plan candidate 2): "
+    parsed = parse(block, prompt)
+    assert parsed is not None
+    cands, pick = parsed
+    assert pick == 2
+    assert [c["idx"] for c in cands] == [1, 2, 3]
+    assert cands[0]["label"].startswith("Candidate 1 — Plan 1")
+
+    # disjoint gating: the analysis best-of-N prompt must NOT match this parser
+    assert parse(block, "accept candidate 2") is None
+    # and a non-candidate buffer must not match either
+    assert parse("REQUESTING FEEDBACK\nReview the plan", prompt) is None
+
+
+def test_stale_buffer_takes_latest_block(capsys):
+    """Two successive reviews in one session buffer -> parser reads the last."""
+    c2 = [json.loads(plan_json(f"Old {i}", f"HO{i}")) for i in (1, 2)]
+    display_plan_candidates(c2, {"scores": [], "reasoning": ""}, selected=1)
+    c3 = [json.loads(plan_json(f"New {i}", f"HN{i}")) for i in (1, 2, 3)]
+    display_plan_candidates(c3, {"scores": [], "reasoning": ""}, selected=3)
+    buffer = capsys.readouterr().out
+
+    parse = _load_ui_parser()
+    cands, pick = parse(buffer, "accept plan candidate 3")
+    assert len(cands) == 3 and pick == 3
+    assert cands[0]["label"] == "Candidate 1 — New 1"

--- a/tests/test_best_of_n_planning.py
+++ b/tests/test_best_of_n_planning.py
@@ -370,6 +370,33 @@ def test_cli_block_roundtrips_through_ui_parser(capsys):
     assert parse("REQUESTING FEEDBACK\nReview the plan", prompt) is None
 
 
+def test_candidate_reports_excluded_from_chat_sweep(tmp_path):
+    """plan.html reaches the chat message; plan_candidates/*.html do not
+    (side artifacts — selection prompt + File Explorer), but are marked
+    known so they never leak into a later message."""
+    src = Path(__file__).resolve().parents[1] / "scilink" / "ui" / "app.py"
+    tree = ast.parse(src.read_text())
+    fn = next(n for n in tree.body
+              if isinstance(n, ast.FunctionDef)
+              and n.name == "_find_new_html_reports")
+    session = tmp_path / "planning_session_x"
+    (session / "plan_candidates").mkdir(parents=True)
+    (session / "plan.html").write_text("<html>winner</html>")
+    for i in (1, 2, 3):
+        (session / "plan_candidates" / f"candidate_{i}.html").write_text("<html>c</html>")
+
+    known = set()
+    st_stub = SimpleNamespace(session_state=SimpleNamespace(
+        session_dir=str(session), known_images=known))
+    ns = {"st": st_stub, "Path": Path}
+    exec(compile(ast.Module(body=[fn], type_ignores=[]), str(src), "exec"), ns)
+    new = ns["_find_new_html_reports"]()
+
+    assert [Path(p).name for p in new] == ["plan.html"]
+    assert len(known) == 4  # all four marked seen
+    assert ns["_find_new_html_reports"]() == []  # nothing leaks later
+
+
 def test_stale_buffer_takes_latest_block(capsys):
     """Two successive reviews in one session buffer -> parser reads the last."""
     c2 = [json.loads(plan_json(f"Old {i}", f"HO{i}")) for i in (1, 2)]

--- a/tests/test_best_of_n_planning.py
+++ b/tests/test_best_of_n_planning.py
@@ -262,6 +262,29 @@ def test_candidate_html_reports_written(tmp_path, no_verify_no_critic):
         str(report_dir / "candidate_1.html"), str(report_dir / "candidate_2.html")]
 
 
+def test_selection_profile_reaches_judge(tmp_path, no_verify_no_critic):
+    """The judge prompt carries the LAB weighting by default and the
+    DISCOVERY weighting when requested; candidates/authors are unaffected
+    (profile changes the pick's weighting, not generation)."""
+    def responses():
+        return [plan_json("P1", "H1"), plan_json("P2", "H2"), judge_json(1, 2)]
+
+    model = ScriptedModel(responses())
+    agent = make_agent(tmp_path / "lab", model)
+    agent.generate_plan("obj", enable_human_feedback=False, n_candidates=2)
+    judge_prompt = model.calls[-1]
+    assert "SELECTION WEIGHTING — LAB PROFILE" in judge_prompt
+    assert "DISCOVERY PROFILE" not in judge_prompt
+    assert all("SELECTION WEIGHTING" not in c for c in model.calls[:-1])
+
+    model2 = ScriptedModel(responses())
+    agent2 = make_agent(tmp_path / "disc", model2)
+    agent2.generate_plan("obj", enable_human_feedback=False, n_candidates=2,
+                         selection_profile="discovery")
+    assert "SELECTION WEIGHTING — DISCOVERY PROFILE" in model2.calls[-1]
+    assert agent2.state["plan_candidates"]["profile"] == "discovery"
+
+
 def test_resolve_n_candidates_default_policy():
     """First plan of a campaign defaults to best-of-3; follow-ups to 1;
     explicit values always win (clamped); junk degrades to 1."""

--- a/tests/test_best_of_n_planning.py
+++ b/tests/test_best_of_n_planning.py
@@ -262,6 +262,29 @@ def test_candidate_html_reports_written(tmp_path, no_verify_no_critic):
         str(report_dir / "candidate_1.html"), str(report_dir / "candidate_2.html")]
 
 
+def test_all_authors_get_one_of_n_note(tmp_path, no_verify_no_critic):
+    """EVERY author (candidate 1 included) is told it writes ONE of N —
+    otherwise an objective phrased 'explore several alternatives' makes the
+    first author pack all strategies into one plan (observed live). Absent
+    entirely at n_candidates=1."""
+    model = ScriptedModel([
+        plan_json("P1", "H1"),
+        plan_json("P2", "H2"),
+        judge_json(1, 2),
+    ])
+    agent = make_agent(tmp_path, model)
+    agent.generate_plan("explore several alternative strategies for X",
+                        enable_human_feedback=False, n_candidates=2)
+    gen1, gen2, _ = model.calls
+    assert "BEST-OF-N AUTHORING NOTE" in gen1
+    assert "BEST-OF-N AUTHORING NOTE" in gen2
+
+    model2 = ScriptedModel([plan_json("Solo", "H")])
+    agent2 = make_agent(tmp_path / "b", model2)
+    agent2.generate_plan("obj", enable_human_feedback=False)
+    assert "BEST-OF-N AUTHORING NOTE" not in model2.calls[0]
+
+
 def test_constraints_reach_all_authors_and_judge(tmp_path, no_verify_no_critic):
     """Lab constraints (additional_context) must reach EVERY candidate's
     authoring prompt AND the judge — feasibility is judged against them."""

--- a/tests/test_best_of_n_planning.py
+++ b/tests/test_best_of_n_planning.py
@@ -290,6 +290,20 @@ def test_selection_profile_reaches_judge(tmp_path, no_verify_no_critic):
     assert all("GROUNDING LATITUDE" not in c for c in model.calls)
 
 
+def test_ideation_profile_is_noop_at_n1(tmp_path, no_verify_no_critic):
+    """DOCUMENTED behavior: ideation requires n_candidates >= 2. The
+    single-plan path ignores the profile entirely — no grounding-latitude
+    override, no weighting note, byte-identical to the pre-profile path."""
+    model = ScriptedModel([plan_json("Solo", "H")])
+    agent = make_agent(tmp_path, model)
+    agent.generate_plan("obj", enable_human_feedback=False, n_candidates=1,
+                        selection_profile="ideation")
+    assert len(model.calls) == 1
+    assert "GROUNDING LATITUDE" not in model.calls[0]
+    assert "SELECTION WEIGHTING" not in model.calls[0]
+    assert "plan_candidates" not in agent.state
+
+
 def test_resolve_n_candidates_default_policy():
     """First plan of a campaign defaults to best-of-3; follow-ups to 1;
     explicit values always win (clamped); junk degrades to 1."""

--- a/tests/test_best_of_n_planning.py
+++ b/tests/test_best_of_n_planning.py
@@ -352,6 +352,18 @@ def test_cli_block_roundtrips_through_ui_parser(capsys):
     assert [c["idx"] for c in cands] == [1, 2, 3]
     assert cands[0]["label"].startswith("Candidate 1 — Plan 1")
 
+    # long names survive un-truncated up to the generous cap (the radio row
+    # has full content width; 60-char clipping hid the distinguishing part)
+    long_name = "Two-Stage Selective Li Recovery from Permian Produced Water " \
+                "via Ion-Sieve Sorption with Staged Elution"
+    cands2 = [json.loads(plan_json(long_name, "H1")),
+              json.loads(plan_json("Short", "H2"))]
+    display_plan_candidates(cands2, {"scores": [], "reasoning": ""}, selected=1)
+    block2 = capsys.readouterr().out
+    parsed2 = parse(block2, "accept plan candidate 1")
+    assert parsed2 is not None
+    assert long_name in parsed2[0][0]["label"]
+
     # disjoint gating: the analysis best-of-N prompt must NOT match this parser
     assert parse(block, "accept candidate 2") is None
     # and a non-candidate buffer must not match either

--- a/tests/test_best_of_n_planning.py
+++ b/tests/test_best_of_n_planning.py
@@ -262,6 +262,26 @@ def test_candidate_html_reports_written(tmp_path, no_verify_no_critic):
         str(report_dir / "candidate_1.html"), str(report_dir / "candidate_2.html")]
 
 
+def test_constraints_reach_all_authors_and_judge(tmp_path, no_verify_no_critic):
+    """Lab constraints (additional_context) must reach EVERY candidate's
+    authoring prompt AND the judge — feasibility is judged against them."""
+    model = ScriptedModel([
+        plan_json("P1", "H1"),
+        plan_json("P2", "H2"),
+        judge_json(1, 2),
+    ])
+    agent = make_agent(tmp_path, model)
+    agent.generate_plan(
+        "obj", enable_human_feedback=False, n_candidates=2,
+        additional_context={"Laboratory Equipment Constraints":
+                            "All experiments run on an Opentrons Flex 2 with "
+                            "96-well plates."})
+    gen1, gen2, judge = model.calls
+    assert all("Opentrons Flex 2" in p for p in (gen1, gen2, judge))
+    # and on the judge it arrives as evidence, not as authoring instructions
+    assert "Additional Context" in judge
+
+
 # ------------------------------------------------- CLI -> UI parser contract
 
 def _load_ui_parser():

--- a/tests/test_best_of_n_planning.py
+++ b/tests/test_best_of_n_planning.py
@@ -283,6 +283,11 @@ def test_selection_profile_reaches_judge(tmp_path, no_verify_no_critic):
                          selection_profile="discovery")
     assert "SELECTION WEIGHTING — DISCOVERY PROFILE" in model2.calls[-1]
     assert agent2.state["plan_candidates"]["profile"] == "discovery"
+    # discovery also relaxes AUTHOR-side derivability — every author prompt
+    # carries the grounding-latitude override; lab authors never see it
+    assert all("DISCOVERY MODE — GROUNDING LATITUDE" in c
+               for c in model2.calls[:-1])
+    assert all("GROUNDING LATITUDE" not in c for c in model.calls)
 
 
 def test_resolve_n_candidates_default_policy():

--- a/tests/test_literature_cross_domain.py
+++ b/tests/test_literature_cross_domain.py
@@ -1,0 +1,181 @@
+"""Offline tests for cross-domain literature retrieval and parallel search.
+
+Contract pinned here (from the benchmarking that motivated the feature):
+- `cross_domain` asks for TRANSFERABLE mechanisms from other fields and
+  explicitly forbids a topical subfield review — the grounding wrapper used
+  by `hypothesis_context` neutralizes cross-domain intent, which was
+  observed live before the fix;
+- several search types can be requested at once and run CONCURRENTLY (each
+  Edison call is minutes of waiting, so serial pairs double the user's wait);
+- merged output is LABELLED per source, so candidates can tell established
+  results (usable as constraints) from analogies (mechanism inspiration);
+- a cross-domain result carries the constraint-compliance caveat;
+- single-type behaviour is unchanged.
+
+No network: the literature agent is a scripted stub.
+"""
+
+import json
+import threading
+import time
+
+import pytest
+
+from scilink.agents.lit_agents.literature_agent import LiteratureSearchAgent
+
+
+# ---------------------------------------------------------------- stubs
+
+class StubLitAgent:
+    """Records queries and how long each search overlapped the others."""
+
+    def __init__(self, delay=0.4, fail=()):
+        self.delay = delay
+        self.fail = set(fail)
+        self.calls = []
+        self._active = 0
+        self.max_concurrent = 0
+        self._lock = threading.Lock()
+
+    def _run(self, kind, query):
+        with self._lock:
+            self._active += 1
+            self.max_concurrent = max(self.max_concurrent, self._active)
+        time.sleep(self.delay)
+        with self._lock:
+            self._active -= 1
+        self.calls.append((kind, query))
+        if kind in self.fail:
+            return {"status": "error", "message": f"{kind} boom"}
+        return {"status": "success", "content": f"CONTENT::{kind}"}
+
+    def search_for_hypothesis_context(self, q):
+        return self._run("hypothesis_context", q)
+
+    def search_for_cross_domain(self, q):
+        return self._run("cross_domain", q)
+
+    def search_for_economic_data(self, q):
+        return self._run("economic_data", q)
+
+    def search_for_fitting_models(self, q):
+        return self._run("fitting_models", q)
+
+
+@pytest.fixture
+def tool(tmp_path, monkeypatch):
+    """Build the registered search_literature callable with stubs."""
+    from scilink.agents.planning_agents import orchestrator_tools as ot
+
+    monkeypatch.setattr(ot, "optimize_search_query",
+                        lambda objective, model: f"optimized::{objective}")
+
+    lit = StubLitAgent()
+    orch = type("O", (), {})()
+    orch.lit_agent = lit
+    orch.planner = type("P", (), {"model": None})()
+
+    tools = ot.OrchestratorTools.__new__(ot.OrchestratorTools)
+    tools.orch = orch
+    tools._output_dir = lambda: tmp_path
+    captured = {}
+    tools._register_tool = lambda func, name, description, parameters, required=None: (
+        captured.update({name: (func, description, parameters)}))
+    ot.OrchestratorTools._register_all_tools(tools)
+    func, desc, params = captured["search_literature"]
+    return func, lit, desc, params, tmp_path
+
+
+# ---------------------------------------------------------------- tests
+
+def test_cross_domain_prompt_forbids_topical_review():
+    """The wrapper must ask for transfer, not a subfield review — the
+    hypothesis_context wrapper reframes the task and kills cross-domain
+    intent (observed live)."""
+    agent = LiteratureSearchAgent.__new__(LiteratureSearchAgent)
+    sent = {}
+    agent._execute_crow_task = lambda q, task_type="general": sent.update(
+        q=q, t=task_type) or {"status": "success", "content": ""}
+    agent.search_for_cross_domain("selective lithium recovery from brine")
+
+    q = sent["q"]
+    assert "ADJACENT and UNRELATED domains" in q
+    assert "TRANSFER" in q
+    assert "NOT provide a topical review" in q
+    assert "selective lithium recovery from brine" in q
+    assert sent["t"] == "CrossDomain"
+    # must NOT inherit the grounding template
+    assert "comprehensive review of experimental methods" not in q
+
+
+def test_single_type_unchanged(tool):
+    func, lit, *_ = tool
+    out = json.loads(func("obj", "hypothesis_context"))
+    assert out["status"] == "success"
+    assert out["searches_run"] == ["hypothesis_context"]
+    assert [k for k, _ in lit.calls] == ["hypothesis_context"]
+    assert lit.max_concurrent == 1
+    assert "caveat" not in out          # caveat is cross-domain-only
+
+
+def test_multi_type_runs_in_parallel_and_labels_sections(tool):
+    func, lit, *_ , tmp = tool
+    t0 = time.time()
+    out = json.loads(func("obj", "hypothesis_context,cross_domain"))
+    elapsed = time.time() - t0
+
+    assert out["status"] == "success"
+    assert set(out["searches_run"]) == {"hypothesis_context", "cross_domain"}
+    # concurrency: both in flight at once, wall clock ~ one call not two
+    assert lit.max_concurrent == 2
+    assert elapsed < lit.delay * 1.8
+
+    text = (tmp / "literature_search_hypothesis_context+cross_domain.md").read_text()
+    assert "ESTABLISHED IN THIS FIELD" in text
+    assert "TRANSFERABLE MECHANISMS FROM OTHER DOMAINS" in text
+    assert "NOT established results in this field" in text
+    assert text.index("ESTABLISHED IN THIS FIELD") < text.index("TRANSFERABLE")
+    assert "CONTENT::hypothesis_context" in text and "CONTENT::cross_domain" in text
+
+
+def test_cross_domain_carries_constraint_caveat(tool):
+    func, *_ = tool
+    out = json.loads(func("obj", "cross_domain"))
+    assert "caveat" in out
+    assert "constraint" in out["caveat"].lower()
+
+
+def test_partial_failure_keeps_the_successful_half(tool, tmp_path, monkeypatch):
+    from scilink.agents.planning_agents import orchestrator_tools as ot
+    monkeypatch.setattr(ot, "optimize_search_query", lambda objective, model: objective)
+    lit = StubLitAgent(fail=("cross_domain",))
+    orch = type("O", (), {})()
+    orch.lit_agent = lit
+    orch.planner = type("P", (), {"model": None})()
+    tools = ot.OrchestratorTools.__new__(ot.OrchestratorTools)
+    tools.orch, tools._output_dir = orch, (lambda: tmp_path)
+    cap = {}
+    tools._register_tool = lambda func, name, description, parameters, required=None: (
+        cap.update({name: func}))
+    ot.OrchestratorTools._register_all_tools(tools)
+
+    out = json.loads(cap["search_literature"]("obj", "hypothesis_context,cross_domain"))
+    assert out["status"] == "success"
+    assert out["searches_run"] == ["hypothesis_context"]
+    assert out["failed_searches"] == ["cross_domain"]
+
+
+def test_invalid_type_rejected(tool):
+    func, *_ = tool
+    out = json.loads(func("obj", "hypothesis_context,nonsense"))
+    assert out["status"] == "error"
+    assert "nonsense" in out["message"]
+
+
+def test_tool_description_states_when_to_use_and_when_not(tool):
+    _, _, desc, params, _ = tool
+    st = params["search_type"]["description"]
+    assert "cross_domain" in st
+    assert "IDEATION" in st
+    assert "AVOID" in st and "constraint" in st.lower()
+    assert "parallel" in desc.lower() or "CONCURRENTLY" in desc

--- a/tests/test_literature_cross_domain.py
+++ b/tests/test_literature_cross_domain.py
@@ -9,7 +9,8 @@ Contract pinned here (from the benchmarking that motivated the feature):
   Edison call is minutes of waiting, so serial pairs double the user's wait);
 - merged output is LABELLED per source, so candidates can tell established
   results (usable as constraints) from analogies (mechanism inspiration);
-- a cross-domain result carries the constraint-compliance caveat;
+- ANY literature result carries the constraint-coverage caveat (the loss was
+  measured for grounding-only retrieval too, so it is not cross-domain-specific);
 - single-type behaviour is unchanged.
 
 No network: the literature agent is a scripted stub.
@@ -115,7 +116,6 @@ def test_single_type_unchanged(tool):
     assert out["searches_run"] == ["hypothesis_context"]
     assert [k for k, _ in lit.calls] == ["hypothesis_context"]
     assert lit.max_concurrent == 1
-    assert "caveat" not in out          # caveat is cross-domain-only
 
 
 def test_multi_type_runs_in_parallel_and_labels_sections(tool):
@@ -138,11 +138,17 @@ def test_multi_type_runs_in_parallel_and_labels_sections(tool):
     assert "CONTENT::hypothesis_context" in text and "CONTENT::cross_domain" in text
 
 
-def test_cross_domain_carries_constraint_caveat(tool):
+@pytest.mark.parametrize("types", ["hypothesis_context", "cross_domain",
+                                   "hypothesis_context,cross_domain"])
+def test_constraint_coverage_caveat_is_literature_general(tool, types):
+    """The coverage loss was measured for grounding-only literature too, so
+    the caveat must not be cross-domain-specific — and it must point at the
+    remedy (map constraints to steps) rather than at withholding literature."""
     func, *_ = tool
-    out = json.loads(func("obj", "cross_domain"))
-    assert "caveat" in out
+    out = json.loads(func("obj", types))
     assert "constraint" in out["caveat"].lower()
+    assert "additional_context" in out["caveat"]
+    assert "avoid" not in out["caveat"].lower()
 
 
 def test_partial_failure_keeps_the_successful_half(tool, tmp_path, monkeypatch):
@@ -177,5 +183,8 @@ def test_tool_description_states_when_to_use_and_when_not(tool):
     st = params["search_type"]["description"]
     assert "cross_domain" in st
     assert "IDEATION" in st
-    assert "AVOID" in st and "constraint" in st.lower()
+    # cross_domain must NOT be singled out as constraint-hostile: the coverage
+    # loss was measured for grounding-only retrieval too, and the remedy is
+    # constraint->step mapping, not withholding a search type.
+    assert "AVOID" not in st
     assert "parallel" in desc.lower() or "CONCURRENTLY" in desc

--- a/tests/test_revision_recritique.py
+++ b/tests/test_revision_recritique.py
@@ -1,0 +1,164 @@
+"""Offline tests: caveat bookkeeping after non-human-path plan revisions.
+
+The advisory critic's findings must describe the CURRENT plan. The refinement
+LLM echoes the prior plan's ``critic_findings`` into revised JSON, so without
+a resolution-check re-critique, an orchestrator-driven revision (e.g.
+``adjust_plan_for_constraints`` fixing a caveat) carries the stale — now
+false — caveat into plan_history, reports, and run_task warnings. Observed
+live in meta session 2026-07-20 09:24 (ICP-MS TDS dilution caveat retained
+verbatim after the adjustment that resolved it).
+
+Contract pinned here:
+- both revision paths (results-driven ``refine_plan``, constraint-driven
+  ``adjust_plan_for_constraints``) pop echoed caveats and re-critique with
+  the before/request/after picture (prior_plan, prior_findings, request);
+- resolved caveats disappear from the plan AND the latest history snapshot;
+- fresh findings are recorded critical-first;
+- the re-critique is annotation-only: no extra refinement calls happen in
+  response to findings (advisory-only preserved).
+"""
+
+import builtins
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from scilink.agents.planning_agents.planning_agent import PlanningAgent
+from scilink.agents.planning_agents.base_agent import BaseAgent
+from scilink.agents.planning_agents import planning_agent as pa_mod
+
+
+TDS_FINDING = {"dimension": "physics", "severity": "minor",
+               "experiment": "Experiment 1",
+               "issue": "Supernatants require ~100-1000x dilution before "
+                        "ICP-MS — a step the plan never specifies."}
+
+
+def make_plan(name="Base Plan", findings=None):
+    plan = {
+        "proposed_experiments": [{
+            "hypothesis": "H", "experiment_name": name,
+            "experimental_steps": ["step"], "required_equipment": ["eq"],
+            "expected_outcome": "out", "justification": "j",
+            "source_documents": [],
+        }],
+        "iteration": 1, "stage": "Science Draft",
+    }
+    if findings is not None:
+        plan["critic_findings"] = list(findings)
+    return plan
+
+
+def make_agent(tmp_path):
+    a = PlanningAgent.__new__(PlanningAgent)
+    BaseAgent.__init__(a, str(tmp_path))
+    a.agent_type = "planning"
+    a.model = SimpleNamespace(generate_content=lambda *args, **kw: (_ for _ in ()).throw(
+        AssertionError("unexpected raw LLM call")))
+    a.generation_config = None
+    a.kb_docs = SimpleNamespace(index=None)
+    a.kb_code = SimpleNamespace(index=None)
+    a.lit_agent = None
+    a.state = {
+        "session_id": "t", "agent_type": "planning", "action_history": [],
+        "objective": "obj", "iteration_index": 1,
+        "current_plan": make_plan(findings=[TDS_FINDING]),
+        "plan_history": [make_plan(findings=[TDS_FINDING])],
+        "experimental_results": [], "human_feedback_history": [],
+        "status": "planned",
+    }
+    return a
+
+
+@pytest.fixture
+def spies(monkeypatch):
+    """Patch refine + critic with spies. The refiner ECHOES critic_findings
+    (the real failure mode); the critic's verdict is settable per-test."""
+    calls = {"refine": [], "critic": [], "critic_verdict": {"findings": []}}
+
+    def fake_refine(original_result, feedback, **kw):
+        calls["refine"].append(feedback)
+        new = json.loads(json.dumps(original_result))  # deep copy, echoes caveats
+        new["proposed_experiments"][0]["experiment_name"] = "Revised Plan"
+        return new
+
+    def fake_critic(objective, result, model, generation_config, **kw):
+        calls["critic"].append(kw)
+        return json.loads(json.dumps(calls["critic_verdict"]))
+
+    monkeypatch.setattr(pa_mod, "refine_plan_with_feedback", fake_refine)
+    monkeypatch.setattr(pa_mod, "critique_plan", fake_critic)
+    return calls
+
+
+def test_adjust_drops_resolved_caveat(tmp_path, spies):
+    agent = make_agent(tmp_path)
+    out = agent.adjust_plan_for_constraints(
+        "Add two-stage dilution to satisfy ICP-MS TDS tolerance.",
+        enable_human_feedback=False)
+
+    # stale echoed caveat removed from plan, current_plan, and latest snapshot
+    assert "critic_findings" not in out
+    assert "critic_findings" not in agent.state["current_plan"]
+    assert "critic_findings" not in agent.state["plan_history"][-1]
+    # the ORIGINAL pre-revision snapshot keeps its historical record
+    assert agent.state["plan_history"][0]["critic_findings"] == [TDS_FINDING]
+    # critic saw the full before/request/after picture
+    ck = spies["critic"][-1]
+    assert ck["prior_findings"] == [TDS_FINDING]
+    assert ck["prior_plan"]["proposed_experiments"][0]["experiment_name"] == "Base Plan"
+    assert "two-stage dilution" in ck["human_feedback"]
+    # advisory-only: exactly one refine (the adjustment), no reaction to critic
+    assert len(spies["refine"]) == 1
+
+
+def test_adjust_records_fresh_findings_sorted(tmp_path, spies):
+    spies["critic_verdict"] = {"findings": [
+        {"dimension": "consistency", "severity": "minor", "experiment": "E", "issue": "m"},
+        {"dimension": "physics", "severity": "critical", "experiment": "E", "issue": "c"},
+    ]}
+    agent = make_agent(tmp_path)
+    out = agent.adjust_plan_for_constraints("constraint", enable_human_feedback=False)
+    sev = [f["severity"] for f in out["critic_findings"]]
+    assert sev == ["critical", "minor"]
+    assert agent.state["plan_history"][-1]["critic_findings"] == out["critic_findings"]
+
+
+def test_refine_plan_drops_resolved_caveat(tmp_path, spies):
+    agent = make_agent(tmp_path)
+    out = agent.refine_plan("Yield improved to 85%; dilution scheme worked.",
+                            enable_human_feedback=False)
+    assert "critic_findings" not in out
+    assert "critic_findings" not in agent.state["plan_history"][-1]
+    ck = spies["critic"][-1]
+    assert ck["prior_findings"] == [TDS_FINDING]
+    assert "experimental results" in ck["human_feedback"]
+    assert len(spies["refine"]) == 1
+
+
+def test_adjust_human_branch_recritiques_final_plan(tmp_path, spies, monkeypatch):
+    agent = make_agent(tmp_path)
+    replies = iter(["tighten the pH grid", ""])
+    monkeypatch.setattr(builtins, "input", lambda *a: next(replies))
+    out = agent.adjust_plan_for_constraints("constraint", enable_human_feedback=True)
+    # two refines (adjustment + human), two re-critiques — every plan that
+    # became current_plan was re-checked
+    assert len(spies["refine"]) == 2
+    assert len(spies["critic"]) == 2
+    assert spies["critic"][-1]["human_feedback"] == "tighten the pH grid"
+    assert "critic_findings" not in out
+
+
+def test_critic_failure_fails_open(tmp_path, spies, monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("critic down")
+    monkeypatch.setattr(pa_mod, "critique_plan", boom)
+    agent = make_agent(tmp_path)
+    # helper is annotation-only; the real critique_plan fails open internally,
+    # but even a raising spy must not lose the revision
+    try:
+        out = agent.adjust_plan_for_constraints("c", enable_human_feedback=False)
+    except RuntimeError:
+        pytest.fail("re-critique crash blocked the revision")
+    assert out["proposed_experiments"][0]["experiment_name"] == "Revised Plan"


### PR DESCRIPTION
Closes #377.

## What this does

When you start a new planning campaign, SciLink no longer commits to the first experimental strategy it thinks of. It now drafts **several genuinely different candidate plans** — each testing a different mechanistic approach to your goal — has an **LLM judge compare them** against the same evidence (your papers, data, images, and lab constraints), and picks the best one. In co-pilot/autopilot you review a compact card for each candidate (hypothesis, expected outcome, justification, judge scores) and can **override the judge with one click/keystroke**; each candidate also gets its own full HTML report saved alongside the plan, so rejected strategies remain readable later.

This happens **by default for a campaign's first plan** (best-of-3) — because even a precisely specified goal usually admits several routes (e.g. precipitation vs. sorption vs. extraction), and the first plan is exactly when no strategy has been committed yet. Follow-up refinements stay single-plan. Asking for "a single plan" or a specific number of candidates always wins.

Honesty is preserved throughout: candidates must be grounded in your evidence, and generation **stops early when the evidence cannot support another distinct approach** — N is a cap, not a quota. A run whose knowledge base lacks method knowledge will say so and produce fewer candidates rather than invent chemistry.

## Two modes: lab and ideation

Planning serves two genuinely different jobs, and one selection policy cannot serve both. A `selection_profile` parameter (default `lab`) switches between them per call:

- **`lab`** — the campaign is headed for actual execution. Candidates must be grounded in the provided evidence, and the judge weights feasibility and actionability most heavily: a plan that cannot run on the available equipment cannot generate information. This is the default and preserves the original behavior.
- **`ideation`** — research ideation. The judge weights information gain and mechanistic novelty first (feasibility becomes a tiebreaker, not a veto), and — the load-bearing half — candidate *authors* receive grounding latitude: where the provided context lacks the decisive mechanism, they may propose one from general scientific knowledge, explicitly marked `(speculative)` in the justification, with fabricated numerics still forbidden. Without this, the evidence-grounding discipline (correct for lab work) structurally suppresses exactly the inspired-leap hypotheses that ideation exists to produce.

Same candidates surface either way, same scoring criteria, same human override — only the authoring latitude and the pick's weighting change. Ideation requires `n_candidates >= 2` — with a single plan there is nothing to select, and the profile is documented as a no-op at N=1. The meta agent switches to ideation when the user is brainstorming rather than planning an executable run.

## Cross-pollination: literature from *other* fields

Scientific literature search previously did one thing: retrieve the problem's
own subfield — established methods, parameter ranges, known pitfalls. That is
what a runnable plan needs, but it also anchors every candidate to what the
field already does.

`search_literature` now offers a second retrieval mode, `cross_domain`, which
asks for **mechanisms from adjacent and unrelated fields that could transfer**
to your problem, and explicitly refuses to produce a topical review. Asked
about flexible heat-harvesting devices, for instance, it returns things like
counter-current heat exchange in fish vasculature and island–bridge
architectures from stretchable electronics — analogies whose *mechanism* might
carry over, which is where genuinely new ideas usually come from.

**Several search types can now be requested at once and run in parallel**
(`search_type="hypothesis_context,cross_domain"`), merging into one document
with labelled sections — "ESTABLISHED IN THIS FIELD" versus "TRANSFERABLE
MECHANISMS FROM OTHER DOMAINS (analogies, NOT established results)". The
labelling matters: it lets candidates use field literature as constraints and
cross-domain material as mechanism inspiration, instead of treating everything
as equally established. Because the searches run concurrently, the pair costs
roughly the wait of a single search.

**It is deliberately scoped rather than on by default**, and paired with a
fix for something literature does to constrained plans. Reading literature —
any literature, not just cross-domain — makes a plan more likely to *omit* a
stated requirement: it stays on-topic and scientifically stronger, but
quietly drops the less glamorous constraints, like a durability check or a
secondary characterisation. The plans do not violate constraints; they just
fail to mention them.

Withholding literature would fix that by giving up its benefit, so instead,
whenever your constraints and literature are both in play, the planner is
required to tie every constraint to a named step that says which requirement
it satisfies. In testing this recovered nearly all of the lost coverage with
no measurable cost to plan quality. So cross-domain retrieval is scoped to
ideation because that is what it is *for* — not because it is unsafe under
constraints.

Two adjacent fixes that surfaced during live testing are included:
- **Plan caveats now always describe the current plan.** Previously, when the orchestrator fixed an issue the critic had raised (e.g. adding the ICP-MS dilution step the critic asked for), the report still showed the old caveat. Revisions are now re-checked so resolved caveats disappear, unresolved ones stay, and new ones are flagged. The critic remains strictly advisory — it annotates, never acts.
- **UI first-render fix**: the mission-control landing page now shows the embedding model/API-key fields and the correct autonomy options immediately, instead of only after the first interaction.

## How to use it

- **Default**: start a campaign (UI, CLI, or via the meta agent) — the first plan generates as best-of-3 automatically. Review the cards, accept the judge's pick (Enter / green button) or pick another candidate (number / radio), then the familiar plan review follows.
- **Control the width**: say "generate 4 candidate plans" or "just one plan"; the meta forwards this.
- **After selection**: everything downstream (implementation code, scalarizer, BO) is unchanged; the runner-up candidates stay available under `plan_candidates/` and are offered if you later discard the plan.

---

<details>
<summary><b>Technical details</b></summary>

### Generation (`planning_rag.py:generate_plan_candidates`)
Sequential, diversity-conditioned: candidate 1 runs the normal science RAG; candidates k>1 see prior hypothesis sentences plus `HYPOTHESIS_DISTINCTNESS_CONDITIONING` and may decline via the existing error-JSON discipline (early stop). Every author — candidate 1 included — receives `HYPOTHESIS_BESTOFN_AUTHOR_NOTE` ("you are writing ONE of N; alternatives are separate candidates"): without it, an objective phrased "explore several alternatives" (user phrasing travels verbatim through the meta) made the unconditioned first author pack all strategies into one plan, which then won at the judge on scope-matching (observed live twice). The instruction tier (strict vs fallback) is detected at candidate 1 via an opt-in `mode_key` stamp on the shared `run_rag` (`rag_engine.py`; existing callers byte-identical) and pinned for the whole run — no mixed-tier candidate sets. All candidates share one retrieval (deterministic), making them comparable for the judge.

### Judge (`planning_rag.py:judge_plan_candidates`)
Comparative selector, not an editor: scores groundedness / testability / actionability / feasibility / information-gain against the same evidence the authors saw — including `additional_context`, where lab constraints (e.g. "Opentrons Flex 2, 96-well plates") travel; feasibility is scored against them. Must state plainly when its pick lacks the top score on some criterion. Fails open to candidate 1. Emits no caveats — the advisory critic remains the single caveat channel.

### Selection UX
`display_plan_candidates` prints ONE stdout block of extractive cards (verbatim plan fields + judge scores — no summarization LLM call, no drift) serving both surfaces: CLI reads it directly; the UI's `_parse_plan_candidate_review` (sibling of the analysis best-of-N parser, gated on its own `accept plan candidate` / `PLAN CANDIDATES` markers to prevent cross-hijack) renders a radio with the judge's pick preselected. Two prompts: stage-1 selection (Enter/index), then the existing stage-2 plan approval on the winner — refining a runner-up = override, then normal feedback. Composes with meta AUTOPILOT delegations through the existing `input()` bridge. Per-candidate HTML reports persist under `plan_candidates/` (`html_generator.py:generate_single_plan`) for runner-up fallback, audit, and checkpoint restore.

### Critic interaction (advisory-only preserved)
The critic runs lazily on whichever candidate is selected (and again on an override) — every plan that becomes `current_plan` is conformance-checked and critiqued; nothing else is (O(1), 2 on override). Critical findings never auto-switch the selection; caveats are displayed at the selection prompt for the human to weigh. Sequential candidates see prior hypotheses only — criticism never enters the generation loop.

**Revision bookkeeping fix** (`planning_agent.py:_recritique_revision`): the refinement LLM echoes prior `critic_findings` into revised JSON; `refine_plan` and `adjust_plan_for_constraints` (and their human-feedback branches) now pop the echo and re-critique in resolution-check mode (drop resolved / keep unresolved / flag new), exactly like `generate_plan`'s human path. Annotation-only; pre-revision history snapshots keep their original findings. Live-validated: a planted TDS-dilution caveat was dropped after the adjustment that resolved it.

### Default policy (`orchestrator_tools.py:resolve_n_candidates`)
Omitted `n_candidates` → best-of-3 for a campaign's FIRST plan, 1 afterwards; explicit values (incl. 1) win, clamped 1–4. Rationale: objective *specificity* is the wrong trigger (upstream routing always narrows objectives before delegating, and specific goals still admit multiple strategies); the meaningful single-plan case is a *committed* strategy. The programmatic `PlanningAgent.generate_plan` API keeps its explicit default of 1 — policy lives at the LLM-tool boundary only. The meta's `delegate_to_planning` description advertises the capability; both descriptions instruct keeping the scientific objective singular (the parameter provides the multiplicity).

### Selection profiles (`selection_profile`, default `lab`)
`BESTOFN_SELECTION_PROFILE_LAB` / `_IDEATION` append the pick-weighting to the judge prompt; `IDEATION_AUTHOR_OVERRIDE` rides the generation instructions adjacent to the safety rule it supersedes, granting authoring latitude in ideation only (lab authors byte-identically). Profile recorded in `state["plan_candidates"]`; exposed on `generate_initial_plan` (enum) with the meta instructed when to switch.

### Cross-domain retrieval and parallel search
`LiteratureSearchAgent.search_for_cross_domain` asks for transferable
mechanisms from adjacent/unrelated domains and forbids a topical subfield
review. It bypasses `search_for_hypothesis_context`'s wrapper rather than
reusing it — that template ("a comprehensive review of experimental
methods… common pitfalls") reframes the task and neutralises cross-domain
intent, observed live before the fix.

`search_literature` accepts comma-separated types, runs them in a
`ThreadPoolExecutor`, and merges into one labelled document; partial failure
keeps the successful half and reports the rest in `failed_searches`; any
successful search carries the constraint-coverage caveat in its payload.
Single-type behaviour is byte-identical. The orchestrator's
`LITERATURE SEARCH WORKFLOW` block gained the pairing rule (cross-domain +
ideation profile), since the tool-parameter description alone was
discoverable only to a model reading parameter docs.

**Constraint coverage** (`instruct.CONSTRAINT_COVERAGE_NOTE`, spliced in
`planning_rag.perform_science_rag`): when `additional_context` and
`external_context` are both present, the author is required to map every
hard constraint to a named step. Injected at the point where the single-plan
and best-of-N paths converge, so every candidate carries it, and scoped to
that condition — a constraints-only run already complies, so the note stays
out of the prompt otherwise. The earlier cross-domain-specific caveat was
misattributed: grounding-only retrieval costs the same coverage, so the
caveat is now literature-general and names the remedy (map constraints to
steps) instead of advising against a search type.

Measured while validating: 4/4 concurrent Edison searches succeed with a
2.6x speedup over serial, and 7+ were observed in flight account-wide, so the
2-way pairing sits well inside capacity and no executor cap was added. Note
the concurrency pool is account-wide — a future fan-out with per-branch
literature search would want a shared semaphore.

### Validation
- **Offline**: 18 tests in `tests/test_best_of_n_planning.py` (sequential conditioning, shared evidence, decline early-stop, fallback pinning, judge fail-open, override + lazy-critique invariant, constraints-to-judge, author note, default policy, CLI→UI parser round-trips, constraint-coverage injection scoping) + 5 in `tests/test_revision_recritique.py`; existing planning suites unchanged.
- **Live orchestrator validation of the scoping** (autonomous session, two turns, verified from recorded tool arguments rather than reply text): an ideation ask produced `search_type='hypothesis_context,cross_domain'` + `selection_profile='ideation'` with both labelled sections present in the merged file; a constraint-bound ask (Opentrons Flex 2, 96-well, UV-Vis) produced field-only retrieval, with the constraints travelling as `additional_context`.
- **Live (Bedrock Opus 4.8 + Gemini embeddings)**: produced-water KB runs (fallback tier, 3 distinct mechanisms, judge tradeoff stated); Opentrons-constrained runs (diversity relocates from mechanism family to strategy lever; judge cites deck-feasibility); FutureHouse literature run (**tier flips to strict** with lit context vs fallback KB-only on the identical KB — the evidence-bundle decline design working; real `source_documents`); two full Playwright-driven Streamlit sessions (override path and accept path, goal form → cards+radio → approval → final summary narrating the override); meta-delegation runs (pass-through, strategy-committed collapse via an articulate decline, default firing unprompted); cross-domain check on solid polymer electrolytes (3 canonical distinct routes — no overfit to the produced-water example).

### Known limits
- Candidate evidence for the post-selection re-critique is the revision context (prior plan + findings + request); the original retrieval context is not persisted across calls.
- In strict tier with a KB that grounds the feed but not alternative methods, later candidates may decline and the set legitimately collapses (honest-decline discipline). A labeled general-knowledge "wildcard" candidate alongside grounded ones is a deferred opt-in (see design note).
- Deferred: per-candidate critique before judging, adaptive N on thin judge margins, best-of-N at the refinement stage, cross-candidate synthesis.

</details>

