### PR TITLE
Script bank: minimal-edit adaptation of proven scripts (Phase B)

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -4451,7 +4451,9 @@ Return JSON with:
             is_regime_anchor=is_regime_anchor,
             reuse_script=reuse_script, reuse_source=reuse_source,
         )
-        return engine.run_item(ctx)
+        res = engine.run_item(ctx)
+        self._bump_bank_adapt_success(res)
+        return res
 
     # --- CodegenQCEngine hooks (bodies moved verbatim from the old driver) ---
 
@@ -4589,10 +4591,148 @@ Return JSON with:
         self.logger.info(f"   Attempt 1: {str(initial_model)[:80]}...")
 
         self._offer_bank_exemplar(ctx)
+        # Minimal-edit adaptation of a strongly matching banked script
+        # (Phase B): one cheap attempt in FRONT of today's exemplar
+        # generation — any failure falls through, so this path can only
+        # add, never subtract.
+        adapted = self._try_bank_edit_adapt(ctx)
+        if adapted is not None:
+            return adapted
         return self._fit_single_spectrum(
             state=ctx.state, curve_data=ctx.data, data_path=ctx.data_path,
             spectrum_name=ctx.item_name, spectrum_idx=ctx.item_idx, base_script=None
         )
+
+    # Calibrated live: the canonical adapt case (same-family single peak,
+    # position shifted 1.5 units) scores 0.495-0.522 across runs — the
+    # jitter comes from the banked script itself being nondeterministic
+    # codegen — so 0.60 never fired and 0.50 was a coin flip. Any match
+    # that cleared the retrieval floor (0.45, with hard filters on
+    # fingerprint kind and axis units) is worth ONE edit-adapt attempt:
+    # the fall-through ladder caps the cost at exactly that attempt.
+    # Raise via $SCILINK_BANK_EDIT_ADAPT_SCORE if live evidence shows
+    # wrong-script anchoring; $SCILINK_BANK_EDIT_ADAPT=0 disables.
+    _BANK_EDIT_ADAPT_MIN_SCORE = 0.45
+
+    def _try_bank_edit_adapt(self, ctx: QCItemContext) -> Optional[dict]:
+        """Adapt a strongly matching banked script via an LLM edit LIST,
+        applied mechanically — instead of whole-script re-emission.
+
+        Full-regeneration "adapt" erodes exactly the provenance that made
+        the script worth banking; a minimal-edit adaptation keeps the
+        proven logic byte-recognizable and (on gate pass) accumulates
+        cross-session success evidence on the SAME bank record. The
+        result enters the UNCHANGED verification loop — execution and
+        the quality gate stay the arbiters. Every fall-through is logged
+        with its reason (no silent fallbacks); returning None resumes
+        today's exemplar-generation path exactly.
+        """
+        state = ctx.state
+        exemplar = state.get("_bank_exemplar")
+        if not exemplar:
+            return None
+        import os as _os
+        if (_os.environ.get("SCILINK_BANK_EDIT_ADAPT", "").strip().lower()
+                in ("0", "false", "off", "no")):
+            return None
+        try:
+            min_score = float(_os.environ.get(
+                "SCILINK_BANK_EDIT_ADAPT_SCORE",
+                self._BANK_EDIT_ADAPT_MIN_SCORE))
+        except ValueError:
+            min_score = self._BANK_EDIT_ADAPT_MIN_SCORE
+        score = float(exemplar.get("score") or 0)
+        if score < min_score:
+            self.logger.info(
+                f"   🏦 Edit-adapt skipped: match score {score} < "
+                f"{min_score} — exemplar-guided generation instead.")
+            return None
+        rec = exemplar.get("record") or {}
+        banked = (rec.get("working_script") or "").strip()
+        if not banked:
+            return None
+        try:
+            from ..instruct import BANK_EDIT_ADAPT_INSTRUCTIONS
+            from scilink.skills._shared._graduation import parse_json_response
+            from scilink.utils.file_edit import apply_snippet_edits
+            prompt = BANK_EDIT_ADAPT_INSTRUCTIONS.format(
+                banked_script=banked,
+                locked_config=json.dumps(
+                    state.get("locked_fitting_config") or {}, indent=2,
+                    default=str),
+                data_context=(
+                    f"system_info: {str(state.get('system_info'))[:800]}\n"
+                    f"data statistics: "
+                    f"{str(state.get('data_statistics'))[:800]}"),
+            )
+            raw = self.model.generate_content(
+                prompt, generation_config=self.generation_config)
+            raw = raw.text if hasattr(raw, "text") else str(raw)
+            try:
+                parsed = parse_json_response(raw)
+            except ValueError:
+                retry = ("Respond with ONLY a single JSON object — no "
+                         "prose before or after it.\n\n" + prompt)
+                raw = self.model.generate_content(
+                    retry, generation_config=self.generation_config)
+                raw = raw.text if hasattr(raw, "text") else str(raw)
+                parsed = parse_json_response(raw)
+            edits = parsed.get("edits")
+            if not isinstance(edits, list):
+                raise ValueError("no edits list in the adaptation reply")
+            if edits:
+                res = apply_snippet_edits(banked, edits)
+                if res["status"] != "success":
+                    raise ValueError(f"edits do not apply: {res['message']}")
+                adapted_script, n_edits = res["text"], res["n_edits"]
+            else:
+                adapted_script, n_edits = banked, 0
+            self.logger.info(
+                f"   🏦 ✏️  Bank edit-adapt: record {rec.get('id')} "
+                f"(score {score}), {n_edits} edit(s) — "
+                f"{str(parsed.get('rationale'))[:120]}")
+            result = self._fit_single_spectrum(
+                state=state, curve_data=ctx.data, data_path=ctx.data_path,
+                spectrum_name=ctx.item_name, spectrum_idx=ctx.item_idx,
+                base_script=adapted_script)
+            if not result.get("success"):
+                self.logger.info(
+                    "   🏦 ↩️  Edit-adapted script did not execute cleanly "
+                    "— falling back to exemplar-guided generation.")
+                return None
+            ctx.initial_label = (f"bank edit-adapt of {rec.get('id')} "
+                                 f"({n_edits} edit(s))")
+            result["bank_edit_adapt"] = {
+                "id": rec.get("id"), "score": score, "n_edits": n_edits,
+                "edits": list(edits), "rationale": parsed.get("rationale"),
+            }
+            return result
+        except Exception as e:  # noqa: BLE001 - never worse than today
+            self.logger.info(
+                f"   🏦 ↩️  Edit-adapt fell through ({e}) — falling back "
+                "to exemplar-guided generation.")
+            return None
+
+    def _bump_bank_adapt_success(self, res) -> None:
+        """CLEAN acceptance of an edit-adapted script accumulates proven-N
+        evidence on the SAME bank record. A verification-loop refit
+        replaces the result and drops the provenance, so a rejected
+        adaptation never bumps — and a kept-but-flagged poor fit
+        (quality_warning) must not either: live, an NMR adaptation
+        executed fine at R²=0.42 and would have counted as "proven".
+        Proven-N feeds the graduation signal; only unflagged survivals
+        are evidence."""
+        try:
+            bea = res.get("bank_edit_adapt") if isinstance(res, dict) else None
+            if (bea and bea.get("id") and res.get("success")
+                    and not res.get("quality_warning")):
+                from scilink.skills._shared import _script_bank
+                _script_bank.record_success("curve_fitting", bea["id"])
+                self.logger.info(
+                    f"   🏦 📈 Bank record {bea['id']}: cross-session "
+                    "success recorded (edit-adapted script survived QC).")
+        except Exception:  # noqa: BLE001 - bookkeeping must never fail a fit
+            pass
 
     def _offer_bank_exemplar(self, ctx: QCItemContext) -> None:
         """Adapt-mode script-bank retrieval (#346 step 2).

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -3146,6 +3146,36 @@ DELETE that section.
 
 Output ONLY the JSON object. Do not wrap in code blocks. Do not include any prose outside the JSON."""
 
