### PR TITLE
File prep: deterministic metadata-only split + unblinded pickled-.npy probe

### DIFF
--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -102,8 +102,22 @@ def _probe_file(path: Path) -> Dict[str, Any]:
     try:
         if ext == ".npy":
             import numpy as np
-            arr = np.load(path, mmap_mode="r", allow_pickle=False)
-            info.update(kind="array", shape=list(arr.shape), dtype=str(arr.dtype))
+            try:
+                arr = np.load(path, mmap_mode="r", allow_pickle=False)
+                info.update(kind="array", shape=list(arr.shape),
+                            dtype=str(arr.dtype))
+            except ValueError:
+                # Pickled object array — e.g. an instrument header dict saved
+                # via np.save. It's a trusted local upload (same trust as every
+                # other format this probe parses), so unpickle to describe its
+                # structure instead of reporting "unreadable" — that blindness
+                # is what starved the prepare_inputs codegen of evidence
+                # (issue #380). Size-capped: object arrays can't be mmap'd, so
+                # a huge pickle would be loaded whole.
+                if path.stat().st_size > 50 * 1024 * 1024:
+                    raise
+                from ...utils.file_prep import probe_pickled_npy
+                info.update(probe_pickled_npy(path))
         elif ext == ".npz":
             import numpy as np
             with np.load(path, allow_pickle=False) as z:
@@ -1056,7 +1070,12 @@ class MetaOrchestratorTools:
                 "falls back to its own split. Use after inspect_uploads when a probe "
                 "shows data and metadata mixed in one file (HDF5/NeXus with attributes, "
                 ".npz/.mat with data+meta keys, a CSV/text with a header/comment "
-                "metadata block, a TIFF with tags/ImageDescription). This is the META "
+                "metadata block, a TIFF with tags/ImageDescription). Also use it on a "
+                "METADATA-ONLY file — e.g. a pickled .npy header/object-array the probe "
+                "reports as kind 'object_array' — where it deterministically serializes "
+                "the container to a metadata JSON and returns data_path=null with "
+                "metadata_only=true; pair that metadata with its sibling data file in "
+                "the delegation. This is the META "
                 "AGENT'S ONLY code-generation tool and it is STRICTLY LIMITED to "
                 "lossless file repackaging: the generated code may only separate "
                 "existing data from metadata and is round-trip verified (the "

--- a/scilink/utils/file_prep.py
+++ b/scilink/utils/file_prep.py
@@ -480,13 +480,16 @@ def _find_data_members(obj, _path: str = "") -> list:
             p = f"{_path}.{k}" if _path else str(k)
             if _is_data_member(v):
                 hits.append(p)
-            elif isinstance(v, dict):
+            elif isinstance(v, (dict, list, tuple)):
+                # Recurse into lists too: a list judged non-data as a WHOLE
+                # (small, or ragged → object dtype) can still hold ndarray
+                # elements, which the any-size rule must catch.
                 hits.extend(_find_data_members(v, p))
             elif isinstance(v, np.ndarray) and v.dtype == object:
                 hits.extend(_find_data_members(list(v.ravel()), p))
     elif isinstance(obj, (list, tuple)):
-        # Only reached when the container ITSELF is a list (or nested); a
-        # list already judged by _is_data_member is not re-walked.
+        # Also reached for a list member judged non-data as a whole; its
+        # elements get their own per-type judgment below.
         for i, v in enumerate(obj):
             p = f"{_path}[{i}]"
             if _is_data_member(v):

--- a/scilink/utils/file_prep.py
+++ b/scilink/utils/file_prep.py
@@ -70,6 +70,10 @@ decide):
   or `key = value` pairs, a units row) ABOVE the numeric data rows.
 - A MATLAB `.mat` (or `.npz`/HDF5) where some keys are arrays (data) and others
   are scalars/strings (metadata).
