### PR TITLE
Honor explicit user crop/region requests: make them visible to the plan validator

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -759,7 +759,10 @@ def _append_fit_domain_guidance(prompt: list, state: dict) -> None:
         "\n## Fit-domain & background guidance\n"
         f"User processing note: {instruction}\n"
         "Express any region-of-interest as the FIT DOMAIN and any "
-        "background/baseline as a FIT PARAMETER — not as preprocessing."
+        "background/baseline as a FIT PARAMETER — not as preprocessing.\n"
+        "This note is a USER request: a region restriction it implies is "
+        "user-authorized — it satisfies any 'unless the user asked' condition "
+        "in domain skill rules and must not be reverted or second-guessed."
     )
 
 
@@ -2070,6 +2073,12 @@ class CurveFittingPlanningController:
         # ambiguous. Mirrors the planning prompt and ImageAnalysis._validate_plan.
         _append_objective_context(prompt_parts, state)
         _append_skill_context(prompt_parts, state, "planning")
+        # The validator must see a user processing note (e.g. a crop /
+        # region-of-interest request): without it, a skill's mandatory
+        # "fit the full measured range" rule reads a user-restricted fit
+        # domain as a violation and reverts it. Mirrors the planning-prompt
+        # injection; no-op when no custom_processing_instruction is set.
+        _append_fit_domain_guidance(prompt_parts, state)
 
         # For a series, show the multi-spectrum scout overlay (the single
         # first-spectrum plot is uninformative — and can render blank — for a