+BANK_EDIT_ADAPT_INSTRUCTIONS = """You are an expert scientific data analyst. A PROVEN fitting script \
+from the script bank closely matches the current dataset. Adapt it with the SMALLEST possible set of \
+exact text edits — do NOT rewrite it. The proven structure is the value: a minimal-edit adaptation \
+keeps the script byte-recognizable, so its cross-session success record keeps accumulating.
+
+**Proven script (adapt THIS):**
+```python
+{banked_script}
+```
+
+**Current analysis plan (authoritative where it conflicts with the script):**
+{locked_config}
+
+**Current dataset / measurement context:**
+{data_context}
+
+**Rules:**
+1. Each edit is an exact-verbatim substring of the proven script (old_text), replaced by new_text. \
+old_text must appear EXACTLY ONCE in the script. Keep each edit small (a value, a line, a few lines).
+2. Re-derive dataset-specific values for THIS data: peak positions/counts, ranges, initial guesses, \
+thresholds, axis windows. Keep the vetted algorithm, model family, and overall structure.
+3. NEVER touch the output contract: the FIT_RESULTS_JSON print, the success marker, the \
+visualization saving, or the results schema.
+4. If the script fits this dataset as-is, return an empty edits list.
+
+Return ONLY a JSON object: {{"edits": [{{"old_text": "...", "new_text": "..."}}, ...], \
+"rationale": "<one sentence on what was adapted and why>"}}
+Do not wrap in code blocks. No prose outside the JSON."""
+
+
 T2_DISTILL_INSTRUCTIONS = """You are an expert scientific data analyst. A curve-fitting run had to \
 abandon its planned model and the available domain skills, regenerate a fitting approach from scratch \
 (the "hot annealing" stage), and only then succeeded. Distill that successful, novel approach into a \

--- a/tests/test_bank_edit_adapt.py
+++ b/tests/test_bank_edit_adapt.py
@@ -1,0 +1,154 @@
+"""Bank minimal-edit adaptation (Phase B of the surgical-refinement plan).
+
+Today's "adapt" regenerates the whole script with the banked one as a
+prompt exemplar — eroding exactly the provenance that made it worth
+banking. The edit-adapt mode asks the LLM for an edit LIST against the
+banked script, applies it mechanically, and lets the UNCHANGED
+verification loop judge the result. The ladder can only add: every
+failure falls through (with its reason logged) to today's exemplar path.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+    UnifiedSeriesProcessingController as C)
+
+BANKED = ("import numpy as np\n"
+          "CENTER_GUESS = 5.0\n"
+          "print('FIT_RESULTS_JSON: {}')\n"
+          "print('CUSTOM_SCRIPT_SUCCESS')\n")
+
+
+class FakeModel:
+    def __init__(self, replies):
+        self.replies = list(replies)
+        self.calls = 0
+
+    def generate_content(self, prompt, generation_config=None):
+        self.calls += 1
+        return SimpleNamespace(text=self.replies.pop(0))
+
+
+def make_self(model_replies, fit_result=None):
+    captured = {}
+
+    def _fit_single_spectrum(**kw):
+        captured.update(kw)
+        return fit_result if fit_result is not None else {
+            "success": True, "fit_quality": {"r_squared": 0.99}}
+
+    s = SimpleNamespace(
+        logger=SimpleNamespace(info=lambda *a, **k: None,
+                               warning=lambda *a, **k: None),
+        model=FakeModel(model_replies),
+        generation_config=None,
+        _fit_single_spectrum=_fit_single_spectrum,
+        _BANK_EDIT_ADAPT_MIN_SCORE=C._BANK_EDIT_ADAPT_MIN_SCORE,
+    )
+    return s, captured
+
+
+def make_ctx(score=0.8, script=BANKED):
+    return SimpleNamespace(
+        state={"_bank_exemplar": {
+            "score": score,
+            "record": {"id": "rec_001", "working_script": script}},
+            "locked_fitting_config": {"physical_model": "gaussian"},
+            "system_info": "test curve"},
+        data=None, data_path="d.csv", item_name="s", item_idx=0,
+        initial_label=None)
+
+
+GOOD_REPLY = json.dumps({
+    "edits": [{"old_text": "CENTER_GUESS = 5.0",
+               "new_text": "CENTER_GUESS = 7.2"}],
+    "rationale": "peak sits at 7.2 in this dataset"})
+
+
+def test_happy_path_applies_edits_and_records_provenance():
+    fake, captured = make_self([GOOD_REPLY])
+    ctx = make_ctx()
+    res = C._try_bank_edit_adapt(fake, ctx)
+    assert res is not None and res["success"]
+    assert "CENTER_GUESS = 7.2" in captured["base_script"]
+    assert captured["base_script"].replace("7.2", "5.0") == BANKED.strip()
+    bea = res["bank_edit_adapt"]
+    assert bea["id"] == "rec_001" and bea["n_edits"] == 1
+    assert "edit-adapt of rec_001" in ctx.initial_label
+
+
+def test_empty_edit_list_means_verbatim():
+    fake, captured = make_self([json.dumps({"edits": [], "rationale": "fits"})])
+    res = C._try_bank_edit_adapt(fake, make_ctx())
+    assert res is not None
+    assert captured["base_script"] == BANKED.strip()
+    assert res["bank_edit_adapt"]["n_edits"] == 0
+
+
+def test_weak_match_skips_without_an_llm_call():
+    fake, _ = make_self([GOOD_REPLY])
+    assert C._try_bank_edit_adapt(fake, make_ctx(score=0.40)) is None
+    assert fake.model.calls == 0
+
+
+def test_kill_switch(monkeypatch):
+    monkeypatch.setenv("SCILINK_BANK_EDIT_ADAPT", "0")
+    fake, _ = make_self([GOOD_REPLY])
+    assert C._try_bank_edit_adapt(fake, make_ctx()) is None
+    assert fake.model.calls == 0
+
+
+def test_score_override(monkeypatch):
+    monkeypatch.setenv("SCILINK_BANK_EDIT_ADAPT_SCORE", "0.95")
+    fake, _ = make_self([GOOD_REPLY])
+    assert C._try_bank_edit_adapt(fake, make_ctx(score=0.8)) is None
+
+
+def test_garbage_json_falls_through_after_one_retry():
+    fake, _ = make_self(["not json at all", "still not json"])
+    assert C._try_bank_edit_adapt(fake, make_ctx()) is None
+    assert fake.model.calls == 2          # one corrective retry, then out
+
+
+def test_non_applying_edits_fall_through():
+    reply = json.dumps({"edits": [{"old_text": "NOT PRESENT",
+                                   "new_text": "x"}], "rationale": "r"})
+    fake, captured = make_self([reply])
+    assert C._try_bank_edit_adapt(fake, make_ctx()) is None
+    assert "base_script" not in captured   # nothing executed
+
+
+def test_execution_failure_falls_through():
+    fake, _ = make_self([GOOD_REPLY], fit_result={"success": False})
+    assert C._try_bank_edit_adapt(fake, make_ctx()) is None
+
+
+def test_success_bump_only_with_surviving_provenance(monkeypatch):
+    from scilink.skills._shared import _script_bank
+    bumped = []
+    monkeypatch.setattr(_script_bank, "record_success",
+                        lambda d, rid, session=None: bumped.append(rid))
+    fake, _ = make_self([])
+    C._bump_bank_adapt_success(fake, {
+        "success": True, "bank_edit_adapt": {"id": "rec_001"}})
+    C._bump_bank_adapt_success(fake, {"success": True})   # refit: no prov
+    C._bump_bank_adapt_success(fake, {
+        "success": False, "bank_edit_adapt": {"id": "rec_002"}})
+    # kept-but-flagged poor fit must NOT count as proven (live: R²=0.42
+    # NMR adaptation executed fine and would have inflated proven-N)
+    C._bump_bank_adapt_success(fake, {
+        "success": True, "quality_warning": "R² below threshold",
+        "bank_edit_adapt": {"id": "rec_003"}})
+    assert bumped == ["rec_001"]
+
+
+def test_template_contract():
+    from scilink.agents.exp_agents.instruct import BANK_EDIT_ADAPT_INSTRUCTIONS
+    filled = BANK_EDIT_ADAPT_INSTRUCTIONS.format(
+        banked_script="s", locked_config="{}", data_context="d")
+    assert '"edits"' in filled and "ONLY a JSON object" in filled
+    assert "EXACTLY ONCE" in filled
+    assert "output contract" in filled     # FIT_RESULTS_JSON stays untouched

