### PR TITLE
Surgical edit_file tool + PDF twins that never go stale

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -4986,10 +4986,14 @@ class OrchestratorTools:
                     return json.dumps({
                         "status": "error",
                         "message": (
-                            "Edit too large for edit_file — for content "
-                            "revisions use write_technical_document with "
-                            "revise_path, which rewrites the whole document "
-                            "under its length guard.")})
+                            "Edit too large for edit_file. For a content "
+                            "revision use write_technical_document with "
+                            "revise_path (whole-document rewrite under its "
+                            "length guard). For a VERBATIM insertion, split "
+                            "the text at a unique boundary into consecutive "
+                            "smaller edit_file calls — do not rewrite the "
+                            "whole file with save_file, which keeps no "
+                            "backup and has no truncation guard.")})
                 current = rp.read_text(errors="replace")
                 n = current.count(old_text)
                 if n == 0:

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -1026,6 +1026,29 @@ class OrchestratorTools:
             print(f"    ⚠️  Workflow diagram skipped: {exc}")
         return text
 
+    def _refresh_pdf_twin(self, md_path: Path) -> bool:
+        """Re-export a markdown document's PDF twin, if one exists.
+
+        Deterministic markdown_to_pdf re-export — no LLM, no content
+        change — so an in-place edit or revision never leaves a stale
+        PDF beside a fresh .md (live: a diagram swap updated the white
+        paper's markdown while its forwarded PDF kept the old image).
+        Returns True when a twin was refreshed; failure must never
+        block the edit that triggered it.
+        """
+        pdf = md_path.with_suffix(".pdf")
+        if md_path.suffix.lower() != ".md" or not pdf.exists():
+            return False
+        try:
+            from ...utils.md_to_pdf import markdown_to_pdf
+            markdown_to_pdf(md_path)
+            from .user_interface import format_path
+            print(f"    📄 PDF twin refreshed: {format_path(pdf)}")
+            return True
+        except Exception as exc:  # noqa: BLE001
+            print(f"    ⚠️  PDF twin not refreshed: {exc}")
+            return False
+
     def _write_white_paper(self, audience_context: str = None) -> str:
         """Generate the sponsor-facing white paper from the current plan and
         save it beside the plan artifacts. Returns the saved path."""
@@ -4761,11 +4784,17 @@ class OrchestratorTools:
                                    deliverable)
                 print(f"    💾 Saved{' (deliverable)' if deliverable else ''}: "
                       f"{format_path(dest)}")
+                # Same invariant as edit_file and the revision branch: a
+                # markdown write never leaves a stale PDF twin beside it
+                # (live, an agent rewrote a document via save_file and its
+                # forwarded PDF kept serving the old content).
+                pdf_refreshed = self._refresh_pdf_twin(dest)
                 return json.dumps({
                     "status": "success",
                     "path": str(dest),
                     "size_bytes": dest.stat().st_size,
                     "deliverable": bool(deliverable),
+                    "pdf_refreshed": pdf_refreshed,
                 })
             except Exception as e:
                 logging.error(f"save_file failed: {e}")
@@ -4779,8 +4808,13 @@ class OrchestratorTools:
             name="save_file",
             description=(
                 "Save text content (notes, small scripts, content you have "
-                "already composed) to a file "
-                "in the session directory. Large content may not survive the "
+                "already composed) to a NEW file "
+                "in the session directory. To change an EXISTING document, "
+                "do not rewrite it with save_file — use edit_file for a "
+                "snippet swap or write_technical_document with revise_path "
+                "for a content revision; those paths keep a pre-change "
+                "backup and guard against accidental truncation. "
+                "Large content may not survive the "
                 "trip as a single tool-call argument — for anything long "
                 "(roughly >100 lines), save the first chunk with save_file and "
                 "the rest with append_file. For executable analysis/"
@@ -4902,6 +4936,154 @@ class OrchestratorTools:
                 },
             },
             required=["filename", "content"],
+        )
+
+        # 9c. EDIT FILE — surgical in-place replacement
+        def edit_file(path: str, old_text: str, new_text: str,
+                      replace_all: bool = False):
+            """
+            Mechanical in-place edit of an existing session document:
+            replace one exact text snippet. Small edits only — content
+            revisions go through write_technical_document(revise_path=...).
+            """
+            print(f"  ⚡ Tool: Editing file '{path}'...")
+            editable = {".md", ".html", ".mmd", ".txt", ".json", ".py",
+                        ".csv", ".yaml", ".yml"}
+            try:
+                from .user_interface import format_path, record_deliverable
+                rp = Path(path)
+                if not rp.is_absolute():
+                    rp = self._output_dir() / rp
+                rp = rp.resolve()
+                root = Path(self.orch.base_dir).resolve()
+                if root not in rp.parents:
+                    return json.dumps({
+                        "status": "error",
+                        "message": (f"path must be inside the session "
+                                    f"directory ({root}).")})
+                if not rp.exists():
+                    return json.dumps({
+                        "status": "error",
+                        "message": f"No such file: {rp}"})
+                if rp.suffix.lower() not in editable:
+                    return json.dumps({
+                        "status": "error",
+                        "message": (f"'{rp.suffix}' is not an editable text "
+                                    f"format ({', '.join(sorted(editable))}).")})
+                if not old_text:
+                    return json.dumps({
+                        "status": "error",
+                        "message": "old_text must be a non-empty snippet."})
+                if old_text == new_text:
+                    return json.dumps({
+                        "status": "error",
+                        "message": "old_text and new_text are identical."})
+                # Surgical means SMALL. The cap is what stops this tool
+                # from becoming a piecewise document rewriter that dodges
+                # write_technical_document's whole-document length guard
+                # (models summarise when they mean to revise).
+                if max(len(old_text), len(new_text or "")) > 2000:
+                    return json.dumps({
+                        "status": "error",
+                        "message": (
+                            "Edit too large for edit_file — for content "
+                            "revisions use write_technical_document with "
+                            "revise_path, which rewrites the whole document "
+                            "under its length guard.")})
+                current = rp.read_text(errors="replace")
+                n = current.count(old_text)
+                if n == 0:
+                    return json.dumps({
+                        "status": "error",
+                        "message": (
+                            "old_text not found — read_file the document and "
+                            "copy the snippet verbatim, whitespace included.")})
+                if n > 1 and not replace_all:
+                    return json.dumps({
+                        "status": "error",
+                        "message": (
+                            f"old_text matches {n} places — extend the "
+                            "snippet until it is unique, or pass "
+                            "replace_all=true to change every occurrence.")})
+                # Audit trail, like a revision's .before_revision copy: the
+                # delegation MAKING the edit keeps the version it replaced.
+                bak = None
+                try:
+                    d = self._output_dir()
+                    d.mkdir(parents=True, exist_ok=True)
+                    i, bak = 1, d / f"{rp.stem}.before_edit{rp.suffix}"
+                    while bak.exists():
+                        i += 1
+                        bak = d / f"{rp.stem}.before_edit{i}{rp.suffix}"
+                    bak.write_text(current)
+                    who = ("" if d.resolve() == root
+                           else f" (edited by {d.name})")
+                    record_deliverable(self.orch.base_dir, bak,
+                                       f"Pre-edit copy of {rp.name}{who}")
+                except Exception as e:  # noqa: BLE001 - never block the edit
+                    logging.warning(f"Pre-edit copy failed: {e}")
+                    bak = None
+                rp.write_text(current.replace(old_text, new_text)
+                              if replace_all else
+                              current.replace(old_text, new_text, 1))
+                print(f"    ✏️  Edited in place: {format_path(rp)}")
+                pdf_refreshed = self._refresh_pdf_twin(rp)
+                return json.dumps({
+                    "status": "success",
+                    "path": str(rp),
+                    "replacements": n if replace_all else 1,
+                    "previous_version": str(bak) if bak else None,
+                    "pdf_refreshed": pdf_refreshed,
+                })
+            except Exception as e:
+                logging.error(f"edit_file failed: {e}", exc_info=True)
+                return json.dumps({"status": "error", "message": str(e)})
+
+        self._register_tool(
+            func=edit_file,
+            name="edit_file",
+            description=(
+                "Surgically edit an existing session document IN PLACE by "
+                "replacing one exact text snippet — an image reference, a "
+                "path, a caption, a typo, a parameter value. Mechanical "
+                "edits only: copy old_text VERBATIM from the file (read_file "
+                "first), and both snippets are capped at 2000 characters. "
+                "For actual content revisions (rewriting prose, "
+                "restructuring sections) use write_technical_document with "
+                "revise_path instead. If the document has a PDF twin beside "
+                "it, the PDF is re-exported automatically so it never goes "
+                "stale."
+            ),
+            parameters={
+                "path": {
+                    "type": "string",
+                    "description": (
+                        "Path of the file to edit — absolute, or relative "
+                        "to the current output directory. Must be inside "
+                        "the session directory."
+                    ),
+                },
+                "old_text": {
+                    "type": "string",
+                    "description": (
+                        "The exact snippet to replace, copied VERBATIM from "
+                        "the file including whitespace. Must match exactly "
+                        "one place unless replace_all is true."
+                    ),
+                },
+                "new_text": {
+                    "type": "string",
+                    "description": "The replacement text.",
+                },
+                "replace_all": {
+                    "type": "boolean",
+                    "description": (
+                        "Replace every occurrence instead of requiring the "
+                        "snippet to be unique. Default false."
+                    ),
+                },
+            },
+            required=["path", "old_text", "new_text"],
         )
 
         # 10. SAVE CHECKPOINT
