### PR TITLE
Session resume in the UI: bring back documents, show failures, checkpoint every turn

### DIFF
--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -472,6 +472,9 @@ class MetaOrchestratorAgent:
         # fusion-entry appends across fan-out worker threads.
         self._complementarity_cache: Dict[frozenset, Dict[str, Any]] = {}
         self._fanout_lock = threading.Lock()
+        # Serializes checkpoint writes: _close_delegation checkpoints on every
+        # completion, and fan-out workers close their entries concurrently.
+        self._checkpoint_lock = threading.Lock()
         # Auto-generated specialist capability inventory — built once on the
         # first chat turn (children must exist to read their tool registries).
         self._capabilities_block: Optional[str] = None
@@ -1373,6 +1376,11 @@ class MetaOrchestratorAgent:
             "error": result.get("error"),
             "completed_at": datetime.now().isoformat(),
         })
+        # A completed delegation is the ledger state worth preserving — the
+        # every-N-messages auto-save left short sessions (fewer than
+        # CHECKPOINT_INTERVAL turns) with no checkpoint at all, making them
+        # unresumable with their delegation history.
+        self._auto_checkpoint()
 
     def _summarize_delegation_result(self, mode, result, index) -> str:
         """Build the JSON string a delegate_to_* tool returns to the meta LLM."""
@@ -1552,18 +1560,26 @@ class MetaOrchestratorAgent:
             logging.warning(f"Failed to restore checkpoint: {e}")
 
     def _auto_checkpoint(self):
-        """Internal auto-checkpoint without LLM interaction."""
+        """Internal auto-checkpoint without LLM interaction.
+
+        Atomic (temp file + replace) and serialized: concurrent fan-out
+        workers checkpoint via _close_delegation, and a torn write would
+        corrupt the one file a resume depends on.
+        """
         try:
-            checkpoint_data = {
-                "timestamp": datetime.now().isoformat(),
-                "meta_mode": self.meta_mode.value,
-                "message_count": self.message_count,
-                "children_instantiated": sorted(self._children.keys()),
-                "delegation_ledger": self._delegation_ledger,
-                "knowledge_dir": str(self.knowledge_dir) if self.knowledge_dir else None,
-            }
-            with open(self.checkpoint_path, 'w') as f:
-                json.dump(checkpoint_data, f, indent=2, default=str)
+            with self._checkpoint_lock:
+                checkpoint_data = {
+                    "timestamp": datetime.now().isoformat(),
+                    "meta_mode": self.meta_mode.value,
+                    "message_count": self.message_count,
+                    "children_instantiated": sorted(self._children.keys()),
+                    "delegation_ledger": self._delegation_ledger,
+                    "knowledge_dir": str(self.knowledge_dir) if self.knowledge_dir else None,
+                }
+                tmp_path = self.checkpoint_path.with_suffix(".json.tmp")
+                with open(tmp_path, 'w') as f:
+                    json.dump(checkpoint_data, f, indent=2, default=str)
+                os.replace(tmp_path, self.checkpoint_path)
             print(f"    ✅ Auto-checkpoint saved")
             return True
         except Exception as e:

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -929,6 +929,27 @@ else:
                         _agent._auto_checkpoint()
                 except Exception as _ckpt_exc:  # noqa: BLE001 - never break the turn
                     logging.warning(f"Per-turn checkpoint failed: {_ckpt_exc}")
+                # Auto-title an unnamed session from its first exchange —
+                # one small LLM call, once per session; a user-set name is
+                # never overwritten and any failure falls back silently to
+                # the timestamp label.
+                try:
+                    from scilink.ui.session_meta import (
+                        load_session_name, save_session_name,
+                        generate_session_title)
+                    _sdir = st.session_state.session_dir
+                    if _sdir and not load_session_name(_sdir):
+                        _cfg = st.session_state.agent_config
+                        _first_user = next(
+                            (m["content"] for m in st.session_state.chat_messages
+                             if m["role"] == "user"), "")
+                        _title = generate_session_title(
+                            _cfg.get("model"), _cfg.get("api_key"),
+                            _cfg.get("base_url"), _first_user, content)
+                        if _title:
+                            save_session_name(_sdir, _title, named_by="agent")
+                except Exception:  # noqa: BLE001 - naming must never break a turn
+                    pass
                 st.session_state.chat_task = ChatTask()
                 st.rerun(scope="app")
                 return
@@ -1387,13 +1408,9 @@ else:
         )
         current = Path(current_session_dir)
         result: list[tuple[str, Path]] = []
+        from scilink.ui.session_meta import session_label
         for s in sessions:
-            # Parse timestamp from directory name like <prefix>_20260223_201729
-            parts = s.name.removeprefix(f"{prefix}_")
-            try:
-                label = f"{parts[:4]}-{parts[4:6]}-{parts[6:8]} {parts[9:11]}:{parts[11:13]}:{parts[13:15]}"
-            except (IndexError, ValueError):
-                label = s.name
+            label = session_label(s, prefix)
             if s.resolve() == current.resolve():
                 label += " (current)"
             result.append((label, s))

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -2,6 +2,7 @@
 
 import base64
 import builtins
+import logging
 import re
 import threading
 from pathlib import Path
