### PR TITLE
Measurement recommendations: session-aware evidence contract (#383) + real media types for stored figures (fixes #382)

### DIFF
--- a/scilink/agents/exp_agents/base_agent.py
+++ b/scilink/agents/exp_agents/base_agent.py
@@ -907,7 +907,7 @@ class BaseAnalysisAgent(LLMAgentMixin, ABC):
                 for img_data in stored_images[:5]:
                     if isinstance(img_data, dict) and 'label' in img_data and 'data' in img_data:
                         prompt_parts.append(f"\n**{img_data['label']}:**")
-                        prompt_parts.append({"mime_type": "image/jpeg", "data": img_data['data']})
+                        prompt_parts.append({"mime_type": self._image_mime_type(img_data['data']), "data": img_data['data']})
             
             if novelty_context:
                 prompt_parts.append(f"\n\n## Novelty Context\n{novelty_context}")
@@ -1299,6 +1299,30 @@ class BaseAnalysisAgent(LLMAgentMixin, ABC):
         """Retrieve stored analysis images."""
         return self._stored_analysis_images.copy()
 
+    @staticmethod
+    def _image_mime_type(data) -> str:
+        """Best-effort media type from magic bytes; stored figures are PNGs
+        more often than JPEGs, and strict providers (Bedrock) reject a
+        declared type that doesn't match the payload. Handles raw bytes and
+        base64 strings; defaults to JPEG when unrecognized."""
+        if isinstance(data, (bytes, bytearray)):
+            head = bytes(data[:8])
+            if head.startswith(b"\x89PNG"):
+                return "image/png"
+            if head.startswith(b"GIF8"):
+                return "image/gif"
+            if head.startswith(b"RIFF"):
+                return "image/webp"
+        else:
+            s = str(data)
+            if s.startswith("iVBOR"):       # base64 of \x89PNG
+                return "image/png"
+            if s.startswith("R0lGO"):       # base64 of GIF8
+                return "image/gif"
+            if s.startswith("UklGR"):       # base64 of RIFF (webp)
+                return "image/webp"
+        return "image/jpeg"
+
     def _clear_stored_images(self) -> None:
         """Clear stored images to free memory."""
         self._stored_analysis_images = []
@@ -1562,7 +1586,7 @@ Maintain the same JSON output format with "detailed_analysis" and "scientific_cl
                 for img_data in stored_images:
                     if isinstance(img_data, dict) and 'label' in img_data and 'data' in img_data:
                         prompt_parts.append(f"\n{img_data['label']}:")
-                        prompt_parts.append({"mime_type": "image/jpeg", "data": img_data['data']})
+                        prompt_parts.append({"mime_type": self._image_mime_type(img_data['data']), "data": img_data['data']})
             
             if system_info:
                 prompt_parts.append(self._build_system_info_prompt_section(system_info))

--- a/scilink/agents/exp_agents/base_agent.py
+++ b/scilink/agents/exp_agents/base_agent.py
@@ -734,26 +734,33 @@ class BaseAnalysisAgent(LLMAgentMixin, ABC):
         system_info: Dict[str, Any] | str | None = None,
         novelty_context: str | None = None,
         novelty_assessment: Dict[str, Any] | None = None,
+        measurement_history: List[Any] | None = None,
         **kwargs
     ) -> Dict[str, Any]:
         """
         Generate measurement recommendations based on analysis.
-        
+
         This is an optional post-processing step that builds on analyze() results.
         If no analysis_result is provided, runs analyze() first.
-        
+
         Args:
             analysis_result: Output from analyze(). If None, runs analyze() first.
             data: Input data (required if analysis_result is None)
             system_info: Metadata (passed to analyze() if running it)
             novelty_context: Optional context from literature review
+            measurement_history: Optional list describing measurements already
+                performed this session (e.g. energy windows / conditions).
+                Recommendations exclude covered ground unless re-measuring
+                under different conditions is explicitly justified.
             **kwargs: Additional arguments passed to analyze() if needed
-        
+
         Returns:
             dict containing:
                 - "status": "success" | "error"
                 - "analysis_integration": str (how analysis informed recommendations)
-                - "measurement_recommendations": list[dict]
+                - "measurement_recommendations": list[dict]; each item may carry
+                  a machine-readable "target" ({"setting", "expected_signature"}
+                  or null) alongside the free-text fields
         """
         # If no analysis provided, run it first
         if analysis_result is None:
