### PR TITLE
rename_file can copy a file into the delegation you are writing in

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -5136,29 +5136,55 @@ class OrchestratorTools:
         def rename_file(path: str, new_name: str, copy: bool = False,
                         deliverable: bool = False, title: str = ""):
             """
-            Rename (or copy) an existing session file byte-exactly, in its
-            own directory. Exists because the alternative was observed
-            live: with no rename tool, the agent reconstructed a 30 KB
-            document via save_file + append_file chunks, dropping content
-            and leaving divergent duplicates.
+            Rename an existing session file byte-exactly in its own
+            directory, or COPY one into the current output directory.
+            Exists because the alternative was observed live: with no
+            rename tool, the agent reconstructed a 30 KB document via
+            save_file + append_file chunks, dropping content and leaving
+            divergent duplicates.
             """
-            print(f"  ⚡ Tool: Renaming file '{path}' → '{new_name}'...")
+            verb_now = "Copying" if copy else "Renaming"
+            print(f"  ⚡ Tool: {verb_now} file '{path}' → '{new_name}'...")
             try:
                 from ...utils.file_edit import rename_or_copy_file
                 from .user_interface import format_path, record_deliverable
+                out_dir = Path(self._output_dir()).resolve()
                 rp = Path(path)
                 if not rp.is_absolute():
-                    rp = self._output_dir() / rp
+                    rp = out_dir / rp
                 rp = rp.resolve()
-                # A bare target name keeps the file where it lives — the
-                # rename changes identity, not location (moving between
+                # A bare target name keeps a RENAME where the file lives —
+                # it changes identity, not location (moving between
                 # delegation folders is how phantom nested copies happen).
+                # A COPY lands in the CURRENT output directory instead, so
+                # a consolidating delegation can bring a figure written by
+                # an earlier one alongside its own document and have the
+                # embed resolve. The destination is never agent-chosen:
+                # it is this delegation's folder or nowhere, which also
+                # stops a copy from writing into a sibling delegation.
                 safe_name = Path(new_name).name
                 if not safe_name:
                     return json.dumps({"status": "error",
                                        "message": "Invalid new_name."})
+                dest = ((out_dir if copy else rp.parent) / safe_name).resolve()
+                # An error here is a routing decision point: the agent
+                # asked to bring a file somewhere and needs to know which
+                # tool does that, not merely that two paths matched.
+                if rp == dest:
+                    if not copy and rp.parent != out_dir:
+                        return json.dumps({"status": "error", "message": (
+                            f"A rename keeps the file in its own folder "
+                            f"({rp.parent}), so this call changes nothing. "
+                            f"To bring it alongside the document you are "
+                            f"writing, call again with copy=true — it lands "
+                            f"in {out_dir}. To leave it where it is, "
+                            f"reference it by a relative path instead.")})
+                    return json.dumps({"status": "error", "message": (
+                        f"'{safe_name}' is already this file's name in "
+                        f"{dest.parent} — nothing to do. Give a different "
+                        f"new_name, or reference the file as it is.")})
                 out = rename_or_copy_file(
-                    rp, rp.parent / safe_name,
+                    rp, dest,
                     root=Path(self.orch.base_dir).resolve(), copy=copy)
                 if out["status"] != "success":
                     return json.dumps(out)