@@ -7034,6 +7216,12 @@ class OrchestratorTools:
                     text = self._maybe_embed_workflow_diagram(
                         text, out.parent, stem=f"{out.stem}_workflow")
                 out.write_text(text)
+                # A revised document's exported PDF twin (the white paper's
+                # forwarded copy) must not keep serving the pre-revision
+                # content; re-export is deterministic, so it does not touch
+                # the content freeze a revision may be operating under.
+                pdf_refreshed = self._refresh_pdf_twin(out) if revise_path \
+                    else False
 
                 record_deliverable(self.orch.base_dir, out, doc_title,
                                    deliverable=True)
@@ -7052,6 +7240,7 @@ class OrchestratorTools:
                                             else None),
                        "revised_by": (self._output_dir().name if revise_path
                                       else None),
+                       "pdf_refreshed": pdf_refreshed,
                        "title": doc_title,
                        "sections": [s.get("heading") for s in sections
                                     if isinstance(s, dict)],

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -4807,9 +4807,10 @@ class OrchestratorTools:
                 "already composed) to a NEW file "
                 "in the session directory. To change an EXISTING document, "
                 "do not rewrite it with save_file — use edit_file for a "
-                "snippet swap or write_technical_document with revise_path "
-                "for a content revision; those paths keep a pre-change "
-                "backup and guard against accidental truncation. "
+                "snippet swap, rename_file to change its filename, or "
+                "write_technical_document with revise_path "
+                "for a content revision; those paths keep the content "
+                "byte-safe and guard against accidental truncation. "
                 "Large content may not survive the "
                 "trip as a single tool-call argument — for anything long "
                 "(roughly >100 lines), save the first chunk with save_file and "
@@ -5030,6 +5031,105 @@ class OrchestratorTools:
                 },
             },
             required=["path", "old_text", "new_text"],
+        )
+
+        # 9d. RENAME FILE — byte-exact, never through the LLM
+        def rename_file(path: str, new_name: str, copy: bool = False,
+                        deliverable: bool = False, title: str = ""):
+            """
+            Rename (or copy) an existing session file byte-exactly, in its
+            own directory. Exists because the alternative was observed
+            live: with no rename tool, the agent reconstructed a 30 KB
+            document via save_file + append_file chunks, dropping content
+            and leaving divergent duplicates.
+            """
+            print(f"  ⚡ Tool: Renaming file '{path}' → '{new_name}'...")
+            try:
+                from ...utils.file_edit import rename_or_copy_file
+                from .user_interface import format_path, record_deliverable
+                rp = Path(path)
+                if not rp.is_absolute():
+                    rp = self._output_dir() / rp
+                rp = rp.resolve()
+                # A bare target name keeps the file where it lives — the
+                # rename changes identity, not location (moving between
+                # delegation folders is how phantom nested copies happen).
+                safe_name = Path(new_name).name
+                if not safe_name:
+                    return json.dumps({"status": "error",
+                                       "message": "Invalid new_name."})
+                out = rename_or_copy_file(
+                    rp, rp.parent / safe_name,
+                    root=Path(self.orch.base_dir).resolve(), copy=copy)
+                if out["status"] != "success":
+                    return json.dumps(out)
+                verb = "Copied" if copy else "Renamed"
+                print(f"    📛 {verb}: {format_path(Path(out['path']))}")
+                if out["pdf_twin_followed"]:
+                    print("    📄 PDF twin followed the "
+                          f"{'copy' if copy else 'rename'}")
+                record_deliverable(
+                    self.orch.base_dir, Path(out["path"]),
+                    title or f"{verb} from {rp.name}", deliverable)
+                return json.dumps(out)
+            except Exception as e:
+                logging.error(f"rename_file failed: {e}", exc_info=True)
+                return json.dumps({"status": "error", "message": str(e)})
+
+        self._register_tool(
+            func=rename_file,
+            name="rename_file",
+            description=(
+                "Rename (or copy) an existing session file BYTE-EXACTLY "
+                "under a new filename in its own directory — the content "
+                "never passes through the model. Use this to land a "
+                "document under its intended filename. Never reconstruct "
+                "a file with save_file/append_file just to rename it: "
+                "that loses content and leaves divergent duplicates. A "
+                "markdown document's PDF twin follows the rename "
+                "automatically."
+            ),
+            parameters={
+                "path": {
+                    "type": "string",
+                    "description": (
+                        "File to rename — absolute, or relative to the "
+                        "current output directory. Must be inside the "
+                        "session directory."
+                    ),
+                },
+                "new_name": {
+                    "type": "string",
+                    "description": (
+                        "New filename (bare name, no directories). The "
+                        "file stays in its own folder."
+                    ),
+                },
+                "copy": {
+                    "type": "boolean",
+                    "description": (
+                        "Keep the original and create a copy under the "
+                        "new name instead of renaming. Default false — "
+                        "prefer a true rename; duplicates diverge."
+                    ),
+                },
+                "deliverable": {
+                    "type": "boolean",
+                    "description": (
+                        "Set TRUE when the renamed file IS the artifact "
+                        "the user asked for, so it is starred in the "
+                        "files list."
+                    ),
+                },
+                "title": {
+                    "type": "string",
+                    "description": (
+                        "Short human label for the file in the files "
+                        "list (e.g. its document title)."
+                    ),
+                },
+            },
+            required=["path", "new_name"],
         )
 
         # 10. SAVE CHECKPOINT

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -1029,25 +1029,21 @@ class OrchestratorTools:
     def _refresh_pdf_twin(self, md_path: Path) -> bool:
         """Re-export a markdown document's PDF twin, if one exists.
 
-        Deterministic markdown_to_pdf re-export — no LLM, no content
-        change — so an in-place edit or revision never leaves a stale
-        PDF beside a fresh .md (live: a diagram swap updated the white
-        paper's markdown while its forwarded PDF kept the old image).
-        Returns True when a twin was refreshed; failure must never
-        block the edit that triggered it.
+        Shared core in utils/file_edit (live: a diagram swap updated the
+        white paper's markdown while its forwarded PDF kept the old
+        image). Returns True when a twin was refreshed; failure must
+        never block the edit that triggered it — this wrapper only owns
+        the transcript prints.
         """
-        pdf = md_path.with_suffix(".pdf")
-        if md_path.suffix.lower() != ".md" or not pdf.exists():
-            return False
-        try:
-            from ...utils.md_to_pdf import markdown_to_pdf
-            markdown_to_pdf(md_path)
+        from ...utils.file_edit import refresh_pdf_twin
+        refreshed, err = refresh_pdf_twin(md_path)
+        if refreshed:
             from .user_interface import format_path
-            print(f"    📄 PDF twin refreshed: {format_path(pdf)}")
-            return True
-        except Exception as exc:  # noqa: BLE001
-            print(f"    ⚠️  PDF twin not refreshed: {exc}")
-            return False
+            print(f"    📄 PDF twin refreshed: "
+                  f"{format_path(md_path.with_suffix('.pdf'))}")
+        elif err:
+            print(f"    ⚠️  PDF twin not refreshed: {err}")
+        return refreshed
 
     def _write_white_paper(self, audience_context: str = None) -> str:
         """Generate the sponsor-facing white paper from the current plan and
@@ -4947,98 +4943,44 @@ class OrchestratorTools:
             revisions go through write_technical_document(revise_path=...).
             """
             print(f"  ⚡ Tool: Editing file '{path}'...")
-            editable = {".md", ".html", ".mmd", ".txt", ".json", ".py",
-                        ".csv", ".yaml", ".yml"}
             try:
+                from ...utils.file_edit import apply_surgical_edit
                 from .user_interface import format_path, record_deliverable
                 rp = Path(path)
                 if not rp.is_absolute():
                     rp = self._output_dir() / rp
                 rp = rp.resolve()
                 root = Path(self.orch.base_dir).resolve()
-                if root not in rp.parents:
-                    return json.dumps({
-                        "status": "error",
-                        "message": (f"path must be inside the session "
-                                    f"directory ({root}).")})
-                if not rp.exists():
-                    return json.dumps({
-                        "status": "error",
-                        "message": f"No such file: {rp}"})
-                if rp.suffix.lower() not in editable:
-                    return json.dumps({
-                        "status": "error",
-                        "message": (f"'{rp.suffix}' is not an editable text "
-                                    f"format ({', '.join(sorted(editable))}).")})
-                if not old_text:
-                    return json.dumps({
-                        "status": "error",
-                        "message": "old_text must be a non-empty snippet."})
-                if old_text == new_text:
-                    return json.dumps({
-                        "status": "error",
-                        "message": "old_text and new_text are identical."})
-                # Surgical means SMALL. The cap is what stops this tool
-                # from becoming a piecewise document rewriter that dodges
-                # write_technical_document's whole-document length guard
-                # (models summarise when they mean to revise).
-                if max(len(old_text), len(new_text or "")) > 2000:
-                    return json.dumps({
-                        "status": "error",
-                        "message": (
-                            "Edit too large for edit_file. For a content "
-                            "revision use write_technical_document with "
-                            "revise_path (whole-document rewrite under its "
-                            "length guard). For a VERBATIM insertion, split "
-                            "the text at a unique boundary into consecutive "
-                            "smaller edit_file calls — do not rewrite the "
-                            "whole file with save_file, which keeps no "
-                            "backup and has no truncation guard.")})
-                current = rp.read_text(errors="replace")
-                n = current.count(old_text)
-                if n == 0:
-                    return json.dumps({
-                        "status": "error",
-                        "message": (
-                            "old_text not found — read_file the document and "
-                            "copy the snippet verbatim, whitespace included.")})
-                if n > 1 and not replace_all:
-                    return json.dumps({
-                        "status": "error",
-                        "message": (
-                            f"old_text matches {n} places — extend the "
-                            "snippet until it is unique, or pass "
-                            "replace_all=true to change every occurrence.")})
+                d = self._output_dir()
+                # Guards + backup live in the shared core; this wrapper owns
+                # path resolution, the planning-specific routing hint below,
+                # deliverable recording, and the PDF-twin invariant.
+                out = apply_surgical_edit(
+                    rp, old_text, new_text,
+                    root=root, backup_dir=d, replace_all=replace_all,
+                    too_large_message=(
+                        "Edit too large for edit_file. For a content "
+                        "revision use write_technical_document with "
+                        "revise_path (whole-document rewrite under its "
+                        "length guard). For a VERBATIM insertion, split "
+                        "the text at a unique boundary into consecutive "
+                        "smaller edit_file calls — do not rewrite the "
+                        "whole file with save_file, which keeps no "
+                        "backup and has no truncation guard."),
+                )
+                if out["status"] != "success":
+                    return json.dumps(out)
                 # Audit trail, like a revision's .before_revision copy: the
                 # delegation MAKING the edit keeps the version it replaced.
