### PR TITLE
Hyperspectral: wire LLM method to unmixer, fail-fast axis gate, STS heuristic, scale-safe SNR

### DIFF
--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -1209,7 +1209,11 @@ class RunComponentTestLoopController:
             state["component_test_visuals"] = []
             return state
 
-        tool_settings = self.settings.copy()
+        # Per-run state settings carry the LLM-selected method; the
+        # constructor dict never receives it (state["settings"] is a copy),
+        # so reading state here is what makes the selection reach the
+        # unmixer instead of only the plot labels.
+        tool_settings = state.get("settings", self.settings).copy()
         for key in AGENT_METADATA_KEYS_TO_STRIP:
             tool_settings.pop(key, None)
 
@@ -1333,8 +1337,11 @@ class GetFinalComponentSelectionController:
         initial_estimate = state.get("initial_n_components", 4)
         component_range = state.get("component_test_range", [])
         
-        if not state.get("elbow_plot_bytes") or not state.get("component_test_visuals"):
-            self.logger.warning("Missing elbow plot or visual examples. Using initial estimate.")
+        # Proceed with whichever evidence exists — a failed summary plot must
+        # not silently disable the LLM selection when the elbow is available
+        # (and vice versa). Fall back only when there is nothing to look at.
+        if not state.get("elbow_plot_bytes") and not state.get("component_test_visuals"):
+            self.logger.warning("Missing elbow plot and visual examples. Using initial estimate.")
             state["final_n_components"] = initial_estimate
             return state
 
@@ -1342,15 +1349,17 @@ class GetFinalComponentSelectionController:
         prompt_parts.append(f"\n\n--- Context ---")
         prompt_parts.append(f"Initial LLM estimate: {initial_estimate} components")
         prompt_parts.append(f"Tested component range: {component_range}")
-        
-        prompt_parts.append(f"\n\n--- Quantitative Analysis: Reconstruction Error ---")
-        prompt_parts.append("Elbow Plot (Error vs. Number of Components):")
-        prompt_parts.append({"mime_type": "image/jpeg", "data": state["elbow_plot_bytes"]})
-        
-        prompt_parts.append(f"\n\n--- Qualitative Analysis: Visual Examples ---")
-        for viz in state.get("component_test_visuals", []):
-            prompt_parts.append(f"\n\n**{viz['label']}:**")
-            prompt_parts.append({"mime_type": "image/jpeg", "data": viz['image']})
+
+        if state.get("elbow_plot_bytes"):
+            prompt_parts.append(f"\n\n--- Quantitative Analysis: Reconstruction Error ---")
+            prompt_parts.append("Elbow Plot (Error vs. Number of Components):")
+            prompt_parts.append({"mime_type": "image/jpeg", "data": state["elbow_plot_bytes"]})
+
+        if state.get("component_test_visuals"):
+            prompt_parts.append(f"\n\n--- Qualitative Analysis: Visual Examples ---")
+            for viz in state.get("component_test_visuals", []):
+                prompt_parts.append(f"\n\n**{viz['label']}:**")
+                prompt_parts.append({"mime_type": "image/jpeg", "data": viz['image']})
 
         _append_objective_context(prompt_parts, state)
 
@@ -1364,7 +1373,7 @@ class GetFinalComponentSelectionController:
 
         _append_auxiliary_context(prompt_parts, state)
 
-        prompt_parts.append(f"\n\nBased on the elbow plot AND the visual examples, decide the optimal number of components.")
+        prompt_parts.append(f"\n\nBased on the evidence above (elbow plot and/or visual examples), decide the optimal number of components.")
 
         param_gen_config = None#GenerationConfig(response_mime_type="application/json")
         try:
@@ -1424,7 +1433,9 @@ class RunFinalSpectralUnmixingController:
             self.logger.warning(f"Auto-selection failed. Using fixed component count: {final_n_components}")
             state["final_n_components"] = final_n_components
 
-        tool_settings = self.settings.copy()
+        # State settings, not constructor settings — see the component test
+        # loop: this is where the LLM-selected method lives.
+        tool_settings = state.get("settings", self.settings).copy()
         for key in AGENT_METADATA_KEYS_TO_STRIP:
             tool_settings.pop(key, None)
             

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -1145,6 +1145,25 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             # Load data
             original_hspy_data = self._load_hyperspectral_data(data_path)
 