@@ -914,6 +915,20 @@ else:
                     "md_reports": new_docs,
                     "verbose": task.verbose_log or "",
                 })
+                # Persist session state now that the turn is complete. The
+                # orchestrators' periodic auto-save (every CHECKPOINT_INTERVAL
+                # messages) left short UI sessions with no checkpoint at all —
+                # unresumable. The CLI saves on quit; the UI has no quit
+                # moment, so save after every finished turn instead.
+                # save_checkpoint (meta) snapshots the children too.
+                _agent = st.session_state.get("agent")
+                try:
+                    if hasattr(_agent, "save_checkpoint"):
+                        _agent.save_checkpoint()
+                    elif hasattr(_agent, "_auto_checkpoint"):
+                        _agent._auto_checkpoint()
+                except Exception as _ckpt_exc:  # noqa: BLE001 - never break the turn
+                    logging.warning(f"Per-turn checkpoint failed: {_ckpt_exc}")
                 st.session_state.chat_task = ChatTask()
                 st.rerun(scope="app")
                 return

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -939,13 +939,12 @@ else:
                         generate_session_title)
                     _sdir = st.session_state.session_dir
                     if _sdir and not load_session_name(_sdir):
-                        _cfg = st.session_state.agent_config
                         _first_user = next(
                             (m["content"] for m in st.session_state.chat_messages
                              if m["role"] == "user"), "")
                         _title = generate_session_title(
-                            _cfg.get("model"), _cfg.get("api_key"),
-                            _cfg.get("base_url"), _first_user, content)
+                            getattr(st.session_state.agent, "model", None),
+                            _first_user, content)
                         if _title:
                             save_session_name(_sdir, _title, named_by="agent")
                 except Exception:  # noqa: BLE001 - naming must never break a turn

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -1417,10 +1417,20 @@ else:
         else:
             labels = [s[0] for s in sessions]
             paths = [s[1] for s in sessions]
+            # Default to the CURRENT session, not the newest by name: a
+            # stray newer (possibly empty) session directory otherwise
+            # opens the tab on "No files found yet." while the session
+            # being worked on sits unselected below it.
+            current_idx = next(
+                (i for i, p in enumerate(paths)
+                 if p.resolve() == Path(st.session_state.session_dir).resolve()),
+                0,
+            )
             selected_idx = st.selectbox(
                 "Session",
                 range(len(labels)),
                 format_func=lambda i: labels[i],
+                index=current_idx,
                 key="session_selector",
             )
             session_path = paths[selected_idx]

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -664,9 +664,12 @@ if not st.session_state.agent_initialized:
             resume_session(**_pending_resume)
         else:
             start_session(**_pending)
-        # start_session / resume_session call st.rerun() on success,
-        # so we only reach here if initialization failed.
-        st.stop()
+        # start_session / resume_session call st.rerun() on success, so we
+        # only reach here if initialization failed. The failure message is
+        # stashed in _session_init_error; rerun so the welcome screen can
+        # show it — st.stop() here would freeze on the spinner screen with
+        # the error invisible behind the dimmed sidebar.
+        st.rerun()
 
     # ── Normal welcome screen ────────────────────────────────
     col_l, col_c, col_r = st.columns([1, 2, 1])
@@ -705,6 +708,14 @@ if not st.session_state.agent_initialized:
             f'{_cur_desc}</p>',
             unsafe_allow_html=True,
         )
+
+        # Session start/resume failure from the previous run (stashed by
+        # start_session / resume_session). Below the mode selector because
+        # the mode-selector-anchor CSS pulls that row upward over anything
+        # rendered above it.
+        _init_err = st.session_state.pop("_session_init_error", None)
+        if _init_err:
+            st.error(_init_err)
 
         _is_dark = st.session_state.get("theme_mode", "dark") == "dark"
         _logo = _LOGO_DARK if _is_dark else _LOGO_LIGHT

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -430,6 +430,11 @@ def render_sidebar() -> None:
                             "restored, but chat history will be loaded."
                         )
 
