### PR TITLE
Documents can be grounded in part of the literature, and declining says what was declined

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -916,6 +916,53 @@ class OrchestratorTools:
             sections.append((m.group(2).strip(), text[m.start():end]))
         return sections
 
+    def _campaign_literature_topics(self) -> List[Dict[str, Any]]:
+        """What the CURRENT campaign's literature COVERS.
+
+        Returns [{'file', 'section_ref', 'question'}, ...] — the question
+        each saved section answers, addressable as '<path>#qN'. The files
+        are read, but only QUESTIONS are returned, never answer bodies, so
+        the index stays small however large the corpus is.
+
+        Ref numbers come from each file's own '# Question N' headings, not
+        from list position: _resolve_section_ref matches a ref against the
+        heading number, and a campaign whose literature accumulated across
+        several searches (each file restarting at 1, each living in its own
+        delegation folder) would otherwise be handed refs that resolve to
+        the wrong section or to nothing. A headingless single-question file
+        is addressable as '#q1', matching the resolver's own special case.
+
+        This exists because the decision to ground a document in the
+        campaign's literature was being made blind — all the agent had
+        ever seen of a 200 KB corpus was one 300-character preview, so it
+        could not know that the corpus answered the very question the
+        document was about (live: a throughput document written from
+        priors while the corpus held a 45 KB section on exactly that).
+        """
+        by_path = {}
+        for e in self._lit_registry():
+            if e.get("path"):
+                by_path[str(Path(e["path"]).resolve())] = e.get("questions") or []
+        topics = []
+        for p in self._campaign_literature_files():
+            try:
+                sections = self._split_literature_sections(p.read_text())
+            except Exception as exc:  # noqa: BLE001 - the index is advisory
+                logging.debug(f"Literature topic scan failed for {p}: {exc}")
+                continue
+            reg_qs = by_path.get(str(p.resolve())) or []
+            for question, chunk in sections:
+                m = _LIT_QUESTION_RE.match(chunk)
+                if m:
+                    ref, label = f"{p}#q{m.group(1)}", question
+                elif len(sections) == 1 and reg_qs:
+                    ref, label = f"{p}#q1", reg_qs[0]
+                else:
+                    continue  # bare title chunk — nothing addressable
+                topics.append({"file": p.name, "section_ref": ref,
+                               "question": label})
+        return topics
+
     def _load_campaign_literature(self) -> Optional[Dict[str, Any]]:
         """Auto-load the CURRENT campaign's literature corpus (issue #425).
 
@@ -1876,11 +1923,14 @@ class OrchestratorTools:
                 "answer, with per-section sizes. Costs almost nothing — "
                 "it reads no corpus into context. Call it before "
                 "refine_plan_with_results() or write_technical_document() "
-                "when the campaign may hold MORE THAN ONE literature file, "
-                "and pass the relevant selection (file paths, or "
-                "'<path>#qN' section refs) as literature_context. If you "
-                "pass nothing, ALL campaign literature is auto-loaded — "
-                "safe, but larger than a considered selection."
+                "WHENEVER YOU HAVE NOT YET SEEN WHAT THE CORPUS COVERS — "
+                "one file with several questions is as worth indexing as "
+                "several files, and you cannot judge whether literature "
+                "bears on a document without knowing what it answers. Then "
+                "pass the relevant selection (file paths, or '<path>#qN' "
+                "section refs) as literature_context. If you pass nothing, "
+                "ALL campaign literature is auto-loaded — safe, but larger "
+                "than a considered selection."
             ),
             parameters={},
             required=[]
@@ -7234,6 +7284,7 @@ class OrchestratorTools:
             source_files: str = None,
             use_literature: bool = True,
             revise_path: str = None,
+            literature_context: str = None,
         ):
             """Author a grounded technical document and save it.
 
@@ -7269,11 +7320,30 @@ class OrchestratorTools:
                             "status": "error",
                             "message": f"No such document: {rp}"})
                     current = rp.read_text(errors="replace")
