### PR TITLE
A second literature search no longer truncates the first

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -1343,7 +1343,20 @@ class OrchestratorTools:
                         parts.extend(secs)
                 content = "\n\n".join(parts)
 
+                # The name is keyed only by search TYPE, so a second search
+                # of the same type in one output directory used to truncate
+                # the first — silently, since the registry then held two
+                # entries pointing at one surviving file. Under the meta
+                # each delegation has its own directory, so this bites the
+                # standalone campaign root hardest. Suffix only on
+                # collision: the first (overwhelmingly common) write keeps
+                # the historical name exactly.
                 lit_path = self._output_dir() / f"literature_search_{label}.md"
+                _n = 1
+                while lit_path.exists():
+                    _n += 1
+                    lit_path = (self._output_dir()
+                                / f"literature_search_{label}_{_n}.md")
                 with open(lit_path, 'w') as f:
                     f.write(f"# Literature Search Results ({label})\n\n")
                     f.write(content)

--- a/tests/test_literature_no_overwrite.py
+++ b/tests/test_literature_no_overwrite.py
@@ -1,0 +1,66 @@
+"""Two same-type literature searches must not truncate each other, and a
+single search must keep the historical filename exactly."""
+import os, tempfile, types
+from pathlib import Path
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+from scilink.agents.planning_agents.planning_orchestrator import (
+    PlanningOrchestratorAgent, AutonomyLevel)
+
+ok = {}
+def check(n, c, d=""): ok[n] = bool(c); print(f"  [{'PASS' if c else 'FAIL'}] {n} {d}")
+
+with tempfile.TemporaryDirectory() as t:
+    d = Path(t); (d/"data").mkdir()
+    import contextlib, io
+    with contextlib.redirect_stdout(io.StringIO()):
+        orch = PlanningOrchestratorAgent(base_dir=str(d), api_key="sk-dummy",
+            autonomy_level=AutonomyLevel.AUTONOMOUS, data_dir=str(d/"data"))
+    tools = orch.tools
+
+    # Stub the literature agent: deterministic per-call content, no network.
+    calls = {"n": 0}
+    def _mk(tag):
+        def f(objective, **kw):
+            calls["n"] += 1
+            return {"status": "success",
+                    "content": f"RESULT-{calls['n']} for {objective}"}
+        return f
+    class FakeLit:
+        search_for_hypothesis_context = staticmethod(_mk("hyp"))
+        search_for_cross_domain = staticmethod(_mk("cross"))
+        search_for_economic_data = staticmethod(_mk("econ"))
+        search_for_fitting_models = staticmethod(_mk("fit"))
+    orch.lit_agent = FakeLit()
+
+    r1 = tools.execute_tool("search_literature", objective="first question",
+                            search_type="hypothesis_context")
+    r2 = tools.execute_tool("search_literature", objective="second question",
+                            search_type="hypothesis_context")
+    import json
+    p1, p2 = json.loads(r1).get("file_path"), json.loads(r2).get("file_path")
+    files = sorted(p.name for p in d.rglob("literature_search_*.md"))
+    check("first keeps historical name",
+          Path(p1).name == "literature_search_hypothesis_context.md",
+          f"({Path(p1).name})")
+    check("second gets a distinct name", p1 != p2, f"({Path(p2).name})")
+    check("both files exist", len(files) == 2, f"({files})")
+    check("first content intact", "RESULT-1" in Path(p1).read_text())
+    check("second content intact", "RESULT-2" in Path(p2).read_text())
+    # registry + newest-wins discovery still work
+    reg = tools._lit_registry()
+    paths = [Path(e["path"]).name for e in reg]
+    check("registry holds BOTH distinct paths",
+          len(set(paths)) == 2, f"({paths})")
+    # Campaign scoping (#396): pending literature is only claimed once a
+    # plan exists. Stamp a campaign and confirm newest-wins still works.
+    for e in reg:
+        e["campaign_id"] = 1
+    orch.planner.state["current_plan"] = {"campaign_id": 1}
+    latest = tools._latest_literature_file()
+    check("newest file discoverable once claimed",
+          latest is not None and latest.name == Path(p2).name,
+          f"({latest.name if latest else None})")
+
+print("=" * 50)
+print(f"LIT COLLISION: {sum(ok.values())}/{len(ok)} passed")
+raise SystemExit(0 if all(ok.values()) else 1)


### PR DESCRIPTION
## Summary

Running a **second literature search of the same kind** in one planning session used to silently destroy the first one's results.

The saved file is named after the search *type* — `literature_search_hypothesis_context.md` — and nothing else. Search the literature about one question, then search again about another, and the second write lands on the same filename and truncates the first. Nothing warns you: the session's internal record ends up with two entries pointing at the one surviving file, so a later white paper happily restores its citations from whichever search happened to survive.

Now the first search keeps its familiar filename and a second one is saved alongside it as `..._2.md`. Nothing else changes.

**Who was actually exposed.** Under the meta agent each delegation writes into its own folder, so the usual rhythm — search, work, come back later and search again — was already safe. The damage was concentrated in standalone `scilink plan`, where every search in the session shares one directory.

---

## Technical details

**Change** (`scilink/agents/planning_agents/orchestrator_tools.py`, `search_literature`): the filename is `literature_search_{label}.md` with `label = "+".join(types)`, written with a plain `open(..., 'w')`. A collision-only suffix loop now runs before the write, so the path is unchanged whenever the file does not already exist.

**Why this cannot disturb the working path.** The suffix fires only on an existing file, so the first (overwhelmingly common) write is byte-identical to before — the existing assertion in `tests/test_literature_cross_domain.py` on the exact name `literature_search_hypothesis_context+cross_domain.md` still passes untouched, which is the no-op proof. Both readers already tolerate a suffixed name: `_latest_literature_file` prefers the registry, which stores absolute paths and sorts by mtime, and its legacy fallback globs `literature_search_*.md`, which `..._2.md` matches. `_record_literature_file` records whatever path was actually written, so campaign scoping (#396) is unaffected.

**Validation.** Offline — `tests/test_literature_no_overwrite.py`, 7 checks with a stubbed literature agent (historical name preserved; distinct second path; both contents intact; registry holds both distinct paths; newest-wins discovery still works once a campaign claims them). Existing suites unchanged: 58 passed across `test_literature_cross_domain` and `test_campaign_scoping`. Live on Bedrock + FutureHouse Edison, standalone planning session, 13/13 — two real same-type searches wrote `literature_search_hypothesis_context.md` and `..._2.md` with genuinely different content, the first was byte-unchanged after the second ran, and the downstream `generate_initial_plan` → `generate_white_paper` chain still produced a literature-grounded paper with discovery returning a real file.

**Note on semantics observed while testing (pre-existing, unchanged here):** literature searched before any plan exists stays *pending* and is not claimed until a plan is generated — the campaign-scoping behaviour from #396. It looks like "discovery returns nothing" if you check too early; the test stamps a campaign to exercise the claimed path.