--- a/tests/test_bank_edit_adapt_live.py
+++ b/tests/test_bank_edit_adapt_live.py
@@ -1,0 +1,180 @@
+"""Live validation for bank minimal-edit adaptation (Phase B) on Bedrock
+Opus 4.8, against an ISOLATED bank (SCILINK_HOME -> temp dir).
+
+  1. adapt    — fit dataset A (auto-banked), then fit similar dataset B
+                fresh: the edit-adapt path must fire, the accepted script
+                must be a small-diff of the banked one, provenance
+                recorded, and the bank record's cross-session success
+                count bumped.
+  2. fallthrough — dissimilar data (damped oscillation vs peaks): the
+                edit-adapt path must NOT anchor to the wrong script; the
+                run still succeeds via normal generation.
+
+Run:
+    AWS_BEARER_TOKEN_BEDROCK=... AWS_REGION_NAME=us-east-1 \
+    UNSAFE_EXECUTION_OK=true python tests/test_bank_edit_adapt_live.py [1 2]
+"""
+from __future__ import annotations
+
+import contextlib
+import difflib
+import io
+import json
+import logging
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import numpy as np
+
+MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+BASE = Path("tests/_bank_edit_adapt_live_runs").resolve()
+
+results = {}
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}", flush=True)
+
+
+class Tee(io.StringIO):
+    def write(self, s):
+        sys.__stdout__.write(s)
+        return super().write(s)
+
+
+@contextlib.contextmanager
+def capture_all(buf):
+    h = logging.StreamHandler(buf)
+    logging.getLogger().addHandler(h)
+    try:
+        with contextlib.redirect_stdout(buf):
+            yield
+    finally:
+        logging.getLogger().removeHandler(h)
+
+
+def make_peak(path, center, seed):
+    rng = np.random.default_rng(seed)
+    x = np.linspace(0, 10, 400)
+    y = (2.0 * np.exp(-((x - center) ** 2) / (2 * 0.4 ** 2))
+         + 0.3 + 0.02 * x + rng.normal(0, 0.02, x.size))
+    np.savetxt(path, np.column_stack([x, y]), delimiter=",",
+               header="position,intensity", comments="")
+
+
+SYS_INFO = {"technique": "generic 1D spectroscopy",
+            "x_axis": "position (a.u.)", "y_axis": "intensity (a.u.)"}
+
+
+def agent(out):
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+    return CurveFittingAgent(api_key=None, model_name=MODEL,
+                             output_dir=str(out),
+                             enable_human_feedback=False,
+                             max_verification_iterations=1)
+
+
+def bank_records():
+    from scilink.skills._shared import _script_bank
+    return _script_bank.list_records("curve_fitting")
+
+
+def part1_adapt():
+    print("\n=== 1. strong match: minimal-edit adapt + proven-N bump ===")
+    run = BASE / "p1"
+    if run.exists():
+        shutil.rmtree(run)
+    run.mkdir(parents=True)
+    make_peak(run / "spec_a.csv", center=5.0, seed=1)
+    make_peak(run / "spec_b.csv", center=6.5, seed=2)   # shifted peak
+
+    res_a = agent(run / "run_a").analyze(str(run / "spec_a.csv"),
+                                         system_info=SYS_INFO)
+    check("p1 run A succeeded", res_a.get("status") == "success")
+    recs = bank_records()
+    check("p1 run A auto-banked (isolated bank)", len(recs) == 1)
+    if not recs:
+        return
+    banked = recs[0]["working_script"]
+
+    buf = Tee()
+    with capture_all(buf):
+        res_b = agent(run / "run_b").analyze(str(run / "spec_b.csv"),
+                                             system_info=SYS_INFO)
+    log = buf.getvalue()
+
+    check("p1 run B succeeded", res_b.get("status") == "success")
+    check("p1 edit-adapt fired", "Bank edit-adapt: record" in log)
+    sfr = json.loads((run / "run_b" / "series_fit_results.json").read_text())
+    r0 = (sfr.get("results") or [{}])[0]
+    bea = r0.get("bank_edit_adapt") or {}
+    check("p1 provenance recorded (id + edits)",
+          bea.get("id") == recs[0]["id"] and "edits" in bea)
+    if bea:
+        script_b = r0.get("script") or ""
+        if not script_b:
+            scripts = sorted((run / "run_b" / "scripts").glob("*.py"))
+            script_b = scripts[0].read_text() if scripts else ""
+        ndiff = sum(1 for l in difflib.unified_diff(
+            banked.strip().splitlines(), script_b.strip().splitlines(),
+            lineterm="")
+            if l.startswith(("+", "-")) and not l.startswith(("+++", "---")))
+        n_lines = max(len(banked.strip().splitlines()), 1)
+        print(f"     adapted-vs-banked diff: {ndiff} changed line(s) "
+              f"of {n_lines} ({100 * ndiff // (2 * n_lines)}%)")
+        # The invariant is "recognizably the banked script": a
+        # regeneration diffs at ~100%; targeted edits stay a small
+        # fraction (live: 5 edits -> 23 diff lines on a ~150-line script).
+        check("p1 adaptation, not regeneration (diff < 40% of script)",
+              ndiff < 0.8 * n_lines)
+    after = bank_records()
+    n_succ = (after[0].get("stats") or {}).get("n_successes", 1)
+    check("p1 proven-N bumped on the SAME record", n_succ >= 2)
+
+
+def part2_fallthrough():
+    print("\n=== 2. dissimilar data: no wrong-script anchoring ===")
+    run = BASE / "p2"
+    if run.exists():
+        shutil.rmtree(run)
+    run.mkdir(parents=True)
+    rng = np.random.default_rng(3)
+    x = np.linspace(0, 10, 400)
+    y = np.exp(-0.3 * x) * np.sin(2 * np.pi * 1.2 * x) \
+        + rng.normal(0, 0.02, x.size)
+    np.savetxt(run / "osc.csv", np.column_stack([x, y]), delimiter=",",
+               header="time,signal", comments="")
+
+    buf = Tee()
+    with capture_all(buf):
+        res = agent(run / "run_c").analyze(
+            str(run / "osc.csv"),
+            system_info={"technique": "time-domain damped oscillation",
+                         "x_axis": "time (s)", "y_axis": "signal (a.u.)"})
+    log = buf.getvalue()
+    check("p2 dissimilar run succeeded via normal generation",
+          res.get("status") == "success")
+    check("p2 edit-adapt did NOT anchor to the peak script",
+          "Bank edit-adapt: record" not in log)
+    blob = json.dumps(res, default=str)
+    # key-specific: the run DIRECTORY name contains the substring
+    check("p2 no adapt provenance", '"bank_edit_adapt":' not in blob)
+
+
+PARTS = {"1": part1_adapt, "2": part2_fallthrough}
+
+if __name__ == "__main__":
+    assert os.environ.get("SCILINK_HOME"), \
+        "Set SCILINK_HOME to an isolated temp dir before running."
+    os.environ.setdefault("SCILINK_SCRIPT_BANK", "1")
+    for k in (sys.argv[1:] or sorted(PARTS)):
+        PARTS[k]()
+    print("\n" + "=" * 60)
+    npass = sum(results.values())
+    for name, ok in results.items():
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name}")
+    print(f"\n{npass}/{len(results)} checks passed")
+    sys.exit(0 if npass == len(results) else 1)


