### PR TITLE
Image agent adopts script_edits (stacked on #434)

### DIFF
--- a/scilink/agents/exp_agents/_qc_engine.py
+++ b/scilink/agents/exp_agents/_qc_engine.py
@@ -38,6 +38,45 @@ from pathlib import Path
 from typing import Any, Optional
 
 
+def apply_reuse_script_edits(state: dict, reuse_script, reuse_source,
+                             logger=None):
+    """Apply the caller's surgical ``script_edits`` to a reused script.
+
+    Shared across the #172 reuse twins (curve fitting, image analysis):
+    the prior script runs byte-identical EXCEPT the requested edits, so
+    consecutive runs stay comparable one variable at a time. Edits were
+    validated at ``analyze()`` entry against this same prior script, so a
+    failure here means the prior run changed on disk mid-run — refuse
+    loudly rather than silently run the UNEDITED script the caller asked
+    to change.
+    """
+    edits = state.get("script_edits") or []
+    if not (reuse_script and edits):
+        return reuse_script, reuse_source
+    from scilink.utils.file_edit import apply_snippet_edits
+    res = apply_snippet_edits(reuse_script, edits)
+    if res["status"] != "success":
+        raise RuntimeError(
+            f"script_edits no longer apply to the prior script "
+            f"({res['message']}) — the prior run changed on disk after "
+            "validation. Nothing was run.")
+    if logger:
+        logger.info(f"   ✏️  Applied {res['n_edits']} surgical edit(s) to "
+                    f"the reused script (execution will verify)")
+    return res["text"], f"{reuse_source} + {res['n_edits']} edit(s)"
+
+
+def attach_script_edit_provenance(ctx, reuse_result: dict) -> None:
+    """Record the exact old/new pairs on a reuse result, so the delta
+    between consecutive runs is auditable from saved artifacts alone."""
+    if ctx.state.get("script_edits"):
+        reuse_result["script_edits_applied"] = list(
+            ctx.state["script_edits"])
+        rv = reuse_result.get("reuse_validity")
+        if isinstance(rv, dict):
+            rv["script_edits"] = len(ctx.state["script_edits"])
+
+
 @dataclass(frozen=True)
 class QCEngineSpec:
     """Modality constants consumed by the shared engine shell.

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2841,11 +2841,11 @@ class AnalysisOrchestratorTools:
                             "status": "error",
                             "message": (
                                 f"script_edits is not supported by "
-                                f"{type(agent).__name__} — it is a "
-                                "curve-fitting capability (surgical edits "
-                                "to a prior fitting script). Re-run "
-                                "without script_edits, or route 1D curve "
-                                "data to the curve-fitting agent.")})
+                                f"{type(agent).__name__} — it applies "
+                                "surgical edits to a prior run's saved "
+                                "script, currently supported for curve "
+                                "fitting and image analysis. Re-run "
+                                "without script_edits.")})
                 if profile:
                     # Operating profile (#346): forward only to agents whose
                     # analyze() accepts it (all three do; introspection keeps
@@ -3256,8 +3256,8 @@ class AnalysisOrchestratorTools:
                         "required": ["old_text", "new_text"],
                     },
                     "description": (
-                        "Surgical single-knob follow-up (curve fitting; "
-                        "requires `prior_analysis_paths` + "
+                        "Surgical single-knob follow-up (curve fitting and "
+                        "image analysis; requires `prior_analysis_paths` + "
                         "`reuse_locked_script=true`): exact old/new snippet "
                         "pairs applied to the prior run's saved script BEFORE "
                         "it re-executes, so the rerun differs from the prior "

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -1069,31 +1069,10 @@ def _first_prior_curve_fit_script(state: dict):
     return None, None
 
 
-def _apply_reuse_script_edits(state: dict, reuse_script, reuse_source,
-                              logger=None):
-    """Apply the caller's surgical ``script_edits`` to the reused script.
-
-    Single-knob follow-ups on the #172 locked-reuse path: the prior script
-    runs byte-identical EXCEPT the requested edits, so consecutive runs stay
-    comparable one variable at a time. Edits were validated at ``analyze()``
-    entry against this same prior script, so a failure here means the prior
-    run changed on disk mid-run — refuse loudly rather than silently run
-    the UNEDITED script the caller asked to change.
-    """
-    edits = state.get("script_edits") or []
-    if not (reuse_script and edits):
-        return reuse_script, reuse_source
-    from scilink.utils.file_edit import apply_snippet_edits
-    res = apply_snippet_edits(reuse_script, edits)
-    if res["status"] != "success":
-        raise RuntimeError(
-            f"script_edits no longer apply to the prior script "
-            f"({res['message']}) — the prior run changed on disk after "
-            "validation. Nothing was run.")
-    if logger:
-        logger.info(f"   ✏️  Applied {res['n_edits']} surgical edit(s) to "
-                    f"the reused script (execution will verify)")
-    return res["text"], f"{reuse_source} + {res['n_edits']} edit(s)"
+# Shared with the image twin — the implementation lives with the QC
+# engine; this alias keeps the established local name.
+from .._qc_engine import (  # noqa: E402
+    apply_reuse_script_edits as _apply_reuse_script_edits)
 
 
 def _append_objective_context(prompt: list, state: dict) -> None:
@@ -4550,14 +4529,9 @@ Return JSON with:
                 "verdict": verdict,
                 "message": message,
             }
-            # Surgical follow-up provenance: the exact old/new pairs applied
-            # to the prior script, so the delta between consecutive runs is
-            # auditable from the saved results alone.
-            if ctx.state.get("script_edits"):
-                reuse_result["script_edits_applied"] = list(
-                    ctx.state["script_edits"])
-                reuse_result["reuse_validity"]["script_edits"] = len(
-                    ctx.state["script_edits"])
+            # Surgical follow-up provenance (shared with the image twin).
+            from .._qc_engine import attach_script_edit_provenance
+            attach_script_edit_provenance(ctx, reuse_result)
             if verdict == "poor":
                 reuse_result["quality_warning"] = message
             # Realtime drift channel (#346 step 3): the gate metric measures

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -3499,6 +3499,9 @@ Return JSON with:
             )
             if verdict == "poor":
                 reuse_result["quality_warning"] = message
+            # Surgical follow-up provenance (shared with the curve twin).
+            from .._qc_engine import attach_script_edit_provenance
+            attach_script_edit_provenance(ctx, reuse_result)
             return reuse_result
         self.logger.warning(
             f"   ⚠️  Prior analysis script could not execute on this "
@@ -5395,9 +5398,22 @@ Return JSON: {{"change_type": "cosmetic" | "analytical" | "rewrite", \
         # rewrite. Verbatim reuse cannot verify or deepen a prior result.
         if state.get("reuse_locked_script"):
             reuse_script, reuse_source = _first_prior_image_script(state)
+            from .._qc_engine import apply_reuse_script_edits
+            reuse_script, reuse_source = apply_reuse_script_edits(
+                state, reuse_script, reuse_source, self.logger)
         else:
             reuse_script, reuse_source = None, None
         if reuse_script and regime_configs:
+            # With script_edits present this must be a loud refusal, not a
+            # silent fallback to free re-derivation (mirrors the curve
+            # twin's regime guard).
+            if state.get("script_edits"):
+                raise RuntimeError(
+                    "script_edits cannot be applied: the series plan split "
+                    "this run into multiple regimes, which disables locked-"
+                    "script reuse. Either re-run without script_edits "
+                    "(per-regime pipelines will be re-derived), or analyze "
+                    "the images individually as single-regime follow-ups.")
             self.logger.info(
                 "   ♻️  Prior image-analysis run supplied, but this run is "
                 "multi-regime — locked-script reuse skipped."

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -245,6 +245,12 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # feature-table schema. Default False: prior runs are agent-judged
         # reference material (reuse / adapt / rewrite is the agent's call).
         reuse_locked_script: bool = False,
+        # Surgical single-knob follow-up on the locked-reuse path: exact
+        # old/new snippet pairs applied to the prior script BEFORE the
+        # verbatim run, so the rerun is byte-identical except the knob
+        # (requires prior_analysis_paths + reuse_locked_script). Validated
+        # up front; the sandbox run remains the verification.
+        script_edits: Optional[List[Dict[str, Any]]] = None,
         literature_file: Optional[str] = None,
         # Quality control overrides
         outlier_sigma: Optional[float] = None,
@@ -343,6 +349,38 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         except (TypeError, ValueError):
             n_candidates = 1
         candidate_escalation = bool(candidate_escalation) and n_candidates > 1
+
+        # Surgical script edits — validated HERE, before any pipeline work:
+        # the edits must apply cleanly to the prior run's saved script or
+        # the run refuses with the per-edit report. Never a partial
+        # application, never a silent unedited run, zero LLM cost on
+        # refusal. Mirrors the curve twin.
+        if script_edits:
+            def _edits_error(err: str, details: str, **extra):
+                return {"status": "error",
+                        "error": {"error": err, "details": details, **extra},
+                        "output_directory": str(self.output_dir)}
+            if not (prior_analysis_paths and reuse_locked_script):
+                return _edits_error(
+                    "script_edits requires locked reuse",
+                    "Pass prior_analysis_paths=[<prior run dir>] and "
+                    "reuse_locked_script=True — script_edits surgically "
+                    "modifies that prior script before the verbatim run.")
+            from .controllers.image_analysis_controllers import (
+                _first_prior_image_script)
+            from scilink.utils.file_edit import apply_snippet_edits
+            _prior_script, _ = _first_prior_image_script(
+                {"prior_analysis_paths": prior_analysis_paths})
+            if not _prior_script:
+                return _edits_error(
+                    "no reusable prior script",
+                    "None of prior_analysis_paths carries a saved analysis "
+                    "script (scripts/*.py in a prior image run).")
+            _res = apply_snippet_edits(_prior_script, script_edits)
+            if _res["status"] != "success":
+                return _edits_error(
+                    "script_edits do not apply", _res["message"],
+                    failed_edit=_res.get("failed_edit"))
 
         # Parse input
         data_path, data_paths, data_array, error = self._parse_data_input(data)
@@ -511,6 +549,9 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             # Opt-in verbatim reuse of the prior locked script (#172); default
             # False — prior runs are agent-judged reference material.
             "reuse_locked_script": bool(reuse_locked_script),
+            # Surgical follow-up edits applied to the reused script (already
+            # validated at entry; the series controller applies them).
+            "script_edits": script_edits or [],
             # Best-of-N: independent parallel anchor attempts; LLM judge
             # selects the winner (1 = no fan-out). Escalation runs attempt 0
             # alone and fans out only when it is weak.

--- a/tests/test_script_edits_live.py
+++ b/tests/test_script_edits_live.py
@@ -541,11 +541,70 @@ def part9_multiregime():
               and "Applied 1 surgical edit" in log)
 
 
+def part11_image_wiring():
+    """Image twin: byte-exact except the edit, provenance recorded —
+    mirrors part 1 through the image agent's #172 reuse path."""
+    print("\n=== 11. image agent: byte-exact except the edit ===")
+    from scilink.agents.exp_agents.image_analysis_agent import (
+        ImageAnalysisAgent)
+
+    run = BASE / "p11"
+    if run.exists():
+        shutil.rmtree(run)
+    run.mkdir(parents=True)
+
+    def make_image(path, seed):
+        rng = np.random.default_rng(seed)
+        yy, xx = np.mgrid[0:128, 0:128]
+        img = rng.normal(0.1, 0.02, (128, 128))
+        for cx, cy in [(30, 40), (80, 90), (100, 30)]:
+            img += 0.8 * np.exp(-(((xx - cx - rng.integers(-3, 4)) ** 2
+                                   + (yy - cy - rng.integers(-3, 4)) ** 2)
+                                  / (2 * 6.0 ** 2)))
+        np.save(path, img.astype(np.float32))
+
+    make_image(run / "img_a.npy", 1)
+    make_image(run / "img_b.npy", 2)
+    si = {"technique": "AFM height image",
+          "description": "nanoparticles on a flat substrate",
+          "pixel_size_nm": 2.0}
+
+    anchor = ImageAnalysisAgent(
+        api_key=None, model_name=MODEL, output_dir=str(run / "anchor"),
+        enable_human_feedback=False, max_verification_iterations=1)
+    res_a = anchor.analyze(str(run / "img_a.npy"), system_info=si)
+    check("p11 anchor succeeded", res_a.get("status") == "success")
+    _, script_a = _saved_script(run / "anchor")
+    assert "import numpy as np" in script_a
+
+    rerun = ImageAnalysisAgent(
+        api_key=None, model_name=MODEL, output_dir=str(run / "rerun"),
+        enable_human_feedback=False, max_verification_iterations=1)
+    buf = Tee()
+    with capture_all(buf):
+        res_b = rerun.analyze(
+            str(run / "img_b.npy"), system_info=si,
+            prior_analysis_paths=[str(run / "anchor")],
+            reuse_locked_script=True, script_edits=[MARK_EDIT])
+    log = buf.getvalue()
+
+    check("p11 rerun succeeded", res_b.get("status") == "success")
+    check("p11 edit applied (log)", "Applied 1 surgical edit" in log)
+    _, script_b = _saved_script(run / "rerun")
+    check("p11 mark present in executed script",
+          "SURGICAL-EDIT-MARK" in script_b)
+    check("p11 byte-identical except the edit",
+          script_b.replace("  # SURGICAL-EDIT-MARK", "") == script_a)
+    blob = "".join(p.read_text() for p in (run / "rerun").glob("*.json"))
+    check("p11 provenance in saved artifacts",
+          "script_edits_applied" in blob and "+ 1 edit(s)" in blob)
+
+
 PARTS = {"1": part1_wiring, "2": part2_routing,
          "3": part3_meta_cross_delegation, "4": part4_meta_same_delegation,
          "5": part5_chaining, "6": part6_realtime,
          "7": part7_fanout_variants, "8": part8_refusals,
-         "9": part9_multiregime}
+         "9": part9_multiregime, "11": part11_image_wiring}
 
 if __name__ == "__main__":
     for k in (sys.argv[1:] or sorted(PARTS)):

