### PR TITLE
Fix UI startup on older Streamlit; ship boto3 for Bedrock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,15 @@ dependencies = [
     "h5py>=3.10",
     "nexusformat>=2.0",
     "pyyaml>=6.0",
-    "streamlit>=1.37.0",
+    # 1.52.0 is the floor for st.html(unsafe_allow_javascript=True), which the
+    # theme injects on every rerun — an older Streamlit takes the app down on
+    # the first inject_theme() call.
+    "streamlit>=1.52.0",
+    # litellm's Bedrock path needs boto3 (credential/region resolution) and
+    # botocore (SigV4 signing); litellm itself declares neither outside its
+    # [proxy] extra. Bedrock is a first-class provider in scilink/providers.py
+    # and selectable from the UI, so this belongs in the base install.
+    "boto3>=1.34.0",
     # Markdown -> PDF export (with pymupdf above). Arrives transitively via
     # streamlit -> rich, but this is a direct import, so pin it directly.
     "markdown-it-py>=2.2.0",

--- a/scilink/ui/theme.py
+++ b/scilink/ui/theme.py
@@ -1,6 +1,44 @@
 """Material Design theme — dark and light variants."""
 
+import sys
+
 import streamlit as st
+
+_JS_DEGRADED_NOTICE_SHOWN = False
+
+
+def _inject_js(html: str) -> None:
+    """Inject a ``<script>`` block, degrading instead of crashing.
+
+    ``st.html``'s ``unsafe_allow_javascript`` kwarg landed in Streamlit
+    1.52.0; older versions raise ``TypeError`` for it. Everything injected
+    through here is cosmetic (widget restyling, emoji collisions), while
+    ``inject_theme()`` runs before anything else on every rerun — so a
+    failure here must cost the effect, not the app.
+    """
+    global _JS_DEGRADED_NOTICE_SHOWN
+    try:
+        st.html(html, unsafe_allow_javascript=True)
+        return
+    except TypeError:
+        pass
+    except Exception:
+        return
+
+    if not _JS_DEGRADED_NOTICE_SHOWN:
+        _JS_DEGRADED_NOTICE_SHOWN = True
+        print(
+            f"SciLink: Streamlit {st.__version__} rejected the "
+            "unsafe_allow_javascript argument; cosmetic theme effects are "
+            "disabled. Fix: pip install -U 'streamlit>=1.52'",
+            file=sys.stderr,
+        )
+    # Pre-1.52 st.html strips <script>, so the effect is lost but the DOM
+    # slot the theme relies on for stable layout is still emitted.
+    try:
+        st.html(html)
+    except Exception:
+        pass
 
 _MATERIAL_CSS_DARK = """
 <style>
@@ -1459,7 +1497,7 @@ def inject_theme() -> None:
     css = _MATERIAL_CSS_DARK if theme_mode == "dark" else _MATERIAL_CSS_LIGHT
     st.markdown(css, unsafe_allow_html=True)
 
-    # Force-restyle widgets via JS injected through st.html(unsafe_allow_javascript=True)
+    # Force-restyle widgets via JS injected through _inject_js -> st.html
     # (st.markdown strips <script> tags). st.html runs inline in the main
     # document — not an iframe — so window.parent resolves to the app window
     # and window.parent.document is the app document itself.
@@ -1494,11 +1532,11 @@ def inject_theme() -> None:
         .observe(doc.body, {childList:true, subtree:true, attributes:true});
 })();
 </script>"""
-        st.html(_LIGHT_WIDGET_JS, unsafe_allow_javascript=True)
+        _inject_js(_LIGHT_WIDGET_JS)
     else:
         # Keep DOM slot count stable; also undo any inline styles
         # left by the light-mode observer on the stop button.
-        st.html("""<script>
+        _inject_js("""<script>
 (function(){
     var doc = window.parent.document;
     function cleanup(){
@@ -1514,7 +1552,7 @@ def inject_theme() -> None:
     new MutationObserver(cleanup)
         .observe(doc.body, {childList:true, subtree:true});
 })();
-</script>""", unsafe_allow_javascript=True)
+</script>""")
 
     vibe = st.session_state.get("vibe_theme", "Professional")
 
@@ -1541,7 +1579,6 @@ def inject_theme() -> None:
         unsafe_allow_html=True,
     )
     # Slot 2: collision JS (always present, no-op script when inactive)
-    st.html(
-        _COLLISION_JS if use_collision_js else "<script>/* noop */</script>",
-        unsafe_allow_javascript=True,
+    _inject_js(
+        _COLLISION_JS if use_collision_js else "<script>/* noop */</script>"
     )

--- a/tests/test_ui_startup_deps.py
+++ b/tests/test_ui_startup_deps.py
@@ -1,0 +1,139 @@
+"""UI startup must survive an older Streamlit, and Bedrock must be installable.
+
+Two failure modes reported from real installs:
+
+* ``st.html``'s ``unsafe_allow_javascript`` kwarg landed in Streamlit 1.52.0,
+  but the pin allowed 1.37. ``inject_theme()`` runs before anything renders on
+  every rerun, so the ``TypeError`` took the whole app down on startup.
+* litellm's Bedrock path imports boto3/botocore, which nothing in the base
+  install pulled in — the failure surfaced as an opaque ``APIConnectionError:
+  No module named 'boto3'`` at first call.
+"""
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from scilink.ui import theme
+
+PYPROJECT = tomllib.loads(Path("pyproject.toml").read_text())
+DEPS = PYPROJECT["project"]["dependencies"]
+THEME_SRC = Path("scilink/ui/theme.py").read_text()
+
+
+class _FakeSt:
+    """Stand-in for the ``streamlit`` module, old or new."""
+
+    __version__ = "1.40.0"
+
+    def __init__(self, supports_kwarg: bool):
+        self._supports_kwarg = supports_kwarg
+        self.calls = []
+        self.session_state = {}
+
+    def html(self, body, **kwargs):
+        if kwargs and not self._supports_kwarg:
+            raise TypeError(
+                "HtmlMixin.html() got an unexpected keyword argument "
+                f"'{next(iter(kwargs))}'"
+            )
+        self.calls.append(("html", body, kwargs))
+
+    def markdown(self, body, **kwargs):
+        self.calls.append(("markdown", body, kwargs))
+
+
+@pytest.fixture
+def old_streamlit(monkeypatch):
+    fake = _FakeSt(supports_kwarg=False)
+    monkeypatch.setattr(theme, "st", fake)
+    monkeypatch.setattr(theme, "_JS_DEGRADED_NOTICE_SHOWN", False, raising=False)
+    return fake
+
+
+@pytest.fixture
+def new_streamlit(monkeypatch):
+    fake = _FakeSt(supports_kwarg=True)
+    monkeypatch.setattr(theme, "st", fake)
+    return fake
+
+
+# --- the wrapper -------------------------------------------------------------
+
+def test_inject_js_uses_the_kwarg_when_streamlit_supports_it(new_streamlit):
+    theme._inject_js("<script>/* x */</script>")
+    assert new_streamlit.calls == [
+        ("html", "<script>/* x */</script>", {"unsafe_allow_javascript": True})
+    ]
+
+
+def test_inject_js_retries_without_the_kwarg_on_old_streamlit(old_streamlit):
+    theme._inject_js("<script>/* x */</script>")
+    # Effect lost, but the DOM slot the theme relies on is still emitted.
+    assert old_streamlit.calls == [("html", "<script>/* x */</script>", {})]
+
+
+def test_inject_js_warns_once_per_process(old_streamlit, capsys):
+    for _ in range(3):
+        theme._inject_js("<script>/* x */</script>")
+    assert capsys.readouterr().err.count("streamlit>=1.52") == 1
+
+
+def test_inject_js_swallows_any_other_streamlit_failure(monkeypatch):
+    """inject_theme() runs on every rerun; cosmetic JS must never kill it."""
+    class _Exploding(_FakeSt):
+        def html(self, body, **kwargs):
+            raise RuntimeError("some future Streamlit API drift")
+
+    monkeypatch.setattr(theme, "st", _Exploding(supports_kwarg=True))
+    theme._inject_js("<script>/* x */</script>")  # must not raise
+
+
+# --- the crash the issue reported --------------------------------------------
+
+@pytest.mark.parametrize("mode", ["dark", "light"])
+def test_inject_theme_does_not_crash_on_old_streamlit(old_streamlit, mode):
+    old_streamlit.session_state = {"theme_mode": mode}
+    theme.inject_theme()  # pre-fix: TypeError, app down on every page load
+    assert old_streamlit.calls
+
+
+@pytest.mark.parametrize("mode", ["dark", "light"])
+def test_slot_count_is_the_same_on_old_and_new_streamlit(monkeypatch, mode):
+    """The dark branch emits a no-op script purely to keep the layout stable —
+    degrading must not drop a slot and shift the page."""
+    counts = []
+    for supports_kwarg in (True, False):
+        fake = _FakeSt(supports_kwarg)
+        fake.session_state = {"theme_mode": mode}
+        monkeypatch.setattr(theme, "st", fake)
+        theme.inject_theme()
+        counts.append(len(fake.calls))
+    assert counts[0] == counts[1]
+
+
+def test_no_unwrapped_kwarg_call_sites_remain():
+    """A new direct call site would reintroduce the crash."""
+    unwrapped = re.findall(r"st\.html\([^)]*unsafe_allow_javascript", THEME_SRC)
+    assert len(unwrapped) == 1, "only _inject_js may pass the kwarg"
+
+
+# --- the pins ----------------------------------------------------------------
+
+def test_streamlit_pin_covers_the_kwarg():
+    pin = next(d for d in DEPS if d.startswith("streamlit"))
+    major, minor = (int(p) for p in pin.split(">=")[1].split(".")[:2])
+    assert (major, minor) >= (1, 52), f"{pin} predates unsafe_allow_javascript"
+
+
+def test_boto3_is_a_required_dependency():
+    """Bedrock is selectable from the base UI, so its SDK ships with it."""
+    assert any(d.split(">=")[0].strip() == "boto3" for d in DEPS)
+
+
+def test_bedrock_is_still_a_live_provider():
+    """If Bedrock ever leaves the base install, the boto3 pin can leave too."""
+    from scilink.providers import provider_for
+
+    assert provider_for("bedrock/us.anthropic.claude-opus-4-6-v1").name == "bedrock"


### PR DESCRIPTION
Closes #412. Closes #413.

## What was broken

Two ways a fresh install could fail, both before you could do anything about it.

**The UI wouldn't start on some machines (#412).** If your Streamlit was older than 1.52, launching the UI crashed immediately with a `TypeError` — no page, no error you could act on, every time. Reported from a Windows/Anaconda install, but nothing Windows-specific: that machine just happened to install an older Streamlit, because our dependency list said we accepted one.

**Bedrock models failed on a plain install (#413).** Bedrock is offered in the model picker out of the box, but the AWS SDK it needs was never listed as a requirement. Picking a Bedrock model gave a connection error that didn't mention the real cause. It only worked if you happened to have installed the optional structure-matching extras, which quietly brought the SDK along.

## What changed

The install now asks for the Streamlit version the code actually needs, and ships the AWS SDK so Bedrock works out of the box.

Separately, the theme code that triggered the crash no longer can. Everything it injects there is cosmetic — button styling and the floating emojis — so if a future Streamlit changes that API again, the effect is skipped and the app keeps running, with a one-line note in the terminal telling you to upgrade. It runs on every page load, so it's the worst possible place for a hard failure.

<details>
<summary><b>Technical details</b></summary>

### #412 — `st.html(unsafe_allow_javascript=True)`

The kwarg landed in Streamlit **1.52.0**; `pyproject.toml` pinned `streamlit>=1.37.0`. `inject_theme()` runs before any page content on every rerun, so the `TypeError` was an unconditional app-killer.

- Pin raised to `streamlit>=1.52.0` — the version the code actually requires.
- The three call sites in `scilink/ui/theme.py` now go through `_inject_js()`, which retries without the kwarg on `TypeError` and returns quietly on anything else.

The plain retry matters beyond politeness: pre-1.52 `st.html` strips `<script>` but still emits the element, preserving the DOM slot the dark branch emits a no-op script for specifically to keep slot count (and therefore layout) stable across theme modes. A one-shot stderr notice, guarded by a module-level flag, names the upgrade so the degradation isn't invisible.

`sidebar.py:568` (Quit App) is untouched — it deliberately still uses `components.html`.

### #413 — boto3

litellm's Bedrock path imports **boto3** (credential/region resolution) and **botocore** (SigV4 signing), and declares neither outside its `[proxy]` extra. boto3 reached environments only via `mp-api`, which lives in the optional `structure-matching` extra.

Verified by blocking both modules from import and calling the bearer-token Bedrock path:

```
APIConnectionError: No module named 'boto3'
```

The wrapping makes the real cause invisible at the call site. Bedrock is a live provider in `scilink/providers.py` and selectable from the UI on a base install, so `boto3>=1.34.0` joins the base dependencies (it pulls botocore transitively).

### Verification

`tests/test_ui_startup_deps.py` (12 tests) covers the wrapper on both Streamlit generations, the equal-slot-count invariant, a guard against new unwrapped call sites, and both pins. **11 of the 12 fail against the pre-fix tree**; all pass after.

Live-checked with `streamlit.testing.v1.AppTest` running the real `app.py`:

| | exceptions | html slots |
|---|---|---|
| Streamlit 1.58 (real) | none | 2 |
| simulated pre-1.52, dark | none | 2 |
| simulated pre-1.52, light | none | 2 |

Against the pre-fix tree the same harness reproduces the reported failure exactly: `TypeError: HtmlMixin.html() got an unexpected keyword argument 'unsafe_allow_javascript'`.

</details>