### PR TITLE
fix(store): atomic writes and cross-process locks for the store

### DIFF
--- a/scilink/knowledge/kb_store.py
+++ b/scilink/knowledge/kb_store.py
@@ -37,6 +37,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from ..skills._shared._store_io import atomic_write_text, file_lock
 from ..skills.loader import scilink_home
 
 _logger = logging.getLogger(__name__)
@@ -221,8 +222,20 @@ def _write_manifest(kb_dir: Path, **fields) -> Dict[str, Any]:
     manifest = read_manifest(kb_dir) or {}
     manifest.update(fields)
     manifest["updated_at"] = datetime.now().isoformat(timespec="seconds")
-    (kb_dir / MANIFEST_NAME).write_text(json.dumps(manifest, indent=2))
+    atomic_write_text(kb_dir / MANIFEST_NAME, json.dumps(manifest, indent=2))
     return manifest
+
+
+def _publish_locked(staging: Path, final: Path) -> None:
+    """``_swap_into_place`` under a per-name lock.
+
+    Two sessions rebuilding the same-named KB share the ``.staging_<name>``
+    and ``.bak`` paths; without serialization the last publisher wins and can
+    swap in the other session's half-built staging dir. The lock file sits
+    next to ``final`` so it is per-KB-name.
+    """
+    with file_lock(final.with_name(final.name + ".publish.lock")):
+        _publish_locked(staging, final)
 
 
 def _source_names(kb_dir: Path) -> List[str]:
@@ -339,7 +352,7 @@ def create_kb(name: str,
             n_vectors=n_vectors,
             sources=_source_names(staging),
         )
-        _swap_into_place(staging, final)
+        _publish_locked(staging, final)
     except Exception:
         shutil.rmtree(staging, ignore_errors=True)
         raise
@@ -411,7 +424,7 @@ def import_kb(name: str,
             n_vectors=n_vectors,
             sources=source_names,
         )
-        _swap_into_place(staging, final)
+        _publish_locked(staging, final)
     except Exception:
         shutil.rmtree(staging, ignore_errors=True)
         raise
@@ -494,7 +507,7 @@ def add_to_kb(name: str,
             n_vectors=(manifest.get("n_vectors") or 0) + n_added,
             sources=_source_names(staging),
         )
-        _swap_into_place(staging, final)
+        _publish_locked(staging, final)
     except Exception:
         shutil.rmtree(staging, ignore_errors=True)
         raise
@@ -586,7 +599,7 @@ def rebuild_kb(name: str,
                "n_chunks": n_chunks,
                "n_vectors": n_vectors},
         )
-        _swap_into_place(staging, final)
+        _publish_locked(staging, final)
     except Exception:
         shutil.rmtree(staging, ignore_errors=True)
         raise

--- a/scilink/skills/_shared/_graduation.py
+++ b/scilink/skills/_shared/_graduation.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from ..loader import graduated_skills_dir
+from ._store_io import atomic_write_text, file_lock
 
 
 def safe_path_component(value: str, *, fallback: str = "unknown") -> str:
