### PR TITLE
Workspace listing: end blind path-probing in meta sessions

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -1256,7 +1256,7 @@ class OrchestratorTools:
                  artifact_names = [f"analysis_artifacts/{f.name}" for f in artifacts_dir.iterdir() if f.is_file()]
             
             all_files = files + artifact_names
-            
+
             # Include data point count for optimization readiness
             data_count = 0
             if self.orch.bo_data_path.exists():
@@ -1265,19 +1265,71 @@ class OrchestratorTools:
                     data_count = len(df)
                 except Exception:
                     pass
-            
-            return json.dumps({
+
+            # Under a meta session every artifact lives in
+            # delegations/<slug>/, which the flat listing cannot see — live,
+            # an agent probed six guessed paths for a companion whose real
+            # filename it could not know (folders are named by task slug,
+            # files by the authoring turn) and only found it by reading
+            # deliverables.json as a last resort. Surface both halves of the
+            # answer here: the registry (title -> path, the semantic index)
+            # and a one-level listing of each delegation folder.
+            deliverables_index = []
+            try:
+                from .user_interface import load_deliverables
+                for e in load_deliverables(self.orch.base_dir):
+                    p = e.get("path")
+                    if not p or not Path(p).exists():
+                        continue
+                    deliverables_index.append({
+                        "title": e.get("title") or Path(p).name,
+                        "path": p,
+                        "deliverable": bool(e.get("deliverable")),
+                    })
+            except Exception:  # noqa: BLE001 - listing must never fail
+                pass
+
+            delegation_folders = {}
+            try:
+                droot = self.orch.base_dir / "delegations"
+                if droot.is_dir():
+                    for d in sorted(droot.iterdir()):
+                        if d.is_dir():
+                            delegation_folders[d.name] = sorted(
+                                f.name + ("/" if f.is_dir() else "")
+                                for f in d.iterdir())
+            except Exception:  # noqa: BLE001
+                pass
+
+            payload = {
                 "status": "success",
                 "files": all_files,
                 "data_points_collected": data_count,
                 "optimization_ready": data_count >= 3,
                 "active_analysis_script": Path(self.orch.active_scalarizer_script).name if self.orch.active_scalarizer_script else None
-            })
-        
+            }
+            if deliverables_index:
+                payload["deliverables_index"] = deliverables_index
+                payload["hint"] = ("deliverables_index maps document titles "
+                                   "to their real paths — use it instead of "
+                                   "guessing filenames.")
+            if delegation_folders:
+                payload["delegation_folders"] = delegation_folders
+            return json.dumps(payload)
+
         self._register_tool(
             func=list_workspace_files,
             name="list_workspace_files",
-            description="Lists files in the session directory (checkpoints, analysis artifacts, etc.). User data files may exist outside the session folder.",
+            description=(
+                "Lists files in the session directory (checkpoints, analysis "
+                "artifacts, etc.), plus — when present — a deliverables index "
+                "(document title -> real path) and the contents of each "
+                "delegations/ folder. To find a document produced earlier, "
+                "use this index rather than guessing paths: delegation "
+                "folders are named by task slug and filenames rarely match "
+                "a document's topic. User data files may exist outside the "
+                "session folder."
+            ),
             parameters={}
         )
         