+                # Literature grounding, in three tiers. An explicit
+                # selection wins (whole files, or '<path>#qN' sections —
+                # the targeted option the all-or-nothing boolean never
+                # offered, and the reason a 200 KB corpus read as too
+                # expensive to include at all). Otherwise the campaign
+                # corpus auto-loads, as before. Declining is still allowed;
+                # it is just no longer done blind.
                 lit = None
-                if use_literature:
+                declined_topics = []
+                if literature_context:
+                    lit = self._resolve_context_text(literature_context)
+                    if lit:
+                        print(f"    📚 Literature selection resolved "
+                              f"({len(lit.split()):,} words)")
+                elif use_literature:
                     _lit = self._load_campaign_literature()
                     if _lit is not None:
                         lit = _lit["text"]
+                else:
+                    # Declining is reported back with WHAT was declined, so
+                    # a wrong opt-out is visible and recoverable on the next
+                    # turn instead of silently shipping an ungrounded
+                    # document. Questions only — no answer bodies.
+                    declined_topics = self._campaign_literature_topics()
 
                 # Prior documents the agent names — this is how a revision or
                 # a merge builds on what the session already wrote instead of
@@ -7429,6 +7499,16 @@ class OrchestratorTools:
                        "sources_used": len(sources)}
                 if missing:
                     res["source_files_not_found"] = missing
+                if declined_topics:
+                    res["literature_declined"] = {
+                        "available_sections": declined_topics,
+                        "note": ("This document was written WITHOUT the "
+                                 "campaign literature above. If any section "
+                                 "answers what this document argues, re-run "
+                                 "with literature_context set to those "
+                                 "section_refs (comma-separated) — the "
+                                 "document is rewritten, not appended to."),
+                    }
                 return json.dumps(res)
             except Exception as e:
                 logging.error(f"Document authoring error: {e}", exc_info=True)
@@ -7494,13 +7574,33 @@ class OrchestratorTools:
                         "for you. Omit for a fresh document."
                     ),
                 },