-                bak = None
-                try:
-                    d = self._output_dir()
-                    d.mkdir(parents=True, exist_ok=True)
-                    i, bak = 1, d / f"{rp.stem}.before_edit{rp.suffix}"
-                    while bak.exists():
-                        i += 1
-                        bak = d / f"{rp.stem}.before_edit{i}{rp.suffix}"
-                    bak.write_text(current)
+                if out.get("previous_version"):
                     who = ("" if d.resolve() == root
                            else f" (edited by {d.name})")
-                    record_deliverable(self.orch.base_dir, bak,
+                    record_deliverable(self.orch.base_dir,
+                                       Path(out["previous_version"]),
                                        f"Pre-edit copy of {rp.name}{who}")
-                except Exception as e:  # noqa: BLE001 - never block the edit
-                    logging.warning(f"Pre-edit copy failed: {e}")
-                    bak = None
-                rp.write_text(current.replace(old_text, new_text)
-                              if replace_all else
-                              current.replace(old_text, new_text, 1))
                 print(f"    ✏️  Edited in place: {format_path(rp)}")
-                pdf_refreshed = self._refresh_pdf_twin(rp)
-                return json.dumps({
-                    "status": "success",
-                    "path": str(rp),
-                    "replacements": n if replace_all else 1,
-                    "previous_version": str(bak) if bak else None,
-                    "pdf_refreshed": pdf_refreshed,
-                })
+                out["pdf_refreshed"] = self._refresh_pdf_twin(rp)
+                return json.dumps(out)
             except Exception as e:
                 logging.error(f"edit_file failed: {e}", exc_info=True)
                 return json.dumps({"status": "error", "message": str(e)})

--- a/scilink/utils/file_edit.py
+++ b/scilink/utils/file_edit.py
@@ -125,6 +125,68 @@ def apply_surgical_edit(
     }
 
 
+def rename_or_copy_file(
+    src: Path,
+    dest: Path,
+    *,
+    root: Path,
+    copy: bool = False,
+    root_label: str = "session directory",
+) -> Dict[str, Any]:
+    """Byte-exact rename (or copy) of a session file — content never
+    passes through a model.
+
+    Exists because the alternative was observed live: with no rename
+    tool, an agent reconstructed a 30 KB document through save_file +
+    append_file chunks to change its filename, dropping content on the
+    way and leaving divergent duplicates. Both paths must be resolved
+    (absolute) and inside `root`; `dest` must not exist (never clobber).
+
+    A markdown file's PDF twin follows the move/copy automatically (when
+    one exists and the destination twin is free), preserving the
+    twins-never-go-stale invariant across renames.
+    """
+    import shutil
+
+    src, dest, root = Path(src), Path(dest), Path(root).resolve()
+    for label, p in (("path", src), ("new path", dest)):
+        if root not in p.parents:
+            return {"status": "error",
+                    "message": (f"{label} must be inside the {root_label} "
+                                f"({root}).")}
+    if not src.is_file():
+        return {"status": "error", "message": f"No such file: {src}"}
+    if src == dest:
+        return {"status": "error",
+                "message": "path and new path are identical."}
+    if dest.exists():
+        return {"status": "error",
+                "message": (f"Destination already exists: {dest} — "
+                            "refusing to overwrite it.")}
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    op = shutil.copy2 if copy else shutil.move
+    op(str(src), str(dest))
+
+    twin_followed = False
+    src_pdf, dest_pdf = src.with_suffix(".pdf"), dest.with_suffix(".pdf")
+    if (src.suffix.lower() == ".md" and src_pdf.exists()
+            and not dest_pdf.exists()):
+        try:
+            op(str(src_pdf), str(dest_pdf))
+            twin_followed = True
+        except Exception as e:  # noqa: BLE001 - never undo the main move
+            logging.warning(f"PDF twin did not follow the rename: {e}")
+
+    return {
+        "status": "success",
+        "path": str(dest),
+        "previous_path": str(src),
+        "copied": bool(copy),
+        "pdf_twin_followed": twin_followed,
+    }
+
+
 def refresh_pdf_twin(md_path: Path) -> Tuple[bool, Optional[str]]:
     """Re-export a markdown document's PDF twin, if one exists.
 

--- a/scilink/utils/file_edit.py
+++ b/scilink/utils/file_edit.py
@@ -1,0 +1,147 @@
+"""Surgical in-place file edits — the shared core of the `edit_file` tool.
+
+One policy, many orchestrators: exact-snippet replacement with a uniqueness
+check, a size cap, a sandbox root check, and counter-suffixed pre-edit
+backups. The guards here are load-bearing (the cap is what keeps the tool
+from becoming a piecewise document rewriter that dodges the whole-document
+revision guards), so every mode must share ONE implementation rather than
+drifting copies. Mode-specific concerns stay in the orchestrator tool
+wrappers: relative-path resolution, deliverable recording, transcript
+prints, and the routing text in error hints (each mode names ITS OWN
+alternative tool for oversized edits).
+
+Consumers today: the planning orchestrator's `edit_file`. Analysis and
+simulation orchestrators are the intended follow-ups — note that VASP
+inputs (POSCAR / INCAR / KPOINTS) are extensionless, which is why the
+suffix policy is a parameter: include "" in `allowed_suffixes` to permit
+extensionless files.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional, Set, Tuple
+
+# Text formats editable by default. A mode may pass its own set; include ""
+# to allow extensionless files (VASP inputs).
+DEFAULT_EDITABLE_SUFFIXES: Set[str] = {
+    ".md", ".html", ".mmd", ".txt", ".json", ".py", ".csv", ".yaml", ".yml",
+}
+
+# Surgical means SMALL — see module docstring.
+DEFAULT_MAX_SNIPPET_LEN = 2000
+
+DEFAULT_TOO_LARGE_MESSAGE = (
+    "Edit too large for edit_file — split the change at a unique boundary "
+    "into consecutive smaller edit_file calls."
+)
+
+
+def apply_surgical_edit(
+    path: Path,
+    old_text: str,
+    new_text: str,
+    *,
+    root: Path,
+    backup_dir: Path,
+    replace_all: bool = False,
+    max_len: int = DEFAULT_MAX_SNIPPET_LEN,
+    allowed_suffixes: Set[str] = DEFAULT_EDITABLE_SUFFIXES,
+    too_large_message: str = DEFAULT_TOO_LARGE_MESSAGE,
+    root_label: str = "session directory",
+) -> Dict[str, Any]:
+    """Replace one exact snippet in `path`, guarded and backed up.
+
+    `path` must already be resolved (absolute); relative-name resolution
+    against a delegation/output directory is the caller's job. Returns a
+    dict with ``status: "success"`` (plus ``path``, ``replacements``,
+    ``previous_version``) or ``status: "error"`` (plus ``message``). Never
+    raises for expected failures; unexpected ones propagate to the caller's
+    error handling.
+
+    Guards, in order: sandbox (inside `root`), existence, suffix allowlist,
+    non-empty and non-identical snippets, size cap (`too_large_message` is
+    the mode's routing hint — it should name that mode's alternative tool),
+    exactly-one occurrence unless `replace_all`.
+
+    The pre-edit copy lands in `backup_dir` as
+    ``<stem>.before_edit[N]<suffix>`` — counter-suffixed, never clobbering
+    an earlier backup. Backup failure is logged and never blocks the edit.
+    """
+    rp = Path(path)
+    root = Path(root).resolve()
+    if root not in rp.parents:
+        return {"status": "error",
+                "message": f"path must be inside the {root_label} ({root})."}
+    if not rp.exists():
+        return {"status": "error", "message": f"No such file: {rp}"}
+    if rp.suffix.lower() not in allowed_suffixes:
+        shown = ", ".join(sorted(s for s in allowed_suffixes if s))
+        return {"status": "error",
+                "message": (f"'{rp.suffix}' is not an editable text "
+                            f"format ({shown}).")}
+    if not old_text:
+        return {"status": "error",
+                "message": "old_text must be a non-empty snippet."}
+    if old_text == new_text:
+        return {"status": "error",
+                "message": "old_text and new_text are identical."}
+    if max(len(old_text), len(new_text or "")) > max_len:
+        return {"status": "error", "message": too_large_message}
+
+    current = rp.read_text(errors="replace")
+    n = current.count(old_text)
+    if n == 0:
+        return {"status": "error",
+                "message": ("old_text not found — read_file the document and "
+                            "copy the snippet verbatim, whitespace included.")}
+    if n > 1 and not replace_all:
+        return {"status": "error",
+                "message": (f"old_text matches {n} places — extend the "
+                            "snippet until it is unique, or pass "
+                            "replace_all=true to change every occurrence.")}
+
+    bak: Optional[Path] = None
+    try:
+        backup_dir = Path(backup_dir)
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        i, bak = 1, backup_dir / f"{rp.stem}.before_edit{rp.suffix}"
+        while bak.exists():
+            i += 1
+            bak = backup_dir / f"{rp.stem}.before_edit{i}{rp.suffix}"
+        bak.write_text(current)
+    except Exception as e:  # noqa: BLE001 - never block the edit
+        logging.warning(f"Pre-edit copy failed: {e}")
+        bak = None
+
+    rp.write_text(current.replace(old_text, new_text)
+                  if replace_all else
+                  current.replace(old_text, new_text, 1))
+    return {
+        "status": "success",
+        "path": str(rp),
+        "replacements": n if replace_all else 1,
+        "previous_version": str(bak) if bak else None,
+    }
+
+
+def refresh_pdf_twin(md_path: Path) -> Tuple[bool, Optional[str]]:
+    """Re-export a markdown document's PDF twin, if one exists.
+
+    Deterministic markdown_to_pdf re-export — no LLM, no content change —
+    so an in-place edit or revision never leaves a stale PDF beside a
+    fresh .md. Returns ``(refreshed, error)``: ``(True, None)`` on refresh,
+    ``(False, None)`` when there is no twin to refresh, ``(False, msg)``
+    when the twin exists but re-export failed. Callers own the transcript
+    prints; a failure must never block the write that triggered it.
+    """
+    md_path = Path(md_path)
+    pdf = md_path.with_suffix(".pdf")
+    if md_path.suffix.lower() != ".md" or not pdf.exists():
+        return False, None
+    try:
+        from .md_to_pdf import markdown_to_pdf
+        markdown_to_pdf(md_path)
+        return True, None
+    except Exception as exc:  # noqa: BLE001
+        return False, str(exc)

--- a/tests/test_edit_file_live.py
+++ b/tests/test_edit_file_live.py
@@ -1,0 +1,220 @@
+"""Live validation for the edit_file tool + PDF-twin refresh (Bedrock
+Opus 4.8).
+
+Seeds a standalone planning session holding an existing markdown document
+with an exported PDF twin, then drives the REAL chat loop and checks the
+agent routes edits correctly:
+
+  1. mechanical_swap   — "point the figure at the new PNG, bump the
+                          caption rev": the agent must use edit_file (not
+                          re-author the document), prose must survive
+                          byte-identical, and the stale PDF twin must be
+                          re-exported with the new caption.
+  2. content_revision  — "merge two sections and rewrite formally": a
+                          content-level ask must route to
+                          write_technical_document(revise_path=...), and
+                          the revision branch must refresh the PDF twin.
+  3. replace_all       — "rename the material everywhere": every
+                          occurrence replaced (directly with
+                          replace_all=true or by recovering from the
+                          ambiguity error), other prose untouched.
+
+Run:
+    AWS_BEARER_TOKEN_BEDROCK=... AWS_REGION_NAME=us-east-1 \
+    python tests/test_edit_file_live.py [1 2 3]
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import shutil
+import sys
+from pathlib import Path
+
+MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+BASE = Path("tests/_edit_file_live_runs").resolve()
+
+results = {}
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+class Tee(io.StringIO):
+    def write(self, s):
+        sys.__stdout__.write(s)
+        return super().write(s)
+
+
+def _write_png(path: Path, color):
+    from PIL import Image
+    Image.new("RGB", (64, 32), color).save(path)
+
+OBJ = "Optimize pulsed-laser deposition of BaTiO3 thin films"
+
+REPORT = """# PLD Campaign Report
+
+## Motivation
+
+Stoichiometric transfer in pulsed-laser deposition of BaTiO3 degrades
+above a fluence threshold that depends on target density; mapping that
+threshold is the campaign's first milestone.
+
+## Workflow
+
+![Campaign workflow](old_diagram.png)
+
+*Figure 1 — campaign workflow (rev A).*
+
+## Approach
+
+A fluence/oxygen-pressure grid is screened first, then Bayesian
+optimization refines around the best cell. Film quality is scored by
+XRD rocking-curve width and RHEED oscillation persistence.
+"""
+
+NOTES = """# Materials Notes
+
+PZT-5H targets sinter at 1250 C. The PZT-5H powder route needs excess
+PbO to offset lead loss. Density above 96% is required before PZT-5H
+targets survive high-fluence ablation, and archived PZT-5H batches
+below that density are reserved for calibration only.
+"""
+
+
+def _pdf_text(pdf_path):
+    import fitz
+    with fitz.open(pdf_path) as doc:
+        return "".join(page.get_text() for page in doc)
+
+
+def _seed_session(run_dir: Path, docs: dict, with_pdf=()):
+    """Fresh AUTONOMOUS planning session with `docs` (name -> text) and a
+    real 1-px PNG for every image the report references; names in
+    `with_pdf` also get an exported PDF twin (the stale artifact)."""
+    from scilink.agents.planning_agents.planning_orchestrator import (
+        PlanningOrchestratorAgent, AutonomyLevel)
+    from scilink.utils.md_to_pdf import markdown_to_pdf
+    if run_dir.exists():
+        shutil.rmtree(run_dir)
+    data_dir = run_dir / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    orch = PlanningOrchestratorAgent(
+        objective=OBJ,
+        base_dir=str(run_dir / "session"),
+        api_key=None, model_name=MODEL,
+        autonomy_level=AutonomyLevel.AUTONOMOUS,
+        data_dir=str(data_dir),
+    )
+    base = Path(orch.base_dir)
+    _write_png(base / "old_diagram.png", "gray")
+    _write_png(base / "campaign_workflow.png", "navy")
+    for name, text in docs.items():
+        (base / name).write_text(text)
+        if name in with_pdf:
+            markdown_to_pdf(base / name)
+    return orch
+
+
+# ---------------------------------------------------------------- parts
+
+def part1_mechanical_swap():
+    print("\n=== 1. mechanical swap: edit_file, prose intact, PDF fresh ===")
+    run = BASE / "p1"
+    orch = _seed_session(run, {"report.md": REPORT}, with_pdf=("report.md",))
+    base = Path(orch.base_dir)
+    before_lines = set(REPORT.splitlines())
+
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        orch.chat(
+            "The workflow figure in report.md is outdated. Point it at "
+            "campaign_workflow.png instead of old_diagram.png, and bump "
+            "the caption from '(rev A)' to '(rev B)'. Do not change any "
+            "other text in the document.")
+    log = buf.getvalue()
+
+    check("p1 edit_file used", "Tool: Editing file" in log)
+    check("p1 no LLM re-authoring",
+          "Technical Document (revision)" not in log)
+    text = (base / "report.md").read_text()
+    check("p1 image reference swapped", "campaign_workflow.png" in text
+          and "old_diagram.png" not in text)
+    check("p1 caption bumped", "(rev B)" in text and "(rev A)" not in text)
+    changed = set(text.splitlines()) ^ before_lines
+    check("p1 only figure+caption lines differ",
+          all(("diagram.png" in l or "workflow.png" in l or "rev " in l)
+              for l in changed) and changed)
+    check("p1 PDF twin refreshed (log)", "PDF twin refreshed" in log)
+    pdf = _pdf_text(base / "report.pdf")
+    check("p1 PDF carries the new caption",
+          "rev B" in pdf and "rev A" not in pdf)
+    baks = list(base.glob("report.before_edit*.md")) \
+        + list(base.glob("report.before_edit.md"))
+    check("p1 pre-edit backup kept",
+          any("old_diagram.png" in b.read_text() for b in baks))
+
+
+def part2_content_revision():
+    print("\n=== 2. content ask routes to revision; twin refreshed ===")
+    run = BASE / "p2"
+    orch = _seed_session(run, {"report.md": REPORT}, with_pdf=("report.md",))
+    base = Path(orch.base_dir)
+
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        orch.chat(
+            "Restructure report.md: merge the Motivation and Approach "
+            "sections into a single 'Background' section and rewrite the "
+            "whole document in a more formal tone. Keep the workflow "
+            "figure as is.")
+    log = buf.getvalue()
+
+    check("p2 routed to document revision", "Revised IN PLACE" in log)
+    check("p2 edit_file not used for the rewrite",
+          "Tool: Editing file" not in log)
+    text = (base / "report.md").read_text()
+    check("p2 sections merged", "Background" in text
+          and "## Motivation" not in text)
+    check("p2 PDF twin refreshed (log)", "PDF twin refreshed" in log)
+    pdf = _pdf_text(base / "report.pdf")
+    check("p2 PDF matches revised content", "Background" in pdf)
+
+
+def part3_replace_all():
+    print("\n=== 3. rename everywhere: replace_all or recovery ===")
+    run = BASE / "p3"
+    orch = _seed_session(run, {"materials_notes.md": NOTES})
+    base = Path(orch.base_dir)
+
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        orch.chat(
+            "In materials_notes.md, replace every mention of PZT-5H with "
+            "PZT-4D. Don't touch anything else.")
+    log = buf.getvalue()
+
+    check("p3 edit_file used", "Tool: Editing file" in log)
+    text = (base / "materials_notes.md").read_text()
+    check("p3 all occurrences renamed", "PZT-5H" not in text
+          and text.count("PZT-4D") == 4)
+    untouched = NOTES.replace("PZT-5H", "PZT-4D")
+    check("p3 rest of prose byte-identical", text == untouched)
+
+
+PARTS = {"1": part1_mechanical_swap, "2": part2_content_revision,
+         "3": part3_replace_all}
+
+if __name__ == "__main__":
+    want = sys.argv[1:] or sorted(PARTS)
+    for k in want:
+        PARTS[k]()
+    print("\n" + "=" * 60)
+    npass = sum(results.values())
+    for name, ok in results.items():
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name}")
+    print(f"\n{npass}/{len(results)} checks passed")
+    sys.exit(0 if npass == len(results) else 1)

--- a/tests/test_edit_file_live.py
+++ b/tests/test_edit_file_live.py
@@ -38,6 +38,12 @@ agent routes edits correctly:
                           not claim success.
   8. html_edit         — a mechanical swap inside portfolio.html (no
                           PDF twin involved).
+  9. rename            — the past-session failure replayed: land a
+                          document under its intended filename. Must be
+                          a byte-exact rename_file (twin follows), NOT a
+                          save_file/append_file reconstruction (which
+                          dropped content and nested a phantom folder,
+                          live).
 
 Run:
     AWS_BEARER_TOKEN_BEDROCK=... AWS_REGION_NAME=us-east-1 \
@@ -405,10 +411,52 @@ def part8_html_edit():
                                          "CDOC Portfolio v2"))
 
 
+def part9_rename():
+    print("\n=== 9. intended-filename rename: byte-exact, no rebuild ===")
+    run = BASE / "p9"
+    orch = _seed_session(run, {})
+    base = Path(orch.base_dir)
+    d08 = base / "delegations" / "08_brainstorm_alternative"
+    d09 = base / "delegations" / "09_revise_and_rename"
+    d08.mkdir(parents=True)
+    d09.mkdir(parents=True)
+    doc = d08 / "technical_document.md"
+    doc.write_text(REPORT)
+    _write_png(d08 / "old_diagram.png", "gray")
+    _write_png(d08 / "campaign_workflow.png", "navy")
+    from scilink.utils.md_to_pdf import markdown_to_pdf
+    markdown_to_pdf(doc)
+    orch._active_output_subdir = d09
+
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        orch.chat(
+            "The engineering companion currently lives at "
+            "technical_document.md — land it under its intended filename "
+            "spm_cdoc_platform_engineering_companion.md. The content is "
+            "final; do not change a single byte of it.")
+    log = buf.getvalue()
+
+    dest = d08 / "spm_cdoc_platform_engineering_companion.md"
+    check("p9 rename_file used", "Tool: Renaming file" in log)
+    check("p9 no chunked reconstruction",
+          "Tool: Saving file" not in log
+          and "Tool: Appending to file" not in log)
+    check("p9 byte-identical at the new name",
+          dest.exists() and dest.read_text() == REPORT)
+    check("p9 old name gone (no divergent duplicate)", not doc.exists())
+    check("p9 stayed in its own folder (no phantom nesting)",
+          not any(base.rglob("*/09_revise_and_rename/*technical*"))
+          and not (d09 / dest.name).exists())
+    check("p9 PDF twin followed", dest.with_suffix(".pdf").exists()
+          and not doc.with_suffix(".pdf").exists())
+
+
 PARTS = {"1": part1_mechanical_swap, "2": part2_content_revision,
          "3": part3_replace_all, "4": part4_delegation_layout,
          "5": part5_disambiguation, "6": part6_cap_fallback,
-         "7": part7_sandbox_honesty, "8": part8_html_edit}
+         "7": part7_sandbox_honesty, "8": part8_html_edit,
+         "9": part9_rename}
 
 if __name__ == "__main__":
     want = sys.argv[1:] or sorted(PARTS)

--- a/tests/test_edit_file_live.py
+++ b/tests/test_edit_file_live.py
@@ -18,10 +18,30 @@ agent routes edits correctly:
                           occurrence replaced (directly with
                           replace_all=true or by recovering from the
                           ambiguity error), other prose untouched.
+  4. delegation_layout — the original failure's geometry: the document
+                          and its PDF twin live in an EARLIER delegation
+                          folder while the edit runs from a later one.
+                          The canonical file must be edited in place,
+                          the backup must land in the delegation making
+                          the edit, and the twin must refresh.
+  5. disambiguation    — the target value appears in TWO sections and
+                          only one may change: the agent must build a
+                          unique snippet (or recover from the ambiguity
+                          error), leaving the other occurrence alone.
+  6. cap_fallback      — "replace the section body with this text
+                          verbatim" where the text exceeds the 2000-char
+                          cap: acceptable routes are the guarded
+                          revision path or chunked edit_file calls —
+                          NOT a whole-file save_file rewrite.
+  7. sandbox_honesty   — asked to edit a file OUTSIDE the session: the
+                          file must stay untouched and the agent must
+                          not claim success.
+  8. html_edit         — a mechanical swap inside portfolio.html (no
+                          PDF twin involved).
 
 Run:
     AWS_BEARER_TOKEN_BEDROCK=... AWS_REGION_NAME=us-east-1 \
-    python tests/test_edit_file_live.py [1 2 3]
+    python tests/test_edit_file_live.py [1 2 ... 8]
 """
 from __future__ import annotations
 
@@ -205,8 +225,190 @@ def part3_replace_all():
     check("p3 rest of prose byte-identical", text == untouched)
 
 
+AMBIG = """# Fluence Study
+
+## Motivation
+
+Earlier work fixed the ablation fluence at 1.2 J/cm2 and attributed all
+composition drift to oxygen pressure; that assignment was never tested
+against target aging.
+
+## Approach
+
+The screening grid holds the fluence at 1.2 J/cm2 while oxygen pressure
+spans 5-50 mTorr, with fresh and aged targets interleaved to separate
+the two effects.
+"""
+
+LONG_BODY = (
+    "Stoichiometric transfer in pulsed-laser deposition is governed by "
+    "the interplay of ablation fluence, plume confinement, and target "
+    "surface state, and each of these couples to the others strongly "
+    "enough that single-variable scans systematically misassign cause. "
+    "UNIQUE-MARKER-7Q4 anchors this replacement paragraph. " +
+    ("The congruent-transfer window narrows as the target surface "
+     "roughens, because preferential ablation of the volatile cation "
+     "enriches the remaining surface and shifts the effective fluence "
+     "threshold upward with cumulative shot count. " * 12)
+)
+
+PORTFOLIO_HTML = """<!DOCTYPE html>
+<html><head><title>CDOC Portfolio v1</title>
+<style>h1 { color: #2a6f4e; }</style></head>
+<body>
+<h1>CDOC Ideation Portfolio</h1>
+<p>Three tiered directions for the chemical dynamics campaign.</p>
+<p class="footer">Compiled from delegations 1-6.</p>
+</body></html>
+"""
+
+
+def part4_delegation_layout():
+    print("\n=== 4. delegation layout: canonical file, sibling folder ===")
+    run = BASE / "p4"
+    orch = _seed_session(run, {})
+    base = Path(orch.base_dir)
+    d01 = base / "delegations" / "01_author_white_paper"
+    d07 = base / "delegations" / "07_swap_diagram"
+    d01.mkdir(parents=True)
+    d07.mkdir(parents=True)
+    _write_png(d01 / "old_diagram.png", "gray")
+    _write_png(d01 / "campaign_workflow.png", "navy")
+    doc = d01 / "white_paper.md"
+    doc.write_text(REPORT)
+    from scilink.utils.md_to_pdf import markdown_to_pdf
+    markdown_to_pdf(doc)
+    orch._active_output_subdir = d07
+
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        orch.chat(
+            "In white_paper.md, point the workflow image at "
+            "campaign_workflow.png instead of old_diagram.png. Do not "
+            "alter any prose.")
+    log = buf.getvalue()
+
+    check("p4 edit_file used", "Tool: Editing file" in log)
+    text = doc.read_text()
+    check("p4 canonical file edited in ITS folder",
+          "campaign_workflow.png" in text and "old_diagram.png" not in text)
+    check("p4 no stray copy in the editing delegation",
+          not (d07 / "white_paper.md").exists())
+    baks = list(d07.glob("white_paper.before_edit*"))
+    check("p4 backup lives with the delegation making the edit",
+          any("old_diagram.png" in b.read_text() for b in baks))
+    check("p4 PDF twin refreshed (log)", "PDF twin refreshed" in log)
+
+
+def part5_disambiguation():
+    print("\n=== 5. one of two occurrences: unique snippet required ===")
+    run = BASE / "p5"
+    orch = _seed_session(run, {"fluence_study.md": AMBIG})
+    base = Path(orch.base_dir)
+
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        orch.chat(
+            "In fluence_study.md, the Approach section's fluence value "
+            "should be 1.5 J/cm2, not 1.2 J/cm2. Change ONLY the Approach "
+            "section — the Motivation section describes earlier work and "
+            "must keep 1.2 J/cm2. No other changes.")
+    log = buf.getvalue()
+
+    check("p5 edit_file used", "Tool: Editing file" in log)
+    check("p5 no LLM re-authoring",
+          "Technical Document (revision)" not in log)
+    text = (base / "fluence_study.md").read_text()
+    mot, app = text.split("## Approach")
+    check("p5 Approach updated", "1.5 J/cm2" in app
+          and "1.2 J/cm2" not in app)
+    check("p5 Motivation untouched", "1.2 J/cm2" in mot
+          and "1.5 J/cm2" not in mot)
+    check("p5 everything else byte-identical",
+          text == AMBIG.replace(
+              "holds the fluence at 1.2 J/cm2",
+              "holds the fluence at 1.5 J/cm2"))
+
+
+def part6_cap_fallback():
+    print("\n=== 6. oversized verbatim replacement: no save_file rewrite ===")
+    run = BASE / "p6"
+    orch = _seed_session(run, {"report.md": REPORT}, with_pdf=("report.md",))
+    base = Path(orch.base_dir)
+
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        orch.chat(
+            "Replace the body of the Motivation section in report.md with "
+            "the following text VERBATIM (do not paraphrase or shorten "
+            "it), leaving every other section exactly as it is:\n\n"
+            + LONG_BODY)
+    log = buf.getvalue()
+
+    check("p6 marker text landed verbatim",
+          "UNIQUE-MARKER-7Q4" in (base / "report.md").read_text())
+    text = (base / "report.md").read_text()
+    check("p6 other sections survived",
+          "![Campaign workflow]" in text and "## Approach" in text
+          and "rocking-curve width" in text)
+    used_revision = "Revised IN PLACE" in log
+    used_edit = "Tool: Editing file" in log
+    check("p6 guarded route (revision or chunked edits), not save_file",
+          (used_revision or used_edit) and "Tool: Saving file" not in log)
+    check("p6 PDF twin refreshed (log)", "PDF twin refreshed" in log)
+
+
+def part7_sandbox_honesty():
+    print("\n=== 7. outside the session: refused, no false success ===")
+    run = BASE / "p7"
+    orch = _seed_session(run, {})
+    outside = run / "protocol_master.md"
+    outside.write_text("# Master Protocol\n\nDeposition at 700 C.\n")
+
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        reply = orch.chat(
+            f"Edit the file {outside} — change 'Deposition at 700 C' to "
+            f"'Deposition at 650 C'.")
+    log = buf.getvalue()
+
+    check("p7 file untouched",
+          outside.read_text() == "# Master Protocol\n\nDeposition at 700 C.\n")
+    attempted = "Tool: Editing file" in log
+    check("p7 attempt (if any) was refused by the sandbox",
+          (not attempted) or ("session directory" in log))
+    check("p7 reply admits inability instead of claiming success",
+          any(w in reply.lower() for w in
+              ("cannot", "can't", "unable", "outside", "session",
+               "not permitted", "refus", "restricted")))
+
+
+def part8_html_edit():
+    print("\n=== 8. HTML mechanical swap ===")
+    run = BASE / "p8"
+    orch = _seed_session(run, {"portfolio.html": PORTFOLIO_HTML})
+    base = Path(orch.base_dir)
+
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        orch.chat(
+            "In portfolio.html, bump the page title from 'CDOC Portfolio "
+            "v1' to 'CDOC Portfolio v2'. Change nothing else.")
+    log = buf.getvalue()
+
+    check("p8 edit_file used", "Tool: Editing file" in log)
+    text = (base / "portfolio.html").read_text()
+    check("p8 title bumped", "CDOC Portfolio v2" in text
+          and "CDOC Portfolio v1" not in text)
+    check("p8 rest of markup byte-identical",
+          text == PORTFOLIO_HTML.replace("CDOC Portfolio v1",
+                                         "CDOC Portfolio v2"))
+
+
 PARTS = {"1": part1_mechanical_swap, "2": part2_content_revision,
-         "3": part3_replace_all}
+         "3": part3_replace_all, "4": part4_delegation_layout,
+         "5": part5_disambiguation, "6": part6_cap_fallback,
+         "7": part7_sandbox_honesty, "8": part8_html_edit}
 
 if __name__ == "__main__":
     want = sys.argv[1:] or sorted(PARTS)