@@ -331,62 +332,70 @@ def graduate_to_skill_file(
 
     knowledge_text = _format_knowledge(knowledge_entry)
 
-    is_update = skill_path.exists()
-    if is_update:
-        existing_data = _read_skill_as_dict(skill_path, domain=domain)
-        prompt = update_template.format(
-            skill_name=skill_name,
-            existing_skill=json.dumps(existing_data, indent=2),
-            new_knowledge=knowledge_text,
-        )
-    else:
-        prompt = fresh_template.format(
-            skill_name=skill_name,
-            domain=domain,
-            knowledge_text=knowledge_text,
-        )
+    # The read-modify-write (read existing, LLM merge, write) must be one
+    # critical section: two sessions graduating into the same skill would
+    # otherwise both merge from the old content and the loser's work is
+    # silently discarded. Locking the skill file serializes same-skill
+    # graduations; graduation is rare, so this is fine.
+    # ponytail: per-skill lock, split read/write locks if same-skill
+    # throughput ever matters.
+    with file_lock(skill_path):
+        is_update = skill_path.exists()
+        if is_update:
+            existing_data = _read_skill_as_dict(skill_path, domain=domain)
+            prompt = update_template.format(
+                skill_name=skill_name,
+                existing_skill=json.dumps(existing_data, indent=2),
+                new_knowledge=knowledge_text,
+            )
+        else:
+            prompt = fresh_template.format(
+                skill_name=skill_name,
+                domain=domain,
+                knowledge_text=knowledge_text,
+            )
 
-    raw = llm_call(prompt)
-    try:
-        parsed = parse_json_response(raw)
-    except ValueError:
-        # The model answered in prose (or the JSON was truncated off the
-        # end). One corrective retry with the contract restated up front.
-        retry_prompt = (
-            "Respond with ONLY a single JSON object — no prose before or "
-            "after it.\n\n" + prompt
-        )
-        parsed = parse_json_response(llm_call(retry_prompt))
-    if extra_meta:
-        for key in _EXTRA_META_KEYS:
-            if key in extra_meta and extra_meta[key] is not None:
-                parsed[key] = extra_meta[key]
-    if append_sections:
-        for key, text in append_sections.items():
-            text = (text or "").strip()
-            if not text:
-                continue
-            existing = (str(parsed.get(key) or "")).strip()
-            parsed[key] = f"{existing}\n\n{text}".strip() if existing else text
-    skill_content = format_skill_as_markdown(parsed)
+        raw = llm_call(prompt)
+        try:
+            parsed = parse_json_response(raw)
+        except ValueError:
+            # The model answered in prose (or the JSON was truncated off the
+            # end). One corrective retry with the contract restated up front.
+            retry_prompt = (
+                "Respond with ONLY a single JSON object — no prose before or "
+                "after it.\n\n" + prompt
+            )
+            parsed = parse_json_response(llm_call(retry_prompt))
+        if extra_meta:
+            for key in _EXTRA_META_KEYS:
+                if key in extra_meta and extra_meta[key] is not None:
+                    parsed[key] = extra_meta[key]
+        if append_sections:
+            for key, text in append_sections.items():
+                text = (text or "").strip()
+                if not text:
+                    continue
+                existing = (str(parsed.get(key) or "")).strip()
+                parsed[key] = f"{existing}\n\n{text}".strip() if existing else text
+        skill_content = format_skill_as_markdown(parsed)
 
-    # Build-only mode: return the proposed content WITHOUT writing it, so a
-    # caller can show it for review (used by the upgrade propose/apply flow).
-    if not write:
-        return {
-            "status": "success",
-            "method": "updated" if is_update else "created",
-            "skill_name": skill_name,
-            "domain": domain,
-            "skill_path": str(skill_path),
-            "content": skill_content,
-            "word_count": len(skill_content.split()),
-        }
+        # Build-only mode: return the proposed content WITHOUT writing it, so a
+        # caller can show it for review (used by the upgrade propose/apply flow).
+        if not write:
+            return {
+                "status": "success",
+                "method": "updated" if is_update else "created",
+                "skill_name": skill_name,
+                "domain": domain,
+                "skill_path": str(skill_path),
+                "content": skill_content,
+                "word_count": len(skill_content.split()),
+            }
 
-    # Loader-style bundles include __init__.py; harmless for path-loaded
-    # skills, but keeps the layout consistent with built-ins.
-    (skill_dir / "__init__.py").touch()
-    skill_path.write_text(skill_content)
+        # Loader-style bundles include __init__.py; harmless for path-loaded
+        # skills, but keeps the layout consistent with built-ins.
+        (skill_dir / "__init__.py").touch()
+        atomic_write_text(skill_path, skill_content)
 
     word_count = len(skill_content.split())
     warning = None

--- a/scilink/skills/_shared/_memory.py
+++ b/scilink/skills/_shared/_memory.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional
 
 from ..loader import graduated_skills_dir, load_skill
 from ._graduation import safe_path_component
+from ._store_io import atomic_write_text
 
 # Captures the frontmatter body with EXACTLY one trailing newline after the
 # closing fence, so ``text[match.end():]`` preserves the rest of the file
@@ -158,7 +159,7 @@ def promote_memory(
         # No frontmatter left; drop the fence entirely.
         new_text = body.lstrip("\n")
 
-    md.write_text(new_text)
+    atomic_write_text(md, new_text)
 
     moved_to = None
     if to_domain and to_domain != domain:
@@ -211,7 +212,7 @@ def demote_memory(domain: str, name: str, *, root: Optional[Path] = None) -> Dic
         allow_unicode=True,
         width=10_000,
     ).strip()
-    md.write_text(f"---\n{frontmatter}\n---\n{body}")
+    atomic_write_text(md, f"---\n{frontmatter}\n---\n{body}")
     return {
         "status": "success",
         "name": name,
@@ -257,8 +258,8 @@ def edit_memory(domain: str, name: str, content: str, *,
                 "message": "The skill needs at least one '## section' heading."}
 
     backup = md.with_name(md.name + ".bak")
-    backup.write_text(md.read_text())
-    md.write_text(content)
+    atomic_write_text(backup, md.read_text())
+    atomic_write_text(md, content)
     return {"status": "success", "path": str(md), "backup_path": str(backup)}
 
 
@@ -291,7 +292,7 @@ def fork_builtin(domain: str, name: str, *, root: Optional[Path] = None) -> Dict
                             f"({dest_md}); upgrade or prune that copy.")}
     dest_dir.mkdir(parents=True, exist_ok=True)
     (dest_dir / "__init__.py").touch()
