### PR TITLE
Report a campaign boundary that carries the previous campaign's literature

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -830,6 +830,42 @@ class OrchestratorTools:
                     out.extend(token_paths)
         return out
 
+    def _outgoing_campaign_literature(self, explicit_context) -> list:
+        """Files in ``explicit_context`` that belong to the campaign this
+        call is LEAVING — [{'file', 'covers'}, ...], covers being the
+        questions the registry recorded for it (issue #425); empty when
+        nothing was passed or nothing is attributable.
+
+        Distinct from _prior_campaign_literature, which reports corpora
+        from campaigns strictly OLDER than the current one and is a hard
+        refusal. The outgoing campaign's own corpus can never appear there
+        — the transition has not been applied when the guard runs, so that
+        literature still reads as current — which is exactly the case a
+        new campaign is most likely to be handed, since its path is the
+        one sitting in the agent's recent context.
+
+        Reported rather than refused. The transition is decided by lexical
+        overlap against the previous objective, a heuristic that has been
+        observed comparing against a placeholder objective, and a hard gate
+        built on it would block legitimate work and push callers to pass
+        new_campaign=true reflexively — which disables the guard that does
+        catch older corpora. The agent has the topic in hand; it only
+        lacked the fact that the campaign moved.
+        """
+        cid = self._campaign_id()
+        owners: Dict[str, set] = {}
+        meta: Dict[str, dict] = {}
+        for e in self._lit_registry():
+            p = str(e.get("path"))
+            owners.setdefault(p, set()).add(e.get("campaign_id"))
+            meta.setdefault(p, e)
+        out = []
+        for p in self._context_file_paths(explicit_context):
+            if p in owners and cid in owners[p] and None not in owners[p]:
+                out.append({"file": Path(p).name,
+                            "covers": (meta[p].get("questions") or [])})
+        return out
+
     def _campaign_literature_files(self) -> List[Path]:
         """ALL literature files belonging to the CURRENT campaign, oldest
         first (issue #425).
@@ -2056,6 +2092,17 @@ class OrchestratorTools:
                         ),
                     })
 
+            # Literature the OUTGOING campaign owns, captured here because
+            # _campaign_id() still reads the pre-transition value; once
+            # generate_plan applies the bump and _adopt_literature re-claims
+            # these files under the new id, the fact is unrecoverable.
+            # Reported on the result so the campaign boundary reaches the
+            # decision that grounds what comes next (see the helper).
+            carried_literature = (
+                self._outgoing_campaign_literature(literature_context)
+                if starts_new else [])
+            outgoing_campaign_id = self._campaign_id()
+
             # Resolve knowledge paths (with fallback to orchestrator dir)
             knowledge_list = self._resolve_knowledge_paths(knowledge_paths)
             if knowledge_list:
@@ -2277,6 +2324,26 @@ class OrchestratorTools:
                     "tea_context_included": self.orch.latest_tea_results is not None,
                     "hint": "Use generate_implementation_code() to add executable code"
                 }
+                if carried_literature:
+                    _now = self._campaign_id()
+                    result["campaign_transition"] = {
+                        "previous_campaign": outgoing_campaign_id,
+                        "new_campaign": _now,
+                        "literature_carried_over": carried_literature,
+                        "note": (
+                            f"This objective opened campaign {_now}. The "
+                            f"literature above was gathered for campaign "
+                            f"{outgoing_campaign_id} and is now also "
+                            f"registered to this one, so later refine and "
+                            f"document calls will auto-load it. If it does "
+                            f"not cover this topic, run search_literature "
+                            f"for THIS objective before grounding further "
+                            f"work on it."
+                        ),
+                    }
+                    print(f"    🧭 Literature carried over from campaign "
+                          f"{outgoing_campaign_id}: "
+                          + ", ".join(c["file"] for c in carried_literature))
                 if html_path is not None:
                     result["html_report"] = str(html_path)
                 if saved_extras:

--- a/tests/test_campaign_transition_surfacing.py
+++ b/tests/test_campaign_transition_surfacing.py
@@ -1,0 +1,149 @@
+"""A campaign boundary must reach the decision that grounds the next work.
+
+When an objective opens a NEW campaign while being handed the OUTGOING
+campaign's literature, nothing told the agent. The hard guard next door
+cannot: it reports corpora from campaigns strictly OLDER than the current
+one, and at guard time the transition has not been applied, so the
+outgoing campaign's corpus still reads as current. Live, campaign 2's
+Pd-colloid corpus silently grounded a campaign-3 portfolio spanning MOFs,
+perovskites and high-entropy alloys, and was then re-registered to
+campaign 3 by adoption while the console said literature is "NOT carried
+forward".
+
+This is REPORTED, not refused — the transition is a lexical heuristic that
+has been seen comparing against a placeholder objective, and a hard gate on
+it would block legitimate work. So the tests below are as much about what
+stays silent as about what speaks.
+"""
+
+import types
+from pathlib import Path
+
+import pytest
+
+from scilink.agents.planning_agents.orchestrator_tools import OrchestratorTools
+
+
+def _tools(tmp_path, entries, campaign_id=2):
+    t = OrchestratorTools.__new__(OrchestratorTools)
+    t._prestate_lit = []
+    t.orch = types.SimpleNamespace(base_dir=tmp_path, planner=None)
+    state = {"campaign_id": campaign_id, "campaign_literature": entries}
+    t._planner_state = lambda: state
+    return t
+
+
+def _lit(tmp_path, name="literature_search_x.md", questions=None):
+    p = tmp_path / name
+    p.write_text("# Question 1: What throughput?\n\nbody\n")
+    return p, questions or ["What throughput is typical?", "How does carryover bite?"]
+
+
+# ------------------------------------------------------- it speaks up
+
+
+def test_outgoing_campaigns_corpus_is_reported(tmp_path):
+    p, qs = _lit(tmp_path)
+    tools = _tools(tmp_path, [{"path": str(p.resolve()), "campaign_id": 2,
+                               "questions": qs}], campaign_id=2)
+
+    carried = tools._outgoing_campaign_literature(str(p))
+
+    assert len(carried) == 1, "the outgoing campaign's corpus went unreported"
+    assert carried[0]["file"] == p.name
+    assert carried[0]["covers"] == qs, "the agent needs WHAT it covers"
+
+
+def test_the_hard_guard_still_cannot_see_it(tmp_path):
+    """Pins the gap this exists to close: the same file, same moment, is
+    invisible to _prior_campaign_literature."""
+    p, qs = _lit(tmp_path)
+    tools = _tools(tmp_path, [{"path": str(p.resolve()), "campaign_id": 2,
+                               "questions": qs}], campaign_id=2)
+
+    assert tools._prior_campaign_literature(str(p)) == []
+    assert tools._outgoing_campaign_literature(str(p)) != []
+
+
+def test_multiple_files_and_section_refs_are_all_reported(tmp_path):
+    a, qa = _lit(tmp_path, "literature_search_a.md", ["Q about A"])
+    b, qb = _lit(tmp_path, "literature_search_b.md", ["Q about B"])
+    tools = _tools(tmp_path, [
+        {"path": str(a.resolve()), "campaign_id": 2, "questions": qa},
+        {"path": str(b.resolve()), "campaign_id": 2, "questions": qb}])
+
+    carried = tools._outgoing_campaign_literature(f"{a}#q1,{b}")
+
+    assert {c["file"] for c in carried} == {a.name, b.name}
+
+
+# ------------------------------------------------- it stays quiet (no-op)
+
+
+def test_silent_when_no_literature_was_passed(tmp_path):
+    p, qs = _lit(tmp_path)
+    tools = _tools(tmp_path, [{"path": str(p.resolve()), "campaign_id": 2,
+                               "questions": qs}])
+    assert tools._outgoing_campaign_literature(None) == []
+    assert tools._outgoing_campaign_literature("") == []
+
+
+def test_silent_for_freshly_searched_literature(tmp_path):
+    """THE regression that matters: a search run for THIS topic before any
+    plan is pending (campaign_id None) and must never be called carried
+    over — that is the search-then-ground flow we want to encourage."""
+    p, qs = _lit(tmp_path)
+    tools = _tools(tmp_path, [{"path": str(p.resolve()), "campaign_id": None,
+                               "questions": qs}])
+    assert tools._outgoing_campaign_literature(str(p)) == []
+
+
+def test_silent_for_literature_from_older_campaigns(tmp_path):
+    """Those are the hard guard's business; reporting them too would
+    double-signal the same file."""
+    p, qs = _lit(tmp_path)
+    tools = _tools(tmp_path, [{"path": str(p.resolve()), "campaign_id": 1,
+                               "questions": qs}], campaign_id=2)
+    assert tools._outgoing_campaign_literature(str(p)) == []
+    assert tools._prior_campaign_literature(str(p)) == [str(p.resolve())]
+
+
+def test_silent_for_unregistered_files_and_raw_text(tmp_path):
+    p, _ = _lit(tmp_path)
+    tools = _tools(tmp_path, [])
+    assert tools._outgoing_campaign_literature(str(p)) == []
+    assert tools._outgoing_campaign_literature(
+        "Some raw literature text pasted inline, not a path") == []
+
+
+def test_missing_questions_field_still_reports_the_file(tmp_path):
+    """Pre-#425 entries have no questions; the file itself is still the
+    signal that matters."""
+    p, _ = _lit(tmp_path)
+    tools = _tools(tmp_path, [{"path": str(p.resolve()), "campaign_id": 2}])
+    carried = tools._outgoing_campaign_literature(str(p))
+    assert len(carried) == 1 and carried[0]["covers"] == []
+
+
+def test_a_corpus_carried_twice_is_reported_at_each_boundary(tmp_path):
+    """Adoption leaves a file owned by the old campaign AND the new one.
+    Passing it across the NEXT boundary is a second carry-over and gets its
+    own notice — each transition is a distinct decision the agent is
+    making, not a repeat of one it already made."""
+    p, qs = _lit(tmp_path)
+    tools = _tools(tmp_path, [
+        {"path": str(p.resolve()), "campaign_id": 2, "questions": qs},
+        {"path": str(p.resolve()), "campaign_id": 3, "questions": qs}],
+        campaign_id=3)
+
+    carried = tools._outgoing_campaign_literature(str(p))
+
+    assert len(carried) == 1, "a second carry-over went unreported"
+    assert carried[0]["file"] == p.name
+    # It is leaving campaign 3, not 2 — the notice reports the id the call
+    # is actually departing.
+    assert tools._campaign_id() == 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
A planning session can hold several unrelated lines of work. When you move
onto a genuinely different topic, the system opens a new "campaign" and
prints that the previous one's literature is not carried forward.

That message isn't quite true, and — more importantly — the agent deciding
what to ground the next document in never learns the topic changed at all.

**What happened.** In a live session, a literature search about palladium
nanoparticle chemistry was reused to ground a brainstorm about metal-organic
frameworks, perovskites and high-entropy alloys. The corpus was then quietly
re-filed under the new topic, so every later document in that session would
pull it in automatically. Nothing anywhere said so. Checking the session
afterwards, the same file is now filed under three consecutive topics.

**What this adds.** When a request opens a new topic while being handed the
previous topic's literature, the result now says so plainly: which topic the
literature came from, what questions it actually answers, that it will keep
being used from here on, and that a fresh search for the new topic is
available. The agent then decides.

**It reports; it does not block.** That is deliberate. The test for "is this
a new topic" is a word-overlap heuristic, and it has been seen comparing
against a placeholder, so refusing work on its say-so would stop legitimate
requests. It is also unnecessary for the obvious cases: asked directly to
ground a titanium fracture-toughness plan in the palladium corpus, the agent
refused on its own — *"worse than no grounding. I won't do that."* — and the
plan generator separately rejected the same mismatch by name. Those catch the
blatant case. This catches the partial one, where the literature half-fits,
the plan succeeds, and nobody notices the topic moved.

**Staying quiet is most of the job.** Nothing is reported when no literature
was passed, when the literature was searched for the current topic, when it
belongs to an older topic already covered by the existing check, or when the
request continues the topic it is already on.

<details>
<summary><b>Technical details</b></summary>

### The gap

`starts_new_campaign` is non-mutating; `generate_plan` applies the transition
later (`planning_agent.py:1032`). So at guard time `_campaign_id()` still
returns the OUTGOING id, and `_prior_campaign_literature` filters for
`cid not in owners[p]` — the outgoing campaign's own corpus reads as
*current* and can never be stale. The existing guard therefore only catches
corpora **two or more campaigns back**, never the one whose path is in the
agent's recent context and most likely to be re-passed.

Downstream, `_adopt_literature` re-registers whatever was passed under the
NEW id (`:2225`), which is what makes the console's "NOT carried forward"
misleading. Live evidence after this PR's test run:

```
campaign_id after the run: 4
registry:
   cid=2 -> literature_search_hypothesis_context+cross_domain.md
   cid=3 -> literature_search_hypothesis_context+cross_domain.md
   cid=4 -> literature_search_hypothesis_context+cross_domain.md
```

### Change (`orchestrator_tools.py`, +67 / -0)

- **`_outgoing_campaign_literature(explicit_context)`** — files in
  `literature_context` owned by the campaign being left, each with the
  `questions` the registry recorded (#425). Deliberately distinct from
  `_prior_campaign_literature`, which stays a hard refusal for older corpora.
- Captured at the guard site, **before** the bump, along with the outgoing
  id — after `generate_plan` bumps and `_adopt_literature` re-claims, the
  fact is unrecoverable.
- Emitted on the success result as `campaign_transition`
  (`previous_campaign`, `new_campaign`, `literature_carried_over`, `note`)
  plus one console line. Pure addition; no existing field or code path
  changed.

### Why not enforce

A hard gate inherits the transition detector's reliability. That detector
compares against `state["objective"]`, which in the motivating session held
the meta's placeholder `"Delegated by meta-agent"` through an entire
campaign. Gating on it would block legitimate work and train callers to pass
`new_campaign=true` reflexively — which disables the guard that *does* catch
older corpora. Two independent layers already refuse blatant mismatches
(the meta agent's own judgment; strict generation's context check); neither
fires on partial overlap, which is the observed failure.

### Validation

**Live**, via `generate_initial_plan` on a COPY of the real session (the
source session was verified unmodified throughout), real model, real
transition:

```
- 🧭 Objective changed materially — starting campaign #4.
    🧭 Literature carried over from campaign 3: literature_search_...md
  campaign_transition: PRESENT
    previous_campaign : 3
    new_campaign      : 4
    carried           : literature_search_...md  (5 questions)
```

| Assertion | Result |
|---|---|
| new topic + outgoing corpus → notice | PASS |
| continuation **with the same corpus passed** → silent | PASS |
| all pre-existing result fields intact | PASS |

Call-2 passes the corpus deliberately: silence must follow from the campaign
condition, not from having nothing to report.

**Offline: 9 new tests**, five asserting silence — no literature passed;
freshly-searched literature (`campaign_id: None`, the search-then-ground flow
we want to encourage); older campaigns' corpora; unregistered files and raw
inline text; and a corpus carried across two boundaries getting a notice at
each. One test pins the gap directly: the same file, same moment, invisible
to `_prior_campaign_literature` and visible to the new helper.

**Regressions**: `test_edit_file_tool`, `test_file_edit_utility`,
`test_literature_autoload_425` (47) green; script-style
`test_technical_document_tool`, `test_literature_no_overwrite`,
`test_lit_planner_injection`, `test_literature_cross_domain` all pass.

### Unrelated sharp edge found while testing

`restore_checkpoint=True` reinstates the checkpoint's `autonomy_level` AFTER
the constructor argument is applied, so a headless resume of a co-pilot
session silently comes back interactive and blocks on `input()`
(`EOFError` → `status: error`). Not touched here; worth its own issue.

Independent of #442 and #443.

</details>