+- A pickled `.npy` object array wrapping a dict — some keys numeric arrays
+  (data), others scalars/strings (metadata). Load it with
+  `numpy.load(_PREP["input"], allow_pickle=True)` and unwrap the 0-d array
+  with `.item()`.
 - An HDF5/NeXus dataset carrying metadata in attributes alongside the array.
 - A `.tif`/`.tiff` carrying acquisition metadata in TIFF tags / ImageDescription
   (ImageJ `key=value` block or OME-XML) alongside the pixel array.
@@ -319,8 +323,16 @@ def _roundtrip_ok(original: Path, recon: Path) -> bool:
     ext = original.suffix.lower()
     try:
         if ext == ".npy":
-            return _members_equal(np.load(original, allow_pickle=True),
-                                  np.load(recon, allow_pickle=True))
+            a = np.load(original, allow_pickle=True)
+            b = np.load(recon, allow_pickle=True)
+            if (getattr(a, "dtype", None) == object
+                    or getattr(b, "dtype", None) == object):
+                # Pickled container: element-wise ndarray comparison would
+                # raise on dict members. Compare the unwrapped Python objects
+                # structurally instead.
+                return _pyobj_equal(_unwrap_object_array(a),
+                                    _unwrap_object_array(b))
+            return _members_equal(a, b)
         if ext == ".npz":
             a, b = np.load(original, allow_pickle=True), np.load(recon, allow_pickle=True)
             return set(a.files) == set(b.files) and all(
@@ -407,13 +419,214 @@ def _file_paths(input_path: Path, output_dir: Path) -> dict:
     """
     stem = re.sub(r"[^0-9A-Za-z_-]", "_", input_path.stem) or "input"
     key = hashlib.sha1(str(input_path.resolve()).encode()).hexdigest()[:8]
-    file_out = Path(output_dir) / f"{stem}_{key}"
+    file_out = (Path(output_dir) / f"{stem}_{key}").resolve()
     file_out.mkdir(parents=True, exist_ok=True)
     return {
-        "input": str(input_path),
+        # Resolved: the generated script executes with cwd=out_dir, where a
+        # relative input path would not resolve.
+        "input": str(input_path.resolve()),
         "out_dir": str(file_out),
         "metadata_out": str(file_out / f"{stem}_metadata.json"),
         "recon_out": str(file_out / f"{stem}_reconstructed{input_path.suffix}"),
+    }
+
+
+# =============================================================================
+# Deterministic metadata-only split for pickled .npy containers (issue #380)
+#
+# Instrument headers routinely arrive as a dict saved via np.save — a 0-d
+# object array that allow_pickle=False cannot read, so it probes as
+# "unreadable" and the codegen split can never satisfy _verify (there is no
+# numerical data leg to write). When a DETERMINISTIC member scan proves the
+# container holds no data member, the split degenerates to "serialize the
+# container to the metadata JSON" — our own vetted code, no LLM, no
+# round-trip needed.
+#
+# Safety: the scan is code-computed (the model cannot hallucinate "no data
+# here"), and it is biased toward extraction — ANY numeric ndarray member,
+# regardless of size, disqualifies the metadata-only path and routes the file
+# through the normal codegen split. Burying real data in a metadata sidecar
+# is the expensive error; over-extracting a small axis vector is harmless.
+# =============================================================================
+
+# A plain Python list/tuple must carry at least this many numeric elements to
+# count as a DATA member. Small parameter tuples ([168, 168] grid dims, an
+# (x, y) position) are metadata; a stored spectrum/axis is data.
+_LIST_DATA_MIN_ELEMS = 32
+
+
+def _is_data_member(v) -> bool:
+    """True if a container member looks like numerical DATA rather than a
+    scalar/string/small-tuple metadata value. Extraction-biased: any numeric
+    ndarray qualifies regardless of size."""
+    if isinstance(v, np.ndarray):
+        return (v.dtype != object and np.issubdtype(v.dtype, np.number)
+                and v.ndim >= 1 and v.size > 0)
+    if isinstance(v, (list, tuple)) and v:
+        try:
+            arr = np.asarray(v)
+        except Exception:  # noqa: BLE001 - ragged/mixed → not a numeric block
+            return False
+        return (arr.dtype != object and np.issubdtype(arr.dtype, np.number)
+                and arr.size >= _LIST_DATA_MIN_ELEMS)
+    return False
+
+
+def _find_data_members(obj, _path: str = "") -> list:
+    """Recursively collect dotted paths of members that qualify as DATA."""
+    hits = []
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            p = f"{_path}.{k}" if _path else str(k)
+            if _is_data_member(v):
+                hits.append(p)
+            elif isinstance(v, dict):
+                hits.extend(_find_data_members(v, p))
+            elif isinstance(v, np.ndarray) and v.dtype == object:
+                hits.extend(_find_data_members(list(v.ravel()), p))
+    elif isinstance(obj, (list, tuple)):
+        # Only reached when the container ITSELF is a list (or nested); a
+        # list already judged by _is_data_member is not re-walked.
+        for i, v in enumerate(obj):
+            p = f"{_path}[{i}]"
+            if _is_data_member(v):
+                hits.append(p)
+            elif isinstance(v, (dict, list, tuple)):
+                hits.extend(_find_data_members(v, p))
+            elif isinstance(v, np.ndarray) and v.dtype == object:
+                hits.extend(_find_data_members(list(v.ravel()), p))
+    elif _is_data_member(obj):
+        hits.append(_path or "<root>")
+    return hits
+
+
+def _unwrap_object_array(obj):
+    """Undo the object-array wrapper np.save puts around a Python object."""
+    if isinstance(obj, np.ndarray) and obj.dtype == object:
+        if obj.ndim == 0:
+            return obj.item()
+        if obj.size == 1:
+            return obj.ravel()[0]
+        return list(obj.ravel())
+    return obj
+
+
+def _load_pickled_container(path: Path):
+    """np.load(allow_pickle=True) with the conventional 0-d/1-element unwrap."""
+    return _unwrap_object_array(np.load(path, allow_pickle=True))
+
+
+def _pyobj_equal(a, b) -> bool:
+    """Structural equality for unpickled containers (dicts holding ndarrays
+    raise inside a naive ``==``); numeric leaves compare within tolerance."""
+    if isinstance(a, dict) and isinstance(b, dict):
+        return set(a) == set(b) and all(_pyobj_equal(a[k], b[k]) for k in a)
+    if isinstance(a, (list, tuple)) and isinstance(b, (list, tuple)):
+        return len(a) == len(b) and all(_pyobj_equal(x, y) for x, y in zip(a, b))
+    if isinstance(a, np.ndarray) or isinstance(b, np.ndarray):
+        try:
+            return _members_equal(a, b)
+        except Exception:  # noqa: BLE001 - mixed/object dtypes
+            return False
+    if isinstance(a, float) and isinstance(b, float):
+        return bool(np.isclose(a, b, equal_nan=True))
+    return a == b
+
+
+def _jsonify_metadata(v):
+    """Total (never-raising) JSON coercion for header-dict values."""
+    if isinstance(v, dict):
+        return {str(k): _jsonify_metadata(x) for k, x in v.items()}
+    if isinstance(v, (list, tuple)):
+        return [_jsonify_metadata(x) for x in v]
+    if isinstance(v, np.ndarray):
+        return _jsonify_metadata(v.tolist())
+    if isinstance(v, np.generic):
+        return v.item()
+    if isinstance(v, bytes):
+        return v.decode("utf-8", errors="replace")
+    if v is None or isinstance(v, (str, int, float, bool)):
+        return v
+    return str(v)
+
+
+def probe_pickled_npy(path, max_keys: int = 40) -> dict:
+    """Structural probe of a pickled object-array .npy (trusted local upload).
+
+    Unpickles the container — the same trust level as every other format the
+    upload probe parses — and reports its shape: container type, top-level
+    keys, and which members the deterministic scan classifies as DATA. Used
+    by the meta's ``_probe_file`` so codegen sees structure instead of
+    "unreadable", and by callers deciding whether the metadata-only split
+    applies. Raises on unpicklable input (caller handles).
+    """
+    container = _load_pickled_container(Path(path))
+    info = {"kind": "object_array", "container": type(container).__name__}
+    if isinstance(container, dict):
+        info["top_level_keys"] = [str(k) for k in list(container)[:max_keys]]
+    data_members = _find_data_members(container)
+    info["data_members"] = data_members[:max_keys]
+    info["metadata_only"] = not data_members
+    return info
+
+
+def split_pickled_metadata_only(input_path, paths: dict, logger=None):
+    """Deterministic, no-LLM split for a METADATA-ONLY pickled .npy container.
+
+    Eligibility (all code-computed): the file is a .npy that allow_pickle=False
+    rejects, it unpickles to a container, and :func:`_find_data_members` finds
+    NOTHING array-shaped in it. Then the container is serialized losslessly to
+    ``paths["metadata_out"]`` and a success result with ``data_path=None`` is
+    returned — the honest outcome the codegen contract cannot express (its
+    verifier requires a numerical data leg).
+
+    Returns the result dict, or ``None`` when the file is not eligible — the
+    caller then proceeds with the normal codegen split (which, per the
+    extraction bias, is ALWAYS the route for a container holding any array).
+    """
+    input_path = Path(input_path)
+    if input_path.suffix.lower() != ".npy":
+        return None
+    try:
+        np.load(input_path, mmap_mode="r", allow_pickle=False)
+        return None  # plain numeric array — a normal combined-split candidate
+    except ValueError:
+        pass  # object dtype → pickled container, continue
+    except Exception:
+        return None  # unreadable for other reasons → let the normal path report
+    try:
+        container = _load_pickled_container(input_path)
+    except Exception as e:  # noqa: BLE001
+        if logger:
+            logger.warning(f"📦 Pickled .npy could not be unpickled: {e}")
+        return None
+    data_members = _find_data_members(container)
+    if data_members:
+        if logger:
+            logger.info(
+                f"📦 Pickled container holds data member(s) "
+                f"{data_members[:5]} — routing through the codegen split."
+            )
+        return None
+    meta = _jsonify_metadata(container)
+    if not isinstance(meta, dict):
+        meta = {"value": meta}
+    if not meta:
+        return None  # empty container — nothing to emit, report via normal path
+    meta_out = Path(paths["metadata_out"])
+    meta_out.write_text(json.dumps(meta, indent=2, default=str))
+    json.loads(meta_out.read_text())  # self-check: valid JSON round-trip
+    if logger:
+        logger.info(f"✅ Metadata-only split (deterministic): {meta_out}")
+    return {
+        "status": "success",
+        "data_path": None,
+        "metadata_path": str(meta_out),
+        "attempts": 0,
+        "metadata_only": True,
+        "note": ("Metadata-only pickled container: no numerical data member "
+                 "found, so there is no data leg — the whole container was "
+                 "serialized to the metadata JSON."),
     }
 
 
@@ -482,8 +695,9 @@ def _generate_split_script(prompt: str, model) -> tuple:
     if guard:
         return None, guard
     if "_PREP" not in script:
-        return None, ("script must read paths from the _PREP dict, not hardcode "
-                      "them — reference _PREP['input'/'out_dir'/'metadata_out'/'recon_out']")
+        return None, ("the split script must reference the runtime `_PREP` dict "
+                      "for every path — _PREP['input'/'out_dir'/'metadata_out'/"
+                      "'recon_out'] — with no literal path strings")
     return script, ""
 
 
@@ -562,6 +776,9 @@ def prepare_inputs(input_path, model, executor, output_dir, probe=None,
     """
     input_path = Path(input_path)
     paths = _file_paths(input_path, Path(output_dir))
+    det = split_pickled_metadata_only(input_path, paths, logger)
+    if det is not None:
+        return det
     base_prompt = _build_prompt(probe, input_path)
     result, _ = _prepare_one(input_path, paths, base_prompt, model, executor,
                              logger, max_retries)
@@ -614,15 +831,24 @@ def prepare_inputs_batch(input_paths, model, executor, output_dir, probes=None,
         probes = [None] * len(input_paths)
     output_dir = Path(output_dir)
 
+    results = [None] * len(input_paths)
+    n_codegens = n_reused = n_fallback = 0
+
+    # Metadata-only pickled containers are handled deterministically (no LLM,
+    # no clustering); everything else proceeds through the codegen machinery.
+    for i, p in enumerate(input_paths):
+        det = split_pickled_metadata_only(p, _file_paths(p, output_dir), logger)
+        if det is not None:
+            results[i] = {"file": str(p), "reused": False, **det}
+
     clusters: dict = {}
     for i, pr in enumerate(probes):
+        if results[i] is not None:
+            continue
         sig = _signature(pr)
         if sig is None:                       # no structural confidence → solo
             sig = ("__solo__", i)
         clusters.setdefault(sig, []).append(i)
-
-    results = [None] * len(input_paths)
-    n_codegens = n_reused = n_fallback = 0
 
     for idxs in clusters.values():
         first = idxs[0]
@@ -691,7 +917,8 @@ def stage_pairs_flat(results: list, flat_dir) -> dict:
     for r in results or []:
         if r.get("status") != "success":
             continue
-        dp, mp = Path(r.get("data_path", "")), Path(r.get("metadata_path", ""))
+        # data_path is None for a metadata-only split — no data leg to stage.
+        dp, mp = Path(r.get("data_path") or ""), Path(r.get("metadata_path") or "")
         if not (dp.is_file() and mp.is_file()):
             continue
         base = re.sub(r"[^0-9A-Za-z_-]", "_", Path(r.get("file") or dp).stem) or "input"

--- a/tests/test_file_prep_metadata_only.py
+++ b/tests/test_file_prep_metadata_only.py
@@ -1,0 +1,203 @@
+"""Deterministic metadata-only split for pickled .npy containers (issue #380).
+
+Covers the three layers of the fix:
+  1. the member-scan gate (extraction-biased: any ndarray → NOT metadata-only);
+  2. the no-LLM metadata-only split (real header-shaped dict → metadata JSON,
+     no data leg, model/executor never touched);
+  3. the unblinded meta probe (pickled .npy → structural description instead
+     of "unreadable").
+"""
+
+import io
+import contextlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from scilink.utils.file_prep import (
+    _is_data_member,
+    _find_data_members,
+    _pyobj_equal,
+    prepare_inputs,
+    prepare_inputs_batch,
+    probe_pickled_npy,
+    split_pickled_metadata_only,
+    stage_pairs_flat,
+    _file_paths,
+)
+
+
+# Mirrors the real-world instrument-header shape that motivated the fix:
+# scalars, strings, and SMALL numeric lists only — no data member anywhere.
+HEADER = {
+    "dim_px": [168, 168],
+    "pos_xy": [-8.826198e-09, 1.862286e-07],
+    "size_xy": [1.5e-08, 1.5e-08],
+    "angle": -70.0,
+    "sweep_signal": "Bias (V)",
+    "fixed_parameters": ["Sweep Start", "Sweep End"],
+    "num_sweep_signal": 151,
+    "channels": ["Current (A)", "LIX 1 omega (A)", "LIY 1 omega (A)"],
+    "measure_delay": 0.01,
+    "comment": "1V 200pA, 1 to -1, 977hz 20mV",
+}
+
+
+def _save_pickled(tmp_path: Path, obj, name="header.npy") -> Path:
+    p = tmp_path / name
+    np.save(p, np.array(obj, dtype=object) if isinstance(obj, dict) else obj,
+            allow_pickle=True)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# 1. Member-scan gate
+# ---------------------------------------------------------------------------
+
+def test_gate_any_ndarray_is_data_regardless_of_size():
+    # Extraction bias: even a 2-element ndarray disqualifies metadata-only.
+    assert _is_data_member(np.array([1.5, 2.5]))
+    assert _is_data_member(np.zeros((168, 168, 151)))
+
+
+def test_gate_small_numeric_lists_are_metadata():
+    assert not _is_data_member([168, 168])
+    assert not _is_data_member((-8.8e-09, 1.9e-07))
+
+
+def test_gate_large_numeric_list_is_data():
+    assert _is_data_member(list(np.linspace(-1, 1, 151)))
+    # ... including a nested numeric block whose OUTER length is small
+    assert _is_data_member([[float(i) for i in range(100)] for _ in range(2)])
+
+
+def test_gate_non_numeric_members_are_metadata():
+    assert not _is_data_member("Bias (V)")
+    assert not _is_data_member(151)
+    assert not _is_data_member(["Sweep Start", "Sweep End"])
+    assert not _is_data_member(np.array([True, False]))  # bool ≠ numeric data
+
+
+def test_scan_finds_nested_data():
+    obj = {"meta": {"a": 1}, "inner": {"spectrum": np.arange(10.0)}}
+    assert _find_data_members(obj) == ["inner.spectrum"]
+    assert _find_data_members(HEADER) == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Metadata-only split
+# ---------------------------------------------------------------------------
+
+def test_metadata_only_split_on_header(tmp_path):
+    p = _save_pickled(tmp_path, HEADER)
+    res = split_pickled_metadata_only(p, _file_paths(p, tmp_path / "out"))
+    assert res is not None and res["status"] == "success"
+    assert res["data_path"] is None and res["metadata_only"] is True
+    meta = json.loads(Path(res["metadata_path"]).read_text())
+    assert meta["dim_px"] == [168, 168]
+    assert meta["comment"] == HEADER["comment"]
+    assert set(meta) == set(HEADER)
+
+
+def test_combined_container_is_not_eligible(tmp_path):
+    combined = dict(HEADER, spectrum=np.linspace(0, 1, 151))
+    p = _save_pickled(tmp_path, combined, "combined.npy")
+    assert split_pickled_metadata_only(p, _file_paths(p, tmp_path / "out")) is None
+
+
+def test_small_ndarray_forces_codegen_path(tmp_path):
+    # The bias rule: an ndarray member of ANY size routes through codegen.
+    p = _save_pickled(tmp_path, dict(HEADER, pos=np.array([1.0, 2.0])), "h2.npy")
+    assert split_pickled_metadata_only(p, _file_paths(p, tmp_path / "out")) is None
+
+
+def test_plain_numeric_npy_is_not_eligible(tmp_path):
+    p = tmp_path / "cube.npy"
+    np.save(p, np.zeros((4, 4, 5)))
+    assert split_pickled_metadata_only(p, _file_paths(p, tmp_path / "out")) is None
+
+
+def test_non_dict_container_is_wrapped(tmp_path):
+    p = tmp_path / "strings.npy"
+    np.save(p, np.array(["a", "b", "c"], dtype=object), allow_pickle=True)
+    res = split_pickled_metadata_only(p, _file_paths(p, tmp_path / "out"))
+    assert res is not None and res["status"] == "success"
+    meta = json.loads(Path(res["metadata_path"]).read_text())
+    assert meta == {"value": ["a", "b", "c"]}
+
+
+def test_prepare_inputs_short_circuits_without_llm(tmp_path):
+    # model/executor are never touched on the deterministic path — passing
+    # None for both proves it.
+    p = _save_pickled(tmp_path, HEADER)
+    res = prepare_inputs(p, model=None, executor=None, output_dir=tmp_path / "out")
+    assert res["status"] == "success" and res.get("metadata_only") is True
+    assert res["attempts"] == 0
+
+
+class _FailingModel:
+    """A model whose use proves the codegen path was entered."""
+    def generate_content(self, prompt):
+        raise AssertionError("codegen path entered")
+
+
+def test_prepare_inputs_combined_still_uses_codegen(tmp_path):
+    # _generate_split_script folds model exceptions into a normal error
+    # result, so the sentinel model's message surfacing there proves the
+    # combined container took the codegen path (not the metadata-only one).
+    combined = dict(HEADER, spectrum=np.linspace(0, 1, 151))
+    p = _save_pickled(tmp_path, combined, "combined.npy")
+    res = prepare_inputs(p, model=_FailingModel(), executor=None,
+                         output_dir=tmp_path / "out", max_retries=0)
+    assert res["status"] == "error"
+    assert "codegen path entered" in res["message"]
+
+
+def test_batch_mixes_metadata_only_and_arrays(tmp_path):
+    h = _save_pickled(tmp_path, HEADER)
+    res = prepare_inputs_batch([h], model=None, executor=None,
+                               output_dir=tmp_path / "out")
+    assert res["status"] == "success"
+    assert res["results"][0]["metadata_only"] is True
+    # metadata-only entries never join flat series staging (no data leg)
+    staged = stage_pairs_flat(res["results"], tmp_path / "flat")
+    assert staged["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Probe + comparator
+# ---------------------------------------------------------------------------
+
+def test_probe_pickled_npy_describes_structure(tmp_path):
+    p = _save_pickled(tmp_path, HEADER)
+    info = probe_pickled_npy(p)
+    assert info["kind"] == "object_array" and info["container"] == "dict"
+    assert "dim_px" in info["top_level_keys"]
+    assert info["metadata_only"] is True
+
+    combined = dict(HEADER, spectrum=np.linspace(0, 1, 151))
+    p2 = _save_pickled(tmp_path, combined, "c.npy")
+    info2 = probe_pickled_npy(p2)
+    assert info2["metadata_only"] is False and "spectrum" in info2["data_members"]
+
+
+def test_meta_probe_file_unblinded(tmp_path):
+    from scilink.agents.meta_agent.meta_orchestrator_tools import _probe_file
+    p = _save_pickled(tmp_path, HEADER)
+    info = _probe_file(p)
+    assert info["kind"] == "object_array"
+    assert info.get("metadata_only") is True
+    # plain arrays are untouched by the change
+    q = tmp_path / "arr.npy"
+    np.save(q, np.zeros((3, 4)))
+    assert _probe_file(q)["kind"] == "array"
+
+
+def test_pyobj_equal_handles_dicts_with_arrays():
+    a = {"x": np.arange(5.0), "meta": {"k": [1, 2]}}
+    b = {"x": np.arange(5.0) + 1e-12, "meta": {"k": [1, 2]}}
+    c = {"x": np.arange(5.0) * 2, "meta": {"k": [1, 2]}}
+    assert _pyobj_equal(a, b)
+    assert not _pyobj_equal(a, c)

--- a/tests/test_file_prep_metadata_only.py
+++ b/tests/test_file_prep_metadata_only.py
@@ -86,6 +86,28 @@ def test_scan_finds_nested_data():
     assert _find_data_members(HEADER) == []
 
 
+def test_scan_finds_ndarrays_nested_in_lists():
+    # The any-size ndarray rule must hold THROUGH a plain list: a list judged
+    # non-data as a whole (ragged, or coerced block under the list threshold)
+    # can still hold real ndarray members.
+    ragged = {"spectra": [np.arange(20.0), np.arange(31.0)], "note": "hdr"}
+    assert _find_data_members(ragged) == ["spectra[0]", "spectra[1]"]
+    small = {"spectra": [np.arange(10.0), np.arange(10.0)]}
+    assert _find_data_members(small) == ["spectra[0]", "spectra[1]"]
+    # small scalar lists (and nested ones) are still metadata
+    assert _find_data_members({"dim_px": [168, 168]}) == []
+    assert _find_data_members({"roi": [[1.0, 2.0], [3.0, 4.0]]}) == []
+
+
+def test_list_nested_ndarray_forces_codegen_path(tmp_path):
+    p = _save_pickled(
+        tmp_path,
+        dict(HEADER, spectra=[np.arange(20.0), np.arange(31.0)]),
+        "h3.npy",
+    )
+    assert split_pickled_metadata_only(p, _file_paths(p, tmp_path / "out")) is None
+
+
 # ---------------------------------------------------------------------------
 # 2. Metadata-only split
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #380.

Instrument headers often arrive as a dict pickled inside a `.npy` file (e.g. a Nanonis-style grid-spectroscopy header saved with `np.save`). Before this change the meta agent could do nothing with such a file: its probe reported it "unreadable", and the file-prep tool failed every attempt because it insists on extracting a numerical data file from something that contains no data — only acquisition parameters. In a real session this forced the agent to ask the user for bias range, scan size, and setpoint that were sitting inside the uploaded header all along.

Now:

- A header-only pickled `.npy` is recognized and converted **deterministically** (no LLM, no code generation) into a clean metadata JSON — bias axis, scan size, channels, comments and all. The specialist gets its metadata; the user is never asked for values the file already carries.
- A pickled file that *also* holds data arrays (cube + axis + header in one dict) still goes through the normal verified split, and now succeeds: the probe describes the container's structure instead of "unreadable", and the round-trip verifier can compare pickled containers.

The decision between the two routes is made by code, not by the model, and it is deliberately biased: **any** numeric array member — however small — disqualifies the metadata-only shortcut and forces the full extraction path. Mis-filing real data into a metadata sidecar (silent under-analysis) is the expensive error; over-extracting a small axis vector is harmless.

Validated live against the original session's real header (19 fields recovered faithfully, zero LLM attempts) and against a synthetic combined container through real codegen (verified lossless, data byte-identical).

---

**Technical details**

- `scilink/utils/file_prep.py`
  - `split_pickled_metadata_only(input_path, paths, logger)` — eligibility: `.npy` rejected by `allow_pickle=False`, unpickles to a container, and `_find_data_members()` finds nothing array-shaped. Serializes via total (never-raising) `_jsonify_metadata`; returns `{status: success, data_path: None, metadata_only: True, attempts: 0}` — the honest outcome `_verify` cannot express (it requires a data leg loading with `allow_pickle=False`).
  - Gate: `_is_data_member` — numeric `ndarray` with `ndim≥1` at **any size**; plain lists/tuples only at ≥32 numeric elements total (`_LIST_DATA_MIN_ELEMS`, checked via `np.asarray(...).size` so a small-outer-length nested block still counts). Recursion covers nested dicts and object-dtype arrays.
  - Wired into `prepare_inputs` (before `_prepare_one`) and `prepare_inputs_batch` (per-file, before clustering); `stage_pairs_flat` tolerates `data_path=None`.
  - Round-trip: `.npy` branch of `_roundtrip_ok` detects object dtype and compares via `_pyobj_equal` (recursive dict/list/ndarray-aware; numeric leaves within tolerance) — a naive element-wise comparison raises on dict members, which previously made any combined-pickled split unverifiable.
  - `_file_paths` resolves all stored paths — generated scripts execute with `cwd=out_dir`, where a relative input path does not resolve.
  - `_PREP` guard message reworded to state the contract without misattributing the failure to hardcoded paths; prompt documents the pickled-dict layout.
- `scilink/agents/meta_agent/meta_orchestrator_tools.py`
  - `_probe_file` `.npy` branch: on the `allow_pickle=False` `ValueError`, describes the container via `probe_pickled_npy` (kind `object_array`, container type, top-level keys, data members, `metadata_only` flag). Size-capped at 50 MB (object arrays cannot be mmap'd). Trust level identical to every other format the upload probe parses. Failures fall through to the existing "unreadable" path.
  - Tool description extended so the meta routes metadata-only headers here deliberately.
- Tests: `tests/test_file_prep_metadata_only.py` (16) — gate bias (any-size ndarray → codegen; small lists → metadata; ≥32-element lists → data), header split fidelity, combined container refusal + sentinel-model proof it enters codegen, batch mixing, probe output, comparator.
- Known limit: unpickling executes pickle bytecode; this is confined to user-supplied local uploads (the same trust the rest of the probe and the ScriptExecutor path already extend) and size-capped.

Live protocol (Bedrock `us.anthropic.claude-opus-4-8`): real `header.npy` via `file_prep.prepare_inputs` and via the registered meta tool → deterministic success, 19 keys, `attempts=0`; synthetic combined dict (8×8×64 cube + 64-pt axis + header fields) → verified codegen split in 2 attempts, `arr_0`/`arr_1` byte-equal to originals, clean top-level metadata with `_reconstruction` bookkeeping nested.
