### PR TITLE
Planning auto-load unions ALL campaign literature instead of silently using only the newest file

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -8,6 +8,7 @@ import json
 from .planning_rag import (author_technical_document,
                            document_to_markdown)
 import logging
+import os
 import re
 import pandas as pd
 from pathlib import Path
@@ -39,6 +40,36 @@ _LIT_HEARTBEAT_SECONDS = 180
 # normally times itself out first and its worker exits cleanly — this
 # deadline is the backstop for when that does not happen.
 _LIT_BATCH_DEADLINE = 1800
+
+# Character budget for AUTO-LOADED multi-file literature context (issue
+# #425). A campaign accumulates literature across searches; unioning
+# without a cap turns the old silent-omission bug into a silent-truncation
+# bug (a refine prompt was measured at ~83k tokens with literature already
+# 85% of it). Applies ONLY when several files are unioned — a campaign's
+# single literature file is always loaded whole, and explicitly passed
+# literature_context is never capped. Over-budget WHOLE sections are
+# dropped (never mid-file truncation: a half-severed review paragraph
+# reads as complete) and the omission is logged.
+_LIT_AUTOLOAD_MAX_CHARS = int(os.environ.get(
+    "SCILINK_LIT_AUTOLOAD_MAX_CHARS", 400_000))
+
+# The question-heading template is the structural contract between the
+# literature write site and every reader that splits a saved corpus into
+# per-question sections (auto-load budgeting, the list_literature_searches
+# index, #q<N> section selection). Third-party search backends supply only
+# the prose INSIDE a section; these boundaries are SciLink-authored, so
+# writer and splitter must share one definition.
+_LIT_QUESTION_RE = re.compile(r"^# Question (\d+): (.*)$", re.MULTILINE)
+
+# '<path>#qN' — one question section of a saved literature file, the
+# selection unit surfaced by list_literature_searches (issue #425).
+_LIT_SECTION_REF_RE = re.compile(r"^(?P<base>.+?)#q(?P<n>\d+)$")
+
+
+def _format_lit_question_heading(n: int, objective: str) -> str:
+    """The one authoring point for '# Question N: <objective>' headings —
+    must stay in lockstep with _LIT_QUESTION_RE."""
+    return f"# Question {n}: {objective}"
 
 
 def _build_planning_skill_description(custom_skills: dict = None) -> str:
@@ -403,13 +434,36 @@ class OrchestratorTools:
         return None
 
     @staticmethod
+    def _resolve_section_ref(s: str) -> Optional[str]:
+        """Resolve a '<path>#qN' section reference (issue #425) to that
+        question section's text. Returns None when ``s`` is not a section
+        reference over an existing file; returns '' (resolved but empty)
+        when the file exists but holds no question N, so the caller can
+        warn instead of letting the ref string masquerade as raw text.
+        """
+        m = _LIT_SECTION_REF_RE.match(s)
+        if not m:
+            return None
+        base = Path(m.group("base"))
+        if not base.is_file():
+            return None
+        n = int(m.group("n"))
+        for _q, chunk in OrchestratorTools._split_literature_sections(
+                base.read_text()):
+            hm = _LIT_QUESTION_RE.match(chunk)
+            if hm and int(hm.group(1)) == n:
+                return chunk
+        return ""
+
+    @staticmethod
     def _resolve_context_text(value) -> Optional[str]:
         """Resolve a literature/molecule context argument to TEXT.
 
-        Accepts a file path, a comma-separated string of file paths, a list
-        of file paths, or raw text. File contents are read and concatenated;
-        anything that isn't resolvable as existing files is treated as raw
-        text (the historical behavior). This closes a live failure where a
+        Accepts a file path, a '<path>#qN' section reference, a
+        comma-separated string of these, a list of them, or raw text.
+        File/section contents are read and concatenated; anything that
+        isn't resolvable as existing files is treated as raw text (the
+        historical behavior). This closes a live failure where a
         comma-joined pair of paths fell through the single-path check and
         the PATH STRING itself became the 'literature', leaving downstream
         consumers (plan grounding, white-paper citations) with filenames
@@ -417,22 +471,36 @@ class OrchestratorTools:
         """
         if value is None:
             return None
+
+        def _read_one(s: str) -> Optional[str]:
+            """Text for one file path or section ref; None if neither."""
+            sec = OrchestratorTools._resolve_section_ref(s)
+            if sec is not None:
+                if not sec:
+                    print(f"    ⚠️  Section reference '{s}' names a "
+                          f"question that file does not contain — skipped")
+                return sec
+            p = Path(s)
+            return p.read_text() if p.is_file() else None
+
         items = value if isinstance(value, list) else [value]
         pieces = []
         for item in items:
             s = str(item).strip()
             if not s:
                 continue
-            p = Path(s)
-            if p.is_file():
-                pieces.append(p.read_text())
+            one = _read_one(s)
+            if one is not None:
+                if one:
+                    pieces.append(one)
                 continue
             tokens = [t.strip() for t in s.split(",") if t.strip()]
-            token_paths = [Path(t) for t in tokens]
-            if len(tokens) > 1 and all(tp.is_file() for tp in token_paths):
-                pieces.extend(tp.read_text() for tp in token_paths)
-            else:
-                pieces.append(s)  # raw text
+            if len(tokens) > 1:
+                texts = [_read_one(t) for t in tokens]
+                if all(t is not None for t in texts):
+                    pieces.extend(t for t in texts if t)
+                    continue
+            pieces.append(s)  # raw text
         return "\n\n".join(pieces) if pieces else None
 
     def _write_ideation_report(self) -> str:
@@ -660,17 +728,29 @@ class OrchestratorTools:
         record_deliverable(self.orch.base_dir, html_path,
                            "Experimental plan (report)", deliverable=True)
 
-    def _record_literature_file(self, path) -> None:
+    def _record_literature_file(self, path, label: str = None,
+                                questions: list = None) -> None:
         """Register a freshly saved literature file (issue #396).
 
         Tagged to the current campaign when one is active (a plan exists);
         otherwise left pending for the next plan call to claim.
+
+        ``label`` (search-type coverage, e.g. 'hypothesis_context
+        +cross_domain') and ``questions`` (the objectives the file
+        answers) record CONTENT coverage on the registry entry (issue
+        #425) so selection and indexing need not be made on filesystem
+        accident (mtime) or re-parsing — older entries simply lack the
+        fields and readers fall back to parsing the file.
         """
         st = self._planner_state() or {}
         cid = (int(st.get("campaign_id") or 1)
                if st.get("current_plan") else None)
-        self._lit_registry().append(
-            {"path": str(Path(path).resolve()), "campaign_id": cid})
+        entry = {"path": str(Path(path).resolve()), "campaign_id": cid}
+        if label:
+            entry["label"] = label
+        if questions:
+            entry["questions"] = [str(q) for q in questions]
+        self._lit_registry().append(entry)
 
     def _adopt_literature(self, explicit_context=None) -> None:
         """Claim literature for the CURRENT campaign: pending entries plus
@@ -714,34 +794,49 @@ class OrchestratorTools:
     def _context_file_paths(value) -> list:
         """Existing-file paths named by a literature_context argument —
         mirrors _resolve_context_text's path resolution (single path,