@@ -780,7 +787,8 @@ class BaseAnalysisAgent(LLMAgentMixin, ABC):
                 }
         
         # Generate recommendations from analysis
-        return self._generate_recommendations(analysis_result, system_info, novelty_context, novelty_assessment)
+        return self._generate_recommendations(analysis_result, system_info, novelty_context, novelty_assessment,
+                                              measurement_history=measurement_history)
 
     # =========================================================================
     # BACKWARD COMPATIBLE ALIASES
@@ -865,6 +873,7 @@ class BaseAnalysisAgent(LLMAgentMixin, ABC):
         system_info: Dict[str, Any] | str | None = None,
         novelty_context: str | None = None,
         novelty_assessment: Dict[str, Any] | None = None,
+        measurement_history: List[Any] | None = None,
     ) -> Dict[str, Any]:
         """Internal method to generate recommendations from analysis results."""
         system_info = self._handle_system_info(system_info)
@@ -909,7 +918,16 @@ class BaseAnalysisAgent(LLMAgentMixin, ABC):
             
             if system_info:
                 prompt_parts.append(f"\n\n## System Information\n{json.dumps(system_info, indent=2)}")
-            
+
+            if measurement_history:
+                prompt_parts.append(
+                    "\n\n## Measurements Already Performed This Session\n"
+                    f"{json.dumps(measurement_history, indent=2, default=str)}\n"
+                    "Do not recommend re-acquiring these; recommend a covered "
+                    "setting again only if different acquisition conditions are "
+                    "scientifically justified, and state what must change."
+                )
+
             prompt_parts.append("\n\nProvide measurement recommendations in JSON format.")
             
             self.logger.info("📋 Generating measurement recommendations...")
@@ -1327,6 +1345,9 @@ class BaseAnalysisAgent(LLMAgentMixin, ABC):
             if isinstance(rec, dict) and all(k in rec for k in required_keys):
                 priority = rec.get("priority")
                 if isinstance(priority, int) and 1 <= priority <= 5:
+                    # normalize the optional machine-readable target: dict or None
+                    if not isinstance(rec.get("target"), dict):
+                        rec["target"] = None
                     valid_recommendations.append(rec)
         
         return sorted(valid_recommendations, key=lambda x: x.get("priority", 5))

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -962,6 +962,7 @@ You MUST output a valid JSON object with two keys: "analysis_integration" and "m
    * **scientific_justification**: (String) Why this measurement provides valuable insights
    * **expected_outcomes**: (String) Specific information to be gained
    * **priority**: (Integer) 1-5 priority ranking
+   * **target**: (Object or null) Machine-readable acquisition target: {"setting": "<concrete instrument setting, e.g. an energy window with numbers>", "expected_signature": "<the specific feature expected there>"}; null when the recommendation is not a direct acquisition
 
 Focus on actionable recommendations that maximize scientific insight while being technically feasible.
 """
@@ -2951,11 +2952,13 @@ the saved fit visualization, extracted parameters, and sample metadata.
             "description": "Specific measurement",
             "scientific_justification": "Why it matters",
             "expected_outcomes": "What you expect to learn",
-            "priority": 1-5
+            "priority": 1-5,
+            "target": {{"setting": "concrete instrument setting (e.g. an energy/wavenumber window with numbers)", "expected_signature": "the specific feature expected there"}}
         }}
     ]
 }}
 ```
+"target" makes a recommendation directly actionable by an instrument; set it to null when the recommendation is not a direct acquisition (e.g. sample preparation or a different technique).
 """
 
 KNOWLEDGE_SYNTHESIS_INSTRUCTIONS = """You are an expert scientific data analyst. You have been given the detailed results from multiple analyses of reference datasets. Your task is to synthesize actionable knowledge from these results, focused on a specific topic.
@@ -4027,9 +4030,11 @@ You have: analysis visualization, extracted features, sample metadata.
             "description": "Specific measurement",
             "scientific_justification": "Why it matters",
             "expected_outcomes": "What you expect to learn",
-            "priority": 1-5
+            "priority": 1-5,
+            "target": {{"setting": "concrete instrument setting (e.g. region + resolution, or a spectral window with numbers)", "expected_signature": "the specific feature expected there"}}
         }}
     ]
 }}
 ```
+"target" makes a recommendation directly actionable by an instrument; set it to null when the recommendation is not a direct acquisition (e.g. sample preparation or a different technique).
 """

