### PR TITLE
Repair tool pairing after trimming, and stop stacking document titles

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1600,6 +1600,13 @@ class AnalysisOrchestratorAgent:
             system_msg = self.messages[0]
             recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)
             self.messages = [system_msg] + recent_msgs
+            # AFTER the trim, not before: the trim is what slices a
+            # tool_use away from its tool_result, so repairing first
+            # cleans a history that was already valid and leaves the
+            # fresh damage unrepaired (live: Bedrock rejected
+            # 'Expected toolResult blocks at messages.10' — index 10
+            # being exactly the splice boundary).
+            self.messages = repair_dangling_tool_calls(self.messages)
         
         iteration = 0
         
@@ -1744,6 +1751,13 @@ class AnalysisOrchestratorAgent:
             system_msg = self.messages[0]
             recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)
             self.messages = [system_msg] + recent_msgs
+            # AFTER the trim, not before: the trim is what slices a
+            # tool_use away from its tool_result, so repairing first
+            # cleans a history that was already valid and leaves the
+            # fresh damage unrepaired (live: Bedrock rejected
+            # 'Expected toolResult blocks at messages.10' — index 10
+            # being exactly the splice boundary).
+            self.messages = repair_dangling_tool_calls(self.messages)
         
         iteration = 0
         

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1726,6 +1726,13 @@ class MetaOrchestratorAgent:
             system_msg = self.messages[0]
             recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)
             self.messages = [system_msg] + recent_msgs
+            # AFTER the trim, not before: the trim is what slices a
+            # tool_use away from its tool_result, so repairing first
+            # cleans a history that was already valid and leaves the
+            # fresh damage unrepaired (live: Bedrock rejected
+            # 'Expected toolResult blocks at messages.10' — index 10
+            # being exactly the splice boundary).
+            self.messages = repair_dangling_tool_calls(self.messages)
 
         iteration = 0
         while iteration < self.max_iterations:
@@ -1875,6 +1882,13 @@ class MetaOrchestratorAgent:
             system_msg = self.messages[0]
             recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)
             self.messages = [system_msg] + recent_msgs
+            # AFTER the trim, not before: the trim is what slices a
+            # tool_use away from its tool_result, so repairing first
+            # cleans a history that was already valid and leaves the
+            # fresh damage unrepaired (live: Bedrock rejected
+            # 'Expected toolResult blocks at messages.10' — index 10
+            # being exactly the splice boundary).
+            self.messages = repair_dangling_tool_calls(self.messages)
 
         iteration = 0
         while iteration < self.max_iterations:

--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -1328,4 +1328,8 @@ come through verbatim: same sections, same order, same wording. The result
 replaces the original file in place, so anything you omit is deleted.
 If the document carries references, keep them and keep their numbering
 consistent with any citations you add.