+            # Fail-fast precondition: the physical axis-2 range is a hard
+            # requirement (interpretation prep and every summary plot call
+            # create_axis, which raises without it — deliberate, fcb77007).
+            # Enforce it here, BEFORE preprocessing and the component test
+            # loop burn minutes of compute on a run that cannot finish.
+            from ...skills.hyperspectral.eels.eels import create_axis
+            try:
+                create_axis(original_hspy_data.shape[-1], system_info, axis_index=2)
+            except ValueError as e:
+                self.logger.error(f"Axis precondition failed: {e}")
+                return None, {
+                    "error": "Missing physical axis range for the spectral axis",
+                    "details": (
+                        f"{e} Supply the physical range of the third (signal/"
+                        f"sweep) axis in the metadata before re-running — no "
+                        f"analysis was performed."
+                    ),
+                }
+
             # Handle structure image
             structure_image_blob = None
             if structure_image_path and os.path.exists(structure_image_path):

--- a/scilink/agents/exp_agents/metadata_converter.py
+++ b/scilink/agents/exp_agents/metadata_converter.py
@@ -178,7 +178,7 @@ Fill Conditional Fields based on Type:
 
 If Microscopy: Focus on extracting spatial_info (field of view and units). Omit or use null for spectroscopy/curve fields if not relevant.
 
-If Spectroscopy/Hyperspectral: Focus on extracting energy_range (start, end, units). Omit or use null for microscopy/curve fields if not relevant. If the third (channel) axis of a 3D hyperspectral dataset is NOT energy/wavelength (e.g. it is time, voltage, force, frequency, or another parameter), populate the optional axis_spec object (with axis_0, axis_1, axis_2 entries — each having name, units, kind, and for the signal axis also start/end) instead of energy_range. Use axis_spec.signal_is_nonnegative=false when the signal can be signed (e.g. derivative spectra, difference spectra).
+If Spectroscopy/Hyperspectral: Focus on extracting energy_range (start, end, units). Omit or use null for microscopy/curve fields if not relevant. If the third (channel) axis of a 3D hyperspectral dataset is NOT energy/wavelength (e.g. it is time, voltage, force, frequency, or another parameter), populate the optional axis_spec object (with axis_0, axis_1, axis_2 entries — each having name, units, kind, and for the signal axis also start/end) instead of energy_range. The signal axis's start/end are REQUIRED for datacube analysis, so extract them from whatever evidence states the sweep/scan range — dedicated fields, a comment string, or a filename — rather than omitting them when no field is explicitly named "range". Use axis_spec.signal_is_nonnegative=false when the signal can be signed (e.g. derivative spectra, difference spectra).
 
 If 1D Curve Data (PL, XRD, etc.): Focus on extracting title, data_columns (determining X and Y column names/units), xlabel, and ylabel. energy_range might also apply if the x-axis represents energy. Omit or use null for microscopy fields.
 
@@ -258,9 +258,12 @@ def _describes_spectral_imaging(metadata: dict) -> bool:
     blob = f"{metadata.get('experiment_type') or ''} {technique}".lower()
     if "hyperspectral" in blob or "datacube" in blob:
         return True
-    # "spectral/spectroscopy ... imaging/mapping/spectrum-image/cube"
+    # "spectral/spectroscopy ... imaging/mapping/spectrum-image/cube/grid".
+    # "grid" covers grid spectroscopy (STS/CITS-style spectra on an x-y
+    # grid), which is a datacube even though nothing in its prose says so.
     return ("spectr" in blob
-            and any(w in blob for w in ("imag", "map", "cube", "spectrum image")))
+            and any(w in blob for w in ("imag", "map", "cube", "spectrum image",
+                                        "grid")))
 
 
 def _has_resolvable_energy_axis(metadata: dict) -> bool:
@@ -313,9 +316,10 @@ def check_schema_conformance(metadata: dict) -> tuple[bool, list[str]]:
             issues.append(f"'{key}' should be a dict or null")
 
     # A spectral-imaging / hyperspectral datacube MUST carry a resolvable energy