+        '<path>#qN' section refs resolving to their base file,
         comma-separated paths, or a list; raw text yields nothing)."""
         if value is None:
             return []
+
+        def _one_path(s: str) -> Optional[str]:
+            m = _LIT_SECTION_REF_RE.match(s)
+            if m and Path(m.group("base")).is_file():
+                return str(Path(m.group("base")).resolve())
+            p = Path(s)
+            return str(p.resolve()) if p.is_file() else None
+
         items = value if isinstance(value, list) else [value]
         out = []
         for item in items:
             s = str(item).strip()
             if not s:
                 continue
-            p = Path(s)
-            if p.is_file():
-                out.append(str(p.resolve()))
+            one = _one_path(s)
+            if one is not None:
+                out.append(one)
                 continue
             tokens = [t.strip() for t in s.split(",") if t.strip()]
-            token_paths = [Path(t) for t in tokens]
-            if len(tokens) > 1 and all(tp.is_file() for tp in token_paths):
-                out.extend(str(tp.resolve()) for tp in token_paths)
+            if len(tokens) > 1:
+                token_paths = [_one_path(t) for t in tokens]
+                if all(tp is not None for tp in token_paths):
+                    out.extend(token_paths)
         return out
 
-    def _latest_literature_file(self) -> Optional[Path]:
-        """Newest literature file belonging to the CURRENT campaign.
+    def _campaign_literature_files(self) -> List[Path]:
+        """ALL literature files belonging to the CURRENT campaign, oldest
+        first (issue #425).
 
         Campaign-scoped via the literature registry (issue #396): a session
         can hold several unrelated campaigns, and the old session-wide
         newest-file glob handed one campaign's corpus to another campaign's
         refine / white paper. Only same-campaign entries are eligible here;
-        a campaign that supplied no literature gets None — an honest miss,
-        never another topic's corpus.
+        a campaign that supplied no literature gets an empty list — an
+        honest miss, never another topic's corpus.
+
+        Oldest-first because literature accumulates as a broad foundational
+        search followed by narrow top-ups: foundation leads, top-ups
+        append — the right reading order and the right truncation order.
 
         Legacy fallback: a session restored from before the registry
         existed has literature files on disk but no entries — for those,
@@ -754,20 +849,25 @@ class OrchestratorTools:
         """
         cid = self._campaign_id()
         reg = self._lit_registry()
-        files = [Path(e["path"]) for e in reg
-                 if e.get("campaign_id") == cid and e.get("path")]
-        files = [p for p in files if p.is_file()]
+        seen: set = set()
+        files = []
+        for e in reg:
+            if e.get("campaign_id") != cid or not e.get("path"):
+                continue
+            p = Path(e["path"])
+            if str(p) not in seen and p.is_file():
+                seen.add(str(p))
+                files.append(p)
         if files:
-            files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-            return files[0]
+            files.sort(key=lambda p: p.stat().st_mtime)
+            return files
         if reg or cid > 1:
-            return None
+            return []
         roots = []
         base = getattr(self.orch, "base_dir", None)
         if base:
             roots.append((Path(base), "rglob"))
         roots.append((self._output_dir(), "glob"))
