### PR TITLE
Set an output ceiling on the orchestrator chat-loop path

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -8015,6 +8015,12 @@ class OrchestratorTools:
             return json.dumps({
                 "status": "error",
                 "tool": tool_name,
+                # Machine-readable so the caller can capture the raw provider
+                # response for this call — the cause of the omission is still
+                # unknown, and the parsed kwargs the guard sees have already
+                # discarded the evidence.
+                "error_kind": "missing_required_arguments",
+                "missing": list(missing),
                 "message": self._missing_args_message(missing, kwargs),
             })
 
@@ -8059,6 +8065,15 @@ class OrchestratorTools:
             fn = schema.get("function", {})
             if fn.get("name") == tool_name:
                 return fn.get("parameters", {}).get("required", []) or []
+        return []
+
+    def _declared_params(self, tool_name: str) -> list:
+        """Parameter names in schema-declaration order (dicts keep it)."""
+        for schema in self.openai_schemas:
+            fn = schema.get("function", {})
+            if fn.get("name") == tool_name:
+                return list((fn.get("parameters", {})
+                             .get("properties", {}) or {}).keys())
         return []
 
     def _missing_args_message(self, missing: list, kwargs: dict) -> str:

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -8015,13 +8015,7 @@ class OrchestratorTools:
             return json.dumps({
                 "status": "error",
                 "tool": tool_name,
-                "message": (
-                    f"Missing required argument(s): {', '.join(missing)}. "
-                    "The tool-call arguments were likely truncated by the "
-                    "response length limit — resend the call with all required "
-                    "arguments, splitting long text across multiple smaller "
-                    "calls (e.g. save_file then append_file chunks)."
-                ),
+                "message": self._missing_args_message(missing, kwargs),
             })
 
         try:
@@ -8066,5 +8060,42 @@ class OrchestratorTools:
             if fn.get("name") == tool_name:
                 return fn.get("parameters", {}).get("required", []) or []
         return []
+
+    def _missing_args_message(self, missing: list, kwargs: dict) -> str:
+        """Explain a missing required argument without guessing the cause.
+
+        Two wrong versions preceded this one. The first asserted the
+        arguments "were likely truncated by the response length limit" and
+        sent the model to save_file/append_file chunks — a cause it never
+        checked and a remedy that abandons the tool. The second inferred
+        the opposite from schema order: a key declared AFTER the missing one
+        having arrived was taken as proof the call was complete.
+
+        That inference is unsound, and instrumentation caught it. A live
+        save_file call came back finish_reason='length' — genuinely cut —
+        as VALID JSON missing `content` (declared second) while
+        `deliverable` and `title` (declared fourth and fifth) were present.
+        Arguments are emitted in the model's chosen order, not the schema's,
+        and when the response is cut the LONG value is the casualty while
+        short ones already emitted survive. Declaration order proves
+        nothing.
+
+        The decisive signal, finish_reason, is not visible here — it lives
+        at the dispatch site. So this states what is known, names the
+        mechanism as a possibility rather than a fact, and asks for the same
+        call again.
+        """
+        arrived = sorted(k for k in kwargs if k not in missing)
+        return (
+            f"Missing required argument(s): {', '.join(missing)}. "
+            + (f"The call did arrive with {', '.join(arrived)}. " if arrived
+               else "")
+            + "The tool was NOT run. Resend the SAME call with the missing "
+            "argument included — do not switch to another tool, which would "
+            "lose what this one does. A long value is the likeliest thing to "
+            "go missing, so if the argument you omitted was large, send a "
+            "shorter one: it is a specification of what is wanted, not the "
+            "finished text."
+        )
 
 

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -1564,6 +1564,92 @@ class PlanningOrchestratorAgent:
         except Exception as e:
             logging.warning(f"Auto-checkpoint failed: {e}")
 