--- a/tests/test_recommend_evidence_contract.py
+++ b/tests/test_recommend_evidence_contract.py
@@ -1,0 +1,102 @@
+"""Offline tests for the analysis-side evidence contract on
+recommend_measurements (#383): the optional measurement_history prompt
+section and the machine-readable per-recommendation `target` field."""
+
+import json
+import logging
+
+from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+
+
+class _FakeResponse:
+    def __init__(self, text):
+        self.text = text
+
+
+class _FakeModel:
+    """Captures the prompt and returns a canned recommendations JSON."""
+
+    def __init__(self, payload):
+        self.payload = payload
+        self.last_contents = None
+
+    def generate_content(self, contents, generation_config=None,
+                         safety_settings=None, **kw):
+        self.last_contents = contents
+        return _FakeResponse(json.dumps(self.payload))
+
+
+def _bare_agent(payload):
+    agent = object.__new__(CurveFittingAgent)
+    agent.logger = logging.getLogger("test_rec_contract")
+    agent.model = _FakeModel(payload)
+    agent.generation_config = None
+    agent.safety_settings = None
+    agent._stored_analysis_images = []
+    agent._stored_analysis_metadata = {}
+    return agent
+
+
+PAYLOAD = {
+    "analysis_integration": "test",
+    "measurement_recommendations": [
+        {"description": "acquire Fe L2,3", "scientific_justification": "valence",
+         "priority": 1,
+         "target": {"setting": "660-750 eV", "expected_signature": "Fe L2,3"}},
+        {"description": "prep thinner region", "scientific_justification": "t/lambda",
+         "priority": 2, "target": "not-a-dict"},
+        {"description": "no target given", "scientific_justification": "x",
+         "priority": 3},
+    ],
+}
+
+
+def _prompt_text(model):
+    return "\n".join(p for p in model.last_contents if isinstance(p, str))
+
+
+def test_target_field_passes_through_and_normalizes():
+    agent = _bare_agent(PAYLOAD)
+    out = agent._generate_recommendations({"detailed_analysis": "spectrum shows X"})
+    assert out["status"] == "success"
+    recs = out["measurement_recommendations"]
+    assert len(recs) == 3
+    assert recs[0]["target"] == {"setting": "660-750 eV",
+                                 "expected_signature": "Fe L2,3"}
+    # non-dict and absent targets both normalize to None
+    assert recs[1]["target"] is None
+    assert recs[2]["target"] is None
+
+
+def test_measurement_history_section_present_only_when_given():
+    agent = _bare_agent(PAYLOAD)
+    agent._generate_recommendations({"detailed_analysis": "x"})
+    assert "Measurements Already Performed" not in _prompt_text(agent.model)
+
+    agent._generate_recommendations(
+        {"detailed_analysis": "x"},
+        measurement_history=["low-loss -34-160 eV", "core-loss 660-750 eV"])
+    text = _prompt_text(agent.model)
+    assert "Measurements Already Performed" in text
+    assert "660-750 eV" in text
+    assert "Do not recommend re-acquiring" in text
+
+
+def test_recommend_measurements_threads_history():
+    agent = _bare_agent(PAYLOAD)
+    out = agent.recommend_measurements(
+        analysis_result={"detailed_analysis": "x"},
+        measurement_history=["window A"])
+    assert out["status"] == "success"
+    assert len(out["measurement_recommendations"]) == 3
+    assert "window A" in _prompt_text(agent.model)
+
+
+def test_prompt_variants_declare_target():
+    from scilink.agents.exp_agents.instruct import (
+        CURVE_FITTING_MEASUREMENT_RECOMMENDATIONS_INSTRUCTIONS as C,
+        SPECTROSCOPY_MEASUREMENT_RECOMMENDATIONS_INSTRUCTIONS as S,
+        IMAGE_ANALYSIS_MEASUREMENT_RECOMMENDATIONS_INSTRUCTIONS as I,
+    )
+    for v in (C, S, I):
+        assert "target" in v and "expected_signature" in v