--- a/tests/test_crop_fitdomain_live.py
+++ b/tests/test_crop_fitdomain_live.py
@@ -1,0 +1,184 @@
+"""Live validation: a user crop request survives plan validation (Bedrock).
+
+Scenario: an IR spectrum (full range ~374-4000 cm-1) with a user request to
+crop to 600-1000 cm-1, routed through custom_processing_instruction — the
+channel the orchestrator steers raw-data operations toward. The IR skill
+auto-selects and injects the mandatory "fit the full measured range" rule;
+pre-fix, the plan validator (which never saw the user note) reverted the
+restricted fit domain to full range.
+
+Modes (argv[1]):
+  agent  — CurveFittingAgent directly with the instruction seeded in
+           system_info (deterministic channel; the pre/post contrast run).
+           Set SCILINK_CROP_REPO to a repo checkout to test (e.g. a main
+           worktree for the pre-fix contrast) — it is prepended to sys.path.
+  meta   — end-to-end MetaOrchestratorAgent session with the crop asked in
+           natural language (the complaint's flow).
+
+PASS = the fitted curve (spectrum_0000/fit.npy) spans only the requested
+window, not the full spectrum.
+
+    SCILINK_IR_FILE=/path/to/spectrum.csv \
+    AWS_BEARER_TOKEN_BEDROCK=... AWS_REGION_NAME=us-east-1 \
+    UNSAFE_EXECUTION_OK=true python tests/test_crop_fitdomain_live.py agent
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+CROP_LO, CROP_HI = 600.0, 1000.0
+TOL = 30.0  # cm-1 slack on the window edges
+MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+
+
+def crop_check(out_dir: Path):
+    """Was the fit restricted to the requested window?
+
+    Judged from the EXECUTED plan and script (fit.npy is written by the
+    ad-hoc generated script and is not reliable): the locked plan /
+    reported model_type must name the window, the generated fitting
+    script must contain both bounds, and the run must have succeeded.
+    """
+    import re
+
+    def has_bounds(text):
+        nums = [float(n) for n in re.findall(r"\b\d{3,4}(?:\.\d+)?\b", text)]
+        return (any(abs(n - CROP_LO) <= TOL for n in nums)
+                and any(abs(n - CROP_HI) <= TOL for n in nums))
+
+    script_says_crop = any(
+        has_bounds(sp.read_text()) for sp in out_dir.rglob("fitting_script.py"))
+
+    centers = []
+    status_ok = False
+    model_type = None
+    r_squared = None
+    for srp in out_dir.rglob("series_fit_results.json"):
+        sr = json.loads(srp.read_text())
+        results = sr.get("results") or []
+        status_ok = bool(results) and all(r.get("success") for r in results)
+        for r in results:
+            model_type = r.get("model_type") or model_type
+            for p in (r.get("parameters") or {}).values():
+                if isinstance(p, dict) and isinstance(
+                        p.get("center"), (int, float)):
+                    centers.append(float(p["center"]))
+    for arp in out_dir.rglob("analysis_results.json"):
+        ar = json.loads(arp.read_text())
+        fq = ar.get("fit_quality") or {}
+        r_squared = fq.get("r_squared")
+    if not centers and not status_ok:
+        return None
+    # Execution-level truth: every fitted band lies inside the window.
+    centers_inside = bool(centers) and all(
+        CROP_LO - TOL <= c <= CROP_HI + TOL for c in centers)
+    return {"script_says_crop": script_says_crop,
+            "centers": sorted(round(c, 1) for c in centers),
+            "centers_inside": centers_inside,
+            "model_type": model_type,
+            "status_ok": status_ok, "r_squared": r_squared}
+
+
+def report(mode, chk):
+    if not chk:
+        print(f"\n[{mode}] no fit artifacts found")
+        print(f"[{mode}] CROP HONORED: NO")
+        return False
+    ok = chk["centers_inside"] and chk["status_ok"] and chk["script_says_crop"]
+    print(f"\n[{mode}] fitted centers: {chk['centers']}; all inside window: "
+          f"{chk['centers_inside']}; script bounds: {chk['script_says_crop']}; "
+          f"success: {chk['status_ok']}; R2: {chk['r_squared']}")
+    print(f"[{mode}] model: {str(chk['model_type'])[:120]}")
+    print(f"[{mode}] CROP HONORED: {'YES' if ok else 'NO'}")
+    return ok
+
+
+def run_agent_mode(work: Path, src_csv: Path) -> bool:
+    repo = os.environ.get("SCILINK_CROP_REPO")
+    if repo:
+        sys.path.insert(0, repo)
+    import scilink  # noqa: F401  (resolve after path injection)
+    print(f"scilink from: {scilink.__file__}")
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+
+    out = work / "agent_out"
+    agent = CurveFittingAgent(
+        api_key=None, model_name=MODEL, output_dir=str(out),
+        enable_human_feedback=False, max_verification_iterations=1,
+    )
+    res = agent.analyze(
+        str(src_csv),
+        system_info={
+            "technique": "Infrared spectroscopy (FTIR)",
+            "x_axis": "wavenumber (cm^-1)",
+            "y_axis": "absorbance (a.u.)",
+            "custom_processing_instruction": (
+                f"crop the spectrum to {CROP_LO:.0f}-{CROP_HI:.0f} cm-1 "
+                f"before fitting; the user only cares about this region"
+            ),
+        },
+    )
+    print("agent status:", res.get("status"))
+    return report("agent", crop_check(out))
+
+
+def run_meta_mode(work: Path, src_csv: Path) -> bool:
+    from scilink.agents.meta_agent.meta_orchestrator import (
+        MetaOrchestratorAgent, MetaMode)
+
+    meta = MetaOrchestratorAgent(
+        base_dir=str(work / "meta_session"), api_key=None,
+        model_name=MODEL, meta_mode=MetaMode.AUTONOMOUS,
+    )
+    reply = meta.chat(
+        f"Analyze the IR spectrum at {src_csv} (curve fitting). "
+        f"Crop the spectrum to {CROP_LO:.0f}-{CROP_HI:.0f} cm-1 before "
+        f"fitting — I only care about that region. Smoke test: "
+        f"max_verification_iterations=1, accept the first reasonable fit."
+    )
+    print("meta reply head:", reply[:200])
+    return report("meta", crop_check(work / "meta_session"))
+
+
+def main() -> int:
+    mode = sys.argv[1] if len(sys.argv) > 1 else "agent"
+    src = Path(os.environ.get(
+        "SCILINK_IR_FILE",
+        "/Users/maxim.ziatdinov/Code/benchmarking_for_paper2/RamanIR/"
+        "IR_staged/01_easy_Calcite_R050127_1.csv"))
+    if not src.exists():
+        print(f"ERROR: IR file not found: {src}", file=sys.stderr)
+        return 1
+    if not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
+        print("ERROR: AWS_BEARER_TOKEN_BEDROCK not set", file=sys.stderr)
+        return 1
+    os.environ.setdefault("AWS_REGION_NAME", "us-east-1")
+    os.environ.setdefault("UNSAFE_EXECUTION_OK", "true")
+
+    tag = os.environ.get("SCILINK_CROP_TAG", mode)
+    work = Path(f"tests/_crop_fitdomain_live_runs/{tag}").resolve()
+    if work.exists():
+        shutil.rmtree(work)
+    work.mkdir(parents=True)
+    # Copy WITHOUT the sidecar: metadata comes from system_info / the chat,
+    # keeping the crop instruction the only special context.
+    csv = work / src.name
+    shutil.copy(src, csv)
+    sidecar = src.with_suffix(".json")
+    if sidecar.exists() and mode == "meta":
+        # meta needs the technique metadata channel; strip ground truth
+        side = json.loads(sidecar.read_text())
+        side.pop("ground_truth", None)
+        (work / sidecar.name).write_text(json.dumps(side, indent=1))
+
+    ok = run_agent_mode(work, csv) if mode == "agent" else run_meta_mode(work, csv)
+    print(f"\nCROP FIT-DOMAIN LIVE [{mode}]: {'PASS' if ok else 'FAIL'}")
+    return 0 if ok else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_fitdomain_validator_visibility.py
+++ b/tests/test_fitdomain_validator_visibility.py
@@ -1,0 +1,121 @@
+"""Offline tests: user fit-domain requests are visible to the plan validator.
+
+A crop / region-of-interest request routed through
+custom_processing_instruction was visible to the planner but NOT to
+_validate_plan — so a skill's mandatory "fit the full measured range" rule
+made the validator revert the user's restricted fit domain. The guidance is
+now injected into the validation prompt too, and states the restriction is
+user-authorized.
+
+The change is strictly conditional: with no custom_processing_instruction
+the validation prompt must be byte-identical to before (asserted here as
+"contains no trace of the guidance block").
+
+  conda run -n scilink python -m pytest tests/test_fitdomain_validator_visibility.py -q
+"""
+import io
+import logging
+import tempfile
+
+import numpy as np
+import pytest
+
+from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+    CurveFittingPlanningController, _append_fit_domain_guidance)
+
+
+class CaptureModel:
+    def __init__(self):
+        self.prompts = []
+
+    def generate_content(self, prompt_parts, **kw):
+        self.prompts.append(prompt_parts)
+        raise RuntimeError("capture only")
+
+
+def _png():
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots(figsize=(2, 2))
+    ax.plot(np.arange(10), np.arange(10))
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png")
+    plt.close(fig)
+    return buf.getvalue()
+
+
+PLOT = _png()
+
+
+def make_state(cpi=None, skill=True):
+    s = {
+        "analysis_approach": "peak fitting",
+        "physical_model": "Two Voigt peaks on a linear baseline",
+        "parameters_to_extract": ["center", "fwhm"],
+        "fitting_strategy": "Fit both peaks",
+        "original_plot_bytes": PLOT,
+        "is_single_spectrum": True,
+        "num_spectra": 1,
+        "system_info": {"technique": "IR"},
+    }
+    if skill:
+        s["skills_loaded"] = [{
+            "name": "ir",
+            "planning": ("MANDATORY: Fit the full measured range. Never "
+                         "restrict fitting to one region unless the user "
+                         "asked for it."),
+        }]
+    if cpi:
+        s["system_info"]["custom_processing_instruction"] = cpi
+    return s
+
+
+def validation_prompt_text(state):
+    model = CaptureModel()
+    ctrl = CurveFittingPlanningController(
+        model=model, logger=logging.getLogger("t"),
+        generation_config=None, safety_settings=None,
+        parse_fn=lambda r: (None, {"error": "n/a"}),
+        instructions="", output_dir=tempfile.mkdtemp())
+    ctrl._validate_plan(state)  # model raises; _validate_plan swallows
+    assert model.prompts, "validator never called the model"
+    return "\n".join(p for p in model.prompts[-1] if isinstance(p, str))
+
+
+def test_no_cpi_prompt_has_no_guidance_block():
+    text = validation_prompt_text(make_state(cpi=None))
+    assert "Fit-domain & background guidance" not in text
+    assert "User processing note" not in text
+    assert "user-authorized" not in text
+
+
+def test_cpi_reaches_validator_with_authorization_principle():
+    text = validation_prompt_text(make_state(cpi="crop to 1000-1800 cm-1"))
+    assert "User processing note: crop to 1000-1800 cm-1" in text
+    # The principle that defuses mandatory full-range skill rules:
+    assert "user-authorized" in text
+    assert "unless the user asked" in text
+    # And the skill rule it must coexist with is present in the same prompt.
+    assert "Fit the full measured range" in text
+
+
+def test_helper_is_noop_without_instruction():
+    prompt = ["base"]
+    _append_fit_domain_guidance(prompt, {"system_info": {"technique": "IR"}})
+    assert prompt == ["base"]
+    _append_fit_domain_guidance(prompt, {})
+    assert prompt == ["base"]
+
+
+def test_helper_text_carries_principle():
+    prompt = []
+    _append_fit_domain_guidance(
+        prompt, {"system_info": {
+            "custom_processing_instruction": "fit only the decay"}})
+    assert len(prompt) == 1
+    assert "must not be reverted" in prompt[0]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
When a user explicitly asks to crop / restrict an IR or Raman fit to a region, the request could be silently undone. The planner honored it, but the plan validator — which never saw the user's note — read the restricted fit range as a violation of the skill's mandatory "fit the full measured range" rule and rewrote the plan back to full range. In meta mode the delegation runs autonomously, so there was no human gate to catch the reversion; the user just got a full-range fit after asking for a windowed one.

**What changes**

- The plan validator now receives the same fit-domain guidance the planner gets whenever a user processing note is present, stating that a region restriction implied by the note is user-authorized: it satisfies the "unless the user asked" condition the ir/raman skills already carry, and must not be reverted or second-guessed.
- Both changes are strictly conditional on a user processing note being present. Runs without one see byte-identical prompts.

**Validation**

- Live before/after on a benchmark calcite IR spectrum with "crop to 600–1000 cm⁻¹" (judged from the executed fit's band centers, `bedrock/us.anthropic.claude-opus-4-8`):
  - before: planner honored the crop → validator "5 issue(s) found, revising" → executed fit was full-range, 7 bands at 375–2514 cm⁻¹;
  - after: validator approved → 2 bands (712.0, 872.3 cm⁻¹) inside the window, windowed R² 0.994 — in both a direct session and an end-to-end meta-mode session (`tests/test_crop_fitdomain_live.py`).
- No-regression, deterministic: validation prompts captured for 16 note-free state combinations (single/series × skill × objective × hints) are byte-for-byte identical between main and this branch; only the 2 note-bearing states gain the guidance block (no removals). `tests/test_fitdomain_validator_visibility.py` pins this.
- No-regression, empirical: 10 RRUFF benchmark datasets (6 IR + 4 Raman across difficulty tiers) re-run through the existing benchmark harness in its baseline configuration — 10/10 success, R²/peak-recall/precision within run-to-run scatter of the recorded baselines in both directions; the one notable recall delta (a hard-tier dataset) was re-run on identical code and reproduced the spread, confirming sampling noise. Fit figures reviewed by eye.

<details>
<summary>Technical details</summary>

`_append_fit_domain_guidance` (the helper that surfaces `custom_processing_instruction` as fit-domain guidance) was injected into the planning prompt and the human refinement gate, but not into `_validate_plan`. The validator's prompt marks skill rules as mandatory and invalidating, and its protective clause for explicit user requirements covers only the `objective` channel — so a crop that traveled via the preprocessing-instruction channel had no visible authorization at validation time. Meta-mode delegations run the child AUTONOMOUS, skipping the refinement gate, which made the reversion unobservable.

Changes: one call to `_append_fit_domain_guidance` in `_validate_plan` (the helper returns immediately when no instruction is set), and two sentences appended to the helper's injected text. The "must not be reverted" clause stands on its own, so a future skill written with an unconditional full-range rule still cannot override an explicit user request. Only `ir` and `raman` carry full-range mandates today; both already include the "unless the user asked for it" exception.

The live test judges crop compliance from `series_fit_results.json` fitted band centers (all inside the requested window), not from `fit.npy` or plan prose — the ad-hoc generated script writes `fit.npy` unreliably, and `locked_config.analysis_approach` retains pre-validation text.

Known gaps, deliberately not addressed here: a crop-style instruction still costs one preprocessing script generation + sandbox execution before the `FitDomainInstruction` deferral fires (the length change is detected from the executed script's output, which is certain, rather than classified upfront from text, which could misfire); figures still render the full spectrum with the fit overlaid on the window, so a windowed fit can look "uncropped"; and the `set_preprocessing_instruction` tool description could steer region-of-interest asks to `hints`/`objective` upfront.
</details>
