### PR TITLE
Show document figures everywhere they render; fit figure pages; red section headings

### DIFF
--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -870,8 +870,16 @@ else:
                         _doc_title = _deliverable_title(md_path, p)
                         with st.expander(f"{_doc_title}: {p.name}"):
                             with st.container(height=600):
+                                # Figures saved beside the document (relative
+                                # refs, e.g. an embedded workflow diagram)
+                                # cannot be fetched by Streamlit's markdown
+                                # renderer — inline them as data URIs.
+                                from scilink.ui.md_images import (
+                                    inline_local_images)
                                 st.markdown(_demote_md_headings(
-                                    p.read_text(encoding="utf-8")))
+                                    inline_local_images(
+                                        p.read_text(encoding="utf-8"),
+                                        p.parent)))
                         st.download_button(
                             f"Download {p.name}",
                             data=p.read_bytes(),

--- a/scilink/ui/components/file_viewer.py
+++ b/scilink/ui/components/file_viewer.py
@@ -67,14 +67,24 @@ def render_file_preview(file_path: Path) -> None:
     if pdf_col is not None:
         with pdf_col:
             try:
-                from scilink.utils.md_to_pdf import markdown_text_to_pdf
-                import tempfile
-                with tempfile.TemporaryDirectory() as td:
-                    pdf = markdown_text_to_pdf(
-                        file_path.read_text(errors="replace"),
-                        Path(td) / f"{file_path.stem}.pdf",
-                        title=file_path.stem)
-                    data = pdf.read_bytes()
+                from scilink.ui.md_images import pdf_twin
+                twin = pdf_twin(file_path)
+                if twin is not None:
+                    # The authoring-time twin was converted in the document's
+                    # own directory, so its relative figures resolved.
+                    data = twin.read_bytes()
+                else:
+                    # Regenerate from the FILE (not in-memory text): the
+                    # file-based converter passes base_dir, so relative
+                    # figures beside the markdown reach the PDF.
+                    from scilink.utils.md_to_pdf import markdown_to_pdf
+                    import tempfile
+                    with tempfile.TemporaryDirectory() as td:
+                        pdf = markdown_to_pdf(
+                            file_path,
+                            Path(td) / f"{file_path.stem}.pdf",
+                            title=file_path.stem)
+                        data = pdf.read_bytes()
                 st.download_button(
                     "Download PDF", data=data,
                     file_name=f"{file_path.stem}.pdf", mime="application/pdf",
@@ -209,7 +219,10 @@ def render_file_preview(file_path: Path) -> None:
         if view == "Source":
             st.code(clipped, language="markdown")
         else:
-            st.markdown(clipped)
+            # Figures saved beside the document (relative refs) cannot be
+            # fetched by Streamlit's markdown renderer — inline them.
+            from scilink.ui.md_images import inline_local_images
+            st.markdown(inline_local_images(clipped, file_path.parent))
         return
 
     # Source code

--- a/scilink/ui/md_images.py
+++ b/scilink/ui/md_images.py
@@ -1,0 +1,77 @@
+"""Inline local images referenced by a markdown document.
+
+Generated documents reference their figures by bare relative filename —
+``![Campaign workflow diagram](campaign_workflow.png)`` saved beside the
+markdown — which only resolves for a renderer running in the document's
+own directory. Streamlit's markdown treats image targets as web URLs, so
+the chat embed and the file-preview pane silently dropped such figures.
+Rewriting local references to base64 data URIs makes the text
+self-contained wherever it is displayed.
+
+Streamlit-free on purpose so the UI-contract tests can exercise it
+headless.
+"""
+
+import base64
+import re
+from pathlib import Path
+
+# ![alt](target) with an optional "title" — target stops at whitespace or
+# the closing paren, so titled refs keep their title untouched.
+_IMG_REF = re.compile(r"(!\[[^\]]*\]\()([^)\s]+)((?:\s+\"[^\"]*\")?\))")
+
+_MIME = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+         ".gif": "image/gif", ".svg": "image/svg+xml", ".webp": "image/webp"}
+
+# Inlining is per-rerun work in the chat loop; a figure past this size
+# stays a link rather than slowing every repaint.
+_MAX_INLINE_BYTES = 4_000_000
+
+
+def inline_local_images(text: str, base_dir,
+                        max_bytes: int = _MAX_INLINE_BYTES) -> str:
+    """Return ``text`` with resolvable local image refs inlined as data URIs.
+
+    Remote (http/https) and already-inlined (data:) targets pass through
+    unchanged, as does any reference that does not resolve to a readable
+    image file under ``max_bytes`` — a broken ref renders exactly as before
+    rather than raising.
+    """
+    base = Path(base_dir)
+
+    def swap(m: re.Match) -> str:
+        target = m.group(2)
+        if target.startswith(("http://", "https://", "data:")):
+            return m.group(0)
+        p = Path(target)
+        if not p.is_absolute():
+            p = base / target
+        mime = _MIME.get(p.suffix.lower())
+        try:
+            if not mime or not p.is_file() or p.stat().st_size > max_bytes:
+                return m.group(0)
+            payload = base64.b64encode(p.read_bytes()).decode("ascii")
+        except OSError:
+            return m.group(0)
+        return f"{m.group(1)}data:{mime};base64,{payload}{m.group(3)}"
+
+    return _IMG_REF.sub(swap, text)
+
+
+def pdf_twin(md_path) -> Path | None:
+    """The authoring-time PDF of a markdown document, when still current.
+
+    Documents are written with a PDF twin beside them whose conversion ran
+    in the document's directory (so relative figures resolved). Serving it
+    beats regenerating from in-memory text in a temp dir, where relative
+    figures cannot resolve. Returns None when the twin is missing or older
+    than the markdown (a revision without a fresh conversion).
+    """
+    md_path = Path(md_path)
+    twin = md_path.with_suffix(".pdf")
+    try:
+        if twin.is_file() and twin.stat().st_mtime >= md_path.stat().st_mtime - 1:
+            return twin
+    except OSError:
+        pass
+    return None

--- a/scilink/utils/md_to_pdf.py
+++ b/scilink/utils/md_to_pdf.py
@@ -23,12 +23,13 @@ _MARGIN = 54          # points (0.75")
 # progress. Far above any real plan: a 105 KB white paper is ~24 pages.
 _MAX_PAGES = 500
 
-# Print styling, not screen styling: dark text on white, with the app's
-# purple for headings so the PDF is recognisably SciLink's.
+# Print styling, not screen styling: dark text on white. Section headings
+# in a dark print red — legible on paper and distinct from body text and
+# links.
 DEFAULT_CSS = """
 body { font-family: sans-serif; font-size: 10pt; color: #1a1a1a; }
 h1 { font-size: 19pt; color: #1a1a2e; margin-bottom: 2pt; }
-h2 { font-size: 14pt; color: #6200EE; margin-top: 14pt; }
+h2 { font-size: 14pt; color: #B00020; margin-top: 14pt; }
 h3 { font-size: 11.5pt; color: #333333; margin-top: 10pt; }
 h4, h5, h6 { font-size: 10.5pt; color: #333333; }
 p { line-height: 1.35; }

--- a/scilink/utils/md_to_pdf.py
+++ b/scilink/utils/md_to_pdf.py
@@ -109,12 +109,22 @@ def _pull_wide_figures(text: str, base_dir):
                 ratio = im.width / im.height if im.height else 1.0
                 if not (_TALL_FIGURE_RATIO <= ratio <= _WIDE_FIGURE_RATIO):
                     figures.append((p, alt))
-                    return ""      # placed later, on its own page
+                    return "\x00FIG\x00"   # placed later, on its own page
         except Exception:  # noqa: BLE001 - not an image we can measure
             pass
         return m.group(0)
 
-    return re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", take, text), figures
+    text = re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", take, text)
+    # A section whose ONLY content was a pulled figure would keep an
+    # orphaned heading over dead space on the text page (live: a document
+    # ending with '## Campaign Workflow' and nothing under it). Take the
+    # heading with the figure — its page already carries the caption. A
+    # figure pulled from MID-section leaves its surrounding prose (and
+    # heading) untouched.
+    text = re.sub(
+        r"(?m)^#{1,6}[^\n]*\n\s*\x00FIG\x00\s*(?=^#{1,6}\s|\Z)", "", text)
+    text = text.replace("\x00FIG\x00", "")
+    return text, figures
 
 
 def _append_figure_pages(doc, figures, fitz) -> None:

--- a/scilink/utils/md_to_pdf.py
+++ b/scilink/utils/md_to_pdf.py
@@ -118,16 +118,35 @@ def _pull_wide_figures(text: str, base_dir):
 
 
 def _append_figure_pages(doc, figures, fitz) -> None:
-    """One page per outsized figure, oriented to match it, with caption."""
+    """One page per outsized figure, oriented to match it, with caption.
+
+    The page is SIZED TO THE FIGURE along its short axis: an extreme
+    ribbon (a left-to-right workflow diagram can be 5:1) fitted onto a
+    fixed letter page is width-bound and floats in a sea of vertical
+    whitespace. The long axis keeps the letter dimension so the figure
+    gets the full width (or height); the short axis shrinks to the scaled
+    figure plus margins and the caption strip, floored so a page never
+    degenerates into a sliver.
+    """
+    _MIN_SHORT = 216       # 3" — keep even the thinnest ribbon page page-like
     for path, caption in figures:
-        wide = True
+        wide, aspect = True, 1.0
         try:
             from PIL import Image
             with Image.open(path) as im:
-                wide = not im.height or im.width / im.height >= 1.0
+                if im.height and im.width:
+                    aspect = im.width / im.height
+                wide = aspect >= 1.0
         except Exception:  # noqa: BLE001
             pass
-        w, h = (792, 612) if wide else (612, 792)
+        if wide:
+            w = 792
+            img_h = (w - 2 * _MARGIN) / aspect
+            h = min(612.0, max(_MIN_SHORT, img_h + 2 * _MARGIN + 24))
+        else:
+            h = 792
+            img_w = (h - 2 * _MARGIN - 24) * aspect
+            w = min(612.0, max(_MIN_SHORT, img_w + 2 * _MARGIN))
         page = doc.new_page(width=w, height=h)
         frame = fitz.Rect(_MARGIN, _MARGIN, w - _MARGIN, h - _MARGIN - 24)
         try:

--- a/tests/test_file_viewer_markdown.py
+++ b/tests/test_file_viewer_markdown.py
@@ -141,9 +141,12 @@ def test_non_markdown_gets_no_pdf_button(rec, tmp_path):
 
 
 def test_a_failing_conversion_never_breaks_the_preview(monkeypatch, tmp_path):
-    """The markdown download and the rendered document must still be there."""
+    """The markdown download and the rendered document must still be there.
+
+    No PDF twin exists beside the file, so the button path regenerates via
+    the file-based converter — which is made to fail here."""
     import scilink.utils.md_to_pdf as m
-    monkeypatch.setattr(m, "markdown_text_to_pdf", lambda *a, **k: 1 / 0)
+    monkeypatch.setattr(m, "markdown_to_pdf", lambda *a, **k: 1 / 0)
     r = _Recorder()
     monkeypatch.setattr(file_viewer, "st", r)
     file_viewer.render_file_preview(_md(tmp_path, "# Title\n"))

--- a/tests/test_md_to_pdf_figures.py
+++ b/tests/test_md_to_pdf_figures.py
@@ -85,6 +85,41 @@ with tempfile.TemporaryDirectory() as t:
     check("no spurious pages without figures",
           all(p.rect.width <= p.rect.height for p in doc))
 
+# ── the figure page fits its figure; a figure-only heading moves with it ──
+
+with tempfile.TemporaryDirectory() as t:
+    d = Path(t)
+    make_png(d / "ribbon.png", 3100, 590)    # ~5.3:1, the live shape
+    md = d / "wp.md"
+    md.write_text("# Paper\n\nBody text.\n\n## References\n\nSome ref.\n\n"
+                  "## Campaign Workflow\n\n![Campaign workflow](ribbon.png)\n")
+
+    text, figs = _pull_wide_figures(md.read_text(), d)
+    check("figure-only heading pulled with its figure",
+          "Campaign Workflow" not in text)
+    check("other headings untouched", "## References" in text)
+    check("no sentinel leaks into the text", "\x00" not in text)
+
+    doc = fitz.open(markdown_to_pdf(md, title="wp"))
+    fig_pages = [p for p in doc if p.get_images()]
+    check("ribbon still gets its page", len(fig_pages) == 1)
+    if fig_pages:
+        r = fig_pages[0].rect
+        check("page is sized to the ribbon, not full letter",
+              r.width == 792 and r.height < 400,
+              f"({r.width:.0f}x{r.height:.0f})")
+
+with tempfile.TemporaryDirectory() as t:
+    d = Path(t)
+    make_png(d / "ribbon.png", 3000, 500)
+    md = d / "mid.md"
+    md.write_text("# Doc\n\n## Methods\n\nBefore the figure.\n\n"
+                  "![Flow](ribbon.png)\n\nAfter the figure.\n")
+    text, _ = _pull_wide_figures(md.read_text(), d)
+    check("mid-section pull keeps the heading", "## Methods" in text)
+    check("mid-section pull keeps surrounding prose",
+          "Before the figure." in text and "After the figure." in text)
+
 print("=" * 50)
 n = sum(results.values())
 print(f"PDF FIGURE PAGES: {n}/{len(results)} checks passed")

--- a/tests/test_ui_doc_image_embedding.py
+++ b/tests/test_ui_doc_image_embedding.py
@@ -1,0 +1,112 @@
+"""A document's relative figure refs must survive every display surface.
+
+Generated white papers reference figures saved beside them
+(``![...](campaign_workflow.png)``). Streamlit's markdown renderer treats
+image targets as web URLs, so the chat embed and the file-preview pane
+dropped such figures, and the file viewer's PDF button regenerated the PDF
+from in-memory text in a temp dir where the figure could not resolve.
+"""
+
+import base64
+from pathlib import Path
+
+import pytest
+
+from scilink.ui.md_images import inline_local_images, pdf_twin
+
+PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGBgAAAABQAB"
+    "h6FO1AAAAABJRU5ErkJggg==")  # 1x1 px
+
+
+@pytest.fixture
+def doc_dir(tmp_path):
+    (tmp_path / "campaign_workflow.png").write_bytes(PNG)
+    return tmp_path
+
+
+def test_relative_ref_is_inlined(doc_dir):
+    out = inline_local_images("![d](campaign_workflow.png)", doc_dir)
+    assert out.startswith("![d](data:image/png;base64,")
+    payload = out.split("base64,")[1].rstrip(")")
+    assert base64.b64decode(payload) == PNG
+
+
+def test_absolute_ref_is_inlined(doc_dir):
+    p = doc_dir / "campaign_workflow.png"
+    out = inline_local_images(f"![d]({p})", doc_dir)
+    assert "data:image/png;base64," in out
+
+
+def test_titled_ref_keeps_its_title(doc_dir):
+    out = inline_local_images('![d](campaign_workflow.png "The workflow")',
+                              doc_dir)
+    assert out.endswith('"The workflow")')
+    assert "data:image/png;base64," in out
+
+
+def test_remote_and_data_refs_pass_through(doc_dir):
+    for target in ("https://x.org/a.png", "http://x.org/a.png",
+                   "data:image/png;base64,AAAA"):
+        text = f"![d]({target})"
+        assert inline_local_images(text, doc_dir) == text
+
+
+def test_missing_file_and_unknown_suffix_pass_through(doc_dir):
+    for text in ("![d](nope.png)", "![d](campaign_workflow.txt)"):
+        assert inline_local_images(text, doc_dir) == text
+
+
+def test_oversize_figure_stays_a_link(doc_dir):
+    assert inline_local_images("![d](campaign_workflow.png)", doc_dir,
+                               max_bytes=10) == "![d](campaign_workflow.png)"
+
+
+def test_surrounding_prose_untouched(doc_dir):
+    text = "before\n\n![d](campaign_workflow.png)\n\nafter"
+    out = inline_local_images(text, doc_dir)
+    assert out.startswith("before\n\n") and out.endswith("\n\nafter")
+
+
+def test_pdf_twin_prefers_fresh_sibling(tmp_path):
+    md = tmp_path / "white_paper.md"
+    md.write_text("x")
+    twin = tmp_path / "white_paper.pdf"
+    twin.write_bytes(b"%PDF")
+    assert pdf_twin(md) == twin
+
+
+def test_pdf_twin_rejects_stale_sibling(tmp_path):
+    import os
+    twin = tmp_path / "white_paper.pdf"
+    twin.write_bytes(b"%PDF")
+    os.utime(twin, (1, 1))
+    md = tmp_path / "white_paper.md"
+    md.write_text("revised later")
+    assert pdf_twin(md) is None
+
+
+def test_pdf_twin_none_when_missing(tmp_path):
+    md = tmp_path / "white_paper.md"
+    md.write_text("x")
+    assert pdf_twin(md) is None
+
+
+# ── the display surfaces actually use the helper ─────────────────────
+
+def test_chat_embed_inlines_images():
+    src = Path("scilink/ui/app.py").read_text()
+    i = src.find("md_reports")
+    assert "inline_local_images" in src[i:i + 1200]
+
+
+def test_file_preview_inlines_images_and_prefers_twin():
+    src = Path("scilink/ui/components/file_viewer.py").read_text()
+    assert "inline_local_images" in src
+    assert "pdf_twin" in src
+    # the in-memory text converter (no base_dir) must be gone
+    assert "markdown_text_to_pdf" not in src
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
A generated white paper embeds its workflow diagram by relative filename beside the markdown. That resolved only for the authoring-time PDF conversion — everywhere the UI showed the document, the figure silently vanished: the chat-embedded document, the file-preview pane, and the "Download PDF" button (which regenerated the PDF from in-memory text in a temp directory where the figure doesn't exist, while the correct PDF sat unused beside the markdown). On top of that, the PDF placed an extreme-ribbon diagram (5:1) centered on a full letter page — a mostly-empty page with an orphaned section heading left behind on the previous page.

**What changes**

- `scilink/ui/md_images.py` (new): inlines resolvable local image refs as base64 data URIs (size-capped; remote/`data:`/broken refs pass through unchanged). Used by the chat document embed and the file-preview pane, so figures display wherever the document text is rendered.
- The "Download PDF" button serves the fresh authoring-time PDF twin beside the markdown when present (the artifact whose conversion resolved figures), and otherwise regenerates via the file-based converter, which passes `base_dir`.
- Outsized-figure PDF pages are sized to the figure along the short axis (floored at 3"): a 5:1 workflow ribbon now gets a 792×261 banner page with the diagram spanning the full width instead of floating in whitespace. Orientation and full-width behavior unchanged for all shapes.
- A heading whose section contained only the pulled figure moves out of the text with it (its page already carries the caption); mid-section figures leave headings and prose untouched.
- Document PDF section headings switch from app purple to a dark print red (`#B00020`).

**Validation**

- Validated against the live session that surfaced the bug: the white paper's diagram inlines for chat/preview; the served PDF is the authoring twin; the figure page went 792×612 (mostly empty) → 792×261; the text now ends cleanly at References with no orphaned heading.
- Offline: 12 new image-embedding checks, 19/19 figure-page checks (6 new), md_to_pdf (13), file-viewer markdown (existing conversion-failure guard retargeted to the file-based converter), and the UI suites (28) all green.