--- a/tests/test_recommend_evidence_contract.py
+++ b/tests/test_recommend_evidence_contract.py
@@ -100,3 +100,28 @@ def test_prompt_variants_declare_target():
     )
     for v in (C, S, I):
         assert "target" in v and "expected_signature" in v
+
+
+def test_image_mime_type_sniffing():
+    """#382: stored figures must be declared with their real media type."""
+    import base64
+    from scilink.agents.exp_agents.base_agent import BaseAnalysisAgent
+    sniff = BaseAnalysisAgent._image_mime_type
+    png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
+    jpg = b"\xff\xd8\xff\xe0" + b"\x00" * 8
+    assert sniff(png) == "image/png"
+    assert sniff(jpg) == "image/jpeg"
+    assert sniff(base64.b64encode(png).decode()) == "image/png"
+    assert sniff(base64.b64encode(jpg).decode()) == "image/jpeg"
+    assert sniff("garbage") == "image/jpeg"  # safe default
+
+
+def test_stored_png_declared_as_png_in_recommendation_prompt():
+    import base64
+    agent = _bare_agent(PAYLOAD)
+    png_b64 = base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16).decode()
+    agent._stored_analysis_images = [{"label": "Fit", "data": png_b64}]
+    out = agent._generate_recommendations({"detailed_analysis": "x"})
+    assert out["status"] == "success"
+    img_parts = [p for p in agent.model.last_contents if isinstance(p, dict)]
+    assert img_parts and img_parts[0]["mime_type"] == "image/png"

