### PR TITLE
Surgical single-knob follow-ups for curve fitting (script_edits)

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2241,6 +2241,7 @@ class AnalysisOrchestratorTools:
             task_mode: str = None,
             prior_analysis_paths: List[str] = None,
             reuse_locked_script: bool = False,
+            script_edits: List[dict] = None,
             profile: str = None,
             literature_file: str = None,
             r2_threshold: float = None,
@@ -2826,6 +2827,13 @@ class AnalysisOrchestratorTools:
                     analyze_kwargs["prior_analysis_paths"] = prior_analysis_paths
                 if reuse_locked_script:
                     analyze_kwargs["reuse_locked_script"] = True
+                if script_edits:
+                    # Surgical follow-up: only forward to agents whose
+                    # analyze() accepts it (currently curve fitting).
+                    import inspect as _inspect
+                    if "script_edits" in _inspect.signature(
+                            agent.analyze).parameters:
+                        analyze_kwargs["script_edits"] = script_edits
                 if profile:
                     # Operating profile (#346): forward only to agents whose
                     # analyze() accepts it (all three do; introspection keeps
@@ -3222,6 +3230,39 @@ class AnalysisOrchestratorTools:
                         "verification or deeper-analysis follow-ups, or for a "
                         "different kind of measurement — leave it false so the "
                         "agent decides how to use the prior run as reference."
