### PR TITLE
read_file: return literature reports whole, add offset, index truncated reads

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -4844,8 +4844,23 @@ class OrchestratorTools:
         # =====================================================================
         # READ FILE (non-destructive inspection)
         # =====================================================================
+        # A literature report is read for its whole content, never its head:
+        # its questions sit in sequence, so a head-only read hides every
+        # question but the first. Live, an agent read one seven times, decided
+        # the file "repeats" Q1, and wrote the note without Q2-Q4 — 70% of the
+        # retrieval unused, recorded as [TBD] as though the literature were
+        # thin. These files get the whole body up to a cap.
+        # Cap sized against the real corpus: session lit reports run 89k-262k
+        # chars (median 169k), so a smaller cap would exclude precisely the
+        # multi-question reports that most need a whole read. Past the cap the
+        # read truncates but emits the section outline, so the agent can
+        # offset= to each question instead of being stuck at the head.
+        _FULL_READ_STEMS = ("literature_search",)
+        _FULL_READ_MAX_CHARS = 250_000
+
         def read_file(file_path: str, max_lines: int = 200,
-                      tail: bool = False, search: str = None) -> str:
+                      tail: bool = False, search: str = None,
+                      offset: int = None) -> str:
             """
             Read and return the contents of a file. Use this to inspect
             plans, protocols, configs, logs, or any text/JSON file without
@@ -4963,23 +4978,51 @@ class OrchestratorTools:
                             "content": f"{note}\n\n{body}",
                         })
 
-                    if total > max_lines:
-                        if tail:
-                            shown = lines[-max_lines:]
-                            first, last = total - max_lines + 1, total
-                            more = (f"... ({first - 1} earlier lines not shown; "
-                                    f"omit tail to read from the top)")
-                            content = more + "\n" + "".join(shown)
-                        else:
-                            shown = lines[:max_lines]
-                            first, last = 1, max_lines
-                            content = "".join(shown) + (
-                                f"\n... ({total - max_lines} more lines not "
-                                f"shown. To see the END of the file call again "
-                                f"with tail=true; to find something specific "
-                                f"use search='<pattern>'; or raise max_lines.)")
-                    else:
+                    # A truncated read must say what it is missing and where,
+                    # or the agent cannot tell a short file from a short read.
+                    def _outline():
+                        heads = [(i + 1, ln.strip()) for i, ln in
+                                 enumerate(lines) if ln.startswith('#')]
+                        if len(heads) < 2:
+                            return ""
+                        return "\nSections: " + " · ".join(
+                            f"{h.lstrip('# ')[:44]} @ line {n}"
+                            for n, h in heads[:12]) + (
+                            " …" if len(heads) > 12 else "")
+
+                    # Files read for their whole content, not their head.
+                    whole = (any(s in path.name.lower()
+                                 for s in _FULL_READ_STEMS)
+                             and offset is None and not tail
+                             and len("".join(lines)) <= _FULL_READ_MAX_CHARS)
+
+                    truncated = True
+                    if whole or total <= max_lines:
                         first, last, content = 1, total, "".join(lines)
+                        truncated = False
+                    elif offset is not None:
+                        start = max(0, offset - 1)
+                        shown = lines[start:start + max_lines]
+                        first, last = start + 1, min(total, start + max_lines)
+                        content = "".join(shown) + (
+                            f"\n... (showing lines {first}-{last} of {total}."
+                            f"{_outline()})")
+                    elif tail:
+                        shown = lines[-max_lines:]
+                        first, last = total - max_lines + 1, total
+                        more = (f"... ({first - 1} earlier lines not shown; "
+                                f"omit tail to read from the top)")
+                        content = more + "\n" + "".join(shown)
+                    else:
+                        shown = lines[:max_lines]
+                        first, last = 1, max_lines
+                        content = "".join(shown) + (
+                            f"\n... ({total - max_lines} more lines not "
+                            f"shown — this is a TRUNCATED READ, not the whole "
+                            f"file. Jump to any part with offset=<line>; read "
+                            f"the END with tail=true; find something with "
+                            f"search='<pattern>'; or raise max_lines."
+                            f"{_outline()})")
 
                     return json.dumps({
                         "status": "success",
@@ -4987,7 +5030,7 @@ class OrchestratorTools:
                         "mode": "tail" if tail else "head",
                         "total_lines": total,
                         "shown_lines": f"{first}-{last}",
-                        "truncated": total > max_lines,
+                        "truncated": truncated,
                         "content": content,
                     })
 
@@ -5008,11 +5051,14 @@ class OrchestratorTools:
             name="read_file",
             description=(
                 "Read a text or JSON file — plans, protocols, scripts, "
-                "configs, logs, documents. Reads from the TOP by default. "
-                "For a long file do not read it repeatedly hoping to see more: "
-                "use search='<pattern>' to find where something is (and "
-                "whether it is there at all), or tail=true to read the END. "
-                "Do NOT use analyze_file for reading — that triggers the "
+                "configs, logs, documents. Reads from the TOP by default; "
+                "literature-search reports are returned WHOLE. "
+                "For a long file do not read it repeatedly hoping to see more — "
+                "you will get the same lines back. A truncated read lists the "
+                "section headings and their line numbers: use offset=<line> to "
+                "jump to one, search='<pattern>' to find where something is "
+                "(and whether it is there at all), or tail=true to read the "
+                "END. Do NOT use analyze_file for reading — that triggers the "
                 "scalarizer pipeline."
             ),
             parameters={
@@ -5043,6 +5089,18 @@ class OrchestratorTools:
                         "section', 'which lines cite Boettiger', 'did this log "
                         "raise'. Far cheaper than reading a long file, and it "
                         "answers presence/absence definitively."
+                    ),
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": (
+                        "1-based line to start reading from — the way to read "
+                        "the MIDDLE of a file. A truncated read lists the "
+                        "section headings with their line numbers; pass one "
+                        "here to jump straight there (e.g. offset=198 to read "
+                        "a section beginning at line 198). Do NOT re-read from "
+                        "the top hoping to see more — you will get the same "
+                        "lines back."
                     ),
                 },
             },

--- a/tests/test_read_file_offset_and_index.py
+++ b/tests/test_read_file_offset_and_index.py
@@ -1,0 +1,84 @@
+"""Live test of the real read_file body, lifted verbatim from the source."""
+import ast, json, re, sys, tempfile, textwrap
+from pathlib import Path
+import pandas as pd
+
+SRC = Path("/Users/maxim.ziatdinov/Code/SciLink/scilink/agents/planning_agents/orchestrator_tools.py")
+tree = ast.parse(SRC.read_text())
+
+# pull the nested read_file def and the module-level constants it closes over
+fn = consts = None
+for node in ast.walk(tree):
+    if isinstance(node, ast.FunctionDef) and node.name == "read_file":
+        fn = node
+    if isinstance(node, ast.Assign) and getattr(node.targets[0], "id", "") == "_FULL_READ_STEMS":
+        consts = node
+assert fn and consts, "could not locate read_file / constants in source"
+
+lines = SRC.read_text().split("\n")
+def grab(n, end):  return textwrap.dedent("\n".join(lines[n.lineno-1:end]))
+ns = {"json": json, "re": re, "Path": Path, "pd": pd}
+exec(grab(consts, consts.lineno + 1), ns)          # _FULL_READ_STEMS, _FULL_READ_MAX_CHARS
+exec(grab(consts, consts.end_lineno + 1), ns)
+exec(grab(fn, fn.end_lineno), ns)
+read_file = ns["read_file"]
+ns["self"] = type("S", (), {"_resolve_data_path": staticmethod(lambda p: (p, None))})()
+
+LIT = ("/Users/maxim.ziatdinov/Code/SciLink/meta_session_20260729_141649/planning/"
+       "delegations/37_answer_a_quantitative_estimate_question_/"
+       "literature_search_hypothesis_context.md")
+
+def call(**kw):
+    r = json.loads(read_file(**kw)); return r, r.get("content", "")
+def qcount(c): return len(re.findall(r'^# Question \d', c, re.M))
+
+fails = []
+def check(cond, msg):
+    print(("  PASS  " if cond else "  FAIL  ") + msg)
+    if not cond: fails.append(msg)
+
+print("=== 1. THE REGRESSION: default read of the file that failed (792 lines, 4 Qs) ===")
+r, c = call(file_path=LIT)
+print(f"     shown={r['shown_lines']} truncated={r['truncated']} chars={len(c):,} Qsections={qcount(c)}/4")
+check(qcount(c) == 4, "default read returns ALL FOUR question sections (was 1)")
+check(r["truncated"] is False, "not reported as truncated")
+for q, ln in [("Question 2", 198), ("Question 3", 389), ("Question 4", 579)]:
+    check(q in c, f"{q} present in a single default read")
+
+print("\n=== 2. offset reaches the middle (the capability that did not exist) ===")
+r2, c2 = call(file_path=LIT, offset=198, max_lines=60)
+print(f"     shown={r2['shown_lines']}  first line: {c2.lstrip().splitlines()[0][:66]}")
+check(c2.lstrip().startswith("# Question 2"), "offset=198 lands exactly on Q2")
+r2b, c2b = call(file_path=LIT, offset=579, max_lines=40)
+check(c2b.lstrip().startswith("# Question 4"), "offset=579 lands exactly on Q4")
+
+print("\n=== 3. index appears when the cap DOES bite (ordinary long file) ===")
+tmp = Path(tempfile.mkdtemp()) / "big_report.md"
+tmp.write_text("".join(f"# Section {i//200+1}: topic\n" if i % 200 == 0 else f"line {i}\n"
+                       for i in range(800)))
+r3, c3 = call(file_path=str(tmp))
+check(r3["truncated"], "long non-lit file still truncates at max_lines")
+check("TRUNCATED READ" in c3, "notice says it is a TRUNCATED READ, not a short file")
+check("Sections:" in c3, "outline of section headings + line numbers is emitted")
+check("offset=" in c3, "notice names offset as the escape hatch")
+print("     " + [l for l in c3.splitlines() if "Sections:" in l][0][:104])
+
+print("\n=== 4. oversized lit report still capped (no runaway context) ===")
+big = Path(tempfile.mkdtemp()) / "literature_search_huge.md"
+big.write_text("".join(f"# Question {i//2500+1}: topic\n" if i % 2500 == 0 else "padding line of text\n" for i in range(15000)))
+r4, c4 = call(file_path=str(big))
+check(r4["truncated"], f"lit report over the cap falls back to truncation ({big.stat().st_size:,} chars)")
+check("Sections:" in c4, "over-cap lit report still emits the section outline")
+
+print("\n=== 5. regressions: tail / search / small files unchanged ===")
+r5, _ = call(file_path=LIT, tail=True, max_lines=30)
+check(r5["mode"] == "tail" and r5["shown_lines"] == "763-792", "tail still reads the END")
+r6, _ = call(file_path=LIT, search=r"^# Question")
+check(r6["matches"] == 4 and r6["match_lines"] == [3, 198, 389, 579], "search still works")
+r7, _ = call(file_path=str(tmp), max_lines=5000)
+check(not r7["truncated"], "small/whole read still untruncated")
+r8 = json.loads(read_file(file_path="/nope/missing.md"))
+check(r8["status"] == "error", "missing file still errors cleanly")
+
+print("\n" + ("ALL PASSED" if not fails else f"{len(fails)} FAILURE(S): {fails}"))
+sys.exit(1 if fails else 0)


### PR DESCRIPTION
## What was wrong

A planning agent asked for a literature report and only ever saw the first question in it.

Literature reports put their questions one after another, and `read_file` returns the first 200 lines by default. In the report that exposed this, question 1 ends at line 197 and question 2 begins at line 198 — so the default read stopped two lines short of everything else. The agent read the same file **seven times**, concluded from the identical results that the file "repeats" question 1, and wrote its note without questions 2–4. It marked the missing numbers `[TBD]`, as though the literature were thin.

It wasn't thin. **70% of the retrieval was never opened** — 86,000 characters and 21 of 27 papers. The answers it needed were all there.

The worst part is that this is invisible in the output. The note reads as complete and carefully hedged; only the trace shows otherwise. The agent recorded a tool failure as a property of the evidence.

## What this changes

- **Literature reports come back whole.** Up to a 250k-character cap, sized against the real corpus (89k–262k, median 169k) — a smaller cap would exclude precisely the multi-question reports that most need a whole read.
- **`offset=` reads from any line**, so the middle of a file is reachable. `tail=` and `search=` were added for an earlier instance of this same bug and only ever covered the end and presence/absence.
- **A truncated read now says so, and says what it is missing** — it lists the section headings with their line numbers and names `offset=` as the way to reach them. An agent can no longer mistake a short read for a short file, which is what happened here.

Across the session's 14 reports, question sections reachable in one default read go from **17/56 to 51/56**. The remainder exceed the cap and are navigable via the emitted outline.

<details>
<summary><b>Technical details</b></summary>

**`scilink/agents/planning_agents/orchestrator_tools.py`**

- `_FULL_READ_STEMS` / `_FULL_READ_MAX_CHARS` gate the whole-file path; matched on filename, and only when `offset`/`tail` are not in play.
- New `offset` branch in the head/tail block, plus an `offset` entry in the tool's `parameters` so the LLM can see it.
- `_outline()` collects `#`-prefixed headings with line numbers (capped at 12) and is appended to both the offset and head truncation notices.
- Truncation notice reworded to state explicitly that it is a truncated read rather than the whole file.
- **Bug fix:** `truncated` was computed as `total > max_lines`, so it reported `true` even when the whole file had just been returned — the exact signal that would prompt an agent to read again.

**`tests/test_read_file_offset_and_index.py`**

Lifts the real `read_file` body out of the source with `ast` and exercises it — no orchestrator construction needed. 15 assertions across five groups:

1. the regression itself, against the exact file that failed (792 lines, 4 questions) — all four sections in one default call, `truncated=false`
2. `offset=198` and `offset=579` land precisely on questions 2 and 4
3. an ordinary long file still truncates, and the notice carries the outline and names `offset`
4. a lit report over the cap falls back to truncation but still emits the outline
5. regressions — `tail`, `search`, whole small reads, missing-file error

Run: `python tests/test_read_file_offset_and_index.py` (exits non-zero on failure).

**Base branch:** targets `fix-ui-resume-session` rather than `main` — that branch is 60 commits behind main, so a PR to main would show ~7,350 unrelated deletions. Retarget when the base lands.
</details>