### PR TITLE
Session titles: stop gluing the model's runoff onto the name

### DIFF
--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -506,9 +506,15 @@ def render_sidebar() -> None:
                 load_session_name, save_session_name)
             _sdir = st.session_state.session_dir
             _current_name = load_session_name(_sdir) or ""
+            # Per-session widget key: with a fixed key, Streamlit keeps the
+            # box's first-render state (empty) and ignores value= forever —
+            # the agent's auto-title never appeared here — and the state
+            # survives switching sessions, writing session A's typed name
+            # into session B's meta as named_by="user", which then blocks
+            # B's auto-titling permanently.
             _typed = st.text_input(
                 "Session name", value=_current_name,
-                key="session_name_input",
+                key=f"session_name_input:{_sdir}",
                 help=("Shown in the resume list and File Explorer. "
                       "Auto-named by the agent after the first turn "
                       "unless you set one."))

--- a/scilink/ui/session_meta.py
+++ b/scilink/ui/session_meta.py
@@ -93,8 +93,21 @@ def generate_session_title(model, first_user_msg: str,
         )
         resp = model.generate_content(
             [prompt], generation_config=SimpleNamespace(max_output_tokens=24))
-        title = re.sub(r'["\'\n\r.]+', " ", getattr(resp, "text", "") or "")
+        raw = getattr(resp, "text", "") or ""
+        # Only the FIRST non-empty line is the title. Models keep talking
+        # past the title often enough that folding newlines into spaces
+        # shipped the runoff as part of the name — a sidebar label read
+        # "Smart interventions along synthesis pathways I have your"
+        # (live), the tail being conversational continuation cut
+        # mid-sentence by the token cap.
+        raw = next((ln for ln in raw.splitlines() if ln.strip()), "")
+        raw = re.sub(r"^\s*title\s*[:\-]\s*", "", raw, flags=re.IGNORECASE)
+        title = re.sub(r'["\'\n\r.]+', " ", raw)
         title = " ".join(title.split()).strip()
+        # Backstop the 3-6-word instruction against one-line rambles.
+        words = title.split()
+        if len(words) > 8:
+            title = " ".join(words[:8])
         if len(title) > 60:
             # Cut on a word boundary — a sidebar label ending mid-word
             # ("...from amorphous precurs") reads as a broken title.

--- a/tests/test_session_title.py
+++ b/tests/test_session_title.py
@@ -95,5 +95,11 @@ t = generate_session_title(ramble, "x")
 print(f"     {t!r}")
 check(len(t.split()) <= 8, "one-line ramble capped at 8 words")
 
+print("\n=== sidebar name box uses a per-session widget key ===")
+check('key=f"session_name_input:{_sdir}"' in sb,
+      "per-session key (fixed key hid the agent title behind stale "
+      "first-render state and bled a typed name into the next session)")
+check('key="session_name_input"' not in sb, "no fixed widget key remains")
+
 print("\n" + ("ALL PASSED" if not fails else f"{len(fails)} FAILURE(S): {fails}"))
 sys.exit(1 if fails else 0)

--- a/tests/test_session_title.py
+++ b/tests/test_session_title.py
@@ -70,10 +70,30 @@ print(f"     {t!r}  (len={len(t)})")
 check(len(t) <= 60, "respects the 60-char label cap")
 check(not t.endswith("precurs"), "does not cut mid-word (live proxy produced exactly this)")
 check(t == "Operando XRD polymorph identification from amorphous", "cuts at the last whole word")
-check(generate_session_title(FakeModel(text="  Ragged\n\n  spacing   here "), "x")
+check(generate_session_title(FakeModel(text="  Ragged \t spacing   here "), "x")
       == "Ragged spacing here", "collapses ragged whitespace")
 check(generate_session_title(FakeModel(text="A"*80), "x") == "A"*60,
       "unbroken 80-char string still yields 60 chars, not empty")
+
+print("\n=== only the FIRST line is the title (live: runoff glued on) ===")
+runoff = FakeModel(text="Smart interventions along synthesis pathways\n\n"
+                        "I have your uploaded PDF and")
+t = generate_session_title(runoff, "x")
+print(f"     {t!r}")
+check(t == "Smart interventions along synthesis pathways",
+      "continuation after the title line is dropped (live session name "
+      "carried it: '...pathways I have your')")
+check(generate_session_title(
+          FakeModel(text="Title: Flash anneal polymorph control"), "x")
+      == "Flash anneal polymorph control", "leading 'Title:' prefix stripped")
+check(generate_session_title(
+          FakeModel(text="\n\n  Operando XRD mapping\nmore chatter"), "x")
+      == "Operando XRD mapping", "leading blank lines skipped, tail dropped")
+ramble = FakeModel(text="This session is broadly about controlling oxide "
+                        "polymorph selection using pulsed annealing schedules")
+t = generate_session_title(ramble, "x")
+print(f"     {t!r}")
+check(len(t.split()) <= 8, "one-line ramble capped at 8 words")
 
 print("\n" + ("ALL PASSED" if not fails else f"{len(fails)} FAILURE(S): {fails}"))
 sys.exit(1 if fails else 0)


### PR DESCRIPTION
## Summary

Sidebar session names sometimes came out garbled — a live session was titled **"Smart interventions along synthesis pathways I have your"**. The title the model actually chose ("Smart interventions along synthesis pathways") was fine; the trailing "I have your" was the model continuing to talk after the title, cut mid-sentence by the 24-token cap, and then glued onto the name by the sanitizer, which folds newlines into spaces. At 56 characters the fused string also slipped under the 60-char trim, so nothing removed the tail.

Fix: only the **first non-empty line** of the titling reply is the name. A leading "Title:" prefix is stripped, and an 8-word cap backstops the "3-6 plain words" instruction against one-line rambles. Titling still fails safe (returns None → timestamp label) on any error.

Already-persisted names are untouched — this only affects how future sessions are titled.

---

## Technical details

`scilink/ui/session_meta.py::generate_session_title`: `raw.splitlines()` → first non-empty line, then the existing quote/period sanitize, word cap, and 60-char word-boundary trim, in that order. The pre-existing behavior tests are unchanged in intent; the ragged-whitespace case now uses same-line whitespace because multi-line folding is exactly the behavior removed. `tests/test_session_title.py` adds four regression checks, including the verbatim live failure (title line + conversational runoff → title line only).

**Second fix — the sidebar "Session name" box never showed the auto-title.** The box used a fixed Streamlit widget key, so it kept its first-render state (empty, from before the agent had titled the session) and ignored `value=` on every rerun — the title was saved and shown everywhere *except* in the box itself. The fixed key's state also survives switching sessions, so a name typed in session A could be silently written into session B's meta as a user-chosen name, permanently blocking B's auto-titling. Keying the widget per session directory fixes both: each session's box gets fresh state initialized from its own stored name.
