### PR TITLE
Planning mode can read PDFs (#397 phase 0)

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -5518,10 +5518,13 @@ class OrchestratorTools:
             try:
                 ext = path.suffix.lower()
 
-                # Size guard — skip for Excel/CSV since we cap at 50 rows × 40 cols
+                # Size guard — skip for Excel/CSV since we cap at 50 rows × 40 cols.
+                # Documents get more headroom: extraction is page-based and a
+                # figure-heavy PDF is megabytes of images, not of text.
                 if ext not in ('.xlsx', '.xls', '.csv'):
                     size_mb = path.stat().st_size / (1024 * 1024)
-                    if size_mb > 5:
+                    cap_mb = 25 if ext in ('.pdf', '.docx') else 5
+                    if size_mb > cap_mb:
                         return json.dumps({
                             "status": "error",
                             "message": f"File too large ({size_mb:.1f} MB)."
@@ -5569,8 +5572,35 @@ class OrchestratorTools:
                     trunc = f" (showing {', '.join(trunc_parts)})" if trunc_parts else ""
                     content = f"Shape: {total_rows} rows × {total_cols} columns{trunc}\n\n{preview_text}"
                 else:
-                    with open(path, 'r', encoding='utf-8', errors='replace') as f:
-                        lines = f.readlines()
+                    doc_meta = {}
+                    if ext in ('.pdf', '.docx'):
+                        # #397 phase 0: opened as text, a PDF returns its
+                        # compressed byte streams — live, a delegation handed
+                        # a proposal PDF could not ground on it (one run
+                        # proceeded from the caller's paraphrase; another
+                        # refused an adversarial review outright). Extraction
+                        # is ALREADY shared infrastructure; route through it.
+                        from ...parsers.extract import extract_text
+                        info = extract_text(
+                            str(path),
+                            ocr_model=getattr(self.orch.planner, "model",
+                                              None))
+                        raw = info.get("text") or ""
+                        if not raw.strip():
+                            return json.dumps({
+                                "status": "error",
+                                "message": (
+                                    f"No extractable text in {path.name} "
+                                    "(empty or image-only document).")})
+                        lines = raw.splitlines(keepends=True)
+                        doc_meta = {k: info[k] for k in
+                                    ("n_pages", "n_ocr_pages", "n_paragraphs")
+                                    if info.get(k) is not None}
+                        doc_meta["extracted"] = ext.lstrip(".")
+                    else:
+                        with open(path, 'r', encoding='utf-8',
+                                  errors='replace') as f:
+                            lines = f.readlines()
                     total = len(lines)
 
                     if search:
@@ -5604,6 +5634,7 @@ class OrchestratorTools:
                             "match_lines": [i + 1 for i in shown],
                             "total_lines": total,
                             "content": f"{note}\n\n{body}",
+                            **doc_meta,
                         })
 
                     # A truncated read must say what it is missing and where,
@@ -5660,6 +5691,7 @@ class OrchestratorTools:
                         "shown_lines": f"{first}-{last}",
                         "truncated": truncated,
                         "content": content,
+                        **doc_meta,
                     })
 
                 return json.dumps({
@@ -5679,7 +5711,10 @@ class OrchestratorTools:
             name="read_file",
             description=(
                 "Read a text or JSON file — plans, protocols, scripts, "
-                "configs, logs, documents. Reads from the TOP by default; "
+                "configs, logs, documents. PDF and Word documents are "
+                "extracted to text automatically (tables preserved, scanned "
+                "pages OCR'd), so uploaded papers and proposals read like "
+                "any text file. Reads from the TOP by default; "
                 "literature-search reports are returned WHOLE. "
                 "For a long file do not read it repeatedly hoping to see more — "
                 "you will get the same lines back. A truncated read lists the "

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -454,7 +454,7 @@ To inspect or query data files before deciding on a workflow, use `read_file` an
       → omit experimental_budget (default behavior)
       
 11. `save_checkpoint`: Save campaign state. Use after every 3-5 experiments.
-12. `read_file`: Read and preview any file (JSON, text, CSV, Excel, scripts, logs, protocols).
+12. `read_file`: Read and preview any file (JSON, text, CSV, Excel, PDF, Word, scripts, logs, protocols).
     Use to inspect data files BEFORE deciding which tool to use next.
     Renders Excel/CSV as formatted tables (max 50 rows × 40 columns).
     Do not re-read files whose contents were just returned by another tool.

--- a/tests/test_planning_pdf_read_live.py
+++ b/tests/test_planning_pdf_read_live.py
@@ -1,0 +1,109 @@
+"""Live validation for #397 phase 0: planning reads PDFs (Bedrock Opus 4.8).
+
+Replays the observed failure: a planning delegation asked to review an
+uploaded PDF could not read it (read_file returned FlateDecode byte
+streams) and — correctly but terminally — refused the review and reported
+a blocker. With extraction routed through the shared parser, the same ask
+must proceed: read the actual text, quote it, no blocker.
+
+Run:
+    AWS_BEARER_TOKEN_BEDROCK=... AWS_REGION_NAME=us-east-1 \
+    python tests/test_planning_pdf_read_live.py
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import shutil
+import sys
+from pathlib import Path
+
+MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+BASE = Path("tests/_planning_pdf_read_live_runs").resolve()
+
+results = {}
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+class Tee(io.StringIO):
+    def write(self, s):
+        sys.__stdout__.write(s)
+        return super().write(s)
+
+
+WHITE_PAPER = """# CDOC White Paper (canonical, 0806)
+
+## Concept and Rationale
+
+The observatory closes the loop between perturbation and phase outcome.
+Reference [6] claims the convex hull holds roughly 380,000 entries, of
+which about 48,000 are on-hull; the committor formalism in Appendix 2
+defines the estimand.
+
+## Appendix 1 — Reciprocity table
+
+Row A: MZI-QPI vs SAXS — reciprocal in q-range.
+Row B: SPM vs WAXS — complementary in surface sensitivity.
+
+## References
+
+[6] Merchant et al., scaling deep learning for materials discovery.
+"""
+
+
+def main():
+    from scilink.agents.planning_agents.planning_orchestrator import (
+        PlanningOrchestratorAgent, AutonomyLevel)
+    from scilink.utils.md_to_pdf import markdown_text_to_pdf
+
+    run = BASE / "p1"
+    if run.exists():
+        shutil.rmtree(run)
+    data_dir = run / "data"
+    data_dir.mkdir(parents=True)
+    orch = PlanningOrchestratorAgent(
+        objective="Chemical dynamics observatory campaign design",
+        base_dir=str(run / "session"),
+        api_key=None, model_name=MODEL,
+        autonomy_level=AutonomyLevel.AUTONOMOUS,
+        data_dir=str(data_dir),
+    )
+    uploads = Path(orch.base_dir) / "uploads"
+    uploads.mkdir(parents=True, exist_ok=True)
+    pdf = uploads / "CDOC_white_paper_0806.pdf"
+    markdown_text_to_pdf(WHITE_PAPER, pdf, title="CDOC White Paper")
+
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        reply = orch.chat(
+            "Read the uploaded white paper at "
+            f"{pdf} and answer two things from its ACTUAL text: "
+            "(1) what does it claim about the convex hull entry counts, "
+            "and (2) which reference number is attached to that claim? "
+            "Quote the numbers exactly.")
+    log = buf.getvalue()
+
+    check("read_file used on the PDF",
+          "Reading file" in log and "CDOC_white_paper_0806.pdf" in log)
+    check("no blocker report", not any(
+        s in reply for s in ("cannot read", "Blocker", "blocker",
+                             "FlateDecode", "no extractable")))
+    check("counts quoted from the actual text",
+          "380,000" in reply and "48,000" in reply)
+    check("reference number correct", "[6]" in reply or "reference 6"
+          in reply.lower() or "ref 6" in reply.lower())
+
+    print()
+    npass = sum(results.values())
+    for name, ok in results.items():
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name}")
+    print(f"\n{npass}/{len(results)} checks passed")
+    sys.exit(0 if npass == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_read_file_modes.py
+++ b/tests/test_read_file_modes.py
@@ -130,3 +130,63 @@ def test_the_schema_tells_the_model_not_to_re_read(read):
     desc = src[i:i + 2600]
     assert "do not read it repeatedly" in desc
     assert "tail=true" in desc and "search=" in desc
+
+
+# ── #397 phase 0: documents route through the shared extractor ─────────────
+
+def _tool(tmp_path):
+    t = OrchestratorTools.__new__(OrchestratorTools)
+    t.functions_map, t.openai_schemas = {}, []
+    t.orch = SimpleNamespace(base_dir=tmp_path, _active_output_subdir=None,
+                             planner=SimpleNamespace())
+    t._resolve_data_path = lambda p: (str(p), None)
+    t._register_tool = lambda func, name, **kw: t.functions_map.setdefault(name, func)
+    OrchestratorTools._register_all_tools(t)
+    return t.functions_map["read_file"]
+
+
+def _make_pdf(tmp_path):
+    pytest.importorskip("fitz")
+    pytest.importorskip("markdown_it")
+    from scilink.utils.md_to_pdf import markdown_to_pdf
+    md = tmp_path / "proposal.md"
+    md.write_text("# Funded Proposal\n\n"
+                  + "".join(f"Aim {i}: paragraph of prose about MARKER-{i}. "
+                            for i in range(1, 30))
+                  + "\n\n## References\n\n[1] MARKER-REF Boettiger 2013\n")
+    return markdown_to_pdf(md, tmp_path / "proposal.pdf")
+
+
+def test_pdf_returns_prose_not_bytes(tmp_path):
+    """#397's observed failure: read_file opened a PDF as text and returned
+    '%PDF-1.7...' compressed streams; the delegation grounded on a
+    paraphrase (one run) or refused an adversarial review (another)."""
+    pdf = _make_pdf(tmp_path)
+    out = json.loads(_tool(tmp_path)(file_path=str(pdf)))
+    assert out["status"] == "success"
+    assert "%PDF" not in out["content"]
+    assert "MARKER-1" in out["content"]
+    assert out["extracted"] == "pdf" and out["n_pages"] >= 1
+
+
+def test_pdf_windowing_works(tmp_path):
+    """Extraction feeds the SAME windowing as text files — search and tail
+    answer questions about a PDF in one call."""
+    pdf = _make_pdf(tmp_path)
+    read = _tool(tmp_path)
+    out = json.loads(read(file_path=str(pdf), search="MARKER-REF"))
+    assert out["mode"] == "search" and out["matches"] == 1
+    assert "Boettiger" in out["content"]
+    out = json.loads(read(file_path=str(pdf), tail=True, max_lines=5))
+    assert "References" in out["content"] or "MARKER-REF" in out["content"]
+
+
+def test_textless_pdf_is_a_clean_error(tmp_path):
+    fitz = pytest.importorskip("fitz")
+    doc = fitz.open()
+    doc.new_page()
+    p = tmp_path / "blank.pdf"
+    doc.save(str(p))
+    out = json.loads(_tool(tmp_path)(file_path=str(p)))
+    assert out["status"] == "error"
+    assert "No extractable text" in out["message"]


### PR DESCRIPTION
## Summary

Phase 0 of #397, the one active observed failure: the planning orchestrator's `read_file` opened PDFs as text and returned compressed byte streams. Seen live twice — a delegation handed a proposal PDF quietly grounded on the caller's paraphrase instead (#397's reproducer), and this week an adversarial white-paper review correctly *refused* to proceed against an unreadable document, after which the meta tried to inline the whole extracted text into a re-delegation and hit the tool-call truncation limit. The extraction machinery has been shared all along (`parsers/extract.py`, already used by meta `view_document` and analysis `read_document`); planning was the one mode without it.

`read_file` now routes `.pdf`/`.docx` through the shared extractor — tables preserved, scanned pages OCR'd via the vision model — and feeds the text into its existing windowing, so `search`/`tail`/`offset` answer questions about a PDF in one call. Text-less (image-only, no OCR-able content) documents return a clean error instead of garbage.

Validation: offline 14/14 (`tests/test_read_file_modes.py` — prose-not-bytes, PDF windowing, textless error, all pre-existing modes untouched). Live on Bedrock Opus 4.8 (`tests/test_planning_pdf_read_live.py`) replays the blocked review: the agent reads the uploaded PDF directly, quotes the exact figures and reference number from its actual text, and reports no blocker — 4/4.

Phases 1–3 of #397 (shared `window()`, meta/analysis adoption, cap reconciliation) are untouched, as scoped in `unified_file_reading_plan.md`.

---

## Technical details

- Routing happens inside `read_file`'s text branch: `.pdf`/`.docx` → `extract_text(path, ocr_model=planner.model)` → `splitlines(keepends=True)` → the unchanged head/tail/offset/search windowing. Result payloads gain `extracted`, `n_pages`/`n_paragraphs`, `n_ocr_pages`.
- Document size guard raised to 25 MB for `.pdf`/`.docx` only (extraction is page-based; figure-heavy PDFs are megabytes of images, not of text). All other types keep the 5 MB cap.
- Tool description and the system prompt's `read_file` line updated to stay truthful (the prompt names the tool in 4 places; only the capability list needed changing).