--- a/tests/test_recommend_evidence_live.py
+++ b/tests/test_recommend_evidence_live.py
@@ -1,0 +1,133 @@
+"""Live tests (Bedrock) for the recommend_measurements evidence contract
+(#383): machine-readable `target` adoption and `measurement_history`
+adherence, across curve (EELS + Raman) and image modalities.
+
+Run manually:
+    AWS_BEARER_TOKEN_BEDROCK=... AWS_REGION_NAME=us-east-1 UNSAFE_EXECUTION_OK=true \
+        python -m pytest tests/test_recommend_evidence_live.py -s -q
+
+Hard assertions cover the contract guarantees (success, target dict-or-None,
+format adoption). History adherence is printed for manual grading — LLM
+behavior, not a schema guarantee.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+BENCH = Path.home() / "Code/benchmarking_for_paper2"
+RUNS = Path(__file__).parent / "_rec_contract_live_runs"
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"),
+    reason="live test: needs Bedrock credentials")
+
+
+def _contract_checks(out, label):
+    assert out.get("status") == "success", f"{label}: {out.get('error')}"
+    recs = out["measurement_recommendations"]
+    assert recs, f"{label}: no recommendations"
+    for r in recs:
+        assert r.get("target") is None or isinstance(r["target"], dict)
+    with_target = [r for r in recs if isinstance(r.get("target"), dict)
+                   and r["target"].get("setting")]
+    assert with_target, f"{label}: no machine-readable targets adopted"
+    print(f"\n=== {label}: {len(recs)} recs, "
+          f"{len(with_target)} with targets ===")
+    for r in recs:
+        print(f"  p{r.get('priority')} target={json.dumps(r.get('target'))}")
+        print(f"     {r.get('description', '')[:140]}")
+    return recs
+
+
+def _fit_and_recommend(agent_cls, data, system_info, history, label, **akw):
+    outdir = RUNS / label
+    agent = agent_cls(model_name=MODEL, api_key=None,
+                      enable_human_feedback=False, output_dir=str(outdir), **akw)
+    res = agent.analyze(str(data), system_info=system_info)
+    # partial (e.g. one HS sub-task failed) still carries detailed_analysis
+    # and is a legitimate recommend_measurements input
+    assert res.get("status") in ("success", "partial") and \
+        res.get("detailed_analysis"), f"{label}: analyze failed"
+    if res.get("status") == "partial":
+        # rec generator rejects status=="error" or an "error" key; a partial
+        # result may carry per-task errors irrelevant to recommendations
+        res = {k: v for k, v in res.items() if k != "error"}
+        res["status"] = "success"
+    # fresh agent for recommendations (no stored figures: #382 workaround)
+    rec_agent = agent_cls(model_name=MODEL, api_key=None,
+                          enable_human_feedback=False,
+                          output_dir=str(outdir / "_rec"))
+    base = rec_agent.recommend_measurements(analysis_result=res,
+                                            system_info=system_info)
+    recs_base = _contract_checks(base, f"{label} (no history)")
+    hist = rec_agent.recommend_measurements(analysis_result=res,
+                                            system_info=system_info,
+                                            measurement_history=history)
+    recs_hist = _contract_checks(hist, f"{label} (with history)")
+    print(f"  history given: {history}")
+    (outdir / "live_outputs.json").write_text(json.dumps(
+        {"base": base, "hist": hist, "history": history}, indent=2,
+        default=str))
+    return recs_base, recs_hist
+
+
+def test_eels_curve_live():
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+    d = BENCH / "EELS/EELS_staged/strong/EEL_8"
+    meta = json.loads((d / "metadata.json").read_text())
+    _fit_and_recommend(
+        CurveFittingAgent, d / "data1.csv", meta,
+        ["EELS core-loss 683-735 eV (Fe L2,3 white lines) — the analyzed "
+         "spectrum", "EELS low-loss -30 to +150 eV (ZLP + plasmon)"],
+        "eels_eel8", max_verification_iterations=1)
+
+
+def test_raman_curve_live():
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+    d = BENCH / "RamanIR/Raman_staged"
+    csv = d / "01_easy_Diamond_R150088.csv"
+    side = json.loads(csv.with_suffix(".json").read_text())
+    info = {k: v for k, v in side.items() if k not in ("ground_truth",
+                                                       "descriptors")}
+    _fit_and_recommend(
+        CurveFittingAgent, csv, info,
+        ["Raman, 532 nm excitation, 100-1500 cm-1 — the analyzed spectrum"],
+        "raman_diamond", max_verification_iterations=1)
+
+
+def test_hyperspectral_live():
+    from scilink.agents.exp_agents.hyperspectral_analysis_agent import (
+        HyperspectralAnalysisAgent)
+    d = Path.home() / "Code/SciLink/meta_session_20260722_194112/uploads"
+    info = {
+        "technique": "Scanning tunneling spectroscopy (grid STS)",
+        "signal": "dI/dV (lock-in X, LIX 1-omega) datacube",
+        "sample": "TaS2",
+        "spatial": "168x168 px over 15x15 nm",
+        "energy_range": {"start": -1.0, "end": 1.0, "units": "V"},
+        "spectral_axis": "bias sweep -1.0 to +1.0 V, 151 points",
+    }
+    _fit_and_recommend(
+        HyperspectralAnalysisAgent, d / "LIX_1_omega__A.npy", info,
+        ["Grid STS dI/dV cube, 168x168 px over 15x15 nm, bias -1.0 to +1.0 V "
+         "(151 pts) — the analyzed cube",
+         "Constant-current topography of the same 15x15 nm region"],
+        "sts_tas2", max_verification_iterations=1)
+
+
+def test_image_live():
+    from scilink.agents.exp_agents.image_analysis_agent import ImageAnalysisAgent
+    d = BENCH / "TEM_staged/01_easy_AuNP"
+    img = next(p for p in sorted(d.iterdir())
+               if p.suffix.lower() in (".png", ".tif", ".tiff", ".jpg"))
+    meta_f = d / "metadata.json"
+    info = json.loads(meta_f.read_text()) if meta_f.exists() else None
+    _fit_and_recommend(
+        ImageAnalysisAgent, img, info,
+        ["HAADF-STEM overview image at the current field of view — the "
+         "analyzed image"],
+        "image_aunp")

--- a/tests/test_recommend_evidence_live.py
+++ b/tests/test_recommend_evidence_live.py
@@ -131,3 +131,20 @@ def test_image_live():
         ["HAADF-STEM overview image at the current field of view — the "
          "analyzed image"],
         "image_aunp")
+
+
+def test_same_agent_recommend_with_stored_figures_live():
+    """#382 repro: analyze -> recommend on the SAME agent (stored PNG figures
+    attached). Pre-fix this 400'd on Bedrock (PNG declared as image/jpeg)."""
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+    d = BENCH / "EELS/EELS_staged/strong/EEL_8"
+    meta = json.loads((d / "metadata.json").read_text())
+    agent = CurveFittingAgent(model_name=MODEL, api_key=None,
+                              enable_human_feedback=False,
+                              output_dir=str(RUNS / "eels_382_same_agent"),
+                              max_verification_iterations=1)
+    res = agent.analyze(str(d / "data1.csv"), system_info=meta)
+    assert res.get("status") == "success"
+    assert agent._get_stored_analysis_images(), "no stored figures — repro invalid"
+    out = agent.recommend_measurements(analysis_result=res, system_info=meta)
+    _contract_checks(out, "eels same-agent with figures (#382)")