--- a/tests/test_edit_file_tool.py
+++ b/tests/test_edit_file_tool.py
@@ -1,0 +1,272 @@
+"""edit_file — surgical in-place document edits + PDF-twin refresh.
+
+The planning agent's only routes to a changed document were save_file
+(whole-file rewrite passed as one tool argument) and
+write_technical_document(revise_path=...) (LLM re-emission of the whole
+document). A one-line image-reference swap cost a full re-authoring, and
+the white paper's exported PDF twin silently kept the old content — live,
+a diagram swap updated white_paper.md while white_paper.pdf still carried
+the overfit image, and the specialist had no tool that could fix it
+without violating a content freeze.
+
+edit_file is exact-snippet replacement (mechanical edits only, capped
+small so it cannot become a piecewise document rewriter), and both it and
+the revise_path branch deterministically re-export a .pdf sibling.
+"""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scilink.agents.planning_agents import orchestrator_tools as ot
+from scilink.agents.planning_agents.orchestrator_tools import OrchestratorTools
+
+
+def make_tools(tmp_path, deleg_name="delegations/07_render_and_embed"):
+    deleg = tmp_path / deleg_name
+    deleg.mkdir(parents=True, exist_ok=True)
+    tools = OrchestratorTools.__new__(OrchestratorTools)
+    tools.orch = SimpleNamespace(
+        planner=SimpleNamespace(state={}, model=None, kb_docs=None,
+                                generation_config=None,
+                                _build_skill_context=lambda s: None),
+        base_dir=tmp_path,
+        _active_output_subdir=deleg,
+        lit_agent=None,
+    )
+    cap = {}
+    tools._register_tool = (
+        lambda func, name, description, parameters, required=None:
+        cap.update({name: func}))
+    ot.OrchestratorTools._register_all_tools(tools)
+    return tools, cap, deleg
+
+
+# ------------------------------------------------------------ edit_file
+
+
+def test_single_replacement_updates_file_and_keeps_backup(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path)
+    doc = tmp_path / "delegations" / "01_brainstorm" / "companion.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("# Companion\n\n![Workflow](old_diagram.png)\n\nProse.\n")
+
+    out = json.loads(cap["edit_file"](
+        str(doc), "![Workflow](old_diagram.png)",
+        "![Workflow](campaign_workflow.png)"))
+
+    assert out["status"] == "success"
+    assert out["replacements"] == 1
+    assert out["pdf_refreshed"] is False          # no twin beside it
+    text = doc.read_text()
+    assert "campaign_workflow.png" in text and "old_diagram.png" not in text
+    assert "Prose." in text                       # rest untouched
+    # the delegation MAKING the edit keeps the replaced version
+    bak = Path(out["previous_version"])
+    assert bak.parent == deleg
+    assert "old_diagram.png" in bak.read_text()
+
+
+def test_relative_path_resolves_into_the_delegation_dir(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path)
+    (deleg / "notes.md").write_text("alpha beta\n")
+    out = json.loads(cap["edit_file"]("notes.md", "beta", "gamma"))
+    assert out["status"] == "success"
+    assert (deleg / "notes.md").read_text() == "alpha gamma\n"
+
+
+def test_missing_snippet_is_an_error_and_file_is_untouched(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path)
+    doc = deleg / "doc.md"
+    doc.write_text("original\n")
+    out = json.loads(cap["edit_file"](str(doc), "not present", "x"))
+    assert out["status"] == "error"
+    assert "not found" in out["message"]
+    assert doc.read_text() == "original\n"
+    assert not list(deleg.glob("*.before_edit*"))  # no backup for a no-op
+
+
+def test_ambiguous_snippet_requires_replace_all(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path)
+    doc = deleg / "doc.md"
+    doc.write_text("fig.png here, fig.png there\n")
+
+    out = json.loads(cap["edit_file"](str(doc), "fig.png", "new.png"))
+    assert out["status"] == "error"
+    assert "2 places" in out["message"]
+    assert doc.read_text() == "fig.png here, fig.png there\n"
+
+    out = json.loads(cap["edit_file"](str(doc), "fig.png", "new.png",
+                                      replace_all=True))
+    assert out["status"] == "success" and out["replacements"] == 2
+    assert doc.read_text() == "new.png here, new.png there\n"
+
+
+def test_large_edits_are_routed_to_the_revision_tool(tmp_path):
+    """The size cap is the guard that keeps edit_file from becoming a
+    piecewise document rewriter dodging write_technical_document's
+    whole-document length guard."""
+    tools, cap, deleg = make_tools(tmp_path)
+    doc = deleg / "doc.md"
+    doc.write_text("short\n")
+    out = json.loads(cap["edit_file"](str(doc), "short", "x" * 2001))
+    assert out["status"] == "error"
+    assert "write_technical_document" in out["message"]
+    assert doc.read_text() == "short\n"
+
+
+def test_sandbox_refuses_paths_outside_the_session(tmp_path):
+    tools, cap, _ = make_tools(tmp_path / "session")
+    outside = tmp_path / "elsewhere.md"
+    outside.write_text("secret\n")
+    out = json.loads(cap["edit_file"](str(outside), "secret", "x"))
+    assert out["status"] == "error"
+    assert "session directory" in out["message"]
+    assert outside.read_text() == "secret\n"
+
+
+def test_binary_formats_are_refused(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path)
+    png = deleg / "diagram.png"
+    png.write_bytes(b"\x89PNG fake")
+    out = json.loads(cap["edit_file"](str(png), "PNG", "JPG"))
+    assert out["status"] == "error"
+    assert ".png" in out["message"] or "editable" in out["message"]
+
+
+def test_degenerate_inputs_are_refused(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path)
+    doc = deleg / "doc.md"
+    doc.write_text("text\n")
+    assert json.loads(cap["edit_file"](str(doc), "", "x"))["status"] == "error"
+    assert json.loads(
+        cap["edit_file"](str(doc), "text", "text"))["status"] == "error"
+    assert json.loads(
+        cap["edit_file"](str(deleg / "nope.md"), "a", "b"))["status"] == "error"
+
+
+def test_second_edit_never_clobbers_the_first_backup(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path)
+    doc = deleg / "doc.md"
+    doc.write_text("v1\n")
+    json.loads(cap["edit_file"](str(doc), "v1", "v2"))
+    json.loads(cap["edit_file"](str(doc), "v2", "v3"))
+    baks = sorted(p.name for p in deleg.glob("doc.before_edit*"))
+    assert baks == ["doc.before_edit.md", "doc.before_edit2.md"]
+    assert (deleg / "doc.before_edit.md").read_text() == "v1\n"
+    assert (deleg / "doc.before_edit2.md").read_text() == "v2\n"
+
+
+# ----------------------------------------------------- PDF twin refresh
+
+
+def _pdf_text(pdf_path):
+    fitz = pytest.importorskip("fitz")
+    with fitz.open(pdf_path) as doc:
+        return "".join(page.get_text() for page in doc)
+
+
+def test_edit_refreshes_a_stale_pdf_twin(tmp_path):
+    pytest.importorskip("fitz")
+    pytest.importorskip("markdown_it")
+    from scilink.utils.md_to_pdf import markdown_to_pdf
+
+    tools, cap, deleg = make_tools(tmp_path)
+    doc = deleg / "white_paper.md"
+    doc.write_text("# Paper\n\nThe OLDTOKEN result.\n")
+    markdown_to_pdf(doc)                          # the forwarded export
+    assert "OLDTOKEN" in _pdf_text(doc.with_suffix(".pdf"))
+
+    out = json.loads(cap["edit_file"](str(doc), "OLDTOKEN", "NEWTOKEN"))
+    assert out["status"] == "success" and out["pdf_refreshed"] is True
+    pdf = _pdf_text(doc.with_suffix(".pdf"))
+    assert "NEWTOKEN" in pdf and "OLDTOKEN" not in pdf
+
+
+def test_pdf_failure_never_loses_the_edit(tmp_path, monkeypatch):
+    pytest.importorskip("fitz")
+    pytest.importorskip("markdown_it")
+    from scilink.utils.md_to_pdf import markdown_to_pdf
+
+    tools, cap, deleg = make_tools(tmp_path)
+    doc = deleg / "paper.md"
+    doc.write_text("# P\n\nOLD.\n")
+    markdown_to_pdf(doc)
+
+    import scilink.utils.md_to_pdf as mod
+
+    def boom(*a, **k):
+        raise RuntimeError("no renderer")
+
+    monkeypatch.setattr(mod, "markdown_to_pdf", boom)
+    out = json.loads(cap["edit_file"](str(doc), "OLD.", "NEW."))
+    assert out["status"] == "success" and out["pdf_refreshed"] is False
+    assert "NEW." in doc.read_text()
+
+
+def test_revision_branch_refreshes_the_pdf_twin(tmp_path, monkeypatch):
+    """write_technical_document(revise_path=...) rewrote the .md and left
+    the exported PDF serving pre-revision content (live)."""
+    pytest.importorskip("fitz")
+    pytest.importorskip("markdown_it")
+    from scilink.utils.md_to_pdf import markdown_to_pdf
+
+    tools, cap, deleg = make_tools(tmp_path)
+    doc = tmp_path / "delegations" / "04_revise" / "white_paper.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("# White Paper\n\nBody with OLDIMAGE reference and "
+                   "enough prose to clear the revision length guard.\n")
+    markdown_to_pdf(doc)
+    assert "OLDIMAGE" in _pdf_text(doc.with_suffix(".pdf"))
+
+    revised = [{"heading": "Body",
+                "body": ("Body with NEWIMAGE reference and enough prose "
+                         "to clear the revision length guard.")}]
+    monkeypatch.setattr(ot, "author_technical_document",
+                        lambda **kw: {"sections": revised})
+    out = json.loads(cap["write_technical_document"](
+        request="swap the image reference only",
+        revise_path=str(doc), use_literature=False))
+
+    assert out["status"] == "success"
+    assert out["revised_in_place"] is True
+    assert out["pdf_refreshed"] is True
+    assert "NEWIMAGE" in doc.read_text()
+    pdf = _pdf_text(doc.with_suffix(".pdf"))
+    assert "NEWIMAGE" in pdf and "OLDIMAGE" not in pdf
+
+
+def test_save_file_overwrite_refreshes_the_pdf_twin(tmp_path):
+    """The invariant holds on EVERY markdown write path: live, the agent
+    rewrote a document via save_file (not the revision tool) and the
+    exported PDF kept serving the old content."""
+    pytest.importorskip("fitz")
+    pytest.importorskip("markdown_it")
+    from scilink.utils.md_to_pdf import markdown_to_pdf
+
+    tools, cap, deleg = make_tools(tmp_path)
+    doc = deleg / "report.md"
+    doc.write_text("# R\n\nOLDBODY.\n")
+    markdown_to_pdf(doc)
+
+    out = json.loads(cap["save_file"]("report.md", "# R\n\nNEWBODY.\n"))
+    assert out["status"] == "success" and out["pdf_refreshed"] is True
+    assert "NEWBODY" in _pdf_text(doc.with_suffix(".pdf"))
+
+    out2 = json.loads(cap["save_file"]("fresh_notes.md", "no twin\n"))
+    assert out2["status"] == "success" and out2["pdf_refreshed"] is False
+
+
+def test_fresh_document_reports_no_pdf_refresh(tmp_path, monkeypatch):
+    tools, cap, deleg = make_tools(tmp_path)
+    monkeypatch.setattr(ot, "author_technical_document",
+                        lambda **kw: {"sections": [
+                            {"heading": "H", "body": "C"}]})
+    monkeypatch.setattr(OrchestratorTools, "_maybe_embed_workflow_diagram",
+                        lambda self, text, out_dir, stem=None: text)
+    out = json.loads(cap["write_technical_document"](
+        request="write a memo", filename="memo.md", use_literature=False))
+    assert out["status"] == "success"
+    assert out["pdf_refreshed"] is False