+                "literature_context": {
+                    "type": "string",
+                    "description": (
+                        "The PART of the campaign's literature this document "
+                        "should be grounded in: comma-separated section refs "
+                        "('<path>#qN') or file paths, as listed by "
+                        "list_literature_searches. Prefer this over "
+                        "use_literature when the corpus is large and only "
+                        "some of it bears on this document — it is cheaper "
+                        "and sharper than loading everything. Omit to "
+                        "auto-load the whole campaign corpus."
+                    ),
+                },
                 "use_literature": {
                     "type": "boolean",
                     "description": (
-                        "Ground in the campaign's most recent literature "
-                        "search (default true). Set false for a document "
-                        "that is purely internal, e.g. merging two documents "
-                        "you already wrote."
+                        "Ground in the campaign's literature, already "
+                        "retrieved and free to include (default true). Set "
+                        "false only when the document asserts nothing the "
+                        "literature could support or contradict — building "
+                        "on earlier work, or needing no NEW search, is not "
+                        "itself a reason. Decide from what the corpus "
+                        "actually covers, not from how the request is "
+                        "phrased: call list_literature_searches first if you "
+                        "have not seen its index, or pass literature_context "
+                        "to take just the sections that bear on this "
+                        "document."
                     ),
                 },
                 "revise_path": {

--- a/tests/test_literature_section_selection.py
+++ b/tests/test_literature_section_selection.py
@@ -1,0 +1,178 @@
+"""Targeted literature selection for documents, and the decline index.
+
+write_technical_document could only take the campaign's literature
+all-or-nothing, and the agent chose knowing nothing about what the corpus
+covered. These cover the three branches:
+
+  literature_context set   -> exactly those sections
+  use_literature=True      -> whole campaign corpus (unchanged default)
+  use_literature=False     -> no literature, but the index comes back
+
+The hard case throughout is a campaign whose literature accumulated across
+delegations: each search writes its own file, EVERY file restarts at
+'# Question 1', and under the meta the files can share a basename. Refs
+derived from list position instead of the file's own heading numbers
+resolve to the wrong section exactly there.
+"""
+import json
+import shutil
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scilink.agents.planning_agents.orchestrator_tools import OrchestratorTools
+
+RESULTS = {}
+
+
+def _tools(root, entries, campaign_id=1):
+    t = OrchestratorTools.__new__(OrchestratorTools)
+    t._prestate_lit = []
+    t.orch = types.SimpleNamespace(base_dir=str(root), planner=None)
+    state = {"campaign_id": campaign_id, "campaign_literature": entries}
+    t._planner_state = lambda: state
+    return t
+
+
+def _write_search(path, marker, questions):
+    """A saved search: title chunk, then '# Question N' sections from 1."""
+    body = "# Literature Search Results\n\n"
+    for i, q in enumerate(questions, start=1):
+        body += f"# Question {i}: {q}\n\n{marker}-BODY-{i} answer text here.\n\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return {"path": str(path), "campaign_id": 1, "label": "hypothesis_context",
+            "questions": questions}
+
+
+def _fixture(root):
+    """Two searches, two delegations, SAME basename — the meta's shape."""
+    name = "literature_search_hypothesis_context.md"
+    a = _write_search(root / "delegations" / "01_first" / name, "AAA",
+                      ["What are the timescales of Pd nucleation?",
+                       "How does BO time an intervention?"])
+    b = _write_search(root / "delegations" / "02_second" / name, "BBB",
+                      ["What throughput do autonomous colloidal campaigns reach?",
+                       "How does carryover degrade reproducibility?"])
+    return _tools(root, [a, b])
+
+
+def test_index_spans_delegations_and_shared_basenames():
+    root = Path(tempfile.mkdtemp(prefix="litsel_"))
+    try:
+        topics = _fixture(root)._campaign_literature_topics()
+        assert len(topics) == 4, f"expected 4 sections, got {len(topics)}"
+        refs = [t["section_ref"] for t in topics]
+        assert len(set(refs)) == 4, "shared basenames collapsed the index"
+        # Both files restart at q1, so #q1 must appear twice under
+        # different paths rather than one shadowing the other.
+        assert sum(r.endswith("#q1") for r in refs) == 2
+        delegs = {r.split("delegations/")[1].split("/")[0] for r in refs}
+        assert delegs == {"01_first", "02_second"}, delegs
+    finally:
+        shutil.rmtree(root)
+
+
+def test_every_ref_resolves_to_its_own_files_own_section():
+    root = Path(tempfile.mkdtemp(prefix="litsel_"))
+    try:
+        for t in _fixture(root)._campaign_literature_topics():
+            text = OrchestratorTools._resolve_context_text(t["section_ref"])
+            n = t["section_ref"].rsplit("#q", 1)[1]
+            mine = "AAA" if "01_first" in t["section_ref"] else "BBB"
+            other = "BBB" if mine == "AAA" else "AAA"
+            assert f"{mine}-BODY-{n}" in text, f"wrong section: {t['section_ref']}"
+            assert other not in text, f"cross-file bleed: {t['section_ref']}"
+    finally:
+        shutil.rmtree(root)
+
+
+def test_selection_is_a_strict_subset_and_composes_across_delegations():
+    root = Path(tempfile.mkdtemp(prefix="litsel_"))
+    try:
+        tools = _fixture(root)
+        topics = tools._campaign_literature_topics()
+        whole = tools._load_campaign_literature()["text"]
+
+        thr = next(t for t in topics if "throughput" in t["question"].lower())
+        one = OrchestratorTools._resolve_context_text(thr["section_ref"])
+        assert "BBB-BODY-1" in one and "BBB-BODY-2" not in one
+        assert "AAA" not in one
+        assert len(one) < len(whole), "selection did not narrow the corpus"
+
+        # A document may need one section from each search.
+        pair = OrchestratorTools._resolve_context_text(
+            f"{topics[0]['section_ref']},{thr['section_ref']}")
+        assert "AAA-BODY-1" in pair and "BBB-BODY-1" in pair
+        assert len(pair) > len(one)
+    finally:
+        shutil.rmtree(root)
+
+
+def test_default_path_still_loads_the_whole_corpus():
+    """use_literature=True with no selection must be unchanged."""
+    root = Path(tempfile.mkdtemp(prefix="litsel_"))
+    try:
+        lit = _fixture(root)._load_campaign_literature()
+        assert lit["n_files"] == 2
+        for marker in ("AAA-BODY-1", "AAA-BODY-2", "BBB-BODY-1", "BBB-BODY-2"):
+            assert marker in lit["text"], f"{marker} missing from auto-load"
+    finally:
+        shutil.rmtree(root)
+
+
+def test_decline_index_carries_questions_not_answers():
+    """The whole point of reporting a decline is that it stays cheap."""
+    root = Path(tempfile.mkdtemp(prefix="litsel_"))
+    try:
+        topics = _fixture(root)._campaign_literature_topics()
+        blob = json.dumps(topics)
+        for marker in ("AAA-BODY", "BBB-BODY"):
+            assert marker not in blob, "answer bodies leaked into the index"
+        assert all(t["question"] and t["file"] for t in topics)
+    finally:
+        shutil.rmtree(root)
+
+
+def test_campaign_without_literature_yields_no_index():
+    """No literature must produce no decline block, not an empty one."""
+    root = Path(tempfile.mkdtemp(prefix="litsel_"))
+    try:
+        assert _tools(root, [], campaign_id=7)._campaign_literature_topics() == []
+    finally:
+        shutil.rmtree(root)
+
+
+def test_headingless_single_question_file_is_addressable_as_q1():
+    """A one-question search is saved WITHOUT headings; the resolver has a
+    special case for '#q1' and the index must agree with it."""
+    root = Path(tempfile.mkdtemp(prefix="litsel_"))
+    try:
+        f = root / "delegations" / "01_only" / "literature_search_solo.md"
+        f.parent.mkdir(parents=True)
+        f.write_text("Solo corpus body with no question headings.\n")
+        entry = {"path": str(f), "campaign_id": 1, "label": "solo",
+                 "questions": ["What is the solo question?"]}
+        topics = _tools(root, [entry])._campaign_literature_topics()
+        assert len(topics) == 1 and topics[0]["section_ref"].endswith("#q1")
+        assert topics[0]["question"] == "What is the solo question?"
+        text = OrchestratorTools._resolve_context_text(topics[0]["section_ref"])
+        assert "Solo corpus body" in text, "index advertised an unresolvable ref"
+    finally:
+        shutil.rmtree(root)
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for fn in tests:
+        try:
+            fn()
+            print(f"  PASS  {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  FAIL  {fn.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
When you ask a follow-up question in a planning session — "write me a memo on
throughput", "spec out this piece of hardware" — the agent decides whether to
ground the answer in the literature it already searched for you. It was making
that decision blind, and it could only choose *all* the literature or *none*.

This PR gives it a third option: take just the part that matters. And when it
does decline, it now has to say what it declined.

**What went wrong.** In a real session, the agent ran one literature search
(five questions, ~200 KB) and then wrote seven follow-up documents. Only one
was grounded in that search. Auditing the rest, most of the skips were
defensible — a one-page consolidation of documents it had already written
genuinely does not need a literature corpus. But one document argued at length
about how many samples the platform could run per day, made concrete
recommendations, and cited nothing — while the corpus held a 45 KB section
answering exactly that question, with numbers from seven comparable published
platforms.

The agent had no way to know that. All it had ever seen of the corpus was a
300-character preview from whenever the search ran. And even if it had known,
including that one section meant loading all 200 KB, which reasonably reads as
too expensive for a short memo.

**What changed.** Documents can now be grounded in specific sections of the
literature rather than all-or-nothing. The tool that lists what the literature
covers — cheap, and it was already there — is now something the agent consults
before deciding, instead of only when a campaign happened to hold several
search files. And declining to use the literature now returns a list of what
was available, so a wrong call is visible on the next turn instead of quietly
shipping an ungrounded document.

The agent keeps its judgment. The audit said that judgment was mostly sound;
what it lacked was information.

**Does it work?** Live meta-mode test, two separate literature searches in
different delegations, then the same throughput question that failed before.
The agent indexed the literature, picked the relevant search, and wrote the
memo grounded in it — 14 citations where the original had none. More
interesting: it reached the **opposite recommendation**. The original memo said
build the autosampler; the grounded one says don't, because the real bottleneck
is a 24-hour sample-aging step that automating the recharge cycle does nothing
about. It also named the three conditions that would flip the verdict back.

<details>
<summary><b>Technical details</b></summary>

### Changes

`scilink/agents/planning_agents/orchestrator_tools.py`

1. **`literature_context` on `write_technical_document`.** Comma-separated
   `'<path>#qN'` section refs or file paths, resolved through the existing
   `_resolve_context_text` — the same resolver `generate_initial_plan` and
   `refine_plan_with_results` already use. Precedence: explicit selection >
   `use_literature` auto-load > decline.

2. **`_campaign_literature_topics()`** — new helper returning
   `[{'file', 'section_ref', 'question'}, ...]` for the current campaign.
   Questions only, never answer bodies (3 KB to describe a 160 KB corpus).
   Surfaced under `literature_declined` in the tool result when
   `use_literature=False`.

3. **`list_literature_searches` gate widened.** Was *"when the campaign may
   hold MORE THAN ONE literature file"* — which is why it was called **zero
   times across six live sessions**: a single file with five distinct sections
   never tripped it. Now gated on "you have not seen what the corpus covers."

4. **`use_literature` description rewritten.** The old text (*"Set false for a
   document that is purely internal, e.g. merging two documents you already
   wrote"*) described every follow-up in a session that builds on prior work.
   New text states the principle — decline only when the document asserts
   nothing the literature could support or contradict — and points at the index
   and the targeted parameter.

The default path (`use_literature=True`, no selection) is unchanged.

### The subtle bit

Section refs are derived from each file's own `# Question N` headings, **not**
from registry list position. `_resolve_section_ref` matches a ref against the
heading number; literature accumulates across delegations, every saved search
restarts at Question 1, and under the meta two searches can share a basename.
Position-derived refs resolve to the wrong section as soon as a campaign holds
two searches. The first implementation had this bug; the multi-delegation test
is what surfaced it.

### Validation

**Live, meta mode, autonomous** (`bedrock/us.anthropic.claude-opus-4-8`):
two searches → two files, same basename, delegations 01 and 02 → throughput
document.

- `list_literature_searches` called (first time in any observed session)
- `write_technical_document` with a targeted selection resolving to
  **9,846 words** = search 2's `q1+q2` exactly (search 1's would be 9,753) —
  correct file despite the shared basename
- Output: 2,385 words, 14 citations, References section; verdict reversed from
  the ungrounded original
- Decline path on the restored session: `literature_used: false` plus a
  4-section index spanning both delegations, all refs resolving, 3,079 chars

**Offline:** `tests/test_literature_section_selection.py` — 7/7. Covers
cross-delegation indexing with shared basenames, per-file section resolution
(no cross-file bleed), strict-subset selection, multi-ref composition across
delegations, the unchanged whole-corpus default, questions-only decline index,
no-literature campaigns, and headingless single-question files.

**Regression:** `test_literature_autoload_425`, `test_technical_document_tool`,
`test_literature_no_overwrite`, `test_lit_planner_injection`,
`test_literature_cross_domain` — 5/5.

</details>
