### PR TITLE
Silence the Bedrock consecutive-blocks warning after a mid-run Stop

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -20,6 +20,7 @@ from enum import Enum
 
 from ...auth import get_internal_proxy_key
 from ...utils.tool_media import (repair_dangling_tool_calls,
+                                 close_interrupted_turn,
                                  build_tool_message, provider_supports_tool_image,
                                  sanitize_history_images)
 from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
@@ -1606,6 +1607,11 @@ class AnalysisOrchestratorAgent:
         # Repair any tool_use left unanswered by a mid-run user Stop
         # (or a trim slicing a pair apart) before extending history.
         self.messages = repair_dangling_tool_calls(self.messages)
+        # A stopped turn ends on a tool result; close it with a stub
+        # assistant note so the new user message does not create
+        # consecutive user-role blocks (Bedrock alternation; silences
+        # litellm's 'trying to merge' warning).
+        self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
         
         if len(self.messages) > 120:
@@ -1757,6 +1763,11 @@ class AnalysisOrchestratorAgent:
         # Repair any tool_use left unanswered by a mid-run user Stop
         # (or a trim slicing a pair apart) before extending history.
         self.messages = repair_dangling_tool_calls(self.messages)
+        # A stopped turn ends on a tool result; close it with a stub
+        # assistant note so the new user message does not create
+        # consecutive user-role blocks (Bedrock alternation; silences
+        # litellm's 'trying to merge' warning).
+        self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
         
         if len(self.messages) > 120:

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -25,6 +25,7 @@ from enum import Enum
 
 from ...auth import get_internal_proxy_key
 from ...utils.tool_media import (repair_dangling_tool_calls,
+                                 close_interrupted_turn,
                                  build_tool_message, provider_supports_tool_image,
                                  sanitize_history_images)
 from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
@@ -1735,6 +1736,11 @@ class MetaOrchestratorAgent:
         # Repair any tool_use left unanswered by a mid-run user Stop
         # (or a trim slicing a pair apart) before extending history.
         self.messages = repair_dangling_tool_calls(self.messages)
+        # A stopped turn ends on a tool result; close it with a stub
+        # assistant note so the new user message does not create
+        # consecutive user-role blocks (Bedrock alternation; silences
+        # litellm's 'trying to merge' warning).
+        self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
 
         if len(self.messages) > 120:
@@ -1891,6 +1897,11 @@ class MetaOrchestratorAgent:
         # Repair any tool_use left unanswered by a mid-run user Stop
         # (or a trim slicing a pair apart) before extending history.
         self.messages = repair_dangling_tool_calls(self.messages)
+        # A stopped turn ends on a tool result; close it with a stub
+        # assistant note so the new user message does not create
+        # consecutive user-role blocks (Bedrock alternation; silences
+        # litellm's 'trying to merge' warning).
+        self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
 
         if len(self.messages) > 120:

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -9,7 +9,8 @@ from datetime import datetime
 from enum import Enum
 
 from ...auth import get_internal_proxy_key