-        seen: set = set()
         legacy = []
         for root, mode in roots:
             it = (root.rglob("literature_search_*.md") if mode == "rglob"
@@ -776,8 +876,96 @@ class OrchestratorTools:
                 if str(p) not in seen:
                     seen.add(str(p))
                     legacy.append(p)
-        legacy.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-        return legacy[0] if legacy else None
+        legacy.sort(key=lambda p: p.stat().st_mtime)
+        return legacy
+
+    def _latest_literature_file(self) -> Optional[Path]:
+        """Newest literature file of the CURRENT campaign (compat wrapper
+        over _campaign_literature_files, which is oldest-first)."""
+        files = self._campaign_literature_files()
+        return files[-1] if files else None
+
+    @staticmethod
+    def _split_literature_sections(text: str) -> list:
+        """Split a saved literature corpus into [(question, chunk), ...].
+
+        Boundaries are the SciLink-authored '# Question N: <objective>'
+        headings (_LIT_QUESTION_RE) — third-party search content only ever
+        appears INSIDE a section, so a format change upstream cannot move
+        them. A chunk includes its heading. Content before the first
+        heading (the file title, or the entire body of a single-question
+        file, which is written without question headings) is one chunk
+        with question=None. Rejoining all chunks reproduces the input
+        byte-for-byte.
+        """
+        matches = list(_LIT_QUESTION_RE.finditer(text))
+        if not matches:
+            return [(None, text)]
+        sections = []
+        if matches[0].start() > 0:
+            sections.append((None, text[:matches[0].start()]))
+        for i, m in enumerate(matches):
+            end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+            sections.append((m.group(2).strip(), text[m.start():end]))
+        return sections
+
+    def _load_campaign_literature(self) -> Optional[Dict[str, Any]]:
+        """Auto-load the CURRENT campaign's literature corpus (issue #425).
+
+        Returns {'text', 'files', 'n_files', 'dropped'} or None when the
+        campaign has no literature. Selection policy:
+
+        - ONE file: loaded whole, verbatim, uncapped — there is no choice
+          to make, and the single-search case is self-limiting. This path
+          is byte-identical to the historical newest-file behavior.
+        - SEVERAL files: oldest-first union. Verbatim-duplicate sections
+          (identical content — e.g. a re-recorded file or a search re-run
+          that returned the same text) are dropped first-occurrence-wins;
+          different prose about the same question is NEVER fused. Then a
+          character budget (_LIT_AUTOLOAD_MAX_CHARS) drops whole
+          over-budget sections (oldest-first fill, never mid-section
+          truncation), and every drop is reported — no silent caps.
+        """
+        files = self._campaign_literature_files()
+        if not files:
+            return None
+        if len(files) == 1:
+            text = files[0].read_text()
+            return {"text": text, "files": [files[0].name],
+                    "n_files": 1, "dropped": []}
+        chunks = []  # (file_name, question, chunk_text)
+        seen_content: set = set()
+        dup_dropped = []
+        for p in files:
+            for question, chunk in self._split_literature_sections(
+                    p.read_text()):
+                key = chunk.strip()
+                if key in seen_content:
+                    dup_dropped.append((p.name, question))
+                    continue
+                seen_content.add(key)
+                chunks.append((p.name, question, chunk))
+        kept, dropped, total = [], [], 0
+        for name, question, chunk in chunks:
+            if kept and total + len(chunk) > _LIT_AUTOLOAD_MAX_CHARS:
+                dropped.append((name, question))
+                continue
+            kept.append(chunk)
+            total += len(chunk)
+        if dup_dropped:
+            print(f"    📚 Literature union: skipped "
+                  f"{len(dup_dropped)} duplicate section(s) repeated "
+                  f"verbatim across files")
+        if dropped:
+            what = "; ".join(
+                f"{name}: {q or 'untitled section'}" for name, q in dropped)
+            print(f"    ⚠️  Literature budget "
+                  f"({_LIT_AUTOLOAD_MAX_CHARS:,} chars): dropped "
+                  f"{len(dropped)} whole section(s) — {what}")
+        return {"text": "\n\n".join(c.strip("\n") for c in kept),
+                "files": [p.name for p in files],
+                "n_files": len(files),
+                "dropped": dropped}
 
     def _get_diagram_agent(self):
         """Lazy DiagramAgent sharing the BO agent's model client (vision-
@@ -848,12 +1036,11 @@ class OrchestratorTools:
                                 + list(state.get("plan_history") or []))
                       if int(p.get("campaign_id") or 1) == cid)
         if not has_lit:
-            lit_file = self._latest_literature_file()
-            if lit_file is not None and state.get("current_plan"):
-                state["current_plan"]["literature_search"] = \
-                    lit_file.read_text()
+            lit = self._load_campaign_literature()
+            if lit is not None and state.get("current_plan"):
+                state["current_plan"]["literature_search"] = lit["text"]
                 print(f"    📚 White paper literature restored from "
-                      f"{lit_file.name}")
+                      f"{', '.join(lit['files'])}")
         text = self.orch.planner.generate_white_paper(
             audience_context=audience_context
         )
@@ -1390,8 +1577,10 @@ class OrchestratorTools:
                     if len(objectives) > 1:
                         # Multi-question runs keep per-question grouping so
                         # downstream readers see which evidence answers what.
-                        parts.append(f"# Question {oi + 1}: {objectives[oi]}\n\n"
-                                     + "\n\n".join(secs))
+                        parts.append(
+                            _format_lit_question_heading(oi + 1,
+                                                         objectives[oi])
+                            + "\n\n" + "\n\n".join(secs))
                     else:
                         parts.extend(secs)
                 content = "\n\n".join(parts)
@@ -1413,7 +1602,11 @@ class OrchestratorTools:
                 with open(lit_path, 'w') as f:
                     f.write(f"# Literature Search Results ({label})\n\n")
                     f.write(content)
-                self._record_literature_file(lit_path)
+                self._record_literature_file(
+                    lit_path, label=label,
+                    questions=[objectives[oi]
+                               for oi in range(len(objectives))
+                               if any((oi, t) in ok for t in types)])
 
                 failed = [(f"q{oi + 1}:{t}" if len(objectives) > 1 else t)
                           for oi, t in tasks if (oi, t) not in ok]
@@ -1517,6 +1710,97 @@ class OrchestratorTools:
                 }
             },
             required=["objective"]
+        )
+
+        # --- LITERATURE INDEX TOOL (issue #425) ---
+        def list_literature_searches():
+            """
+            Index of the CURRENT campaign's saved literature searches:
+            every file, the question each section answers, and the
+            beginning of each answer — the information needed to DECIDE
+            what a refine / plan call should read, without loading
+            hundreds of KB to find out.
+            """
+            print("  ⚡ Tool: Listing campaign literature searches...")
+            try:
+                files = self._campaign_literature_files()
+                if not files:
+                    return json.dumps({
+                        "status": "success", "count": 0, "files": [],
+                        "message": ("No literature saved for the current "
+                                    "campaign. Use search_literature() to "
+                                    "gather some.")})
+                meta = {}
+                for e in self._lit_registry():
+                    if e.get("path"):
+                        meta[str(Path(e["path"]).resolve())] = e
+                out_files = []
+                for p in files:
+                    text = p.read_text()
+                    entry = meta.get(str(p.resolve()), {})
+                    reg_qs = entry.get("questions") or []
+                    sections = []
+                    for question, chunk in self._split_literature_sections(
+                            text):
+                        m = _LIT_QUESTION_RE.match(chunk)
+                        body = (chunk[m.end():] if m else chunk).strip()
+                        if (question is None and len(body) < 200
+                                and body.startswith(
+                                    "# Literature Search Results")):
+                            continue  # bare title chunk, not content
+                        if question is None and len(reg_qs) == 1:
+                            # Single-question files are written without a
+                            # question heading; the registry knows the
+                            # objective.
+                            question = reg_qs[0]
+                        item = {"question": question,
+                                "chars": len(chunk),
+                                "answer_preview": body[:300]}
+                        if m:
+                            item["section_ref"] = f"{p}#q{m.group(1)}"
+                        sections.append(item)
+                    out_files.append({
+                        "path": str(p),
+                        "label": entry.get("label"),
+                        "chars": len(text),
+                        "modified": datetime.fromtimestamp(
+                            p.stat().st_mtime).strftime("%Y-%m-%d %H:%M"),
+                        "sections": sections,
+                    })
+                return json.dumps({
+                    "status": "success",
+                    "count": len(out_files),
+                    "files": out_files,
+                    "hint": (
+                        "Decide from the questions/previews what the next "
+                        "plan or refine call should read, then pass that "
+                        "selection as literature_context — whole files by "
+                        "path, or individual sections by their "
+                        "section_ref ('<path>#qN'), comma-separated. "
+                        "Omit literature_context to auto-load ALL of the "
+                        "above (oldest-first union, deduped, capped at "
+                        f"{_LIT_AUTOLOAD_MAX_CHARS:,} chars).")})
+            except Exception as e:
+                logging.error(f"Literature listing error: {e}", exc_info=True)
+                return json.dumps({"status": "error", "message": str(e)})
+
+        self._register_tool(
+            func=list_literature_searches,
+            name="list_literature_searches",
+            description=(
+                "Lists the current campaign's saved literature searches as "
+                "an index: each file's questions and the beginning of each "
+                "answer, with per-section sizes. Costs almost nothing — "
+                "it reads no corpus into context. Call it before "
+                "refine_plan_with_results() or write_technical_document() "
+                "when the campaign may hold MORE THAN ONE literature file, "
+                "and pass the relevant selection (file paths, or "
+                "'<path>#qN' section refs) as literature_context. If you "
+                "pass nothing, ALL campaign literature is auto-loaded — "
+                "safe, but larger than a considered selection."
+            ),
+            parameters={},
+            required=[]
         )
 
         # --- MOLECULES QUERY TOOL ---
@@ -2516,17 +2800,19 @@ class OrchestratorTools:
                 lit_text = self._resolve_context_text(literature_context)
                 print(f"    📚 Literature context provided")
             else:
-                # Auto-load the newest saved literature from the CURRENT
-                # campaign (campaign-scoped registry, issue #396) — matched
-                # by glob-shaped labels (e.g. '...hypothesis_context
-                # +cross_domain.md') via the registry entries. A campaign
+                # Auto-load ALL saved literature from the CURRENT campaign
+                # (campaign-scoped registry, issue #396; plural union,
+                # issue #425 — the newest-file singular load silently
+                # dropped 77% of a live session's corpus). A campaign
                 # that supplied no literature refines without any; another
                 # topic's corpus is never injected.
-                lit_path = self._latest_literature_file()
-                if lit_path is not None:
-                    lit_text = lit_path.read_text()
+                lit = self._load_campaign_literature()
+                if lit is not None:
+                    lit_text = lit["text"]
                     print(f"    📚 Auto-loaded literature context from "
-                          f"session ({lit_path.name})")
+                          f"session ({lit['n_files']} file(s), "
+                          f"{len(lit_text):,} chars: "
+                          f"{', '.join(lit['files'])})")
             ext_parts = [lit_text] if lit_text else []
             if molecule_context:
                 mol_text = self._resolve_context_text(molecule_context)
@@ -2605,7 +2891,17 @@ class OrchestratorTools:
                 },
                 "literature_context": {
                     "type": "string",
-                    "description": "File path or text from search_literature() tool. Provides external scientific literature context for refinement."
+                    "description": (
+                        "External scientific literature for refinement: "
+                        "file path(s) or '<path>#qN' section refs "
+                        "(comma-separated; see list_literature_searches), "
+                        "or raw text. OMITTED: all of the current "
+                        "campaign's saved literature is auto-loaded — the "
+                        "right default. When the campaign holds several "
+                        "literature files and the refinement is narrow, "
+                        "consider selecting via list_literature_searches "
+                        "first."
+                    )
                 },
                 "molecule_context": {
                     "type": "string",
@@ -6601,9 +6897,9 @@ class OrchestratorTools:
                     current = rp.read_text(errors="replace")
                 lit = None
                 if use_literature:
-                    lit_file = self._latest_literature_file()
-                    if lit_file is not None:
-                        lit = lit_file.read_text()
+                    _lit = self._load_campaign_literature()
+                    if _lit is not None:
+                        lit = _lit["text"]
 
                 # Prior documents the agent names — this is how a revision or
                 # a merge builds on what the session already wrote instead of

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -448,11 +448,18 @@ class OrchestratorTools:
         if not base.is_file():
             return None
         n = int(m.group("n"))
-        for _q, chunk in OrchestratorTools._split_literature_sections(
-                base.read_text()):
+        text = base.read_text()
+        sections = OrchestratorTools._split_literature_sections(text)
+        for _q, chunk in sections:
             hm = _LIT_QUESTION_RE.match(chunk)
             if hm and int(hm.group(1)) == n:
                 return chunk
+        if n == 1 and len(sections) == 1:
+            # A single-question corpus is written WITHOUT question
+            # headings; its whole body is section 1 (live: the model
+            # selected '<file>#q1' for exactly such a file, and a strict
+            # resolver skipped the campaign's most relevant corpus).
+            return text
         return ""
 
     @staticmethod
@@ -1739,9 +1746,9 @@ class OrchestratorTools:
                     text = p.read_text()
                     entry = meta.get(str(p.resolve()), {})
                     reg_qs = entry.get("questions") or []
+                    chunks = self._split_literature_sections(text)
                     sections = []
-                    for question, chunk in self._split_literature_sections(
-                            text):
+                    for question, chunk in chunks:
                         m = _LIT_QUESTION_RE.match(chunk)
                         body = (chunk[m.end():] if m else chunk).strip()
                         if (question is None and len(body) < 200
@@ -1756,8 +1763,13 @@ class OrchestratorTools:
                         item = {"question": question,
                                 "chars": len(chunk),
                                 "answer_preview": body[:300]}
+                        # Headingless single-question files are addressable
+                        # as their one-and-only section, '#q1' — keep the
+                        # selection syntax uniform across file shapes.
                         if m:
                             item["section_ref"] = f"{p}#q{m.group(1)}"
+                        elif len(chunks) == 1:
+                            item["section_ref"] = f"{p}#q1"
                         sections.append(item)
                     out_files.append({
                         "path": str(p),

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -249,6 +249,9 @@ process constraints, pass them as additional_context (each is then mapped to a
 named step) rather than withholding the literature.
 
 For refinement, reuse existing literature or run a new search as needed.
+Omitting literature_context auto-loads ALL of the campaign's saved literature;
+when several searches have accumulated and only part is relevant, consult
+`list_literature_searches` and pass a selection instead.
 
 **MOLECULAR DESIGN WORKFLOW:**
 When the objective involves molecular design, molecular synthesis planning, or molecular discovery,

--- a/tests/test_literature_autoload_425.py
+++ b/tests/test_literature_autoload_425.py
@@ -1,0 +1,325 @@
+"""Plural literature auto-load (issue #425).
+
+A campaign accumulates literature across several searches, but auto-load
+used only the NEWEST file — a live refine reasoned over 77 KB while
+silently ignoring the 256 KB corpus holding most of the evidence, and the
+log line read like success. Covers:
+
+- _campaign_literature_files: full campaign-scoped list, oldest first;
+  legacy pre-registry glob fallback stays plural too;
+- _latest_literature_file compat wrapper (newest);
+- _load_campaign_literature: ONE file loads whole and byte-identical
+  (registry AND legacy paths — the empirical no-op proof), several files
+  union oldest-first, verbatim-duplicate sections deduped, over-budget
+  whole sections dropped with the omission logged — no silent caps;
+- the question-heading contract: writer/splitter lockstep, round-trip;
+- '<path>#qN' section refs in _resolve_context_text/_context_file_paths;
+- list_literature_searches: per-question index with previews, sizes and
+  section refs; registry label/questions stamping.
+
+All offline; no LLM, no network.
+"""
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scilink.agents.planning_agents import orchestrator_tools as ot
+from scilink.agents.planning_agents.orchestrator_tools import (
+    OrchestratorTools,
+    _format_lit_question_heading,
+)
+
+
+FOUNDATION = (
+    "# Literature Search Results (hypothesis_context+cross_domain)\n\n"
+    + _format_lit_question_heading(1, "What is known about defect kinetics?")
+    + "\n\n## ESTABLISHED IN THIS FIELD\nFoundational corpus on defect "
+      "kinetics. " + "Broad evidence. " * 40 + "\n\n"
+    + _format_lit_question_heading(2, "Capture a state that exists only "
+                                      "under drive?")
+    + "\n\n## TRANSFERABLE MECHANISMS\nCross-domain nucleation one-shot "
+      "path selection. " + "Analogy evidence. " * 40 + "\n"
+)
+
+TOPUP = (
+    "# Literature Search Results (hypothesis_context)\n\n"
+    "## ESTABLISHED IN THIS FIELD\nNarrow top-up on annealing schedules. "
+    + "Recent evidence. " * 30 + "\n"
+)
+
+
+def make_tools(tmp_path, state):
+    tools = OrchestratorTools.__new__(OrchestratorTools)
+    tools.orch = SimpleNamespace(
+        planner=SimpleNamespace(state=state),
+        base_dir=Path(tmp_path),
+        _active_output_subdir=None,
+    )
+    tools._prestate_lit = []
+    return tools
+
+
+def _lit_file(tmp_path, name, text, mtime=None):
+    p = Path(tmp_path) / name
+    p.write_text(text)
+    if mtime is not None:
+        os.utime(p, (mtime, mtime))
+    return p
+
+
+def _registry_state(*entries, cid=1):
+    return {"campaign_id": cid, "current_plan": {"x": 1},
+            "campaign_literature": list(entries)}
+
+
+T0 = 1_700_000_000  # arbitrary fixed epoch; deltas are what matter
+
+
+# ------------------------------------------------- plural resolver
+
+def test_all_campaign_files_oldest_first(tmp_path):
+    old = _lit_file(tmp_path, "literature_search_a.md", FOUNDATION, T0)
+    new = _lit_file(tmp_path, "literature_search_b.md", TOPUP, T0 + 100)
+    other = _lit_file(tmp_path, "literature_search_c.md", "other", T0 + 50)
+    state = _registry_state(
+        {"path": str(new), "campaign_id": 1},
+        {"path": str(old), "campaign_id": 1},
+        {"path": str(other), "campaign_id": 2},
+    )
+    tools = make_tools(tmp_path, state)
+    assert tools._campaign_literature_files() == [old, new]
+    assert tools._latest_literature_file() == new  # wrapper: newest
+
+
+def test_legacy_glob_fallback_is_plural_and_oldest_first(tmp_path):
+    old = _lit_file(tmp_path, "literature_search_x.md", FOUNDATION, T0)
+    sub = tmp_path / "delegations" / "02_refine"
+    sub.mkdir(parents=True)
+    new = _lit_file(sub, "literature_search_y.md", TOPUP, T0 + 100)
+    tools = make_tools(tmp_path, {"campaign_id": 1, "current_plan": {"x": 1}})
+    assert tools._campaign_literature_files() == [old, new]
+    # after a campaign transition, still no session-wide scraping
+    tools2 = make_tools(tmp_path, {"campaign_id": 2, "current_plan": {"x": 1}})
+    assert tools2._campaign_literature_files() == []
+
+
+def test_duplicate_registry_entries_yield_one_file(tmp_path):
+    f = _lit_file(tmp_path, "literature_search_a.md", FOUNDATION, T0)
+    state = _registry_state({"path": str(f), "campaign_id": 1},
+                            {"path": str(f), "campaign_id": 1})
+    tools = make_tools(tmp_path, state)
+    assert tools._campaign_literature_files() == [f]
+
+
+# ------------------------------------------------- single-file fast path
+
+def test_single_file_loads_byte_identical_registry(tmp_path):
+    f = _lit_file(tmp_path, "literature_search_a.md", FOUNDATION, T0)
+    tools = make_tools(tmp_path,
+                       _registry_state({"path": str(f), "campaign_id": 1}))
+    lit = tools._load_campaign_literature()
+    assert lit["text"] == FOUNDATION          # byte-identical, uncapped
+    assert lit["n_files"] == 1 and lit["dropped"] == []
+
+
+def test_single_file_loads_byte_identical_legacy_glob(tmp_path):
+    _lit_file(tmp_path, "literature_search_a.md", FOUNDATION, T0)
+    tools = make_tools(tmp_path, {"campaign_id": 1, "current_plan": {"x": 1}})
+    lit = tools._load_campaign_literature()
+    assert lit["text"] == FOUNDATION
+
+
+def test_single_file_ignores_budget(tmp_path, monkeypatch):
+    monkeypatch.setattr(ot, "_LIT_AUTOLOAD_MAX_CHARS", 100)
+    f = _lit_file(tmp_path, "literature_search_a.md", FOUNDATION, T0)
+    tools = make_tools(tmp_path,
+                       _registry_state({"path": str(f), "campaign_id": 1}))
+    assert tools._load_campaign_literature()["text"] == FOUNDATION
+
+
+def test_no_literature_yields_none(tmp_path):
+    tools = make_tools(tmp_path, _registry_state(cid=2))
+    assert tools._load_campaign_literature() is None
+
+
+# ------------------------------------------------- multi-file union
+
+def test_two_files_union_oldest_first(tmp_path):
+    old = _lit_file(tmp_path, "literature_search_a.md", FOUNDATION, T0)
+    new = _lit_file(tmp_path, "literature_search_b.md", TOPUP, T0 + 100)
+    state = _registry_state({"path": str(new), "campaign_id": 1},
+                            {"path": str(old), "campaign_id": 1})
+    tools = make_tools(tmp_path, state)
+    lit = tools._load_campaign_literature()
+    assert lit["n_files"] == 2
+    assert lit["files"] == [old.name, new.name]
+    i_found = lit["text"].index("Foundational corpus")
+    i_top = lit["text"].index("Narrow top-up")
+    assert i_found < i_top                     # foundation leads
+    assert "nucleation one-shot" in lit["text"]  # nothing silently dropped
+
+
+def test_verbatim_duplicate_sections_deduped(tmp_path, capsys):
+    dup_q = (_format_lit_question_heading(1, "Same question?")
+             + "\n\n## ESTABLISHED IN THIS FIELD\nIdentical answer text.\n")
+    a = ("# Literature Search Results (hypothesis_context)\n\n" + dup_q
+         + "\n" + _format_lit_question_heading(2, "Only in A?")
+         + "\n\nUnique-to-A evidence.\n")
+    b = ("# Literature Search Results (hypothesis_context)\n\n" + dup_q
+         + "\n" + _format_lit_question_heading(2, "Only in B?")
+         + "\n\nUnique-to-B evidence.\n")
+    fa = _lit_file(tmp_path, "literature_search_a.md", a, T0)
+    fb = _lit_file(tmp_path, "literature_search_b.md", b, T0 + 100)
+    state = _registry_state({"path": str(fa), "campaign_id": 1},
+                            {"path": str(fb), "campaign_id": 1})
+    tools = make_tools(tmp_path, state)
+    lit = tools._load_campaign_literature()
+    assert lit["text"].count("Identical answer text.") == 1
+    assert "Unique-to-A" in lit["text"] and "Unique-to-B" in lit["text"]
+    assert "duplicate section" in capsys.readouterr().out
+
+
+def test_over_budget_drops_whole_sections_and_logs(tmp_path, monkeypatch,
+                                                   capsys):
+    monkeypatch.setattr(ot, "_LIT_AUTOLOAD_MAX_CHARS",
+                        len(FOUNDATION) + 50)
+    old = _lit_file(tmp_path, "literature_search_a.md", FOUNDATION, T0)
+    new = _lit_file(tmp_path, "literature_search_b.md", TOPUP, T0 + 100)
+    state = _registry_state({"path": str(old), "campaign_id": 1},
+                            {"path": str(new), "campaign_id": 1})
+    tools = make_tools(tmp_path, state)
+    lit = tools._load_campaign_literature()
+    # the older foundation survives whole; the top-up is dropped whole
+    assert "Foundational corpus" in lit["text"]
+    assert "nucleation one-shot" in lit["text"]
+    assert "Narrow top-up" not in lit["text"]
+    assert lit["dropped"]                      # reported, not silent
+    out = capsys.readouterr().out
+    assert "Literature budget" in out and "dropped" in out
+    # never mid-section truncation: kept text holds only complete sections
+    assert lit["text"].rstrip().endswith("Analogy evidence.")
+
+
+# ------------------------------------------------- heading contract
+
+def test_split_round_trip_and_writer_lockstep():
+    sections = OrchestratorTools._split_literature_sections(FOUNDATION)
+    assert "".join(chunk for _q, chunk in sections) == FOUNDATION
+    questions = [q for q, _c in sections if q is not None]
+    assert questions == ["What is known about defect kinetics?",
+                         "Capture a state that exists only under drive?"]
+    # a single-question corpus has no headings: one chunk, question=None
+    assert OrchestratorTools._split_literature_sections(TOPUP) == [
+        (None, TOPUP)]
+
+
+# ------------------------------------------------- section refs
+
+def test_section_ref_resolves_one_question(tmp_path):
+    f = _lit_file(tmp_path, "literature_search_a.md", FOUNDATION, T0)
+    text = OrchestratorTools._resolve_context_text(f"{f}#q2")
+    assert text.startswith("# Question 2:")
+    assert "nucleation one-shot" in text
+    assert "Foundational corpus" not in text
+
+
+def test_section_ref_mixes_with_paths_comma_separated(tmp_path):
+    fa = _lit_file(tmp_path, "literature_search_a.md", FOUNDATION, T0)
+    fb = _lit_file(tmp_path, "literature_search_b.md", TOPUP, T0 + 100)
+    text = OrchestratorTools._resolve_context_text(f"{fa}#q1,{fb}")
+    assert "Foundational corpus" in text and "Narrow top-up" in text
+    assert "nucleation one-shot" not in text   # q2 not selected
+    paths = OrchestratorTools._context_file_paths(f"{fa}#q1,{fb}")
+    assert paths == [str(fa.resolve()), str(fb.resolve())]  # ref → base file
+
+
+def test_missing_section_ref_never_becomes_raw_text(tmp_path, capsys):
+    f = _lit_file(tmp_path, "literature_search_a.md", FOUNDATION, T0)
+    text = OrchestratorTools._resolve_context_text(f"{f}#q9")
+    assert text is None                        # skipped, not the ref string
+    assert "does not contain" in capsys.readouterr().out
+
+
+def test_raw_text_and_plain_paths_unchanged(tmp_path):
+    f = _lit_file(tmp_path, "literature_search_a.md", FOUNDATION, T0)
+    assert OrchestratorTools._resolve_context_text(str(f)) == FOUNDATION
+    raw = "Yield was 12%, precipitation observed"
+    assert OrchestratorTools._resolve_context_text(raw) == raw
+    assert OrchestratorTools._context_file_paths(raw) == []
+
+
+# ------------------------------------------------- registry stamping
+
+def test_record_literature_file_stamps_label_and_questions(tmp_path):
+    f = _lit_file(tmp_path, "literature_search_a.md", FOUNDATION, T0)
+    state = _registry_state()
+    tools = make_tools(tmp_path, state)
+    tools._record_literature_file(f, label="hypothesis_context+cross_domain",
+                                  questions=["Q one", "Q two"])
+    entry = state["campaign_literature"][-1]
+    assert entry["label"] == "hypothesis_context+cross_domain"
+    assert entry["questions"] == ["Q one", "Q two"]
+
+
+def test_record_literature_file_without_metadata_keeps_legacy_shape(tmp_path):
+    f = _lit_file(tmp_path, "literature_search_a.md", FOUNDATION, T0)
+    state = _registry_state()
+    tools = make_tools(tmp_path, state)
+    tools._record_literature_file(f)
+    assert state["campaign_literature"][-1] == {
+        "path": str(f.resolve()), "campaign_id": 1}
+
+
+# ------------------------------------------------- index tool
+
+def _registered(tools):
+    cap = {}
+    tools._register_tool = (
+        lambda func, name, description, parameters, required=None:
+        cap.update({name: func}))
+    ot.OrchestratorTools._register_all_tools(tools)
+    return cap
+
+
+def _full_tools(tmp_path, state):
+    tools = make_tools(tmp_path, state)
+    tools.orch.planner.model = None
+    tools.orch.lit_agent = None
+    return tools
+
+
+def test_list_literature_searches_index(tmp_path):
+    old = _lit_file(tmp_path, "literature_search_a.md", FOUNDATION, T0)
+    new = _lit_file(tmp_path, "literature_search_b.md", TOPUP, T0 + 100)
+    state = _registry_state(
+        {"path": str(old), "campaign_id": 1,
+         "label": "hypothesis_context+cross_domain",
+         "questions": ["What is known about defect kinetics?",
+                       "Capture a state that exists only under drive?"]},
+        {"path": str(new), "campaign_id": 1, "label": "hypothesis_context",
+         "questions": ["Which annealing schedule?"]},
+    )
+    tools = _full_tools(tmp_path, state)
+    out = json.loads(_registered(tools)["list_literature_searches"]())
+    assert out["status"] == "success" and out["count"] == 2
+    first, second = out["files"]
+    assert first["path"] == str(old)           # oldest first
+    qs = [s["question"] for s in first["sections"]]
+    assert qs == ["What is known about defect kinetics?",
+                  "Capture a state that exists only under drive?"]
+    assert all(s["answer_preview"] for s in first["sections"])
+    assert first["sections"][1]["section_ref"] == f"{old}#q2"
+    # single-question file: no heading in the file, question from registry
+    assert second["sections"][0]["question"] == "Which annealing schedule?"
+    assert "section_ref" not in second["sections"][0]
+    assert "auto-load" in out["hint"].lower() or "Omit" in out["hint"]
+
+
+def test_list_literature_searches_empty_campaign(tmp_path):
+    tools = _full_tools(tmp_path, _registry_state(cid=2))
+    out = json.loads(_registered(tools)["list_literature_searches"]())
+    assert out["status"] == "success" and out["count"] == 0

--- a/tests/test_literature_autoload_425.py
+++ b/tests/test_literature_autoload_425.py
@@ -237,6 +237,15 @@ def test_section_ref_mixes_with_paths_comma_separated(tmp_path):
     assert paths == [str(fa.resolve()), str(fb.resolve())]  # ref → base file
 
 
+def test_headingless_file_q1_resolves_to_whole_body(tmp_path):
+    # live: the model selected '<file>#q1' for a single-question corpus
+    # written without question headings — that must mean "its only
+    # section", not an empty skip
+    f = _lit_file(tmp_path, "literature_search_b.md", TOPUP, T0)
+    assert OrchestratorTools._resolve_context_text(f"{f}#q1") == TOPUP
+    assert OrchestratorTools._resolve_context_text(f"{f}#q2") is None
+
+
 def test_missing_section_ref_never_becomes_raw_text(tmp_path, capsys):
     f = _lit_file(tmp_path, "literature_search_a.md", FOUNDATION, T0)
     text = OrchestratorTools._resolve_context_text(f"{f}#q9")
@@ -313,9 +322,10 @@ def test_list_literature_searches_index(tmp_path):
                   "Capture a state that exists only under drive?"]
     assert all(s["answer_preview"] for s in first["sections"])
     assert first["sections"][1]["section_ref"] == f"{old}#q2"
-    # single-question file: no heading in the file, question from registry
+    # single-question file: no heading in the file, question from registry,
+    # and its whole body addressable as '#q1' (uniform selection syntax)
     assert second["sections"][0]["question"] == "Which annealing schedule?"
-    assert "section_ref" not in second["sections"][0]
+    assert second["sections"][0]["section_ref"] == f"{new}#q1"
     assert "auto-load" in out["hint"].lower() or "Omit" in out["hint"]
 
 

--- a/tests/test_literature_autoload_live.py
+++ b/tests/test_literature_autoload_live.py
@@ -1,0 +1,347 @@
+"""Live validation for plural literature auto-load, issue #425 (Bedrock
+Opus 4.8).
+
+Seeds a planning session whose campaign holds one or several saved
+literature files, then exercises the REAL refine / white-paper / chat
+paths against a live model:
+
+  1. single_file_refine   — 1 file: auto-load logs '1 file(s)', refined
+                            plan's literature_search carries the corpus.
+  2. two_file_refine      — 2 files: auto-load logs '2 file(s)' and BOTH
+                            corpora markers reach the refined plan (the
+                            pre-fix behavior lost the older file).
+  3. white_paper_multi    — no plan literature: the rescue restores the
+                            UNION and the white paper can cite both.
+  4. budget_drop_refine   — tight budget: whole-section drop is logged,
+                            refine still succeeds on what was kept.
+  5. chat_auto_default    — neutral chat refine: the LLM omits
+                            literature_context and auto-load unions all
+                            campaign literature.
+  6. chat_selection       — chat says only part of the literature is
+                            relevant: the LLM consults
+                            list_literature_searches and passes a
+                            selection instead of loading everything.
+
+Run:
+    AWS_BEARER_TOKEN_BEDROCK=... AWS_REGION_NAME=us-east-1 \
+    python tests/test_literature_autoload_live.py [1 2 ...]
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+BASE = Path("tests/_lit_autoload_live_runs").resolve()
+
+results = {}
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+class Tee(io.StringIO):
+    def write(self, s):
+        sys.__stdout__.write(s)
+        return super().write(s)
+
+
+OBJ = ("Control polymorph selection in flash-annealed TiO2 thin films "
+       "through pulsed sub-threshold annealing schedules")
+
+Q1 = ("What is established about nucleation path selection in "
+      "flash-annealed oxide thin films?")
+Q2 = ("Capture a metastable state that exists only under drive and "
+      "relaxes within milliseconds?")
+Q_TOP = "Which pulse spacings and duty cycles suppress rutile takeover?"
+
+FOUNDATION_MARK = "LEVERAGE-INDEX SCREENING PROTOCOL"
+CROSS_MARK = "DELAYED-COUNTER-PULSE FALSIFICATION BATTERY"
+TOPUP_MARK = "GRADIENT-FURNACE PULSE-SPACING MAP"
+
+
+def foundation_text():
+    para_a = (
+        "Nucleation in flash-annealed anatase/rutile systems proceeds "
+        "through transient sub-critical clusters whose lifetime is set by "
+        "the quench rate; classical nucleation theory underestimates the "
+        "anatase persistence window by 2-3x when pulse heating is used. "
+    )
+    para_b = (
+        "Analogous behavior in driven colloidal crystallization and in "
+        "magnetization reversal suggests a one-shot path-selection event "
+        "within the first pulse, after which the polymorph identity is "
+        "locked. The " + CROSS_MARK + " distinguishes true path selection "
+        "from cumulative dose effects: equal-dose, opposite-timing and "
+        "delayed-counter-pulse arms must disagree if selection is "
+        "one-shot. The " + FOUNDATION_MARK + " ranks candidate control "
+        "parameters by the ratio of their effect on the selection event "
+        "to their effect on total dose. "
+    )
+    return (
+        "# Literature Search Results (hypothesis_context+cross_domain)\n\n"
+        f"# Question 1: {Q1}\n\n"
+        "## ESTABLISHED IN THIS FIELD (known methods, parameter ranges, "
+        "failure modes)\n" + para_a * 30 + "\n\n"
+        f"# Question 2: {Q2}\n\n"
+        "## TRANSFERABLE MECHANISMS FROM OTHER DOMAINS (analogies — NOT "
+        "established results in this field)\n" + para_b * 30 + "\n"
+    )
+
+
+def topup_text():
+    para = (
+        "Recent pulse-programmed furnace studies map rutile takeover as a "
+        "function of pulse spacing (0.5-50 ms) and duty cycle (5-40%). "
+        "The " + TOPUP_MARK + " shows a suppression valley near 5 ms / "
+        "10% where anatase fraction exceeds 80% at total doses that "
+        "otherwise fully convert. "
+    )
+    return ("# Literature Search Results (hypothesis_context)\n\n"
+            "## ESTABLISHED IN THIS FIELD (known methods, parameter "
+            "ranges, failure modes)\n" + para * 20 + "\n")
+
+
+PLAN = {
+    "campaign_id": 1,
+    "hypothesis": "one-shot nucleation path selection",
+    "proposed_experiments": [{
+        "hypothesis": ("Polymorph identity is decided by a one-shot path "
+                       "selection event during the first sub-threshold "
+                       "pulse, not by cumulative thermal dose."),
+        "experiment_name": "Pulse-timing polymorph control",
+        "experimental_steps": [
+            "Sputter 50 nm amorphous TiO2 films on Si with native oxide.",
+            "Apply pulse trains varying spacing (1-20 ms) at fixed total "
+            "dose using the flash-anneal stage.",
+            "Quantify anatase/rutile fraction by GIXRD and Raman.",
+        ],
+        "expected_outcome": ("Anatase fraction depends on pulse timing at "
+                             "fixed dose."),
+        "justification": ("Cross-domain evidence suggests timing-dependent "
+                          "one-shot selection."),
+    }],
+}
+
+RESULTS_TXT = (
+    "Run 7 results: at fixed total dose, 5 ms spacing gave 78% anatase; "
+    "1 ms gave 22%; 20 ms gave 31%. Raman confirms no brookite. A repeat "
+    "at 5 ms with the pulse order reversed reproduced 76% anatase."
+)
+
+
+def _seed_session(run_dir: Path, lit_specs):
+    """Fresh orchestrator whose campaign registry holds lit_specs =
+    [(name, text, label, questions, age_s), ...] (age_s: older = larger)."""
+    from scilink.agents.planning_agents.planning_orchestrator import (
+        PlanningOrchestratorAgent, AutonomyLevel)
+    data_dir = run_dir / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    orch = PlanningOrchestratorAgent(
+        objective=OBJ,
+        base_dir=str(run_dir / "session"),
+        api_key=None, model_name=MODEL,
+        autonomy_level=AutonomyLevel.AUTONOMOUS,
+        data_dir=str(data_dir),
+    )
+    now = time.time()
+    reg = []
+    for name, text, label, questions, age_s in lit_specs:
+        p = Path(orch.base_dir) / name
+        p.write_text(text)
+        os.utime(p, (now - age_s, now - age_s))
+        entry = {"path": str(p.resolve()), "campaign_id": 1}
+        if label:
+            entry["label"] = label
+        if questions:
+            entry["questions"] = questions
+        reg.append(entry)
+    orch.planner.state = {
+        "objective": OBJ,
+        "campaign_id": 1,
+        "iteration_index": 1,
+        "experimental_results": [],
+        "action_history": [],
+        "current_plan": json.loads(json.dumps(PLAN)),
+        "plan_history": [json.loads(json.dumps(PLAN))],
+        "campaign_literature": reg,
+    }
+    return orch
+
+
+TWO_FILES = [
+    ("literature_search_hypothesis_context+cross_domain.md",
+     foundation_text(), "hypothesis_context+cross_domain", [Q1, Q2], 3600),
+    ("literature_search_hypothesis_context.md",
+     topup_text(), "hypothesis_context", [Q_TOP], 60),
+]
+
+
+# ---------------------------------------------------------------- parts
+
+def part1_single_file_refine():
+    print("\n=== 1. single-file refine: fast path, loaded whole ===")
+    run = BASE / "p1"
+    orch = _seed_session(run, TWO_FILES[:1])
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        out = json.loads(orch.tools.functions_map["refine_plan_with_results"](
+            RESULTS_TXT))
+    log = buf.getvalue()
+    check("p1 refine succeeded", out.get("status") == "success")
+    check("p1 log names 1 file", "1 file(s)" in log)
+    lit = (orch.planner.state.get("current_plan") or {}).get(
+        "literature_search", "")
+    check("p1 corpus reached refined plan", FOUNDATION_MARK in lit
+          and CROSS_MARK in lit)
+    check("p1 corpus verbatim (fast path)",
+          lit == foundation_text() or foundation_text() in lit)
+
+
+def part2_two_file_refine():
+    print("\n=== 2. two-file refine: union, both corpora ===")
+    run = BASE / "p2"
+    orch = _seed_session(run, TWO_FILES)
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        out = json.loads(orch.tools.functions_map["refine_plan_with_results"](
+            RESULTS_TXT))
+    log = buf.getvalue()
+    check("p2 refine succeeded", out.get("status") == "success")
+    check("p2 log names 2 files", "2 file(s)" in log)
+    check("p2 log names both filenames",
+          "cross_domain" in log and "hypothesis_context.md" in log)
+    lit = (orch.planner.state.get("current_plan") or {}).get(
+        "literature_search", "")
+    check("p2 OLDER foundation corpus present (pre-fix: lost)",
+          FOUNDATION_MARK in lit and CROSS_MARK in lit)
+    check("p2 newer top-up present", TOPUP_MARK in lit)
+    check("p2 foundation leads (oldest first)",
+          lit.index(FOUNDATION_MARK) < lit.index(TOPUP_MARK))
+
+
+def part3_white_paper_multi():
+    print("\n=== 3. white paper: rescue restores the union ===")
+    run = BASE / "p3"
+    orch = _seed_session(run, TWO_FILES)
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        wp_path = orch.tools._write_white_paper()
+    log = buf.getvalue()
+    check("p3 restore log names both files",
+          "restored from" in log and "cross_domain" in log
+          and "hypothesis_context.md" in log)
+    lit = (orch.planner.state.get("current_plan") or {}).get(
+        "literature_search", "")
+    check("p3 union in state", FOUNDATION_MARK in lit and TOPUP_MARK in lit)
+    text = Path(wp_path).read_text()
+    check("p3 white paper written", len(text) > 1000)
+
+
+def part4_budget_drop_refine():
+    print("\n=== 4. tight budget: whole-section drop, logged ===")
+    from scilink.agents.planning_agents import orchestrator_tools as ot
+    run = BASE / "p4"
+    orch = _seed_session(run, TWO_FILES)
+    keep = ot._LIT_AUTOLOAD_MAX_CHARS
+    ot._LIT_AUTOLOAD_MAX_CHARS = len(foundation_text()) + 100
+    try:
+        buf = Tee()
+        with contextlib.redirect_stdout(buf):
+            out = json.loads(
+                orch.tools.functions_map["refine_plan_with_results"](
+                    RESULTS_TXT))
+    finally:
+        ot._LIT_AUTOLOAD_MAX_CHARS = keep
+    log = buf.getvalue()
+    check("p4 refine succeeded", out.get("status") == "success")
+    check("p4 drop logged", "Literature budget" in log and "dropped" in log)
+    lit = (orch.planner.state.get("current_plan") or {}).get(
+        "literature_search", "")
+    check("p4 foundation kept whole", FOUNDATION_MARK in lit
+          and CROSS_MARK in lit)
+    check("p4 top-up dropped whole", TOPUP_MARK not in lit)
+
+
+def part5_chat_auto_default():
+    print("\n=== 5. chat refine, neutral ask: auto-load all ===")
+    run = BASE / "p5"
+    orch = _seed_session(run, TWO_FILES)
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        orch.chat(f"Please refine the plan based on these new results: "
+                  f"{RESULTS_TXT}")
+    log = buf.getvalue()
+    check("p5 refine tool ran", "Refining Plan" in log)
+    auto = "Auto-loaded literature context from session (2 file(s)" in log
+    explicit = "Literature context provided" in log
+    check("p5 literature reached refine (auto-union or explicit)",
+          auto or explicit)
+    lit = (orch.planner.state.get("current_plan") or {}).get(
+        "literature_search", "")
+    check("p5 older corpus not lost", FOUNDATION_MARK in lit)
+
+
+def part6_chat_selection():
+    print("\n=== 6. chat refine, narrow ask: index consulted ===")
+    run = BASE / "p6"
+    orch = _seed_session(run, TWO_FILES)
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        orch.chat(
+            "New results, purely about pulse spacing: " + RESULTS_TXT +
+            " These results only bear on the annealing-schedule aspect. "
+            "Refine the plan grounding it ONLY on the saved literature "
+            "that is actually relevant to pulse spacing/schedules — check "
+            "what literature this campaign has saved and pass just the "
+            "relevant part, not everything.")
+    log = buf.getvalue()
+    check("p6 index tool consulted",
+          "Listing campaign literature searches" in log)
+    check("p6 explicit selection passed",
+          "Literature context provided" in log)
+    check("p6 no selection skipped as missing",
+          "does not contain" not in log)
+    lit = (orch.planner.state.get("current_plan") or {}).get(
+        "literature_search", "")
+    check("p6 relevant (pulse-spacing) corpus reached the refine",
+          TOPUP_MARK in lit)
+
+
+PARTS = {1: part1_single_file_refine, 2: part2_two_file_refine,
+         3: part3_white_paper_multi, 4: part4_budget_drop_refine,
+         5: part5_chat_auto_default, 6: part6_chat_selection}
+
+
+if __name__ == "__main__":
+    if not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
+        sys.exit("AWS_BEARER_TOKEN_BEDROCK not set")
+    os.environ.setdefault("AWS_REGION_NAME", "us-east-1")
+    wanted = [int(a) for a in sys.argv[1:]] or sorted(PARTS)
+    if BASE.exists() and set(wanted) == set(PARTS):
+        shutil.rmtree(BASE)
+    BASE.mkdir(parents=True, exist_ok=True)
+    t0 = time.time()
+    for n in wanted:
+        try:
+            PARTS[n]()
+        except Exception as e:  # noqa: BLE001
+            import traceback
+            traceback.print_exc()
+            check(f"p{n} completed without exception ({e})", False)
+    print("\n" + "=" * 50)
+    npass = sum(results.values())
+    print(f"LIT AUTOLOAD LIVE: {npass}/{len(results)} passed "
+          f"({time.time() - t0:.0f}s)")
+    for k, v in results.items():
+        if not v:
+            print(f"  FAILED: {k}")
+    sys.exit(0 if npass == len(results) else 1)

--- a/tests/test_literature_autoload_live.py
+++ b/tests/test_literature_autoload_live.py
@@ -316,16 +316,101 @@ def part6_chat_selection():
           TOPUP_MARK in lit)
 
 