+                    if not consent:
+                        st.caption(
+                            "☝️ Check the code-execution consent box above "
+                            "to enable resuming."
+                        )
                     if st.button(
                         "Resume Session",
                         disabled=not consent,
@@ -795,7 +800,11 @@ def start_session(model: str, api_key: str, base_url: str, mode: str, fh_api_key
         resolved_key = auth.api_key or os.environ.get("GEMINI_API_KEY") or os.environ.get("OPENAI_API_KEY") or os.environ.get("ANTHROPIC_API_KEY")
 
     if not (api_key or base_url or any(os.environ.get(e) for e in spec.cred_env)):
-        st.sidebar.error(spec.cred_error)
+        # Stash rather than render: the caller runs behind the init spinner,
+        # which dims the sidebar — an error drawn there is invisible and the
+        # spinner never clears. app.py reruns and shows this on the welcome
+        # screen instead.
+        st.session_state._session_init_error = spec.cred_error
         return
 
     # Optional MP key: register so the DFT pipeline's auto-discovery picks it up
@@ -835,7 +844,7 @@ def start_session(model: str, api_key: str, base_url: str, mode: str, fh_api_key
                 session_dir, resolved_key, model, base_url, mode, fh_api_key,
             )
     except Exception as exc:
-        st.error(f"Failed to initialize agent: {exc}")
+        st.session_state._session_init_error = f"Failed to initialize agent: {exc}"
         return
 
     st.session_state.agent = agent
@@ -1016,6 +1025,31 @@ def _convert_chat_history_for_display(history: list) -> list:
     return messages
 
 
+def _collect_restored_deliverables(session_path: Path) -> tuple:
+    """Marked deliverables from the session's manifest(s), split for the
+    chat renderer: (md_paths, html_paths).
+
+    Chat-message attachments (md_reports / html_reports) live only in
+    Streamlit state and are lost on restore — the deliverables manifests
+    are the durable record of what the session produced, so a resumed
+    chat re-embeds from them.
+    """
+    from scilink.agents.planning_agents.user_interface import load_deliverables
+
+    md_docs, html_docs = [], []
+    for entry in load_deliverables(session_path):
+        if not entry.get("deliverable"):
+            continue
+        p = Path(entry.get("path", ""))
+        if not p.exists():
+            continue
+        if p.suffix.lower() == ".md":
+            md_docs.append(str(p))
+        elif p.suffix.lower() in (".html", ".htm"):
+            html_docs.append(str(p))
+    return md_docs, html_docs
+
+
 def resume_session(
     session_dir: str,
     model: str,
@@ -1048,7 +1082,9 @@ def resume_session(
         )
 
     if not (api_key or base_url or any(os.environ.get(e) for e in spec.cred_env)):
-        st.sidebar.error(spec.cred_error)
+        # See start_session: rendering here would land behind the dimmed
+        # spinner screen; the welcome screen shows it after the rerun.
+        st.session_state._session_init_error = spec.cred_error
         return
 
     # Optional MP key registration (see start_session for rationale).
@@ -1127,7 +1163,7 @@ def resume_session(
                 futurehouse_api_key=fh_api_key or None,
             )
     except Exception as exc:
-        st.error(f"Failed to restore session: {exc}")
+        st.session_state._session_init_error = f"Failed to restore session: {exc}"
         return
 
     # Load chat history for Streamlit display
@@ -1139,6 +1175,18 @@ def resume_session(
             display_messages = _convert_chat_history_for_display(raw)
         except Exception:
             pass
+
+    # Re-embed the session's deliverables. The per-message attachments the
+    # live chat carries are not persisted, so without this a restored chat
+    # shows the conversation but silently drops every embedded document.
+    md_docs, html_docs = _collect_restored_deliverables(session_path)
+    if md_docs or html_docs:
+        display_messages.append({
+            "role": "assistant",
+            "content": "📎 Deliverables produced in this session:",
+            "md_reports": md_docs,
+            "html_reports": html_docs,
+        })
 
     # Pre-populate known images so they don't re-appear as "new"
     known: set = set()
@@ -1318,7 +1366,9 @@ def _start_simulate_session(
         )
 
     if not (api_key or base_url or any(os.environ.get(e) for e in spec.cred_env)):
-        st.sidebar.error("Provide an API key or set an environment variable.")
+        st.session_state._session_init_error = (
+            "Provide an API key or set an environment variable."
+        )
         return
 
     # Direct providers: export the typed key to the conventional vendor env var

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -500,6 +500,21 @@ def render_sidebar() -> None:
             elif app_mode == "meta":
                 _render_meta_sidebar_uploads()
 
+            # ── Session name (display-only; dir name stays load-bearing) ──
+            st.divider()
+            from scilink.ui.session_meta import (
+                load_session_name, save_session_name)
+            _sdir = st.session_state.session_dir
+            _current_name = load_session_name(_sdir) or ""
+            _typed = st.text_input(
+                "Session name", value=_current_name,
+                key="session_name_input",
+                help=("Shown in the resume list and File Explorer. "
+                      "Auto-named by the agent after the first turn "
+                      "unless you set one."))
+            if _typed.strip() and _typed.strip() != _current_name:
+                save_session_name(_sdir, _typed, named_by="user")
+
             # ── Agent status (mode-specific) ─────────────────────
             st.divider()
             st.subheader("Agent Status")
@@ -853,6 +868,10 @@ def start_session(model: str, api_key: str, base_url: str, mode: str, fh_api_key
     st.session_state.agent_config = {
         "model": model,
         "mode": mode,
+        # For the auto-title call after the first turn (session_meta):
+        # litellm needs the same credentials the agent got.
+        "api_key": resolved_key,
+        "base_url": base_url or None,
     }
     st.session_state.chat_messages = []
     st.session_state.known_images = set()
@@ -976,12 +995,10 @@ def _discover_resumable_sessions(app_mode: str) -> list:
         if not has_checkpoint and not has_chat:
             continue
 
-        # Build human-readable label from timestamp in dir name
-        parts = s.name.removeprefix(f"{prefix}_")
-        try:
-            label = f"{parts[:4]}-{parts[4:6]}-{parts[6:8]} {parts[9:11]}:{parts[11:13]}:{parts[13:15]}"
-        except (IndexError, ValueError):
-            label = s.name
+        # Human-readable label: stored display name (session_meta.json)
+        # with the timestamp, or the bare timestamp when unnamed.
+        from scilink.ui.session_meta import session_label
+        label = session_label(s, prefix)
 
         summary: dict = {}
         if has_checkpoint:
@@ -1216,7 +1233,9 @@ def resume_session(
     st.session_state.agent = agent
     st.session_state.agent_initialized = True
     st.session_state.session_dir = str(session_path)
-    st.session_state.agent_config = {"model": model, "mode": mode}
+    st.session_state.agent_config = {"model": model, "mode": mode,
+                                     "api_key": resolved_key,
+                                     "base_url": base_url or None}
     st.session_state.chat_messages = display_messages
     st.session_state.known_images = known
     st.rerun()

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -1201,6 +1201,17 @@ def resume_session(
     for ext in (".png", ".jpg", ".jpeg"):
         for p in session_path.rglob(f"*{ext}"):
             known.add(str(p))
+    # ...and existing reports/documents. The .html/.md sweeps key on
+    # path+mtime in this same set; without pre-marking them, the first
+    # completed turn after a resume treats every report the session ever
+    # produced as "new this turn" and embeds them all in its answer.
+    # (The resume itself already re-embeds the latest deliverable.)
+    for ext in (".html", ".md"):
+        for p in session_path.rglob(f"*{ext}"):
+            try:
+                known.add(f"{p}:{p.stat().st_mtime_ns}")
+            except OSError:
+                known.add(str(p))
 
     st.session_state.agent = agent
     st.session_state.agent_initialized = True

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -868,10 +868,6 @@ def start_session(model: str, api_key: str, base_url: str, mode: str, fh_api_key
     st.session_state.agent_config = {
         "model": model,
         "mode": mode,
-        # For the auto-title call after the first turn (session_meta):
-        # litellm needs the same credentials the agent got.
-        "api_key": resolved_key,
-        "base_url": base_url or None,
     }
     st.session_state.chat_messages = []
     st.session_state.known_images = set()
@@ -1233,9 +1229,7 @@ def resume_session(
     st.session_state.agent = agent
     st.session_state.agent_initialized = True
     st.session_state.session_dir = str(session_path)
-    st.session_state.agent_config = {"model": model, "mode": mode,
-                                     "api_key": resolved_key,
-                                     "base_url": base_url or None}
+    st.session_state.agent_config = {"model": model, "mode": mode}
     st.session_state.chat_messages = display_messages
     st.session_state.known_images = known
     st.rerun()

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -1036,18 +1036,25 @@ def _collect_restored_deliverables(session_path: Path) -> tuple:
     """
     from scilink.agents.planning_agents.user_interface import load_deliverables
 
-    md_docs, html_docs = [], []
+    # Only the most recent deliverable is re-embedded: a session may hold
+    # several revisions under the same title (a revision inherits the
+    # document's name), and embedding all of them repeats near-identical
+    # documents. Manifest entries carry no timestamp, so recency = file
+    # mtime, which also orders correctly across per-child manifests.
+    # Older versions stay reachable in the Files tab.
+    candidates = []
     for entry in load_deliverables(session_path):
         if not entry.get("deliverable"):
             continue
         p = Path(entry.get("path", ""))
-        if not p.exists():
-            continue
-        if p.suffix.lower() == ".md":
-            md_docs.append(str(p))
-        elif p.suffix.lower() in (".html", ".htm"):
-            html_docs.append(str(p))
-    return md_docs, html_docs
+        if p.exists() and p.suffix.lower() in (".md", ".html", ".htm"):
+            candidates.append(p)
+    if not candidates:
+        return [], []
+    latest = max(candidates, key=lambda p: p.stat().st_mtime)
+    if latest.suffix.lower() == ".md":
+        return [str(latest)], []
+    return [], [str(latest)]
 
 
 def resume_session(
@@ -1183,7 +1190,8 @@ def resume_session(
     if md_docs or html_docs:
         display_messages.append({
             "role": "assistant",
-            "content": "📎 Deliverables produced in this session:",
+            "content": ("📎 Latest deliverable from this session "
+                        "(earlier versions are in the Files tab):"),
             "md_reports": md_docs,
             "html_reports": html_docs,
         })

--- a/scilink/ui/session_meta.py
+++ b/scilink/ui/session_meta.py
@@ -10,6 +10,7 @@ user-set name always wins and is never overwritten by the agent.
 import json
 import re
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Optional
 
 _META_FILE = "session_meta.json"
@@ -67,15 +68,22 @@ def session_label(session_dir, prefix: str) -> str:
     return f"{name} — {ts}" if name else ts
 
 
-def generate_session_title(model: str, api_key, base_url,
-                           first_user_msg: str,
+def generate_session_title(model, first_user_msg: str,
                            first_reply: str = "") -> Optional[str]:
     """One small LLM call -> a concise session title, or None on any
-    failure (callers fall back to the timestamp label silently)."""
+    failure (callers fall back to the timestamp label silently).
+
+    Takes the agent's already-constructed model object — the one whose
+    transport is set up for wherever this deployment actually talks.
+    Calling litellm directly instead would re-derive the credentials and
+    get the internal proxy wrong: with a base_url set and a project-suffixed
+    model, litellm reads a claude-* name as the Anthropic provider and never
+    speaks the proxy's schema, so titling silently no-ops on the deployment
+    most sessions run on.
+    """
     if not (model and first_user_msg):
         return None
     try:
-        import litellm
         prompt = (
             "Name this scientific-assistant session in 3-6 plain words "
             "(no quotes, no trailing period). Base it on the topic, not "
@@ -83,15 +91,9 @@ def generate_session_title(model: str, api_key, base_url,
             f"First request: {first_user_msg[:600]}\n"
             f"Start of reply: {first_reply[:300]}"
         )
-        kwargs = {"model": model,
-                  "messages": [{"role": "user", "content": prompt}],
-                  "max_tokens": 24}
-        if api_key:
-            kwargs["api_key"] = api_key
-        if base_url:
-            kwargs["base_url"] = base_url
-        title = litellm.completion(**kwargs).choices[0].message.content
-        title = re.sub(r'["\'\n\r.]+', " ", title or "").strip()
-        return title[:60] or None
+        resp = model.generate_content(
+            [prompt], generation_config=SimpleNamespace(max_output_tokens=24))
+        title = re.sub(r'["\'\n\r.]+', " ", getattr(resp, "text", "") or "")
+        return title.strip()[:60] or None
     except Exception:
         return None

--- a/scilink/ui/session_meta.py
+++ b/scilink/ui/session_meta.py
@@ -1,0 +1,97 @@
+"""Session display names: sidecar label + LLM auto-titling.
+
+The directory name (``<prefix>_<timestamp>``) is load-bearing — deliverables
+manifests and checkpoints store absolute paths into it — so a session's
+human name lives in a sidecar ``session_meta.json`` and is display-only.
+The agent titles an unnamed session after its first completed turn; a
+user-set name always wins and is never overwritten by the agent.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+_META_FILE = "session_meta.json"
+
+
+def _meta_path(session_dir) -> Path:
+    return Path(session_dir) / _META_FILE
+
+
+def load_session_meta(session_dir) -> dict:
+    try:
+        return json.loads(_meta_path(session_dir).read_text())
+    except Exception:
+        return {}
+
+
+def load_session_name(session_dir) -> Optional[str]:
+    name = load_session_meta(session_dir).get("name")
+    return name if isinstance(name, str) and name.strip() else None
+
+
+def save_session_name(session_dir, name: str, named_by: str) -> bool:
+    """Persist a display name. ``named_by`` is "user" or "agent"; an
+    agent title never overwrites a user-chosen name. Returns True if
+    written."""
+    name = (name or "").strip()
+    if not name:
+        return False
+    meta = load_session_meta(session_dir)
+    if named_by == "agent" and meta.get("named_by") == "user":
+        return False
+    meta.update({"name": name[:80], "named_by": named_by})
+    try:
+        _meta_path(session_dir).write_text(json.dumps(meta, indent=1))
+        return True
+    except OSError:
+        return False
+
+
+def timestamp_label(dir_name: str, prefix: str) -> str:
+    """'<prefix>_20260730_135341' -> '2026-07-30 13:53:41' (best effort)."""
+    parts = dir_name.removeprefix(f"{prefix}_")
+    try:
+        return (f"{parts[:4]}-{parts[4:6]}-{parts[6:8]} "
+                f"{parts[9:11]}:{parts[11:13]}:{parts[13:15]}")
+    except (IndexError, ValueError):
+        return dir_name
+
+
+def session_label(session_dir, prefix: str) -> str:
+    """Display label for pickers: 'Name — 2026-07-30 13:53:41', or the
+    bare timestamp when the session is unnamed."""
+    ts = timestamp_label(Path(session_dir).name, prefix)
+    name = load_session_name(session_dir)
+    return f"{name} — {ts}" if name else ts
+
+
+def generate_session_title(model: str, api_key, base_url,
+                           first_user_msg: str,
+                           first_reply: str = "") -> Optional[str]:
+    """One small LLM call -> a concise session title, or None on any
+    failure (callers fall back to the timestamp label silently)."""
+    if not (model and first_user_msg):
+        return None
+    try:
+        import litellm
+        prompt = (
+            "Name this scientific-assistant session in 3-6 plain words "
+            "(no quotes, no trailing period). Base it on the topic, not "
+            "the phrasing.\n\n"
+            f"First request: {first_user_msg[:600]}\n"
+            f"Start of reply: {first_reply[:300]}"
+        )
+        kwargs = {"model": model,
+                  "messages": [{"role": "user", "content": prompt}],
+                  "max_tokens": 24}
+        if api_key:
+            kwargs["api_key"] = api_key
+        if base_url:
+            kwargs["base_url"] = base_url
+        title = litellm.completion(**kwargs).choices[0].message.content
+        title = re.sub(r'["\'\n\r.]+', " ", title or "").strip()
+        return title[:60] or None
+    except Exception:
+        return None

--- a/scilink/ui/session_meta.py
+++ b/scilink/ui/session_meta.py
@@ -94,6 +94,11 @@ def generate_session_title(model, first_user_msg: str,
         resp = model.generate_content(
             [prompt], generation_config=SimpleNamespace(max_output_tokens=24))
         title = re.sub(r'["\'\n\r.]+', " ", getattr(resp, "text", "") or "")
-        return title.strip()[:60] or None
+        title = " ".join(title.split()).strip()
+        if len(title) > 60:
+            # Cut on a word boundary — a sidebar label ending mid-word
+            # ("...from amorphous precurs") reads as a broken title.
+            title = title[:60].rsplit(" ", 1)[0].rstrip(" ,;:-") or title[:60]
+        return title or None
     except Exception:
         return None

--- a/scilink/ui/theme.py
+++ b/scilink/ui/theme.py
@@ -850,6 +850,30 @@ div:has(> [data-testid="stMarkdown"] .theme-toggle-anchor) + div button:hover {
     color: #212121 !important;
     box-shadow: none !important;
 }
+/* Main-area secondary buttons (e.g. the Files tab's Refresh) — the sidebar
+   and mode-selector rules miss them, so they fall through to the
+   launch-time dark native theme: a dark box under a forced-dark label.
+   The mode-selector's outlined-purple rule is more specific and keeps
+   winning where it applies. */
+section[data-testid="stMain"] .stButton > button[kind="secondary"],
+section[data-testid="stMain"] button[data-testid="stBaseButton-secondary"] {
+    background-color: #EEEEEE !important;
+    color: #212121 !important;
+    border: 1px solid #E0E0E0 !important;
+}
+section[data-testid="stMain"] .stButton > button[kind="secondary"] *,
+section[data-testid="stMain"] button[data-testid="stBaseButton-secondary"] * {
+    color: #212121 !important;
+}
+section[data-testid="stMain"] .stButton > button[kind="secondary"]:hover,
+section[data-testid="stMain"] button[data-testid="stBaseButton-secondary"]:hover {
+    background-color: #E3F2FD !important;
+    border-color: #5B8DEF !important;
+    box-shadow: none !important;
+}
+/* Streamlit ≥1.49 drops the `kind` DOM attribute (it became a styled-prop
+   filtered before the DOM), so the [kind=…] halves above are for older
+   versions; the stBaseButton testid halves are what actually match. */
 /* The popover panel is portaled to the document root (not inside the expander),
    so style it globally for light mode. baseweb gives the body (and a nested
    content wrapper) a dark inline background, so whiten the body AND its block

--- a/tests/test_session_title.py
+++ b/tests/test_session_title.py
@@ -62,5 +62,18 @@ app = open("/Users/maxim.ziatdinov/Code/SciLink/scilink/ui/app.py").read()
 check("_cfg.get(\"api_key\")" not in app, "call site no longer reads credentials from agent_config")
 check("getattr(st.session_state.agent, \"model\", None)" in app, "call site passes the agent's model")
 
+# ── title shaping ───────────────────────────────────────────────────────────
+print("\n=== titles are cut on a word boundary, not mid-word ===")
+long = FakeModel(text="Operando XRD polymorph identification from amorphous precursor phases")
+t = generate_session_title(long, "x")
+print(f"     {t!r}  (len={len(t)})")
+check(len(t) <= 60, "respects the 60-char label cap")
+check(not t.endswith("precurs"), "does not cut mid-word (live proxy produced exactly this)")
+check(t == "Operando XRD polymorph identification from amorphous", "cuts at the last whole word")
+check(generate_session_title(FakeModel(text="  Ragged\n\n  spacing   here "), "x")
+      == "Ragged spacing here", "collapses ragged whitespace")
+check(generate_session_title(FakeModel(text="A"*80), "x") == "A"*60,
+      "unbroken 80-char string still yields 60 chars, not empty")
+
 print("\n" + ("ALL PASSED" if not fails else f"{len(fails)} FAILURE(S): {fails}"))
 sys.exit(1 if fails else 0)

--- a/tests/test_session_title.py
+++ b/tests/test_session_title.py
@@ -1,0 +1,66 @@
+"""generate_session_title must work through whatever transport the agent has."""
+import sys, types
+from types import SimpleNamespace
+sys.path.insert(0, "/Users/maxim.ziatdinov/Code/SciLink")
+from scilink.ui.session_meta import generate_session_title
+
+fails = []
+def check(c, m):
+    print(("  PASS  " if c else "  FAIL  ") + m)
+    if not c: fails.append(m)
+
+class FakeModel:
+    """Stands in for OpenAIAsGenerativeModel / LiteLLMGenerativeModel — both
+    expose generate_content(contents, generation_config=...) -> .text"""
+    def __init__(self, text='"Operando synthesis pathway mapping."'):
+        self.text, self.seen = text, {}
+    def generate_content(self, contents, generation_config=None, safety_settings=None):
+        self.seen = {"contents": contents, "cfg": generation_config}
+        return SimpleNamespace(text=self.text)
+
+print("=== titles through the agent's model object (both wrappers share this API) ===")
+m = FakeModel()
+t = generate_session_title(m, "Analyze the operando XRD data from run 12", "Sure, I'll start by")
+print(f"     title -> {t!r}")
+check(t == "Operando synthesis pathway mapping", "title generated and cleaned")
+check(isinstance(m.seen["contents"], list), "prompt passed as the flat list both wrappers expect")
+check(getattr(m.seen["cfg"], "max_output_tokens", None) == 24,
+      "max_output_tokens=24 passed via generation_config (maps to max_tokens on both)")
+check("Analyze the operando XRD" in m.seen["contents"][0], "first user message reaches the prompt")
+
+print("\n=== THE REGRESSION: proxy transport must not be bypassed ===")
+import scilink.ui.session_meta as sm
+import inspect
+src = inspect.getsource(sm.generate_session_title)
+# strip the docstring: it explains the bug and legitimately names litellm/base_url
+import ast as _ast
+_fn = _ast.parse(src.lstrip()).body[0]
+code = "\n".join(src.splitlines()[_fn.body[0].end_lineno:])
+check("litellm" not in code, "no direct litellm call (was: bypassed the proxy wrapper)")
+check("api_key" not in code and "base_url" not in code, "no credential re-derivation")
+check("generate_content" in code, "goes through the model object's transport")
+
+print("\n=== fails safe, never raises into the turn ===")
+class Boom:
+    def generate_content(self, *a, **k): raise RuntimeError("proxy down")
+check(generate_session_title(Boom(), "x") is None, "model raising -> None, not an exception")
+check(generate_session_title(None, "x") is None, "no model -> None")
+check(generate_session_title(FakeModel(), "") is None, "no first message -> None")
+check(generate_session_title(FakeModel(text=""), "x") is None, "empty completion -> None")
+check(generate_session_title(FakeModel(text="   ...  "), "x") is None, "punctuation-only -> None")
+
+print("\n=== agent_config no longer carries credentials ===")
+sb = open("/Users/maxim.ziatdinov/Code/SciLink/scilink/ui/components/sidebar.py").read()
+import re
+blocks = re.findall(r'st\.session_state\.agent_config = \{[^}]*\}', sb, re.S)
+# the third assignment predates this PR (carries fh_api_key); scope to the two it touched
+blocks = [b for b in blocks if "fh_api_key" not in b]
+check(len(blocks) >= 2, f"found {len(blocks)} agent_config assignments")
+check(all("api_key" not in b and "base_url" not in b for b in blocks),
+      "no agent_config assignment carries api_key/base_url")
+app = open("/Users/maxim.ziatdinov/Code/SciLink/scilink/ui/app.py").read()
+check("_cfg.get(\"api_key\")" not in app, "call site no longer reads credentials from agent_config")
+check("getattr(st.session_state.agent, \"model\", None)" in app, "call site passes the agent's model")
+
+print("\n" + ("ALL PASSED" if not fails else f"{len(fails)} FAILURE(S): {fails}"))
+sys.exit(1 if fails else 0)


### PR DESCRIPTION
## Summary

1. **The root cause of unresumable sessions is fixed: checkpoints were almost never written.** The meta agent only wrote its checkpoint every 10 user turns, and the UI (unlike the CLI, which saves on quit) never saved one explicitly — so **15 of 17 real meta sessions on the development machine had no checkpoint at all** and restored without their delegation history. Now the UI checkpoints after every completed turn, and the meta checkpoints immediately whenever a delegation finishes. Any session that completes even one turn is fully resumable.

The rest of the PR fixes three problems in the resume flow itself, all observed live:

2. **Restored chats lost their documents.** A resumed session showed the conversation but silently dropped every embedded white paper, report, and dossier. Documents are chat-message attachments that live only in the UI's in-memory state — nothing re-attached them from disk. Resume now reads the session's deliverables manifests (the durable record of what a session produced) and appends a final "📎 Deliverables produced in this session" message, so restored documents come back as the same expandable embeds with download buttons the live chat shows.

3. **Failures looked like a hang.** If resume (or session start) failed — most commonly because the provider credentials weren't re-entered — the error was rendered into the sidebar *behind* the initialization spinner overlay, which dims the sidebar and disables clicks. The app froze on "Restoring session…" forever with the real message invisible. Failures now return to the welcome screen and show the error prominently.

4. **The Resume button was mysteriously greyed out.** It is gated on the same code-execution consent checkbox as Start Session, but nothing said so. A caption now points at the checkbox.

## Technical details

**Commit 2 — `scilink/ui/app.py`, `scilink/agents/meta_agent/meta_orchestrator.py`** (item 1)
- UI monitor-fragment completion branch calls `save_checkpoint()` (meta — also snapshots instantiated children) or `_auto_checkpoint()` (standalone orchestrators), guarded so a checkpoint failure can never break the turn.
- `_close_delegation` calls `_auto_checkpoint()` — a completed delegation is exactly the ledger state a resume needs. Fan-out workers close entries concurrently, so `_auto_checkpoint` now writes atomically (temp file + `os.replace`) under a new `_checkpoint_lock`.

**Commit 1 — `scilink/ui/components/sidebar.py`, `scilink/ui/app.py`** (items 2–4)
- `_collect_restored_deliverables` (sidebar.py) walks `load_deliverables(session_path)` (rglob over per-orchestrator `deliverables.json` manifests, so meta/plan/analyze all work), keeps `deliverable: true` entries whose files exist, splits `.md` vs `.html`, and `resume_session` appends them as a synthetic assistant message with `md_reports` / `html_reports` — reusing the live chat's rendering path (titles resolve via `_deliverable_title` from the manifest).
- All five start/resume failure sites (cred checks ×3, init exception, restore exception) stash `st.session_state._session_init_error` instead of rendering into the dimmed sidebar; app.py replaces the post-failure `st.stop()` with `st.rerun()` and renders the stashed error on the welcome screen below the mode selector (above it, the mode-row's negative-margin CSS overlaps the banner).
- Consent hint caption above the disabled Resume button.

**Validation**
- Live (browser, real sessions): restored a 4-turn meta session — chat history, 4 embedded documents (ideation report + three white-paper revisions), delegation tree all present; credential-failure path shows the banner instead of hanging; consent hint renders.
- Offline harness: `_close_delegation` writes the checkpoint immediately; 8 concurrent closes leave valid JSON; restore round-trip recovers all 9 entries; `save_checkpoint` works on a restored agent.

**Known limits**
- Resume uses the *current* sidebar credentials — a session does not carry its own. The failure is now visible, but re-entering the key is still required.
- The per-turn UI save could not be exercised with a live LLM turn (no credentials in the test shell); the call it makes is the one the offline harness verifies.
- Cosmetic: meta sessions list as "(0 analyses)" in the resume picker (the label reads `analysis_results`, which meta checkpoints don't have) (the revision-stacking half of this was fixed in round 2 below).

---

## Round 2 — from live testing of the resumed session (4 more commits)

Resuming the real session immediately surfaced four more issues; each was diagnosed on the live artifacts and fixed:

5. **Resume embedded every revision of every document.** A revised white paper keeps its title, so a session with three revisions re-embedded all three (plus the ideation report). Resume now embeds only the most recent deliverable, and says so: "Latest deliverable from this session (earlier versions are in the Files tab)."

6. **The File Explorer opened on the wrong session.** It defaulted to the newest directory by name — a stray empty session directory opened the tab on "No files found yet." while the resumed session (28 files) sat unselected below it. It now defaults to the current session.

7. **The first question after a resume embedded the session's entire document history** — portfolios, white papers, ideation reports. The live chat's "new this turn" sweep keys documents by path+mtime in a known-set that resume populated with images only, so every existing document looked new. Resume now pre-marks all existing reports; documents a new turn actually produces still embed (probe-verified).

8. **The Refresh button was unreadable in light mode** (dark box, dark label). Main-area secondary buttons had no light-mode rule and fell through to the launch-time dark native theme. While fixing it: **Streamlit ≥1.49 no longer renders the `kind` DOM attribute** (it became a styled-prop filtered before the DOM), so every `button[kind=…]` selector in the theme silently matches nothing on 1.58 — the working selector is `button[data-testid="stBaseButton-secondary"]`. This fix uses both forms; the rest of the theme still relies on `[kind=…]` and is a recommended follow-up sweep.

Plus one small feature the testing motivated:

9. **Sessions have names now.** After the first completed turn, one small LLM call titles the session from its opening exchange (live-checked: an STM request came back "TaS2 Charge Density Wave Analysis"); a "Session name" sidebar input overrides, and a user-set name is never overwritten by the agent. Both the resume picker and the File Explorer show "Name — timestamp". Existing unnamed sessions get titled retroactively on their next completed turn.

### Technical details (round 2)

**`3a24f05` — sidebar.py**: `_collect_restored_deliverables` returns only the newest marked deliverable; recency = file mtime (manifest entries carry no timestamp; mtime also orders across per-child manifests). Verified against the real session: selects exactly the round-3 `white_paper.md` of the three revisions.

**`3a24f05` — app.py**: Files-tab selectbox gets `index=current_idx` (position of the session whose label carries "(current)").

**`c1f7c1c` — sidebar.py**: resume's known-set pre-population adds `.html`/`.md` files with the same `path:mtime_ns` key form the sweeps use (images keep plain-path keys). Offline probe on the real session: 0 pre-existing documents register as new; a freshly written file still does. The path+mtime key is deliberate — a turn that genuinely rewrites a document (plan refine) re-embeds it by design.

**`776ef3d` — theme.py**: light-CSS rule for `section[data-testid="stMain"]` secondary buttons, in both `[kind="secondary"]` (older Streamlit) and `stBaseButton-secondary` testid (≥1.49) forms; popover-trigger palette; placement verified to be in `_MATERIAL_CSS_LIGHT` only. The mode-selector's more-specific rule still wins where it applies.

**`3bf9719` — new `scilink/ui/session_meta.py` + wiring**: sidecar `session_meta.json` (`{name, named_by}`) — the directory name stays load-bearing (manifests/checkpoints store absolute paths into it), so the label is display-only. `generate_session_title` = one litellm call with the agent's own model/credentials (now stashed in `agent_config` by all three start/resume paths), `max_tokens=24`, quote/newline cleanup, 60-char cap, `None` on any failure. Turn-completion hook in app.py fires only when the session is unnamed; agent titles never overwrite `named_by: "user"`. Unit checks: save/load round-trip, user-beats-agent precedence, label formatting; live Bedrock call for the title itself.

### Known limits (round 2)
- Rounds 5–9 are verified by offline logic checks against the real session artifacts plus a live LLM title call — not yet by a full browser pass (the round-1 items were browser-verified; these landed after that pass).
- The theme-wide `[kind=…]` dead-selector issue (item 8) is fixed only for the button it broke visibly; a mechanical sweep of the remaining rules is follow-up.
- The auto-title call runs synchronously at first-turn completion (~1–2 s, once per session).
