### PR TITLE
Manual meta checkpoint: /checkpoint command, save-on-quit, and a save_checkpoint tool

### DIFF
--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1344,8 +1344,32 @@ class MetaOrchestratorAgent:
             with open(self.checkpoint_path, 'w') as f:
                 json.dump(checkpoint_data, f, indent=2, default=str)
             print(f"    ✅ Auto-checkpoint saved")
+            return True
         except Exception as e:
             logging.warning(f"Auto-checkpoint failed: {e}")
+            return False
+
+    def save_checkpoint(self) -> str:
+        """Save the meta checkpoint on demand and reset the auto-save timer.
+
+        Children checkpoint themselves during delegations; this persists the
+        meta-level state (mode, message count, delegation ledger) so the
+        session can be resumed without waiting for the periodic auto-save.
+
+        Returns:
+            The checkpoint file path.
+
+        Raises:
+            RuntimeError: if the checkpoint could not be written.
+        """
+        if not self._auto_checkpoint():
+            raise RuntimeError(
+                f"Failed to write checkpoint to {self.checkpoint_path} "
+                "(see log for details)."
+            )
+        self.last_checkpoint_message_count = self.message_count
+        self._save_history()
+        return str(self.checkpoint_path)
 
     def _trim_history(self, history: List[Dict], max_messages: int = None) -> List[Dict]:
         """Keep only recent messages to avoid context window overflow."""

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -751,6 +751,33 @@ class MetaOrchestratorTools:
             required=[],
         )
 
+        # -- save_checkpoint -------------------------------------------------
+        def save_checkpoint() -> str:
+            print("  💾 Tool: Saving meta checkpoint...")
+            try:
+                path = self.orch.save_checkpoint()
+                return json.dumps({
+                    "status": "success",
+                    "checkpoint_path": path,
+                    "delegations_saved": len(self.orch._delegation_ledger),
+                })
+            except Exception as e:
+                return json.dumps({"status": "error", "message": str(e)})
+
+        self._register_tool(
+            func=save_checkpoint,
+            name="save_checkpoint",
+            description=(
+                "Save the meta session state (mode, delegation ledger, chat "
+                "history) to checkpoint.json so the session can be resumed "
+                "later. The state is also auto-saved periodically; call this "
+                "when the user asks to save/checkpoint the session, or before "
+                "they intend to stop."
+            ),
+            parameters={},
+            required=[],
+        )
+
         # -- review_distilled_skills ----------------------------------------
         def review_distilled_skills(action: str = "list", skill: str = None,
                                     to_domain: str = None, staged: str = None,

--- a/scilink/cli/meta.py
+++ b/scilink/cli/meta.py
@@ -544,8 +544,9 @@ a nested child sub-session under this meta session.
         print("  /skill <path>      Register a custom skill (.md), shared with specialists")
         print("  /tool <path>       Register a custom tool file (.py), shared with specialists")
         print("  /mcp <config>      Connect an MCP server, shared with specialists")
+        print("  /checkpoint        Save session state now (also auto-saved, and saved on exit)")
         print("  /clear             Clear screen")
-        print("  /quit or /exit     Exit")
+        print("  /quit or /exit     Exit (saves a checkpoint)")
         print("\nOr just describe your research goal and let the meta-agent route it!")
         print("=" * 60)
 
@@ -637,6 +638,10 @@ a nested child sub-session under this meta session.
                 self._connect_mcp_servers([parts[1].strip()])
             return True
 
+        if cmd == "/checkpoint":
+            self._save_checkpoint()
+            return True
+
         if cmd == "/clear":
             os.system('cls' if os.name == 'nt' else 'clear')
             print("🧭  Meta-Agent - Session Resumed\n")
@@ -646,6 +651,14 @@ a nested child sub-session under this meta session.
             return "QUIT"
 
         return False
+
+    def _save_checkpoint(self):
+        """Save the meta checkpoint, reporting rather than raising on failure."""
+        try:
+            path = self.agent.save_checkpoint()
+            print(f"\n💾 Checkpoint saved: {path}")
+        except Exception as e:
+            print(f"\n❌ Checkpoint failed: {e}")
 
     def run(self):
         """Main interactive loop."""
@@ -671,7 +684,9 @@ a nested child sub-session under this meta session.
             try:
                 user_input = input("You: ").strip()
             except (EOFError, KeyboardInterrupt):
-                print("\n\n👋 Goodbye!")
+                print()
+                self._save_checkpoint()
+                print("\n👋 Goodbye!")
                 break
 
             if not user_input:
@@ -679,6 +694,7 @@ a nested child sub-session under this meta session.
 
             handled = self.handle_command(user_input)
             if handled == "QUIT":
+                self._save_checkpoint()
                 print("\n👋 Goodbye!")
                 break
             if handled is True:


### PR DESCRIPTION
## Summary

The meta (explore) session previously saved its state only automatically — every 10 messages, or when a chat error occurred. Quitting at the wrong moment could silently lose up to 9 messages of session state, including the record of recent delegations, and there was no way to ask for a save explicitly.

This PR adds manual checkpointing at the meta level, on all surfaces:

- **`/checkpoint` CLI command** — saves the session state immediately and prints the checkpoint path (listed in `/help`).
- **Checkpoint on exit** — `/quit`, `/exit`, and Ctrl-C/EOF now save a checkpoint before leaving, so a resumed session always has the full delegation record.
- **"Save a checkpoint" from chat, including the UI** — the meta now has a `save_checkpoint` tool (the planning and analysis specialists already had one), so asking the meta to save the session works in the UI chat as well as the CLI.

A failed explicit save now reports an error instead of quietly logging a warning, so a manual save can't silently do nothing.

---

## Technical details

- `MetaOrchestratorAgent.save_checkpoint()` (`meta_orchestrator.py`): public on-demand save. Wraps `_auto_checkpoint()` (which now returns a bool), flushes chat history via `_save_history()`, resets `last_checkpoint_message_count` so the 10-message auto-save timer restarts, returns the checkpoint path, and raises `RuntimeError` on write failure.
- `save_checkpoint` meta tool (`meta_orchestrator_tools.py`): registered alongside `get_delegation_history`, mirroring the children's tool shape; returns `{status, checkpoint_path, delegations_saved}` JSON. This is what makes the feature reachable from the UI — the UI chat input passes text straight to the agent with no slash-command interception, so tool-mediated saving is the UI path.
- CLI (`cli/meta.py`): `_save_checkpoint()` helper (reports failure, never raises into the loop), `/checkpoint` command, save on the `QUIT` branch and on the `EOFError`/`KeyboardInterrupt` branch of the main loop.
- Checkpoint content is unchanged (meta mode, message count, instantiated children, delegation ledger); children continue to checkpoint themselves in their own sub-directories.

**Testing:** offline smoke tests — happy path writes correct state and resets the timer; unwritable path raises `RuntimeError`; tool wrapper returns clean success/error JSON; `/checkpoint` handles success and failure without breaking the CLI loop; case-insensitive command parsing. Existing offline meta suites pass (21/21: `test_meta_simulation_delegation`, `test_meta_fanout_robustness`, `test_file_prep_metadata_only`).

**Known limits:** no live end-to-end run of the UI chat → `save_checkpoint` tool → resume cycle yet; the UI still has no dedicated save button (chat-mediated only).