### PR TITLE
Image agent adopts bank minimal-edit adaptation (stacked on #436)

### DIFF
--- a/scilink/agents/exp_agents/_qc_engine.py
+++ b/scilink/agents/exp_agents/_qc_engine.py
@@ -38,6 +38,139 @@ from pathlib import Path
 from typing import Any, Optional
 
 
+# Bank minimal-edit adaptation (Phase B), shared across the codegen
+# twins. Fires only on matches clearing the retrieval floor (0.45, hard
+# filtered on fingerprint kind + axis/pixel metadata) — calibrated live
+# on the curve corpus: the canonical adapt case scores 0.495-0.522
+# across runs, so stricter thresholds never fired. One attempt, capped
+# by the fall-through ladder. $SCILINK_BANK_EDIT_ADAPT_SCORE raises it;
+# $SCILINK_BANK_EDIT_ADAPT=0 disables the mode.
+BANK_EDIT_ADAPT_MIN_SCORE = 0.45
+
+
+def try_bank_edit_adapt(host, ctx, *, domain: str, script_kind: str,
+                        output_contract: str, config_key: str,
+                        data_context: str, run_fn):
+    """Adapt a strongly matching banked script via an LLM edit LIST,
+    applied mechanically — instead of whole-script re-emission.
+
+    Full-regeneration "adapt" erodes exactly the provenance that made
+    the script worth banking; a minimal-edit adaptation keeps the proven
+    logic byte-recognizable and (on clean acceptance) accumulates
+    cross-session success evidence on the SAME bank record. The result
+    enters the UNCHANGED verification loop — execution and the quality
+    gate stay the arbiters. Every fall-through is logged with its reason
+    (no silent fallbacks); returning None resumes the exemplar-
+    generation path exactly.
+
+    `host` supplies model / generation_config / logger; `run_fn(script)`
+    executes the adapted script through the modality's single-item
+    runner and returns its result dict.
+    """
+    import json as _json
+    import os as _os
+
+    state = ctx.state
+    exemplar = state.get("_bank_exemplar")
+    if not exemplar:
+        return None
+    if (_os.environ.get("SCILINK_BANK_EDIT_ADAPT", "").strip().lower()
+            in ("0", "false", "off", "no")):
+        return None
+    try:
+        min_score = float(_os.environ.get(
+            "SCILINK_BANK_EDIT_ADAPT_SCORE", BANK_EDIT_ADAPT_MIN_SCORE))
+    except ValueError:
+        min_score = BANK_EDIT_ADAPT_MIN_SCORE
+    score = float(exemplar.get("score") or 0)
+    if score < min_score:
+        host.logger.info(
+            f"   🏦 Edit-adapt skipped: match score {score} < "
+            f"{min_score} — exemplar-guided generation instead.")
+        return None
+    rec = exemplar.get("record") or {}
+    banked = (rec.get("working_script") or "").strip()
+    if not banked:
+        return None
+    try:
+        from .instruct import BANK_EDIT_ADAPT_INSTRUCTIONS
+        from scilink.skills._shared._graduation import parse_json_response
+        from scilink.utils.file_edit import apply_snippet_edits
+        prompt = BANK_EDIT_ADAPT_INSTRUCTIONS.format(
+            script_kind=script_kind,
+            banked_script=banked,
+            locked_config=_json.dumps(state.get(config_key) or {},
+                                      indent=2, default=str),
+            data_context=data_context,
+            output_contract=output_contract,
+        )
+        raw = host.model.generate_content(
+            prompt, generation_config=host.generation_config)
+        raw = raw.text if hasattr(raw, "text") else str(raw)
+        try:
+            parsed = parse_json_response(raw)
+        except ValueError:
+            retry = ("Respond with ONLY a single JSON object — no prose "
+                     "before or after it.\n\n" + prompt)
+            raw = host.model.generate_content(
+                retry, generation_config=host.generation_config)
+            raw = raw.text if hasattr(raw, "text") else str(raw)
+            parsed = parse_json_response(raw)
+        edits = parsed.get("edits")
+        if not isinstance(edits, list):
+            raise ValueError("no edits list in the adaptation reply")
+        if edits:
+            res = apply_snippet_edits(banked, edits)
+            if res["status"] != "success":
+                raise ValueError(f"edits do not apply: {res['message']}")
+            adapted_script, n_edits = res["text"], res["n_edits"]
+        else:
+            adapted_script, n_edits = banked, 0
+        host.logger.info(
+            f"   🏦 ✏️  Bank edit-adapt: record {rec.get('id')} "
+            f"(score {score}), {n_edits} edit(s) — "
+            f"{str(parsed.get('rationale'))[:120]}")
+        result = run_fn(adapted_script)
+        if not result.get("success"):
+            host.logger.info(
+                "   🏦 ↩️  Edit-adapted script did not execute cleanly — "
+                "falling back to exemplar-guided generation.")
+            return None
+        ctx.initial_label = (f"bank edit-adapt of {rec.get('id')} "
+                             f"({n_edits} edit(s))")
+        result["bank_edit_adapt"] = {
+            "id": rec.get("id"), "score": score, "n_edits": n_edits,
+            "edits": list(edits), "rationale": parsed.get("rationale"),
+        }
+        return result
+    except Exception as e:  # noqa: BLE001 - never worse than today
+        host.logger.info(
+            f"   🏦 ↩️  Edit-adapt fell through ({e}) — falling back to "
+            "exemplar-guided generation.")
+        return None
+
+
+def bump_bank_adapt_success(host, res, *, domain: str) -> None:
+    """CLEAN acceptance of an edit-adapted script accumulates proven-N
+    evidence on the SAME bank record. A verification-loop refit replaces
+    the result and drops the provenance, so a rejected adaptation never
+    bumps — and a kept-but-flagged poor fit (quality_warning) must not
+    either (live: an NMR adaptation executed fine at R²=0.42 and would
+    have counted as "proven"). Proven-N feeds the graduation signal;
+    only unflagged survivals are evidence."""
+    try:
+        bea = res.get("bank_edit_adapt") if isinstance(res, dict) else None
+        if (bea and bea.get("id") and res.get("success")
+                and not res.get("quality_warning")):
+            from scilink.skills._shared import _script_bank
+            _script_bank.record_success(domain, bea["id"])
+            host.logger.info(
+                f"   🏦 📈 Bank record {bea['id']}: cross-session success "
+                "recorded (edit-adapted script survived QC).")
+    except Exception:  # noqa: BLE001 - bookkeeping must never fail a run
+        pass
+
+
 @dataclass(frozen=True)
 class QCEngineSpec:
     """Modality constants consumed by the shared engine shell.

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -4603,136 +4603,33 @@ Return JSON with:
             spectrum_name=ctx.item_name, spectrum_idx=ctx.item_idx, base_script=None
         )
 
-    # Calibrated live: the canonical adapt case (same-family single peak,
-    # position shifted 1.5 units) scores 0.495-0.522 across runs — the
-    # jitter comes from the banked script itself being nondeterministic
-    # codegen — so 0.60 never fired and 0.50 was a coin flip. Any match
-    # that cleared the retrieval floor (0.45, with hard filters on
-    # fingerprint kind and axis units) is worth ONE edit-adapt attempt:
-    # the fall-through ladder caps the cost at exactly that attempt.
-    # Raise via $SCILINK_BANK_EDIT_ADAPT_SCORE if live evidence shows
-    # wrong-script anchoring; $SCILINK_BANK_EDIT_ADAPT=0 disables.
-    _BANK_EDIT_ADAPT_MIN_SCORE = 0.45
-
     def _try_bank_edit_adapt(self, ctx: QCItemContext) -> Optional[dict]:
-        """Adapt a strongly matching banked script via an LLM edit LIST,
-        applied mechanically — instead of whole-script re-emission.
-
-        Full-regeneration "adapt" erodes exactly the provenance that made
-        the script worth banking; a minimal-edit adaptation keeps the
-        proven logic byte-recognizable and (on gate pass) accumulates
-        cross-session success evidence on the SAME bank record. The
-        result enters the UNCHANGED verification loop — execution and
-        the quality gate stay the arbiters. Every fall-through is logged
-        with its reason (no silent fallbacks); returning None resumes
-        today's exemplar-generation path exactly.
-        """
-        state = ctx.state
-        exemplar = state.get("_bank_exemplar")
-        if not exemplar:
-            return None
-        import os as _os
-        if (_os.environ.get("SCILINK_BANK_EDIT_ADAPT", "").strip().lower()
-                in ("0", "false", "off", "no")):
-            return None
-        try:
-            min_score = float(_os.environ.get(
-                "SCILINK_BANK_EDIT_ADAPT_SCORE",
-                self._BANK_EDIT_ADAPT_MIN_SCORE))
-        except ValueError:
-            min_score = self._BANK_EDIT_ADAPT_MIN_SCORE
-        score = float(exemplar.get("score") or 0)
-        if score < min_score:
-            self.logger.info(
-                f"   🏦 Edit-adapt skipped: match score {score} < "
-                f"{min_score} — exemplar-guided generation instead.")
-            return None
-        rec = exemplar.get("record") or {}
-        banked = (rec.get("working_script") or "").strip()
-        if not banked:
-            return None
-        try:
-            from ..instruct import BANK_EDIT_ADAPT_INSTRUCTIONS
-            from scilink.skills._shared._graduation import parse_json_response
-            from scilink.utils.file_edit import apply_snippet_edits
-            prompt = BANK_EDIT_ADAPT_INSTRUCTIONS.format(
-                banked_script=banked,
-                locked_config=json.dumps(
-                    state.get("locked_fitting_config") or {}, indent=2,
-                    default=str),
-                data_context=(
-                    f"system_info: {str(state.get('system_info'))[:800]}\n"
-                    f"data statistics: "
-                    f"{str(state.get('data_statistics'))[:800]}"),
-            )
-            raw = self.model.generate_content(
-                prompt, generation_config=self.generation_config)
-            raw = raw.text if hasattr(raw, "text") else str(raw)
-            try:
-                parsed = parse_json_response(raw)
-            except ValueError:
-                retry = ("Respond with ONLY a single JSON object — no "
-                         "prose before or after it.\n\n" + prompt)
-                raw = self.model.generate_content(
-                    retry, generation_config=self.generation_config)
-                raw = raw.text if hasattr(raw, "text") else str(raw)
-                parsed = parse_json_response(raw)
-            edits = parsed.get("edits")
-            if not isinstance(edits, list):
-                raise ValueError("no edits list in the adaptation reply")
-            if edits:
-                res = apply_snippet_edits(banked, edits)
-                if res["status"] != "success":
-                    raise ValueError(f"edits do not apply: {res['message']}")
-                adapted_script, n_edits = res["text"], res["n_edits"]
-            else:
-                adapted_script, n_edits = banked, 0
-            self.logger.info(
-                f"   🏦 ✏️  Bank edit-adapt: record {rec.get('id')} "
-                f"(score {score}), {n_edits} edit(s) — "
-                f"{str(parsed.get('rationale'))[:120]}")
-            result = self._fit_single_spectrum(
-                state=state, curve_data=ctx.data, data_path=ctx.data_path,
-                spectrum_name=ctx.item_name, spectrum_idx=ctx.item_idx,
-                base_script=adapted_script)
-            if not result.get("success"):
-                self.logger.info(
-                    "   🏦 ↩️  Edit-adapted script did not execute cleanly "
-                    "— falling back to exemplar-guided generation.")
-                return None
-            ctx.initial_label = (f"bank edit-adapt of {rec.get('id')} "
-                                 f"({n_edits} edit(s))")
-            result["bank_edit_adapt"] = {
-                "id": rec.get("id"), "score": score, "n_edits": n_edits,
-                "edits": list(edits), "rationale": parsed.get("rationale"),
-            }
-            return result
-        except Exception as e:  # noqa: BLE001 - never worse than today
-            self.logger.info(
-                f"   🏦 ↩️  Edit-adapt fell through ({e}) — falling back "
-                "to exemplar-guided generation.")
-            return None
+        """Curve wrapper over the shared minimal-edit adapt attempt
+        (implementation, threshold and calibration history live in
+        _qc_engine.try_bank_edit_adapt — shared with the image twin so
+        the two cannot drift)."""
+        from .._qc_engine import try_bank_edit_adapt
+        return try_bank_edit_adapt(
+            self, ctx,
+            domain="curve_fitting",
+            script_kind="curve-fitting",
+            output_contract=(
+                "the FIT_RESULTS_JSON print, the success marker, the "
+                "visualization saving, and the results schema"),
+            config_key="locked_fitting_config",
+            data_context=(
+                f"system_info: {str(ctx.state.get('system_info'))[:800]}\n"
+                f"data statistics: "
+                f"{str(ctx.state.get('data_statistics'))[:800]}"),
+            run_fn=lambda script: self._fit_single_spectrum(
+                state=ctx.state, curve_data=ctx.data,
+                data_path=ctx.data_path, spectrum_name=ctx.item_name,
+                spectrum_idx=ctx.item_idx, base_script=script),
+        )
 
     def _bump_bank_adapt_success(self, res) -> None:
-        """CLEAN acceptance of an edit-adapted script accumulates proven-N
-        evidence on the SAME bank record. A verification-loop refit
-        replaces the result and drops the provenance, so a rejected
-        adaptation never bumps — and a kept-but-flagged poor fit
-        (quality_warning) must not either: live, an NMR adaptation
-        executed fine at R²=0.42 and would have counted as "proven".
-        Proven-N feeds the graduation signal; only unflagged survivals
-        are evidence."""
-        try:
-            bea = res.get("bank_edit_adapt") if isinstance(res, dict) else None
-            if (bea and bea.get("id") and res.get("success")
-                    and not res.get("quality_warning")):
-                from scilink.skills._shared import _script_bank
-                _script_bank.record_success("curve_fitting", bea["id"])
-                self.logger.info(
-                    f"   🏦 📈 Bank record {bea['id']}: cross-session "
-                    "success recorded (edit-adapted script survived QC).")
-        except Exception:  # noqa: BLE001 - bookkeeping must never fail a fit
-            pass
+        from .._qc_engine import bump_bank_adapt_success
+        bump_bank_adapt_success(self, res, domain="curve_fitting")
 
     def _offer_bank_exemplar(self, ctx: QCItemContext) -> None:
         """Adapt-mode script-bank retrieval (#346 step 2).

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -3410,7 +3410,9 @@ Return JSON with:
             is_regime_anchor=is_regime_anchor,
             reuse_script=reuse_script, reuse_source=reuse_source,
         )
-        return engine.run_item(ctx)
+        res = engine.run_item(ctx)
+        self._bump_bank_adapt_success(res)
+        return res
 
     # --- CodegenQCEngine hooks (bodies moved verbatim from the old driver) ---
 
@@ -3516,10 +3518,44 @@ Return JSON with:
         self.logger.info(f"   Attempt 1: {initial_pipeline[:80]}...")
 
         self._offer_bank_exemplar(ctx)
+        # Minimal-edit adaptation of a strongly matching banked script
+        # (Phase B, shared with the curve twin): one cheap attempt in
+        # FRONT of exemplar generation — any failure falls through.
+        adapted = self._try_bank_edit_adapt(ctx)
+        if adapted is not None:
+            return adapted
         return self._process_single_image(
             state=ctx.state, image_data=ctx.data, data_path=ctx.data_path,
             image_name=ctx.item_name, image_idx=ctx.item_idx, base_script=None,
         )
+
+    def _try_bank_edit_adapt(self, ctx: QCItemContext):
+        """Image wrapper over the shared minimal-edit adapt attempt
+        (implementation, threshold and calibration history live in
+        _qc_engine.try_bank_edit_adapt — shared with the curve twin so
+        the two cannot drift)."""
+        from .._qc_engine import try_bank_edit_adapt
+        return try_bank_edit_adapt(
+            self, ctx,
+            domain="image_analysis",
+            script_kind="image-analysis",
+            output_contract=(
+                "the IMAGE_ANALYSIS_RESULTS_JSON print, the success "
+                "marker, the visualization saving, and the results "
+                "schema"),
+            config_key="locked_analysis_config",
+            data_context=(
+                f"system_info: {str(ctx.state.get('system_info'))[:800]}\n"
+                f"image shape: {getattr(ctx.data, 'shape', None)}"),
+            run_fn=lambda script: self._process_single_image(
+                state=ctx.state, image_data=ctx.data,
+                data_path=ctx.data_path, image_name=ctx.item_name,
+                image_idx=ctx.item_idx, base_script=script),
+        )
+
+    def _bump_bank_adapt_success(self, res) -> None:
+        from .._qc_engine import bump_bank_adapt_success
+        bump_bank_adapt_success(self, res, domain="image_analysis")
 
     def _offer_bank_exemplar(self, ctx: QCItemContext) -> None:
         """Adapt-mode script-bank retrieval (#346 step 2) — image mirror of

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -3146,7 +3146,7 @@ DELETE that section.
 
 Output ONLY the JSON object. Do not wrap in code blocks. Do not include any prose outside the JSON."""
 
-BANK_EDIT_ADAPT_INSTRUCTIONS = """You are an expert scientific data analyst. A PROVEN fitting script \
+BANK_EDIT_ADAPT_INSTRUCTIONS = """You are an expert scientific data analyst. A PROVEN {script_kind} script \
 from the script bank closely matches the current dataset. Adapt it with the SMALLEST possible set of \
 exact text edits — do NOT rewrite it. The proven structure is the value: a minimal-edit adaptation \
 keeps the script byte-recognizable, so its cross-session success record keeps accumulating.
@@ -3165,10 +3165,9 @@ keeps the script byte-recognizable, so its cross-session success record keeps ac
 **Rules:**
 1. Each edit is an exact-verbatim substring of the proven script (old_text), replaced by new_text. \
 old_text must appear EXACTLY ONCE in the script. Keep each edit small (a value, a line, a few lines).
-2. Re-derive dataset-specific values for THIS data: peak positions/counts, ranges, initial guesses, \
-thresholds, axis windows. Keep the vetted algorithm, model family, and overall structure.
-3. NEVER touch the output contract: the FIT_RESULTS_JSON print, the success marker, the \
-visualization saving, or the results schema.
+2. Re-derive dataset-specific values for THIS data: positions/counts, ranges, initial guesses, \
+thresholds, windows, scale factors. Keep the vetted algorithm, model family, and overall structure.
+3. NEVER touch the output contract: {output_contract}.
 4. If the script fits this dataset as-is, return an empty edits list.
 
 Return ONLY a JSON object: {{"edits": [{{"old_text": "...", "new_text": "..."}}, ...], \

--- a/tests/test_bank_edit_adapt.py
+++ b/tests/test_bank_edit_adapt.py
@@ -46,7 +46,9 @@ def make_self(model_replies, fit_result=None):
         model=FakeModel(model_replies),
         generation_config=None,
         _fit_single_spectrum=_fit_single_spectrum,
-        _BANK_EDIT_ADAPT_MIN_SCORE=C._BANK_EDIT_ADAPT_MIN_SCORE,
+        _process_single_image=lambda **kw: (
+            captured.update(kw) or (fit_result if fit_result is not None
+                                    else {"success": True})),
     )
     return s, captured
 
@@ -148,7 +150,57 @@ def test_success_bump_only_with_surviving_provenance(monkeypatch):
 def test_template_contract():
     from scilink.agents.exp_agents.instruct import BANK_EDIT_ADAPT_INSTRUCTIONS
     filled = BANK_EDIT_ADAPT_INSTRUCTIONS.format(
-        banked_script="s", locked_config="{}", data_context="d")
+        script_kind="curve-fitting", banked_script="s", locked_config="{}",
+        data_context="d", output_contract="the FIT_RESULTS_JSON print")
     assert '"edits"' in filled and "ONLY a JSON object" in filled
     assert "EXACTLY ONCE" in filled
-    assert "output contract" in filled     # FIT_RESULTS_JSON stays untouched
+    assert "FIT_RESULTS_JSON" in filled    # contract text is caller-supplied
+
+
+# ------------------------------------------- image twin (shared core)
+
+
+def make_image_ctx(score=0.8):
+    ctx = make_ctx(score=score)
+    ctx.state["locked_analysis_config"] = {"processing_pipeline": "blobs"}
+    ctx.data = SimpleNamespace(shape=(64, 64))
+    return ctx
+
+
+def test_image_wrapper_shares_the_core():
+    from scilink.agents.exp_agents.controllers.image_analysis_controllers \
+        import UnifiedImageProcessingController as IC
+    fake, captured = make_self([GOOD_REPLY])
+    ctx = make_image_ctx()
+    res = IC._try_bank_edit_adapt(fake, ctx)
+    assert res is not None and res["bank_edit_adapt"]["id"] == "rec_001"
+    assert "CENTER_GUESS = 7.2" in captured["base_script"]
+    assert captured["image_name"] == "s"       # image runner was used
+    assert "edit-adapt of rec_001" in ctx.initial_label
+
+
+def test_image_bump_uses_image_domain(monkeypatch):
+    from scilink.agents.exp_agents.controllers.image_analysis_controllers \
+        import UnifiedImageProcessingController as IC
+    from scilink.skills._shared import _script_bank
+    bumped = []
+    monkeypatch.setattr(_script_bank, "record_success",
+                        lambda d, rid, session=None: bumped.append((d, rid)))
+    fake, _ = make_self([])
+    IC._bump_bank_adapt_success(fake, {
+        "success": True, "bank_edit_adapt": {"id": "rec_009"}})
+    assert bumped == [("image_analysis", "rec_009")]
+
+
+def test_single_shared_implementation():
+    from pathlib import Path
+    curve = Path("scilink/agents/exp_agents/controllers/"
+                 "curve_fitting_controllers.py").read_text()
+    image = Path("scilink/agents/exp_agents/controllers/"
+                 "image_analysis_controllers.py").read_text()
+    engine = Path("scilink/agents/exp_agents/_qc_engine.py").read_text()
+    assert engine.count("def try_bank_edit_adapt") == 1
+    for src in (curve, image):
+        assert "from .._qc_engine import try_bank_edit_adapt" in src
+        assert "def try_bank_edit_adapt" not in src.replace(
+            "from .._qc_engine import try_bank_edit_adapt", "")

--- a/tests/test_bank_edit_adapt_live.py
+++ b/tests/test_bank_edit_adapt_live.py
@@ -164,7 +164,92 @@ def part2_fallthrough():
     check("p2 no adapt provenance", '"bank_edit_adapt":' not in blob)
 
 
-PARTS = {"1": part1_adapt, "2": part2_fallthrough}
+def part3_image_adapt():
+    print("\n=== 3. image twin: adapt + bump through the shared core ===")
+    from scilink.agents.exp_agents.image_analysis_agent import (
+        ImageAnalysisAgent)
+
+    run = BASE / "p3"
+    if run.exists():
+        shutil.rmtree(run)
+    run.mkdir(parents=True)
+
+    def make_image(path, seed):
+        rng = np.random.default_rng(seed)
+        yy, xx = np.mgrid[0:128, 0:128]
+        img = rng.normal(0.1, 0.02, (128, 128))
+        for cx, cy in [(30, 40), (80, 90), (100, 30)]:
+            img += 0.8 * np.exp(-(((xx - cx - rng.integers(-4, 5)) ** 2
+                                   + (yy - cy - rng.integers(-4, 5)) ** 2)
+                                  / (2 * 6.0 ** 2)))
+        np.save(path, img.astype(np.float32))
+
+    make_image(run / "img_a.npy", 1)
+    make_image(run / "img_b.npy", 2)
+    si = {"technique": "AFM height image",
+          "description": "nanoparticles on a flat substrate",
+          "pixel_size_nm": 2.0}
+
+    def img_agent(out):
+        return ImageAnalysisAgent(api_key=None, model_name=MODEL,
+                                  output_dir=str(out),
+                                  enable_human_feedback=False,
+                                  max_verification_iterations=1)
+
+    res_a = img_agent(run / "run_a").analyze(str(run / "img_a.npy"),
+                                             system_info=si)
+    check("p3 run A succeeded", res_a.get("status") == "success")
+    from scilink.skills._shared import _script_bank
+    recs = _script_bank.list_records("image_analysis")
+    if not recs:
+        # The organic write gate requires QC APPROVAL, stochastic at
+        # max_verification_iterations=1. The gate is pre-existing #346
+        # behavior with its own tests; THIS scenario tests adaptation —
+        # seed the bank deterministically from run A's saved script.
+        scripts = sorted((run / "run_a" / "scripts").glob("*.py"))
+        img_a = np.load(run / "img_a.npy")
+        _script_bank.add_record("image_analysis", {
+            "technique_signals": {"analysis_type":
+                                  "particle blob detection (seeded)"},
+            "measurement_context": _script_bank.measurement_context(si),
+            "data_fingerprint": _script_bank.image_fingerprint(
+                img_a, pixel_size_nm=2.0),
+            "outcome": {"metric": {"name": "score", "value": 0.9}},
+            "working_script": scripts[0].read_text(),
+        })
+        recs = _script_bank.list_records("image_analysis")
+        print("     (bank seeded from run A's script — organic gate "
+              "did not approve at smoke settings)")
+    check("p3 bank holds a record", len(recs) >= 1)
+    if not recs:
+        return
+
+    buf = Tee()
+    with capture_all(buf):
+        res_b = img_agent(run / "run_b").analyze(str(run / "img_b.npy"),
+                                                 system_info=si)
+    log = buf.getvalue()
+    check("p3 run B succeeded", res_b.get("status") == "success")
+    check("p3 edit-adapt fired", "Bank edit-adapt: record" in log)
+    # Image analyze() flattens its return; provenance lives in the saved
+    # artifacts (same read the corpus matrix uses).
+    blob = "".join(p.read_text() for p in (run / "run_b").rglob("*.json"))
+    check("p3 provenance present", '"bank_edit_adapt"' in blob)
+    after = {r["id"]: (r.get("stats") or {}).get("n_successes", 1)
+             for r in _script_bank.list_records("image_analysis")}
+    bumped = any(n >= 2 for n in after.values())
+    # Clean-acceptance rule: an adaptation kept WITH a quality_warning
+    # must not bump (observed live both ways: clean run bumped; a
+    # score-0.54 flagged run was correctly withheld).
+    flagged = '"quality_warning": "' in blob
+    if flagged:
+        check("p3 bump correctly WITHHELD (adaptation kept but flagged)",
+              not bumped)
+    else:
+        check("p3 proven-N bumped on a clean adaptation", bumped)
+
+
+PARTS = {"1": part1_adapt, "2": part2_fallthrough, "3": part3_image_adapt}
 
 if __name__ == "__main__":
     assert os.environ.get("SCILINK_HOME"), \


### PR DESCRIPTION
## Summary

Stacked on #436 (merge that first; GitHub retargets this when its base merges). The image agent gets the same minimal-edit bank adaptation as curve fitting, through **one shared implementation**: `try_bank_edit_adapt` / `bump_bank_adapt_success` and the calibrated threshold move into `_qc_engine.py`, the prompt template is generalized (`{script_kind}`, `{output_contract}`), and both controllers become thin wrappers — a test asserts exactly one implementation exists, so the twins cannot drift.

## Live evidence (Bedrock Opus 4.8)

**Real-corpus matrix** — left/right halves of real AFM, OM, and TEM benchmark images ("next frame of the same sample"), three anchors into one shared bank, six follow-ups:

- All three same-source pairs **adapted from the banked SAM particle-segmentation record with 1–2 edits and survived QC** — the same proven script generalized across AFM → OM → TEM (proven-N reached 3). Cross-modality generalization within the image domain is exactly the provenance-accumulation payoff this feature exists for.
- Cross-case probes (MFM stripe domains, LLTO lattice) correctly declined to anchor and generated fresh pipelines — which the bank then captured.
- The synthetic-stripe "control" then adapted from the *just-banked MFM stripe-domain periodicity script* — a semantically **right** cross-sample match (periodicity image → proven periodicity pipeline), not a wrong anchor; the control's empty-bank premise was invalidated by concurrent banking, and the episode ends up demonstrating right-record selection instead.

**Committed scenario** (`tests/test_bank_edit_adapt_live.py` part 3) exercised **both bump branches** across runs: a clean adaptation bumped proven-N, and a kept-but-flagged one (score 0.54, `quality_warning`) was **correctly withheld** — the clean-acceptance rule from the curve matrix's NMR finding, observed working on the image side.

Offline: 13/13 (shared-core wrapper behavior, image-domain bump, single-implementation assertion) plus the script-bank suite, 56 total.

---

## Technical details

- Image wiring mirrors curve exactly: the attempt sits in `qc_run_initial` ahead of exemplar generation (`run_fn` = `_process_single_image(base_script=...)`); the bump wraps the engine's `run_item` return.
- The committed live scenario seeds the bank deterministically when the organic write gate (QC approval) doesn't fire at smoke settings — the gate is pre-existing #346 behavior with its own tests; the scenario tests adaptation.
- Hyperspectral is NOT included: its integration needs a given-script execution mode for `_run_attempt` first — scoped in `hyperspectral_surgical_plan.md` (repo root) along with the full HS parity plan (H1 edit-adapt → H2 locked reuse → H3 script_edits).

**Visual audit of the adapted outputs** (not just metrics — the actual visualizations were inspected):
- AFM pair: SAM overlay traces real grain boundaries; sensible size distribution.
- OM vaterite (the cross-modality case): every particle tightly segmented, correct sphere/ellipsoid split, µm-scale sizes — the AFM-trained script genuinely transferred.
- TEM AuNP: 224 close-packed particles cleanly watershed-segmented, boundary particles excluded, median 145.7 nm — one wart: a spurious ~0–10 nm debris peak in a histogram labeled "unimodal".
- Stripe control: the adapted FFT analysis is *correct* (fundamental + harmonics at the 135° stripe orientation) — visual confirmation that the match was semantically right, not a wrong anchor ("period=N/A nm" wart: synthetic image has no pixel size).
- The flagged committed-scenario run: 3 real particles boxed correctly plus 5 spurious noise detections — the verifier's 0.54 score / `quality_warning` was visually justified, and the clean-acceptance rule correctly withheld the proven-N bump. The full safety chain (adapt → verify → flag → withhold) is confirmed by inspection.