-from ...utils.tool_media import repair_dangling_tool_calls
+from ...utils.tool_media import (repair_dangling_tool_calls,
+                                 close_interrupted_turn)
 from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
 from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
 from .planning_agent import (
@@ -1603,6 +1604,11 @@ class PlanningOrchestratorAgent:
         # Repair any tool_use left unanswered by a mid-run user Stop
         # (or a trim slicing a pair apart) before extending history.
         self.messages = repair_dangling_tool_calls(self.messages)
+        # A stopped turn ends on a tool result; close it with a stub
+        # assistant note so the new user message does not create
+        # consecutive user-role blocks (Bedrock alternation; silences
+        # litellm's 'trying to merge' warning).
+        self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
         
         if len(self.messages) > 120:
@@ -1747,6 +1753,11 @@ class PlanningOrchestratorAgent:
         # Repair any tool_use left unanswered by a mid-run user Stop
         # (or a trim slicing a pair apart) before extending history.
         self.messages = repair_dangling_tool_calls(self.messages)
+        # A stopped turn ends on a tool result; close it with a stub
+        # assistant note so the new user message does not create
+        # consecutive user-role blocks (Bedrock alternation; silences
+        # litellm's 'trying to merge' warning).
+        self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
         
         if len(self.messages) > 120:

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -29,7 +29,8 @@ from ...auth import (
     APIKeyNotFoundError, get_api_key, get_internal_proxy_key, infer_provider,
     require_vendor_credentials,
 )
-from ...utils.tool_media import repair_dangling_tool_calls
+from ...utils.tool_media import (repair_dangling_tool_calls,
+                                 close_interrupted_turn)
 from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
 from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
 from .simulation_orchestrator_tools import SimulationOrchestratorTools
@@ -800,6 +801,11 @@ class SimulationOrchestratorAgent:
         # Repair any tool_use left unanswered by a mid-run user Stop
         # (or a trim slicing a pair apart) before extending history.
         self.messages = repair_dangling_tool_calls(self.messages)
+        # A stopped turn ends on a tool result; close it with a stub
+        # assistant note so the new user message does not create
+        # consecutive user-role blocks (Bedrock alternation; silences
+        # litellm's 'trying to merge' warning).
+        self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
 
         if len(self.messages) > 120:
@@ -890,6 +896,11 @@ class SimulationOrchestratorAgent:
         # Repair any tool_use left unanswered by a mid-run user Stop
         # (or a trim slicing a pair apart) before extending history.
         self.messages = repair_dangling_tool_calls(self.messages)
+        # A stopped turn ends on a tool result; close it with a stub
+        # assistant note so the new user message does not create
+        # consecutive user-role blocks (Bedrock alternation; silences
+        # litellm's 'trying to merge' warning).
+        self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
 
         if len(self.messages) > 120:

--- a/scilink/utils/tool_media.py
+++ b/scilink/utils/tool_media.py
@@ -209,3 +209,23 @@ def sanitize_history_images(messages: list) -> list:
         else:
             out.append(m)
     return out
+
+
+def close_interrupted_turn(messages: list) -> list:
+    """Restore user/assistant alternation after an interrupted turn.
+
+    A mid-run Stop ends a turn on a tool result with no assistant reply.
+    The next user message would then directly follow a tool block — on
+    Bedrock's converse API both are user-role blocks, and litellm papers
+    over the pair with a noisy "Potential consecutive user/tool blocks.
+    Trying to merge." warning on every subsequent call in the session.
+    Closing the turn with a one-line assistant note keeps alternation
+    intact instead. A normally completed turn (assistant last) — and
+    anything else — passes through unchanged.
+    """
+    if messages and messages[-1].get("role") == "tool":
+        messages.append({
+            "role": "assistant",
+            "content": "[Turn interrupted before a reply was produced.]",
+        })
+    return messages

--- a/tests/test_stop_turn_alternation.py
+++ b/tests/test_stop_turn_alternation.py
@@ -1,0 +1,99 @@
+"""A stopped turn is closed before the next user message.
+
+A mid-run Stop ends a turn on a tool result with no assistant reply; the
+next user message then follows a tool block, and litellm's Bedrock adapter
+prints "Potential consecutive user/tool blocks. Trying to merge." on every
+later call. close_interrupted_turn appends a stub assistant note at the
+turn-start seam so alternation holds — and does nothing on healthy
+histories.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from scilink.utils.tool_media import close_interrupted_turn
+
+ASSISTANT_CALL = {"role": "assistant", "tool_calls": [
+    {"id": "c1", "type": "function",
+     "function": {"name": "f", "arguments": "{}"}}]}
+TOOL_RESULT = {"role": "tool", "tool_call_id": "c1", "content": "done"}
+
+
+def test_tool_tail_gets_a_stub_assistant():
+    msgs = [{"role": "user", "content": "go"}, ASSISTANT_CALL, TOOL_RESULT]
+    out = close_interrupted_turn(list(msgs))
+    assert out[-1]["role"] == "assistant"
+    assert "interrupted" in out[-1]["content"]
+    assert out[:-1] == msgs
+
+
+def test_idempotent():
+    msgs = close_interrupted_turn(
+        [{"role": "user", "content": "go"}, ASSISTANT_CALL, TOOL_RESULT])
+    assert close_interrupted_turn(list(msgs)) == msgs
+
+
+@pytest.mark.parametrize("tail", [
+    [],
+    [{"role": "user", "content": "hi"}],
+    [{"role": "user", "content": "hi"},
+     {"role": "assistant", "content": "reply"}],
+])
+def test_healthy_histories_untouched(tail):
+    assert close_interrupted_turn(list(tail)) == tail
+
+
+ORCHESTRATORS = [
+    Path("scilink/agents/exp_agents/analysis_orchestrator.py"),
+    Path("scilink/agents/planning_agents/planning_orchestrator.py"),
+    Path("scilink/agents/sim_agents/simulation_orchestrator.py"),
+    Path("scilink/agents/meta_agent/meta_orchestrator.py"),
+]
+
+# The seam: every place a NEW user message enters the history must close
+# an interrupted turn first (both litellm and openai chat loops).
+_SEAM = re.compile(
+    r"close_interrupted_turn\(self\.messages\)\s*\n\s*"
+    r"self\.messages\.append\(\{\"role\": \"user\", \"content\": user_input\}\)")
+
+
+@pytest.mark.parametrize("src", ORCHESTRATORS, ids=lambda p: p.stem)
+def test_every_turn_start_closes_interrupted_turns(src):
+    text = src.read_text()
+    appends = len(re.findall(
+        r"self\.messages\.append\(\{\"role\": \"user\", "
+        r"\"content\": user_input\}\)", text))
+    assert appends == 2, f"{src.name}: expected both chat loops"
+    assert len(_SEAM.findall(text)) == appends
+
+
+def test_litellm_bedrock_warning_is_actually_silenced(caplog):
+    """The real litellm transform: a tool-tailed history warns, a closed
+    one does not."""
+    pytest.importorskip("litellm")
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        _bedrock_converse_messages_pt)
+
+    def convert(msgs):
+        caplog.clear()
+        import logging
+        with caplog.at_level(logging.WARNING):
+            _bedrock_converse_messages_pt(
+                messages=msgs, model="anthropic.claude", llm_provider="bedrock")
+        return " ".join(r.message for r in caplog.records)
+
+    broken = [{"role": "user", "content": "go"}, ASSISTANT_CALL, TOOL_RESULT,
+              {"role": "user", "content": "next request"}]
+    healthy = close_interrupted_turn(
+        [{"role": "user", "content": "go"}, ASSISTANT_CALL, TOOL_RESULT])
+    healthy.append({"role": "user", "content": "next request"})
+
+    assert "consecutive" in convert(broken).lower(), \
+        "probe failed: the unclosed history should trigger the merge warning"
+    assert "consecutive" not in convert(healthy).lower()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
After stopping an agent mid-run, every later call in the session printed litellm's "Potential consecutive user/tool blocks. Trying to merge." warning. Harmless — the merge succeeds — but noisy and alarming-looking.

**Why it happened:** a Stop ends the turn on a tool result with no assistant reply. The next user message then directly follows a tool block; on Bedrock's converse API both are user-role blocks, so litellm has to merge them and says so.

**What changes:** `close_interrupted_turn` (`utils/tool_media.py`) appends a one-line stub assistant note — "[Turn interrupted before a reply was produced.]" — when and only when the history ends on a tool result. Healthy histories pass through byte-identical. Applied at the eight turn-start seams (both chat loops of all four orchestrators), directly after the dangling-tool-call repair, and deliberately NOT inside the repair helper: post-trim repairs run mid-turn, where a tool-result tail is the normal state the model is about to answer.

**Validation:** `tests/test_stop_turn_alternation.py` (10 checks) includes a probe against litellm's real Bedrock transform — the unclosed history reproduces the warning, the closed one is silent — plus seam-coverage checks over all four orchestrators and pass-through checks for healthy histories. Trim/title (15), UI stop (12), and metadata-ownership (31) suites green. (Noted, unrelated: `test_ui_stop`'s logging test fails when collected together with the trim tests — identical on clean main, pre-existing cross-file logging pollution.)
