### PR TITLE
Fix signed spectral background masking

### DIFF
--- a/scilink/skills/hyperspectral/eels/spectral_unmixer.py
+++ b/scilink/skills/hyperspectral/eels/spectral_unmixer.py
@@ -47,9 +47,9 @@ class SpectralUnmixer:
         spectra_matrix = hspy_data.reshape((h * w, e))
         
         # 2. FILTER (Internal Masking)
-        # Identify pixels that have actual data (sum > small epsilon)
-        pixel_sums = np.sum(spectra_matrix, axis=1)
-        valid_pixel_mask = pixel_sums > 1e-6 
+        # Identify pixels that have actual data without assuming a sign or scale.
+        pixel_magnitudes = np.sum(np.abs(spectra_matrix), axis=1)
+        valid_pixel_mask = pixel_magnitudes > 0
         
         # Create a subset containing ONLY valid pixels
         spectra_to_fit = spectra_matrix[valid_pixel_mask]
@@ -64,7 +64,7 @@ class SpectralUnmixer:
         l1_norms_subset = None
         if self.normalize:
             # Calculate norms only for the valid subset
-            l1_norms_subset = np.sum(spectra_to_fit, axis=1, keepdims=True)
+            l1_norms_subset = np.sum(np.abs(spectra_to_fit), axis=1, keepdims=True)
             l1_norms_subset[l1_norms_subset == 0] = 1 
             spectra_to_fit = spectra_to_fit / l1_norms_subset
 

--- a/tests/test_spectral_unmixer.py
+++ b/tests/test_spectral_unmixer.py
@@ -1,0 +1,36 @@
+"""Focused tests for hyperspectral background masking and normalization."""
+
+import importlib.util
+
+import numpy as np
+
+
+# Avoid importing the package root, which eagerly imports optional heavy dependencies.
+_spec = importlib.util.spec_from_file_location(
+    "_spectral_unmixer_under_test",
+    "scilink/skills/hyperspectral/eels/spectral_unmixer.py",
+)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+SpectralUnmixer = _module.SpectralUnmixer
+
+
+class _RecordingModel:
+    def fit_transform(self, values):
+        self.values = values.copy()
+        self.components_ = np.ones((1, values.shape[1]))
+        return np.ones((values.shape[0], 1))
+
+
+def test_signed_small_magnitude_spectra_are_not_treated_as_background():
+    spectrum = np.array([1e-12, -1e-12, 2e-12])
+    cube = np.array([[spectrum, np.zeros(3)]])
+    model = _RecordingModel()
+    unmixer = SpectralUnmixer(method="pca", n_components=1, normalize=True)
+    unmixer.model = model
+
+    _, abundance_maps = unmixer.fit(cube)
+
+    assert np.allclose(model.values, [spectrum / np.abs(spectrum).sum()])
+    assert abundance_maps[0, 0, 0] == np.abs(spectrum).sum()
+    assert abundance_maps[0, 1, 0] == 0


### PR DESCRIPTION
Closes #381

Signed or small-magnitude spectra were discarded because background detection used a positive absolute threshold. Use sign- and scale-independent absolute magnitude for both masking and normalization, while retaining all-zero pixels as background; the focused regression covers signed input, L1 normalization, and zero-background restoration.