--- a/tests/test_edit_file_tool.py
+++ b/tests/test_edit_file_tool.py
@@ -159,6 +159,44 @@ def test_second_edit_never_clobbers_the_first_backup(tmp_path):
     assert (deleg / "doc.before_edit2.md").read_text() == "v2\n"
 
 
+# --------------------------------------------------------- rename_file
+
+
+def test_rename_is_byte_exact_and_stays_in_place(tmp_path):
+    """The live failure this replaces: no rename tool, so the agent
+    reconstructed a 30 KB document via save_file + append_file chunks,
+    dropping content and nesting it in a phantom directory."""
+    tools, cap, deleg = make_tools(tmp_path)
+    d08 = tmp_path / "delegations" / "08_brainstorm"
+    d08.mkdir(parents=True)
+    doc = d08 / "technical_document.md"
+    doc.write_text("# Companion\n\nfull body, every byte kept\n")
+
+    out = json.loads(cap["rename_file"](
+        str(doc), "spm_companion.md", deliverable=True, title="Companion"))
+    assert out["status"] == "success"
+    dest = Path(out["path"])
+    assert dest == d08 / "spm_companion.md"       # same folder, new identity
+    assert dest.read_text() == "# Companion\n\nfull body, every byte kept\n"
+    assert not doc.exists()
+
+    # directories in new_name are stripped, not nested (the phantom-folder
+    # failure came from a path passed as a name)
+    src2 = deleg / "notes.md"
+    src2.write_text("n\n")
+    out2 = json.loads(cap["rename_file"](str(src2), "sub/dir/final.md"))
+    assert Path(out2["path"]) == deleg / "final.md"
+
+
+def test_rename_refuses_to_clobber(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path)
+    (deleg / "a.md").write_text("a\n")
+    (deleg / "b.md").write_text("b\n")
+    out = json.loads(cap["rename_file"](str(deleg / "a.md"), "b.md"))
+    assert out["status"] == "error"
+    assert (deleg / "b.md").read_text() == "b\n"
+
+
 # ----------------------------------------------------- PDF twin refresh
 
 

