### PR TITLE
Plan-mode documents: sentence discipline, no stock phrases, audience-matched vocabulary

### DIFF
--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -321,6 +321,16 @@ Structure:
 
 Length: roughly 800-1400 words. Write in confident, direct prose — no
 filler, no unexplained acronyms on first use, no marketing superlatives.
+
+**Sentence and vocabulary discipline:**
+- One idea per sentence. When a sentence stacks several clauses behind
+  dashes or semicolons, split it into two or three plain sentences instead.
+- No stock rhetorical phrases: never "load-bearing", and never the
+  "not merely X, but Y" construction. State the point directly.
+- Write in the audience's own vocabulary. For natural scientists
+  (physicists, chemists, materials scientists, biologists), express methods
+  in the science's terms and avoid software-engineering jargon unless the
+  subject itself is software.
 """
 
 
@@ -1197,6 +1207,14 @@ Rules:
   decided, what is open, and what each choice costs.
 - This is not an experimental plan: no hypothesis/steps/equipment schema
   unless the request explicitly asks for a protocol section.
+- Sentence discipline: one idea per sentence — when a sentence stacks
+  several clauses behind dashes or semicolons, split it into plain
+  sentences instead. Avoid stock rhetorical phrases: never "load-bearing",
+  and never the "not merely X, but Y" construction.
+- Write in the audience's own vocabulary: for natural scientists
+  (physicists, chemists, materials scientists, biologists), express methods
+  in the science's terms and avoid software-engineering jargon unless the
+  subject itself is software.
 - Return ONLY the JSON object.
 """
 

--- a/tests/test_doc_writing_style.py
+++ b/tests/test_doc_writing_style.py
@@ -1,0 +1,36 @@
+"""The white-paper and technical-document prompts carry writing-style rules:
+one idea per sentence, no stock rhetorical phrases, and audience-matched
+vocabulary (no software jargon for natural-science readers)."""
+
+import pytest
+
+from scilink.agents.planning_agents.instruct import (
+    TECHNICAL_DOCUMENT_INSTRUCTIONS, WHITE_PAPER_INSTRUCTIONS)
+
+
+@pytest.mark.parametrize("prompt", [WHITE_PAPER_INSTRUCTIONS,
+                                    TECHNICAL_DOCUMENT_INSTRUCTIONS],
+                         ids=["white_paper", "technical_document"])
+def test_sentence_discipline_is_stated(prompt):
+    assert "one idea per sentence" in prompt.lower()
+    assert "split" in prompt.lower()
+
+
+@pytest.mark.parametrize("prompt", [WHITE_PAPER_INSTRUCTIONS,
+                                    TECHNICAL_DOCUMENT_INSTRUCTIONS],
+                         ids=["white_paper", "technical_document"])
+def test_stock_phrases_are_banned(prompt):
+    assert 'never "load-bearing"' in prompt
+    assert 'not merely X, but Y' in prompt
+
+
+@pytest.mark.parametrize("prompt", [WHITE_PAPER_INSTRUCTIONS,
+                                    TECHNICAL_DOCUMENT_INSTRUCTIONS],
+                         ids=["white_paper", "technical_document"])
+def test_audience_vocabulary_rule_present(prompt):
+    assert "software-engineering jargon" in prompt
+    assert "natural scientists" in prompt
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
White papers and technical documents written in plan mode tended toward three habits that hurt readability: sentences that chain several ideas behind dashes and semicolons, stock rhetorical phrases, and software-engineering jargon in documents whose readers are natural scientists. This states the style rules directly in the authoring prompts.

**What changes**

Both authoring prompts (`WHITE_PAPER_INSTRUCTIONS`, `TECHNICAL_DOCUMENT_INSTRUCTIONS`) now carry the same three rules:

- One idea per sentence — a sentence that stacks clauses behind dashes or semicolons gets split into plain sentences.
- No stock rhetorical phrases: never "load-bearing", never the "not merely X, but Y" construction.
- Audience-matched vocabulary: for natural scientists (physicists, chemists, materials scientists, biologists), methods are expressed in the science's own terms, without software-engineering jargon unless the subject itself is software.

The revision contract (`TECHNICAL_DOCUMENT_REVISION_RULES`) is deliberately untouched: it instructs the model to return the document verbatim apart from requested changes, and style rules there would invite unrequested prose rewrites on every targeted revision.

**Validation**

Prompt-content guard tests in `tests/test_doc_writing_style.py` (6 checks) keep the rules from silently falling out of either prompt. Prompt-only change; no code paths touched. No conflict with #408, which edits a different constant in the same file.
