### PR TITLE
Ban stock rhetorical phrases across all agent prose

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from enum import Enum
 
 from ...auth import get_internal_proxy_key
+from ...utils.prose_style import PROSE_STYLE_RULE
 from ...utils.tool_media import (repair_dangling_tool_calls,
                                  build_tool_message, provider_supports_tool_image,
                                  sanitize_history_images)
@@ -492,7 +493,7 @@ def get_system_prompt(
             "When running analysis on data that matches a custom skill's domain, "
             "pass the skill name via the `skill` parameter in `run_analysis`.\n"
         )
-    return directives[analysis_mode] + body
+    return directives[analysis_mode] + body + "\n\n" + PROSE_STYLE_RULE
 
 
 class AnalysisOrchestratorAgent:

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -3131,7 +3131,7 @@ Update an existing skill with new knowledge while preserving what is already cor
    `user_correction` (`user_feedback`) → planning constraints/preferences and validation \
    acceptance criteria (treat human corrections as high-priority ground truth).
 4. Be ADDITIVE: the existing skill already routes real analyses, and every existing rule, \
-   constraint, and section is load-bearing — removing or weakening one regresses working \
+   constraint, and section is in active use — removing or weakening one regresses working \
    behavior. Remove or weaken existing guidance ONLY when the new knowledge explicitly \
    contradicts it.
 5. When there is a conflict, prefer the newer knowledge but note the discrepancy briefly.

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -24,6 +24,7 @@ from datetime import datetime
 from enum import Enum
 
 from ...auth import get_internal_proxy_key
+from ...utils.prose_style import PROSE_STYLE_RULE
 from ...utils.tool_media import (repair_dangling_tool_calls,
                                  build_tool_message, provider_supports_tool_image,
                                  sanitize_history_images)
@@ -319,7 +320,7 @@ def get_system_prompt(meta_mode: MetaMode) -> str:
         MetaMode.AUTOPILOT: _AUTOPILOT_DIRECTIVE,
         MetaMode.AUTONOMOUS: _AUTONOMOUS_DIRECTIVE,
     }
-    return directives[meta_mode] + _SYSTEM_PROMPT_BODY
+    return directives[meta_mode] + _SYSTEM_PROMPT_BODY + "\n\n" + PROSE_STYLE_RULE
 
 
 def _tool_lines(schemas) -> str:

--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -168,7 +168,7 @@ against the SAME evidence (provided below), so differences between them
 reflect strategy, not information. Judge them comparatively.
 
 Score EACH candidate 1-5 on:
-- "groundedness": every load-bearing claim is traceable to the provided evidence.
+- "groundedness": every substantive claim is traceable to the provided evidence.
 - "testability": the hypothesis is falsifiable by the stated expected_outcome.
 - "actionability": steps are executable without placeholders; optimization
   parameters are well-bounded.

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from enum import Enum
 
 from ...auth import get_internal_proxy_key
+from ...utils.prose_style import PROSE_STYLE_RULE
 from ...utils.tool_media import repair_dangling_tool_calls
 from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
 from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