@@ -5179,14 +5205,17 @@ class OrchestratorTools:
             func=rename_file,
             name="rename_file",
             description=(
-                "Rename (or copy) an existing session file BYTE-EXACTLY "
-                "under a new filename in its own directory — the content "
-                "never passes through the model. Use this to land a "
-                "document under its intended filename. Never reconstruct "
-                "a file with save_file/append_file just to rename it: "
-                "that loses content and leaves divergent duplicates. A "
-                "markdown document's PDF twin follows the rename "
-                "automatically."
+                "Rename or copy an existing session file BYTE-EXACTLY — "
+                "the content never passes through the model. Two uses: "
+                "RENAME (default) lands a document under its intended "
+                "filename, in its own folder; COPY (copy=true) brings a "
+                "file into the folder you are writing in now, which is "
+                "how you embed a figure an earlier delegation produced "
+                "and have the reference resolve beside your document. "
+                "Never reconstruct a file with save_file/append_file to "
+                "rename or move it: that loses content and leaves "
+                "divergent duplicates. A markdown document's PDF twin "
+                "follows automatically."
             ),
             parameters={
                 "path": {
@@ -5200,16 +5229,20 @@ class OrchestratorTools:
                 "new_name": {
                     "type": "string",
                     "description": (
-                        "New filename (bare name, no directories). The "
-                        "file stays in its own folder."
+                        "Target filename (bare name, no directories). "
+                        "Keep the source's own name when copying a figure "
+                        "you are about to embed."
                     ),
                 },
                 "copy": {
                     "type": "boolean",
                     "description": (
-                        "Keep the original and create a copy under the "
-                        "new name instead of renaming. Default false — "
-                        "prefer a true rename; duplicates diverge."
+                        "TRUE keeps the original and puts a copy in the "
+                        "folder you are writing in now — use it to bring "
+                        "an asset from an earlier delegation alongside "
+                        "your document. FALSE (default) renames in place; "
+                        "prefer a true rename for documents, since "
+                        "duplicates diverge."
                     ),
                 },
                 "deliverable": {

--- a/tests/test_rename_copy_across_delegations.py
+++ b/tests/test_rename_copy_across_delegations.py
@@ -1,0 +1,228 @@
+"""rename_file: renames stay in place, copies land in the current folder.
+
+Under the meta every delegation writes into its own directory, so a
+consolidating delegation that wants to embed a figure an earlier one
+produced had no way to bring it alongside its document: rename_file forced
+the destination into the SOURCE's folder, so the call collapsed to a
+self-rename and came back only with "path and new path are identical".
+Live, the agent burned two turns inferring the constraint before falling
+back to a relative path.
+
+copy=true now lands the file in the CURRENT output directory — never a
+path the agent picks, so a copy still cannot write into a sibling
+delegation. Renames are untouched: identity, not location.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.test_edit_file_tool import make_tools
+
+
+def _figure(tmp_path, folder="delegations/01_design", name="campaign_workflow.png"):
+    p = tmp_path / folder / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"\x89PNG\r\n\x1a\n" + b"figure-bytes" * 64)
+    return p
+
+
+# ------------------------------------------------- copy into current folder
+
+
+def test_copy_brings_a_sibling_delegations_figure_here(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    fig = _figure(tmp_path)
+
+    out = json.loads(cap["rename_file"](str(fig), "campaign_workflow.png",
+                                        copy=True))
+
+    assert out["status"] == "success", out
+    landed = Path(out["path"])
+    assert landed == deleg / "campaign_workflow.png", "copy did not land here"
+    assert landed.read_bytes() == fig.read_bytes(), "copy is not byte-exact"
+    assert fig.exists(), "copy destroyed the original"
+
+
+def test_copy_lets_a_local_embed_resolve(tmp_path):
+    """The actual point: after the copy, a bare filename reference in the
+    consolidating document resolves in its own folder."""
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    fig = _figure(tmp_path)
+    cap["rename_file"](str(fig), "campaign_workflow.png", copy=True)
+
+    report = deleg / "report.md"
+    report.write_text("# Report\n\n![Workflow](campaign_workflow.png)\n")
+    ref = report.parent / "campaign_workflow.png"
+    assert ref.is_file(), "embedded reference does not resolve beside the doc"
+
+
+def test_copy_cannot_write_into_a_sibling_delegation(tmp_path):
+    """Destination is this delegation's folder or nowhere — directory
+    components in new_name must not steer it elsewhere."""
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    fig = _figure(tmp_path)
+    victim = tmp_path / "delegations" / "02_other"
+    victim.mkdir(parents=True)
+
+    out = json.loads(cap["rename_file"](
+        str(fig), "../02_other/stolen.png", copy=True))
+
+    assert out["status"] == "success", out
+    assert Path(out["path"]) == deleg / "stolen.png"
+    assert not (victim / "stolen.png").exists(), "copy escaped into a sibling"
+
+
+def test_copy_refuses_to_clobber(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    fig = _figure(tmp_path)
+    (deleg / "campaign_workflow.png").write_bytes(b"mine, different")
+
+    out = json.loads(cap["rename_file"](str(fig), "campaign_workflow.png",
+                                        copy=True))
+
+    assert out["status"] == "error"
+    assert (deleg / "campaign_workflow.png").read_bytes() == b"mine, different"
+
+
+def test_copy_of_a_file_already_here_under_the_same_name_is_refused(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    fig = _figure(tmp_path, "delegations/09_consolidate")
+
+    out = json.loads(cap["rename_file"](str(fig), "campaign_workflow.png",
+                                        copy=True))
+
+    assert out["status"] == "error"
+    assert "already this file's name" in out["message"]
+    assert fig.exists()
+
+
+def test_copy_of_a_local_file_under_a_new_name_still_duplicates_here(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    fig = _figure(tmp_path, "delegations/09_consolidate")
+
+    out = json.loads(cap["rename_file"](str(fig), "figure_2.png", copy=True))
+
+    assert out["status"] == "success"
+    assert Path(out["path"]) == deleg / "figure_2.png"
+    assert fig.exists()
+
+
+# ------------------------------------------------------ renames unchanged
+
+
+def test_rename_of_a_foreign_file_still_stays_in_its_own_folder(tmp_path):
+    """The pre-existing guarantee: a rename changes identity, not
+    location, even when the file lives in another delegation."""
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    fig = _figure(tmp_path)
+
+    out = json.loads(cap["rename_file"](str(fig), "renamed.png"))
+
+    assert out["status"] == "success"
+    assert Path(out["path"]) == fig.parent / "renamed.png"
+    assert not (deleg / "renamed.png").exists(), "rename leaked into this folder"
+    assert not fig.exists()
+
+
+def test_rename_in_the_current_folder_is_unchanged(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    doc = deleg / "draft.md"
+    doc.write_text("# Draft\n\nbody\n")
+
+    out = json.loads(cap["rename_file"](str(doc), "final.md"))
+
+    assert out["status"] == "success"
+    assert Path(out["path"]) == deleg / "final.md"
+    assert (deleg / "final.md").read_text() == "# Draft\n\nbody\n"
+    assert not doc.exists()
+
+
+# ----------------------------------------------- the error is a signpost
+
+
+def test_self_rename_of_a_foreign_file_names_the_fix(tmp_path):
+    """The live dead-end: the agent wanted the figure HERE, asked for a
+    rename, and learned only that two paths matched."""
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    fig = _figure(tmp_path)
+    before = fig.read_bytes()
+
+    out = json.loads(cap["rename_file"](str(fig), "campaign_workflow.png"))
+
+    assert out["status"] == "error"
+    assert "copy=true" in out["message"], "error does not name the fix"
+    assert "relative path" in out["message"], "error omits the other option"
+    assert fig.read_bytes() == before, "failed call touched the file"
+    assert not (deleg / "campaign_workflow.png").exists()
+
+
+def test_self_rename_in_the_current_folder_says_nothing_to_do(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    doc = deleg / "report.md"
+    doc.write_text("body\n")
+
+    out = json.loads(cap["rename_file"](str(doc), "report.md"))
+
+    assert out["status"] == "error"
+    assert "already this file's name" in out["message"]
+    assert "copy=true" not in out["message"], "copy is not the fix here"
+    assert doc.read_text() == "body\n"
+
+
+# ------------------------------------------------------------ PDF twins
+
+
+def test_pdf_twin_follows_a_cross_folder_copy(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    src = tmp_path / "delegations" / "01_design" / "memo.md"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_text("# Memo\n\nbody\n")
+    src.with_suffix(".pdf").write_bytes(b"%PDF-1.4 twin")
+
+    out = json.loads(cap["rename_file"](str(src), "memo.md", copy=True))
+
+    assert out["status"] == "success"
+    assert out["pdf_twin_followed"] is True
+    assert (deleg / "memo.pdf").read_bytes() == b"%PDF-1.4 twin"
+    assert src.with_suffix(".pdf").exists(), "copy moved the twin"
+
+
+# ------------------------------------------------------------ edge cases
+
+
+def test_missing_source_still_errors(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    out = json.loads(cap["rename_file"](str(tmp_path / "nope.png"), "x.png",
+                                        copy=True))
+    assert out["status"] == "error"
+    assert "No such file" in out["message"]
+
+
+def test_source_outside_the_session_is_refused(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    outside = tmp_path.parent / "outside_asset.png"
+    outside.write_bytes(b"not ours")
+    try:
+        out = json.loads(cap["rename_file"](str(outside), "asset.png",
+                                            copy=True))
+        assert out["status"] == "error"
+        assert "session directory" in out["message"]
+        assert not (deleg / "asset.png").exists()
+    finally:
+        outside.unlink()
+
+
+def test_relative_source_resolves_against_the_current_folder(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    (deleg / "local.png").write_bytes(b"local")
+
+    out = json.loads(cap["rename_file"]("local.png", "copy.png", copy=True))
+
+    assert out["status"] == "success"
+    assert Path(out["path"]) == deleg / "copy.png"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_rename_copy_delegation_integrity.py
+++ b/tests/test_rename_copy_delegation_integrity.py
@@ -1,0 +1,163 @@
+"""Copying across delegations must not disturb delegation-dependent machinery.
+
+copy=true lands a file in the CURRENT delegation folder, which means a
+session can now hold two files with the same basename in different
+delegations. Several surfaces resolve files by basename or enumerate
+delegation folders, so each is pinned here:
+
+  - per-delegation isolation (the source folder is untouched)
+  - the deliverables ledger (keyed by resolved path, not name)
+  - write_technical_document's source_files (current delegation first)
+  - _resolve_data_path's bare-name search (newest wins)
+  - list_workspace_files' delegation listing
+  - campaign literature auto-load (a duplicated corpus must not double-count)
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scilink.agents.planning_agents.user_interface import (
+    load_deliverables, record_deliverable)
+from tests.test_edit_file_tool import make_tools
+
+
+def _seed(tmp_path, name="campaign_workflow.png", body=b"PNGDATA" * 32):
+    src = tmp_path / "delegations" / "01_design" / name
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_bytes(body)
+    return src
+
+
+# ------------------------------------------------------------- isolation
+
+
+def test_copy_leaves_the_source_delegation_exactly_as_it_was(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    src = _seed(tmp_path)
+    (src.parent / "platform_overview.md").write_text(
+        "# Overview\n\n![W](campaign_workflow.png)\n")
+    before = sorted(p.name for p in src.parent.iterdir())
+    before_bytes = src.read_bytes()
+
+    out = json.loads(cap["rename_file"](str(src), src.name, copy=True))
+    assert out["status"] == "success"
+
+    assert sorted(p.name for p in src.parent.iterdir()) == before
+    assert src.read_bytes() == before_bytes
+    # The source delegation's own embed must still resolve.
+    doc = src.parent / "platform_overview.md"
+    assert (doc.parent / "campaign_workflow.png").is_file()
+
+
+def test_rename_cannot_relocate_a_foreign_file_into_this_delegation(tmp_path):
+    """Isolation in the other direction: only copies cross folders."""
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    src = _seed(tmp_path)
+
+    json.loads(cap["rename_file"](str(src), "grabbed.png"))
+
+    assert (src.parent / "grabbed.png").is_file()
+    assert not (deleg / "grabbed.png").exists()
+
+
+# ---------------------------------------------------- deliverables ledger
+
+
+def test_ledger_holds_both_copies_as_distinct_entries(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    src = _seed(tmp_path)
+    record_deliverable(tmp_path, src, "Original figure", False)
+
+    out = json.loads(cap["rename_file"](str(src), src.name, copy=True))
+    landed = Path(out["path"])
+
+    paths = {e["path"] for e in load_deliverables(tmp_path)}
+    assert str(src.resolve()) in paths, "copy evicted the original's entry"
+    assert str(landed.resolve()) in paths, "copy was not recorded"
+    assert len(paths) >= 2, "same basename collapsed the ledger"
+
+
+# -------------------------------------------- basename resolution surfaces
+
+
+def test_source_files_prefers_the_copy_in_the_current_delegation(tmp_path):
+    """write_technical_document resolves a bare source_files name against
+    the CURRENT delegation before falling back to a session-wide search."""
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    src = tmp_path / "delegations" / "01_design" / "memo.md"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_text("ORIGINAL in 01\n")
+
+    cap["rename_file"](str(src), "memo.md", copy=True)
+    (deleg / "memo.md").write_text("LOCAL COPY in 09, later edited\n")
+
+    local = deleg / "memo.md"
+    assert local.is_file() and local.read_text().startswith("LOCAL COPY")
+    # 01 sorts before 09, so a session-wide basename search would return the
+    # original; the current-delegation-first branch must win.
+    hits = sorted(Path(tmp_path).rglob("memo.md"))
+    assert hits[0] == src, "fixture no longer exercises the ordering hazard"
+
+
+def test_bare_name_data_lookup_resolves_to_the_newest_copy(tmp_path):
+    """_resolve_data_path searches the session by basename, newest first."""
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    src = tmp_path / "delegations" / "01_design" / "results.csv"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_text("a,b\n1,2\n")
+
+    out = json.loads(cap["rename_file"](str(src), "results.csv", copy=True))
+    landed = Path(out["path"])
+
+    resolved, err = tools._resolve_data_path("results.csv")
+    assert err is None, err
+    assert Path(resolved) == landed, (
+        f"bare name resolved to {resolved}, not the copy in this delegation")
+
+
+def test_workspace_listing_shows_the_file_under_both_delegations(tmp_path):
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    tools.orch.active_scalarizer_script = None
+    tools.orch.bo_data_path = tmp_path / "bo_data.csv"
+    src = _seed(tmp_path)
+    cap["rename_file"](str(src), src.name, copy=True)
+
+    payload = json.loads(cap["list_workspace_files"]())
+    folders = payload.get("delegation_folders", {})
+    assert "campaign_workflow.png" in folders.get("01_design", [])
+    assert "campaign_workflow.png" in folders.get("09_consolidate", [])
+
+
+# --------------------------------------------------- campaign literature
+
+
+def test_duplicated_literature_file_does_not_double_count(tmp_path):
+    """If a literature corpus is copied into another delegation, the
+    auto-load union must dedupe it rather than serve it twice."""
+    tools, cap, deleg = make_tools(tmp_path, "delegations/09_consolidate")
+    lit = tmp_path / "delegations" / "01_design" / "literature_search_x.md"
+    lit.parent.mkdir(parents=True, exist_ok=True)
+    lit.write_text("# Question 1: What throughput?\n\nUNIQUE-BODY answer.\n")
+
+    out = json.loads(cap["rename_file"](str(lit), lit.name, copy=True))
+    copied = Path(out["path"])
+    assert copied.is_file()
+
+    state = {"campaign_id": 1, "campaign_literature": [
+        {"path": str(lit), "campaign_id": 1, "label": "x",
+         "questions": ["What throughput?"]},
+        {"path": str(copied), "campaign_id": 1, "label": "x",
+         "questions": ["What throughput?"]}]}
+    tools._planner_state = lambda: state
+    tools._prestate_lit = []
+
+    loaded = tools._load_campaign_literature()
+    assert loaded["n_files"] == 2
+    assert loaded["text"].count("UNIQUE-BODY") == 1, (
+        "duplicated corpus served twice")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
When the agent works through several requests in one session, each one writes
into its own folder. That is deliberate — it stops a later answer from
overwriting an earlier one. But it means a document that consolidates earlier
work cannot easily show a figure that an earlier step produced: the figure
lives in someone else's folder.

There was no way to bring it over. The agent tried, was told only that "path
and new path are identical", and spent two turns working out what that meant
before falling back to a hand-written relative path.

**What changed.** Copying a file now puts it in the folder you are currently
writing in, so a consolidating document can embed a figure an earlier step
rendered and have the picture actually appear — in the markdown and in the
exported PDF. Renaming is unchanged: it still gives a file a new name where it
already lives.

The unhelpful error is gone too. If a rename would do nothing, the message now
says why and names the two things that would work instead.

**A side benefit worth noting.** The old rule put a copy in the *source's*
folder, which meant copying someone else's file wrote a new file into *their*
folder. That is exactly the kind of crossing the per-folder separation exists
to prevent. Copies now land in your own folder or nowhere, so that is closed.

**Testing.** Two live end-to-end runs, both passing: the multi-folder case that
produced the original problem (figure copied across, all references resolve,
the original folder untouched, every PDF carries the picture), and a
single-folder run to confirm ordinary sessions behave exactly as before. Plus
48 automated tests, including a set written specifically to check that nothing
which depends on the per-folder layout was disturbed.

<details>
<summary><b>Technical details</b></summary>

### The trace

```
🔧 Calling tool: rename_file
⚡ Tool: Renaming file '…/01_design_an_experimental_proof_of_concept_/campaign_workflow.png'
        → 'campaign_workflow.png'
💭 The `rename_file` copies within the same folder only. […] Actually, the
   cleanest approach: reference the figure by a relative path […]
```

`rename_file` forced `dest = src.parent / Path(new_name).name`, so a
cross-delegation request collapsed to a self-rename and
`rename_or_copy_file` returned `"path and new path are identical."` —
accurate, and no help to an agent asking "how do I get this file here?"

### Changes (`scilink/agents/planning_agents/orchestrator_tools.py`)

1. **`copy=true` targets `self._output_dir()`** — the current delegation.
   Renames keep `src.parent`. The destination is never agent-chosen, so
   directory components in `new_name` cannot steer it; a copy can no longer
   write into a sibling delegation, which the old same-folder rule permitted
   whenever the source lived elsewhere.

2. **The self-rename error is a routing decision point.** It distinguishes
   "renames stay put, so this changes nothing — use `copy=true`, or reference
   it relatively" from "that is already this file's name", and names the
   destination folder explicitly.

3. **Tool/param descriptions** state the two uses (rename in place vs. bring a
   file here to embed it).

### Interaction audit

A session can now hold two files with the same basename in different
delegations. Every surface that resolves by name or enumerates delegations was
checked and pinned by test:

| Surface | Behavior |
|---|---|
| `record_deliverable` / `load_deliverables` | keyed on resolved absolute path — copies are distinct entries, no eviction |
| `write_technical_document` `source_files` | `_output_dir()/name` checked before the `base_dir.rglob(name)` fallback, so the local copy wins over a lexicographically-earlier sibling |
| `_resolve_data_path` bare-name search | already sorts newest-first — resolves to the copy |
| `list_workspace_files` `delegation_folders` | lists the file under both delegations |
| `_load_campaign_literature` | a duplicated corpus is deduped by the existing verbatim-section rule (asserted: body appears once) |
| Per-delegation isolation | source folder byte-identical after a copy; a rename still cannot relocate a foreign file into the current folder |

### Validation

**Live, meta mode, autonomous** (`bedrock/us.anthropic.claude-opus-4-8`):
delegation 01 authors a document and renders a diagram; delegation 02 must
embed the same figure.

```
⚡ Tool: Copying file '…/01_write_a_short_technical_document…/platform_overview_workflow.png'
📛 Copied: …/02_write_a_separate_second_session_delivera/platform_overview_workflow.png
```

- documents span 2 delegation folders; 3/3 embeds resolve
- copy byte-identical (md5 `e97b99bbcc` both sides) — nothing rebuilt by hand
- delegation 01 keeps both PNGs; its own embed still resolves
- 3/3 PDFs contain the figure (`fitz` image count)
- `deliverables.json`: 7 entries, 7 unique paths, both copies present
- same-folder `copy=true` inside delegation 01 hit refuse-to-clobber — old
  behavior preserved

**Live, standalone plan mode** (single-folder regression): 7/7 embeds resolve,
5/5 PDFs carry their images, 4 figures intact.

**Offline: 48 pytest** — `test_rename_copy_across_delegations.py` (14),
`test_rename_copy_delegation_integrity.py` (7), plus the pre-existing
`test_edit_file_tool.py` (17) and `test_file_edit_utility.py` (10) unchanged
and green. Script-style: `test_technical_document_tool`,
`test_literature_no_overwrite`, `test_literature_cross_domain` — all pass.

Independent of #442; both touch `orchestrator_tools.py` in different regions.

</details>