+                    )
+                },
+                "script_edits": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "old_text": {"type": "string"},
+                            "new_text": {"type": "string"},
+                            "replace_all": {"type": "boolean"},
+                        },
+                        "required": ["old_text", "new_text"],
+                    },
+                    "description": (
+                        "Surgical single-knob follow-up (curve fitting; "
+                        "requires `prior_analysis_paths` + "
+                        "`reuse_locked_script=true`): exact old/new snippet "
+                        "pairs applied to the prior run's saved script BEFORE "
+                        "it re-executes, so the rerun differs from the prior "
+                        "run in EXACTLY the requested change — a controlled "
+                        "one-variable-at-a-time comparison. Use when the user "
+                        "asks to redo an accepted analysis with one parameter "
+                        "changed (a threshold, a bound, a window) — NOT for a "
+                        "different model or a re-derivation, where the agent "
+                        "should plan freely. Copy old_text VERBATIM from the "
+                        "prior run's saved script (scripts/*.py in its output "
+                        "dir); each edit must match exactly once. All edits "
+                        "apply atomically or the run refuses with a per-edit "
+                        "report before any execution. The result records "
+                        "`script_edits_applied` and the usual "
+                        "`reuse_validity` R² verdict (signal, not gate — the "
+                        "knob change is intentional; judge the outcome "
+                        "yourself)."
                     )
                 },
                 "profile": {

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2828,12 +2828,24 @@ class AnalysisOrchestratorTools:
                 if reuse_locked_script:
                     analyze_kwargs["reuse_locked_script"] = True
                 if script_edits:
-                    # Surgical follow-up: only forward to agents whose
-                    # analyze() accepts it (currently curve fitting).
+                    # Surgical follow-up: only curve fitting supports it.
+                    # An unsupported agent must REFUSE, not silently drop
+                    # the caller's explicitly requested change (same
+                    # principle as the multi-regime guard).
                     import inspect as _inspect
                     if "script_edits" in _inspect.signature(
                             agent.analyze).parameters:
                         analyze_kwargs["script_edits"] = script_edits
+                    else:
+                        return json.dumps({
+                            "status": "error",
+                            "message": (
+                                f"script_edits is not supported by "
+                                f"{type(agent).__name__} — it is a "
+                                "curve-fitting capability (surgical edits "
+                                "to a prior fitting script). Re-run "
+                                "without script_edits, or route 1D curve "
+                                "data to the curve-fitting agent.")})
                 if profile:
                     # Operating profile (#346): forward only to agents whose
                     # analyze() accepts it (all three do; introspection keeps

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1069,6 +1069,33 @@ def _first_prior_curve_fit_script(state: dict):
     return None, None
 
 
+def _apply_reuse_script_edits(state: dict, reuse_script, reuse_source,
+                              logger=None):
+    """Apply the caller's surgical ``script_edits`` to the reused script.
+
+    Single-knob follow-ups on the #172 locked-reuse path: the prior script
+    runs byte-identical EXCEPT the requested edits, so consecutive runs stay
+    comparable one variable at a time. Edits were validated at ``analyze()``
+    entry against this same prior script, so a failure here means the prior
+    run changed on disk mid-run — refuse loudly rather than silently run
+    the UNEDITED script the caller asked to change.
+    """
+    edits = state.get("script_edits") or []
+    if not (reuse_script and edits):
+        return reuse_script, reuse_source
+    from scilink.utils.file_edit import apply_snippet_edits
+    res = apply_snippet_edits(reuse_script, edits)
+    if res["status"] != "success":
+        raise RuntimeError(
+            f"script_edits no longer apply to the prior script "
+            f"({res['message']}) — the prior run changed on disk after "
+            "validation. Nothing was run.")
+    if logger:
+        logger.info(f"   ✏️  Applied {res['n_edits']} surgical edit(s) to "
+                    f"the reused script (execution will verify)")
+    return res["text"], f"{reuse_source} + {res['n_edits']} edit(s)"
+
+
 def _append_objective_context(prompt: list, state: dict) -> None:
     """Append high-level scientific objective to an LLM prompt.
 
@@ -4523,6 +4550,14 @@ Return JSON with:
                 "verdict": verdict,
                 "message": message,
             }
+            # Surgical follow-up provenance: the exact old/new pairs applied
+            # to the prior script, so the delta between consecutive runs is
+            # auditable from the saved results alone.
+            if ctx.state.get("script_edits"):
+                reuse_result["script_edits_applied"] = list(
+                    ctx.state["script_edits"])
+                reuse_result["reuse_validity"]["script_edits"] = len(
+                    ctx.state["script_edits"])
             if verdict == "poor":
                 reuse_result["quality_warning"] = message
             # Realtime drift channel (#346 step 3): the gate metric measures
@@ -6117,6 +6152,8 @@ Return JSON with:
         # reproduces it).
         if state.get("reuse_locked_script"):
             reuse_script, reuse_source = _first_prior_curve_fit_script(state)
+            reuse_script, reuse_source = _apply_reuse_script_edits(
+                state, reuse_script, reuse_source, self.logger)
         else:
             reuse_script, reuse_source = None, None
         # Verbatim cold start (#346 step 4): a realtime run with no explicit

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -6166,6 +6166,17 @@ Return JSON with:
             reuse_script = cs.get("script")
             reuse_source = f"script_bank:{cs.get('id')}"
         if reuse_script and regime_configs:
+            # script_edits made it past entry validation, but the series
+            # plan split this run into regimes, which disables reuse — the
+            # caller's explicitly requested edits would be silently dropped
+            # and the run would re-derive freely. Refuse loudly instead.
+            if state.get("script_edits"):
+                raise RuntimeError(
+                    "script_edits cannot be applied: the series plan split "
+                    "this run into multiple regimes, which disables locked-"
+                    "script reuse. Either re-run without script_edits "
+                    "(per-regime models will be re-derived), or fit the "
+                    "points individually as single-regime follow-ups.")
             self.logger.info(
                 "   ♻️  Locked-script reuse requested, but this run is "
                 "multi-regime — reuse skipped."

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -301,6 +301,12 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # with a fixed model / feature-table schema (#172).
         prior_analysis_paths: Optional[List[str]] = None,
         reuse_locked_script: bool = False,
+        # Surgical single-knob follow-up on the locked-reuse path: exact
+        # old/new snippet pairs applied to the prior script BEFORE the
+        # verbatim run, so the rerun is byte-identical except the knob
+        # (requires prior_analysis_paths + reuse_locked_script). Validated
+        # up front; the sandbox run remains the verification.
+        script_edits: Optional[List[Dict[str, Any]]] = None,
         literature_file: Optional[str] = None,
         # Quality control overrides (optional)
         r2_threshold: Optional[float] = None,
@@ -500,6 +506,37 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                     "can be cold-started."
                 )
             realtime_cold_start = True
+
+        # Surgical script edits — validated HERE, before any pipeline work:
+        # the edits must apply cleanly to the prior run's saved script or the
+        # run refuses with the per-edit report. Never a partial application,
+        # never a silent unedited run, zero LLM cost on refusal.
+        if script_edits:
+            def _edits_error(err: str, details: str, **extra):
+                return {"status": "error",
+                        "error": {"error": err, "details": details, **extra},
+                        "output_directory": str(self.output_dir)}
+            if not (prior_analysis_paths and reuse_locked_script):
+                return _edits_error(
+                    "script_edits requires locked reuse",
+                    "Pass prior_analysis_paths=[<prior run dir>] and "
+                    "reuse_locked_script=True — script_edits surgically "
+                    "modifies that prior script before the verbatim run.")
+            from .controllers.curve_fitting_controllers import (
+                _first_prior_curve_fit_script)
+            from scilink.utils.file_edit import apply_snippet_edits
+            _prior_script, _ = _first_prior_curve_fit_script(
+                {"prior_analysis_paths": prior_analysis_paths})
+            if not _prior_script:
+                return _edits_error(
+                    "no reusable prior script",
+                    "None of prior_analysis_paths carries a saved fitting "
+                    "script (series_fit_results.json + scripts/*.py).")
+            _res = apply_snippet_edits(_prior_script, script_edits)
+            if _res["status"] != "success":
+                return _edits_error(
+                    "script_edits do not apply", _res["message"],
+                    failed_edit=_res.get("failed_edit"))
 
         # Resolve task_mode — caller sets this explicitly (standalone user or
         # orchestrator). Defaults to "fitting" when unset.
@@ -819,6 +856,9 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             # Opt-in: force verbatim reuse of the prior locked script (#172).
             # Default False — prior runs are agent-judged reference material.
             "reuse_locked_script": bool(reuse_locked_script),
+            # Surgical follow-up edits applied to the reused script (already
+            # validated above; the series controller applies them).
+            "script_edits": script_edits or [],
             # Verbatim cold start (#346 step 4): the audition winner, threaded
             # into the series controller's reuse path (None when not used).
             "_cold_start_reuse": ({

--- a/tests/test_script_edits_live.py
+++ b/tests/test_script_edits_live.py
@@ -192,7 +192,360 @@ def part2_routing():
         check("p2 provenance recorded", bool(r0.get("script_edits_applied")))
 
 
-PARTS = {"1": part1_wiring, "2": part2_routing}
+MARK_EDIT = {"old_text": "import numpy as np",
+             "new_text": "import numpy as np  # SURGICAL-EDIT-MARK"}
+
+
+def _rglob_sfrs(root: Path):
+    return sorted(Path(root).rglob("series_fit_results.json"),
+                  key=lambda p: p.stat().st_mtime)
+
+
+def part3_meta_cross_delegation():
+    """S1: the designed case — knob follow-up across meta delegations."""
+    print("\n=== 3. meta: cross-delegation knob follow-up ===")
+    from scilink.agents.meta_agent.meta_orchestrator import (
+        MetaOrchestratorAgent, MetaMode)
+
+    run = BASE / "p3"
+    if run.exists():
+        shutil.rmtree(run)
+    run.mkdir(parents=True)
+    make_spectrum(run / "spec_a.csv", center=5.0, seed=11)
+    make_spectrum(run / "spec_b.csv", center=5.1, seed=12)
+
+    meta = MetaOrchestratorAgent(
+        base_dir=str(run / "meta_session"), api_key=None,
+        model_name=MODEL, meta_mode=MetaMode.AUTONOMOUS)
+    buf = Tee()
+    with capture_all(buf):
+        meta.chat(
+            f"Fit the 1D spectrum at {run / 'spec_a.csv'} (single Gaussian "
+            "peak on a linear background, curve fitting). Smoke test: "
+            "max_verification_iterations=1, accept the first reasonable "
+            "fit.")
+        meta.chat(
+            f"{run / 'spec_b.csv'} is the NEXT measurement of the same "
+            "series. Re-fit it reusing the locked script so the feature "
+            "columns stay identical — but with ONE surgical change: read "
+            "the saved fitting script and modify a single numeric value "
+            "(initial guess, tolerance, or iteration limit). Report what "
+            "you changed.")
+    log = buf.getvalue()
+
+    # Child agents log inside the delegation, not to the meta's stream —
+    # assert on the child session's ARTIFACTS, which are stronger anyway.
+    sfrs = _rglob_sfrs(run / "meta_session")
+    check("p3 two fit runs in the child session", len(sfrs) >= 2)
+    if len(sfrs) >= 2:
+        rec = json.loads(sfrs[-1].read_text())
+        r0 = (rec.get("results") or [{}])[0]
+        rv = r0.get("reuse_validity") or {}
+        check("p3 reuse fast path used (validity verdict attached)",
+              rv.get("reused") is True)
+        check("p3 edit applied through the delegation chain",
+              "edit(s)" in str(rv.get("source"))
+              and bool(r0.get("script_edits_applied")))
+
+
+def part4_meta_same_delegation():
+    """S2: one delegation carries both steps (fit, then tweak)."""
+    print("\n=== 4. meta: same-delegation two-step ===")
+    from scilink.agents.meta_agent.meta_orchestrator import (
+        MetaOrchestratorAgent, MetaMode)
+
+    run = BASE / "p4"
+    if run.exists():
+        shutil.rmtree(run)
+    run.mkdir(parents=True)
+    make_spectrum(run / "spec_a.csv", center=5.0, seed=21)
+    make_spectrum(run / "spec_b.csv", center=5.05, seed=22)
+
+    meta = MetaOrchestratorAgent(
+        base_dir=str(run / "meta_session"), api_key=None,
+        model_name=MODEL, meta_mode=MetaMode.AUTONOMOUS)
+    buf = Tee()
+    with capture_all(buf):
+        meta.chat(
+            f"Two-step curve-fitting job (smoke test, "
+            f"max_verification_iterations=1): first fit {run / 'spec_a.csv'} "
+            "(single Gaussian on linear background). Then fit "
+            f"{run / 'spec_b.csv'} as the next measurement of the same "
+            "series, reusing the locked script for schema consistency but "
+            "with ONE surgical numeric change of your choice to the saved "
+            "script. Report the change.")
+    log = buf.getvalue()
+
+    sfrs = _rglob_sfrs(run / "meta_session")
+    check("p4 two fit runs present", len(sfrs) >= 2)
+    if len(sfrs) >= 2:
+        r0 = (json.loads(sfrs[-1].read_text()).get("results") or [{}])[0]
+        rv = r0.get("reuse_validity") or {}
+        check("p4 reuse fast path used", rv.get("reused") is True)
+        check("p4 edit applied within one delegation",
+              bool(r0.get("script_edits_applied")))
+
+
+def part5_chaining():
+    """S3: anchor-pointed vs previous-point-pointed chaining, plus the
+    mixing failure (re-passing a baked-in edit refuses cleanly)."""
+    print("\n=== 5. chaining semantics (agent-level, deterministic) ===")
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+
+    run = BASE / "p5"
+    if run.exists():
+        shutil.rmtree(run)
+    run.mkdir(parents=True)
+    for i, (c, s) in enumerate([(5.0, 31), (5.05, 32), (5.1, 33),
+                                (5.15, 34)]):
+        make_spectrum(run / f"spec_{i}.csv", center=c, seed=s)
+
+    def agent(sub):
+        return CurveFittingAgent(
+            api_key=None, model_name=MODEL, output_dir=str(run / sub),
+            enable_human_feedback=False, max_verification_iterations=1)
+
+    res = agent("anchor").analyze(str(run / "spec_0.csv"),
+                                  system_info=SYS_INFO)
+    check("p5 anchor succeeded", res.get("status") == "success")
+    _, script_a = _saved_script(run / "anchor")
+    assert "import numpy as np" in script_a
+
+    # A knob-shaped edit: old_text is fully CONSUMED by new_text (like a
+    # real value change), so re-applying it against the edited script
+    # cannot match — that is what makes the mixing case refuse.
+    chain_edit = {"old_text": "import numpy as np",
+                  "new_text": ("import numpy as xx_np  "
+                               "# SURGICAL-EDIT-MARK\nnp = xx_np")}
+
+    # b1: anchor-pointed WITH the edit
+    r1 = agent("b1").analyze(
+        str(run / "spec_1.csv"), system_info=SYS_INFO,
+        prior_analysis_paths=[str(run / "anchor")],
+        reuse_locked_script=True, script_edits=[chain_edit])
+    _, s1 = _saved_script(run / "b1")
+    check("p5 anchor-pointed edit applied",
+          r1.get("status") == "success" and "SURGICAL-EDIT-MARK" in s1)
+
+    # b2: previous-point-pointed, NO edits -> the edit is baked in
+    r2 = agent("b2").analyze(
+        str(run / "spec_2.csv"), system_info=SYS_INFO,
+        prior_analysis_paths=[str(run / "b1")],
+        reuse_locked_script=True)
+    _, s2 = _saved_script(run / "b2")
+    check("p5 baked-in edit persists without re-passing",
+          r2.get("status") == "success" and "SURGICAL-EDIT-MARK" in s2
+          and s2 == s1)
+
+    # b3: mixing styles — re-passing the edit against the edited run
+    r3 = agent("b3").analyze(
+        str(run / "spec_3.csv"), system_info=SYS_INFO,
+        prior_analysis_paths=[str(run / "b1")],
+        reuse_locked_script=True, script_edits=[chain_edit])
+    check("p5 mixing styles refuses cleanly (old_text already replaced)",
+          r3.get("status") == "error"
+          and r3["error"]["error"] == "script_edits do not apply")
+
+
+def part6_realtime():
+    """S4: realtime frames execute the EDITED script, zero-LLM happy path."""
+    print("\n=== 6. realtime stream with script_edits ===")
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+
+    run = BASE / "p6"
+    if run.exists():
+        shutil.rmtree(run)
+    run.mkdir(parents=True)
+    make_spectrum(run / "anchor.csv", center=5.0, seed=41)
+    for i in range(2):
+        make_spectrum(run / f"frame_{i}.csv", center=5.0 + 0.02 * i,
+                      seed=42 + i)
+
+    anchor = CurveFittingAgent(
+        api_key=None, model_name=MODEL, output_dir=str(run / "anchor_run"),
+        enable_human_feedback=False, max_verification_iterations=1)
+    res = anchor.analyze(str(run / "anchor.csv"), system_info=SYS_INFO)
+    check("p6 anchor succeeded", res.get("status") == "success")
+
+    buf = Tee()
+    with capture_all(buf):
+        for i in range(2):
+            frame_agent = CurveFittingAgent(
+                api_key=None, model_name=MODEL,
+                output_dir=str(run / f"frame_run_{i}"),
+                enable_human_feedback=False)
+            fr = frame_agent.analyze(
+                str(run / f"frame_{i}.csv"), system_info=SYS_INFO,
+                profile="realtime",
+                prior_analysis_paths=[str(run / "anchor_run")],
+                reuse_locked_script=True, script_edits=[MARK_EDIT])
+            check(f"p6 frame {i} succeeded", fr.get("status") == "success")
+    log = buf.getvalue()
+    check("p6 edit applied on every frame",
+          log.count("Applied 1 surgical edit") == 2)
+    marks = [
+        "SURGICAL-EDIT-MARK" in _saved_script(run / f"frame_run_{i}")[1]
+        for i in range(2)]
+    check("p6 every frame executed the edited script", all(marks))
+
+
+def part7_fanout_variants():
+    """S5: knob VARIANTS in parallel branches (or sequential delegations —
+    either route validates the per-branch mechanics; the route is
+    reported)."""
+    print("\n=== 7. meta: two knob variants of the same anchor ===")
+    from scilink.agents.meta_agent.meta_orchestrator import (
+        MetaOrchestratorAgent, MetaMode)
+
+    run = BASE / "p7"
+    if run.exists():
+        shutil.rmtree(run)
+    run.mkdir(parents=True)
+    make_spectrum(run / "spec_a.csv", center=5.0, seed=51)
+    make_spectrum(run / "spec_b.csv", center=5.05, seed=52)
+
+    meta = MetaOrchestratorAgent(
+        base_dir=str(run / "meta_session"), api_key=None,
+        model_name=MODEL, meta_mode=MetaMode.AUTONOMOUS)
+    buf = Tee()
+    with capture_all(buf):
+        meta.chat(
+            f"Fit {run / 'spec_a.csv'} (single Gaussian on linear "
+            "background, curve fitting; smoke test, "
+            "max_verification_iterations=1). Then produce TWO surgical "
+            f"variants of that fit on {run / 'spec_b.csv'}: both reuse the "
+            "locked script, each changing the SAME single numeric value to "
+            "a different setting (e.g. two different iteration limits). "
+            "Compare the two R² values at the end.")
+    log = buf.getvalue()
+
+    edited = []
+    for sfr in _rglob_sfrs(run / "meta_session"):
+        r0 = (json.loads(sfr.read_text()).get("results") or [{}])[0]
+        if r0.get("script_edits_applied"):
+            edited.append(r0["script_edits_applied"])
+    print(f"     edited variants found: {len(edited)}")
+    check("p7 at least two edited variants ran", len(edited) >= 2)
+    check("p7 the two variants differ",
+          len(edited) >= 2 and edited[-1] != edited[-2])
+    check("p7 route observed (informational)", True)
+    print("     route: " + ("fan-out" if "fan" in log.lower()
+                            else "sequential delegations"))
+
+
+def part8_refusals():
+    """S6: the pre-execution refusals, against the real agent stack."""
+    print("\n=== 8. refusals: zero-cost, nothing runs ===")
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+
+    run = BASE / "p8"
+    if run.exists():
+        shutil.rmtree(run)
+    run.mkdir(parents=True)
+    make_spectrum(run / "spec.csv", center=5.0, seed=61)
+    # a minimal but real prior run: reuse part 1's anchor if present,
+    # else make a stub that the loader accepts
+    prior = BASE / "p1" / "anchor"
+    if not (prior / "series_fit_results.json").exists():
+        prior = run / "prior"
+        (prior / "scripts").mkdir(parents=True)
+        (prior / "scripts" / "fitting_script.py").write_text(
+            "import numpy as np\nprint('CUSTOM_SCRIPT_SUCCESS')\n")
+        (prior / "series_fit_results.json").write_text(
+            json.dumps({"results": [{"success": True}]}))
+
+    agent = CurveFittingAgent(
+        api_key=None, model_name=MODEL, output_dir=str(run / "out"),
+        enable_human_feedback=False)
+
+    r = agent.analyze(str(run / "spec.csv"), system_info=SYS_INFO,
+                      prior_analysis_paths=[str(prior)],
+                      script_edits=[MARK_EDIT])
+    check("p8 edits without reuse flag refused",
+          r.get("status") == "error"
+          and "reuse_locked_script" in r["error"]["details"])
+
+    r = agent.analyze(str(run / "spec.csv"), system_info=SYS_INFO,
+                      prior_analysis_paths=[str(prior)],
+                      reuse_locked_script=True,
+                      script_edits=[{"old_text": "NOT IN THE SCRIPT",
+                                     "new_text": "x"}])
+    check("p8 non-matching edit refused with per-edit report",
+          r.get("status") == "error"
+          and r["error"]["error"] == "script_edits do not apply")
+    check("p8 nothing ran", not (run / "out" / "scripts").exists())
+
+
+def part9_multiregime():
+    """The patched gap: a regime-split series REFUSES script_edits loudly
+    instead of silently dropping them and re-deriving freely."""
+    print("\n=== 9. multi-regime series: loud refusal, not silent drop ===")
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+
+    run = BASE / "p9"
+    if run.exists():
+        shutil.rmtree(run)
+    run.mkdir(parents=True)
+    # anchor: single Gaussian
+    make_spectrum(run / "anchor.csv", center=5.0, seed=71)
+    # series crossing a "transition": 2 one-peak frames, then 2 two-peak
+    rng = np.random.default_rng(72)
+    x = np.linspace(0, 10, 400)
+    series = []
+    for i in range(4):
+        y = 2.0 * np.exp(-((x - 5.0) ** 2) / (2 * 0.4 ** 2)) + 0.3
+        if i >= 2:
+            y = y + 1.5 * np.exp(-((x - 7.5) ** 2) / (2 * 0.3 ** 2))
+        y = y + rng.normal(0, 0.02, x.size)
+        p = run / f"series_{i}.csv"
+        np.savetxt(p, np.column_stack([x, y]), delimiter=",",
+                   header="position,intensity", comments="")
+        series.append(str(p))
+
+    anchor = CurveFittingAgent(
+        api_key=None, model_name=MODEL, output_dir=str(run / "anchor_run"),
+        enable_human_feedback=False, max_verification_iterations=1)
+    res = anchor.analyze(str(run / "anchor.csv"), system_info=SYS_INFO)
+    check("p9 anchor succeeded", res.get("status") == "success")
+
+    agent = CurveFittingAgent(
+        api_key=None, model_name=MODEL, output_dir=str(run / "series_run"),
+        enable_human_feedback=False, max_verification_iterations=1)
+    buf = Tee()
+    with capture_all(buf):
+        r = agent.analyze(
+            series, system_info={
+                **SYS_INFO,
+                "note": ("temperature series crossing a known structural "
+                         "phase transition between frames 2 and 3 — a "
+                         "second peak appears; plan separate per-regime "
+                         "models for before and after the transition")},
+            series_metadata={"variable": "temperature",
+                             "values": [10, 20, 30, 40]},
+            prior_analysis_paths=[str(run / "anchor_run")],
+            reuse_locked_script=True, script_edits=[MARK_EDIT])
+    log = buf.getvalue()
+
+    regimes_declared = "regime configuration(s)" in log
+    print(f"     regimes declared by the planner: {regimes_declared}")
+    if regimes_declared:
+        check("p9 refused loudly (patched gap)",
+              r.get("status") == "error"
+              and "multiple regimes" in str(r.get("error", {})))
+    else:
+        # planner chose a single regime — the refusal cannot fire; the
+        # run must then be a normal edited reuse (still a valid outcome)
+        check("p9 single-regime fallback: edited reuse ran (INCONCLUSIVE "
+              "for the regime guard — planner declared no regimes)",
+              r.get("status") == "success"
+              and "Applied 1 surgical edit" in log)
+
+
+PARTS = {"1": part1_wiring, "2": part2_routing,
+         "3": part3_meta_cross_delegation, "4": part4_meta_same_delegation,
+         "5": part5_chaining, "6": part6_realtime,
+         "7": part7_fanout_variants, "8": part8_refusals,
+         "9": part9_multiregime}
 
 if __name__ == "__main__":
     for k in (sys.argv[1:] or sorted(PARTS)):

--- a/tests/test_script_edits_live.py
+++ b/tests/test_script_edits_live.py
@@ -1,0 +1,205 @@
+"""Live validation for script_edits (Phase A of the surgical-refinement
+plan) on Bedrock Opus 4.8.
+
+  1. wiring   — agent-level, deterministic: a real anchor fit, then a
+                reuse run with a test-constructed surgical edit. The
+                rerun's saved script must equal the anchor's byte-for-
+                byte EXCEPT the edit; provenance recorded; reuse
+                validity attached.
+  2. routing  — orchestrator chat: "next point of the same series, but
+                change one knob". The LLM must read the saved script,
+                pass script_edits with a verbatim snippet, and the two
+                runs' scripts must differ in only a few lines — not a
+                re-derivation, not an unedited reuse.
+
+Needs AWS_BEARER_TOKEN_BEDROCK (+ UNSAFE_EXECUTION_OK=true: curve
+fitting executes generated code).
+
+Run:
+    AWS_BEARER_TOKEN_BEDROCK=... AWS_REGION_NAME=us-east-1 \
+    UNSAFE_EXECUTION_OK=true python tests/test_script_edits_live.py [1 2]
+"""
+from __future__ import annotations
+
+import contextlib
+import difflib
+import io
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import numpy as np
+
+MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+BASE = Path("tests/_script_edits_live_runs").resolve()
+
+results = {}
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+class Tee(io.StringIO):
+    def write(self, s):
+        sys.__stdout__.write(s)
+        return super().write(s)
+
+
+@contextlib.contextmanager
+def capture_all(buf):
+    """Agents narrate via logging, orchestrators via print — capture both."""
+    import logging
+    handler = logging.StreamHandler(buf)
+    logging.getLogger().addHandler(handler)
+    try:
+        with contextlib.redirect_stdout(buf):
+            yield
+    finally:
+        logging.getLogger().removeHandler(handler)
+
+
+def make_spectrum(path, center, seed):
+    rng = np.random.default_rng(seed)
+    x = np.linspace(0, 10, 400)
+    y = (2.0 * np.exp(-((x - center) ** 2) / (2 * 0.4 ** 2))
+         + 0.3 + 0.02 * x + rng.normal(0, 0.02, x.size))
+    np.savetxt(path, np.column_stack([x, y]), delimiter=",",
+               header="position,intensity", comments="")
+
+
+SYS_INFO = {"technique": "generic 1D spectroscopy",
+            "x_axis": "position (a.u.)", "y_axis": "intensity (a.u.)"}
+
+
+def _saved_script(run_dir: Path) -> tuple[Path, str]:
+    scripts = sorted((Path(run_dir) / "scripts").glob("*.py"))
+    assert scripts, f"no saved script under {run_dir}/scripts"
+    return scripts[0], scripts[0].read_text()
+
+
+def part1_wiring():
+    print("\n=== 1. agent-level: byte-exact except the edit ===")
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+
+    run = BASE / "p1"
+    if run.exists():
+        shutil.rmtree(run)
+    run.mkdir(parents=True)
+    spec_a, spec_b = run / "spec_a.csv", run / "spec_b.csv"
+    make_spectrum(spec_a, center=5.0, seed=1)
+    make_spectrum(spec_b, center=5.1, seed=2)
+
+    agent_a = CurveFittingAgent(
+        api_key=None, model_name=MODEL, output_dir=str(run / "anchor"),
+        enable_human_feedback=False, max_verification_iterations=1)
+    res_a = agent_a.analyze(str(spec_a), system_info=SYS_INFO)
+    check("p1 anchor fit succeeded", res_a.get("status") == "success")
+    _, script_a = _saved_script(run / "anchor")
+
+    # A guaranteed-present, behavior-neutral snippet: the numpy import.
+    # Part 1 validates the MECHANISM (exact application, provenance,
+    # execution); part 2 exercises a real knob chosen by the LLM.
+    assert "import numpy as np" in script_a
+    edit = {"old_text": "import numpy as np",
+            "new_text": "import numpy as np  # SURGICAL-EDIT-MARK"}
+
+    agent_b = CurveFittingAgent(
+        api_key=None, model_name=MODEL, output_dir=str(run / "rerun"),
+        enable_human_feedback=False, max_verification_iterations=1)
+    buf = Tee()
+    with capture_all(buf):
+        res_b = agent_b.analyze(
+            str(spec_b), system_info=SYS_INFO,
+            prior_analysis_paths=[str(run / "anchor")],
+            reuse_locked_script=True, script_edits=[edit])
+    log = buf.getvalue()
+
+    check("p1 rerun succeeded", res_b.get("status") == "success")
+    check("p1 edit applied (log)", "Applied 1 surgical edit" in log)
+    check("p1 reuse fast path used (not re-derivation)",
+          "Reusing locked fitting script" in log)
+    _, script_b = _saved_script(run / "rerun")
+    check("p1 mark present in executed script",
+          "SURGICAL-EDIT-MARK" in script_b)
+    check("p1 byte-identical except the edit",
+          script_b.replace("  # SURGICAL-EDIT-MARK", "") == script_a)
+    sfr = json.loads((run / "rerun" / "series_fit_results.json").read_text())
+    r0 = (sfr.get("results") or [{}])[0]
+    rv = r0.get("reuse_validity") or {}
+    check("p1 provenance: source labeled with the edit count",
+          "+ 1 edit(s)" in str(rv.get("source")))
+    check("p1 provenance: edits recorded in the result",
+          r0.get("script_edits_applied") == [edit])
+
+
+def part2_routing():
+    print("\n=== 2. orchestrator: single-knob follow-up routes to edits ===")
+    from scilink.agents.exp_agents.analysis_orchestrator import (
+        AnalysisOrchestratorAgent, AnalysisMode)
+
+    run = BASE / "p2"
+    if run.exists():
+        shutil.rmtree(run)
+    run.mkdir(parents=True)
+    spec_a, spec_b = run / "spec_a.csv", run / "spec_b.csv"
+    make_spectrum(spec_a, center=5.0, seed=3)
+    make_spectrum(spec_b, center=5.15, seed=4)
+
+    orch = AnalysisOrchestratorAgent(
+        base_dir=str(run / "session"), api_key=None, model_name=MODEL,
+        analysis_mode=AnalysisMode.AUTONOMOUS)
+
+    buf = Tee()
+    with capture_all(buf):
+        orch.chat(
+            f"Fit the 1D spectrum at {spec_a} (single Gaussian peak on a "
+            "linear background). Smoke test: max_verification_iterations=1, "
+            "accept the first reasonable fit.")
+        reply = orch.chat(
+            f"{spec_b} is the NEXT measurement of the same series. Re-fit "
+            "it reusing the locked script so the feature columns stay "
+            "identical — but with ONE surgical change: read the saved "
+            "fitting script first, then modify a single numeric value in "
+            "it (an initial guess, tolerance, or iteration limit of your "
+            "choice). Tell me exactly what you changed.")
+    log = buf.getvalue()
+
+    check("p2 edit path used (log)", "Applied 1 surgical edit" in log
+          or "surgical edit" in log)
+    check("p2 reuse fast path used", "Reusing locked fitting script" in log)
+
+    session = run / "session"
+    run_dirs = sorted(d for d in (session / "results").glob("*CurveFit*")
+                      if d.is_dir()) if (session / "results").is_dir() else \
+        sorted(d for d in session.rglob("series_fit_results.json"))
+    # locate the two runs' scripts wherever the session layout put them
+    sfrs = sorted(session.rglob("series_fit_results.json"))
+    check("p2 two fit runs present", len(sfrs) >= 2)
+    if len(sfrs) >= 2:
+        s1 = _saved_script(sfrs[0].parent)[1]
+        s2 = _saved_script(sfrs[-1].parent)[1]
+        ndiff = sum(1 for l in difflib.unified_diff(
+            s1.splitlines(), s2.splitlines(), lineterm="")
+            if l.startswith(("+", "-")) and not l.startswith(("+++", "---")))
+        print(f"     script diff: {ndiff} changed line(s)")
+        check("p2 scripts differ minimally (edit, not re-derivation)",
+              1 <= ndiff <= 6)
+        rec = json.loads(sfrs[-1].read_text())
+        r0 = (rec.get("results") or [{}])[0]
+        check("p2 provenance recorded", bool(r0.get("script_edits_applied")))
+
+
+PARTS = {"1": part1_wiring, "2": part2_routing}
+
+if __name__ == "__main__":
+    for k in (sys.argv[1:] or sorted(PARTS)):
+        PARTS[k]()
+    print("\n" + "=" * 60)
+    npass = sum(results.values())
+    for name, ok in results.items():
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name}")
+    print(f"\n{npass}/{len(results)} checks passed")
+    sys.exit(0 if npass == len(results) else 1)

--- a/tests/test_script_edits_reuse.py
+++ b/tests/test_script_edits_reuse.py
@@ -114,6 +114,19 @@ def test_non_matching_edits_refused_before_any_work(agent, tmp_path):
     assert out["error"]["failed_edit"] == 2
 
 
+def test_multi_regime_refuses_rather_than_dropping_edits():
+    """Regime split disables reuse; with script_edits present that must be
+    a loud refusal, not a silent fallback to free re-derivation (the run
+    would quietly ignore the caller's explicitly requested change)."""
+    src = Path("scilink/agents/exp_agents/controllers/"
+               "curve_fitting_controllers.py").read_text()
+    i = src.index("multi-regime — reuse skipped")
+    guard = src[i - 1200:i]
+    assert 'state.get("script_edits")' in guard
+    assert "raise RuntimeError" in guard
+    assert "script_edits cannot be applied" in guard
+
+
 # ---------------------------------------------- orchestrator surface
 
 

--- a/tests/test_script_edits_reuse.py
+++ b/tests/test_script_edits_reuse.py
@@ -1,0 +1,131 @@
+"""script_edits — surgical single-knob follow-ups on the #172 reuse path.
+
+Phase A of analysis_script_surgical_refinement_plan.md: "same analysis,
+but with one knob changed" re-ran full codegen and produced a script
+differing in a dozen incidental ways, breaking one-variable-at-a-time
+comparability. script_edits applies exact old/new pairs to the prior
+run's saved script BEFORE the verbatim reuse run — the rerun differs in
+exactly the knob, and the sandbox run remains the verification
+(execute-don't-gate semantics unchanged from #172).
+"""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+    _apply_reuse_script_edits)
+
+SCRIPT = ("import numpy as np\n"
+          "THRESH = 0.02\n"
+          "WINDOW = (1.0, 9.0)\n"
+          "print('CUSTOM_SCRIPT_SUCCESS')\n")
+
+
+def make_prior_run(tmp_path):
+    run = tmp_path / "prior_run"
+    (run / "scripts").mkdir(parents=True)
+    (run / "scripts" / "fitting_script.py").write_text(SCRIPT)
+    (run / "series_fit_results.json").write_text(json.dumps({
+        "results": [{"model_type": "pseudo_voigt", "success": True}],
+        "total_spectra": 1, "successful": 1,
+    }))
+    return run
+
+
+# ---------------------------------------------- controller helper
+
+
+def test_edits_applied_and_source_labeled(tmp_path):
+    state = {"script_edits": [
+        {"old_text": "THRESH = 0.02", "new_text": "THRESH = 0.05"}]}
+    text, src = _apply_reuse_script_edits(state, SCRIPT, "prior_run_001")
+    assert "THRESH = 0.05" in text and "THRESH = 0.02" not in text
+    assert text.replace("THRESH = 0.05", "THRESH = 0.02") == SCRIPT
+    assert src == "prior_run_001 + 1 edit(s)"
+
+
+def test_no_edits_or_no_script_is_a_no_op():
+    assert _apply_reuse_script_edits({}, SCRIPT, "s") == (SCRIPT, "s")
+    assert _apply_reuse_script_edits(
+        {"script_edits": [{"old_text": "a", "new_text": "b"}]},
+        None, None) == (None, None)
+
+
+def test_non_applying_edit_refuses_loudly():
+    """Post-validation failure means the prior run changed on disk — refuse
+    rather than silently run the UNEDITED script."""
+    state = {"script_edits": [{"old_text": "NOT THERE", "new_text": "x"}]}
+    with pytest.raises(RuntimeError, match="no longer apply"):
+        _apply_reuse_script_edits(state, SCRIPT, "s")
+
+
+# ---------------------------------------------- analyze() entry validation
+
+
+@pytest.fixture
+def agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNSAFE_EXECUTION_OK", "true")
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+    return CurveFittingAgent(
+        api_key="offline-dummy", model_name="claude-opus-5",
+        output_dir=str(tmp_path / "out"), enable_human_feedback=False,
+        use_literature=False)
+
+
+DATA = np.column_stack([np.linspace(0, 10, 50),
+                        np.exp(-((np.linspace(0, 10, 50) - 5) ** 2))])
+
+
+def test_edits_without_reuse_flag_refused(agent, tmp_path):
+    run = make_prior_run(tmp_path)
+    out = agent.analyze(
+        DATA, system_info="curve",
+        prior_analysis_paths=[str(run)],
+        script_edits=[{"old_text": "THRESH = 0.02",
+                       "new_text": "THRESH = 0.05"}])
+    assert out["status"] == "error"
+    assert "reuse_locked_script" in out["error"]["details"]
+
+
+def test_edits_with_no_prior_script_refused(agent, tmp_path):
+    empty = tmp_path / "empty_run"
+    empty.mkdir()
+    out = agent.analyze(
+        DATA, system_info="curve",
+        prior_analysis_paths=[str(empty)], reuse_locked_script=True,
+        script_edits=[{"old_text": "a", "new_text": "b"}])
+    assert out["status"] == "error"
+    assert "prior script" in out["error"]["error"]
+
+
+def test_non_matching_edits_refused_before_any_work(agent, tmp_path):
+    run = make_prior_run(tmp_path)
+    out = agent.analyze(
+        DATA, system_info="curve",
+        prior_analysis_paths=[str(run)], reuse_locked_script=True,
+        script_edits=[
+            {"old_text": "THRESH = 0.02", "new_text": "THRESH = 0.05"},
+            {"old_text": "NOT IN SCRIPT", "new_text": "x"}])
+    assert out["status"] == "error"
+    assert out["error"]["error"] == "script_edits do not apply"
+    assert out["error"]["failed_edit"] == 2
+
+
+# ---------------------------------------------- orchestrator surface
+
+
+def test_orchestrator_forwards_and_documents_script_edits():
+    src = Path("scilink/agents/exp_agents/analysis_orchestrator_tools.py"
+               ).read_text()
+    assert '"script_edits"' in src
+    i = src.index('"script_edits": {')
+    desc = src[i:i + 1800]
+    assert "reuse_locked_script" in desc          # names its preconditions
+    assert "VERBATIM" in desc                     # copy-from-saved-script rule
+    assert "signal, not gate" in desc             # execute-don't-gate semantics
+    # forwarding is signature-gated so non-curve agents never see it
+    j = src.index('analyze_kwargs["script_edits"]')
+    assert "_inspect.signature" in src[j - 300:j]

--- a/tests/test_script_edits_reuse.py
+++ b/tests/test_script_edits_reuse.py
@@ -130,6 +130,18 @@ def test_multi_regime_refuses_rather_than_dropping_edits():
 # ---------------------------------------------- orchestrator surface
 
 
+def test_unsupported_agent_refuses_script_edits():
+    """Image/HS runs must REFUSE script_edits, not silently drop them —
+    the forwarding gate alone completed the run with the caller's
+    explicitly requested change ignored."""
+    src = Path("scilink/agents/exp_agents/analysis_orchestrator_tools.py"
+               ).read_text()
+    i = src.index('analyze_kwargs["script_edits"]')
+    guard = src[i:i + 800]
+    assert "is not supported by" in guard
+    assert '"status": "error"' in guard
+
+
 def test_orchestrator_forwards_and_documents_script_edits():
     src = Path("scilink/agents/exp_agents/analysis_orchestrator_tools.py"
                ).read_text()


### PR DESCRIPTION
## Summary

When a scientist wants to re-run an accepted fit with exactly one thing changed — a threshold, an initial guess, an iteration limit — the only path was full re-generation, which produces a script differing in a dozen incidental ways and breaks the one-variable-at-a-time comparability an incremental campaign depends on.

`run_analysis` (and `CurveFittingAgent.analyze`) now accept **`script_edits`**: exact old/new snippet pairs applied to the prior run's saved fitting script *before* the verbatim locked-reuse run. The rerun's script is byte-identical to the prior one except the requested change; execution in the sandbox remains the verification; the usual `reuse_validity` R² verdict is attached as a signal (the knob change is intentional — judging the outcome stays with the caller). The exact pairs are recorded as `script_edits_applied` in the saved results, so the delta between consecutive runs is auditable from artifacts alone.

Guards: edits are validated up front against the prior script — a non-matching edit refuses with a per-edit report at zero LLM cost, atomically (nothing half-applied, nothing run). No new execution machinery: this rides the existing locked-reuse fast path (#172), which already runs prior scripts verbatim inside the QC harness.

Live validation on Bedrock Opus 4.8 (`tests/test_script_edits_live.py`, 13/13): an agent-level rerun whose saved script equals the anchor's byte-for-byte except the edit, with provenance recorded; and an orchestrator-level "next point of the series, change one knob" conversation where the model read the saved script on its own, passed a verbatim snippet, and the two runs' scripts differ in exactly one line. Offline: 7/7 plus neighboring suites green.

This is Phase A of `analysis_script_surgical_refinement_plan.md` (in the repo root). Phase B — minimal-edit adaptation of proven script-bank entries — is a follow-up PR.

---

## Technical details

- Entry validation in `analyze()` loads the prior script via the same `_first_prior_curve_fit_state` loader the reuse path uses and applies `utils/file_edit.apply_snippet_edits` (the atomic batch primitive from the edit_file work). Requires `prior_analysis_paths` + `reuse_locked_script=true`; refuses otherwise.
- Application point is a small testable helper (`_apply_reuse_script_edits`) at the series controller's reuse chokepoint; a post-validation failure there (prior run changed on disk mid-run) raises rather than silently running the unedited script.
- `reuse_source` is labeled `"<prior> + N edit(s)"`, flowing into the existing reuse messages and validity verdict; `reuse_validity` gains a `script_edits` count.
- Orchestrator forwarding is signature-gated (`inspect.signature`), so image/hyperspectral agents never see the parameter until their reuse paths adopt it.

**Second commit — regime guard + full scenario matrix.** A gap found while walking the scenario space: a series whose plan splits into multiple regimes disables locked reuse, which would have silently dropped explicitly requested `script_edits` and re-derived freely. That skip now refuses loudly (structured error naming the two ways forward). The live suite grew from 2 to 9 scenarios, 36/36 on Bedrock Opus 4.8: meta-mode cross-delegation and same-delegation follow-ups, chaining semantics (anchor-pointed re-pass / baked-in persistence / clean refusal on mixing), realtime frames executing the edited script per-frame with zero LLM calls, two knob variants with distinct provenance, the zero-cost refusals, and the regime guard firing against a live planner-declared regime split.


**No-op regression across the benchmark corpus** (`benchmarking_for_paper2`, 18/18): every curve-data family runs its benchmark configuration through plain `analyze()`, which executes none of the new code — verified empirically with one representative per family (NMR electrolyte campaign, RRUFF Raman, Raman strong-metadata, RRUFF XRD pattern, EELS staged case): fit succeeds, result JSON carries zero contamination (`script_edits_applied` / edit-labeled sources / surgical-edit log lines all absent). The genuinely modified path — locked reuse and realtime on the in-situ dehydration XRD series, run WITHOUT edits — behaves exactly as before: reuse verdict attached, source unlabeled, no edit machinery engaged. Image and hyperspectral agents have zero code intersection with this diff; a follow-up commit makes `run_analysis` REFUSE `script_edits` for them (structured error naming the capability boundary) instead of silently dropping the parameter.