--- a/tests/test_workspace_listing.py
+++ b/tests/test_workspace_listing.py
@@ -1,0 +1,93 @@
+"""list_workspace_files must expose the delegation tree and the
+deliverables index.
+
+Live failure this pins: under a meta session every artifact lives in
+delegations/<task-slug>/, invisible to the flat listing — an agent
+probed six guessed paths for a companion whose real filename it could
+not know, and only found it by reading deliverables.json as a last
+resort. The listing now answers both questions directly: what exists
+(one-level delegation contents) and what things are called
+(title -> path index from the registry).
+"""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from scilink.agents.planning_agents import orchestrator_tools as ot
+from scilink.agents.planning_agents.orchestrator_tools import OrchestratorTools
+from scilink.agents.planning_agents.user_interface import record_deliverable
+
+
+def make_tools(tmp_path):
+    tools = OrchestratorTools.__new__(OrchestratorTools)
+    tools.orch = SimpleNamespace(
+        planner=SimpleNamespace(state={}, model=None),
+        base_dir=tmp_path,
+        _active_output_subdir=None,
+        lit_agent=None,
+        bo_data_path=tmp_path / "optimization_data.csv",
+        active_scalarizer_script=None,
+    )
+    cap = {}
+    tools._register_tool = (
+        lambda func, name, description, parameters, required=None:
+        cap.update({name: func}))
+    ot.OrchestratorTools._register_all_tools(tools)
+    return cap
+
+
+def test_listing_surfaces_delegations_and_registry(tmp_path):
+    d01 = tmp_path / "delegations" / "01_brainstorm_a_chemical_dynamic"
+    d01.mkdir(parents=True)
+    doc = d01 / "cdoc_platform_engineering_companion.md"
+    doc.write_text("# Companion\n")
+    (d01 / "campaign_workflow.png").write_bytes(b"png")
+    (d01 / "outputs").mkdir()
+    (tmp_path / "chat_history.json").write_text("[]")
+    record_deliverable(tmp_path, doc, "MZI Engineering Companion",
+                       deliverable=True)
+
+    cap = make_tools(tmp_path)
+    out = json.loads(cap["list_workspace_files"]())
+
+    assert out["status"] == "success"
+    assert "chat_history.json" in out["files"]
+
+    # the semantic index: title -> real path, starred flag preserved
+    idx = out["deliverables_index"]
+    assert idx == [{"title": "MZI Engineering Companion",
+                    "path": str(doc), "deliverable": True}]
+    assert "guessing" in out["hint"]
+
+    # one-level delegation contents, dirs marked with a trailing slash
+    assert out["delegation_folders"] == {
+        "01_brainstorm_a_chemical_dynamic": [
+            "campaign_workflow.png",
+            "cdoc_platform_engineering_companion.md",
+            "outputs/",
+        ]}
+
+
+def test_vanished_registry_entries_are_dropped(tmp_path):
+    d = tmp_path / "delegations" / "02_x"
+    d.mkdir(parents=True)
+    gone = d / "renamed_away.md"
+    gone.write_text("x")
+    record_deliverable(tmp_path, gone, "Old name")
+    gone.unlink()                      # renamed/deleted since recording
+
+    cap = make_tools(tmp_path)
+    out = json.loads(cap["list_workspace_files"]())
+    assert "deliverables_index" not in out   # only existing files listed
+    assert out["delegation_folders"] == {"02_x": []}
+
+
+def test_flat_session_payload_unchanged(tmp_path):
+    (tmp_path / "plan.json").write_text("{}")
+    cap = make_tools(tmp_path)
+    out = json.loads(cap["list_workspace_files"]())
+    assert out["files"] == ["plan.json"]
+    assert "deliverables_index" not in out
+    assert "delegation_folders" not in out
+    assert out["optimization_ready"] is False

