### PR TITLE
Fix silent 4096-token output cap for custom Anthropic deployment names

### DIFF
--- a/scilink/wrappers/litellm_wrapper.py
+++ b/scilink/wrappers/litellm_wrapper.py
@@ -116,12 +116,13 @@ DEFAULT_MAX_OUTPUT_TOKENS = 32000
 
 
 def _resolve_max_output_tokens(model: str) -> int:
-    """Best-effort max output tokens for a model (Bedrock path only — see #238).
+    """Best-effort max output tokens for a model (bedrock/ and anthropic/ paths).
 
-    litellm fills ``max_tokens`` with the model's registered ceiling for direct
-    Anthropic/OpenAI/Gemini, but the Bedrock converse transform omits ``maxTokens``
-    when unset, so Bedrock falls back to a low server-side default and truncates
-    large generations. Returns litellm's registered ceiling when the model is
+    The Bedrock converse transform omits ``maxTokens`` when unset, so Bedrock
+    falls back to a low server-side default and truncates large generations
+    (#238). Direct Anthropic fills the registered ceiling for mapped models but
+    falls back to a 4096 default for names missing from litellm's registry
+    (custom deployments). Returns litellm's registered ceiling when the model is
     mapped (e.g. Bedrock opus-4-1 -> 32000), else ``DEFAULT_MAX_OUTPUT_TOKENS``. A
     litellm upgrade that maps the model makes this resolve to the true ceiling.
     """
@@ -518,10 +519,12 @@ class LiteLLMGenerativeModel:
                     params[new] = val
 
         # Bedrock omits maxTokens when unset -> a low server-side default truncates
-        # large outputs (#238). Request the model's max on the Bedrock path only;
-        # every other provider already gets a sane ceiling from litellm, so leave
-        # their requests untouched. An explicit max_output_tokens above still wins.
-        if "max_tokens" not in params and str(self.model or "").startswith("bedrock/"):
+        # large outputs (#238). Direct Anthropic has the same trap for model names
+        # missing from litellm's registry (custom deployments): litellm falls back
+        # to a 4096 default and silently caps output. Request the model's max on
+        # both paths; other providers already get a sane ceiling from litellm.
+        # An explicit max_output_tokens above still wins.
+        if "max_tokens" not in params and str(self.model or "").startswith(("bedrock/", "anthropic/")):
             params["max_tokens"] = _resolve_max_output_tokens(self.model)
 
         if tools:


### PR DESCRIPTION
## Summary

When SciLink talks to Claude through a custom deployment name (e.g. `anthropic/<internal-deployment>`), responses were being silently cut off at 4096 tokens unless the caller set an output limit explicitly. Long generations — big analysis scripts, full reports — would just stop mid-output with no error. This PR makes the wrapper request the model's real output ceiling on the direct Anthropic path, the same protection the Bedrock path has had since #238. Standard model names (`claude-…`) and all other providers behave exactly as before.

## Technical details

**Root cause.** litellm's Anthropic transform requires `max_tokens` and, when the caller omits it, fills it via a model-registry lookup (`AnthropicConfig.get_max_tokens_for_model`). For names missing from the registry — any custom deployment — it falls back to `DEFAULT_ANTHROPIC_CHAT_MAX_TOKENS = 4096` (litellm `constants.py:394`, verified on 1.83.10). Our `_build_params` only injected an explicit ceiling on the `bedrock/` prefix, on the assumption that "every other provider already gets a sane ceiling from litellm" — false for unmapped `anthropic/` names.

**Fix.** `scilink/wrappers/litellm_wrapper.py:526` — the guard becomes `startswith(("bedrock/", "anthropic/"))`, so `_resolve_max_output_tokens` runs on both paths: litellm's registered ceiling when the model is mapped, else `DEFAULT_MAX_OUTPUT_TOKENS` (32000). Comment and the `_resolve_max_output_tokens` docstring updated to match.

**Verification** (direct `_build_params` calls, litellm 1.83.10):

| Case | Before | After |
|---|---|---|
| `anthropic/<custom-deployment>` | no `max_tokens` → litellm caps at 4096 | explicit 32000 |
| `anthropic/claude-sonnet-4-20250514` (mapped) | litellm fills 64000 | explicit 64000 — wire-identical |
| `bedrock/anthropic.claude-opus-4-1` | 32000 | 32000 — unchanged |
| `gemini/…`, `openai/…` | untouched | untouched |
| explicit `max_output_tokens=1234` | wins | still wins |

Note that bare `claude-*` names are auto-prefixed to `anthropic/` by `_normalize_model_name`, so all direct-Anthropic traffic enters the new branch — but mapped names resolve through the same `litellm.get_max_tokens` call litellm's own fill uses, so those requests are byte-identical to before.

**Known limits.** The changed behavior is confined to unmapped `anthropic/` names. Two narrow caveats there: a deployment fronting a retired small-cap model (≤8192 output) could now get a loud 400 where 4096 silently worked (every currently served Claude model caps at ≥32000), and rate limiters that reserve budget from `max_tokens` will reserve more per request. Explicit `max_output_tokens` remains the escape hatch for both.