+    # Diagnostics for tool calls that arrive without a required argument.
+    # Cap the raw string so one runaway argument cannot fill the disk; the
+    # head is what identifies the shape, and the length is recorded exactly.
+    _RAW_ARGS_CAP = 40000
+
+    def _record_tool_arg_anomaly(self, tool_call, result, *,
+                                 finish_reason=None, response=None) -> None:
+        """TEMPORARY DIAGNOSTIC — remove once the omission is explained.
+
+        This exists to answer one open question and should not outlive the
+        answer. Everything it touches is confined to this method, the two
+        call sites that invoke it, and the ``error_kind`` marker on the
+        guard, so reverting the commit that added it removes it whole.
+
+        Append the RAW provider output for a tool call whose required
+        arguments did not arrive.
+
+        The cause of these omissions is unresolved. The output-token ceiling
+        was ruled out (it is injected explicitly on the bedrock/anthropic
+        paths and resolves far above the arguments involved), and so was tail
+        truncation: the observed calls were valid JSON missing only the FIRST
+        declared parameter while later-declared ones came through. What is
+        missing is evidence from the moment it happens, because by the time
+        the guard runs the raw response is gone — it sees parsed kwargs.
+
+        ``finish_reason`` is the decisive field: "length" would mean the
+        response really was cut, anything else rules truncation out for that
+        call. Written as JSONL so occurrences accumulate across sessions
+        instead of overwriting one another. Never raises: a diagnostic that
+        breaks the turn it is diagnosing is worse than no diagnostic.
+        """
+        try:
+            payload = json.loads(result) if isinstance(result, str) else {}
+        except (json.JSONDecodeError, TypeError):
+            return
+        if not isinstance(payload, dict):
+            return
+        if payload.get("error_kind") != "missing_required_arguments":
+            return
+
+        try:
+            raw = getattr(getattr(tool_call, "function", None),
+                          "arguments", "") or ""
+            try:
+                # Insertion order, NOT sorted: which arguments the model
+                # emitted before the response was cut is the evidence, and
+                # sorting threw it away in the first version of this.
+                parsed_keys = list(json.loads(raw).keys())
+                parses = True
+            except Exception:  # noqa: BLE001 - malformed is itself a finding
+                parsed_keys, parses = None, False
+
+            # Declared order alongside emitted order: the gap between them
+            # is what disproved the schema-order inference, so record both
+            # rather than leaving a future reader to reconstruct it.
+            try:
+                declared = self.tools._declared_params(payload.get("tool"))
+            except Exception:  # noqa: BLE001 - evidence is best-effort
+                declared = None
+
+            usage = getattr(response, "usage", None)
+            record = {
+                "timestamp": datetime.now().isoformat(timespec="seconds"),
+                "tool": payload.get("tool"),
+                "missing": payload.get("missing"),
+                # The decisive field: "length" => genuinely truncated.
+                "finish_reason": finish_reason,
+                "arguments_parse_ok": parses,
+                "arguments_keys": parsed_keys,      # emission order
+                "declared_params": declared,        # schema order
+                "arguments_len": len(raw),
+                "arguments_raw": raw[:self._RAW_ARGS_CAP],
+                "arguments_truncated_in_log": len(raw) > self._RAW_ARGS_CAP,
+                "model": getattr(self, "model_name", None),
+                "completion_tokens": getattr(usage, "completion_tokens", None),
+                "prompt_tokens": getattr(usage, "prompt_tokens", None),
+            }
+            path = Path(self.base_dir) / "tool_call_diagnostics.jsonl"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record) + "\n")
+            print(f"    🔬 Raw tool-call arguments recorded for diagnosis: "
+                  f"{path.name} (finish_reason={finish_reason!r})")
+        except Exception as e:  # noqa: BLE001 - diagnostics never break a turn
+            logging.debug(f"Tool-arg anomaly recording failed: {e}")
+
     @staticmethod
     def _parse_tool_args(tool_call, finish_reason=None):
         """Parse a tool call's JSON arguments, failing loud on bad input.
@@ -1689,6 +1775,9 @@ class PlanningOrchestratorAgent:
                     result = args_error
                 else:
                     result = self.tools.execute_tool(func_name, **args)
+                    self._record_tool_arg_anomaly(
+                        tool_call, result, finish_reason=finish_reason,
+                        response=response)
 
                 self.messages.append({
                     "role": "tool",
@@ -1846,6 +1935,9 @@ class PlanningOrchestratorAgent:
                     result = args_error
                 else:
                     result = self.tools.execute_tool(func_name, **args)
+                    self._record_tool_arg_anomaly(
+                        tool_call, result, finish_reason=finish_reason,
+                        response=response)
                 
                 self.messages.append({
                     "role": "tool",

--- a/scilink/wrappers/litellm_wrapper.py
+++ b/scilink/wrappers/litellm_wrapper.py
@@ -115,6 +115,22 @@ except ImportError:
 DEFAULT_MAX_OUTPUT_TOKENS = 32000
 
 
+def _registered_max_output_tokens(model: str):
+    """litellm's registered output ceiling for ``model``, or None when it has
+    no entry for it.
+
+    The None is the point. :func:`_resolve_max_output_tokens` substitutes
+    ``DEFAULT_MAX_OUTPUT_TOKENS`` for unknown models, which is the right
+    trade where a number must be produced; callers that would rather send
+    nothing than send a guess use this instead.
+    """
+    try:
+        mt = litellm.get_max_tokens(model)
+    except Exception:  # noqa: BLE001 - unknown model is the normal miss here
+        return None
+    return int(mt) if mt else None
+
+
 def _resolve_max_output_tokens(model: str) -> int:
     """Best-effort max output tokens for a model (bedrock/ and anthropic/ paths).
 
