### PR TITLE
Dataset-aware metadata ownership; plan validator re-derives series regimes (#411)

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -630,6 +630,11 @@ class AnalysisOrchestratorAgent:
         
         # Session state
         self.current_metadata: Optional[Dict[str, Any]] = None
+        # Dataset that current_metadata belongs to. None = unbound (freshly
+        # loaded, not yet consumed by run_analysis). Binds on first use; a
+        # run_analysis on a *different* dataset must re-resolve rather than
+        # silently reuse another dataset's metadata (issue #411).
+        self.current_metadata_owner: Optional[str] = None
         self.current_data_path: Optional[str] = None
         self.current_data_type: Optional[str] = None
         self.selected_agent_id: Optional[int] = None
@@ -1284,6 +1289,13 @@ class AnalysisOrchestratorAgent:
                 state = json.load(f)
             
             self.current_metadata = state.get("current_metadata")
+            # Older checkpoints predate ownership: backfill from the last data
+            # path so restored metadata stays bound to the dataset it served,
+            # instead of silently binding to whatever runs next.
+            self.current_metadata_owner = state.get("current_metadata_owner") or (
+                state.get("current_data_path")
+                if state.get("current_metadata") is not None else None
+            )
             self.current_data_path = state.get("current_data_path")
             self.current_data_type = state.get("current_data_type")
             self.selected_agent_id = state.get("selected_agent_id")
@@ -1552,6 +1564,7 @@ class AnalysisOrchestratorAgent:
             checkpoint_data = {
                 "timestamp": datetime.now().isoformat(),
                 "current_metadata": self.current_metadata,
+                "current_metadata_owner": self.current_metadata_owner,
                 "current_data_path": self.current_data_path,
                 "current_data_type": self.current_data_type,
                 "selected_agent_id": self.selected_agent_id,

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -15,6 +15,7 @@ LLM reasoning.  If extraction fails, the user is prompted and shown the
 sidecar contents to help them specify the variable manually.
 """
 
+import fnmatch
 import glob
 import hashlib
 import json
@@ -275,6 +276,59 @@ def _resolve_glob_files(pattern: str) -> tuple[list[Path], list[Path]]:
         if sidecar.is_file():
             all_files.append(sidecar)
     return data_files, all_files
+
+
+def _dataset_key(data_path: str) -> str:
+    """Canonical form of a dataset reference for ownership comparison.
+
+    Globs keep their pattern (resolved to an absolute base) so two different
+    patterns over the same folder stay distinct datasets; real paths resolve
+    to their absolute form.
+    """
+    if _is_glob(data_path):
+        p = Path(data_path)
+        try:
+            return str(p.parent.resolve() / p.name)
+        except OSError:
+            return data_path
+    try:
+        return str(Path(data_path).resolve())
+    except OSError:
+        return data_path
+
+
+def _same_dataset(owner: str, requested: str) -> bool:
+    """Does metadata bound to *owner* also cover *requested*?
+
+    True when they are the same path, when *requested* drills into the
+    owner directory (a member file, or a glob selecting files within it),
+    or when *requested* is a file the owner glob matches. A broader or
+    sibling dataset is NOT covered — reuse must be re-resolved.
+    """
+    owner_key = _dataset_key(owner)
+    req_key = _dataset_key(requested)
+    if owner_key == req_key:
+        return True
+
+    owner_is_glob = _is_glob(owner)
+    req_is_glob = _is_glob(requested)
+
+    if not owner_is_glob:
+        owner_p = Path(owner_key)
+        if owner_p.is_dir():
+            # Member file/dir of the owner folder, or a glob over it.
+            probe = Path(req_key).parent if req_is_glob else Path(req_key)
+            try:
+                probe.relative_to(owner_p)
+                return True
+            except ValueError:
+                return False
+        return False
+
+    # Owner is a glob: a single file it matches belongs to its dataset.
+    if not req_is_glob:
+        return fnmatch.fnmatch(req_key, owner_key)
+    return False
 
 
 def _detect_sidecar_jsons(
@@ -754,6 +808,9 @@ class AnalysisOrchestratorTools:
             old_instruction = self.orch.current_metadata.get(_CPI)
 
         self.orch.current_metadata = new_metadata
+        # A fresh document is unbound: it binds to the first dataset
+        # run_analysis consumes it for (issue #411).
+        self.orch.current_metadata_owner = None
 
         if not old_instruction:
             return None  # Nothing to preserve
@@ -2263,7 +2320,17 @@ class AnalysisOrchestratorTools:
                     "message": "No agent selected. Use select_agent first."
                 })
             
-            if self.orch.current_metadata is None:
+            # Dataset-aware metadata resolution (issue #411). The loaded
+            # document may serve this run only if it is unbound (freshly
+            # loaded) or bound to this same dataset; metadata bound to a
+            # *different* dataset is stale and must be re-resolved — never
+            # silently reused across techniques.
+            _stale_owner = None
+            if self.orch.current_metadata is not None:
+                _owner = getattr(self.orch, "current_metadata_owner", None)
+                if _owner and not _same_dataset(_owner, data_path):
+                    _stale_owner = _owner
+            if self.orch.current_metadata is None or _stale_owner:
                 # When a data directory contains sidecar JSONs, allow
                 # run_analysis to proceed so the sidecar extraction code
                 # below can populate metadata automatically.
@@ -2282,14 +2349,20 @@ class AnalysisOrchestratorTools:
                     _smap, _ = _detect_sidecar_jsons(_data, _all)
                     has_sidecars = bool(_smap)
                 if has_sidecars:
+                    if _stale_owner:
+                        print(f"  📎 Metadata loaded for '{_stale_owner}' does not "
+                              f"cover this dataset; using its sidecar JSONs instead")
                     self.orch.current_metadata = {}
+                    self.orch.current_metadata_owner = None
                 else:
                     # Single-file backstop: if a stem-matched sidecar JSON sits
                     # next to the data file (foo.npy -> foo.json), auto-load it
-                    # instead of erroring. This ONLY runs when no metadata was
-                    # loaded (so it can never override an explicit load); it
-                    # converts a hard error into a usable run and makes metadata
-                    # forwarding deterministic for the meta fan-out path.
+                    # instead of erroring. It never overrides an explicit load
+                    # *for this dataset* (that case is not re-resolved at all);
+                    # it converts a hard error into a usable run and makes
+                    # metadata forwarding deterministic for the meta fan-out
+                    # path.
+                    _resolved_from_sidecar = False
                     if data_p.is_file():
                         sidecar = data_p.with_suffix(".json")
                         if sidecar.exists():
@@ -2298,14 +2371,35 @@ class AnalysisOrchestratorTools:
                                     _md = json.load(_fh)
                                 if isinstance(_md, dict) and _md:
                                     self.orch.current_metadata = _md
+                                    self.orch.current_metadata_owner = None
+                                    _resolved_from_sidecar = True
                                     print(f"  📎 Auto-loaded sidecar metadata: {sidecar.name}")
                             except Exception:  # noqa: BLE001 - bad sidecar -> fall through to error
                                 pass
-                    if self.orch.current_metadata is None:
-                        return json.dumps({
-                            "status": "error",
-                            "message": "No metadata available. Use load_metadata or convert_metadata first."
-                        })
+                    if not _resolved_from_sidecar:
+                        if _stale_owner:
+                            # Refuse rather than reuse: a plausible fit against
+                            # another dataset's schema is worse than a stopped
+                            # run. Recovery is one tool call.
+                            return json.dumps({
+                                "status": "error",
+                                "message": (
+                                    f"The loaded metadata belongs to a different "
+                                    f"dataset ('{_stale_owner}') and no sidecar "
+                                    f"metadata was found for '{data_path}'. Use "
+                                    f"load_metadata or convert_metadata for this "
+                                    f"dataset before analyzing it."
+                                )
+                            })
+                        if self.orch.current_metadata is None:
+                            return json.dumps({
+                                "status": "error",
+                                "message": "No metadata available. Use load_metadata or convert_metadata first."
+                            })
+            # Bind unbound metadata to the dataset now consuming it.
+            if (self.orch.current_metadata is not None
+                    and not getattr(self.orch, "current_metadata_owner", None)):
+                self.orch.current_metadata_owner = _dataset_key(data_path)
             
             try:
                 # === Handle directory / glob input - filter out metadata files ===
@@ -3361,6 +3455,7 @@ class AnalysisOrchestratorTools:
                 checkpoint_data = {
                     "timestamp": datetime.now().isoformat(),
                     "current_metadata": self.orch.current_metadata,
+                    "current_metadata_owner": self.orch.current_metadata_owner,
                     "current_data_path": self.orch.current_data_path,
                     "current_data_type": self.orch.current_data_type,
                     "selected_agent_id": self.orch.selected_agent_id,

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2694,9 +2694,11 @@ If you identify problems, return:
     "series_analysis_plan": null
 }}}}
 If your correction changes the technique or the physical model, the existing series
-regimes are invalid — return a re-derived series_analysis_plan (same schema as the
-original plan) rather than carrying them over; leave it null only when the regimes
-remain valid under your correction (or this is not a series).
+regimes are invalid — return a re-derived series_analysis_plan rather than carrying
+them over; leave it null only when the regimes remain valid under your correction
+(or this is not a series). A re-derived plan uses exactly these regime fields:
+{{"regimes": [{{"name": str, "spectrum_indices": [int], "physical_model": str,
+"fitting_strategy": str, "parameters_to_extract": [str]}}]}}
 Only flag genuine problems — do not redesign a reasonable plan.
 
 An explicit requirement in the stated objective (e.g. a region to exclude, a parameter

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2693,7 +2693,10 @@ If you identify problems, return:
     "fitting_strategy": "revised strategy if needed",
     "series_analysis_plan": null
 }}}}
-Include series_analysis_plan only if this is a series with regimes that need revision.
+If your correction changes the technique or the physical model, the existing series
+regimes are invalid — return a re-derived series_analysis_plan (same schema as the
+original plan) rather than carrying them over; leave it null only when the regimes
+remain valid under your correction (or this is not a series).
 Only flag genuine problems — do not redesign a reasonable plan.
 
 An explicit requirement in the stated objective (e.g. a region to exclude, a parameter

--- a/tests/test_411_multimodal_meta_live.py
+++ b/tests/test_411_multimodal_meta_live.py
@@ -1,0 +1,251 @@
+"""Live multimodal reproduction for issue #411 (meta agent, Bedrock).
+
+Reproduces the cross-technique metadata failure in one meta session with
+three analysis delegations over real instrument exports:
+
+  1. A thermal measurement (heat flow vs temperature) analyzed with ONE
+     combined instrument-export metadata JSON loaded into the session slot
+     — the state that used to go stale.
+  2. An in-situ diffraction series (per-file sidecar JSONs) requested with
+     NO technique named. Pre-fix, the slot's thermal document was silently
+     reused — sidecar detection was skipped entirely once any metadata
+     occupied the slot — so the planner read the diffraction axes through
+     the thermal schema and dropped the technique skill. Post-fix, the
+     dataset must resolve its own metadata (ownership backstop or explicit
+     re-resolution), select the diffraction skill, and plan diffraction.
+  3. An in-situ spectroscopy series (sidecars), again technique-unnamed,
+     to confirm the slot re-resolves per dataset every time.
+
+Point the env vars at any dataset trio with this shape (dirs or globs;
+data files need stem-matched .json sidecars for datasets 2 and 3):
+
+    SCILINK_411_THERMAL_FILE=...   SCILINK_411_THERMAL_META=...
+    SCILINK_411_DIFFRACTION_DATA=... SCILINK_411_SPECTROSCOPY_DATA=...
+    AWS_BEARER_TOKEN_BEDROCK=... AWS_REGION_NAME=us-east-1 \
+    UNSAFE_EXECUTION_OK=true \
+    python tests/test_411_multimodal_meta_live.py
+"""
+from __future__ import annotations
+
+import contextlib
+import glob as _glob
+import io
+import json
+import logging
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+BASE = Path("tests/_411_multimodal_live_runs").resolve()
+
+results = {}
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+class Tee(io.TextIOBase):
+    def __init__(self, *streams):
+        self.streams = streams
+
+    def write(self, s):
+        for st in self.streams:
+            st.write(s)
+        return len(s)
+
+    def flush(self):
+        for st in self.streams:
+            st.flush()
+
+
+def _sidecar_files(spec: str, cap: int) -> list[Path]:
+    """Data files (with stem-matched sidecars) from a dir or glob, evenly
+    subsampled to at most *cap* for wall time."""
+    p = Path(spec)
+    files = sorted(p.glob("*.txt")) if p.is_dir() else sorted(
+        Path(f) for f in _glob.glob(spec))
+    files = [f for f in files if f.suffix.lower() != ".json"
+             and f.with_suffix(".json").is_file()]
+    if len(files) > cap:
+        step = max(1, len(files) // cap)
+        files = files[::step][:cap]
+    return files
+
+
+def stage_data() -> tuple[Path, Path, Path, Path, list[str]]:
+    thermal_file = Path(os.environ["SCILINK_411_THERMAL_FILE"])
+    thermal_meta = Path(os.environ["SCILINK_411_THERMAL_META"])
+    diff_spec = os.environ["SCILINK_411_DIFFRACTION_DATA"]
+    spec_spec = os.environ["SCILINK_411_SPECTROSCOPY_DATA"]
+
+    data = BASE / "data"
+    thermal = data / "thermal"
+    diffraction = data / "insitu_diffraction"
+    spectroscopy = data / "insitu_spectroscopy"
+    for d in (thermal, diffraction, spectroscopy):
+        d.mkdir(parents=True, exist_ok=True)
+
+    shutil.copy(thermal_file, thermal / "thermal_run.txt")
+    meta_path = thermal / "instrument_metadata.json"
+    shutil.copy(thermal_meta, meta_path)
+
+    for f in _sidecar_files(diff_spec, cap=8):
+        shutil.copy(f, diffraction / f.name)
+        shutil.copy(f.with_suffix(".json"), diffraction / (f.stem + ".json"))
+    for f in _sidecar_files(spec_spec, cap=4):
+        shutil.copy(f, spectroscopy / f.name)
+        shutil.copy(f.with_suffix(".json"), spectroscopy / (f.stem + ".json"))
+
+    # Distinctive string values from the thermal document, used to detect
+    # any leakage of that document into a later dataset's metadata.
+    doc = json.loads(meta_path.read_text())
+    markers = [v for v in doc.values()
+               if isinstance(v, str) and len(v) > 6][:5]
+    return thermal, meta_path, diffraction, spectroscopy, markers
+
+
+def main() -> int:
+    for var in ("AWS_BEARER_TOKEN_BEDROCK", "SCILINK_411_THERMAL_FILE",
+                "SCILINK_411_THERMAL_META", "SCILINK_411_DIFFRACTION_DATA",
+                "SCILINK_411_SPECTROSCOPY_DATA"):
+        if not os.environ.get(var):
+            print(f"ERROR: {var} not set", file=sys.stderr)
+            return 1
+    os.environ.setdefault("AWS_REGION_NAME", "us-east-1")
+    os.environ.setdefault("UNSAFE_EXECUTION_OK", "true")
+
+    if BASE.exists():
+        shutil.rmtree(BASE)
+    thermal, meta_path, diffraction, spectroscopy, markers = stage_data()
+
+    log_buf = io.StringIO()
+    capture = logging.StreamHandler(log_buf)
+    capture.setLevel(logging.INFO)
+    logging.getLogger().addHandler(capture)
+    logging.getLogger().setLevel(logging.INFO)
+
+    from scilink.agents.meta_agent.meta_orchestrator import (
+        MetaOrchestratorAgent, MetaMode)
+    from scilink.agents.exp_agents.analysis_orchestrator_tools import (
+        _same_dataset)
+
+    meta = MetaOrchestratorAgent(
+        base_dir=str(BASE / "meta_session"),
+        api_key=None, model_name=MODEL,
+        meta_mode=MetaMode.AUTONOMOUS,
+    )
+
+    turns = [
+        ("thermal",
+         f"Delegate to the analysis specialist: fit the thermal analysis "
+         f"measurement at {thermal / 'thermal_run.txt'} (multi-column "
+         f"instrument export; fit heat flow vs temperature). First load the "
+         f"combined instrument metadata JSON at {meta_path}. This is a smoke "
+         f"test: tell the specialist to use max_verification_iterations=1 "
+         f"and accept the first reasonable fit."),
+        ("diffraction",
+         f"Next, delegate analysis of the in-situ series of the same sample "
+         f"in {diffraction} — track how the patterns evolve across the "
+         f"series. Same smoke-test settings (max_verification_iterations=1). "
+         f"Proceed autonomously."),
+        ("spectroscopy",
+         f"Finally, delegate analysis of the in-situ series in "
+         f"{spectroscopy} for the same sample — what changes across the "
+         f"series? Same smoke-test settings (max_verification_iterations=1). "
+         f"Proceed autonomously."),
+    ]
+
+    captured = {}
+    logged = {}
+    for name, prompt in turns:
+        buf = io.StringIO()
+        log_start = len(log_buf.getvalue())
+        print(f"\n>>> turn [{name}]")
+        t0 = time.perf_counter()
+        with contextlib.redirect_stdout(Tee(sys.__stdout__, buf)):
+            reply = meta.chat(prompt)
+        captured[name] = buf.getvalue()
+        logged[name] = log_buf.getvalue()[log_start:]
+        print(f"<<< [{name}] done in {time.perf_counter() - t0:.0f}s: "
+              f"{reply[:180]}")
+
+    logging.getLogger().removeHandler(capture)
+    for name in captured:
+        (BASE / f"captured_{name}.log").write_text(captured[name])
+        (BASE / f"logging_{name}.log").write_text(logged[name])
+    (BASE / "root_logging.log").write_text(log_buf.getvalue())
+
+    child = meta._children.get("analysis")
+    ledger = meta._delegation_ledger
+
+    def ok(entry):
+        # Known defect (plan 1.4, unfixed): status can read "success" on a
+        # failed child - also require the summary isn't an error banner.
+        return (entry.get("status") == "success"
+                and not (entry.get("summary") or "").strip().startswith("❌"))
+
+    print("\n--- checks ---")
+    check("I1: three delegations recorded", len(ledger) >= 3)
+    check("I2: thermal delegation succeeded", bool(ledger) and ok(ledger[0]))
+
+    diff_txt = captured["diffraction"]
+    # No-silent-reuse can be satisfied two ways: the run_analysis ownership
+    # backstop fires (displacement/refusal message), OR the child explicitly
+    # re-resolves metadata for the diffraction dataset before running (fresh
+    # load, binds to it). Only a run with NEITHER means the thermal document
+    # leaked.
+    backstop = ("does not cover this dataset" in diff_txt
+                or "belongs to a different dataset" in diff_txt)
+    re_resolved = (("Loading metadata from" in diff_txt
+                    and "insitu_diffraction"
+                    in diff_txt.split("Running analysis")[0])
+                   or "Synthesized global metadata" in diff_txt
+                   or "using its sidecar JSONs" in diff_txt)
+    check("I3: no silent reuse of the thermal metadata "
+          "(backstop fired or child re-resolved)",
+          backstop or re_resolved)
+    check("I4: diffraction delegation succeeded",
+          len(ledger) >= 2 and ok(ledger[1]))
+
+    dl = (diff_txt + logged["diffraction"]).lower()
+    check("I5: xrd_profile skill auto-selected for the diffraction run",
+          "auto-selected domain skill(s): xrd_profile" in dl
+          or "skill loaded: xrd_profile" in dl)
+    check("I6: diffraction plan is diffraction, not thermogram",
+          any(k in dl for k in ("2theta", "2-theta", "2θ",
+                                "pseudo-voigt", "d-spacing", "diffraction",
+                                "bragg")))
+    # Scan ONLY this turn's captured stdout: the turn's logging includes the
+    # child planner/validator prose which may legitimately reference the
+    # prior thermal findings as context.
+    ds = diff_txt.lower()
+    check("I7: no thermal-analysis plan leaked into the diffraction run",
+          "heat flow" not in ds and "heat-flow" not in ds
+          and "j/g" not in ds and "enthalpy" not in ds)
+
+    check("I8: spectroscopy delegation succeeded",
+          len(ledger) >= 3 and ok(ledger[2]))
+    check("I9: spectroscopy run re-resolved metadata again",
+          child is not None
+          and child.current_metadata_owner is not None
+          and _same_dataset(child.current_metadata_owner, str(spectroscopy)))
+    md_txt = json.dumps(child.current_metadata or {}) if child else ""
+    check("I10: final child metadata carries nothing from the thermal doc",
+          child is not None and not any(m in md_txt for m in markers))
+
+    print("\n" + "=" * 50)
+    npass = sum(results.values())
+    print(f"MULTIMODAL META LIVE (#411): {npass}/{len(results)} checks passed")
+    for k, v in results.items():
+        if not v:
+            print("  FAILED:", k)
+    return 0 if npass == len(results) else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_metadata_dataset_ownership.py
+++ b/tests/test_metadata_dataset_ownership.py
@@ -1,0 +1,248 @@
+"""Offline tests for dataset-aware metadata ownership (issue #411).
+
+Defect 1: `current_metadata` was one session-global slot — a second dataset
+with no sidecar of its own silently inherited the first technique's metadata.
+Ownership now binds on first use by run_analysis; a different dataset must
+re-resolve (sidecars -> stem backstop -> refuse, naming the previous owner).
+
+Defect 2: plan validation could rewrite the physical model while carrying
+over the previous technique's series regimes; the apply path is exercised
+here with a mocked validator response.
+
+  conda run -n scilink python tests/test_metadata_dataset_ownership.py
+"""
+import os
+import tempfile
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+import scilink.agents.exp_agents.analysis_orchestrator_tools as aot
+from scilink.agents.exp_agents.analysis_orchestrator_tools import (
+    _dataset_key, _same_dataset,
+)
+
+results = {}
+SENTINEL = "SENTINEL_REACHED_AGENT_CREATION"
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+def make_orchestrator():
+    from scilink.agents.exp_agents.analysis_orchestrator import (
+        AnalysisOrchestratorAgent, AnalysisMode)
+    bd = tempfile.mkdtemp()
+    ag = AnalysisOrchestratorAgent(base_dir=bd, api_key="sk-dummy",
+                                   model_name="claude-opus-4-6",
+                                   restore_checkpoint=False,
+                                   analysis_mode=AnalysisMode.AUTONOMOUS)
+
+    def _sentinel(*a, **k):
+        raise RuntimeError(SENTINEL)
+
+    ag.create_agent_for_analysis = _sentinel
+    ag.selected_agent_id = 1
+    return ag
+
+
+def run(ag, data_path, **kw):
+    r = json.loads(ag.tools.functions_map["run_analysis"](
+        data_path=data_path, agent_id=1, **kw))
+    return r
+
+
+def reached_agent(r):
+    return r.get("status") == "error" and SENTINEL in (r.get("message") or "")
+
+
+def main():
+    # --- Fixture datasets -------------------------------------------------
+    root = Path(tempfile.mkdtemp())
+    dir_a = root / "xps_run"          # dataset A: dir, global metadata doc
+    dir_a.mkdir()
+    np.savetxt(dir_a / "xps.csv", np.random.rand(50, 2), delimiter=",")
+    (dir_a / "metadata.json").write_text(json.dumps(
+        {"technique": "XPS", "x_units": "eV"}))
+
+    file_b = root / "epr_spectrum.csv"   # dataset B: bare file, NO sidecar
+    np.savetxt(file_b, np.random.rand(50, 2), delimiter=",")
+
+    dir_c = root / "ftir_series"      # dataset C: series with sidecars
+    dir_c.mkdir()
+    for t in (30, 40, 50):
+        np.savetxt(dir_c / f"ftir_{t}C.txt", np.random.rand(20, 2))
+        (dir_c / f"ftir_{t}C.json").write_text(
+            json.dumps({"technique": "FTIR", "temperature_C": t}))
+
+    file_d = root / "raman.csv"       # dataset D: file WITH stem sidecar
+    np.savetxt(file_d, np.random.rand(50, 2), delimiter=",")
+    (root / "raman.json").write_text(json.dumps({"technique": "Raman"}))
+
+    # Avoid any LLM call from series sidecar extraction; return a resolved
+    # control variable so the series run proceeds past the user prompt.
+    aot._extract_series_from_sidecars = lambda *a, **k: (
+        {"variable": "temperature_C", "values": [30, 40, 50], "units": "C"},
+        {f"ftir_{t}C.txt": {"technique": "FTIR", "temperature_C": t}
+         for t in (30, 40, 50)},
+    )
+
+    print("1) _dataset_key / _same_dataset semantics:")
+    check("same file matches", _same_dataset(str(file_b), str(file_b)))
+    check("dir covers member file", _same_dataset(str(dir_a), str(dir_a / "xps.csv")))
+    check("dir covers glob within it",
+          _same_dataset(str(dir_c), str(dir_c / "ftir_*.txt")))
+    check("sibling file NOT covered by dir",
+          not _same_dataset(str(dir_a), str(file_b)))
+    check("file does NOT cover its parent dir",
+          not _same_dataset(str(dir_a / "xps.csv"), str(dir_a)))
+    check("glob covers a file it matches",
+          _same_dataset(str(dir_c / "ftir_*.txt"), str(dir_c / "ftir_30C.txt")))
+    check("glob does NOT cover non-matching file",
+          not _same_dataset(str(dir_c / "ftir_*.txt"), str(file_b)))
+    check("distinct globs over one dir are distinct datasets",
+          not _same_dataset(str(dir_c / "ftir_3*.txt"), str(dir_c / "ftir_4*.txt")))
+
+    print("2) explicit load binds on first use; different dataset refused:")
+    ag = make_orchestrator()
+    lm = json.loads(ag.tools.functions_map["load_metadata"](
+        str(dir_a / "metadata.json")))
+    check("metadata loaded", lm.get("status") in ("success", "warning"))
+    check("fresh load is unbound", ag.current_metadata_owner is None)
+
+    r = run(ag, str(dir_a))
+    check("first run proceeds to agent creation", reached_agent(r))
+    check("slot bound to dataset A", ag.current_metadata_owner == _dataset_key(str(dir_a)))
+
+    r = run(ag, str(dir_a / "xps.csv"))
+    check("drill-down into owner dir still allowed", reached_agent(r))
+
+    r = run(ag, str(file_b))
+    check("different dataset w/o sidecar is REFUSED", r.get("status") == "error"
+          and "different dataset" in (r.get("message") or ""))
+    check("refusal names the previous owner",
+          _dataset_key(str(dir_a)) in (r.get("message") or ""))
+    check("stale metadata not clobbered by refusal",
+          (ag.current_metadata or {}).get("technique") == "XPS")
+
+    print("3) stale slot displaced by the new dataset's own sidecars:")
+    r = run(ag, str(dir_c))
+    check("series with sidecars proceeds despite stale slot", reached_agent(r))
+    check("stale XPS doc was cleared",
+          (ag.current_metadata or {}).get("technique") != "XPS")
+    check("slot rebound to dataset C",
+          ag.current_metadata_owner == _dataset_key(str(dir_c)))
+
+    r = run(ag, str(file_d))
+    check("stem-sidecar file proceeds despite stale slot", reached_agent(r))
+    check("stem sidecar replaced the stale doc",
+          (ag.current_metadata or {}).get("technique") == "Raman")
+    check("slot rebound to dataset D",
+          ag.current_metadata_owner == _dataset_key(str(file_d)))
+
+    print("4) fresh explicit load serves the NEXT dataset (bind-on-first-use):")
+    json.loads(ag.tools.functions_map["load_metadata"](
+        str(dir_a / "metadata.json")))
+    check("re-load unbinds", ag.current_metadata_owner is None)
+    r = run(ag, str(file_b))
+    check("fresh load usable for new dataset", reached_agent(r))
+    check("slot bound to dataset B",
+          ag.current_metadata_owner == _dataset_key(str(file_b)))
+
+    print("5) checkpoint round-trip and legacy backfill:")
+    ag._auto_checkpoint()
+    saved = json.loads(ag.checkpoint_path.read_text())
+    check("owner persisted in checkpoint",
+          saved.get("current_metadata_owner") == _dataset_key(str(file_b)))
+
+    from scilink.agents.exp_agents.analysis_orchestrator import (
+        AnalysisOrchestratorAgent, AnalysisMode)
+    ag2 = AnalysisOrchestratorAgent(base_dir=str(ag.base_dir), api_key="sk-dummy",
+                                    model_name="claude-opus-4-6",
+                                    restore_checkpoint=True,
+                                    analysis_mode=AnalysisMode.AUTONOMOUS)
+    check("owner restored", ag2.current_metadata_owner == _dataset_key(str(file_b)))
+
+    # Legacy checkpoint (no owner field): backfill from current_data_path.
+    legacy = {k: v for k, v in saved.items() if k != "current_metadata_owner"}
+    legacy["current_data_path"] = str(dir_a)
+    ag.checkpoint_path.write_text(json.dumps(legacy))
+    ag3 = AnalysisOrchestratorAgent(base_dir=str(ag.base_dir), api_key="sk-dummy",
+                                    model_name="claude-opus-4-6",
+                                    restore_checkpoint=True,
+                                    analysis_mode=AnalysisMode.AUTONOMOUS)
+    check("legacy checkpoint backfills owner from last data path",
+          ag3.current_metadata_owner == str(dir_a))
+
+    print("6) plan validation apply path re-derives series regimes (fix 2):")
+    from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+        CurveFittingPlanningController)
+    from scilink.agents.exp_agents.instruct import (
+        CURVE_FITTING_PLAN_VALIDATION_PROMPT)
+    check("prompt states the re-derive principle",
+          "regimes are invalid" in CURVE_FITTING_PLAN_VALIDATION_PROMPT
+          and "re-derived series_analysis_plan" in CURVE_FITTING_PLAN_VALIDATION_PROMPT)
+
+    corrected = {
+        "valid": False,
+        "issues": ["wrong technique: data is EPR, not XPS"],
+        "physical_model": "EPR axial powder pattern (Lorentzian derivative)",
+        "parameters_to_extract": ["g_parallel", "g_perp", "linewidth"],
+        "fitting_strategy": "fit derivative lineshape per spectrum",
+        "series_analysis_plan": {
+            "regimes": [
+                {"name": "low_T", "spectrum_indices": [0, 1, 2],
+                 "physical_model": "axial powder pattern"},
+                {"name": "high_T", "spectrum_indices": [3, 4, 5],
+                 "physical_model": "isotropic Lorentzian"},
+            ],
+        },
+    }
+
+    class FakeModel:
+        def generate_content(self, *a, **k):
+            return corrected
+
+    ctrl = CurveFittingPlanningController(
+        model=FakeModel(), logger=aot.logging.getLogger("t"),
+        generation_config=None, safety_settings=None,
+        parse_fn=lambda resp: (resp, None),
+        instructions="", output_dir=tempfile.mkdtemp())
+
+    state = {
+        "is_single_spectrum": False,
+        "num_spectra": 6,
+        "physical_model": "XPS doublet (Voigt)",
+        "parameters_to_extract": ["binding_energy"],
+        "fitting_strategy": "Voigt peaks with Shirley background",
+        "analysis_approach": "peak fitting",
+        "series_analysis_plan": {
+            "regimes": [{"name": "all", "spectrum_indices": list(range(6)),
+                         "physical_model": "XPS doublet (Voigt)"}],
+        },
+    }
+    out = ctrl._validate_plan(dict(state))
+    check("model correction applied",
+          out["physical_model"].startswith("EPR"))
+    new_regimes = (out.get("series_analysis_plan") or {}).get("regimes") or []
+    check("series regimes re-derived (not carried over)",
+          len(new_regimes) == 2
+          and {r["name"] for r in new_regimes} == {"low_T", "high_T"})
+
+    print("\n" + "=" * 50)
+    npass = sum(results.values())
+    print(f"METADATA OWNERSHIP (#411): {npass}/{len(results)} checks passed")
+    for k, v in results.items():
+        if not v:
+            print("  FAILED:", k)
+    raise SystemExit(0 if npass == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_metadata_ownership_live.py
+++ b/tests/test_metadata_ownership_live.py
@@ -1,0 +1,286 @@
+"""Live validation for issue #411 fixes (Bedrock Opus 4.8).
+
+Part A (defect 2, one model call): a wrong-technique plan (XPS, one regime)
+is validated against an EPR-looking series overlay. The validator must not
+only correct the physical model but return a RE-DERIVED series_analysis_plan
+instead of carrying the XPS regime over.
+
+Part B (defects 1+3, two-turn orchestrator chat): dataset A (XPS dir with an
+explicitly loaded metadata doc) is analyzed; then dataset B (EPR-like file,
+NO sidecar) is requested with no technique info. run_analysis must REFUSE to
+reuse A's metadata (naming A), the LLM must recover by creating metadata for
+B, and the slot must end bound to B with non-XPS content.
+
+Run:
+    AWS_BEARER_TOKEN_BEDROCK=... AWS_REGION_NAME=us-east-1 \
+    UNSAFE_EXECUTION_OK=true \
+    python tests/test_metadata_ownership_live.py
+"""
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+BASE = Path("tests/_metadata_ownership_live_runs").resolve()
+
+results = {}
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+def _gauss(x, amp, mu, sigma):
+    return amp * np.exp(-0.5 * ((x - mu) / sigma) ** 2)
+
+
+def _epr_deriv(B, amp, B0, w):
+    """Derivative-of-Lorentzian EPR lineshape."""
+    hw = w / 2.0
+    return -2.0 * amp * hw ** 2 * (B - B0) / ((B - B0) ** 2 + hw ** 2) ** 2
+
+
+def make_xps_dataset(d: Path) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    rng = np.random.default_rng(3)
+    x = np.linspace(282.0, 290.0, 401)
+    y = (_gauss(x, 1.0, 284.6, 0.45) + _gauss(x, 0.55, 286.5, 0.5)
+         + 0.05 + rng.normal(0, 0.005, x.size))
+    np.savetxt(d / "c1s.csv", np.column_stack([x, y]), delimiter=",",
+               header="binding_energy_eV,intensity", comments="")
+    (d / "metadata.json").write_text(json.dumps({
+        "experiment": {"technique": "XPS", "edge": "C 1s",
+                       "x_units": "eV binding energy"},
+        "sample": {"material": "synthetic carbon film"},
+        "instrument": {"name": "test_instrument"},
+    }, indent=2))
+
+
+def make_epr_file(path: Path) -> None:
+    rng = np.random.default_rng(7)
+    B = np.linspace(320.0, 340.0, 501)
+    y = (_epr_deriv(B, 1.0, 329.0, 1.2) + _epr_deriv(B, 0.6, 331.5, 1.8)
+         + rng.normal(0, 0.004, B.size))
+    np.savetxt(path, np.column_stack([B, y]), delimiter=",",
+               header="field_mT,dI_dB", comments="")
+
+
+def make_epr_series_overlay() -> bytes:
+    """6-spectrum EPR series with a visible regime change at index 3."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    B = np.linspace(320.0, 340.0, 501)
+    fig, ax = plt.subplots(figsize=(7, 4.5))
+    for i in range(6):
+        if i < 3:  # two overlapping derivative features
+            y = (_epr_deriv(B, 1.0, 328.5 + 0.2 * i, 1.2)
+                 + _epr_deriv(B, 0.7, 331.5 + 0.2 * i, 1.6))
+        else:      # collapsed to one narrow isotropic line
+            y = _epr_deriv(B, 1.4, 330.0 + 0.1 * i, 0.9)
+        ax.plot(B, y + 0.6 * i, label=f"spectrum {i} (T={20 + 15 * i}K)")
+    ax.set_xlabel("x")
+    ax.set_ylabel("signal (offset for clarity)")
+    ax.legend(fontsize=7)
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=110)
+    plt.close(fig)
+    return buf.getvalue()
+
+
+def part_a() -> None:
+    print("\n=== PART A: validator re-derives regimes on technique change ===")
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+    from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+        CurveFittingPlanningController)
+
+    agent = CurveFittingAgent(
+        api_key=None, model_name=MODEL,
+        output_dir=str(BASE / "part_a_out"),
+        enable_human_feedback=False, run_preprocessing=False,
+    )
+    ctrl = CurveFittingPlanningController(
+        model=agent.model, logger=logging.getLogger("live_a"),
+        generation_config=agent.generation_config,
+        safety_settings=getattr(agent, "safety_settings", None),
+        parse_fn=agent._parse_llm_response,
+        instructions="", output_dir=str(BASE / "part_a_out"),
+    )
+
+    xps_regime = {
+        "name": "single_phase",
+        "spectrum_indices": list(range(6)),
+        "physical_model": "Two Voigt components (C 1s / shifted C 1s) on a "
+                          "Shirley background",
+        "fitting_strategy": "Voigt doublet, Shirley background per spectrum",
+    }
+    state = {
+        "is_single_spectrum": False,
+        "num_spectra": 6,
+        "scout_data": [0, 2, 5],
+        "analysis_approach": "XPS core-level peak fitting",
+        "physical_model": "Two Voigt components on a Shirley background "
+                          "(XPS C 1s doublet)",
+        "parameters_to_extract": ["binding_energy", "fwhm", "area_ratio"],
+        "fitting_strategy": "Fit Voigt doublet with Shirley background to "
+                            "every spectrum in the series",
+        "series_analysis_plan": {"regimes": [dict(xps_regime)]},
+        "scout_overlay_plot": make_epr_series_overlay(),
+    }
+
+    out = ctrl._validate_plan(dict(state))
+    model_txt = (out.get("physical_model") or "").lower()
+    plan = out.get("series_analysis_plan") or {}
+    regimes = plan.get("regimes") or []
+    regime_txt = json.dumps(regimes).lower()
+
+    (BASE / "part_a_out").mkdir(parents=True, exist_ok=True)
+    (BASE / "part_a_out" / "validated_state.json").write_text(json.dumps({
+        "physical_model": out.get("physical_model"),
+        "parameters_to_extract": out.get("parameters_to_extract"),
+        "fitting_strategy": out.get("fitting_strategy"),
+        "series_analysis_plan": plan,
+    }, indent=2, default=str))
+
+    check("A1: model corrected away from XPS/Voigt+Shirley",
+          "shirley" not in model_txt
+          and any(k in model_txt for k in
+                  ("derivative", "epr", "lorentzian", "resonance", "dysonian")))
+    check("A2: series plan returned by the validator (not carried over)",
+          bool(regimes)
+          and regime_txt != json.dumps([xps_regime]).lower())
+    regime_models = " ".join(
+        (r.get("physical_model") or "").lower() for r in regimes)
+    check("A3: regime physical_model re-derived (EPR-appropriate, "
+          "no placeholder, no Shirley)",
+          bool(regimes) and "shirley" not in regime_txt
+          and "to be determined" not in regime_models
+          and any(k in regime_models for k in
+                  ("derivative", "epr", "lorentzian", "resonance")))
+    print(f"  validated model: {out.get('physical_model')}")
+    print(f"  regimes: {[r.get('name') for r in regimes]}")
+
+
+def part_b() -> None:
+    print("\n=== PART B: two-dataset orchestrator session ===")
+    from scilink.agents.exp_agents.analysis_orchestrator import (
+        AnalysisOrchestratorAgent, AnalysisMode)
+    from scilink.agents.exp_agents.analysis_orchestrator_tools import (
+        _dataset_key)
+
+    data = BASE / "data"
+    dir_a = data / "xps_run"
+    make_xps_dataset(dir_a)
+    file_b = data / "epr_spectrum.csv"
+    make_epr_file(file_b)
+
+    log_buf = io.StringIO()
+    capture = logging.StreamHandler(log_buf)
+    capture.setLevel(logging.INFO)
+    logging.getLogger().addHandler(capture)
+    logging.getLogger().setLevel(logging.INFO)
+
+    try:
+        orch = AnalysisOrchestratorAgent(
+            base_dir=str(BASE / "session"),
+            api_key=None, model_name=MODEL,
+            analysis_mode=AnalysisMode.AUTONOMOUS,
+        )
+
+        p1 = (f"Load the metadata file {dir_a / 'metadata.json'}, then analyze "
+              f"the XPS spectrum in {dir_a} with the curve fitting agent. "
+              f"Two Gaussian-like peaks near 284.6 and 286.5 eV on a flat "
+              f"background. This is a smoke test: use "
+              f"max_verification_iterations=1 and accept the first "
+              f"reasonable fit.")
+        print(f"\n>>> turn 1: {p1}\n")
+        t0 = time.perf_counter()
+        r1 = orch.chat(p1)
+        print(f"<<< turn 1 done in {time.perf_counter() - t0:.0f}s: {r1[:200]}")
+
+        n_after_1 = len(orch.analysis_results)
+        owner_after_1 = orch.current_metadata_owner
+
+        p2 = (f"Now analyze the spectrum at {file_b} with the curve fitting "
+              f"agent. Same smoke-test settings "
+              f"(max_verification_iterations=1). Do not ask me questions; "
+              f"proceed autonomously.")
+        print(f"\n>>> turn 2: {p2}\n")
+        t0 = time.perf_counter()
+        r2 = orch.chat(p2)
+        print(f"<<< turn 2 done in {time.perf_counter() - t0:.0f}s: {r2[:200]}")
+    finally:
+        logging.getLogger().removeHandler(capture)
+
+    transcript = json.dumps(orch.messages, default=str)
+    log_text = log_buf.getvalue()
+    (BASE / "session" / "captured.log").write_text(log_text)
+
+    check("B1: first analysis completed", n_after_1 >= 1)
+    check("B2: metadata bound to dataset A after turn 1",
+          owner_after_1 is not None
+          and _same_or_sub(owner_after_1, dir_a))
+    check("B3: stale reuse REFUSED for dataset B (error names dataset A)",
+          "belongs to a different dataset" in transcript)
+    check("B4: LLM recovered and completed the second analysis",
+          len(orch.analysis_results) >= n_after_1 + 1
+          and (orch.analysis_results[-1].get("status") in
+               (None, "success", "completed", "success_with_warnings")))
+    md_txt = json.dumps(orch.current_metadata or {}).lower()
+    check("B5: final metadata is NOT dataset A's XPS document",
+          "c 1s" not in md_txt and "carbon film" not in md_txt)
+    check("B6: slot ends bound to dataset B",
+          orch.current_metadata_owner == _dataset_key(str(file_b)))
+
+    # Soft report: which skill(s) each run selected (defect 3 signal).
+    for line in log_text.splitlines():
+        if "skill" in line.lower() and ("select" in line.lower()
+                                        or "loaded" in line.lower()):
+            print("  [skill-log]", line.strip()[:160])
+
+
+def _same_or_sub(owner: str, d: Path) -> bool:
+    from scilink.agents.exp_agents.analysis_orchestrator_tools import (
+        _same_dataset)
+    return _same_dataset(owner, str(d)) or _same_dataset(str(d), owner)
+
+
+def main() -> int:
+    if not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
+        print("ERROR: AWS_BEARER_TOKEN_BEDROCK not set", file=sys.stderr)
+        return 1
+    os.environ.setdefault("AWS_REGION_NAME", "us-east-1")
+    os.environ.setdefault("UNSAFE_EXECUTION_OK", "true")
+
+    only = sys.argv[1] if len(sys.argv) > 1 else None
+    if only is None and BASE.exists():
+        shutil.rmtree(BASE)
+    BASE.mkdir(parents=True, exist_ok=True)
+
+    if only in (None, "a"):
+        part_a()
+    if only in (None, "b"):
+        part_b()
+
+    print("\n" + "=" * 50)
+    npass = sum(results.values())
+    print(f"METADATA OWNERSHIP LIVE (#411): {npass}/{len(results)} checks passed")
+    for k, v in results.items():
+        if not v:
+            print("  FAILED:", k)
+    return 0 if npass == len(results) else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #411.

When one session analyzes more than one technique, metadata loaded for the first dataset silently carried over to the next one. The planner then read the new data through the old technique's schema — axes, units, and control variable all wrong — and the correct technique skill was dropped. The run didn't fail; it produced a confidently wrong plan. A second, related gap: when the plan validator re-identified the technique from the data, it corrected the model sections but left the series regimes from the old technique in place, so a series still fit under the wrong recipe.

**What changes**

- Loaded metadata now belongs to a dataset. A freshly loaded document binds to the first dataset it is used for; a later analysis of a *different* dataset re-resolves metadata on its own (per-file sidecar JSONs, then a stem-matched sidecar). If nothing resolves, the run stops with an error naming which dataset the loaded metadata belongs to — one `load_metadata` call away from recovery — instead of silently fitting against the wrong schema.
- This also repairs a stricter case: previously, once *any* metadata was loaded, sidecar detection was skipped entirely — so even a dataset carrying its own sidecars inherited the stale document.
- The plan validator's prompt now states that a technique or physical-model correction invalidates the series regimes and must return a re-derived series plan (with the regime fields named explicitly).
- Ownership survives checkpoint/restore; older checkpoints backfill it from the last data path.

**Validation**

- Offline: `tests/test_metadata_dataset_ownership.py` — 31 checks (ownership semantics, refusal naming the owner, sidecar displacement, bind-on-first-use, checkpoint round-trip, and the validator apply path with a mocked response). Neighboring suites unchanged and green (`test_run_analysis_glob`, `test_file_prep_metadata_only`, `test_metadata_conformance_energy_axis`, `test_analyze_file_shapes`).
- Live (`bedrock/us.anthropic.claude-opus-4-8`):
  - `tests/test_metadata_ownership_live.py` (9/9) — a wrong-technique plan validated against a mismatched series overlay gets both the model *and* the regimes re-derived; a two-turn session shows the refusal firing for a second dataset with no sidecar, followed by autonomous recovery and correct re-binding.
  - `tests/test_411_multimodal_meta_live.py` (10/10) — one meta session, three delegations over real instrument exports (thermal → in-situ diffraction → in-situ spectroscopy), with the later turns naming no technique: no silent reuse of the thermal document, `xrd_profile` auto-selected for the diffraction series, plan free of thermogram leakage, and the slot re-resolved per dataset every time. Dataset paths are env-configured so the harness runs against any trio of this shape.

<details>
<summary>Technical details</summary>

**Defect 1 (load-bearing).** `current_metadata` was a single session-level slot (`analysis_orchestrator.py`); `load_metadata`/`convert_metadata` wrote into it wholesale and `run_analysis` error-checked only `if current_metadata is None`, so a second dataset without a sidecar inherited the first dataset's document. The whole resolution ladder also sat inside that `None` guard, so once the slot was filled, per-file sidecar detection never ran for later datasets.

Fix: `current_metadata_owner` on the orchestrator, with **bind-on-first-use** semantics. `_replace_metadata` (the single choke point for all load paths) resets the owner to unbound; `run_analysis` binds the slot to the dataset that first consumes it. On an owner mismatch the existing ladder re-runs — per-file sidecars (clear slot, resolve per file), stem-matched sidecar backstop, then a refusal naming the previous owner. Bind-on-first-use is what keeps "load metadata, then analyze the next dataset" working — a fresh explicit load is never refused. `_dataset_key`/`_same_dataset` normalize paths and define coverage: a dir covers its member files and globs within it; a glob covers files it matches; siblings and broader paths are distinct datasets. Owner is persisted in both checkpoint writers and restored; legacy checkpoints without the field backfill from `current_data_path`.

**Defect 2.** `CurveFitting._validate_plan` already had the apply path for a returned `series_analysis_plan`; the response schema made it opt-in (`"series_analysis_plan": null`) with nothing tying regime validity to the technique. The prompt now states the principle and names the exact regime fields — the first live run showed the validator returning re-derived regimes under improvised keys (`model`/`params`), which the extractor then backfilled with placeholders.

**Defect 3** (skill selection consuming stale metadata) needed no new mechanism: selection runs before planning and reads whatever metadata reaches it, which after defect 1's fix is either the right document or none. A post-validation re-selection pass was deliberately not added.

**Known non-goal:** explicitly loading wrong metadata for the *same* dataset is still honored — user authority over their own dataset's metadata is out of scope here.

Observed while testing, not addressed here: delegations through `run_task` never write the child's `checkpoint.json`, and the delegation ledger still trusts the child's self-reported status (plan item 1.4).
</details>