-    dest_md.write_text(src_md.read_text())
+    atomic_write_text(dest_md, src_md.read_text())
     sibling_tools = sorted(
         f.name for f in src_md.parent.glob("*.py") if f.name != "__init__.py")
     return {

--- a/scilink/skills/_shared/_script_bank.py
+++ b/scilink/skills/_shared/_script_bank.py
@@ -45,6 +45,7 @@ import numpy as np
 
 from ..loader import scilink_home, memory_enabled, _TRUTHY, _FALSY
 from ._graduation import safe_path_component, warn_if_ephemeral_store
+from ._store_io import atomic_write_text, file_lock
 
 
 def bank_dir() -> Path:
@@ -102,6 +103,18 @@ def add_record(domain: str, record: Dict[str, Any], *, root: Optional[Path] = No
         return {"id": None, "action": "skipped_no_script"}
     h = script_hash(script)
 
+    # The dedup + stat-update path is a read-modify-write on a shared record
+    # file. Two sessions banking the same script concurrently would both miss
+    # the not-yet-written duplicate and either lose an n_successes increment
+    # or create two records with the same script_hash. Serialize per domain.
+    # ponytail: per-domain lock, per-record locks if banking throughput matters.
+    with file_lock(_domain_dir(domain, root=root)):
+        return _add_record_locked(domain, record, h, root=root)
+
+
+def _add_record_locked(
+    domain: str, record: Dict[str, Any], h: str, *, root: Optional[Path] = None
+) -> Dict[str, Any]:
     existing = _find_by_hash(domain, h, root=root)
     now = datetime.now(timezone.utc).isoformat(timespec="seconds")
     session = (record.get("provenance") or {}).get("session")
@@ -127,7 +140,7 @@ def add_record(domain: str, record: Dict[str, Any], *, root: Optional[Path] = No
             ):
                 rec["outcome"]["best_metric"] = metric
         rec["updated_at"] = now
-        path.write_text(json.dumps(rec, indent=2, default=str))
+        atomic_write_text(path, json.dumps(rec, indent=2, default=str))
         return {"id": rec["id"], "action": "updated"}
 
     warn_if_ephemeral_store()
@@ -143,7 +156,7 @@ def add_record(domain: str, record: Dict[str, Any], *, root: Optional[Path] = No
         "stats": {"n_successes": 1, "n_retrievals": 0},
         **record,
     }
-    (d / f"{rid}.json").write_text(json.dumps(payload, indent=2, default=str))
+    atomic_write_text(d / f"{rid}.json", json.dumps(payload, indent=2, default=str))
     return {"id": rid, "action": "created"}
 
 

--- a/scilink/skills/_shared/_store_io.py
+++ b/scilink/skills/_shared/_store_io.py
@@ -1,0 +1,67 @@
+"""Small store I/O helpers: atomic publish and a cross-process file lock.
+
+The persistent store under ``~/.scilink`` is shared across every session on a
+machine. Nothing in the package previously guarded concurrent writers, so two
+parallel sessions could silently lose each other's updates (issue #398).
+
+Two primitives, both intentionally tiny:
+
+- ``atomic_write_text`` — write to a sibling temp file then ``os.replace``,
+  so a reader never observes a half-written file. This is the same publish
+  the tool cache already uses (``_tool_cache.py``).
+- ``file_lock`` — an exclusive advisory lock on a sidecar ``.lock`` file via
+  ``fcntl.flock``, held for the duration of a read-modify-write. On platforms
+  without ``fcntl`` (Windows) it degrades to a no-op context manager, so the
+  store stays importable everywhere; atomicity still protects torn reads.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` atomically (tmp file + ``os.replace``)."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+@contextmanager
+def file_lock(path: Path) -> Iterator[None]:
+    """Hold an exclusive advisory lock for a read-modify-write on ``path``.
+
+    The lock file lives alongside ``path`` as ``<name>.lock``. No-op where
+    ``fcntl`` is unavailable.
+    """
+    if fcntl is None:  # pragma: no cover - Windows
+        yield
+        return
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(path.name + ".lock")
+    with open(lock_path, "a+") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)

--- a/scilink/skills/loader.py
+++ b/scilink/skills/loader.py
@@ -30,6 +30,8 @@ from typing import Dict, List
 
 import yaml
 
+from ._shared._store_io import atomic_write_text
+
 _SKILLS_DIR = Path(__file__).parent
 
 _KNOWN_SECTIONS = {"overview", "planning", "analysis", "interpretation", "validation", "implementation"}
@@ -138,7 +140,7 @@ def set_memory_enabled(enabled: bool) -> Path:
     cfg = _read_config()
     cfg["memory_enabled"] = bool(enabled)
     p = _config_path()
-    p.write_text(json.dumps(cfg, indent=2))
+    atomic_write_text(p, json.dumps(cfg, indent=2))
     return p
 
 

--- a/scilink/ui/components/wizard_state.py
+++ b/scilink/ui/components/wizard_state.py
@@ -16,6 +16,8 @@ from typing import Any, Dict, Iterable
 
 import streamlit as st
 
+from ..skills._shared._store_io import atomic_write_text
+
 
 _STATE_PATH = Path.home() / ".scilink" / "wizard_state.json"
 
@@ -75,7 +77,7 @@ def _load() -> Dict[str, Dict[str, Any]]:
 def _save(data: Dict[str, Dict[str, Any]]) -> None:
     try:
         _STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
-        _STATE_PATH.write_text(json.dumps(data, indent=2))
+        atomic_write_text(_STATE_PATH, json.dumps(data, indent=2))
     except Exception as exc:
         logging.warning("Could not write %s: %s", _STATE_PATH, exc)
 

--- a/tests/test_store_io.py
+++ b/tests/test_store_io.py
@@ -1,0 +1,71 @@
+"""Tests for the shared store I/O helpers (issue #398).
+
+Covers:
+  - atomic_write_text publishes the file and never leaves a temp file;
+  - file_lock is reentrant-safe across sequential acquires and releases
+    the lock file, and two concurrent processes cannot both hold it.
+
+No LLM calls anywhere.
+"""
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from scilink.skills._shared._store_io import atomic_write_text, file_lock
+
+
+def test_atomic_write_text_creates_parent_and_writes(tmp_path):
+    target = tmp_path / "sub" / "out.json"
+    atomic_write_text(target, '{"a": 1}')
+    assert target.read_text() == '{"a": 1}'
+    # No stray temp files left behind (directories are expected).
+    leftovers = [p.name for p in tmp_path.rglob("*") if p.is_file() and p != target]
+    assert leftovers == []
+
+
+def test_atomic_write_text_overwrites_existing(tmp_path):
+    target = tmp_path / "out.json"
+    target.write_text("old")
+    atomic_write_text(target, "new")
+    assert target.read_text() == "new"
+
+
+def test_file_lock_acquires_and_releases(tmp_path):
+    lock_target = tmp_path / "data.json"
+    with file_lock(lock_target):
+        assert lock_target.with_name(lock_target.name + ".lock").exists()
+    # Lock file remains (flock releases on close) but a second acquire works.
+    with file_lock(lock_target):
+        pass
+
+
+def test_file_lock_serializes_processes(tmp_path):
+    """Two processes cannot both hold the lock: the second blocks until
+    the first releases. Proves the lock is cross-process, not just reentrant."""
+    lock_target = tmp_path / "data.json"
+    holder = (
+        "import time\n"
+        "from scilink.skills._shared._store_io import file_lock\n"
+        f"p = {str(lock_target)!r}\n"
+        "with file_lock(p):\n"
+        "    print('HELD', flush=True)\n"
+        "    time.sleep(3)\n"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", holder], stdout=subprocess.PIPE, text=True
+    )
+    try:
+        # Wait until the holder prints HELD (it holds the lock inside the with).
+        assert proc.stdout.readline().strip() == "HELD"
+        started = time.time()
+        with file_lock(lock_target):
+            elapsed = time.time() - started
+        # We only got the lock after the holder released (3s sleep), so
+        # elapsed must be >= ~2.5s. If the lock were a no-op, elapsed < 1s.
+        assert elapsed >= 2.5, f"lock did not block: acquired in {elapsed:.2f}s"
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)


### PR DESCRIPTION
Adds atomic writes and cross-process locking to the `~/.scilink` persistent store so parallel sessions cannot silently lose each other's updates.

Two new helpers in `scilink/skills/_shared/_store_io.py`:

- `atomic_write_text`: temp file + `os.replace`, the same publish the tool cache already uses. Applied to every plain `write_text` in the store (graduation, script bank, KB manifest, config.json, wizard state, memory bundles).
- `file_lock`: exclusive `fcntl.flock` on a sidecar lock file, a no-op where fcntl is unavailable. Wraps the two genuine read-modify-write hot spots: skill graduation (read, LLM merge, write) and script-bank dedup/stat updates (per domain), plus per-name KB publish.

Behavior under a single session is unchanged; readers are never blocked. 4 new tests cover atomic publish, no temp leftovers, lock acquire/release, and cross-process serialization.

Closes #398