-    # axis (energy_range.start/end or axis_spec.axis_2.start/end). Without it the
-    # axis silently falls back to channel indices, so the spectral axis is only
-    # in prose — flag it non-conformant so the LLM normalizer re-extracts it.
+    # axis (energy_range.start/end or axis_spec.axis_2.start/end). Without it
+    # the analysis hard-fails when the axis is first built (deliberate — no
+    # silent channel-index fallback), so flag it non-conformant here and let
+    # the LLM normalizer re-extract it while the evidence is still in front of it.
     if _describes_spectral_imaging(metadata) and not _has_resolvable_energy_axis(metadata):
         issues.append(
             "Spectral-imaging/hyperspectral metadata is missing a resolvable "

--- a/scilink/agents/exp_agents/preprocess.py
+++ b/scilink/agents/exp_agents/preprocess.py
@@ -118,19 +118,22 @@ class HyperspectralPreprocessingAgent(BaseUtilityAgent):
         
         signal = stats["p99"]
         noise = stats["p50"]
-        
-        # Avoid division by zero if median is 0
-        if noise > 1e-9:
-            snr = (signal - noise) / noise
-            reasoning = f"Calculated as (P99 - P50) / P50: ({signal:.2e} - {noise:.2e}) / {noise:.2e}"
+
+        # Zero-only division guards, on purpose: an absolute epsilon here
+        # (1e-9) declares real but tiny-scale data (amperes-scale STS,
+        # normalized signals) "signalless" — the same absolute-threshold
+        # trap as the unmixer mask (#381). |P50| so a signed-signal median
+        # scales the ratio without flipping its sign.
+        if abs(noise) > 0:
+            snr = (signal - noise) / abs(noise)
+            reasoning = f"Calculated as (P99 - P50) / |P50|: ({signal:.2e} - {noise:.2e}) / {abs(noise):.2e}"
+        elif stats["std"] > 0:
+            # Fallback if median is exactly zero: use std dev
+            snr = signal / stats["std"]
+            reasoning = f"Calculated as P99 / Std (P50 was zero): {signal:.2e} / {stats['std']:.2e}"
         else:
-            # Fallback if median is zero: use std dev (less ideal but won't crash)
-            if stats["std"] > 1e-9:
-                snr = signal / stats["std"]
-                reasoning = f"Calculated as P99 / Std (P50 was zero): {signal:.2e} / {stats['std']:.2e}"
-            else:
-                snr = 0.0 # No signal or no variance
-                reasoning = "SNR is 0.0 (no variance or signal)"
+            snr = 0.0  # truly constant data
+            reasoning = "SNR is 0.0 (no variance or signal)"
 
         # Cap SNR at a reasonable max to avoid infinity/huge numbers
         snr = min(max(snr, 0.0), 1000.0) 

--- a/tests/test_hyperspectral_session_fixes.py
+++ b/tests/test_hyperspectral_session_fixes.py
@@ -1,0 +1,243 @@
+"""Regression tests for the four grid-STS session defects (2026-07-22).
+
+1. METHOD WIRING — the LLM-selected decomposition method is written to the
+   per-run ``state["settings"]`` (a copy), but the unmixing controllers read
+   their constructor settings dict, so PCA/ICA selection never reached the
+   unmixer (labels said PCA, sklearn ran NMF) since 96de3d18.
+2. AXIS PRECONDITION — the deliberately-required physical axis-2 range
+   (fcb77007) was enforced only at interpretation/plot time, after
+   preprocessing + the full component test loop had burned compute.
+3. SPECTRAL-IMAGING HEURISTIC — grid spectroscopy (STS) prose matched none
+   of the datacube keywords, so schema conformance never demanded the axis.
+4. SNR GUARDS — absolute 1e-9 epsilons (meant as division guards) declared
+   amperes-scale data "signalless" (same class as the #381 mask bug).
+"""
+
+import logging
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from scilink.agents.exp_agents.controllers import hyperspectral_controllers as hc
+from scilink.agents.exp_agents.metadata_converter import (
+    _describes_spectral_imaging,
+    check_schema_conformance,
+)
+from scilink.agents.exp_agents.preprocess import HyperspectralPreprocessingAgent
+
+
+LOGGER = logging.getLogger("test")
+
+AXIS_OK = {
+    "axis_spec": {
+        "axis_2": {"name": "Bias", "units": "V", "start": 1.0, "end": -1.0},
+        "signal_is_nonnegative": False,
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. Method wiring: state settings (LLM choice) reach the unmixer
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def recorded_methods(monkeypatch):
+    """Stub the unmixing tool and record the method each call receives."""
+    seen = []
+
+    def fake_unmix(hspy_data, n_comp, settings, logger):
+        seen.append(settings.get("method"))
+        h, w, e = hspy_data.shape
+        return np.zeros((n_comp, e)), np.zeros((h, w, n_comp)), 1.0
+
+    monkeypatch.setattr(hc.tools, "run_spectral_unmixing", fake_unmix)
+    monkeypatch.setattr(
+        hc.tools, "create_nmf_summary_plot",
+        lambda *a, **k: b"img",
+    )
+    return seen
+
+
+def _constructor_settings():
+    # What the agent passes at pipeline construction: default method.
+    return {"method": "nmf", "min_auto_components": 2, "max_auto_components": 3,
+            "output_dir": "unused"}
+
+
+def _state_with_selected_method(method="pca"):
+    # What GetInitialComponentParamsController produces at runtime.
+    return {
+        "hspy_data": np.random.rand(4, 4, 8),
+        "system_info": dict(AXIS_OK),
+        "settings": {"method": method, "normalize": True},
+        "initial_n_components": 2,
+        "iteration_title": "t",
+    }
+
+
+def test_component_test_loop_uses_llm_selected_method(recorded_methods, tmp_path):
+    ctrl = hc.RunComponentTestLoopController(LOGGER, _constructor_settings())
+    ctrl.settings["output_dir"] = str(tmp_path)
+    state = ctrl.execute(_state_with_selected_method("pca"))
+    assert recorded_methods and set(recorded_methods) == {"pca"}
+    assert state["component_test_errors"]
+
+
+def test_final_unmixing_uses_llm_selected_method(recorded_methods):
+    ctrl = hc.RunFinalSpectralUnmixingController(LOGGER, _constructor_settings())
+    state = _state_with_selected_method("pca")
+    state["final_n_components"] = 2
+    ctrl.execute(state)
+    assert recorded_methods == ["pca"]
+
+
+def test_controllers_fall_back_to_constructor_settings(recorded_methods):
+    # A state without "settings" (defensive path) still works.
+    ctrl = hc.RunFinalSpectralUnmixingController(LOGGER, _constructor_settings())
+    state = _state_with_selected_method()
+    del state["settings"]
+    state["final_n_components"] = 2
+    ctrl.execute(state)
+    assert recorded_methods == ["nmf"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Axis precondition: fail before compute, not after decomposition
+# ---------------------------------------------------------------------------
+
+def _make_agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNSAFE_EXECUTION_OK", "true")
+    from scilink.agents.exp_agents.hyperspectral_analysis_agent import (
+        HyperspectralAnalysisAgent,
+    )
+    return HyperspectralAnalysisAgent(
+        api_key="dummy", base_url="http://localhost:1",
+        output_dir=str(tmp_path / "out"), enable_human_feedback=False,
+    )
+
+
+class _SentinelController:
+    """Records whether the iteration pipeline was ever entered."""
+    def __init__(self):
+        self.entered = False
+
+    def execute(self, state):
+        self.entered = True
+        state["error_dict"] = {"error": "sentinel-reached"}
+        return state
+
+
+def test_missing_axis_range_fails_before_pipeline(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, monkeypatch)
+    sentinel = _SentinelController()
+    agent.iteration_pipeline = [sentinel]
+    agent.synthesis_pipeline = []
+
+    cube = tmp_path / "cube.npy"
+    np.save(cube, np.random.rand(4, 4, 8))
+
+    result_json, error_dict = agent._run_analysis_pipeline(
+        data_path=str(cube), system_info={}, instruction_prompt="x",
+    )
+    assert result_json is None
+    assert "Missing physical axis range" in error_dict["error"]
+    assert "no analysis was performed" in error_dict["details"]
+    assert sentinel.entered is False  # nothing was computed
+
+
+def test_valid_axis_range_proceeds_into_pipeline(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, monkeypatch)
+    sentinel = _SentinelController()
+    agent.iteration_pipeline = [sentinel]
+    agent.synthesis_pipeline = []
+
+    cube = tmp_path / "cube.npy"
+    np.save(cube, np.random.rand(4, 4, 8))
+
+    _, error_dict = agent._run_analysis_pipeline(
+        data_path=str(cube), system_info=dict(AXIS_OK), instruction_prompt="x",
+    )
+    assert sentinel.entered is True
+    assert error_dict == {"error": "sentinel-reached"}
+
+
+# ---------------------------------------------------------------------------
+# 2b. Final-N selection proceeds with partial visual evidence
+# ---------------------------------------------------------------------------
+
+def _final_select_controller():
+    model = SimpleNamespace(generate_content=lambda **k: "resp")
+    parse_fn = lambda resp: ({"final_components": 3, "reasoning": "r"}, None)
+    return hc.GetFinalComponentSelectionController(
+        model, LOGGER, generation_config=None, safety_settings=None,
+        parse_fn=parse_fn,
+    )
+
+
+def test_final_selection_runs_with_elbow_only():
+    ctrl = _final_select_controller()
+    state = {"initial_n_components": 5, "component_test_range": [2, 3, 4],
+             "elbow_plot_bytes": b"elbow", "component_test_visuals": []}
+    ctrl.execute(state)
+    # Pre-fix: visuals missing => silent fallback to the initial estimate (5).
+    assert state["final_n_components"] == 3
+
+
+def test_final_selection_falls_back_when_no_evidence():
+    ctrl = _final_select_controller()
+    state = {"initial_n_components": 5, "component_test_range": [2, 3, 4],
+             "elbow_plot_bytes": None, "component_test_visuals": []}
+    ctrl.execute(state)
+    assert state["final_n_components"] == 5
+
+
+# ---------------------------------------------------------------------------
+# 3. Spectral-imaging heuristic recognizes grid spectroscopy
+# ---------------------------------------------------------------------------
+
+def test_grid_spectroscopy_is_spectral_imaging():
+    md = {"experiment_type": "Spectroscopy",
+          "experiment": {"technique": "Grid Spectroscopy (STS)"},
+          "sample": {"material": "TaS2"}}
+    assert _describes_spectral_imaging(md)
+    ok, issues = check_schema_conformance(md)
+    assert not ok
+    assert any("resolvable" in i for i in issues)
+
+
+def test_plain_1d_spectroscopy_is_not_spectral_imaging():
+    md = {"experiment_type": "Spectroscopy",
+          "experiment": {"technique": "Raman spectroscopy"},
+          "sample": {"material": "Si"}}
+    assert not _describes_spectral_imaging(md)
+
+
+# ---------------------------------------------------------------------------
+# 4. SNR guards are scale-invariant
+# ---------------------------------------------------------------------------
+
+def _snr(stats):
+    host = SimpleNamespace(logger=LOGGER)
+    return HyperspectralPreprocessingAgent._calculate_snr(host, stats)
+
+
+def test_snr_nonzero_on_amperes_scale_data():
+    # The real session's scale: p50 ~2.5e-12 sat under the old 1e-9 floor
+    # and reported "SNR is 0.0 (no variance or signal)".
+    stats = {"p99": 1.42e-11, "p50": 2.47e-12, "std": 1.0e-12}
+    snr, reasoning = _snr(stats)
+    assert snr > 1.0
+    assert "no variance" not in reasoning
+
+
+def test_snr_is_scale_invariant():
+    stats = {"p99": 1.42e-11, "p50": 2.47e-12, "std": 1.0e-12}
+    scaled = {k: v * 1e13 for k, v in stats.items()}
+    assert _snr(stats)[0] == pytest.approx(_snr(scaled)[0])
+
+
+def test_snr_zero_only_for_constant_data():
+    snr, reasoning = _snr({"p99": 0.0, "p50": 0.0, "std": 0.0})
+    assert snr == 0.0
+    assert "no variance" in reasoning

--- a/tests/test_spectral_unmixer_mask.py
+++ b/tests/test_spectral_unmixer_mask.py
@@ -146,8 +146,13 @@ def test_iteration_error_propagates_to_caller(tmp_path, monkeypatch):
     cube_path = tmp_path / "cube.npy"
     np.save(cube_path, RNG.rand(4, 4, 8))
 
+    # Axis-complete metadata so the run reaches the (stubbed) pipeline —
+    # the fail-fast axis precondition would otherwise return first.
+    system_info = {"axis_spec": {
+        "axis_2": {"name": "energy", "units": "eV", "start": 0.0, "end": 1.0},
+    }}
     result_json, error_dict = agent._run_analysis_pipeline(
-        data_path=str(cube_path), system_info={}, instruction_prompt="x",
+        data_path=str(cube_path), system_info=system_info, instruction_prompt="x",
     )
     assert result_json is None
     # Pre-fix this came back as the derivative


### PR DESCRIPTION
Four defects diagnosed from a real TaS2 grid-STS meta session (follow-up to #380/#381/#385).

The headline: since the PCA/ICA option was added in February, the LLM's method choice never actually reached the decomposition — every run silently executed NMF while the plots and logs said PCA. On signed dI/dV data NMF's non-negativity shift destroys the physics the LLM chose PCA to preserve. Three smaller traps compounded it on this session's data: a missing spectral-axis range killed the run only *after* minutes of decomposition work, the metadata conformance gate didn't recognize grid spectroscopy as a datacube (so it never demanded the axis up front), and the deterministic SNR declared the amperes-scale cube "signalless."

- **Method selection now reaches the unmixer.** The unmixing controllers read the per-run settings (where the LLM's choice is written) instead of the constructor-time dict. Live: PCA selected AND executed, zero NMF warnings.
- **Axis requirement enforced up front.** The deliberate hard requirement for a physical axis range (no channel-index fallback) is unchanged — it now fires immediately after data load with a clean "no analysis was performed" error, instead of after preprocessing plus the full component test loop. Final-N selection also proceeds with whichever visual evidence exists, instead of silently skipping the LLM when one plot fails.
- **Grid spectroscopy recognized as spectral imaging.** The schema-conformance heuristic now matches "grid" techniques, so metadata missing the sweep range is flagged before any run; the normalizer prompt states that signal-axis start/end are required and should be extracted from whatever evidence carries the range (comments, filenames).
- **SNR guards are scale-invariant.** Zero-only division guards with |P50|; the real cube reads SNR = 2.10 instead of 0.00.

---

**Technical details**

- `controllers/hyperspectral_controllers.py` — `RunComponentTestLoopController` / `RunFinalSpectralUnmixingController`: `tool_settings = state.get("settings", self.settings).copy()`; `GetFinalComponentSelectionController`: evidence guard `or` → `and` with per-block gating.
- `hyperspectral_analysis_agent.py` — `create_axis(..., axis_index=2)` precondition in `_run_analysis_pipeline` right after `_load_hyperspectral_data`; returns `{"error": "Missing physical axis range …"}` before any pipeline work.
- `metadata_converter.py` — `_describes_spectral_imaging` adds "grid" to the datacube terms; `METADATA_GENERATION_PROMPT` gains one sentence on extracting signal-axis start/end from sweep evidence.
- `preprocess.py` — `_calculate_snr`: `noise > 1e-9` → `abs(noise) > 0` with `|P50|` denominator, `std > 1e-9` → `std > 0`.
- Tests: `tests/test_hyperspectral_session_fixes.py` (12) — recorded-method wiring for both controllers + constructor fallback, fail-fast ordering via sentinel pipeline (gate fires before any controller), elbow-only selection, STS heuristic + conformance flagging, SNR scale-invariance. `test_spectral_unmixer_mask.py`'s propagation test updated to pass axis-complete metadata (the new gate correctly fires first on empty metadata).
- Archaeology: the wiring gap dates to 96de3d18 (method written to the state copy; controllers kept reading constructor settings — the same commit added the PCA error-metric branch inside `run_spectral_unmixing`, reachable only via the settings dict that never carried the method). The axis hard-raise is deliberate (fcb77007) and is preserved.
- Live protocol (Bedrock `us.anthropic.claude-opus-4-8`): real 168×168×151 signed dI/dV cube, exploratory objective, `max_verification_iterations=0` — PCA selected and executed (0 NMF warnings), SNR 2.10, LLM final-N selection ran (chose 4), end-to-end `partial` with a physically substantive Gap_Width critique from QC.
- Known limits: constructor-passed `spectral_unmixing_settings['method']` remains the default the LLM can override per run (intended); the session surfaced additional QC-side issues (coverage epsilon, reviewer context) that are deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)