--- a/tests/test_workspace_listing_live.py
+++ b/tests/test_workspace_listing_live.py
@@ -1,0 +1,110 @@
+"""Live validation: the workspace listing ends blind path-probing
+(Bedrock Opus 4.8).
+
+Replays the observed struggle: a document whose TITLE ("MZI engineering
+companion") matches neither its filename (cdoc_platform_engineering_
+companion.md) nor its delegation folder (named by task slug). Pre-fix,
+the agent probed six guessed paths and only recovered by reading
+deliverables.json as a last resort. With the deliverables index folded
+into list_workspace_files, one listing call must be enough.
+
+Run:
+    AWS_BEARER_TOKEN_BEDROCK=... AWS_REGION_NAME=us-east-1 \
+    python tests/test_workspace_listing_live.py
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import re
+import shutil
+import sys
+from pathlib import Path
+
+MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+BASE = Path("tests/_workspace_listing_live_runs").resolve()
+
+results = {}
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+class Tee(io.StringIO):
+    def write(self, s):
+        sys.__stdout__.write(s)
+        return super().write(s)
+
+
+COMPANION = """# CDOC Platform Engineering Companion
+
+## Characterization
+Mach-Zehnder interferometer quantitative phase imaging (MZI-QPI) is the
+platform's primary channel; the MARKER-MZI-COST budget line is $46k.
+
+## Cell design
+Flow cell with top optical access; reset by rinse-in-place.
+"""
+
+
+def main():
+    from scilink.agents.planning_agents.planning_orchestrator import (
+        PlanningOrchestratorAgent, AutonomyLevel)
+    from scilink.agents.planning_agents.user_interface import (
+        record_deliverable)
+
+    run = BASE / "p1"
+    if run.exists():
+        shutil.rmtree(run)
+    data_dir = run / "data"
+    data_dir.mkdir(parents=True)
+    orch = PlanningOrchestratorAgent(
+        objective="Chemical dynamics observatory campaign design",
+        base_dir=str(run / "session"),
+        api_key=None, model_name=MODEL,
+        autonomy_level=AutonomyLevel.AUTONOMOUS,
+        data_dir=str(data_dir),
+    )
+    base = Path(orch.base_dir)
+    # Title matches neither the filename nor the task-slug folder name.
+    d01 = base / "delegations" / "01_brainstorm_and_sketch_a_chemical_dynamic"
+    d01.mkdir(parents=True)
+    doc = d01 / "cdoc_platform_engineering_companion.md"
+    doc.write_text(COMPANION)
+    record_deliverable(base, doc, "MZI Engineering Companion (Track 1)",
+                       deliverable=True)
+    # decoys: other delegations with similar-looking files
+    for slug, name in (("09_revise_in_place_the_spm_centered", "spm_notes.md"),
+                       ("19_brainstorm_a_saxs_waxs_version", "saxs_notes.md")):
+        d = base / "delegations" / slug
+        d.mkdir(parents=True)
+        (d / name).write_text(f"# {name}\nnot the MZI doc\n")
+
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        reply = orch.chat(
+            "What does the MZI engineering companion say the MZI-QPI "
+            "budget line is? Quote the exact dollar figure.")
+    log = buf.getvalue()
+
+    check("listing was consulted", "Listing files in" in log)
+    reads = re.findall(r"Reading file '([^']+)'", log)
+    check("read the real file on the first read attempt",
+          bool(reads) and reads[0].endswith(
+              "cdoc_platform_engineering_companion.md"))
+    check("no blind path probes",
+          "No such file" not in log and "Could not find" not in log)
+    check("answer extracted from the right document", "46k" in reply)
+
+    print()
+    npass = sum(results.values())
+    for name, ok in results.items():
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name}")
+    print(f"\n{npass}/{len(results)} checks passed")
+    sys.exit(0 if npass == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

When the planning specialist needed a document produced by an earlier delegation, it often couldn't find it. Its only listing tool showed just the session root — but under a meta session every artifact lives in `delegations/<task-slug>/` subfolders. Observed live: an agent hunting "the MZI engineering companion" probed six guessed paths (delegation folders are named after task text, and the file was actually called `cdoc_platform_engineering_companion.md`), tried reading a directory, and only recovered by reading `deliverables.json` as a last resort — eight tool calls for what should be one.

`list_workspace_files` now answers both discovery questions directly:

- a **deliverables index** — each recorded document's title mapped to its real path (with its starred flag), folded from the existing registry; entries whose file has since been renamed or deleted are dropped;
- a **one-level listing of each `delegations/` folder** (subdirectories marked with a trailing slash).

The tool description now steers the agent to the index instead of guessing paths. Standalone (non-meta) sessions see a byte-identical payload — both new fields appear only when there is something to show.

Validation: offline tests (`tests/test_workspace_listing.py`) cover the index, vanished-entry dropping, and the unchanged flat-session payload. A live test on Bedrock Opus 4.8 (`tests/test_workspace_listing_live.py`) replays the observed struggle with decoy delegation folders: the agent made one listing call, read the correct file on its first attempt, no blind probes, and quoted the right figure — 4/4.

---

## Technical details

`scilink/agents/planning_agents/orchestrator_tools.py::list_workspace_files`: reuses `user_interface.load_deliverables` (which already dedupes across per-orchestrator manifests) for the index; the delegation listing is `sorted(d.iterdir())` one level deep, names only. Both additions are wrapped so listing can never fail, and both are conditional keys so existing consumers of the payload are unaffected.