### PR TITLE
lammps validate_script: respect unfix lifecycle, skip defined template vars

### DIFF
--- a/scilink/skills/molecular_dynamics/lammps/lammps.py
+++ b/scilink/skills/molecular_dynamics/lammps/lammps.py
@@ -868,9 +868,11 @@ def validate_script(
     commands_seen: set = set()
     command_order: List[str] = []
 
-    # Track thermostat/barostat per group
-    npt_groups: set = set()
-    nvt_groups: set = set()
+    # Track the fix lifecycle: fix_id -> (group, style). `unfix` removes an
+    # entry, so only fixes active when the script ends participate in the
+    # nvt/npt overlap check below.
+    active_fixes: Dict[str, Tuple[str, str]] = {}
+    defined_vars: set = set()
 
     for line in lines:
         stripped = line.strip()
@@ -898,15 +900,22 @@ def validate_script(
             result["has_minimize"] = True
         elif keyword == "run":
             result["has_run"] = True
+        elif keyword == "variable" and len(parts) >= 2:
+            defined_vars.add(parts[1].lower())
         elif keyword == "fix" and len(parts) >= 4:
             group = parts[2]
             style = parts[3].lower()
             if "shake" in style or "rattle" in style:
                 result["has_shake"] = True
-            if style in ("npt", "nph"):
-                npt_groups.add(group)
-            elif style == "nvt":
-                nvt_groups.add(group)
+            active_fixes[parts[1]] = (group, style)
+        elif keyword == "unfix" and len(parts) >= 2:
+            active_fixes.pop(parts[1], None)
+
+    # Only fixes still active at the end of the script count for the overlap
+    # check. A sequential deck (NPT equilibration, unfix, NVT production) is
+    # legitimate and must not be flagged.
+    npt_groups = {g for g, s in active_fixes.values() if s in ("npt", "nph")}
+    nvt_groups = {g for g, s in active_fixes.values() if s == "nvt"}
 
     errors = result["errors"]
     warnings = result["warnings"]
@@ -1108,7 +1117,17 @@ def validate_script(
                 pass
 
     # ── Unresolved templates ──
-    templates = re.findall(r'\$\{[a-z_]+\}|\{[a-z_]+\}', content, re.IGNORECASE)
+    # Scan only executable lines: a comment that merely *mentions* ${var}
+    # must not be flagged. And a ${name}/{name} whose `name` has a matching
+    # `variable name` definition earlier in the deck is valid LAMMPS syntax,
+    # not an unresolved SciLink template.
+    code_lines = [ln for ln in lines if ln.strip() and not ln.strip().startswith("#")]
+    code_text = "\n".join(code_lines)
+    templates = [
+        m.group(0)
+        for m in re.finditer(r"\$\{([a-z_]+)\}|\{([a-z_]+)\}", code_text, re.IGNORECASE)
+        if (m.group(1) or m.group(2)).lower() not in defined_vars
+    ]
     if templates:
         errors.append(f"Unresolved template variables: {sorted(set(templates))}")
 

--- a/tests/test_lammps_skill/test_lammps_tools.py
+++ b/tests/test_lammps_skill/test_lammps_tools.py
@@ -339,6 +339,66 @@ class TestValidateScriptErrors:
         r = lammps_tools.validate_script("/no/such/file.lammps")
         assert r["valid"] is False
 
+    def test_sequential_npt_unfix_nvt_ok(self, script_dir):
+        # Issue #409: a legitimate NPT equilibration -> unfix -> NVT production
+        # deck was flagged as nvt+npt overlap because unfix was ignored.
+        deck = script_dir / "ok_seq_npt_unfix_nvt.lammps"
+        deck.write_text("""\
+units metal
+atom_style atomic
+boundary p p p
+read_data cu_bulk.data
+pair_style eam/alloy
+pair_coeff * * Cu_mishin1.eam.alloy Cu
+fix NPT all npt temp 300.0 300.0 0.1 iso 0.0 0.0 1.0
+run 1000
+unfix NPT
+fix NVT all nvt temp 300.0 300.0 0.1
+timestep 0.001
+run 10000
+""")
+        r = lammps_tools.validate_script(str(deck))
+        assert not any("nvt" in e.lower() and "npt" in e.lower() for e in r["errors"])
+
+    def test_template_mention_in_comment_ok(self, script_dir):
+        # Issue #409: a comment that merely mentions ${scale} was flagged as
+        # an unresolved template even though `variable scale` is defined.
+        deck = script_dir / "ok_template_in_comment.lammps"
+        deck.write_text("""\
+units metal
+atom_style atomic
+boundary p p p
+read_data cu_bulk.data
+pair_style eam/alloy
+pair_coeff * * Cu_mishin1.eam.alloy Cu
+# Green-Kubo viscosity: ${scale} is set below
+variable scale equal 5.0
+fix 1 all nvt temp 300.0 300.0 0.1
+timestep 0.001
+run 10000
+""")
+        r = lammps_tools.validate_script(str(deck))
+        assert not any("unresolved" in e.lower() or "template" in e.lower() for e in r["errors"])
+
+    def test_template_with_defined_variable_ok(self, script_dir):
+        # A ${name} whose `variable name` is defined in the deck is valid
+        # LAMMPS syntax, not an unresolved SciLink template.
+        deck = script_dir / "ok_defined_variable.lammps"
+        deck.write_text("""\
+units metal
+atom_style atomic
+boundary p p p
+read_data cu_bulk.data
+pair_style eam/alloy
+pair_coeff * * Cu_mishin1.eam.alloy Cu
+variable temperature equal 300.0
+fix 1 all nvt temp ${temperature} ${temperature} 0.1
+timestep 0.001
+run 10000
+""")
+        r = lammps_tools.validate_script(str(deck))
+        assert not any("unresolved" in e.lower() or "template" in e.lower() for e in r["errors"])
+
 
 # =====================================================================
 # validate_script — warnings (non-fatal)


### PR DESCRIPTION
Fixes the two false positives in `validate_script` from #409 on a correct sequential deck.

- Track the fix lifecycle: `unfix <id>` now removes a fix, so NPT equilibration then `unfix` then NVT production on the same group no longer trips the nvt/npt overlap error. Only fixes still active at the end of the script are compared.
- The template scan now skips comment lines and treats `${name}` / `{name}` as resolved when a matching `variable name` is defined in the deck. A comment that merely mentions `${scale}` no longer fails validation.

Closes #409