+REAL_Q1 = ("What annealing parameters control the anatase-to-rutile "
+           "transformation in TiO2 thin films?")
+REAL_Q2 = ("How does pulsed or flash annealing differ from furnace "
+           "annealing for oxide thin-film crystallization?")
+REAL_Q3 = ("What in-situ probes can track polymorph selection during "
+           "rapid thermal annealing of oxide films?")
+
+
+def part7_real_search_end_to_end():
+    """REAL Edison searches (needs FUTUREHOUSE_API_KEY; ~20-30 min):
+    write site → headings/registry → index → auto-union refine, all on
+    genuine third-party literature content."""
+    print("\n=== 7. real Edison searches: write → index → union ===")
+    from scilink.agents.planning_agents.orchestrator_tools import (
+        _LIT_QUESTION_RE, OrchestratorTools as OT)
+    run = BASE / "p7"
+    orch = _seed_session(run, [])
+    fns = orch.tools.functions_map
+
+    out1 = json.loads(fns["search_literature"](
+        objective=[REAL_Q1, REAL_Q2], search_type="hypothesis_context"))
+    check("p7 search 1 (2 questions) succeeded",
+          out1.get("status") == "success")
+    if out1.get("status") != "success":
+        return
+    f1 = Path(out1["file_path"])
+    text1 = f1.read_text()
+    heads = _LIT_QUESTION_RE.findall(text1)
+    check("p7 real 2-question file carries both headings",
+          [h[1] for h in heads] == [REAL_Q1, REAL_Q2])
+    secs = OT._split_literature_sections(text1)
+    check("p7 splitter round-trips real content",
+          "".join(c for _q, c in secs) == text1)
+    reg = orch.planner.state["campaign_literature"]
+    e1 = [e for e in reg if e["path"] == str(f1.resolve())]
+    check("p7 registry stamped label+questions",
+          bool(e1) and e1[0].get("label") == "hypothesis_context"
+          and e1[0].get("questions") == [REAL_Q1, REAL_Q2])
+    ref2 = OT._resolve_context_text(f"{f1}#q2")
+    check("p7 #q2 ref resolves on real file",
+          bool(ref2) and ref2.startswith("# Question 2:")
+          and REAL_Q1 not in ref2)
+
+    out2 = json.loads(fns["search_literature"](
+        objective=REAL_Q3, search_type="hypothesis_context"))
+    check("p7 search 2 (1 question) succeeded",
+          out2.get("status") == "success")
+    if out2.get("status") != "success":
+        return
+    f2 = Path(out2["file_path"])
+    text2 = f2.read_text()
+    check("p7 second file collision-suffixed, first intact",
+          f2 != f1 and f1.read_text() == text1)
+    check("p7 single-question real file is headingless",
+          not _LIT_QUESTION_RE.search(text2))
+
+    idx = json.loads(fns["list_literature_searches"]())
+    check("p7 index lists both real files", idx.get("count") == 2)
+    fe2 = [fe for fe in idx["files"] if fe["path"] == str(f2)]
+    check("p7 headingless real file indexed with #q1 ref and question",
+          bool(fe2) and fe2[0]["sections"]
+          and fe2[0]["sections"][0]["section_ref"] == f"{f2}#q1"
+          and fe2[0]["sections"][0]["question"] == REAL_Q3
+          and fe2[0]["sections"][0]["answer_preview"])
+
+    # mid-section snippets from each real corpus must survive the union
+    body1 = secs[1][1]
+    snip1 = body1[len(body1) // 2: len(body1) // 2 + 40]
+    snip2 = text2[len(text2) // 2: len(text2) // 2 + 40]
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        out3 = json.loads(fns["refine_plan_with_results"](RESULTS_TXT))
+    log = buf.getvalue()
+    check("p7 refine succeeded on real union",
+          out3.get("status") == "success")
+    check("p7 auto-union of 2 real files logged", "2 file(s)" in log)
+    lit = (orch.planner.state.get("current_plan") or {}).get(
+        "literature_search", "")
+    check("p7 both real corpora reach the refined plan",
+          snip1 in lit and snip2 in lit)
+
+
 PARTS = {1: part1_single_file_refine, 2: part2_two_file_refine,
          3: part3_white_paper_multi, 4: part4_budget_drop_refine,
-         5: part5_chat_auto_default, 6: part6_chat_selection}
+         5: part5_chat_auto_default, 6: part6_chat_selection,
+         7: part7_real_search_end_to_end}
 
 
 if __name__ == "__main__":
     if not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
         sys.exit("AWS_BEARER_TOKEN_BEDROCK not set")
     os.environ.setdefault("AWS_REGION_NAME", "us-east-1")
-    wanted = [int(a) for a in sys.argv[1:]] or sorted(PARTS)
+    default = (sorted(PARTS) if os.environ.get("FUTUREHOUSE_API_KEY")
+               else [n for n in sorted(PARTS) if n != 7])
+    wanted = [int(a) for a in sys.argv[1:]] or default
     if BASE.exists() and set(wanted) == set(PARTS):
         shutil.rmtree(BASE)
     BASE.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Closes #425.

## Summary

When a planning campaign had gathered literature across several searches, refining a plan (or writing a white paper) silently used only the most recent literature file and discarded the rest. In a real session this meant a refinement reasoned over 77 KB of literature while ignoring the 256 KB corpus that held most of the evidence — and the log looked like success.

Now the session loads **all** of the campaign's saved literature. If there is only one file, it is loaded whole, exactly as before. If there are several, they are combined in the order they were gathered (broad foundational search first, follow-up searches after), repeated sections are removed, and an overall size budget is enforced by dropping whole sections — with every omission reported in the log, never silently.

The agent can also now be selective instead of loading everything: a new `list_literature_searches` tool shows every saved search — each question asked and the beginning of its answer — so when only part of the literature is relevant, the agent can pass just the relevant files or individual question sections to a refinement.

## Technical details

<details>
<summary>Expand</summary>

**Plural resolver** (`orchestrator_tools.py`)
- `_campaign_literature_files()` returns the full campaign-scoped list (registry filter + legacy pre-registry glob fallback), sorted oldest-first; `_latest_literature_file()` is reduced to a compat wrapper (`files[-1]`).
- `_load_campaign_literature()` implements the selection policy: single file → whole, verbatim, uncapped (byte-identical with the historical newest-file behavior); multi-file → oldest-first union, verbatim-duplicate section dedupe (content identity, never heading identity — different prose about the same question is never fused), then `_LIT_AUTOLOAD_MAX_CHARS` (400k default, `SCILINK_LIT_AUTOLOAD_MAX_CHARS` env override) drops whole sections with a logged report.
- All three consumers migrated: refine auto-load, the white-paper literature rescue, and `write_technical_document`'s `use_literature`. Log lines now name the file count, total chars, and filenames.

**Question-heading contract**
- `# Question N: <objective>` headings are SciLink-authored (third-party search backends only supply prose inside a section), so writer and splitter now share one definition: `_format_lit_question_heading` / `_LIT_QUESTION_RE`. `_split_literature_sections` round-trips byte-for-byte.

**Index + selection (issue #425 Tier 3 folded in)**
- `_record_literature_file` stamps `label` and `questions` onto the registry entry at save time, so indexing/selection run on content coverage rather than mtime.
- `list_literature_searches` tool: per-file, per-question index — question, answer preview (300 chars), section size, and a `<path>#qN` section ref. Single-question files (written without headings) are addressable as `#q1` and their question is recovered from the registry.
- `_resolve_context_text` / `_context_file_paths` accept `#qN` section refs alongside paths; a ref to a missing section is warned and skipped, never treated as raw text.
- Refine's `literature_context` parameter description and the planning system prompt teach the flow: omit → auto-load all; narrow refinement over an accumulated corpus → consult the index and pass a selection.

**Validation**
- Offline: `tests/test_literature_autoload_425.py` (20 tests) including the byte-identical single-file no-op on both registry and legacy paths, oldest-first union, dedupe, whole-section budget drops with logging, section refs, and the index tool. Full regression sweep across the neighboring literature/campaign/planning suites: 131 pytest + 7/7 collision script, green.
- Live on `bedrock/us.anthropic.claude-opus-4-8`: `tests/test_literature_autoload_live.py`, parts 1–6 (24/24) — single-file fast path, two-file union, white-paper rescue, budget drop, neutral-chat auto-load, and narrow-chat index consultation where the model selected only the relevant corpus via section refs. Part 7 (13/13, opt-in via `FUTUREHOUSE_API_KEY`) runs two REAL Edison searches (multi-question and single-question) and validates write-site headings, registry stamping, collision suffixing, the index, `#qN` resolution, and the refine auto-union of the 109 KB real corpus end-to-end.
- The live run also caught a design gap that is fixed here: the model naturally selects `<file>#q1` for a headingless single-question corpus, so that ref now resolves to the file's whole body instead of being skipped.

</details>