@@ -238,14 +254,43 @@ def _scope_drop_params(model) -> None:
 
 
 def litellm_completion(*args, **kwargs):
-    """``litellm.completion`` with Bedrock-scoped param dropping.
+    """``litellm.completion`` with Bedrock-scoped param dropping and the
+    output ceiling #238 asks for.
 
     Drop-in replacement for direct ``litellm.completion`` calls; see
     :func:`_scope_drop_params`. Reads the target model from the ``model`` kwarg
     (or first positional arg) and scopes param-dropping to it before the call.
+
+    The ``max_tokens`` injection mirrors :class:`LiteLLMGenerativeModel`, which
+    has had it since #238. This function did not, and it is what every
+    chat-driven orchestrator calls — so their loops ran on Bedrock's low
+    server-side default while the fix appeared to be in place. Caught live: a
+    tool call came back ``finish_reason='length'`` at exactly 4096 completion
+    tokens with a required argument missing, and the model then "recovered"
+    into a second tool whose content hit the same wall.
+
+    Deliberately narrower than :func:`_resolve_max_output_tokens`, which
+    substitutes a flat default for models litellm does not know. A ceiling is
+    sent ONLY when the registry actually reports one; an unrecognised name —
+    a custom deployment, or simply a model litellm has not mapped yet, which
+    includes ordinary Bedrock names like
+    ``bedrock/us.anthropic.claude-sonnet-4-5-v1:0`` — is left alone rather
+    than asked for a number nobody verified. Guessing high on an unknown
+    deployment trades a silent truncation for an outright rejection, and this
+    function sits under every orchestrator chat loop.
+
+    An explicit ``max_tokens`` from the caller still wins, and non-Bedrock /
+    non-Anthropic models are untouched — litellm already gives those a sane
+    ceiling.
     """
-    _scope_drop_params(kwargs.get("model") or (args[0] if args else None))
+    model = kwargs.get("model") or (args[0] if args else None)
+    _scope_drop_params(model)
     kwargs.setdefault("num_retries", 4)   # retry transient provider errors w/ backoff
+    if ("max_tokens" not in kwargs
+            and str(model or "").startswith(("bedrock/", "anthropic/"))):
+        ceiling = _registered_max_output_tokens(model)
+        if ceiling:
+            kwargs["max_tokens"] = ceiling
     return litellm.completion(*args, **kwargs)
 
 

--- a/tests/test_litellm_completion_max_tokens.py
+++ b/tests/test_litellm_completion_max_tokens.py
@@ -1,0 +1,117 @@
+"""The orchestrator chat loops must not run on Bedrock's default output cap.
+
+#238 injected a model-appropriate ``max_tokens`` because Bedrock omits
+``maxTokens`` when unset and falls back to a low server-side default. That
+injection went into ``LiteLLMGenerativeModel`` only — but every chat-driven
+orchestrator (planning, meta, simulation) and ``structure_agent`` call
+``litellm_completion`` instead, so their loops kept the low default.
+
+Caught live: a tool call returned ``finish_reason='length'`` at exactly 4096
+completion tokens with a required argument missing, and the fallback the
+model chose hit the same wall. These pin the ceiling at the shared entry
+point without disturbing other providers.
+"""
+
+import sys
+from unittest import mock
+
+import pytest
+
+from scilink.wrappers import litellm_wrapper
+from scilink.wrappers.litellm_wrapper import litellm_completion
+
+
+def _captured(**kwargs):
+    """Call through a stubbed litellm and return the params it received."""
+    seen = {}
+
+    def fake_completion(*a, **kw):
+        seen.update(kw)
+        seen["_positional"] = a
+        return object()
+
+    with mock.patch.object(litellm_wrapper.litellm, "completion",
+                           side_effect=fake_completion):
+        litellm_completion(**kwargs)
+    return seen
+
+
+def test_bedrock_gets_an_explicit_ceiling():
+    seen = _captured(model="bedrock/us.anthropic.claude-opus-4-8",
+                     messages=[{"role": "user", "content": "hi"}])
+    assert "max_tokens" in seen, "the chat loop would run on Bedrock's default"
+    assert seen["max_tokens"] > 4096, seen["max_tokens"]
+
+
+def test_anthropic_direct_gets_one_too():
+    seen = _captured(model="anthropic/claude-opus-4-8",
+                     messages=[{"role": "user", "content": "hi"}])
+    assert seen.get("max_tokens", 0) > 4096
+
+
+def test_an_explicit_value_from_the_caller_still_wins():
+    seen = _captured(model="bedrock/us.anthropic.claude-opus-4-8",
+                     messages=[], max_tokens=256)
+    assert seen["max_tokens"] == 256
+
+
+def test_other_providers_are_untouched():
+    """Scope check: litellm already gives these a sane ceiling, so injecting
+    one here would be a behaviour change nobody asked for."""
+    for model in ("gpt-4o", "openai/gpt-4o", "gemini/gemini-2.0-flash",
+                  "vertex_ai/gemini-2.0-flash"):
+        seen = _captured(model=model, messages=[])
+        assert "max_tokens" not in seen, model
+
+
+def test_the_model_can_be_positional():
+    seen = {}
+
+    def fake_completion(*a, **kw):
+        seen.update(kw)
+        return object()
+
+    with mock.patch.object(litellm_wrapper.litellm, "completion",
+                           side_effect=fake_completion):
+        litellm_completion("bedrock/us.anthropic.claude-opus-4-8", messages=[])
+    assert seen.get("max_tokens", 0) > 4096
+
+
+def test_retries_still_defaulted():
+    """Pre-existing behaviour must survive the change."""
+    seen = _captured(model="gpt-4o", messages=[])
+    assert seen["num_retries"] == 4
+
+
+def test_it_sends_exactly_what_the_registry_reports():
+    """Never a rounded-up or invented number — the registry value or nothing."""
+    m = "bedrock/us.anthropic.claude-opus-4-8"
+    seen = _captured(model=m, messages=[])
+    assert seen["max_tokens"] == litellm_wrapper._registered_max_output_tokens(m)
+
+
+@pytest.mark.parametrize("model", [
+    # An ordinary Bedrock name litellm has no entry for — not exotic.
+    "bedrock/us.anthropic.claude-sonnet-4-5-v1:0",
+    "bedrock/some.custom.unmapped-model",
+    "anthropic/my-private-deployment",
+])
+def test_unknown_models_are_left_alone(model):
+    """Guessing high on a deployment nobody verified trades a silent
+    truncation for an outright rejection, under every orchestrator loop."""
+    assert litellm_wrapper._registered_max_output_tokens(model) is None
+    seen = _captured(model=model, messages=[])
+    assert "max_tokens" not in seen, model
+
+
+def test_the_helper_reports_none_rather_than_a_default():
+    """The distinction this whole tightening rests on."""
+    assert litellm_wrapper._registered_max_output_tokens(
+        "bedrock/definitely-not-a-real-model") is None
+    assert litellm_wrapper._resolve_max_output_tokens(
+        "bedrock/definitely-not-a-real-model") == \
+        litellm_wrapper.DEFAULT_MAX_OUTPUT_TOKENS
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_missing_arg_diagnosis.py
+++ b/tests/test_missing_arg_diagnosis.py
@@ -1,0 +1,128 @@
+"""A missing required argument must not be blamed on truncation by guess.
+
+The old message asserted the arguments "were likely truncated by the
+response length limit" and told the model to split its content across
+save_file + append_file chunks — a cause it never checked, and a remedy that
+abandons the tool rather than retrying it.
+
+An inference from schema order was tried and is unsound: instrumentation
+caught a save_file call with finish_reason='length' — genuinely cut — that
+was VALID JSON missing `content` (declared second) while `deliverable` and
+`title` (declared fourth and fifth) arrived. Arguments are emitted in the
+model's chosen order, and a cut response loses the LONG value while short
+ones already emitted survive. So the message claims nothing about the cause
+and simply asks for the call again.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scilink.agents.planning_agents.orchestrator_tools import OrchestratorTools
+
+
+def _tools():
+    tmp = Path(tempfile.mkdtemp(prefix="missingargs_"))
+    t = OrchestratorTools.__new__(OrchestratorTools)
+    t.orch = SimpleNamespace(
+        planner=SimpleNamespace(state={}, model=None, kb_docs=None,
+                                generation_config=None,
+                                _build_skill_context=lambda s: None),
+        base_dir=tmp, _active_output_subdir=None, lit_agent=None)
+    t.functions_map, t.gemini_functions, t.openai_schemas = {}, [], []
+    OrchestratorTools._register_all_tools(t)
+    return t
+
+
+def _declared(t, tool):
+    """Schema-declaration order, read straight off the registered schema."""
+    for schema in t.openai_schemas:
+        fn = schema["function"]
+        if fn["name"] == tool:
+            return list(fn["parameters"]["properties"].keys())
+    return []
+
+
+def _msg(t, tool, **kw):
+    return json.loads(t.execute_tool(tool, **kw))["message"]
+
+
+def test_schema_order_is_available_and_request_comes_first():
+    """Declaration order is still read (the diagnostic records it), but it
+    is no longer used to infer whether the call was truncated."""
+    t = _tools()
+    order = _declared(t, "write_technical_document")
+    assert order[0] == "request", order
+    assert {"filename", "title", "source_files"} <= set(order[1:])
+    assert t._required_params("write_technical_document") == ["request"]
+
+
+def test_it_claims_nothing_about_truncation():
+    """The live shape: request missing, later-declared args all arrived."""
+    t = _tools()
+    m = _msg(t, "write_technical_document", filename="memo.md", title="T",
+             use_literature=False, source_files="x.md")
+
+    for claim in ("nothing was truncated", "complete JSON", "not emitted",
+                  "response length limit"):
+        assert claim not in m, f"still asserting a cause: {claim!r}"
+    assert "append_file" not in m and "save_file" not in m
+
+
+def test_the_counterexample_that_killed_schema_order_reasoning():
+    """save_file, finish_reason='length', content missing while deliverable
+    and title — both declared AFTER it — arrived. Any message telling the
+    model this call was complete would be factually wrong."""
+    t = _tools()
+    order = _declared(t, "save_file")
+    assert order.index("content") < order.index("deliverable")
+    assert order.index("content") < order.index("title")
+
+    m = _msg(t, "save_file", filename="m.md", deliverable=True, title="T")
+    assert "content" in m
+    assert "nothing was truncated" not in m
+    assert "complete" not in m
+
+
+def test_it_reports_what_did_arrive():
+    """Useful without being a claim about why the rest did not."""
+    t = _tools()
+    m = _msg(t, "write_technical_document", filename="memo.md", title="T")
+    assert "filename" in m and "title" in m
+
+
+def test_it_says_resend_not_switch_tools():
+    """The failure mode being fixed is abandonment of the tool."""
+    t = _tools()
+    m = _msg(t, "write_technical_document", filename="memo.md")
+    assert "Resend the SAME call" in m
+    # And it corrects the misuse that produced the omission: the brief is a
+    # specification, not the document.
+    assert "specification" in m
+    assert "not the finished text" in m
+
+
+def test_every_tool_gets_the_same_cause_neutral_message():
+    """Sweep every registered tool: none may assert or deny truncation."""
+    t = _tools()
+    for schema in t.openai_schemas:
+        name = schema["function"]["name"]
+        if not t._required_params(name):
+            continue
+        m = _msg(t, name)
+        assert "nothing was truncated" not in m, name
+        assert "response length limit" not in m, name
+        assert "Resend the SAME call" in m, name
+
+
+def test_the_missing_argument_is_always_named():
+    t = _tools()
+    m = _msg(t, "write_technical_document", filename="memo.md")
+    assert "request" in m
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_tool_arg_anomaly_log.py
+++ b/tests/test_tool_arg_anomaly_log.py
@@ -1,0 +1,133 @@
+"""Capture the raw provider output when a required argument goes missing.
+
+The cause of these omissions is still unknown. Two candidate explanations
+were ruled out — the output-token ceiling (injected explicitly on the
+bedrock/anthropic paths, far above the arguments involved) and tail
+truncation (the observed calls were valid JSON missing only the FIRST
+declared parameter while later-declared ones arrived) — but the evidence
+needed to identify the real cause is destroyed before anyone can look at
+it: by the time the guard runs it holds parsed kwargs, not the response.
+
+So record it. `finish_reason` is the decisive field: "length" means the
+response really was cut; anything else rules truncation out for that call.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scilink.agents.planning_agents.planning_orchestrator import (
+    PlanningOrchestratorAgent)
+
+
+def _orch(tmp):
+    o = PlanningOrchestratorAgent.__new__(PlanningOrchestratorAgent)
+    o.base_dir = Path(tmp)
+    o.model_name = "bedrock/us.anthropic.claude-opus-4-8"
+    return o
+
+
+def _call(raw_args, name="write_technical_document"):
+    return SimpleNamespace(
+        function=SimpleNamespace(name=name, arguments=raw_args))
+
+
+def _missing_result(tool="write_technical_document", missing=("request",)):
+    return json.dumps({"status": "error", "tool": tool,
+                       "error_kind": "missing_required_arguments",
+                       "missing": list(missing), "message": "..."})
+
+
+def _log(tmp):
+    p = Path(tmp) / "tool_call_diagnostics.jsonl"
+    if not p.exists():
+        return []
+    return [json.loads(l) for l in p.read_text().splitlines() if l.strip()]
+
+
+def test_records_the_raw_arguments_and_finish_reason():
+    """The live shape: valid JSON, later-declared args present, no request."""
+    tmp = tempfile.mkdtemp()
+    raw = '{"filename": "memo.md", "title": "T", "use_literature": false}'
+    _orch(tmp)._record_tool_arg_anomaly(
+        _call(raw), _missing_result(),
+        finish_reason="tool_calls",
+        response=SimpleNamespace(usage=SimpleNamespace(
+            completion_tokens=812, prompt_tokens=41000)))
+
+    rec, = _log(tmp)
+    assert rec["arguments_raw"] == raw, "the raw string is the whole point"
+    assert rec["finish_reason"] == "tool_calls", "decides the truncation question"
+    assert rec["arguments_parse_ok"] is True
+    assert rec["arguments_keys"] == ["filename", "title", "use_literature"]
+    assert rec["missing"] == ["request"]
+    assert rec["completion_tokens"] == 812
+    assert rec["model"].startswith("bedrock/")
+    assert rec["arguments_len"] == len(raw)
+
+
+def test_a_genuinely_truncated_call_is_distinguishable():
+    """If truncation IS the cause, the record must show it plainly."""
+    tmp = tempfile.mkdtemp()
+    _orch(tmp)._record_tool_arg_anomaly(
+        _call('{"request": "half a brie'), _missing_result(),
+        finish_reason="length", response=None)
+
+    rec, = _log(tmp)
+    assert rec["finish_reason"] == "length"
+    assert rec["arguments_parse_ok"] is False
+    assert rec["arguments_keys"] is None
+
+
+def test_successful_calls_write_nothing():
+    """No anomaly, no file — this must not become a per-call trace log."""
+    tmp = tempfile.mkdtemp()
+    o = _orch(tmp)
+    o._record_tool_arg_anomaly(_call('{"request": "x"}'),
+                               json.dumps({"status": "success", "path": "p"}))
+    o._record_tool_arg_anomaly(_call('{}'),
+                               json.dumps({"status": "error",
+                                           "message": "some other failure"}))
+    assert not (Path(tmp) / "tool_call_diagnostics.jsonl").exists()
+
+
+def test_occurrences_accumulate():
+    """JSONL so a second occurrence does not overwrite the first."""
+    tmp = tempfile.mkdtemp()
+    o = _orch(tmp)
+    for i in range(3):
+        o._record_tool_arg_anomaly(_call('{"filename": "m%d.md"}' % i),
+                                   _missing_result())
+    assert len(_log(tmp)) == 3
+
+
+def test_a_runaway_argument_cannot_fill_the_disk():
+    tmp = tempfile.mkdtemp()
+    o = _orch(tmp)
+    huge = '{"request": "' + "x" * 200000 + '"}'
+    o._record_tool_arg_anomaly(_call(huge), _missing_result())
+
+    rec, = _log(tmp)
+    assert rec["arguments_truncated_in_log"] is True
+    assert len(rec["arguments_raw"]) == o._RAW_ARGS_CAP
+    assert rec["arguments_len"] == len(huge), "true length still recorded exactly"
+
+
+def test_recording_never_breaks_the_turn():
+    """A diagnostic that kills the turn it is diagnosing is worse than none."""
+    tmp = tempfile.mkdtemp()
+    o = _orch(tmp)
+    o.base_dir = Path("/proc/nonexistent-and-unwritable")  # force a write error
+    o._record_tool_arg_anomaly(_call('{"filename": "m.md"}'), _missing_result())
+
+    o2 = _orch(tmp)
+    o2._record_tool_arg_anomaly(_call(None), _missing_result())      # bad raw
+    o2._record_tool_arg_anomaly(_call('{}'), "not json at all")      # bad result
+    o2._record_tool_arg_anomaly(_call('{}'), None)                   # no result
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
The agent kept losing a tool call. It would try to write a document, the call
would come back missing one of its arguments, it would try once more, and then
give up and write the file by hand instead — which quietly skips the literature
grounding that tool exists to provide.

The cause turned out to have nothing to do with the document tool. **The chat
loops were running with no limit set on how long a reply could be**, so the
model's replies were being cut off mid-sentence, and a long argument was the
first thing to go.

A fix for this was written a while back (#238) and it works — but it was
installed on a code path the chat loops do not use. So the loops kept the old
behaviour while the fix looked like it was in place. This puts it where they
actually run.

**Seen directly.** Instrumentation caught a call cut off at exactly 4096 tokens
with a required argument gone; the agent's attempt to recover by writing the
file in pieces then hit the same wall. With the limit set, the same task
produces no cut-offs at all and the document is written in one go instead of
four.

**Deliberately cautious.** The limit is only sent when the model is one the
library actually has a record for. For anything unrecognised — a private
deployment, or simply a model not yet listed — nothing is sent, rather than a
number nobody has verified. Asking for too much on an unknown deployment
turns a quiet truncation into an outright failure, and this code sits under
every orchestrator.

Also here: the error message shown when an argument goes missing used to
blame the response length and tell the agent to use a different tool. It was
guessing, and the tool it recommended is the one without literature grounding
— so following the advice quietly downgraded the result. It now reports what
happened and asks for the same call again.

The third commit is **temporary** and marked as such: it records the raw
provider output when this happens, so we can confirm the occurrences stop.
Revert it once they have.

<details>
<summary><b>Technical details</b></summary>

### 1. `33b83ecb` — the substantive fix

`#238` added a model-appropriate `max_tokens` because Bedrock omits
`maxTokens` when unset and falls back to a low server-side default. It landed
in `LiteLLMGenerativeModel._build_params` only.

`litellm_completion` is a passthrough that set no `max_tokens` at all, and it
is what **every chat-driven orchestrator** calls — planning
(`planning_orchestrator.py:1871`), meta (`meta_orchestrator.py:1927`, `:1954`),
simulation (`simulation_orchestrator.py:926`, `:953`) and
`structure_agent.py:341`. None passes `max_tokens`, so all six ran on the
default. Note the two `tool_choice="none"` follow-ups: those produce the final
answer text the user reads, so long summaries were being cut there too.

Coverage check: `litellm.completion` is called in exactly three places, all
inside the wrapper — line 266 (this fix) and lines 384/746, both of which
build params via `_build_params` and already had the ceiling. After this,
every path to the provider has one.

New `_registered_max_output_tokens()` returns the registry value **or None**,
deliberately unlike `_resolve_max_output_tokens()`, which substitutes
`DEFAULT_MAX_OUTPUT_TOKENS` (32000). Resulting behaviour:

| model | sent |
|---|---|
| `bedrock/us.anthropic.claude-opus-4-8` | 128000 |
| `bedrock/us.anthropic.claude-sonnet-4-5-v1:0` | **not sent** — no registry entry |
| `anthropic/claude-sonnet-4-5` | 64000 |
| `anthropic/my-private-deployment` | **not sent** |
| `claude-opus-4-8` (bare — internal-proxy naming) | not sent |
| `gpt-4o`, `openai/*`, `gemini/*`, `vertex_ai/*` | not sent |

`_build_params` still substitutes its default for unknown models. That
pre-existing behaviour is left alone rather than changed as a side effect, so
the two entry points differ for unmapped names. Deliberate; flagging it for
review rather than deciding it here.

### 2. `6c30062d` — the message stops guessing

The old text asserted truncation "by the response length limit" and advised
splitting content across `save_file` + `append_file`.

Two attempts to *derive* the cause also failed and are worth recording. The
output ceiling looked like an alibi (it resolves far above any realistic
argument) — but that resolution belongs to the path the chat loops don't use.
Then schema order looked like proof: a key declared *after* the missing one
arriving should mean nothing was truncated. The instrumentation refuted it —
a `save_file` call came back `finish_reason='length'`, genuinely cut, as valid
JSON missing `content` (declared 2nd) while `deliverable` and `title`
(declared 4th, 5th) were present. **Arguments are emitted in the model's
chosen order, not the schema's**, and a cut response loses the long value
while short ones already emitted survive.

So it claims nothing: names what is missing, notes what arrived, asks for the
same call again, and mentions a long value as the likeliest casualty without
asserting it. A regression test reconstructs the refuting call and fails if
anything tells the model it was complete.

An A/B against a live model showed the wording alone does **not** change
recovery — one failure and the model retries under either message, two and it
abandons the tool under both. This is a correctness fix, not a behavioural
one; the behavioural fix is commit 1.

### 3. `0b2720a6` — TEMPORARY, revert to remove

`tool_call_diagnostics.jsonl` in the session dir, written only when a required
argument is missing. Records raw arguments, emission order, declared order,
token counts and `finish_reason` — decisive, and not visible at the guard.

Rationale for keeping it briefly: the calls that started this predate any
instrumentation, so commit 1 explaining them is a strong inference from a
later call with the same signature, not a demonstration. If no records appear
now, that is the confirmation.

Scoped so it cannot become a nuisance: successful calls create no file at all;
JSONL so occurrences accumulate; the raw string is capped at 40 KB with the
true length recorded exactly; every failure path swallowed. Everything it adds
is confined to this commit — `_declared_params`, the `error_kind` marker, the
method and its test — verified by simulating the revert: exactly 240 lines
across exactly 3 files, and the permanent tests still pass afterward.

### Validation

- **108 offline tests**, including a scope test pinning that other providers
  receive no `max_tokens` at all
- **Live, real Bedrock**, before/after: `finish_reason='length'` events 2 → 0;
  tool sequence `save_file, save_file, append_file` → a single `save_file`;
  document 14,915 bytes in one write
- Revert of the temporary commit simulated and re-verified after a history
  rewrite

Caveat: the live evidence was gathered before the tightening. The tightening
only ever *removes* a value, and for the model tested (registry hit) the value
sent is identical — but an unmapped name has not been live-tested.

</details>