--- a/tests/test_script_edits_reuse.py
+++ b/tests/test_script_edits_reuse.py
@@ -130,6 +130,72 @@ def test_multi_regime_refuses_rather_than_dropping_edits():
 # ---------------------------------------------- orchestrator surface
 
 
+# ---------------------------------------------- image twin
+
+
+def make_prior_image_run(tmp_path):
+    run = tmp_path / "prior_image_run"
+    (run / "scripts").mkdir(parents=True)
+    (run / "scripts" / "analysis_script.py").write_text(SCRIPT)
+    (run / "analysis_results.json").write_text(json.dumps({
+        "status": "success", "analysis_approach": "blob detection"}))
+    return run
+
+
+@pytest.fixture
+def image_agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("UNSAFE_EXECUTION_OK", "true")
+    from scilink.agents.exp_agents.image_analysis_agent import (
+        ImageAnalysisAgent)
+    return ImageAnalysisAgent(
+        api_key="offline-dummy", model_name="claude-opus-5",
+        output_dir=str(tmp_path / "img_out"), enable_human_feedback=False)
+
+
+IMG = np.random.default_rng(0).random((64, 64))
+
+
+def test_image_entry_validation_mirrors_curve(image_agent, tmp_path):
+    run = make_prior_image_run(tmp_path)
+    out = image_agent.analyze(
+        IMG, system_info="test image",
+        prior_analysis_paths=[str(run)],
+        script_edits=[{"old_text": "a", "new_text": "b"}])
+    assert out["status"] == "error"
+    assert "reuse_locked_script" in out["error"]["details"]
+
+    out = image_agent.analyze(
+        IMG, system_info="test image",
+        prior_analysis_paths=[str(run)], reuse_locked_script=True,
+        script_edits=[{"old_text": "NOT THERE", "new_text": "x"}])
+    assert out["status"] == "error"
+    assert out["error"]["error"] == "script_edits do not apply"
+
+    empty = tmp_path / "empty_img_run"
+    empty.mkdir()
+    out = image_agent.analyze(
+        IMG, system_info="test image",
+        prior_analysis_paths=[str(empty)], reuse_locked_script=True,
+        script_edits=[{"old_text": "a", "new_text": "b"}])
+    assert out["status"] == "error"
+    assert "prior script" in out["error"]["error"]
+
+
+def test_image_regime_guard_and_shared_helper():
+    src = Path("scilink/agents/exp_agents/controllers/"
+               "image_analysis_controllers.py").read_text()
+    i = src.index("multi-regime — locked-script reuse skipped")
+    guard = src[i - 1500:i]
+    assert 'state.get("script_edits")' in guard
+    assert "raise RuntimeError" in guard
+    # both twins consume the ONE shared implementation
+    assert "apply_reuse_script_edits" in src
+    curve = Path("scilink/agents/exp_agents/controllers/"
+                 "curve_fitting_controllers.py").read_text()
+    assert "from .._qc_engine import" in curve
+    assert curve.count("def apply_reuse_script_edits") == 0
+
+
 def test_unsupported_agent_refuses_script_edits():
     """Image/HS runs must REFUSE script_edits, not silently drop them —
     the forwarding gate alone completed the run with the caller's
@@ -147,7 +213,7 @@ def test_orchestrator_forwards_and_documents_script_edits():
                ).read_text()
     assert '"script_edits"' in src
     i = src.index('"script_edits": {')
-    desc = src[i:i + 1800]
+    desc = src[i:i + 2400]
     assert "reuse_locked_script" in desc          # names its preconditions
     assert "VERBATIM" in desc                     # copy-from-saved-script rule
     assert "signal, not gate" in desc             # execute-don't-gate semantics


### PR DESCRIPTION
## Summary

Stacked on #434 (merge that first; GitHub will retarget this to main when its base merges). The image agent is the second #172 reuse twin, and it now supports the same surgical single-knob follow-ups: exact old/new pairs applied to a prior run's saved analysis script before the verbatim reuse run — byte-identical except the knob, execution as the verification, provenance in the saved artifacts.

The important design move is **one shared implementation**: the edit-application and provenance helpers now live in `_qc_engine.py` (`apply_reuse_script_edits`, `attach_script_edit_provenance`), consumed by both curve and image controllers — guard code that drifts per copy is how the piecewise-rewriter bypass would eventually reopen. Image gets the same multi-regime loud refusal, the same zero-cost entry validation, and the orchestrator forwarding activates automatically via the existing signature gate (no orchestrator wiring needed). The unsupported-agent refusal now names both supported agents and fires only for hyperspectral — which has no reuse path at all; whether to build one is a separate design question, deliberately not assumed here.

Validation: offline 11/11 (image entry refusals mirror curve's; regime guard present; exactly one shared implementation asserted). Live on Bedrock Opus 4.8: the image wiring scenario 6/6 — anchor AFM-style analysis, then a reuse rerun whose saved script equals the anchor's byte-for-byte except the injected edit, with `script_edits_applied` and the "+1 edit(s)" source label in the saved artifacts — plus the curve wiring scenario re-smoked 8/8 after the helper relocation.