### PR TITLE
KB build degrades to keyword-only instead of aborting; knowledge_paths is for corpora

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -2303,7 +2303,13 @@ class OrchestratorTools:
             ),
             parameters={
                 "specific_objective": {"type": "string", "description": "Research objective"},
-                "knowledge_paths": {"type": "string", "description": "Comma-separated paths to papers/reports/docs folders"},
+                "knowledge_paths": {"type": "string", "description": (
+                    "Comma-separated paths to papers/reports/docs folders — "
+                    "for document CORPORA too large to read directly "
+                    "(triggers a full embedding knowledge-base build for "
+                    "retrieval). A handful of documents you have ALREADY "
+                    "read this session belongs in additional_context, not "
+                    "here.")},
                 "primary_data_set": {
                     "type": "string",
                     "description": (
@@ -2565,8 +2571,7 @@ class OrchestratorTools:
             
             print(f"  ⚡ Tool: Generating implementation code for existing plan...")
 
-            kb_available = (self.orch.planner.kb_code.index and 
-                            self.orch.planner.kb_code.index.ntotal > 0)
+            kb_available = bool(self.orch.planner.kb_code.chunks)
 
             if not kb_available and not code_paths:
                 return json.dumps({
@@ -2613,7 +2618,9 @@ class OrchestratorTools:
                 
                 print(f"    💻 Code sources: {code_list}")
             elif kb_available:
-                print(f"    💻 Using existing Code KB ({self.orch.planner.kb_code.index.ntotal} vectors)")
+                print(f"    💻 Using existing Code KB "
+                      f"({self.orch.planner.kb_code.index.ntotal if self.orch.planner.kb_code.index else 0} vectors, "
+                      f"{len(self.orch.planner.kb_code.chunks)} chunks)")
             
             try:
                 updated_plan = self.orch.planner.generate_implementation_code(
@@ -7592,7 +7599,12 @@ class OrchestratorTools:
                 },
                 "knowledge_paths": {
                     "type": "string",
-                    "description": "Comma-separated paths to papers/reports/docs folders",
+                    "description": (
+                        "Comma-separated paths to papers/reports/docs "
+                        "folders — for document CORPORA too large to read "
+                        "directly (triggers a full embedding KB build). "
+                        "Documents already read this session belong in "
+                        "additional_context, not here."),
                 },
                 "additional_context": {
                     "type": "string",

--- a/scilink/agents/planning_agents/planning_agent.py
+++ b/scilink/agents/planning_agents/planning_agent.py
@@ -1494,7 +1494,7 @@ class PlanningAgent(BaseAgent):
             return error_result
         
         # Check if code KB has content
-        if not (self.kb_code.index and self.kb_code.index.ntotal > 0):
+        if not self.kb_code.chunks:   # keyword-only KBs count as content
             print("  - ⚠️  Code KB is empty, skipping code generation")
             self._log_action(
                 action="generate_implementation_code",
@@ -1878,7 +1878,7 @@ Select the most appropriate strategy:
 
         # Local KB RAG (optional, additive)
         if use_literature_rag:
-            if self.kb_docs.index and self.kb_docs.index.ntotal > 0:
+            if self.kb_docs.chunks:   # keyword-only KBs count as content
                 search_query = f"Implications and causes of: {consolidated_feedback[:400]}"
                 print(f"  - 🔍 Searching local KB for context on results...")
                 try:
@@ -2180,7 +2180,7 @@ Select the most appropriate strategy:
             Updated plan dict with implementation_code added/updated
         """
         
-        if not self.kb_code.index or self.kb_code.index.ntotal == 0:
+        if not self.kb_code.chunks:   # keyword-only KBs count as content
             print("  - ℹ️  No Code KB available, skipping implementation update")
             self._log_action(
                 action="refine_implementation_code",

--- a/scilink/knowledge/kb_store.py
+++ b/scilink/knowledge/kb_store.py
@@ -279,7 +279,7 @@ def _build_index_into(target: Path, embedding_model: str,
         str(prefix.with_suffix(".json")),
         sources_path=str(prefix.with_suffix(".sources.json")),
     )
-    return len(chunks), int(kb.index.ntotal)
+    return len(chunks), int(kb.index.ntotal) if kb.index else 0
 
 
 def create_kb(name: str,
@@ -532,7 +532,7 @@ def _append_index_into(target: Path, new_doc_paths: List[str],
                    str(prefix.with_suffix(".json")),
                    sources_path=str(prefix.with_suffix(".sources.json"))):
         raise ValueError(f"Could not load the existing index from {target}.")
-    before = int(kb.index.ntotal)
+    before = int(kb.index.ntotal) if kb.index else 0
     # Record the additions under the FINAL sources path so the orchestrator's
     # source-difference check keeps recognising everything as embedded.
     kb.sources.append({
@@ -545,7 +545,7 @@ def _append_index_into(target: Path, new_doc_paths: List[str],
         str(prefix.with_suffix(".json")),
         sources_path=str(prefix.with_suffix(".sources.json")),
     )
-    return len(chunks), int(kb.index.ntotal) - before
+    return len(chunks), (int(kb.index.ntotal) if kb.index else 0) - before
 
 
 def rebuild_kb(name: str,

--- a/scilink/knowledge/knowledge_base.py
+++ b/scilink/knowledge/knowledge_base.py
@@ -128,8 +128,24 @@ class KnowledgeBase:
                         print(f"    - ❌ Rate limit hit on final attempt. Build failed.")
                         raise e 
                 except Exception as e:
+                    # Build-time leg of the degradation ladder ("retrieval
+                    # is grounding, not a dependency"): an unavailable
+                    # embedding provider (e.g. a Bedrock-only session with
+                    # the default Gemini embedder) must not abort
+                    # generation. Fall back to a KEYWORD-ONLY KB: chunks
+                    # are kept, the dense index is dropped entirely (a
+                    # partial index would silently search a stale subset),
+                    # and the query path's existing BM25 tier takes over.
                     print(f"    - ❌ Error embedding batch {i//batch_size + 1}: {e}")
-                    raise e
+                    print(
+                        "  - ⚠️  Embeddings unavailable — building a "
+                        "KEYWORD-ONLY knowledge base (BM25 retrieval tier). "
+                        "Dense retrieval is disabled for this KB; to enable "
+                        "it, configure the embedding provider "
+                        f"('{self.embedding_model_name}') and rebuild.")
+                    self.index = None
+                    self._bm25_state = None
+                    return
 
         embeddings_np = np.array(all_embeddings, dtype=np.float32)
         dimension = embeddings_np.shape[1]
@@ -176,12 +192,20 @@ class KnowledgeBase:
         chunks_file = Path(chunks_path)
         sources_file = Path(sources_path)
 
-        if not index_file.exists() or not chunks_file.exists() or not sources_file.exists() :
-            print("  - ⚠️  Cannot load: Index or chunks or sources file missing.")
+        if not chunks_file.exists() or not sources_file.exists():
+            print("  - ⚠️  Cannot load: chunks or sources file missing.")
             return False
-            
+
         try:
-            self.index = faiss.read_index(index_path)
+            if index_file.exists():
+                self.index = faiss.read_index(index_path)
+            else:
+                # A keyword-only KB (built while embeddings were
+                # unavailable) has chunks but no dense index — load it in
+                # that mode rather than refusing.
+                self.index = None
+                print("  - ⚠️  No dense index on disk — loading as a "
+                      "KEYWORD-ONLY knowledge base (BM25 retrieval tier).")
             with open(chunks_file, 'r', encoding='utf-8') as f:
                 self.chunks = json.load(f)
             
@@ -197,7 +221,8 @@ class KnowledgeBase:
                 except Exception as e:
                     print(f"    - ⚠️ Error loading repo maps file: {e}")
             
-            print(f"  - ✅ Successfully loaded {len(self.chunks)} chunks and index with {self.index.ntotal} vectors from {len(self.sources)} sources.")
+            n_vec = self.index.ntotal if self.index is not None else 0
+            print(f"  - ✅ Successfully loaded {len(self.chunks)} chunks and index with {n_vec} vectors from {len(self.sources)} sources.")
             return True
         except Exception as e:
             print(f"  - ❌ Error loading knowledge base: {e}")
@@ -210,6 +235,13 @@ class KnowledgeBase:
         Retrieves the most relevant document chunks for a given query.
         """
         if not self.index:
+            if self.chunks:
+                # Keyword-only KB: the dense tier does not exist, so ANY
+                # caller of retrieve() degrades to BM25 here instead of
+                # each call site re-implementing the ladder.
+                print("  - ℹ️  No dense index (keyword-only KB) — "
+                      "retrieving via BM25.")
+                return self.retrieve_sparse(query, top_k=top_k)
             print("⚠️  Cannot retrieve: Knowledge base has not been built.")
             return []
             

--- a/tests/test_kb_keyword_only.py
+++ b/tests/test_kb_keyword_only.py
@@ -1,0 +1,107 @@
+"""Build-time leg of the KB degradation ladder.
+
+Live failure: a Bedrock-only session (no Google key) uploaded two PDFs;
+generate_initial_plan triggered a KB build, the Gemini embedding call
+raised, and the WHOLE plan call aborted — even though the documents had
+already been read and the query-time ladder (dense -> BM25 ->
+no-context) would have coped had the KB existed. Build now degrades to
+a KEYWORD-ONLY KB (chunks kept, dense index dropped, loud warning);
+save/load round-trips it; retrieve() itself falls to BM25 so every
+call site gets the ladder; content gates count chunks, not vectors.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from scilink.knowledge.knowledge_base import KnowledgeBase
+
+
+class NoKeyEmbedder:
+    def __init__(self):
+        self.calls = 0
+
+    def embed_content(self, **kw):
+        self.calls += 1
+        raise RuntimeError(
+            "Missing Gemini API key. Set the GEMINI_API_KEY or "
+            "GOOGLE_API_KEY environment variable.")
+
+
+CHUNKS = [
+    {"text": "The controllability map plots intervention timing against "
+             "endpoint distribution shift.", "metadata": {"source": "a"}},
+    {"text": "Bayesian optimization selects the next perturbation from "
+             "the acquisition function.", "metadata": {"source": "a"}},
+    {"text": "Opentrons handoff limits throughput to twelve samples per "
+             "day between the two laboratories.", "metadata": {"source": "b"}},
+]
+
+
+def make_kb():
+    kb = KnowledgeBase.__new__(KnowledgeBase)
+    kb.embedding_client = NoKeyEmbedder()
+    kb.embedding_model_name = "gemini-embedding-001"
+    kb.index = None
+    kb.chunks = []
+    kb.sources = []
+    kb.repo_maps = {}
+    return kb
+
+
+def test_build_degrades_to_keyword_only(capsys):
+    kb = make_kb()
+    kb.build(list(CHUNKS))                      # must NOT raise
+    out = capsys.readouterr().out
+    assert "KEYWORD-ONLY" in out
+    assert kb.index is None and len(kb.chunks) == 3
+
+
+def test_keyword_only_kb_retrieves_via_bm25():
+    kb = make_kb()
+    kb.build(list(CHUNKS))
+    hits = kb.retrieve("throughput Opentrons handoff", top_k=1)
+    assert hits and "Opentrons" in hits[0]["text"]
+    assert kb.embedding_client.calls == 1       # only the failed build call
+
+
+def test_save_load_roundtrip_keyword_only(tmp_path):
+    kb = make_kb()
+    kb.build(list(CHUNKS))
+    idx = tmp_path / "kb.faiss"
+    ch = tmp_path / "kb.json"
+    src = tmp_path / "kb.sources.json"
+    kb.save(str(idx), str(ch), sources_path=str(src))
+    assert not idx.exists()                     # no dense index written
+
+    kb2 = make_kb()
+    ok = kb2.load(str(idx), str(ch), sources_path=str(src))
+    assert ok and kb2.index is None and len(kb2.chunks) == 3
+    hits = kb2.retrieve("acquisition function Bayesian", top_k=1)
+    assert hits and "Bayesian" in hits[0]["text"]
+
+
+def test_partial_dense_state_is_dropped_entirely():
+    """An existing dense index + a failed incremental build would
+    silently search a stale subset — the whole index must drop so BM25
+    over ALL chunks is the single source of truth."""
+    kb = make_kb()
+    kb.index = SimpleNamespace(ntotal=5)        # pre-existing dense index
+    kb.build(list(CHUNKS))
+    assert kb.index is None
+    assert len(kb.chunks) == 3
+
+
+def test_content_gates_count_chunks_not_vectors():
+    from pathlib import Path
+    pa = Path("scilink/agents/planning_agents/planning_agent.py").read_text()
+    assert pa.count("keyword-only KBs count as content") == 3
+    ot = Path("scilink/agents/planning_agents/orchestrator_tools.py").read_text()
+    assert "kb_available = bool(self.orch.planner.kb_code.chunks)" in ot
+
+
+def test_routing_guidance_on_knowledge_paths():
+    from pathlib import Path
+    ot = Path("scilink/agents/planning_agents/orchestrator_tools.py").read_text()
+    assert ot.count("additional_context, not") >= 2   # both plan tools
+    assert ot.count("CORPORA too large to read") >= 2


### PR DESCRIPTION
## Summary

Observed live (Bedrock-only session): a planning delegation passed two uploaded PDFs — which it had **already fully read** — as `knowledge_paths`, triggering an embedding knowledge-base build with the default Gemini embedder. No Google key was present, the embedding call raised, and the entire `generate_initial_plan` call died. The agent recovered on its own by retrying with the documents folded into `additional_context` — which was the right call from the start, and exposes that the failure had two halves:

**1. Routing (primary).** `knowledge_paths` exists for document *corpora* too large to read directly — that's what retrieval is for. A handful of documents already read this session belongs in `additional_context`. The parameter descriptions on `generate_initial_plan` and `generate_ideation_portfolio` now state this, so the common case never builds a KB at all.

**2. Build-time degradation (safety net).** The "retrieval is grounding, not a dependency" ladder (dense → BM25 → no-context) existed only at *query* time; *building* a new KB still hard-required the embedding provider. `build()` now degrades on a hard embedding failure to a **keyword-only KB**: chunks kept, dense index dropped entirely (a partial index would silently search a stale subset), loud warning naming the remedy. The keyword-only state round-trips through save/load, `retrieve()` itself falls back to BM25 when no dense index exists (so every call site inherits the ladder), and the various "is the KB non-empty" gates now count chunks rather than dense vectors.

Validation: 7 new offline tests (degrade-not-raise, BM25 retrieval on a keyword-only KB, save/load round-trip, partial-index drop, gate and routing-text checks) plus the kb_store and campaign-scoping suites — 81 green. Live on Bedrock with Google keys explicitly unset: the exact failing call from the session — fresh PDF uploads passed as `knowledge_paths` — completes with the keyword-only warning, BM25-grounded retrieval, and a successful plan.