@@ -552,7 +553,7 @@ def get_system_prompt(
             lines.append(f"- **{t['name']}**: {t.get('description', '')}")
         prompt += "\n".join(lines)
 
-    return prompt
+    return prompt + "\n\n" + PROSE_STYLE_RULE
 
 
 

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -29,6 +29,7 @@ from ...auth import (
     APIKeyNotFoundError, get_api_key, get_internal_proxy_key, infer_provider,
     require_vendor_credentials,
 )
+from ...utils.prose_style import PROSE_STYLE_RULE
 from ...utils.tool_media import repair_dangling_tool_calls
 from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
 from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
@@ -229,7 +230,7 @@ def get_system_prompt(
             f"  {names}\n"
             "Pass the skill name to the relevant tool when applicable.\n"
         )
-    return directives[simulation_mode] + body
+    return directives[simulation_mode] + body + "\n\n" + PROSE_STYLE_RULE
 
 
 class SimulationOrchestratorAgent:

--- a/scilink/utils/prose_style.py
+++ b/scilink/utils/prose_style.py
@@ -1,0 +1,14 @@
+"""House prose-style rule appended to every orchestrator system prompt.
+
+One sentence, principle-form (see CLAUDE.md on prompt patches). The
+document-authoring prompts (white paper / technical document) carry a
+fuller style block of their own; this constant extends the two banned
+rhetorical moves to everything else the agents write — chat replies,
+summaries, interpretations, reports, plans.
+"""
+
+PROSE_STYLE_RULE = (
+    "**Writing style (all prose you produce):** never use the phrase "
+    '"load-bearing", and never the "not merely X, but Y" construction — '
+    "state the point directly."
+)

--- a/tests/test_global_prose_style.py
+++ b/tests/test_global_prose_style.py
@@ -1,0 +1,53 @@
+"""Every orchestrator system prompt carries the house prose-style rule
+(no "load-bearing", no "not merely X, but Y"), and no prompt teaches
+those phrases as vocabulary."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from scilink.utils.prose_style import PROSE_STYLE_RULE
+
+
+def test_rule_names_both_banned_moves():
+    assert '"load-bearing"' in PROSE_STYLE_RULE
+    assert "not merely X, but Y" in PROSE_STYLE_RULE
+
+
+def _prompts():
+    from scilink.agents.exp_agents.analysis_orchestrator import (
+        AnalysisMode, get_system_prompt as analysis_sp)
+    from scilink.agents.planning_agents.planning_orchestrator import (
+        AutonomyLevel, get_system_prompt as planning_sp)
+    from scilink.agents.sim_agents.simulation_orchestrator import (
+        SimulationMode, get_system_prompt as sim_sp)
+    from scilink.agents.meta_agent.meta_orchestrator import (
+        MetaMode, get_system_prompt as meta_sp)
+    return {
+        "analysis": analysis_sp(AnalysisMode.AUTONOMOUS),
+        "planning": planning_sp(AutonomyLevel.AUTONOMOUS),
+        "simulation": sim_sp(SimulationMode.AUTONOMOUS),
+        "meta": meta_sp(MetaMode.AUTONOMOUS),
+    }
+
+
+def test_all_four_system_prompts_carry_the_rule():
+    for name, prompt in _prompts().items():
+        assert PROSE_STYLE_RULE in prompt, name
+
+
+def test_no_prompt_teaches_the_phrase_as_vocabulary():
+    """The phrases may appear only where they are being BANNED — never as a
+    rubric term or descriptive vocabulary the model could imitate."""
+    for f in (Path("scilink/agents/planning_agents/instruct.py"),
+              Path("scilink/agents/exp_agents/instruct.py")):
+        text = f.read_text()
+        for m in re.finditer(r"load.bearing", text, re.I):
+            ctx = text[max(0, m.start() - 200):m.end() + 200]
+            assert "never" in ctx or "Never" in ctx, (
+                f"{f.name}: 'load-bearing' used outside a ban context:\n{ctx}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Extends the writing-style rules from the document prompts (#419) to everything the agents write. Two stock rhetorical moves — "load-bearing" and the "not merely X, but Y" construction — are now banned across all agent prose: chat replies, summaries, interpretations, reports, and plans.

**What changes**

- One shared sentence (`scilink/utils/prose_style.py`) appended to the system prompt of all four orchestrators (analysis, planning, simulation, meta), so every prose surface inherits it without per-prompt duplication.
- Two prompts that themselves *taught* the phrase as vocabulary are reworded: the plan-judge groundedness rubric ("every load-bearing claim" → "every substantive claim") and the skill-upgrade additivity rule ("is load-bearing" → "is in active use"). Semantics unchanged in both.
- Code comments keep the term — they address developers, not the model.

**Validation**

`tests/test_global_prose_style.py`: the rule is present in all four system prompts (exercised through the real `get_system_prompt` functions), names both banned moves, and a sweep asserts the phrase appears in prompt files only where it is being banned. Neighboring suites green; the simulation-orchestrator fixture errors reproduce identically on clean main (missing `ase` extra in the test env, pre-existing).