--- a/tests/test_file_edit_utility.py
+++ b/tests/test_file_edit_utility.py
@@ -1,0 +1,95 @@
+"""Direct tests for the shared surgical-edit core (utils/file_edit).
+
+The orchestrator-facing behavior is covered by test_edit_file_tool.py;
+these pin the utility's own contract, including the parameters future
+consumers depend on — notably the suffix policy that must admit
+extensionless VASP inputs (POSCAR / INCAR) when the simulation
+orchestrator adopts the tool.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from scilink.utils.file_edit import (
+    DEFAULT_EDITABLE_SUFFIXES, apply_surgical_edit, refresh_pdf_twin)
+
+
+def edit(path, old, new, *, root, **kw):
+    kw.setdefault("backup_dir", Path(root) / "backups")
+    return apply_surgical_edit(path, old, new, root=root, **kw)
+
+
+def test_success_shape_and_backup(tmp_path):
+    f = tmp_path / "doc.md"
+    f.write_text("alpha beta\n")
+    out = edit(f, "beta", "gamma", root=tmp_path)
+    assert out["status"] == "success" and out["replacements"] == 1
+    assert f.read_text() == "alpha gamma\n"
+    bak = Path(out["previous_version"])
+    assert bak.parent == tmp_path / "backups"
+    assert bak.read_text() == "alpha beta\n"
+
+
+def test_guard_order_and_messages(tmp_path):
+    f = tmp_path / "doc.md"
+    f.write_text("x y x\n")
+    outside = tmp_path.parent / "outside.md"
+    assert "session directory" in edit(
+        outside, "a", "b", root=tmp_path)["message"]
+    assert "No such file" in edit(
+        tmp_path / "nope.md", "a", "b", root=tmp_path)["message"]
+    assert "non-empty" in edit(f, "", "b", root=tmp_path)["message"]
+    assert "identical" in edit(f, "x", "x", root=tmp_path)["message"]
+    assert "2 places" in edit(f, "x", "z", root=tmp_path)["message"]
+    out = edit(f, "x", "z", root=tmp_path, replace_all=True)
+    assert out["status"] == "success" and out["replacements"] == 2
+
+
+def test_cap_uses_the_callers_routing_hint(tmp_path):
+    f = tmp_path / "doc.md"
+    f.write_text("short\n")
+    out = edit(f, "short", "y" * 2001, root=tmp_path,
+               too_large_message="USE-MODE-SPECIFIC-TOOL")
+    assert out == {"status": "error", "message": "USE-MODE-SPECIFIC-TOOL"}
+    assert f.read_text() == "short\n"
+
+
+def test_suffix_policy_is_configurable_for_extensionless_vasp(tmp_path):
+    incar = tmp_path / "INCAR"
+    incar.write_text("ENCUT = 400\n")
+    out = edit(incar, "400", "520", root=tmp_path)
+    assert out["status"] == "error"          # default policy refuses
+
+    out = edit(incar, "400", "520", root=tmp_path,
+               allowed_suffixes=DEFAULT_EDITABLE_SUFFIXES | {""})
+    assert out["status"] == "success"
+    assert incar.read_text() == "ENCUT = 520\n"
+
+
+def test_backup_counter_never_clobbers(tmp_path):
+    f = tmp_path / "doc.md"
+    f.write_text("v1\n")
+    edit(f, "v1", "v2", root=tmp_path)
+    edit(f, "v2", "v3", root=tmp_path)
+    baks = sorted(p.name for p in (tmp_path / "backups").iterdir())
+    assert baks == ["doc.before_edit.md", "doc.before_edit2.md"]
+
+
+def test_refresh_pdf_twin_states(tmp_path, monkeypatch):
+    pytest.importorskip("fitz")
+    pytest.importorskip("markdown_it")
+    from scilink.utils.md_to_pdf import markdown_to_pdf
+
+    doc = tmp_path / "r.md"
+    doc.write_text("# R\n\nbody\n")
+    assert refresh_pdf_twin(doc) == (False, None)          # no twin
+    markdown_to_pdf(doc)
+    assert refresh_pdf_twin(doc) == (True, None)           # refreshed
+
+    import scilink.utils.md_to_pdf as mod
+    monkeypatch.setattr(mod, "markdown_to_pdf",
+                        lambda *a, **k: (_ for _ in ()).throw(
+                            RuntimeError("boom")))
+    ok, err = refresh_pdf_twin(doc)
+    assert ok is False and "boom" in err                   # failure reported

--- a/tests/test_file_edit_utility.py
+++ b/tests/test_file_edit_utility.py
@@ -76,6 +76,53 @@ def test_backup_counter_never_clobbers(tmp_path):
     assert baks == ["doc.before_edit.md", "doc.before_edit2.md"]
 
 
+def test_rename_moves_bytes_and_pdf_twin(tmp_path):
+    pytest.importorskip("fitz")
+    pytest.importorskip("markdown_it")
+    from scilink.utils.md_to_pdf import markdown_to_pdf
+    from scilink.utils.file_edit import rename_or_copy_file
+
+    src = tmp_path / "technical_document.md"
+    src.write_text("# Companion\n\nbody\n")
+    markdown_to_pdf(src)
+    dest = tmp_path / "spm_companion.md"
+
+    out = rename_or_copy_file(src, dest, root=tmp_path)
+    assert out["status"] == "success" and out["pdf_twin_followed"] is True
+    assert not src.exists() and not src.with_suffix(".pdf").exists()
+    assert dest.read_text() == "# Companion\n\nbody\n"
+    assert dest.with_suffix(".pdf").exists()
+
+
+def test_copy_keeps_the_original(tmp_path):
+    from scilink.utils.file_edit import rename_or_copy_file
+    src = tmp_path / "a.md"
+    src.write_text("x\n")
+    out = rename_or_copy_file(src, tmp_path / "b.md", root=tmp_path,
+                              copy=True)
+    assert out["status"] == "success" and out["copied"] is True
+    assert src.exists() and (tmp_path / "b.md").read_text() == "x\n"
+
+
+def test_rename_guards(tmp_path):
+    from scilink.utils.file_edit import rename_or_copy_file
+    src = tmp_path / "a.md"
+    src.write_text("x\n")
+    taken = tmp_path / "b.md"
+    taken.write_text("occupied\n")
+
+    assert "already exists" in rename_or_copy_file(
+        src, taken, root=tmp_path)["message"]
+    assert taken.read_text() == "occupied\n"          # never clobbered
+    assert "session directory" in rename_or_copy_file(
+        src, tmp_path.parent / "esc.md", root=tmp_path)["message"]
+    assert "No such file" in rename_or_copy_file(
+        tmp_path / "nope.md", tmp_path / "c.md", root=tmp_path)["message"]
+    assert "identical" in rename_or_copy_file(
+        src, src, root=tmp_path)["message"]
+    assert src.read_text() == "x\n"                   # untouched throughout
+
+
 def test_refresh_pdf_twin_states(tmp_path, monkeypatch):
     pytest.importorskip("fitz")
     pytest.importorskip("markdown_it")


### PR DESCRIPTION
## Summary

When a planning session needed a small mechanical change to a document it had already written — swap a figure reference, fix a caption, rename a material — there was no small way to do it. The agent either re-authored the whole document through the LLM (slow, and it can paraphrase text that was supposed to stay fixed) or rewrote the file wholesale. Worse, documents exported to PDF (like the white paper) kept serving the old content after their markdown was updated: observed live, a diagram swap updated `white_paper.md` while the forwarded `white_paper.pdf` still carried the old image, and no tool could fix it without re-authoring prose under a content freeze.

This PR adds:

- **`edit_file`** — a surgical editing tool: replace one exact snippet in an existing session document. It keeps a backup of what it replaced, refuses ambiguous or oversized edits, and works only inside the session folder.
- **A "PDF twins never go stale" guarantee** — every path that writes a markdown document (`edit_file`, document revision, `save_file`) now automatically re-exports a PDF sibling if one exists. The re-export is deterministic — no LLM, no content change — so it is safe even under a content freeze.

Live validation on Bedrock Opus 4.8 (`tests/test_edit_file_live.py`, 36/36 checks across 8 scenarios): figure swap with prose byte-intact, content restructure routed to the guarded revision path, rename-everywhere in one call, editing a document that lives in an earlier delegation folder, changing one of two identical values, an oversized verbatim replacement split into consecutive small edits, refusal (with an honest explanation) to edit outside the session, and an HTML edit. Offline: `tests/test_edit_file_tool.py`, 14/14.

Two routing gaps were found and fixed during live testing, both at decision points the agent reads: `save_file`'s description now steers existing-document changes to the guarded paths (round 1: the agent rewrote a document wholesale via `save_file`), and the size-cap error now names the chunked-edits route for verbatim insertions (round 2: the agent correctly rejected LLM re-emission for verbatim text but had no other visible option).

---

## Technical details

**`edit_file(path, old_text, new_text, replace_all=False)`** (planning `orchestrator_tools.py`):
- Exact-string match; `old_text` must occur exactly once unless `replace_all` — line numbers and regex are deliberately excluded, so the model must have read the text it is changing, and a stale match fails loudly.
- Both snippets capped at 2000 chars. The cap is the load-bearing guard: it keeps the tool from becoming a piecewise document rewriter that dodges `write_technical_document`'s <50%-length revision guard (which exists because models summarise when they mean to revise). Larger edits are routed by the error message: content revisions → `revise_path`; verbatim insertions → consecutive smaller `edit_file` calls.
- Session-sandboxed (same root check as `revise_path`), text formats only, relative paths resolve against the active delegation dir.
- Pre-edit copy `<stem>.before_edit[N]<suffix>` kept in the delegation making the edit (counter-suffixed, never clobbers), recorded via `record_deliverable` like `.before_revision` copies.

**`_refresh_pdf_twin(md_path)`**: deterministic `markdown_to_pdf` re-export of an existing `.pdf` sibling; wired into `edit_file`, the `write_technical_document(revise_path=...)` branch, and `save_file`. Failure never blocks the write that triggered it. All three tools report `pdf_refreshed` in their result JSON.

**Live-found routing fixes** (one principle sentence each, per the prompt-patch convention):
- `save_file` description: existing-document changes go through `edit_file` / `revise_path`, which keep a backup and guard against truncation.
- Cap error message: names the chunked-edits route and warns off whole-file `save_file` rewrites. On re-run the agent split a 2.3k-char verbatim insertion at a unique anchor into three edits and re-read the file to verify.

**Shared core for future modes** (`scilink/utils/file_edit.py`): the guard logic (sandbox, uniqueness, cap, backups) and the PDF-twin refresh are extracted into a mode-neutral utility so the analysis and simulation orchestrators can adopt `edit_file` in follow-up PRs without drifting copies of guard code. The suffix policy and the cap error's routing hint are parameters — VASP inputs are extensionless, and each mode names its own alternative tool for oversized edits. Planning remains the only wired consumer here; behavior is unchanged (error messages byte-identical, offline 20/20, live smoke 12/12 after the extraction).


**`rename_file`** (added after a past-session trace surfaced the gap): byte-exact rename/copy of a session file — content never passes through the model. Without it, an agent needing to land a finished 30 KB document under its intended filename reconstructed it through `save_file` + `append_file` chunks, dropping content, leaving divergent duplicates, and nesting the copy in a phantom directory. The tool keeps the file in its own folder (bare target name only), refuses to overwrite, and brings the PDF twin along. Live scenario 9 replays the observed failure: the agent chose `rename_file` directly — byte-identical content, twin followed, no chunked rebuild (6/6; full live suite now 42 checks across 9 scenarios).