+
+Do NOT return the document's TITLE as a section. The title is written for
+you when the sections are assembled; returning it as well stacks a second
+copy on top of the document, and one more with every later revision.
 """

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -1610,6 +1610,13 @@ class PlanningOrchestratorAgent:
             system_msg = self.messages[0]
             recent_msgs = self._trim_history(self.messages[1:], max_messages=100)
             self.messages = [system_msg] + recent_msgs
+            # AFTER the trim, not before: the trim is what slices a
+            # tool_use away from its tool_result, so repairing first
+            # cleans a history that was already valid and leaves the
+            # fresh damage unrepaired (live: Bedrock rejected
+            # 'Expected toolResult blocks at messages.10' — index 10
+            # being exactly the splice boundary).
+            self.messages = repair_dangling_tool_calls(self.messages)
 
         self._compress_large_tool_results()
 
@@ -1747,6 +1754,13 @@ class PlanningOrchestratorAgent:
             system_msg = self.messages[0]
             recent_msgs = self._trim_history(self.messages[1:], max_messages=100)
             self.messages = [system_msg] + recent_msgs
+            # AFTER the trim, not before: the trim is what slices a
+            # tool_use away from its tool_result, so repairing first
+            # cleans a history that was already valid and leaves the
+            # fresh damage unrepaired (live: Bedrock rejected
+            # 'Expected toolResult blocks at messages.10' — index 10
+            # being exactly the splice boundary).
+            self.messages = repair_dangling_tool_calls(self.messages)
 
         self._compress_large_tool_results()
 

--- a/scilink/agents/planning_agents/planning_rag.py
+++ b/scilink/agents/planning_agents/planning_rag.py
@@ -1130,7 +1130,25 @@ def author_technical_document(request: str,
 
 
 def document_to_markdown(title: str, sections: List[Dict[str, Any]]) -> str:
-    """Assemble authored sections into a markdown document."""
+    """Assemble authored sections into a markdown document.
+
+    The title is owned HERE, not by the author. On a revision the model is
+    shown a document that already opens with its title and told to return
+    everything verbatim, so it faithfully returns the title as a section —
+    and prepending it again added one copy per revision (live: six stacked
+    titles, readable as the title's own edit history). A leading section that
+    merely repeats the title is therefore dropped.
+    """
+    def _is_title_echo(sec) -> bool:
+        if not isinstance(sec, dict) or (sec.get("body") or "").strip():
+            return False
+        h = str(sec.get("heading") or "").strip().lstrip("#").strip()
+        return h.casefold() == str(title).strip().casefold()
+
+    sections = list(sections or [])
+    while sections and _is_title_echo(sections[0]):
+        sections.pop(0)
+
     out = [f"# {title}", ""]
     for sec in sections or []:
         if not isinstance(sec, dict):

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -807,6 +807,13 @@ class SimulationOrchestratorAgent:
             system_msg = self.messages[0]
             recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)
             self.messages = [system_msg] + recent_msgs
+            # AFTER the trim, not before: the trim is what slices a
+            # tool_use away from its tool_result, so repairing first
+            # cleans a history that was already valid and leaves the
+            # fresh damage unrepaired (live: Bedrock rejected
+            # 'Expected toolResult blocks at messages.10' — index 10
+            # being exactly the splice boundary).
+            self.messages = repair_dangling_tool_calls(self.messages)
 
         iteration = 0
         while iteration < self.max_iterations:
@@ -890,6 +897,13 @@ class SimulationOrchestratorAgent:
             system_msg = self.messages[0]
             recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)
             self.messages = [system_msg] + recent_msgs
+            # AFTER the trim, not before: the trim is what slices a
+            # tool_use away from its tool_result, so repairing first
+            # cleans a history that was already valid and leaves the
+            # fresh damage unrepaired (live: Bedrock rejected
+            # 'Expected toolResult blocks at messages.10' — index 10
+            # being exactly the splice boundary).
+            self.messages = repair_dangling_tool_calls(self.messages)
 
         iteration = 0
         while iteration < self.max_iterations:

--- a/tests/test_history_trim_and_title_dup.py
+++ b/tests/test_history_trim_and_title_dup.py
@@ -22,11 +22,13 @@ from scilink.utils.tool_media import repair_dangling_tool_calls
 
 PLANNING = Path("scilink/agents/planning_agents/planning_orchestrator.py")
 META = Path("scilink/agents/meta_agent/meta_orchestrator.py")
+ANALYSIS = Path("scilink/agents/exp_agents/analysis_orchestrator.py")
+SIMULATION = Path("scilink/agents/sim_agents/simulation_orchestrator.py")
 
 
 # ── 1 · repair must run AFTER the trim ───────────────────────────────
 
-@pytest.mark.parametrize("src", [PLANNING, META])
+@pytest.mark.parametrize("src", [PLANNING, META, ANALYSIS, SIMULATION])
 def test_repair_follows_every_trim(src):
     """Repairing before the trim fixes a history that was already fine."""
     text = src.read_text()
@@ -39,7 +41,7 @@ def test_repair_follows_every_trim(src):
             f"{src.name}: a trim at offset {pos} is not followed by a repair")
 
 
-@pytest.mark.parametrize("src", [PLANNING, META])
+@pytest.mark.parametrize("src", [PLANNING, META, ANALYSIS, SIMULATION])
 def test_the_reason_is_recorded_at_the_call_site(src):
     assert "AFTER the trim, not before" in src.read_text()
 

--- a/tests/test_history_trim_and_title_dup.py
+++ b/tests/test_history_trim_and_title_dup.py
@@ -1,0 +1,128 @@
+"""Two live failures from one long session.
+
+1. History trimming sliced a tool_use away from its tool_result and the
+   repair pass ran BEFORE the trim, so it cleaned an already-valid history
+   and left the fresh damage. Bedrock rejected the turn with "Expected
+   toolResult blocks at messages.10" — index 10 being exactly the splice
+   boundary of `history[:10] + history[-90:]`.
+
+2. Revising a document stacked its title: the assembler always prepends
+   `# {title}`, while the revision contract tells the model to return the
+   whole document verbatim, so it returns the title as a section too. Six
+   copies had accumulated, readable as the title's own edit history.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from scilink.agents.planning_agents.planning_rag import document_to_markdown
+from scilink.utils.tool_media import repair_dangling_tool_calls
+
+PLANNING = Path("scilink/agents/planning_agents/planning_orchestrator.py")
+META = Path("scilink/agents/meta_agent/meta_orchestrator.py")
+
+
+# ── 1 · repair must run AFTER the trim ───────────────────────────────
+
+@pytest.mark.parametrize("src", [PLANNING, META])
+def test_repair_follows_every_trim(src):
+    """Repairing before the trim fixes a history that was already fine."""
+    text = src.read_text()
+    trims = [m.start() for m in
+             re.finditer(r"self\.messages = \[system_msg\] \+ recent_msgs", text)]
+    assert trims, f"no trim site found in {src.name}"
+    for pos in trims:
+        after = text[pos:pos + 700]
+        assert "repair_dangling_tool_calls(self.messages)" in after, (
+            f"{src.name}: a trim at offset {pos} is not followed by a repair")
+
+
+@pytest.mark.parametrize("src", [PLANNING, META])
+def test_the_reason_is_recorded_at_the_call_site(src):
+    assert "AFTER the trim, not before" in src.read_text()
+
+
+def test_repair_fixes_exactly_the_damage_a_trim_causes():
+    """The splice keeps head+tail, so it can orphan a result at the head
+    boundary and strand a call at the tail boundary. Both must survive."""
+    history = [
+        {"role": "user", "content": "go"},
+        {"role": "assistant", "tool_calls": [
+            {"id": "call_A", "type": "function",
+             "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_A", "content": "A done"},
+        {"role": "assistant", "tool_calls": [
+            {"id": "call_B", "type": "function",
+             "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_B", "content": "B done"},
+    ]
+    # the exact shape a head/tail splice produces: call_A's result dropped,
+    # call_B's result kept without its call
+    sliced = [history[0], history[1], history[4]]
+    fixed = repair_dangling_tool_calls(sliced)
+
+    pending = []
+    for m in fixed:
+        for tc in (m.get("tool_calls") or []):
+            pending.append(tc["id"])
+        if m.get("role") == "tool":
+            cid = m.get("tool_call_id")
+            assert cid in pending, "orphan tool result survived the repair"
+            pending.remove(cid)
+    assert not pending, f"unanswered tool_use survived the repair: {pending}"
+
+
+# ── 2 · the title is written once, however many revisions ────────────
+
+def test_a_title_echoed_as_a_section_is_dropped():
+    md = document_to_markdown("My Doc", [{"heading": "My Doc", "body": ""},
+                                         {"heading": "Intro", "body": "text"}])
+    assert md.count("My Doc") == 1
+    assert md.startswith("# My Doc")
+    assert "## Intro" in md and "text" in md
+
+
+def test_successive_revisions_do_not_stack_titles():
+    """The live failure: one extra copy per revision, six by the end."""
+    title = "Staging CDOC: Mini-CDOC MVPs"
+    sections = [{"heading": "Framing", "body": "body text"}]
+    doc = document_to_markdown(title, sections)
+    for _ in range(5):
+        # what a revision returns: the title echoed back, then the content
+        returned = [{"heading": title, "body": ""}] + sections
+        doc = document_to_markdown(title, returned)
+        assert doc.count(title) == 1, doc[:200]
+
+
+def test_a_real_section_that_merely_starts_with_the_title_is_kept():
+    """Only an EMPTY leading echo is dropped — never content."""
+    md = document_to_markdown("Roadmap", [
+        {"heading": "Roadmap", "body": "This section has real content."},
+        {"heading": "Next", "body": "more"}])
+    assert "This section has real content." in md
+    assert md.count("Roadmap") == 2       # the title, and the kept section
+
+
+def test_only_a_LEADING_echo_is_dropped():
+    """A title-like heading later in the document is the author's choice."""
+    md = document_to_markdown("Doc", [{"heading": "Intro", "body": "a"},
+                                      {"heading": "Doc", "body": ""}])
+    assert md.count("## Doc") == 1
+
+
+def test_case_and_hash_variation_still_counts_as_an_echo():
+    for h in ("my doc", "MY DOC", "## My Doc", "  My Doc  "):
+        md = document_to_markdown("My Doc", [{"heading": h, "body": ""},
+                                             {"heading": "S", "body": "b"}])
+        assert md.count("My Doc") == 1, h
+
+
+def test_the_contract_tells_the_author_not_to_emit_a_title():
+    """Dropping it in the assembler alone leaves the model emitting a copy
+    every revision that is then silently swallowed."""
+    from scilink.agents.planning_agents.instruct import (
+        TECHNICAL_DOCUMENT_REVISION_RULES as R)
+    flat = " ".join(R.split())
+    assert "Do NOT return the document's TITLE as a section" in flat


### PR DESCRIPTION
Two bugs found in one long live session on `main`. Both are small, both were biting an active session, and each is fixed with a test that is red on `main` and green here.

## 1. A long session crashes when its history is trimmed

Once a chat passes 120 messages the history is trimmed to 100, and the trim can cut between a tool call and its result. There is already a repair pass for exactly this — its docstring even says *"history trimming can likewise slice a pair apart"* — but it ran **before** the trim:

```python
self.messages = repair_dangling_tool_calls(self.messages)   # repairs
...
recent_msgs = self._trim_history(self.messages[1:], 100)     # then breaks it
```

So it cleaned a history that was already valid and left the new damage untouched. Bedrock rejected the turn:

```
BedrockException - Expected toolResult blocks at messages.10.content
for the following Ids: tooluse_QziVtVLg1RUTamg31mh9KU
```

Index 10 is exactly the splice boundary of `history[:10] + history[-90:]`, which keeps a `tool_use` in the head window while its result falls in the discarded middle. There is a symmetric hazard at the other seam, where the tail window can open with an orphan result.

The same inverted order was present at **all four** chat loops (planning and meta, litellm and openai paths), so this fires in either mode on any provider strict enough to validate — Bedrock simply catches it.

**Fix:** move the repair after the splice. No new logic; the helper already inserts synthetic results for unanswered calls and drops orphan results.

## 2. Revising a document stacks its title

`document_to_markdown` always prepends `# {title}`, while the revision contract tells the author to return the complete document verbatim — so it returns the title as a section as well, and the assembler adds another. One copy per revision:

```
1 → 3 → 3 → 4 → 6 titles
```

Six had accumulated in a live document, readable as the title's own edit history (`Independent Parallel` → `Three Cluster-Based` → `Three Instrument-Cluster`).

**Fix, both halves** — either alone recurs. The assembler drops a leading section that merely echoes the title, and the revision contract now states that the title is written at assembly time and must not be returned as a section. Without the contract change the model keeps emitting it and the assembler silently swallows one copy every time.

## Validation

- **Unit:** 11 new tests, **8 of them red on unfixed `main`**. Coverage includes repair following every splice site, the helper against the exact shape a head/tail splice produces, five successive revisions keeping the title singular, and the cases that must *not* be touched — a real section whose heading matches the title, and a title-like heading that is not leading.
- **Suite:** 1,651 passed vs 1,640 baseline (the +11), failure set identical — the 31 pre-existing failures and 24 errors are unchanged.
- **Live** (Bedrock Opus 4.8), with a control against unfixed code so the probe is known to detect the bug:
  - seeding a tool pair that straddles the splice leaves **1 unanswered `tool_use` before the fix, 0 after**;
  - authoring a document and revising it twice gives title counts **[1, 1, 1]**, where it previously grew by one each revision.

## Noted, not fixed here

`tests/test_literature_no_overwrite.py` raises `SystemExit` at module level, which aborts pytest collection with `INTERNALERROR`. About 31 files under `tests/` are standalone scripts of this shape; combined with `pytest-randomly`, whether the suite completes depends on the shuffle seed. Out of scope for this PR, but it makes CI results unreliable and is worth its own cleanup.