### PR DESCRIPTION
## Summary

When the script bank holds a proven script closely matching new data, today's "adapt" mode regenerates the whole script with the banked one as a prompt exemplar — which erodes exactly the provenance that made the script worth banking. This PR adds a **minimal-edit adapt mode**: on a strong match, the first attempt asks the LLM for an *edit list* against the banked script, applies it mechanically (atomic — nothing half-applied), and executes. The unchanged verification loop remains the arbiter, and every failure — weak match, unparseable reply, non-applying edits, execution failure — falls through with its reason logged to today's exemplar path. The mode can only add one cheap attempt in front of existing behavior, never subtract.

The payoff is provenance: a **cleanly accepted** adaptation bumps cross-session success (proven-N) on the *same* bank record, accumulating the graduation evidence that full regeneration never could. "Cleanly" matters — a kept-but-flagged poor fit does not count (found live: an NMR adaptation executed fine at R²=0.42 and would have silently inflated the graduation signal).

## Live evidence (Bedrock Opus 4.8)

- **Two-run scenario** (isolated bank): fires at score 0.502, 5 targeted edits (baseline + profile swapped per the data), survives QC, proven-N bumps. 7/7.
- **14-run matrix over the real benchmark corpus** (`benchmarking_for_paper2`): five anchors (NMR, Raman, RRUFF, in-situ XRD, EELS) into one shared bank, then nine follow-ups. Edit-adapt fired on **all four** follow-ups that had a same-family record — NMR pair (5 edits), cross-nucleus NMR (5 edits), XRD near-frame (3 edits, R²=0.9999), XRD far-frame (**verbatim, 0 edits**, R²=0.99999) — and matched the right record every time. **Zero wrong-family anchoring**: EELS follow-ups (whose anchor never banked), two cross-mineral Raman cases, and a dissimilar control all fell through safely; all nine runs succeeded.
- **Threshold calibrated empirically, twice**: the canonical adapt case scores 0.495–0.522 across runs (jitter from the banked script itself being nondeterministic codegen), so 0.60 never fired and 0.50 was a coin flip. Final: any match clearing the retrieval floor (0.45, hard-filtered on fingerprint kind and axis units) earns exactly one attempt. `$SCILINK_BANK_EDIT_ADAPT_SCORE` raises it; `$SCILINK_BANK_EDIT_ADAPT=0` disables the mode.

Offline: 10/10 new tests plus the script-bank suite (43/43).

---

## Technical details

- One **new additive** prompt template (`BANK_EDIT_ADAPT_INSTRUCTIONS`); the four codegen prompt variants are untouched. Structured-JSON reply (`{edits, rationale}`) with one corrective retry, parsed by the shared `_graduation.parse_json_response`.
- Edits applied via `utils/file_edit.apply_snippet_edits` (the atomic batch primitive); an empty edit list means the script fits verbatim — observed live on the XRD far-frame.
- `_try_bank_edit_adapt` sits in `qc_run_initial` before generation; the result (with `bank_edit_adapt` provenance: record id, score, edits, rationale) enters the normal verification loop. A refit replaces the result and drops the provenance, so a rejected adaptation can never bump.
- This is Phase B of `analysis_script_surgical_refinement_plan.md`; curve fitting only, behind the bank's existing enable flag.