### PR TITLE
Add crystalline_deformation image-analysis skill (2D-PTM + CoS defect classification, GPA/Burgers tools)

### DIFF
--- a/scilink/skills/image_analysis/crystalline_deformation/crystalline_deformation.md
+++ b/scilink/skills/image_analysis/crystalline_deformation/crystalline_deformation.md
@@ -1,0 +1,578 @@
+---
+description: Atomic-resolution STEM deformation and defect analysis — per-atom 2D-PTM structural classification, Center-of-Symmetry distortion mapping, twin boundary / stacking fault / grain boundary identification, GPA validity gating, and Burgers vector extraction on zone-axis crystalline materials.
+---
+# Crystalline Deformation Mechanisms — Atomic-Resolution Skill
+
+## overview
+
+Identification and characterization of deformation mechanisms in
+crystalline materials from **atomic-resolution STEM images where
+individual atomic columns are resolved**. Do NOT apply to SEM, EBSD,
+or diffraction-contrast TEM. Applies to **cubic systems** (FCC, BCC)
+and **hexagonal** (HCP) structures viewed along low-index zone axes.
+Covers twin boundaries, stacking faults, dislocations, grain
+boundaries, and strain mapping at atomic scale using per-atom
+structural classification and local symmetry analysis.
+
+
+**Relationship to the general atomic-resolution STEM skill:** this skill
+may be selected alongside the general atomic-resolution skill on the same
+image. For objectives concerning defects, boundaries, strain, or
+deformation, the detection sequence in THIS skill governs: detector
+choice, the PTM unidentified-fraction gate, and the fallback order. The
+general skill's guidance on sublattice separation, lattice metrology, and
+calibration-aware quality criteria remains complementary and applicable.
+Where the two skills differ on detector selection for a defect-analysis
+objective, follow this skill.
+
+## planning
+
+### foundational
+The key insight for atomic-resolution defect analysis is that
+**structural classification of individual atom columns directly reveals
+defects** without needing orientation mapping, FFT filtering, or domain
+segmentation as intermediate steps.
+
+**2D Polyhedral Template Matching (2D-PTM)** classifies each atom's
+local neighbor environment against ideal crystal structure templates
+by Kabsch-aligned RMSD matching. For each atom: find 6 nearest
+neighbors via Delaunay triangulation, sort angularly, align against
+rotated ideal templates (FCC, BCC, HCP projections), assign the
+best-matching structure if RMSD is below threshold. This gives a
+per-atom label: FCC, BCC, HCP, or unidentified.
+
+**Center of Symmetry (CoS)** quantifies how much each atom's local
+environment deviates from centrosymmetry. For each atom with N bond
+vectors to neighbors, find the best anti-parallel partner for each
+bond: D[j] = min_i(||bond_i + bond_j||). The metric:
+M = sum(D²/2) / (2 × sum(||bond||²)). M=0 is perfectly
+centrosymmetric (bulk); M>0 indicates broken symmetry (defect,
+surface, boundary).
+
+Always run both PTM and CoS — they are complementary. PTM gives
+discrete classification; CoS gives a continuous distortion measure.
+
+### advanced
+**Deformation mechanisms in FCC — the Shockley partial progression:**
+
+In FCC metals viewed along [110], deformation proceeds by passage of
+Shockley partial dislocations (b = a/6<112>) on {111} planes. Each
+partial shifts the stacking sequence by one position. The accumulated
+effect is directly visible in 2D-PTM classification:
+
+1. **One Shockley partial → Intrinsic Stacking Fault (ISF):**
+   ABCABC becomes ABC|BCA. The fault plane comprises **2 adjacent
+   atomic layers that classify as HCP** amid the FCC matrix. This is
+   because locally the stacking is ...ABA... which is the HCP motif.
+
+2. **Second Shockley partial on adjacent plane → Extrinsic Stacking
+   Fault (ESF):** Creates **2 HCP layers sandwiching 1 FCC layer**
+   (HCP-FCC-HCP). The enclosed FCC layer has the "wrong" registry
+   relative to the surrounding matrix.
+
+3. **Third Shockley partial → Twin Boundary:** Creates a coherent
+   Σ3{111} twin. In PTM output: **1 HCP layer** at the boundary
+   plane, with the FCC matrix on either side showing a mirror
+   relationship. The twin misorientation is 70.53° about <110> (in
+   3D). In [110] projection, the two domains show mirrored lattice
+   vector angles.
+
+**Counting HCP layers in PTM output directly identifies the defect:**
+- 2 adjacent HCP layers → ISF
+- 2 HCP layers separated by 1 FCC layer → ESF
+- 1 HCP layer with mirror-related FCC on both sides → twin boundary
+- Multiple isolated HCP layers → multiple stacking faults or
+  deformation band
+
+**Classification priority — the layer count is the primary classifier.**
+The HCP layer-count signature is topological: it requires no plane
+identification, no per-domain lattice-vector fitting, and no angular
+measurement, and it is reliable whenever the classification is clean
+(low unidentified fraction, correct zone axis). Angular corroborations
+(mirror relationship, misorientation, {111} trace alignment) depend on
+correctly identifying a specific plane and fitting lattice vectors per
+domain — measurements that are fragile in exactly the mirror-symmetric
+configurations they are meant to confirm. Therefore: angular checks may
+STRENGTHEN a layer-count classification but must never overturn it. If
+an angular check returns a physically impossible value (exactly 0° or
+exactly 90° misorientation), the measurement itself has failed —
+re-measure with a different method, or report the classification from
+the layer count alone and note the corroboration as unavailable. Do
+NOT downgrade a clean single-HCP-layer twin signature to "unresolved"
+or "artifact" because an angular measurement failed to confirm it.
+
+**Grain boundaries from PTM:**
+- **Low-angle grain boundaries (LAGB):** Array of dislocation cores.
+  Each core shows a cluster of unidentified atoms (no template match)
+  with surrounding distorted FCC. The dislocation spacing gives the
+  misorientation via Frank's formula: θ = b/d.
+- **High-angle grain boundaries (HAGB):** Continuous band of
+  unidentified atoms — the boundary core is too disordered for any
+  template to match. Width is typically 2-5 atomic layers.
+- **CSL boundaries (Σ3, Σ5, Σ7, etc.):** Σ3 twins as described above.
+  Higher-Σ boundaries show periodic structural units with
+  characteristic repeat distances.
+
+**Unidentified atoms in PTM are diagnostic:**
+- Isolated unidentified atoms in bulk → point defects, beam damage,
+  or noise in atom positions
+- Linear arrangement → dislocation line or planar defect edge-on
+- Continuous band → grain boundary core
+- Clustered region → amorphous pocket, radiation damage, or
+  precipitate interface
+
+**CoS map interpretation:**
+- Bulk crystal: M ≈ 0 (uniform blue in viridis colormap)
+- Stacking fault: slight elevation, M ≈ 0.001-0.005
+- Twin boundary: moderate elevation at boundary plane, M ≈ 0.005-0.02
+  for disordered or incoherent segments; a COHERENT twin boundary in
+  2D projection can show negligible elevation (M < 0.001, near bulk
+  noise) because the projected 6-NN environment of the boundary layer
+  remains nearly mirror-symmetric — absent CoS elevation does NOT
+  invalidate a coherent single-HCP-layer twin
+- Dislocation core: strong peak, M ≈ 0.02-0.10
+- Grain boundary: elevated band, M ≈ 0.01-0.05
+- Surface/edge: elevated (fewer neighbors), exclude from analysis
+- Threshold M > 0.05 typically indicates fitting artifacts, not real
+  distortion — clamp or exclude these values
+
+**Zone axis identification:**
+Different zone axes produce different projected atom patterns. For FCC:
+- [110]: dumbbells visible (two sublattices), hexagonal projected
+  pattern, most common for defect analysis
+- [100]: square pattern, single sublattice visible
+- [111]: hexagonal pattern, three sublattices overlapping
+- [112]: rectangular pattern, complex sublattice structure
+
+The zone axis determines which defect features are visible. {111}
+stacking faults and twins are edge-on in [110] and [112], but
+inclined in [100] and [111].
+
+## analysis
+
+### foundational
+**Required pipeline for defect characterization:**
+
+1. Detect atom column positions (DCNN preferred with GPU, classical
+   peak detection as fallback)
+2. Run 2D-PTM classification on all detected positions
+3. Compute CoS metric for all detected positions
+4. Generate classification map (FCC=green, HCP=red, BCC=blue,
+   unidentified=black/gray)
+5. Generate CoS heatmap via griddata interpolation
+6. Identify defect types from PTM pattern (see planning section)
+7. Measure defect geometry: trace angle, spacing, width
+
+**Detection quality gate — PTM unidentified fraction:**
+After step 2, compute the fraction of atoms classified as "unidentified"
+by PTM. If >15% of atoms are unidentified AND classical peak detection
+(`detect_atoms`) was used in step 1, this indicates the detector missed
+or mislocated atom columns (poor peak finding in noisy/low-contrast
+regions). In this case:
+- Retry atom detection using DCNN (`detect_atoms_dcnn`). If `fov_nm`
+  is not provided in metadata, compute it as:
+  `fov_nm = estimated_pixel_size_nm * image_width_px` (estimate pixel
+  size from FFT lattice spacing and known bulk lattice parameter).
+- Re-run PTM classification on the new DCNN positions
+- Do NOT fall back to adjusting classical detection parameters — if
+  classical detection failed to produce <15% unidentified, it is
+  unlikely to succeed with parameter tweaks alone. DCNN is the
+  required retry path.
+- Do NOT proceed to defect interpretation with >15% unidentified atoms
+  unless the image genuinely contains that level of disorder (e.g.,
+  heavily irradiated material or amorphous regions)
+
+### advanced
+**Per-atom analysis workflow:**
+
+Given N atom positions as (x, y) arrays from Tier 1 detection:
+
+Step 1 — Build neighbor lists: For each atom, find 6 nearest
+neighbors. Use Delaunay triangulation or KDTree with distance cutoff
+at ~1.5× expected NN distance. Exclude atoms with fewer than 4
+neighbors (edge atoms).
+
+Step 2 — PTM classification: For each atom, extract the 6 NN
+positions relative to the central atom, sort angularly. Compare
+against pre-computed rotated templates for each crystal structure.
+Use Kabsch algorithm for optimal alignment, compute RMSD. Assign
+structure with lowest RMSD if below threshold (typically 0.1-0.15
+in normalized units). Record: structure label, RMSD, rotation angle,
+scaling factor.
+
+Step 3 — CoS calculation: For each atom's bond vectors to its
+neighbors, compute the anti-parallel partner distances D[j] and the
+normalized metric M. This requires only the neighbor list from Step 1.
+
+Step 4 — Boundary extraction from PTM map: Identify connected
+regions of same-type atoms. Boundaries are where the classification
+changes. For twin boundaries specifically: find contiguous lines of
+HCP-classified atoms separating FCC regions. The boundary trace is
+the best-fit line through the HCP atom positions.
+
+Step 5 — Misorientation from lattice vectors: Within each
+PTM-identified domain (connected FCC region), fit lattice vectors
+from the NN displacement vector histogram. Compare lattice vector
+angles between adjacent domains. For Σ3 twin in [110]: expect
+mirrored a2 vectors (equal magnitude, opposite sign angles relative
+to the boundary normal).
+
+Robustness warning — this step is SUPPORTING evidence only,
+subordinate to the layer count (see planning, classification
+priority). Comparing a single "first" or dominant lattice vector per
+side is degenerate for mirror twins: the mirror maps the NN vector
+family onto itself, so a canonical-sort pick returns near-identical
+angles (misorientation ≈ 0°) even for a genuine twin. If attempted,
+compare the FULL set of NN vector angles per domain reflected about
+the boundary normal, or compare the {111} plane-trace angles on each
+side (for an edge-on Σ3 twin in [110], symmetric at about ±35° to
+the boundary). A 0° result means the measurement is degenerate —
+discard it, not the twin.
+
+Step 6 — Technique decision after classification: After PTM
+classifies all atoms and domains are identified, decide whether
+downstream techniques are physically valid for this image:
+
+- **Multiple grain orientations detected** (>1 distinct FCC domain
+  with different lattice vector angles): Do NOT apply GPA. GPA
+  computes strain relative to a single reference lattice — when
+  multiple orientations are present, the phase field is discontinuous
+  at every grain boundary, producing physically meaningless strain
+  values (often hundreds of percent) at and near boundaries. The
+  correct approach is per-atom PTM + CoS, which handles multiple
+  orientations natively because each atom is classified independently
+  against templates.
+- **Multiple phases detected** (PTM finds domains of different
+  structure types, e.g., FCC + BCC, or FCC + HCP beyond a stacking
+  fault): Do NOT apply GPA. GPA tracks displacement of a periodic
+  lattice by locking onto specific Bragg reflections (g-vectors).
+  When the lattice structure changes, the periodicity changes — the
+  reference g-vectors no longer exist in the second phase, so the
+  phase field becomes undefined and the computed "strain" reflects
+  the lattice mismatch between phases, not real elastic strain.
+  Example: an FCC/BCC interface has different d-spacings and
+  symmetry; GPA across the interface produces strain artifacts of
+  10–50% that are crystallographic misfit, not deformation. Use PTM
+  to classify each phase independently, then measure interfacial
+  relationships (orientation, habit plane) from lattice vectors.
+- **Single grain, no boundary**: GPA is valid and complementary to
+  PTM — it maps continuous strain at every pixel, not just at atom
+  positions. Use GPA for dislocation strain fields, compositional
+  strain, or subtle elastic distortion below PTM sensitivity.
+- **Image contains a twin boundary or grain boundary (bicrystal)**:
+  Do NOT apply GPA — even "within individual domains." When the
+  boundary is the region of scientific interest, GPA cannot
+  characterize it because the phase field is undefined at the boundary
+  and unreliable within ~20–50 px of it. Even within one domain of a
+  bicrystal, the field of view is typically too small for meaningful
+  GPA statistics, and boundary-proximity artifacts bleed inward. The
+  correct approach is:
+  1. Detect atomic columns (DCNN + refinement, or classical peak
+     detection as fallback)
+  2. Run PTM to classify the boundary structure (HCP layer count,
+     misorientation)
+  3. Compute Center of Symmetry (CoS) maps as a **proxy for strain**
+     — CoS measures local lattice distortion without requiring a
+     single reference lattice, works natively across boundaries, and
+     directly highlights deformation concentration at the boundary
+  4. If the user or objective explicitly asks for "strain maps" or
+     "GPA," do NOT apply GPA anyway. Report CoS maps as "local
+     distortion maps" and explain why GPA is not applicable to
+     bicrystals/twin boundaries. The objective may be written by
+     someone unfamiliar with GPA's limitations — always prioritize
+     physical correctness over literal compliance with the request.
+- **Single grain with stacking faults (no boundary traversing the
+  full image)**: GPA is valid only within the continuous domain. The
+  fault itself produces a phase discontinuity — mask fault regions
+  (±5 px from PTM boundary atoms) before interpreting GPA strain
+  values. This case applies only when the stacking fault is a minor
+  feature within a large single-crystal field of view, NOT when the
+  image is fundamentally a bicrystal.
+
+If the user or objective requests a technique that is not physically
+valid for the image (e.g., GPA on a multi-grain image), do NOT
+silently apply it. Instead, explain why the technique is unsuitable
+and what the correct alternative is. For example: "GPA cannot be
+applied to this image because it contains two grain orientations
+with different lattice vectors. GPA assumes a single reference
+lattice and would produce artifact strain values at the grain
+boundary. Per-atom PTM classification already identifies the
+boundary structure and defect type without this limitation."
+
+**Physical constraints for validation:**
+- Σ3 twin misorientation: 70.53° about <110> (3D), projected angle
+  depends on zone axis
+- ISF: exactly 2 HCP layers, not 1, not 3
+- ESF: exactly HCP-FCC-HCP sandwich (3 layers)
+- Twin: exactly 1 HCP layer at coherent boundary
+- NN distance should be consistent across the image (CV < 10%)
+- Lattice vectors in both domains should have same magnitude (twins
+  preserve lattice parameters)
+- CoS should be elevated along the same trace as PTM boundary atoms
+
+**What NOT to do (with physics reasons):**
+- Do not apply GPA to images with multiple grain orientations or
+  multiple phases. GPA measures displacement relative to one reference
+  lattice; a second orientation produces a linearly-growing phase ramp
+  that wraps repeatedly, creating artificial strain of 10–1000%. A
+  different crystal structure has different g-vectors entirely, making
+  the GPA phase field undefined in the second phase. PTM handles both
+  cases because it classifies each atom independently against all
+  templates.
+- Do not use GPA as the primary defect identification tool when
+  atomic columns are resolved. PTM directly classifies defect
+  structure (twin vs SF vs GB) from atom positions; GPA only shows
+  that "something is strained" without identifying what. Use GPA as
+  a complement for continuous strain mapping within a single domain,
+  not as a substitute for structural classification.
+- Do not use orientation clustering (GMM, k-means) as the primary
+  domain segmentation method — it is fragile against scan distortion,
+  intensity gradients, and sample tilt. Use PTM classification
+  instead.
+- Do not use FFT Bragg filtering for twin identification — it is
+  complex to implement correctly and unnecessary when PTM gives the
+  answer directly from atom positions.
+- Do not report misorientation angles that are physically impossible:
+  -90° is never a crystallographic misorientation, 70.53° ± 5° is
+  expected for Σ3, 36.87° for Σ5, 38.21° for Σ7.
+- Do not classify a boundary as "low_angle" if misorientation > 15°.
+  Low-angle: < 15°. High-angle: > 15°. CSL: specific angles.
+
+## interpretation
+
+### foundational
+**Reading a PTM classification map:**
+
+A well-classified image of defect-free FCC crystal is uniformly
+green (all atoms match FCC template). Deviations indicate structural
+features:
+
+- Red line (HCP atoms) across green (FCC) background → stacking
+  fault or twin boundary. Count the red layers to distinguish ISF
+  (2 layers) from twin (1 layer).
+- Black/gray spots (unidentified) in a line → dislocation array or
+  grain boundary.
+- Large black region → amorphous, heavily damaged, or wrong zone axis
+  (templates don't match the projection).
+- Uniform red (all HCP) → the material is HCP, or viewing along a
+  zone axis where FCC projects as HCP-like pattern. Check zone axis.
+
+### advanced
+**Quantitative defect characterization from PTM + CoS:**
+
+- **Stacking fault energy (qualitative):** Materials with many ISFs
+  and ESFs have low stacking fault energy (e.g., austenitic stainless
+  steel, CoCrNi). Materials with only twins and no isolated ISFs have
+  moderate SFE. Materials with no planar defects likely have high SFE.
+
+- **Deformation history:** ISFs form first (one partial), then ESFs
+  (two partials), then twins (three partials). Observing only twins
+  with no ISFs suggests significant accumulated strain. Observing
+  ISFs without twins suggests early-stage deformation.
+
+- **Boundary character from CoS profile:** The width of the CoS
+  elevation across a boundary indicates its core width. Coherent
+  twins: sharp (1-2 atom layers). Incoherent segments: broader
+  (3-5 layers). HAGB: broadest (5+ layers). Use the full-width at
+  half-maximum of the CoS peak perpendicular to the boundary trace.
+
+- **Rigid body translation at boundary:** Compare the lattice
+  registries on both sides. For a perfect Σ3 twin, there should be
+  zero rigid body translation parallel to the boundary. Non-zero
+  translation indicates a displacement shift complete (DSC) vector,
+  which means the boundary contains disconnections.
+
+## validation
+
+### foundational
+**PTM quality checks:**
+- Fraction of unidentified atoms in bulk (away from boundaries)
+  should be < 5%. Higher values indicate the RMSD threshold is too
+  tight, poor atom positions, wrong templates, or wrong zone axis.
+  If >5%, use `ptm_classify_sweep()` to auto-select a threshold.
+- RMSD distribution: bulk atoms should cluster at low RMSD (< 0.1).
+  A bimodal distribution with a second peak at 0.1-0.15 suggests
+  a second structure type (e.g., HCP at stacking faults).
+- All atoms in a single domain should have the same PTM label. Mixed
+  FCC/HCP in bulk (not at a boundary) indicates noisy positions.
+
+**CoS quality checks:**
+- Bulk CoS should be near zero and spatially uniform. Large-scale
+  gradients in bulk CoS indicate systematic position errors (scan
+  distortion, drift) rather than real structural features.
+- CoS > 0.05 is almost always artifact — clamp to zero or exclude.
+- Edge atoms (< 6 neighbors) will have artificially high CoS —
+  apply a border cutout before analysis (trim 2-3 NN distances
+  from all edges).
+
+### advanced
+**Cross-validation between PTM and CoS:**
+- A disordered PTM boundary (unidentified-atom band, dislocation
+  array) should show elevated CoS; if it does not, that boundary is
+  likely a classification artifact. This test does NOT apply to a
+  coherent single-HCP-layer twin line, which can legitimately show
+  negligible CoS elevation in 2D projection (see CoS map
+  interpretation) — never reject a coherent twin on low CoS alone.
+- CoS peaks without corresponding PTM transitions indicate subtle
+  distortion (elastic strain, composition gradient) that doesn't
+  change the structure type.
+- The boundary trace from PTM atom positions and the ridge line of
+  CoS elevation should coincide within 1 NN distance.
+- For twins: CoS peak height at the boundary should be consistent
+  along its length. Variations indicate boundary steps or
+  disconnections.
+
+**Physically impossible results that indicate analysis errors** (these
+mean the MEASUREMENT failed — fix or omit that measurement; they are
+never evidence that the defect is absent, and they never override the
+layer-count classification):
+- Misorientation of exactly 0° or exactly 90° between domains
+- Twin boundary with 0 or 3+ HCP layers (should be exactly 1)
+- ISF with 1 or 3+ HCP layers (should be exactly 2)
+- Lattice parameter ratio between domains ≠ 1.0 for a twin
+  (twins preserve the lattice)
+- Negative CoS values (mathematically impossible with the standard
+  metric)
+- Boundary trace angle that doesn't correspond to any {111} trace
+  for the identified zone axis
+
+## implementation
+
+### foundational
+**Tool priority for defect analysis:**
+
+1. Always start with atom detection — see detection strategy below
+2. Run PTM classification immediately after detection — it requires
+   only (x, y) positions and pre-computed templates
+3. Run CoS calculation in parallel with PTM — same input, independent
+   computation
+4. Use PTM map as the primary defect identification, CoS as
+   confirmation and continuous distortion measure
+5. Extract boundary geometry from PTM-classified atom positions, not
+   from orientation maps or FFT
+
+**Atom detection strategy — critical for downstream PTM/CoS:**
+
+Detection completeness is the single most important upstream step.
+Missing atoms corrupt Delaunay neighbor-finding, causing PTM to
+classify most atoms as "unidentified" and CoS to show false patterns.
+A 1540×1540 atomic-resolution STEM image typically contains 1500–2500
+atom columns.
+
+Preferred approach: `detect_atoms_dcnn` with GPU. However, DCNN can
+fail when the image has strong intensity gradients (e.g., thickness
+fringes, detector nonuniformity) — it will only detect atoms in
+bright regions and miss the rest.
+
+**Always validate detection count.** If DCNN returns fewer than ~1500
+atoms for a full-field atomic-resolution image, fall back to classical
+detection:
+```python
+from scilink.skills.image_analysis.atomic_stem.atom_finding import detect_atoms
+result = detect_atoms(image, separation=<NN_from_FFT>,
+                      threshold_rel=0.02, refine=True)
+```
+Classical `detect_atoms` with a low `threshold_rel` (0.01–0.03) is
+more robust to intensity gradients than DCNN. Estimate `separation`
+from the FFT lattice peak spacing.
+
+If the image has a visible intensity gradient, apply background
+subtraction (large-sigma Gaussian blur, subtract) before detection.
+Do NOT apply heavy filtering or CLAHE before DCNN — the model expects
+raw or near-raw input.
+
+### advanced
+**PTM and CoS tools are available.** Call them directly — do NOT
+reimplement template matching or symmetry calculations from scratch.
+
+```python
+from scilink.skills.image_analysis.crystalline_deformation.ptm_tools import ptm_classify, ptm_classify_sweep, compute_cos
+
+# After atom detection gives x, y arrays (pixel coordinates):
+result = ptm_classify(x, y, threshold=0.05, structures=["FCC", "HCP"],
+                      edge_cutout_nn=3)
+
+labels = result["labels"]       # per-atom: "FCC", "HCP", "unidentified", "edge"
+rmsd   = result["rmsd"]         # per-atom RMSD (NaN for unidentified/edge)
+cos    = result["cos"]          # per-atom Center of Symmetry metric
+codes  = result["structure_code"]  # 1=FCC, 2=BCC, 3=HCP, 0=other, -1=edge
+```
+
+**RMSD threshold sweep — use when default threshold gives too many
+unidentified atoms (>5% of interior atoms).** Runs Kabsch alignment
+once, then reclassifies at each candidate threshold in O(N) time:
+
+```python
+sweep = ptm_classify_sweep(x, y, structures=["FCC", "HCP"],
+                           target_unidentified=0.05)
+print(f"Best threshold: {sweep['best_threshold']}")
+for s in sweep['sweep']:
+    print(f"  t={s['threshold']:.3f}  unid={s['frac_unidentified']:.1%}  {s['per_structure']}")
+
+# Use the auto-selected result
+result = sweep['best_result']
+labels = result['labels']
+```
+
+These tools encode pre-validated crystallographic templates (FCC
+[110], BCC [111], HCP [2-1-10]) and correct Kabsch alignment,
+neighbor-finding, and CoS normalization. Reimplementing them wastes
+API calls and introduces errors in template construction.
+
+**GPA strain mapping and Burgers vector tools are available.** Use
+them when the objective asks for strain fields, Burgers vectors, or
+dislocation character (edge/screw/mixed).
+
+```python
+from scilink.skills.image_analysis.crystalline_deformation.gpa_tools import compute_gpa_strain, burgers_from_gpa
+
+# Step 1: GPA strain mapping from the raw image
+# calib = pixel size in nm (get from metadata or FFT lattice spacing)
+gpa_result = compute_gpa_strain(image, calib=pixel_size_nm,
+                                 calib_units="nm", auto_spots=True)
+e_xx = gpa_result['e_xx']  # normal strain X
+e_yy = gpa_result['e_yy']  # normal strain Y
+e_th = gpa_result['e_th']  # rotation (omega_z)
+e_dg = gpa_result['e_dg']  # shear strain (epsilon_xy)
+
+# Step 2: Burgers vectors from strain maps
+# Option A — per-dislocation (if you know core positions from PTM/CoS):
+bv = burgers_from_gpa(e_xx, e_yy, e_xy=e_dg, w_z=e_th,
+                      pixel_size=pixel_size_nm,
+                      dislocation_positions=[(row, col), ...],
+                      circuit_half_width=10)
+for d in bv['burgers_vectors']:
+    print(d['b_vector'], d['b_magnitude'], d['b_direction'])
+
+# Option B — full-field (auto-detect dislocations):
+bv = burgers_from_gpa(e_xx, e_yy, e_xy=e_dg, w_z=e_th,
+                      pixel_size=pixel_size_nm,
+                      compute_field=True, field_half_width=5,
+                      field_cutoff=0.01)
+cores = bv['cores']       # (N, 2) dislocation positions
+b_field = bv['b_field']   # (Ny, Nx, 2) vector field
+b_mag = bv['b_mag']       # (Ny, Nx) magnitude map
+```
+
+**Dislocation character from Burgers vector:**
+Once you have the Burgers vector **b** and the dislocation line
+direction **t** (from the PTM boundary trace or CoS ridge):
+- Edge: b perpendicular to t (dot product ≈ 0)
+- Screw: b parallel to t (cross product ≈ 0)
+- Mixed: b has components both parallel and perpendicular to t
+- Character angle: α = arccos(|b·t| / |b||t|). α=90° → pure edge,
+  α=0° → pure screw.
+
+**GPA workflow notes:**
+- GPA needs a reference region of unstrained crystal. The auto mode
+  uses the central 25% of the image. For images with a defect at
+  center, manually specify ref_region as a slice in a defect-free area.
+- auto_spots detects Bragg peaks from FFT. If it picks wrong spots,
+  pass spot1, spot2 manually from the FFT peak positions.
+- The image does NOT need to be square — rectangular images work.
+- GPA produces strain at every pixel, not just at atom positions.
+  It complements PTM (which gives per-atom classification).
+
+Do NOT reimplement GPA (FFT masking, phase unwrapping, strain
+differentiation) or Burgers vector line integrals from scratch —
+call these tools directly.

--- a/scilink/skills/image_analysis/crystalline_deformation/crystalline_deformation.md
+++ b/scilink/skills/image_analysis/crystalline_deformation/crystalline_deformation.md
@@ -524,20 +524,20 @@ them when the objective asks for strain fields, Burgers vectors, or
 dislocation character (edge/screw/mixed).
 
 ```python
-from scilink.skills.image_analysis.crystalline_deformation.gpa_tools import compute_gpa_strain, burgers_from_gpa
+from scilink.skills._shared.strain import gpa_strain_map
+from scilink.skills.image_analysis.crystalline_deformation.gpa_tools import burgers_from_gpa
 
-# Step 1: GPA strain mapping from the raw image
-# calib = pixel size in nm (get from metadata or FFT lattice spacing)
-gpa_result = compute_gpa_strain(image, calib=pixel_size_nm,
-                                 calib_units="nm", auto_spots=True)
-e_xx = gpa_result['e_xx']  # normal strain X
-e_yy = gpa_result['e_yy']  # normal strain Y
-e_th = gpa_result['e_th']  # rotation (omega_z)
-e_dg = gpa_result['e_dg']  # shear strain (epsilon_xy)
+# Step 1: GPA strain mapping — use the SHARED, validated tool.
+gpa = gpa_strain_map(image)          # auto reflections + auto reference
+e_xx = gpa['exx']                    # normal strain X
+e_yy = gpa['eyy']                    # normal strain Y
+e_xy = gpa['exy']                    # shear strain (epsilon_xy)
+w_z  = gpa['wxy']                    # rigid rotation omega_z — use + sign as-is
+valid = gpa['valid_mask']            # exclude invalid pixels from interpretation
 
 # Step 2: Burgers vectors from strain maps
 # Option A — per-dislocation (if you know core positions from PTM/CoS):
-bv = burgers_from_gpa(e_xx, e_yy, e_xy=e_dg, w_z=e_th,
+bv = burgers_from_gpa(e_xx, e_yy, e_xy=e_xy, w_z=w_z,
                       pixel_size=pixel_size_nm,
                       dislocation_positions=[(row, col), ...],
                       circuit_half_width=10)
@@ -545,7 +545,7 @@ for d in bv['burgers_vectors']:
     print(d['b_vector'], d['b_magnitude'], d['b_direction'])
 
 # Option B — full-field (auto-detect dislocations):
-bv = burgers_from_gpa(e_xx, e_yy, e_xy=e_dg, w_z=e_th,
+bv = burgers_from_gpa(e_xx, e_yy, e_xy=e_xy, w_z=w_z,
                       pixel_size=pixel_size_nm,
                       compute_field=True, field_half_width=5,
                       field_cutoff=0.01)
@@ -553,6 +553,9 @@ cores = bv['cores']       # (N, 2) dislocation positions
 b_field = bv['b_field']   # (Ny, Nx, 2) vector field
 b_mag = bv['b_mag']       # (Ny, Nx) magnitude map
 ```
+
+Sign convention: `w_z` is `gpa_strain_map`'s `wxy` passed with the +
+sign (omega_z = 0.5*(duy/dx − dux/dy)). Do not negate it.
 
 **Dislocation character from Burgers vector:**
 Once you have the Burgers vector **b** and the dislocation line
@@ -564,11 +567,13 @@ direction **t** (from the PTM boundary trace or CoS ridge):
   α=0° → pure screw.
 
 **GPA workflow notes:**
-- GPA needs a reference region of unstrained crystal. The auto mode
-  uses the central 25% of the image. For images with a defect at
-  center, manually specify ref_region as a slice in a defect-free area.
-- auto_spots detects Bragg peaks from FFT. If it picks wrong spots,
-  pass spot1, spot2 manually from the FFT peak positions.
+- GPA needs an undistorted reference region. `gpa_strain_map`'s
+  `reference_roi="auto"` finds one; for images with a defect at center,
+  pass `reference_roi=(x, y, w, h)` in a defect-free area.
+- Reflections are auto-selected from the FFT; if the wrong pair is
+  picked, pass `reflections=[(gx1, gy1), (gx2, gy2)]` explicitly.
+- Respect `valid_mask` / `valid_fraction` in the returned dict — cores,
+  vacuum, and edges are marked invalid and must not be interpreted.
 - The image does NOT need to be square — rectangular images work.
 - GPA produces strain at every pixel, not just at atom positions.
   It complements PTM (which gives per-atom classification).

--- a/scilink/skills/image_analysis/crystalline_deformation/gpa_tools.py
+++ b/scilink/skills/image_analysis/crystalline_deformation/gpa_tools.py
@@ -1,218 +1,16 @@
-"""Geometric Phase Analysis (GPA) and Burgers vector tools.
-
-GPA extracts local strain and rotation fields from atomic-resolution
-HRTEM/STEM images by analyzing the phase of Bragg reflections in the FFT.
-
-Reference: Hytch, Snoeck & Kilaas, Ultramicroscopy 74 (1998) 131-146.
-
-Burgers vector computation via line integral of displacement gradient
-tensor beta around a dislocation core.
+"""Burgers vector tools (line integral of the displacement gradient
+tensor beta around a dislocation core).
 
 Reference: Cloete, Tarleton & Hofmann, Proc. R. Soc. A 478 (2022) 20210909.
+Ported from MATLAB (https://github.com/JacquesCloete/Burgers-Vector-Calculator).
 
-GPA code extracted from stemtool (https://github.com/stemtool/stemtools).
-Burgers vector code ported from MATLAB
-(https://github.com/JacquesCloete/Burgers-Vector-Calculator).
+Strain/rotation inputs come from the shared GPA tool
+``scilink.skills._shared.strain.gpa_strain_map`` (exx, eyy, exy, wxy) —
+this module deliberately ships no GPA implementation of its own.
 """
 
 import numpy as np
-import skimage.restoration as skr
-import scipy.ndimage as scnd
 from scipy.integrate import simpson
-
-
-# ═══════════════════════════════════════════════════════════════════
-# GPA — Geometric Phase Analysis
-# ═══════════════════════════════════════════════════════════════════
-
-def _make_circle(size_circ, center_x, center_y, radius):
-    p, q = int(size_circ[0]), int(size_circ[1])
-    yV, xV = np.mgrid[0:p, 0:q]
-    return (((yV - center_y)**2 + (xV - center_x)**2)**0.5 < radius).astype(np.float64)
-
-
-def _image_normalizer(img):
-    lo, hi = np.amin(img), np.amax(img)
-    return (img - lo) / (hi - lo) if hi != lo else np.zeros_like(img, dtype=np.float64)
-
-
-def _phase_diff(angle_image):
-    """Differentiate a wrapped phase image without wrapping artifacts."""
-    z = np.exp(1j * angle_image)
-    dx = np.zeros_like(z)
-    dx[:, :-1] = np.diff(z, axis=1)
-    dy = np.zeros_like(z)
-    dy[:-1, :] = np.diff(z, axis=0)
-    conj = np.conj(z)
-    return np.imag(conj * dx), np.imag(conj * dy)
-
-
-def _circ_to_G(circ_pos, image):
-    return np.divide(np.flip(np.asarray(circ_pos)), np.asarray(image.shape)) - 0.5
-
-
-def _G_to_circ(g_vec, image):
-    circ = np.zeros(2)
-    circ[1] = g_vec[0] * image.shape[0] + 0.5 * image.shape[0]
-    circ[0] = g_vec[1] * image.shape[1] + 0.5 * image.shape[1]
-    return circ
-
-
-def _phase_matrix(gvec, image, circ_size=0, g_blur=True):
-    """Compute real-space phase by masking around a Bragg spot in FFT."""
-    imshape = np.asarray(image.shape)
-    circ_rad = np.amin(0.01 * imshape) if circ_size == 0 else circ_size
-    yy, xx = np.mgrid[0:imshape[0], 0:imshape[1]]
-    circ_pos = np.multiply(np.flip(gvec), imshape) + 0.5 * imshape
-    circ_mask = _make_circle(imshape, circ_pos[0], circ_pos[1], circ_rad).astype(bool)
-    ham = np.sqrt(np.outer(np.hamming(imshape[0]), np.hamming(imshape[1])))
-    ft = np.fft.fftshift(np.fft.fft2(image * ham))
-
-    if g_blur:
-        sigma2 = np.sum((0.5 * gvec * imshape)**2)
-        zz = ((yy[circ_mask] - circ_pos[1])**2 + (xx[circ_mask] - circ_pos[0])**2) / sigma2
-        four_mask = np.zeros_like(yy, dtype=np.float64)
-        four_mask[circ_mask] = np.exp(-0.5 * zz)
-        return np.angle(np.fft.ifft2(four_mask * ft))
-    else:
-        return np.angle(np.fft.ifft2(circ_mask * ft))
-
-
-class _GPA:
-    """Internal GPA engine."""
-
-    def __init__(self, image, calib, calib_units="nm", ref_iter=20,
-                 use_blur=True, max_strain=0.4):
-        self.image = np.asarray(image, dtype=np.float64)
-        self.calib = calib
-        self.calib_units = calib_units
-        self.blur = use_blur
-        self.ref_iter = int(ref_iter)
-        self.imshape = np.asarray(self.image.shape)
-        self.inv_calib = 1.0 / (self.calib * self.imshape)
-        self.max_strain = max_strain
-        self._spots = False
-        self._ref = False
-        self._refined = False
-
-    def find_spots(self, circ1, circ2, circ_size=15):
-        self.circ_1 = self.imshape / 2 + np.asarray(circ1) / self.inv_calib
-        self.circ_2 = self.imshape / 2 + np.asarray(circ2) / self.inv_calib
-        self.circ_size = circ_size
-        self.gvec_1 = _circ_to_G(self.circ_1, self.image)
-        self.gvec_2 = _circ_to_G(self.circ_2, self.image)
-        self.P1 = _phase_matrix(self.gvec_1, self.image, circ_size, self.blur)
-        self.P2 = _phase_matrix(self.gvec_2, self.image, circ_size, self.blur)
-        self._spots = True
-
-    def find_spots_auto(self, n_peaks=6, min_distance=20):
-        from skimage.feature import peak_local_max
-        ham = np.sqrt(np.outer(np.hamming(self.imshape[0]), np.hamming(self.imshape[1])))
-        ft = np.fft.fftshift(np.fft.fft2(self.image * ham))
-        ps = scnd.gaussian_filter(np.log10(np.abs(ft) + 1e-10), 3)
-
-        center = self.imshape / 2
-        yy, xx = np.mgrid[0:self.imshape[0], 0:self.imshape[1]]
-        central = ((yy - center[0])**2 + (xx - center[1])**2) < min_distance**2
-        ps_m = ps.copy()
-        ps_m[central] = 0
-
-        coords = peak_local_max(ps_m, min_distance=min_distance,
-                                num_peaks=n_peaks * 2)
-        # Keep one of each Friedel pair
-        unique = []
-        for c in coords:
-            mir = 2 * center - c
-            dup = any(np.linalg.norm(u - mir) < min_distance for u in unique)
-            if not dup:
-                unique.append(c)
-            if len(unique) >= n_peaks:
-                break
-
-        if len(unique) < 2:
-            raise ValueError(f"Only {len(unique)} Bragg peaks found, need 2")
-
-        ints = [ps[c[0], c[1]] for c in unique]
-        order = np.argsort(ints)[::-1]
-        s1, s2 = unique[order[0]], unique[order[1]]
-        g1 = (s1 - center) * self.inv_calib
-        g2 = (s2 - center) * self.inv_calib
-        self.circ_size = max(min_distance // 2, 10)
-        self.find_spots(tuple(g1), tuple(g2), circ_size=self.circ_size)
-        return tuple(g1), tuple(g2)
-
-    def define_reference_rect(self, row_slice, col_slice):
-        if not self._spots:
-            raise RuntimeError("Call find_spots() first")
-        self.ref_reg = np.zeros(self.image.shape, dtype=bool)
-        self.ref_reg[row_slice, col_slice] = True
-        self._ref = True
-
-    def refine_phase(self):
-        if not self._ref:
-            raise RuntimeError("Call define_reference*() first")
-        ry = np.arange(-self.imshape[0] / 2, self.imshape[0] / 2, 1)
-        rx = np.arange(-self.imshape[1] / 2, self.imshape[1] / 2, 1)
-        Rx, Ry = np.meshgrid(rx, ry)
-
-        g1, g2 = self.gvec_1.copy(), self.gvec_2.copy()
-        P1, P2 = self.P1.copy(), self.P2.copy()
-
-        # Mask out zero-coordinate pixels to avoid divide-by-zero
-        ref_nz = self.ref_reg & (Ry != 0) & (Rx != 0)
-
-        for _ in range(self.ref_iter):
-            G1x, G1y = _phase_diff(P1)
-            G2x, G2y = _phase_diff(P2)
-            g1r = (G1x + G1y) / (2 * np.pi)
-            g2r = (G2x + G2y) / (2 * np.pi)
-            g1 += np.array([np.median(g1r[ref_nz] / Ry[ref_nz]),
-                            np.median(g1r[ref_nz] / Rx[ref_nz])])
-            g2 += np.array([np.median(g2r[ref_nz] / Ry[ref_nz]),
-                            np.median(g2r[ref_nz] / Rx[ref_nz])])
-            P1 = _phase_matrix(g1, self.image, self.circ_size, self.blur)
-            P2 = _phase_matrix(g2, self.image, self.circ_size, self.blur)
-
-        self.gvec_1_fin, self.gvec_2_fin = g1, g2
-        self.P1_fin, self.P2_fin = P1, P2
-        self._refined = True
-
-    def get_strain(self):
-        if not self._refined:
-            raise RuntimeError("Call refine_phase() first")
-
-        gm = np.zeros((2, 2))
-        gm[0, :] = np.flip(self.gvec_1_fin)
-        gm[1, :] = np.flip(self.gvec_2_fin)
-        self.a_matrix = np.linalg.inv(gm.T)
-
-        P1u = skr.unwrap_phase(self.P1_fin)
-        P2u = skr.unwrap_phase(self.P2_fin)
-
-        rolled = np.array([P1u.ravel(), P2u.ravel()])
-        u = self.a_matrix @ rolled
-        ux = u[0].reshape(P1u.shape)
-        uy = u[1].reshape(P1u.shape)
-
-        exx, exy = _phase_diff(ux)
-        eyx, eyy = _phase_diff(uy)
-        eth = 0.5 * (exy - eyx)
-        edg = 0.5 * (exy + eyx)
-
-        ref = self.ref_reg
-        for f in (exx, eyy, eth, edg):
-            f -= np.median(f[ref])
-        if self.max_strain > 0:
-            for f in (exx, eyy, eth, edg):
-                np.clip(f, -self.max_strain, self.max_strain, out=f)
-
-        self.e_xx, self.e_yy, self.e_th, self.e_dg = exx, eyy, eth, edg
-        return exx, eyy, eth, edg
-
-    def get_phase_maps(self):
-        if not self._refined:
-            raise RuntimeError("Call refine_phase() first")
-        return skr.unwrap_phase(self.P1_fin), skr.unwrap_phase(self.P2_fin)
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -231,15 +29,22 @@ def _strains_to_beta_2d(e_xx, e_yy, e_xy, w_z):
 
 
 def _line_integral(beta, interval):
-    """Burgers vector via rectangular line integral (Simpson's rule)."""
+    """Burgers vector via rectangular line integral (Simpson's rule).
+
+    Closed circulation requires the horizontal-edge pair to enter as
+    (top − bottom) alongside (right − left). Verified against an analytic
+    edge-dislocation field with known |b| — see
+    tests/test_crystalline_deformation_gpa.py; flipping either pair of
+    signs breaks |b| in a Poisson-ratio-dependent (non-calibratable) way.
+    """
     Ny, Nx = beta.shape[:2]
     xv = np.arange(Nx) * interval
     yv = np.arange(Ny) * interval
     b = np.zeros(2)
     for i in range(2):
-        b[i] = (-simpson(y=beta[0, :, i, 0], x=xv)
+        b[i] = (+simpson(y=beta[0, :, i, 0], x=xv)
                 - simpson(y=beta[:, 0, i, 1], x=yv)
-                + simpson(y=beta[-1, :, i, 0], x=xv)
+                - simpson(y=beta[-1, :, i, 0], x=xv)
                 + simpson(y=beta[:, -1, i, 1], x=yv))
     return b
 
@@ -298,75 +103,6 @@ def _find_cores(b_mag, threshold_factor=3.0, min_distance=5):
 # Public API
 # ═══════════════════════════════════════════════════════════════════
 
-def compute_gpa_strain(image, calib, calib_units="nm",
-                       spot1=None, spot2=None,
-                       ref_region=None,
-                       circ_size=15, ref_iter=20, max_strain=0.4,
-                       auto_spots=True, auto_ref_fraction=0.25):
-    """One-call GPA strain computation.
-
-    Parameters
-    ----------
-    image : 2-D ndarray
-        Atomic-resolution HRTEM or STEM image.
-    calib : float
-        Pixel size in physical units.
-    calib_units : str
-        Unit of calibration (default "nm").
-    spot1, spot2 : tuple or None
-        Bragg spot positions in inverse-length units.  If None and
-        auto_spots is True, spots are detected automatically.
-    ref_region : tuple of 2 slices, or None
-        Reference region as ``(slice(r0, r1), slice(c0, c1))`` in pixel
-        coordinates.  If None, a central patch is used.
-    circ_size : float
-        Aperture radius in FFT pixels.
-    ref_iter : int
-        Number of g-vector refinement iterations.
-    max_strain : float
-        Clamp strain maps to [-max_strain, max_strain].
-    auto_spots : bool
-        Auto-detect Bragg spots when spot1/spot2 are None.
-    auto_ref_fraction : float
-        Fraction of image to use as reference when ref_region is None.
-
-    Returns
-    -------
-    dict with keys:
-        'e_xx', 'e_yy', 'e_th', 'e_dg' : 2-D ndarrays (strain maps)
-        'P1', 'P2' : 2-D ndarrays (unwrapped phase maps)
-        'gpa' : the internal GPA object
-    """
-    gpa = _GPA(image, calib, calib_units,
-               ref_iter=ref_iter, max_strain=max_strain)
-
-    if spot1 is not None and spot2 is not None:
-        gpa.find_spots(spot1, spot2, circ_size=circ_size)
-    elif auto_spots:
-        gpa.find_spots_auto()
-    else:
-        raise ValueError("Provide spot1/spot2 or set auto_spots=True")
-
-    if ref_region is not None:
-        gpa.define_reference_rect(*ref_region)
-    else:
-        ny, nx = image.shape
-        f = auto_ref_fraction
-        r0, r1 = int(ny * (0.5 - f / 2)), int(ny * (0.5 + f / 2))
-        c0, c1 = int(nx * (0.5 - f / 2)), int(nx * (0.5 + f / 2))
-        gpa.define_reference_rect(slice(r0, r1), slice(c0, c1))
-
-    gpa.refine_phase()
-    exx, eyy, eth, edg = gpa.get_strain()
-    P1, P2 = gpa.get_phase_maps()
-
-    return {
-        'e_xx': exx, 'e_yy': eyy, 'e_th': eth, 'e_dg': edg,
-        'P1': P1, 'P2': P2,
-        'gpa': gpa,
-    }
-
-
 def burgers_from_gpa(e_xx, e_yy, e_xy, w_z, pixel_size,
                      dislocation_positions=None, circuit_half_width=10,
                      n_shrink=3, compute_field=False, field_half_width=3,
@@ -378,9 +114,12 @@ def burgers_from_gpa(e_xx, e_yy, e_xy, w_z, pixel_size,
     e_xx, e_yy : 2-D ndarray
         Normal strain maps from GPA.
     e_xy : 2-D ndarray
-        Shear strain — this is 'e_dg' from compute_gpa_strain.
+        Shear strain — pass ``exy`` from
+        ``scilink.skills._shared.strain.gpa_strain_map``.
     w_z : 2-D ndarray
-        Rotation — this is 'e_th' from compute_gpa_strain.
+        Rigid rotation omega_z = 0.5*(duy/dx - dux/dy) — pass
+        ``gpa_strain_map``'s ``wxy`` WITH THE + SIGN (note: the legacy
+        e_th convention had the opposite sign).
     pixel_size : float
         Physical pixel size in consistent units (nm or m).
     dislocation_positions : list of (row, col) or None
@@ -448,29 +187,13 @@ from scilink.skills._shared._spec import ToolSpec
 
 TOOL_SPECS = [
     ToolSpec(
-        name="compute_gpa_strain",
-        description=(
-            "One-call Geometric Phase Analysis: full-field strain tensor maps "
-            "(e_xx, e_yy, shear e_dg, rotation e_th) from an atomic-resolution "
-            "image via FFT Bragg-spot phase analysis. ONLY valid on "
-            "single-grain, single-phase images — see skill guidance for the "
-            "validity gate (never on bicrystals/twin boundaries)."
-        ),
-        import_line="from scilink.skills.image_analysis.crystalline_deformation.gpa_tools import compute_gpa_strain",
-        signature=(
-            "compute_gpa_strain(image, calib, calib_units='nm', spot1=None, spot2=None, "
-            "ref_region=None, circ_size=15, ref_iter=20, max_strain=0.4, "
-            "auto_spots=True, auto_ref_fraction=0.25)"
-        ),
-        returns="dict: e_xx, e_yy, e_th (rotation), e_dg (shear), spots, ref_region",
-    ),
-    ToolSpec(
         name="burgers_from_gpa",
         description=(
             "Burgers vectors from GPA strain/rotation maps via line-integral "
             "circuits: per-dislocation (given core positions) or full-field "
             "auto-detection of dislocation cores with a Burgers vector field. "
-            "Feed cores from PTM/CoS analysis when available."
+            "Feed strain/rotation from the shared gpa_strain_map tool "
+            "(e_xy=exy, w_z=+wxy) and cores from PTM/CoS analysis when available."
         ),
         import_line="from scilink.skills.image_analysis.crystalline_deformation.gpa_tools import burgers_from_gpa",
         signature=(

--- a/scilink/skills/image_analysis/crystalline_deformation/gpa_tools.py
+++ b/scilink/skills/image_analysis/crystalline_deformation/gpa_tools.py
@@ -1,0 +1,483 @@
+"""Geometric Phase Analysis (GPA) and Burgers vector tools.
+
+GPA extracts local strain and rotation fields from atomic-resolution
+HRTEM/STEM images by analyzing the phase of Bragg reflections in the FFT.
+
+Reference: Hytch, Snoeck & Kilaas, Ultramicroscopy 74 (1998) 131-146.
+
+Burgers vector computation via line integral of displacement gradient
+tensor beta around a dislocation core.
+
+Reference: Cloete, Tarleton & Hofmann, Proc. R. Soc. A 478 (2022) 20210909.
+
+GPA code extracted from stemtool (https://github.com/stemtool/stemtools).
+Burgers vector code ported from MATLAB
+(https://github.com/JacquesCloete/Burgers-Vector-Calculator).
+"""
+
+import numpy as np
+import skimage.restoration as skr
+import scipy.ndimage as scnd
+from scipy.integrate import simpson
+
+
+# ═══════════════════════════════════════════════════════════════════
+# GPA — Geometric Phase Analysis
+# ═══════════════════════════════════════════════════════════════════
+
+def _make_circle(size_circ, center_x, center_y, radius):
+    p, q = int(size_circ[0]), int(size_circ[1])
+    yV, xV = np.mgrid[0:p, 0:q]
+    return (((yV - center_y)**2 + (xV - center_x)**2)**0.5 < radius).astype(np.float64)
+
+
+def _image_normalizer(img):
+    lo, hi = np.amin(img), np.amax(img)
+    return (img - lo) / (hi - lo) if hi != lo else np.zeros_like(img, dtype=np.float64)
+
+
+def _phase_diff(angle_image):
+    """Differentiate a wrapped phase image without wrapping artifacts."""
+    z = np.exp(1j * angle_image)
+    dx = np.zeros_like(z)
+    dx[:, :-1] = np.diff(z, axis=1)
+    dy = np.zeros_like(z)
+    dy[:-1, :] = np.diff(z, axis=0)
+    conj = np.conj(z)
+    return np.imag(conj * dx), np.imag(conj * dy)
+
+
+def _circ_to_G(circ_pos, image):
+    return np.divide(np.flip(np.asarray(circ_pos)), np.asarray(image.shape)) - 0.5
+
+
+def _G_to_circ(g_vec, image):
+    circ = np.zeros(2)
+    circ[1] = g_vec[0] * image.shape[0] + 0.5 * image.shape[0]
+    circ[0] = g_vec[1] * image.shape[1] + 0.5 * image.shape[1]
+    return circ
+
+
+def _phase_matrix(gvec, image, circ_size=0, g_blur=True):
+    """Compute real-space phase by masking around a Bragg spot in FFT."""
+    imshape = np.asarray(image.shape)
+    circ_rad = np.amin(0.01 * imshape) if circ_size == 0 else circ_size
+    yy, xx = np.mgrid[0:imshape[0], 0:imshape[1]]
+    circ_pos = np.multiply(np.flip(gvec), imshape) + 0.5 * imshape
+    circ_mask = _make_circle(imshape, circ_pos[0], circ_pos[1], circ_rad).astype(bool)
+    ham = np.sqrt(np.outer(np.hamming(imshape[0]), np.hamming(imshape[1])))
+    ft = np.fft.fftshift(np.fft.fft2(image * ham))
+
+    if g_blur:
+        sigma2 = np.sum((0.5 * gvec * imshape)**2)
+        zz = ((yy[circ_mask] - circ_pos[1])**2 + (xx[circ_mask] - circ_pos[0])**2) / sigma2
+        four_mask = np.zeros_like(yy, dtype=np.float64)
+        four_mask[circ_mask] = np.exp(-0.5 * zz)
+        return np.angle(np.fft.ifft2(four_mask * ft))
+    else:
+        return np.angle(np.fft.ifft2(circ_mask * ft))
+
+
+class _GPA:
+    """Internal GPA engine."""
+
+    def __init__(self, image, calib, calib_units="nm", ref_iter=20,
+                 use_blur=True, max_strain=0.4):
+        self.image = np.asarray(image, dtype=np.float64)
+        self.calib = calib
+        self.calib_units = calib_units
+        self.blur = use_blur
+        self.ref_iter = int(ref_iter)
+        self.imshape = np.asarray(self.image.shape)
+        self.inv_calib = 1.0 / (self.calib * self.imshape)
+        self.max_strain = max_strain
+        self._spots = False
+        self._ref = False
+        self._refined = False
+
+    def find_spots(self, circ1, circ2, circ_size=15):
+        self.circ_1 = self.imshape / 2 + np.asarray(circ1) / self.inv_calib
+        self.circ_2 = self.imshape / 2 + np.asarray(circ2) / self.inv_calib
+        self.circ_size = circ_size
+        self.gvec_1 = _circ_to_G(self.circ_1, self.image)
+        self.gvec_2 = _circ_to_G(self.circ_2, self.image)
+        self.P1 = _phase_matrix(self.gvec_1, self.image, circ_size, self.blur)
+        self.P2 = _phase_matrix(self.gvec_2, self.image, circ_size, self.blur)
+        self._spots = True
+
+    def find_spots_auto(self, n_peaks=6, min_distance=20):
+        from skimage.feature import peak_local_max
+        ham = np.sqrt(np.outer(np.hamming(self.imshape[0]), np.hamming(self.imshape[1])))
+        ft = np.fft.fftshift(np.fft.fft2(self.image * ham))
+        ps = scnd.gaussian_filter(np.log10(np.abs(ft) + 1e-10), 3)
+
+        center = self.imshape / 2
+        yy, xx = np.mgrid[0:self.imshape[0], 0:self.imshape[1]]
+        central = ((yy - center[0])**2 + (xx - center[1])**2) < min_distance**2
+        ps_m = ps.copy()
+        ps_m[central] = 0
+
+        coords = peak_local_max(ps_m, min_distance=min_distance,
+                                num_peaks=n_peaks * 2)
+        # Keep one of each Friedel pair
+        unique = []
+        for c in coords:
+            mir = 2 * center - c
+            dup = any(np.linalg.norm(u - mir) < min_distance for u in unique)
+            if not dup:
+                unique.append(c)
+            if len(unique) >= n_peaks:
+                break
+
+        if len(unique) < 2:
+            raise ValueError(f"Only {len(unique)} Bragg peaks found, need 2")
+
+        ints = [ps[c[0], c[1]] for c in unique]
+        order = np.argsort(ints)[::-1]
+        s1, s2 = unique[order[0]], unique[order[1]]
+        g1 = (s1 - center) * self.inv_calib
+        g2 = (s2 - center) * self.inv_calib
+        self.circ_size = max(min_distance // 2, 10)
+        self.find_spots(tuple(g1), tuple(g2), circ_size=self.circ_size)
+        return tuple(g1), tuple(g2)
+
+    def define_reference_rect(self, row_slice, col_slice):
+        if not self._spots:
+            raise RuntimeError("Call find_spots() first")
+        self.ref_reg = np.zeros(self.image.shape, dtype=bool)
+        self.ref_reg[row_slice, col_slice] = True
+        self._ref = True
+
+    def refine_phase(self):
+        if not self._ref:
+            raise RuntimeError("Call define_reference*() first")
+        ry = np.arange(-self.imshape[0] / 2, self.imshape[0] / 2, 1)
+        rx = np.arange(-self.imshape[1] / 2, self.imshape[1] / 2, 1)
+        Rx, Ry = np.meshgrid(rx, ry)
+
+        g1, g2 = self.gvec_1.copy(), self.gvec_2.copy()
+        P1, P2 = self.P1.copy(), self.P2.copy()
+
+        # Mask out zero-coordinate pixels to avoid divide-by-zero
+        ref_nz = self.ref_reg & (Ry != 0) & (Rx != 0)
+
+        for _ in range(self.ref_iter):
+            G1x, G1y = _phase_diff(P1)
+            G2x, G2y = _phase_diff(P2)
+            g1r = (G1x + G1y) / (2 * np.pi)
+            g2r = (G2x + G2y) / (2 * np.pi)
+            g1 += np.array([np.median(g1r[ref_nz] / Ry[ref_nz]),
+                            np.median(g1r[ref_nz] / Rx[ref_nz])])
+            g2 += np.array([np.median(g2r[ref_nz] / Ry[ref_nz]),
+                            np.median(g2r[ref_nz] / Rx[ref_nz])])
+            P1 = _phase_matrix(g1, self.image, self.circ_size, self.blur)
+            P2 = _phase_matrix(g2, self.image, self.circ_size, self.blur)
+
+        self.gvec_1_fin, self.gvec_2_fin = g1, g2
+        self.P1_fin, self.P2_fin = P1, P2
+        self._refined = True
+
+    def get_strain(self):
+        if not self._refined:
+            raise RuntimeError("Call refine_phase() first")
+
+        gm = np.zeros((2, 2))
+        gm[0, :] = np.flip(self.gvec_1_fin)
+        gm[1, :] = np.flip(self.gvec_2_fin)
+        self.a_matrix = np.linalg.inv(gm.T)
+
+        P1u = skr.unwrap_phase(self.P1_fin)
+        P2u = skr.unwrap_phase(self.P2_fin)
+
+        rolled = np.array([P1u.ravel(), P2u.ravel()])
+        u = self.a_matrix @ rolled
+        ux = u[0].reshape(P1u.shape)
+        uy = u[1].reshape(P1u.shape)
+
+        exx, exy = _phase_diff(ux)
+        eyx, eyy = _phase_diff(uy)
+        eth = 0.5 * (exy - eyx)
+        edg = 0.5 * (exy + eyx)
+
+        ref = self.ref_reg
+        for f in (exx, eyy, eth, edg):
+            f -= np.median(f[ref])
+        if self.max_strain > 0:
+            for f in (exx, eyy, eth, edg):
+                np.clip(f, -self.max_strain, self.max_strain, out=f)
+
+        self.e_xx, self.e_yy, self.e_th, self.e_dg = exx, eyy, eth, edg
+        return exx, eyy, eth, edg
+
+    def get_phase_maps(self):
+        if not self._refined:
+            raise RuntimeError("Call refine_phase() first")
+        return skr.unwrap_phase(self.P1_fin), skr.unwrap_phase(self.P2_fin)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Burgers vector computation
+# ═══════════════════════════════════════════════════════════════════
+
+def _strains_to_beta_2d(e_xx, e_yy, e_xy, w_z):
+    """Convert 2D strain + rotation to displacement gradient beta."""
+    Ny, Nx = e_xx.shape
+    beta = np.zeros((Ny, Nx, 2, 2), dtype=np.float64)
+    beta[:, :, 0, 0] = e_xx
+    beta[:, :, 0, 1] = e_xy - w_z
+    beta[:, :, 1, 0] = e_xy + w_z
+    beta[:, :, 1, 1] = e_yy
+    return beta
+
+
+def _line_integral(beta, interval):
+    """Burgers vector via rectangular line integral (Simpson's rule)."""
+    Ny, Nx = beta.shape[:2]
+    xv = np.arange(Nx) * interval
+    yv = np.arange(Ny) * interval
+    b = np.zeros(2)
+    for i in range(2):
+        b[i] = (-simpson(y=beta[0, :, i, 0], x=xv)
+                - simpson(y=beta[:, 0, i, 1], x=yv)
+                + simpson(y=beta[-1, :, i, 0], x=xv)
+                + simpson(y=beta[:, -1, i, 1], x=yv))
+    return b
+
+
+def _line_integral_repeated(beta, interval, n_shrink=3):
+    """Averaged Burgers vector from concentric shrinking circuits."""
+    Ny, Nx = beta.shape[:2]
+    results = []
+    for m in range(n_shrink + 1):
+        if 2 * m >= Ny - 2 or 2 * m >= Nx - 2:
+            break
+        sub = beta[m:Ny - m, m:Nx - m, :, :] if m > 0 else beta
+        results.append(_line_integral(sub, interval))
+    if not results:
+        return np.zeros(2), np.empty((0, 2))
+    b_all = np.array(results)
+    mags = np.linalg.norm(b_all, axis=1)
+    if len(mags) > 2:
+        med = np.median(mags)
+        inlier = np.abs(mags - med) < 1.5 * np.std(mags)
+        b_mean = np.mean(b_all[inlier], axis=0) if inlier.any() else np.mean(b_all, axis=0)
+    else:
+        b_mean = np.mean(b_all, axis=0)
+    return b_mean, b_all
+
+
+def _compute_burgers_field(beta, interval, half_width=3, cutoff=None):
+    """Sliding-window Burgers vector at every pixel."""
+    Ny, Nx = beta.shape[:2]
+    b_field = np.zeros((Ny, Nx, 2))
+    hw = half_width
+    for j in range(hw, Ny - hw):
+        for i in range(hw, Nx - hw):
+            sub = beta[j - hw:j + hw + 1, i - hw:i + hw + 1, :, :]
+            b_field[j, i] = _line_integral(sub, interval)
+    b_mag = np.linalg.norm(b_field, axis=2)
+    if cutoff is not None:
+        mask = b_mag < cutoff
+        b_field[mask] = 0.0
+        b_mag[mask] = 0.0
+    return b_field, b_mag
+
+
+def _find_cores(b_mag, threshold_factor=3.0, min_distance=5):
+    """Locate dislocation cores as peaks in |b| field."""
+    from skimage.feature import peak_local_max
+    nz = b_mag[b_mag > 0]
+    if len(nz) == 0:
+        return np.empty((0, 2), dtype=int)
+    threshold = threshold_factor * np.median(nz)
+    return peak_local_max(b_mag, min_distance=min_distance,
+                          threshold_abs=threshold)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Public API
+# ═══════════════════════════════════════════════════════════════════
+
+def compute_gpa_strain(image, calib, calib_units="nm",
+                       spot1=None, spot2=None,
+                       ref_region=None,
+                       circ_size=15, ref_iter=20, max_strain=0.4,
+                       auto_spots=True, auto_ref_fraction=0.25):
+    """One-call GPA strain computation.
+
+    Parameters
+    ----------
+    image : 2-D ndarray
+        Atomic-resolution HRTEM or STEM image.
+    calib : float
+        Pixel size in physical units.
+    calib_units : str
+        Unit of calibration (default "nm").
+    spot1, spot2 : tuple or None
+        Bragg spot positions in inverse-length units.  If None and
+        auto_spots is True, spots are detected automatically.
+    ref_region : tuple of 2 slices, or None
+        Reference region as ``(slice(r0, r1), slice(c0, c1))`` in pixel
+        coordinates.  If None, a central patch is used.
+    circ_size : float
+        Aperture radius in FFT pixels.
+    ref_iter : int
+        Number of g-vector refinement iterations.
+    max_strain : float
+        Clamp strain maps to [-max_strain, max_strain].
+    auto_spots : bool
+        Auto-detect Bragg spots when spot1/spot2 are None.
+    auto_ref_fraction : float
+        Fraction of image to use as reference when ref_region is None.
+
+    Returns
+    -------
+    dict with keys:
+        'e_xx', 'e_yy', 'e_th', 'e_dg' : 2-D ndarrays (strain maps)
+        'P1', 'P2' : 2-D ndarrays (unwrapped phase maps)
+        'gpa' : the internal GPA object
+    """
+    gpa = _GPA(image, calib, calib_units,
+               ref_iter=ref_iter, max_strain=max_strain)
+
+    if spot1 is not None and spot2 is not None:
+        gpa.find_spots(spot1, spot2, circ_size=circ_size)
+    elif auto_spots:
+        gpa.find_spots_auto()
+    else:
+        raise ValueError("Provide spot1/spot2 or set auto_spots=True")
+
+    if ref_region is not None:
+        gpa.define_reference_rect(*ref_region)
+    else:
+        ny, nx = image.shape
+        f = auto_ref_fraction
+        r0, r1 = int(ny * (0.5 - f / 2)), int(ny * (0.5 + f / 2))
+        c0, c1 = int(nx * (0.5 - f / 2)), int(nx * (0.5 + f / 2))
+        gpa.define_reference_rect(slice(r0, r1), slice(c0, c1))
+
+    gpa.refine_phase()
+    exx, eyy, eth, edg = gpa.get_strain()
+    P1, P2 = gpa.get_phase_maps()
+
+    return {
+        'e_xx': exx, 'e_yy': eyy, 'e_th': eth, 'e_dg': edg,
+        'P1': P1, 'P2': P2,
+        'gpa': gpa,
+    }
+
+
+def burgers_from_gpa(e_xx, e_yy, e_xy, w_z, pixel_size,
+                     dislocation_positions=None, circuit_half_width=10,
+                     n_shrink=3, compute_field=False, field_half_width=3,
+                     field_cutoff=None):
+    """Compute Burgers vectors from GPA strain/rotation maps.
+
+    Parameters
+    ----------
+    e_xx, e_yy : 2-D ndarray
+        Normal strain maps from GPA.
+    e_xy : 2-D ndarray
+        Shear strain — this is 'e_dg' from compute_gpa_strain.
+    w_z : 2-D ndarray
+        Rotation — this is 'e_th' from compute_gpa_strain.
+    pixel_size : float
+        Physical pixel size in consistent units (nm or m).
+    dislocation_positions : list of (row, col) or None
+        Known dislocation core positions (pixel coords).  For each,
+        a Burgers circuit is placed around the core.
+    circuit_half_width : int
+        Half-width of circuit in pixels for per-dislocation mode.
+    n_shrink : int
+        Number of concentric shrinking circuits for averaging.
+    compute_field : bool
+        If True, compute full-field Burgers vector map.
+    field_half_width : int
+        Half-width for sliding circuit in field mode.
+    field_cutoff : float or None
+        Magnitude cutoff for noise filtering in field mode.
+
+    Returns
+    -------
+    dict with keys:
+        'beta' : (Ny, Nx, 2, 2) displacement gradient tensor
+        'burgers_vectors' : list of dicts (if dislocation_positions given)
+            each with 'position', 'b_vector', 'b_magnitude', 'b_direction'
+        'b_field' : (Ny, Nx, 2) vector field (if compute_field)
+        'b_mag' : (Ny, Nx) magnitude field (if compute_field)
+        'cores' : (N, 2) auto-detected core positions (if compute_field)
+    """
+    beta = _strains_to_beta_2d(e_xx, e_yy, e_xy, w_z)
+    interval = pixel_size
+    result = {'beta': beta}
+
+    if dislocation_positions is not None:
+        Ny, Nx = e_xx.shape
+        bvecs = []
+        hw = circuit_half_width
+        for pos in dislocation_positions:
+            r, c = int(pos[0]), int(pos[1])
+            r0, r1 = max(0, r - hw), min(Ny, r + hw + 1)
+            c0, c1 = max(0, c - hw), min(Nx, c + hw + 1)
+            sub = beta[r0:r1, c0:c1, :, :]
+            if sub.shape[0] < 3 or sub.shape[1] < 3:
+                continue
+            b_mean, _ = _line_integral_repeated(sub, interval, n_shrink)
+            mag = np.linalg.norm(b_mean)
+            bvecs.append({
+                'position': (r, c),
+                'b_vector': b_mean,
+                'b_magnitude': mag,
+                'b_direction': b_mean / mag if mag > 0 else np.zeros(2),
+            })
+        result['burgers_vectors'] = bvecs
+
+    if compute_field or dislocation_positions is None:
+        b_field, b_mag = _compute_burgers_field(
+            beta, interval, half_width=field_half_width, cutoff=field_cutoff)
+        result['b_field'] = b_field
+        result['b_mag'] = b_mag
+        result['cores'] = _find_cores(b_mag)
+
+    return result
+
+
+# ── Tool registry specs: auto-discovered by scilink.skills._shared._registry
+#    when the crystalline_deformation bundle is active ───────────────────────
+from scilink.skills._shared._spec import ToolSpec
+
+TOOL_SPECS = [
+    ToolSpec(
+        name="compute_gpa_strain",
+        description=(
+            "One-call Geometric Phase Analysis: full-field strain tensor maps "
+            "(e_xx, e_yy, shear e_dg, rotation e_th) from an atomic-resolution "
+            "image via FFT Bragg-spot phase analysis. ONLY valid on "
+            "single-grain, single-phase images — see skill guidance for the "
+            "validity gate (never on bicrystals/twin boundaries)."
+        ),
+        import_line="from scilink.skills.image_analysis.crystalline_deformation.gpa_tools import compute_gpa_strain",
+        signature=(
+            "compute_gpa_strain(image, calib, calib_units='nm', spot1=None, spot2=None, "
+            "ref_region=None, circ_size=15, ref_iter=20, max_strain=0.4, "
+            "auto_spots=True, auto_ref_fraction=0.25)"
+        ),
+        returns="dict: e_xx, e_yy, e_th (rotation), e_dg (shear), spots, ref_region",
+    ),
+    ToolSpec(
+        name="burgers_from_gpa",
+        description=(
+            "Burgers vectors from GPA strain/rotation maps via line-integral "
+            "circuits: per-dislocation (given core positions) or full-field "
+            "auto-detection of dislocation cores with a Burgers vector field. "
+            "Feed cores from PTM/CoS analysis when available."
+        ),
+        import_line="from scilink.skills.image_analysis.crystalline_deformation.gpa_tools import burgers_from_gpa",
+        signature=(
+            "burgers_from_gpa(e_xx, e_yy, e_xy, w_z, pixel_size, "
+            "dislocation_positions=None, circuit_half_width=10, n_shrink=3, "
+            "compute_field=False, field_half_width=3, field_cutoff=None)"
+        ),
+        returns="dict: burgers_vectors (per-dislocation) or cores/b_field/b_mag (full-field)",
+    ),
+]

--- a/scilink/skills/image_analysis/crystalline_deformation/ptm_tools.py
+++ b/scilink/skills/image_analysis/crystalline_deformation/ptm_tools.py
@@ -1,0 +1,590 @@
+"""2D Polyhedral Template Matching and Center of Symmetry tools.
+
+PTM algorithm based on Britton & Medlin, Materials Characterization 213
+(2024) 114017 (https://github.com/sandialabs/2D-PTM). Classifies each
+atom's local neighbor environment against ideal crystal structure
+templates using Kabsch-aligned RMSD with optimal point correspondence.
+
+Center of Symmetry uses a robust anti-parallel partner search rather
+than fixed i/i+3 pairing, following Mukhopadhyay's implementation.
+
+Both tools take only (x, y) atom positions as input.
+"""
+
+import numpy as np
+from scipy.spatial import Delaunay, ConvexHull
+
+
+# ── Templates ──────────────────────────────────────────────
+# Ideal 7-point motifs (centroid + 6 neighbors) for each structure.
+# Defined analytically from lattice parameters following Britton & Medlin.
+
+def _fcc_110_template(a=1.0):
+    """FCC viewed along [110]. Regular hexagonal projected pattern."""
+    s6 = np.sqrt(6)
+    s3 = np.sqrt(3)
+    return np.array([
+        [0, 0],
+        [a * s6 / 4, 0],
+        [a / s6, a / s3],
+        [-a * s6 / 12, a / s3],
+        [-a * s6 / 4, 0],
+        [-a / s6, -a / s3],
+        [a * s6 / 12, -a / s3],
+    ])
+
+
+def _bcc_111_template(a_fcc=1.0):
+    """BCC viewed along [111]. Lattice parameter scaled to FCC close-packed."""
+    a = a_fcc * np.sqrt(6) / 3
+    s6 = np.sqrt(6)
+    s2 = np.sqrt(2)
+    return np.array([
+        [0, 0],
+        [a * s6 / 3, 0],
+        [a * s6 / 6, a * s2 / 2],
+        [-a * s6 / 6, a * s2 / 2],
+        [-a * s6 / 3, 0],
+        [-a * s6 / 6, -a * s2 / 2],
+        [a * s6 / 6, -a * s2 / 2],
+    ])
+
+
+def _hcp_2110_template(a_fcc=1.0):
+    """HCP viewed along [2-1-10]. Lattice parameter scaled to FCC."""
+    a = a_fcc / np.sqrt(2)
+    s3 = np.sqrt(3)
+    s6 = np.sqrt(6)
+    return np.array([
+        [0, 0],
+        [a * s3 / 2, 0],
+        [a * s3 / 6, a * s6 / 3],
+        [-a * s3 / 3, a * s6 / 3],
+        [-a * s3 / 2, 0],
+        [-a * s3 / 3, -a * s6 / 3],
+        [a * s3 / 6, -a * s6 / 3],
+    ])
+
+
+DEFAULT_TEMPLATES = {
+    "FCC": _fcc_110_template,
+    "BCC": _bcc_111_template,
+    "HCP": _hcp_2110_template,
+}
+
+STRUCTURE_CODES = {"FCC": 1, "BCC": 2, "HCP": 3}
+
+
+# ── Kabsch alignment ──────────────────────────────────────
+
+def _kabsch_2d(P, Q):
+    """Kabsch algorithm for 2D point sets. Returns rotation matrix."""
+    P_c = P - P.mean(axis=0)
+    Q_c = Q - Q.mean(axis=0)
+    H = P_c.T @ Q_c
+    U, _, Vt = np.linalg.svd(H)
+    d = np.linalg.det(Vt.T @ U.T)
+    S = np.diag([1.0, np.sign(d)])
+    R = Vt.T @ S @ U.T
+    return R
+
+
+def _scaled_rmsd(v, w):
+    """Compute scaled RMSD between experimental points v and template w.
+
+    Following Britton & Medlin RMSD.m:
+    - s = sqrt(sum||w-wbar||² / sum||v-vbar||²) scales v to template size
+    - R = Kabsch rotation aligning template w onto experimental v
+    - residual = s*(v_i - vbar) - (R @ (w_i - wbar))
+
+    Returns (rmsd, scale_factor, rotation_matrix).
+    """
+    N = len(v)
+    v_bar = v.mean(axis=0)
+    w_bar = w.mean(axis=0)
+
+    v_c = v - v_bar
+    w_c = w - w_bar
+
+    sv = np.sum(np.linalg.norm(v_c, axis=1) ** 2)
+    sw = np.sum(np.linalg.norm(w_c, axis=1) ** 2)
+    s = np.sqrt(sw / sv) if sv > 1e-15 else 1.0
+
+    # Kabsch: find R that rotates w_c onto s*v_c  →  H = P^T @ Q where P=w_c, Q=s*v_c
+    H = w_c.T @ (s * v_c)
+    U, _, Vt = np.linalg.svd(H)
+    d = np.linalg.det(Vt.T @ U.T)
+    S = np.diag([1.0, np.sign(d)])
+    R = Vt.T @ S @ U.T
+
+    # Residual: s*v_centered - R @ w_centered
+    rotated_w = (R @ w_c.T).T
+    residuals = s * v_c - rotated_w
+    rmsd = np.sqrt(np.sum(residuals ** 2) / N)
+    return rmsd, s, R
+
+
+# ── Neighbor finding ──────────────────────────────────────
+
+def _find_neighbors_delaunay(positions):
+    """Build neighbor lists from Delaunay triangulation.
+
+    Returns dict mapping atom index to list of neighbor indices.
+    """
+    tri = Delaunay(positions)
+    neighbors = {i: set() for i in range(len(positions))}
+    for simplex in tri.simplices:
+        for i in range(3):
+            for j in range(i + 1, 3):
+                neighbors[simplex[i]].add(simplex[j])
+                neighbors[simplex[j]].add(simplex[i])
+    return neighbors
+
+
+def _get_6nn_sorted(center, all_neighbor_positions):
+    """Select 6 closest neighbors and sort angularly around center.
+
+    If Delaunay gives more than 6 neighbors, keep only the 6 nearest.
+    Returns (7, 2) array: center + 6 sorted neighbors, or None if < 6.
+    """
+    dists = np.linalg.norm(all_neighbor_positions - center, axis=1)
+    if len(dists) < 6:
+        return None
+    closest_idx = np.argsort(dists)[:6]
+    nn6 = all_neighbor_positions[closest_idx]
+    vecs = nn6 - center
+    angles = np.arctan2(vecs[:, 1], vecs[:, 0])
+    order = np.argsort(angles)
+    return np.vstack([center.reshape(1, 2), nn6[order]])
+
+
+# ── Per-atom PTM classification ───────────────────────────
+
+def _classify_atom(sorted_points, templates, threshold):
+    """Classify a single atom by testing all templates with circular permutations.
+
+    Following Britton & Medlin: try all 6 cyclic permutations of the
+    neighbor ordering for each template, pick the best Kabsch-aligned RMSD.
+
+    Args:
+        sorted_points: (7, 2) array — center + 6 angularly-sorted neighbors.
+        templates: dict of {name: (7, 2) template array}.
+        threshold: max RMSD for valid classification.
+
+    Returns:
+        (label, rmsd, angle_deg, scale_factor)
+    """
+    best_rmsd = np.inf
+    best_label = "unidentified"
+    best_angle = np.nan
+    best_scale = np.nan
+
+    # Center at origin
+    center = sorted_points[0]
+    pts = sorted_points - center
+    neighbors = pts[1:]  # (6, 2)
+    N = len(neighbors)
+
+    for name, tmpl in templates.items():
+        tmpl_c = tmpl - tmpl[0]
+
+        for shift in range(N):
+            perm = np.roll(neighbors, shift, axis=0)
+            v = np.vstack([pts[0:1], perm])
+
+            rmsd, s, R = _scaled_rmsd(v, tmpl_c)
+
+            if rmsd < best_rmsd:
+                best_rmsd = rmsd
+                if rmsd < threshold:
+                    best_label = name
+                    best_scale = s
+                    # Extract rotation angle
+                    cos_val = np.clip(R[0, 0], -1.0, 1.0)
+                    angle = np.degrees(np.arctan2(R[1, 0], cos_val))
+                    if angle < 0:
+                        angle += 180.0
+                    best_angle = angle
+
+    if best_label == "unidentified":
+        best_rmsd = np.nan
+        best_angle = np.nan
+        best_scale = np.nan
+
+    return best_label, best_rmsd, best_angle, best_scale
+
+
+# ── Center of Symmetry ────────────────────────────────────
+
+def _compute_cos_single(center, neighbor_positions):
+    """Compute Center of Symmetry for one atom.
+
+    Uses robust anti-parallel partner search: for each bond vector j,
+    find D[j] = min_i(||bond_i + bond_j||). Then:
+        M = sum(D² / 2) / (2 * sum(||bond||²))
+
+    M = 0 is perfectly centrosymmetric. M > 0 indicates broken symmetry.
+    """
+    bonds = neighbor_positions - center
+    n = len(bonds)
+    if n < 2:
+        return np.nan
+
+    bond_norms_sq = np.sum(bonds ** 2, axis=1)
+    denom = 2.0 * np.sum(bond_norms_sq)
+    if denom < 1e-15:
+        return np.nan
+
+    D_sq_sum = 0.0
+    for j in range(n):
+        pair_norms = np.sqrt(np.sum((bonds + bonds[j]) ** 2, axis=1))
+        D_sq_sum += np.min(pair_norms) ** 2
+
+    M = (D_sq_sum / 2.0) / denom
+    return M
+
+
+# ── Public API ────────────────────────────────────────────
+
+def ptm_classify(x, y, threshold=0.05, structures=None, edge_cutout_nn=3):
+    """Run 2D Polyhedral Template Matching on detected atom positions.
+
+    Args:
+        x: 1D array of x-coordinates (N atoms).
+        y: 1D array of y-coordinates (N atoms).
+        threshold: RMSD threshold for classification (default 0.05,
+            following Britton & Medlin). Atoms with best RMSD above
+            this are labeled 'unidentified'.
+        structures: list of structure names to test, e.g. ["FCC", "HCP"].
+            Default: all three (FCC, BCC, HCP).
+        edge_cutout_nn: exclude atoms within this many NN distances of
+            image edges from classification (set label to 'edge').
+            Default 3.
+
+    Returns:
+        dict with keys:
+            labels: list of str — per-atom classification
+            rmsd: (N,) float array — best RMSD (NaN for unidentified/edge)
+            angle: (N,) float array — rotation angle in degrees
+            scale: (N,) float array — scaling factor
+            cos: (N,) float array — Center of Symmetry metric
+            structure_code: (N,) int array — 1=FCC, 2=BCC, 3=HCP, 0=other, -1=edge
+            positions: (N, 2) array — input positions
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    positions = np.column_stack([x, y])
+    N = len(positions)
+
+    if structures is None:
+        structures = ["FCC", "BCC", "HCP"]
+
+    # Build templates
+    templates = {}
+    for name in structures:
+        if name in DEFAULT_TEMPLATES:
+            templates[name] = DEFAULT_TEMPLATES[name]()
+
+    # Neighbor lists via Delaunay
+    neighbors = _find_neighbors_delaunay(positions)
+
+    # Compute mean NN distance for edge exclusion
+    nn_dists = []
+    for i in range(N):
+        if neighbors[i]:
+            dists = np.linalg.norm(positions[list(neighbors[i])] - positions[i], axis=1)
+            nn_dists.append(np.min(dists))
+    mean_nn = np.median(nn_dists) if nn_dists else 0.0
+
+    # Edge mask
+    margin = edge_cutout_nn * mean_nn
+    xmin, ymin = positions.min(axis=0)
+    xmax, ymax = positions.max(axis=0)
+    edge_mask = (
+        (x < xmin + margin) | (x > xmax - margin) |
+        (y < ymin + margin) | (y > ymax - margin)
+    )
+
+    # Initialize output arrays
+    labels = ["unidentified"] * N
+    rmsd_arr = np.full(N, np.nan)
+    angle_arr = np.full(N, np.nan)
+    scale_arr = np.full(N, np.nan)
+    cos_arr = np.full(N, np.nan)
+    code_arr = np.zeros(N, dtype=int)
+
+    for i in range(N):
+        nn_idx = list(neighbors[i])
+        nn_pos = positions[nn_idx]
+
+        # CoS is computed for all atoms with enough neighbors (uses all Delaunay NN)
+        if len(nn_idx) >= 4:
+            # Use 6 closest for CoS
+            dists = np.linalg.norm(nn_pos - positions[i], axis=1)
+            n_use = min(6, len(nn_idx))
+            closest = np.argsort(dists)[:n_use]
+            cos_arr[i] = _compute_cos_single(positions[i], nn_pos[closest])
+
+        # Edge atoms: mark but still compute CoS
+        if edge_mask[i]:
+            labels[i] = "edge"
+            code_arr[i] = -1
+            continue
+
+        # Need at least 6 neighbors for PTM
+        if len(nn_idx) < 6:
+            continue
+
+        sorted_pts = _get_6nn_sorted(positions[i], nn_pos)
+        if sorted_pts is None:
+            continue
+
+        label, rmsd, angle, scale = _classify_atom(sorted_pts, templates, threshold)
+        labels[i] = label
+        rmsd_arr[i] = rmsd
+        angle_arr[i] = angle
+        scale_arr[i] = scale
+        code_arr[i] = STRUCTURE_CODES.get(label, 0)
+
+    # Clamp CoS artifacts
+    cos_arr = np.where(cos_arr > 0.05, np.nan, cos_arr)
+    cos_arr = np.where(cos_arr < 0, 0.0, cos_arr)
+
+    return {
+        "labels": labels,
+        "rmsd": rmsd_arr,
+        "angle": angle_arr,
+        "scale": scale_arr,
+        "cos": cos_arr,
+        "structure_code": code_arr,
+        "positions": positions,
+    }
+
+
+def ptm_classify_sweep(
+    x, y, thresholds=None, structures=None, edge_cutout_nn=3,
+    target_unidentified=0.05,
+):
+    """Sweep RMSD thresholds to find the best classification cutoff.
+
+    Runs Kabsch alignment once (expensive), then reclassifies at each
+    candidate threshold (cheap) by comparing stored per-atom RMSD values.
+
+    Args:
+        x, y: 1D arrays of atom coordinates.
+        thresholds: list of RMSD thresholds to test.  Default covers
+            the range 0.03–0.20 in 10 steps.
+        structures: structure names to test (default: all).
+        edge_cutout_nn: edge exclusion margin in NN distances.
+        target_unidentified: target fraction of non-edge unidentified
+            atoms.  The sweep picks the smallest threshold that puts
+            unidentified fraction below this value.
+
+    Returns:
+        dict with keys:
+            best_threshold: float — recommended RMSD threshold
+            best_result: dict — full ptm_classify output at that threshold
+            sweep: list of dicts — per-threshold statistics:
+                threshold, n_classified, n_unidentified, frac_unidentified,
+                per_structure (dict of structure→count)
+            raw_rmsd: (N,) float array — best RMSD per atom (NaN for
+                edge atoms), independent of threshold
+    """
+    if thresholds is None:
+        thresholds = [0.03, 0.05, 0.06, 0.075, 0.08, 0.10, 0.12, 0.15, 0.18, 0.20]
+    thresholds = sorted(thresholds)
+
+    # Run once with permissive threshold to get raw RMSDs
+    base = ptm_classify(x, y, threshold=np.inf, structures=structures,
+                        edge_cutout_nn=edge_cutout_nn)
+
+    raw_rmsd = base["rmsd"].copy()
+    base_labels = base["labels"]
+    base_codes = base["structure_code"]
+    N = len(base_labels)
+
+    edge_mask = np.array([l == "edge" for l in base_labels])
+    n_interior = int(np.sum(~edge_mask))
+
+    sweep_stats = []
+    best_threshold = thresholds[-1]
+    best_result = None
+
+    for thr in thresholds:
+        labels = list(base_labels)
+        codes = base_codes.copy()
+        rmsd_out = raw_rmsd.copy()
+
+        for i in range(N):
+            if edge_mask[i]:
+                continue
+            if np.isnan(raw_rmsd[i]) or raw_rmsd[i] >= thr:
+                labels[i] = "unidentified"
+                codes[i] = 0
+                rmsd_out[i] = np.nan
+
+        n_unid = sum(1 for i in range(N) if labels[i] == "unidentified")
+        n_classified = n_interior - n_unid
+        frac_unid = n_unid / n_interior if n_interior > 0 else 0.0
+
+        per_struct = {}
+        for label in labels:
+            if label not in ("unidentified", "edge"):
+                per_struct[label] = per_struct.get(label, 0) + 1
+
+        sweep_stats.append({
+            "threshold": thr,
+            "n_classified": n_classified,
+            "n_unidentified": n_unid,
+            "frac_unidentified": round(frac_unid, 4),
+            "per_structure": per_struct,
+        })
+
+        if frac_unid <= target_unidentified and best_result is None:
+            best_threshold = thr
+            best_result = {
+                "labels": labels,
+                "rmsd": rmsd_out,
+                "angle": base["angle"].copy(),
+                "scale": base["scale"].copy(),
+                "cos": base["cos"].copy(),
+                "structure_code": codes,
+                "positions": base["positions"],
+            }
+
+    # If no threshold met target, use the most permissive
+    if best_result is None:
+        thr = thresholds[-1]
+        labels = list(base_labels)
+        codes = base_codes.copy()
+        rmsd_out = raw_rmsd.copy()
+        for i in range(N):
+            if edge_mask[i]:
+                continue
+            if np.isnan(raw_rmsd[i]) or raw_rmsd[i] >= thr:
+                labels[i] = "unidentified"
+                codes[i] = 0
+                rmsd_out[i] = np.nan
+        best_result = {
+            "labels": labels,
+            "rmsd": rmsd_out,
+            "angle": base["angle"].copy(),
+            "scale": base["scale"].copy(),
+            "cos": base["cos"].copy(),
+            "structure_code": codes,
+            "positions": base["positions"],
+        }
+        best_threshold = thr
+
+    return {
+        "best_threshold": best_threshold,
+        "best_result": best_result,
+        "sweep": sweep_stats,
+        "raw_rmsd": raw_rmsd,
+    }
+
+
+def compute_cos(x, y, n_neighbors=6, edge_cutout_nn=3):
+    """Compute Center of Symmetry metric for all atom positions.
+
+    Standalone CoS calculation (no PTM). Useful when template matching
+    is not needed but distortion mapping is.
+
+    Args:
+        x, y: 1D arrays of atom coordinates.
+        n_neighbors: number of neighbors to use (default 6).
+        edge_cutout_nn: edge exclusion in NN distances.
+
+    Returns:
+        dict with keys:
+            cos: (N,) float array — CoS metric per atom
+            positions: (N, 2) array
+            edge_mask: (N,) bool array
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    positions = np.column_stack([x, y])
+    N = len(positions)
+
+    neighbors = _find_neighbors_delaunay(positions)
+
+    # Mean NN distance
+    nn_dists = []
+    for i in range(N):
+        if neighbors[i]:
+            dists = np.linalg.norm(positions[list(neighbors[i])] - positions[i], axis=1)
+            nn_dists.append(np.min(dists))
+    mean_nn = np.median(nn_dists) if nn_dists else 0.0
+
+    margin = edge_cutout_nn * mean_nn
+    xmin, ymin = positions.min(axis=0)
+    xmax, ymax = positions.max(axis=0)
+    edge_mask = (
+        (x < xmin + margin) | (x > xmax - margin) |
+        (y < ymin + margin) | (y > ymax - margin)
+    )
+
+    cos_arr = np.full(N, np.nan)
+    for i in range(N):
+        nn_idx = list(neighbors[i])
+        if len(nn_idx) < 4:
+            continue
+        # Use closest n_neighbors if more are available
+        dists = np.linalg.norm(positions[nn_idx] - positions[i], axis=1)
+        closest = np.argsort(dists)[:n_neighbors]
+        nn_pos = positions[np.array(nn_idx)[closest]]
+        cos_arr[i] = _compute_cos_single(positions[i], nn_pos)
+
+    cos_arr = np.where(cos_arr > 0.05, np.nan, cos_arr)
+    cos_arr = np.where(cos_arr < 0, 0.0, cos_arr)
+
+    return {
+        "cos": cos_arr,
+        "positions": positions,
+        "edge_mask": edge_mask,
+    }
+
+
+# ── Tool registry specs: auto-discovered by scilink.skills._shared._registry
+#    when the crystalline_deformation bundle is active ───────────────────────
+from scilink.skills._shared._spec import ToolSpec
+
+TOOL_SPECS = [
+    ToolSpec(
+        name="ptm_classify",
+        description=(
+            "2D Polyhedral Template Matching: classifies each atom column as "
+            "FCC, BCC, HCP, or unidentified by Kabsch-aligned RMSD matching of "
+            "its 6-NN environment against ideal zone-axis templates, and "
+            "computes the per-atom Center-of-Symmetry (CoS) distortion metric. "
+            "Primary defect-identification tool for atomic-resolution images."
+        ),
+        import_line="from scilink.skills.image_analysis.crystalline_deformation.ptm_tools import ptm_classify",
+        signature="ptm_classify(x, y, threshold=0.05, structures=None, edge_cutout_nn=3)",
+        returns="dict: labels, rmsd, cos, structure_code, rotation, per-structure counts",
+    ),
+    ToolSpec(
+        name="ptm_classify_sweep",
+        description=(
+            "RMSD-threshold sweep for PTM: runs Kabsch alignment once, then "
+            "reclassifies at each candidate threshold to auto-select the cutoff "
+            "meeting a target unidentified fraction. Use when default-threshold "
+            "ptm_classify leaves >5% of interior atoms unidentified."
+        ),
+        import_line="from scilink.skills.image_analysis.crystalline_deformation.ptm_tools import ptm_classify_sweep",
+        signature="ptm_classify_sweep(x, y, thresholds=None, structures=None, edge_cutout_nn=3, target_unidentified=0.05)",
+        returns="dict: best_threshold, best_result, sweep (per-threshold stats)",
+    ),
+    ToolSpec(
+        name="compute_cos",
+        description=(
+            "Standalone Center-of-Symmetry metric per atom (0=centrosymmetric "
+            "bulk; elevated at defects, boundaries, dislocation cores). Use as "
+            "a continuous local-distortion / strain-proxy map, valid across "
+            "grain boundaries where GPA is not."
+        ),
+        import_line="from scilink.skills.image_analysis.crystalline_deformation.ptm_tools import compute_cos",
+        signature="compute_cos(x, y, n_neighbors=6, edge_cutout_nn=3)",
+        returns="dict: cos (per-atom array), neighbor counts",
+    ),
+]

--- a/tests/test_crystalline_deformation_gpa.py
+++ b/tests/test_crystalline_deformation_gpa.py
@@ -1,0 +1,74 @@
+"""Ground-truth regression tests for the crystalline_deformation Burgers tool.
+
+Pattern (from the PR #393 review): numeric skill tools are validated against
+analytic fields with known answers, not against themselves. The displacement
+gradient of an isotropic edge dislocation is known in closed form, so
+burgers_from_gpa must recover |b| exactly; the horizontal-edge signs in
+_line_integral are exactly what this test pins down (a sign flip there gives a
+Poisson-ratio-dependent error, |b| ~ 0.455 nm for nu = 0.3).
+"""
+import numpy as np
+import pytest
+
+from scilink.skills.image_analysis.crystalline_deformation.gpa_tools import (
+    burgers_from_gpa,
+)
+
+H = W = 512
+CALIB = 0.1   # nm/px
+NU = 0.3      # Poisson ratio
+B_TRUE = 1.0  # nm, along +x
+
+
+def _edge_dislocation_beta():
+    """Analytic displacement-gradient components of an edge dislocation
+    (isotropic elasticity), b = B_TRUE along +x, core at the field centre."""
+    b_px = B_TRUE / CALIB
+    yy, xx = np.mgrid[0:H, 0:W].astype(float)
+    x = xx - W / 2 + 0.5
+    y = yy - H / 2 + 0.5
+    r2 = x * x + y * y
+    cc = 1 / (2 * (1 - NU))
+    dd = (1 - 2 * NU) / (4 * (1 - NU))
+    ee = 1 / (4 * (1 - NU))
+    pref = b_px / (2 * np.pi)
+    bxx = pref * (-y / r2 + cc * y * (y * y - x * x) / r2**2)      # dux/dx
+    bxy = pref * (x / r2 + cc * x * (x * x - y * y) / r2**2)       # dux/dy
+    byx = -pref * (2 * dd * x / r2 + 4 * ee * x * y * y / r2**2)   # duy/dx
+    byy = -pref * (2 * dd * y / r2 - 4 * ee * y * x * x / r2**2)   # duy/dy
+    e_xy = 0.5 * (bxy + byx)
+    w_z = 0.5 * (byx - bxy)   # standard omega_z (= gpa_strain_map's wxy, + sign)
+    return bxx, byy, e_xy, w_z
+
+
+def test_edge_dislocation_magnitude_exact():
+    bxx, byy, e_xy, w_z = _edge_dislocation_beta()
+    out = burgers_from_gpa(bxx, byy, e_xy, w_z, pixel_size=CALIB,
+                           dislocation_positions=[(H // 2, W // 2)],
+                           circuit_half_width=60, n_shrink=0)
+    b = out["burgers_vectors"][0]
+    assert b["b_magnitude"] == pytest.approx(B_TRUE, abs=5e-3)
+
+
+def test_edge_dislocation_direction_along_x():
+    bxx, byy, e_xy, w_z = _edge_dislocation_beta()
+    out = burgers_from_gpa(bxx, byy, e_xy, w_z, pixel_size=CALIB,
+                           dislocation_positions=[(H // 2, W // 2)],
+                           circuit_half_width=60, n_shrink=0)
+    bx, by = out["burgers_vectors"][0]["b_vector"]
+    assert abs(bx) == pytest.approx(B_TRUE, abs=5e-3)
+    assert abs(by) < 5e-2 * B_TRUE
+
+
+def test_magnitude_stable_across_circuit_sizes():
+    """|b| must not depend on the circuit size (the closed-loop invariant a
+    wrong edge sign destroys)."""
+    bxx, byy, e_xy, w_z = _edge_dislocation_beta()
+    mags = []
+    for hw in (30, 60, 100):
+        out = burgers_from_gpa(bxx, byy, e_xy, w_z, pixel_size=CALIB,
+                               dislocation_positions=[(H // 2, W // 2)],
+                               circuit_half_width=hw, n_shrink=0)
+        mags.append(out["burgers_vectors"][0]["b_magnitude"])
+    assert np.ptp(mags) < 2e-2 * B_TRUE
+    assert np.mean(mags) == pytest.approx(B_TRUE, abs=1e-2)


### PR DESCRIPTION
## What

Adds a new image-analysis skill bundle, `skills/image_analysis/crystalline_deformation/`, following the native `<domain>/<name>/<name>.md` convention — a knowledge file plus two self-contained tool modules whose `TOOL_SPECS` are auto-registered by `skills/_shared/_registry.py` when the skill is active. No loader, registry, or core-code changes.

**Scope:** identification and characterization of deformation mechanisms in atomic-resolution STEM images of crystalline materials (FCC/BCC/HCP, low-index zone axes): twin boundaries, stacking faults (ISF/ESF), dislocations, grain boundaries, and strain.

## Tools

`ptm_tools.py` (numpy/scipy only):
- `ptm_classify` — per-atom 2D Polyhedral Template Matching: Kabsch-aligned RMSD classification of each column's 6-NN environment against zone-axis templates (FCC [110], BCC [111], HCP [2-1-10]), plus per-atom Center-of-Symmetry metric
- `ptm_classify_sweep` — one-shot alignment + O(N) threshold reclassification to auto-select the RMSD cutoff
- `compute_cos` — standalone CoS distortion map (a strain proxy valid across boundaries where GPA is not)

`gpa_tools.py` (numpy/scipy/skimage):
- `compute_gpa_strain` — one-call GPA strain tensor maps
- `burgers_from_gpa` — Burgers vectors via line-integral circuits, per-dislocation or full-field auto-detection with a Burgers vector field (capability not currently in SciLink)

## Key design points in the skill text

- **Layer-count-primary classification**: the topological HCP-layer-count signature (1 = twin, 2 = ISF, HCP-FCC-HCP = ESF) is the primary classifier; angular corroborations (mirror relation, misorientation, {111} trace) can strengthen but never overturn it, and physically impossible angular results (exactly 0°/90°) are treated as measurement failures to re-measure, not evidence against the defect. This doctrine was added after observing a genuine Σ3 twin being vetoed by a degenerate single-vector mirror comparison.
- **GPA validity gating**: explicit rules for when GPA is physically invalid (multi-grain, multi-phase, bicrystal/twin-boundary images) with CoS as the boundary-safe alternative.
- Detection-quality gate (PTM unidentified fraction) with a DCNN retry path, and a precedence paragraph for co-selection alongside the general `atomic_stem` skill.

## Validation (real benchmark data, pinned ref 0fc406f)

- Auto-selected (alongside `atomic_stem`) for atomic-resolution HAADF-STEM of FeCrNi austenitic steel; generated analysis code imported and called `ptm_classify`, `ptm_classify_sweep`, and `compute_cos` per the skill's recipes
- Correctly identified a coherent Σ3 {111} twin boundary (single-HCP-layer signature, 2085 columns, 2.1% unidentified, boundary trace/position quantified) in **both** `AnalysisOrchestratorAgent` and direct `ImageAnalysisAgent` modes
- Correctly **not** selected for SEM and AFM datasets (scope exclusions respected)
- Loader/catalog/registry mechanics verified: discovered by `list_skills`, frontmatter + all six sections parse, listed in the auto-selector catalog, all five tools surfaced by `get_tools_for(..., active_skills=["crystalline_deformation"])`

## Known overlap / open question

`compute_gpa_strain` overlaps `skills/_shared/strain.py::gpa_strain_map` (the `gpa_strain` skill). It is kept bundle-local here for self-containment, but I'm happy to refactor the skill text to call the shared tool and contribute only `burgers_from_gpa` if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