### PR DESCRIPTION
## Summary

Two upgrades to `recommend_measurements`, the surface where SciLink suggests what to measure next after an analysis.

**For scientists:** recommendations now come back in a form an instrument session can actually use. Each suggestion carries a machine-readable target — the concrete setting to acquire (an energy window, a bias sweep with lock-in settings, a magnification and pixel size) and the signature expected there — alongside the usual narrative. You can also tell the agent what was already measured this session; it will then propose genuinely new acquisitions, or, when it revisits covered ground, say explicitly what must change (higher resolution, different polarization, a co-registered point) and why. Separately, asking for recommendations right after an analysis no longer errors on AWS Bedrock when the analysis produced figures.

Live-validated on Bedrock Opus 4.8 across all four analysis surfaces: EELS (Fe L₂,₃, hematite), Raman (diamond), TEM imaging (Au nanoparticles), and a TaS₂ grid-STS dI/dV cube. 34/34 recommendations carried concrete numeric targets in each technique's native vocabulary; with history declared, outputs pivoted to uncovered ground or stated the changed conditions.

---

**Technical details**

*#383 — analysis-side evidence contract (scoped per the issue: evidence generation only; action selection and stopping stay with the planning/meta layer):*
- `recommend_measurements(measurement_history=...)` (optional, backward-compatible) → `_generate_recommendations` renders a "Measurements Already Performed This Session" section with a single principle rule (no re-acquisition without explicitly justified changed conditions). No kwarg → byte-identical prompt.
- Per-recommendation `target` object (`{"setting", "expected_signature"}` or `null` for non-acquisition advice) added to the three live prompt variants in `instruct.py` (curve `:2938`, spectroscopy `:928`, image `:4012`); the four unreferenced legacy variants untouched. `_validate_measurement_recommendations` normalizes `target` to dict-or-None so consumers get a stable shape.

*#382 — media-type fix:*
- Both call sites that attach stored analysis figures (`base_agent.py` recommendation + refinement paths) hardcoded `image/jpeg`; the stored figures are PNGs, and Bedrock validates declared type against payload magic bytes → 400 on the normal analyze→recommend sequence. New `BaseAnalysisAgent._image_mime_type` sniffs magic bytes (raw bytes or base64 strings; PNG/GIF/WebP, JPEG default). Providers that don't validate are byte-identical except for the now-correct declaration.

*Tests:*
- Offline (`tests/test_recommend_evidence_contract.py`, 6/6): target pass-through + normalization, history section rendering gated on the kwarg, kwarg threading, all three prompt variants declare the field, mime sniffing, PNG declared as PNG in the assembled prompt.
- Live (`tests/test_recommend_evidence_live.py`, cred-gated, 5 scenarios): the four modalities above with paired no-history/with-history calls, plus the #382 same-agent repro (pre-fix 400, now passes). The hyperspectral scenario also exercises the partial-status passthrough (one sub-task failed at `max_verification_iterations=1`; recommendations consumed the partial analysis correctly).

*Known limits:* history adherence is prompt-guided model behavior, asserted manually from live outputs rather than by schema; the covered-ground rule permits re-acquisition with stated changed conditions by design.

Fixes #382. Implements the rescoped #383.