### PR TITLE
Strip the label a model writes before a session title, not just "Title:"

### DIFF
--- a/scilink/ui/session_meta.py
+++ b/scilink/ui/session_meta.py
@@ -101,7 +101,17 @@ def generate_session_title(model, first_user_msg: str,
         # (live), the tail being conversational continuation cut
         # mid-sentence by the token cap.
         raw = next((ln for ln in raw.splitlines() if ln.strip()), "")
-        raw = re.sub(r"^\s*title\s*[:\-]\s*", "", raw, flags=re.IGNORECASE)
+        # Strip a leading LABEL the model wrote before the answer. Matching
+        # only "title:" let "Session name: CDOC and GM proposal adaptation"
+        # through, and the label shipped as part of the sidebar name (live).
+        # Deliberately narrow: it must be a name-for-the-name word, so a
+        # real title that happens to contain a colon ("CDOC: a perturbation
+        # platform") keeps its own prefix.
+        raw = re.sub(
+            r"^\s*(?:suggested|proposed|possible)?\s*"
+            r"(?:session|conversation|chat)?\s*"
+            r"(?:name|title)\s*[:\-]\s*",
+            "", raw, flags=re.IGNORECASE)
         title = re.sub(r'["\'\n\r.]+', " ", raw)
         title = " ".join(title.split()).strip()
         # Backstop the 3-6-word instruction against one-line rambles.

--- a/tests/test_session_title.py
+++ b/tests/test_session_title.py
@@ -86,6 +86,31 @@ check(t == "Smart interventions along synthesis pathways",
 check(generate_session_title(
           FakeModel(text="Title: Flash anneal polymorph control"), "x")
       == "Flash anneal polymorph control", "leading 'Title:' prefix stripped")
+
+# The label the model writes before its answer is not always "Title:".
+# Live, a session sat in the sidebar named "Session name: CDOC and GM
+# proposal adaptation" — the label had shipped as part of the name.
+for _label in ("Session name", "Name", "Session title", "Chat name",
+               "Suggested title", "Proposed session name"):
+    check(generate_session_title(
+              FakeModel(text=f"{_label}: CDOC and GM proposal adaptation"), "x")
+          == "CDOC and GM proposal adaptation",
+          f"leading '{_label}:' prefix stripped")
+
+# ...but stripping must not eat a real title that owns its colon, or a
+# title that merely starts with those letters.
+check(generate_session_title(
+          FakeModel(text="CDOC: a perturbation response platform"), "x")
+      == "CDOC: a perturbation response platform",
+      "a real title's own colon prefix is kept")
+check(generate_session_title(
+          FakeModel(text="Phase 1: anneal schedule sweep"), "x")
+      == "Phase 1: anneal schedule sweep",
+      "a numbered-section title keeps its prefix")
+check(generate_session_title(
+          FakeModel(text="Nameplate corrosion mapping"), "x")
+      == "Nameplate corrosion mapping",
+      "a title starting with 'Name' is untouched without a colon")
 check(generate_session_title(
           FakeModel(text="\n\n  Operando XRD mapping\nmore chatter"), "x")
       == "Operando XRD mapping", "leading blank lines skipped, tail dropped")


### PR DESCRIPTION
Sessions get an automatic name from their first exchange. One of mine came
out as **"Session name: CDOC and GM proposal adaptation"** — the label the
model wrote in front of its answer ended up inside the name itself.

The code already trimmed such a label, but only when it was written exactly
as "Title:". This model wrote "Session name:", which slipped through.

Now the usual label forms are trimmed — name, title, and the same preceded
by session/conversation/chat or by suggested/proposed/possible.

It stays narrow on purpose. Trimming everything before the first colon would
have been simpler and wrong: a title is allowed to contain a colon of its
own, and "CDOC: a perturbation response platform" should keep it.

<details>
<summary><b>Technical details</b></summary>

### Before

`scilink/ui/session_meta.py:104`

```python
raw = re.sub(r"^\s*title\s*[:\-]\s*", "", raw, flags=re.IGNORECASE)
```

Only `Title:` / `Title-`. The live session was titled from
`"Session name: CDOC and GM proposal adaptation"`, which does not match, so
the label was carried into `session_meta.json` and the sidebar.

### After

```python
raw = re.sub(
    r"^\s*(?:suggested|proposed|possible)?\s*"
    r"(?:session|conversation|chat)?\s*"
    r"(?:name|title)\s*[:\-]\s*",
    "", raw, flags=re.IGNORECASE)
```

The head word must be `name` or `title` — a name-for-the-name — and a colon
or hyphen is still required, so the two failure modes of a looser rule are
avoided:

| Model output | Result |
|---|---|
| `Session name: CDOC and GM proposal adaptation` | `CDOC and GM proposal adaptation` |
| `Name:` / `Session title:` / `Chat name:` / `Suggested title:` / `Proposed session name:` | label stripped |
| `CDOC: a perturbation response platform` | unchanged — real title owning its colon |
| `Phase 1: anneal schedule sweep` | unchanged |
| `Nameplate corrosion mapping` | unchanged — begins with "Name", no colon |

### Tests

Added to the existing `tests/test_session_title.py`: 6 label forms and 3
false-positive guards. The pre-existing assertions (`Title:` stripping,
runoff-after-the-title-line dropping, blank-line skipping, 8-word cap,
per-session sidebar widget key) are unchanged and pass, as does
`tests/test_history_trim_and_title_dup.py`.

### Note on existing sessions

This only affects names generated from here on. A session already stored
with the label keeps it until renamed; a user-set name (`named_by: "user"`)
is never overwritten by the agent, so renaming in the sidebar is the fix for
an existing one.

Independent of #442, #443 and #444 — different file.

</details>
