### PR TITLE
Read a Word document's tables and figures

### DIFF
--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -1503,6 +1503,11 @@ class MetaOrchestratorTools:
         # note or white paper carrying a few diagrams — while a figure-heavy
         # atlas reports its count instead of spending the context on it.
         _VIEW_DOC_MAX_FIGURES = 8
+        # The most images ever put in one reply, even when explicitly asked
+        # for. An unbounded payload under the agent's control is how a
+        # context window gets spent in a single call, so 'on' raises the
+        # ceiling rather than removing it — and says when it had to stop.
+        _VIEW_DOC_HARD_FIGURE_CAP = 24
 
         def view_document(paths, figures: str = "auto") -> str:
             """Read one or more documents and return their text content."""
@@ -1527,13 +1532,18 @@ class MetaOrchestratorTools:
             n_fig_total = sum(count_docx_figures(p) for p in paths
                               if str(p).lower().endswith(".docx"))
             if want == "on":
-                attach = True
+                # Asked for explicitly: attach as many as the hard cap allows
+                # rather than silently stopping at the auto threshold, which
+                # made 'on' quietly mean 'on, up to 8' (caught live).
+                attach, fig_ceiling = True, _VIEW_DOC_HARD_FIGURE_CAP
             elif want == "off":
-                attach = False
+                attach, fig_ceiling = False, 0
             else:
                 attach = 0 < n_fig_total <= _VIEW_DOC_MAX_FIGURES
+                fig_ceiling = _VIEW_DOC_MAX_FIGURES
 
             docs, errors, images_b64 = [], [], []
+            undeliverable = []
             for p in paths:
                 pp = Path(p)
                 if not pp.is_file():
@@ -1550,8 +1560,14 @@ class MetaOrchestratorTools:
                     if attach and pp.suffix.lower() == ".docx":
                         parsed = extract_document(pp)
                         for f in parsed.figures:
-                            if len(images_b64) >= _VIEW_DOC_MAX_FIGURES:
+                            if len(images_b64) >= fig_ceiling:
                                 break
+                            if not f.deliverable:
+                                # Keeps its number; say which one and why,
+                                # so the marker is not an unexplained gap.
+                                undeliverable.append(
+                                    f"[Figure {f.index + 1}] {f.note}")
+                                continue
                             images_b64.append(f.to_base64())
                     text = info.get("text", "")
                     truncated = len(text) > _VIEW_DOC_MAX_CHARS
@@ -1589,6 +1605,15 @@ class MetaOrchestratorTools:
                 # that render images inside a tool result, and the [Figure N]
                 # markers in the text say which is which.
                 payload_extra["images_base64"] = images_b64
+                if len(images_b64) < n_fig_total:
+                    # Partial delivery must be stated, not inferred. Left
+                    # unsaid, the reply looks complete while [Figure N] for
+                    # the rest points at nothing.
+                    payload_extra["figures_attached"] = (
+                        f"{len(images_b64)} of {n_fig_total} figures are "
+                        f"attached, in document order — [Figure 1] through "
+                        f"[Figure {len(images_b64)}]. The rest were not "
+                        f"delivered; their markers remain in the text.")
             elif n_fig_total:
                 payload_extra["figures_not_attached"] = (
                     f"{n_fig_total} embedded figure(s) were found but not "
@@ -1598,6 +1623,8 @@ class MetaOrchestratorTools:
                        f"limit)")
                     + ". The text marks their positions as [Figure N]; "
                     "re-read with figures='on' to see them.")
+            if undeliverable:
+                payload_extra["figures_undisplayable"] = undeliverable
             return json.dumps({
                 "status": "success",
                 "n_documents": len(docs),
@@ -1643,10 +1670,12 @@ class MetaOrchestratorTools:
                         "Whether to attach a Word document's embedded "
                         "figures as viewable images: 'auto' (default) "
                         "attaches them when there are few enough to be "
-                        "worth the context, 'on' forces it for a document "
-                        "whose figures you specifically need to see, 'off' "
-                        "keeps the reply text-only. Either way the text "
-                        "marks where each figure sits."
+                        "worth the context, 'on' raises the limit for a "
+                        "document whose figures you specifically need to "
+                        "see, 'off' keeps the reply text-only. Even 'on' "
+                        "stops at a ceiling; when not everything fits, the "
+                        "result says how many of how many arrived. Either "
+                        "way the text marks where each figure sits."
                     ),
                 },
                 "paths": {

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -1498,8 +1498,13 @@ class MetaOrchestratorTools:
                           ".json", ".yaml", ".yml",
                           ".csv", ".xlsx", ".xls"}
         _VIEW_DOC_MAX_CHARS = 200_000  # ~50k tokens; long docs are truncated
+        # Figures ride along automatically up to this many across the whole
+        # call. Chosen to cover the documents figures actually help with — a
+        # note or white paper carrying a few diagrams — while a figure-heavy
+        # atlas reports its count instead of spending the context on it.
+        _VIEW_DOC_MAX_FIGURES = 8
 
-        def view_document(paths) -> str:
+        def view_document(paths, figures: str = "auto") -> str:
             """Read one or more documents and return their text content."""
             if isinstance(paths, str):
                 paths = [paths]
@@ -1508,9 +1513,27 @@ class MetaOrchestratorTools:
                                    "message": "No document path provided."})
             print(f"  📄 Tool: Reading {len(paths)} document(s)...")
 
-            from scilink.parsers import extract_text
+            from scilink.parsers import extract_document, extract_text
+            from scilink.parsers.docx_document import count_docx_figures
 
-            docs, errors = [], []
+            # Whether to carry embedded figures back as images. Counted
+            # exactly rather than estimated from document length — for DOCX
+            # the images are enumerable without decoding them — so the
+            # decision is made on the real cost, before paying it. A short
+            # document with a handful of figures is the case worth spending
+            # on; an atlas of forty is not, and gets a count instead so the
+            # agent still knows they exist and can ask for a subset.
+            want = str(figures or "auto").strip().lower()
+            n_fig_total = sum(count_docx_figures(p) for p in paths
+                              if str(p).lower().endswith(".docx"))
+            if want == "on":
+                attach = True
+            elif want == "off":
+                attach = False
+            else:
+                attach = 0 < n_fig_total <= _VIEW_DOC_MAX_FIGURES
+
+            docs, errors, images_b64 = [], [], []
             for p in paths:
                 pp = Path(p)
                 if not pp.is_file():
@@ -1524,6 +1547,12 @@ class MetaOrchestratorTools:
                     continue
                 try:
                     info = extract_text(pp, ocr_model=self.orch.model)
+                    if attach and pp.suffix.lower() == ".docx":
+                        parsed = extract_document(pp)
+                        for f in parsed.figures:
+                            if len(images_b64) >= _VIEW_DOC_MAX_FIGURES:
+                                break
+                            images_b64.append(f.to_base64())
                     text = info.get("text", "")
                     truncated = len(text) > _VIEW_DOC_MAX_CHARS
                     if truncated:
@@ -1537,7 +1566,8 @@ class MetaOrchestratorTools:
                     # Format-specific metadata flows through transparently
                     # (n_pages for PDFs, n_paragraphs for DOCX, plus the
                     # OCR page count when the vision fallback fired).
-                    for k in ("n_pages", "n_paragraphs", "n_ocr_pages"):
+                    for k in ("n_pages", "n_paragraphs", "n_ocr_pages",
+                              "n_tables", "n_figures"):
                         if k in info:
                             doc_info[k] = info[k]
                     docs.append(doc_info)
@@ -1553,10 +1583,26 @@ class MetaOrchestratorTools:
                                    "message": "No documents could be read.",
                                    "errors": errors})
             n_ocr = sum(d.get("n_ocr_pages", 0) for d in docs)
+            payload_extra = {}
+            if images_b64:
+                # tool_media lifts this into real image content on providers
+                # that render images inside a tool result, and the [Figure N]
+                # markers in the text say which is which.
+                payload_extra["images_base64"] = images_b64
+            elif n_fig_total:
+                payload_extra["figures_not_attached"] = (
+                    f"{n_fig_total} embedded figure(s) were found but not "
+                    f"attached"
+                    + (" (figures='off')" if want == "off" else
+                       f" (over the {_VIEW_DOC_MAX_FIGURES}-figure auto "
+                       f"limit)")
+                    + ". The text marks their positions as [Figure N]; "
+                    "re-read with figures='on' to see them.")
             return json.dumps({
                 "status": "success",
                 "n_documents": len(docs),
                 "n_ocr_pages": n_ocr,
+                **payload_extra,
                 "ocr_note": (
                     f"{n_ocr} scanned page(s) had no text layer and were "
                     "transcribed by vision-OCR — verify any figures/numerics."
@@ -1579,7 +1625,10 @@ class MetaOrchestratorTools:
                 "adaptive parser — small files return the full table as "
                 "Markdown, large files a statistical summary; a sibling "
                 "JSON metadata file (e.g. data.json next to data.xlsx) "
-                "auto-enriches the preview. Use this to inspect / "
+                "auto-enriches the preview. A Word document's tables are "
+                "read in place, and its embedded figures come back as "
+                "images you can see, marked [Figure N] where they sit in "
+                "the text. Use this to inspect / "
                 "summarize a file's contents right here — for a routing "
                 "decision, to extract context to thread into a "
                 "delegate_to_* call, or to answer a quick question about "
@@ -1588,6 +1637,18 @@ class MetaOrchestratorTools:
                 "`knowledge_paths` in delegate_to_planning."
             ),
             parameters={
+                "figures": {
+                    "type": "string",
+                    "description": (
+                        "Whether to attach a Word document's embedded "
+                        "figures as viewable images: 'auto' (default) "
+                        "attaches them when there are few enough to be "
+                        "worth the context, 'on' forces it for a document "
+                        "whose figures you specifically need to see, 'off' "
+                        "keeps the reply text-only. Either way the text "
+                        "marks where each figure sits."
+                    ),
+                },
                 "paths": {
                     "type": "array",
                     "items": {"type": "string"},

--- a/scilink/parsers/__init__.py
+++ b/scilink/parsers/__init__.py
@@ -8,11 +8,13 @@ Two entry points:
 
 - ``extract_text(path)`` — flat text + markdown tables, no embeddings. For
   reading a handful of documents straight into context.
+- ``extract_document(path)`` — the same text, plus a .docx's embedded figures
+  as image bytes, for callers that can deliver images.
 - ``ingest_files(...)`` — chunked output for ``scilink.knowledge.KnowledgeBase``
   ingestion (the heavyweight retrieval path).
 """
 
-from .extract import extract_text
+from .extract import extract_document, extract_text
 from .pdf_parser import (
     extract_pdf_text,
     extract_pdf_two_pass,
@@ -29,6 +31,7 @@ from .ingestor import (
 
 __all__ = [
     "extract_text",
+    "extract_document",
     "extract_pdf_text",
     "extract_pdf_two_pass",
     "chunk_text",

--- a/scilink/parsers/docx_document.py
+++ b/scilink/parsers/docx_document.py
@@ -1,0 +1,213 @@
+"""DOCX → text, tables and figures, in document order.
+
+``extract_text`` reads a .docx as ``"\\n".join(p.text for p in doc.paragraphs)``,
+which silently discards two things a scientific document usually carries its
+content in: every table, and every embedded figure. A white paper whose
+methods sit in a table comes back with the methods missing, and nothing
+reports the loss.
+
+Ported from the peerpanel document loader (same author, MIT). Two decisions
+from there are load-bearing and worth restating, because the obvious
+implementations get both wrong:
+
+**Document order, not `doc.paragraphs` then `doc.tables`.** python-docx
+exposes paragraphs and tables as separate sequences, so the obvious join
+appends every table at the end, detached from the heading it belongs under.
+Walking ``document.element.body`` keeps a table where the reader sees it.
+
+**Figures are marked in place AND returned.** Each embedded image emits a
+``[Figure N]`` marker at its exact position in the text, and ``figures[N-1]``
+is that image. DOCX has no page concept, so the marker is the only thing that
+ties a figure to the caption or sentence it belongs to; passing the images
+alone would leave the model unable to say which is which.
+"""
+from __future__ import annotations
+
+import base64
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+
+@dataclass
+class Figure:
+    """An embedded image, numbered to match its ``[Figure N]`` marker."""
+    index: int          # 0-based; marker in the text is index + 1
+    ext: str            # "png", "jpeg", ...
+    bytes: bytes
+
+    @property
+    def mime(self) -> str:
+        e = self.ext.lower()
+        return "image/jpeg" if e in ("jpg", "jpeg") else f"image/{e}"
+
+    def to_base64(self) -> str:
+        return base64.b64encode(self.bytes).decode("ascii")
+
+
+@dataclass
+class Table:
+    """A table rendered as GitHub-flavored markdown, in document order."""
+    index: int
+    markdown: str
+
+
+@dataclass
+class ParsedDocument:
+    source: str
+    text: str
+    tables: List[Table] = field(default_factory=list)
+    figures: List[Figure] = field(default_factory=list)
+
+    def composed(self, max_chars: Optional[int] = None) -> str:
+        """Text plus tables as one markdown string.
+
+        Figures are deliberately NOT inlined here — they stay in ``figures``
+        for a caller that can deliver images, and the ``[Figure N]`` markers
+        already sitting in the text tell a text-only caller they exist.
+        """
+        parts = [self.text.strip()]
+        for t in self.tables:
+            parts.append(f"\n\n### Table {t.index + 1}\n\n{t.markdown}\n")
+        out = "\n".join(parts)
+        if max_chars is not None and len(out) > max_chars:
+            out = out[:max_chars] + "\n\n[... truncated ...]"
+        return out
+
+
+def rows_to_markdown(rows: List[List[str]]) -> str:
+    """Render a 2D list as a GitHub-flavored markdown table.
+
+    Cells are flattened to one line and pipes escaped, so a multi-line or
+    pipe-bearing cell cannot break the table's shape. Short rows are padded
+    to the widest row rather than dropped.
+    """
+    if not rows:
+        return ""
+    cleaned = [[(c or "").strip().replace("\n", " ").replace("|", "\\|")
+                for c in row] for row in rows]
+    width = max(len(r) for r in cleaned)
+    cleaned = [r + [""] * (width - len(r)) for r in cleaned]
+    header, body = cleaned[0], cleaned[1:]
+    lines = ["| " + " | ".join(header) + " |",
+             "| " + " | ".join(["---"] * width) + " |"]
+    lines += ["| " + " | ".join(r) + " |" for r in body]
+    return "\n".join(lines)
+
+
+def _paragraph_to_text(p, *, fig_counter_start: int):
+    """Walk a paragraph's XML in order -> (text_with_markers, image_rIds).
+
+    Reading ``p.text`` would be shorter and would lose three things: tabs and
+    line breaks (they are elements, not characters), and the POSITION of any
+    embedded image, which is exactly what makes a figure attributable to its
+    caption.
+    """
+    from docx.oxml.ns import qn
+
+    parts: List[str] = []
+    rids: List[str] = []
+    counter = fig_counter_start
+    for el in p._element.iter():
+        tag = el.tag
+        if tag == qn("w:t"):
+            if el.text:
+                parts.append(el.text)
+        elif tag == qn("w:tab"):
+            parts.append("\t")
+        elif tag == qn("w:br"):
+            parts.append("\n")
+        elif tag == qn("a:blip"):
+            rid = el.get(qn("r:embed"))
+            if rid:
+                parts.append(f" [Figure {counter}] ")
+                rids.append(rid)
+                counter += 1
+    return "".join(parts), rids
+
+
+def load_docx(path, *, include_figures: bool = True) -> ParsedDocument:
+    """Read a .docx into text, tables and figures, in document order."""
+    import docx  # python-docx
+
+    p = Path(path)
+    doc = docx.Document(str(p))
+
+    text_parts: List[str] = []
+    tables: List[Table] = []
+    rid_order: List[str] = []       # image relationship ids, document order
+
+    body = doc.element.body
+    para_map = {id(x._element): x for x in doc.paragraphs}
+    tbl_map = {id(x._element): x for x in doc.tables}
+
+    for child in body.iterchildren():
+        para = para_map.get(id(child))
+        if para is not None:
+            text, rids = _paragraph_to_text(
+                para, fig_counter_start=len(rid_order) + 1)
+            if text.strip() or rids:
+                text_parts.append(text)
+            rid_order.extend(rids)
+            continue
+
+        tbl = tbl_map.get(id(child))
+        if tbl is not None:
+            # Cells go through the same walker, so an image inside a table
+            # keeps its place in the global figure numbering.
+            rows: List[List[str]] = []
+            for row in tbl.rows:
+                cells: List[str] = []
+                for cell in row.cells:
+                    chunks: List[str] = []
+                    for cp in cell.paragraphs:
+                        text, rids = _paragraph_to_text(
+                            cp, fig_counter_start=len(rid_order) + 1)
+                        if text:
+                            chunks.append(text)
+                        rid_order.extend(rids)
+                    cells.append(" ".join(chunks))
+                rows.append(cells)
+            md = rows_to_markdown(rows)
+            if md:
+                idx = len(tables)
+                tables.append(Table(index=idx, markdown=md))
+                # Leave a marker where the table stood, so its position in the
+                # narrative survives even though the table renders below.
+                text_parts.append(f"[Table {idx + 1}]")
+
+    figures: List[Figure] = []
+    if include_figures:
+        rels = doc.part.rels
+        for rid in rid_order:
+            rel = rels.get(rid)
+            if rel is None or "image" not in getattr(rel, "reltype", ""):
+                continue
+            try:
+                blob = rel.target_part.blob
+                ctype = getattr(rel.target_part, "content_type", "image/png")
+                figures.append(Figure(index=len(figures),
+                                      ext=ctype.split("/")[-1], bytes=blob))
+            except Exception as e:  # noqa: BLE001 - one bad image, not a failure
+                logging.debug(f"Skipping unreadable image {rid}: {e}")
+
+    return ParsedDocument(source=str(p), text="\n\n".join(text_parts),
+                          tables=tables, figures=figures)
+
+
+def count_docx_figures(path) -> int:
+    """How many embedded images a .docx holds, without decoding them.
+
+    Lets a caller decide whether attaching figures is affordable BEFORE
+    paying for them — for DOCX the count is exact, so there is no need to
+    estimate it from document length.
+    """
+    import zipfile
+    try:
+        with zipfile.ZipFile(str(path)) as z:
+            xml = z.read("word/document.xml").decode("utf-8", "ignore")
+        return xml.count("<a:blip")
+    except Exception as e:  # noqa: BLE001 - a count is advisory
+        logging.debug(f"Figure count failed for {path}: {e}")
+        return 0

--- a/scilink/parsers/docx_document.py
+++ b/scilink/parsers/docx_document.py
@@ -30,12 +30,31 @@ from pathlib import Path
 from typing import List, Optional
 
 
+#: What vision APIs actually accept. A Word document routinely carries
+#: formats outside this set — scanned figures as BMP/TIFF, Excel charts and
+#: SmartArt as EMF/WMF — and shipping one is worse than dropping it: the
+#: delivery layer guesses mime from magic bytes and falls back to PNG, so a
+#: BMP arrives labelled as a PNG and takes the whole request down with it.
+SUPPORTED_IMAGE_MIMES = frozenset(
+    {"image/jpeg", "image/png", "image/gif", "image/webp"})
+
+
 @dataclass
 class Figure:
-    """An embedded image, numbered to match its ``[Figure N]`` marker."""
+    """An embedded image, numbered to match its ``[Figure N]`` marker.
+
+    ``deliverable`` is False for an image whose format no vision API takes
+    and which could not be converted (EMF/WMF, typically an Excel chart or
+    SmartArt). Such a figure is KEPT rather than removed: dropping it would
+    renumber everything after it, so ``[Figure 5]`` in the text would point
+    at what was really figure 6 — precisely the mis-attribution the markers
+    exist to prevent.
+    """
     index: int          # 0-based; marker in the text is index + 1
     ext: str            # "png", "jpeg", ...
     bytes: bytes
+    deliverable: bool = True
+    note: str = ""
 
     @property
     def mime(self) -> str:
@@ -187,13 +206,46 @@ def load_docx(path, *, include_figures: bool = True) -> ParsedDocument:
             try:
                 blob = rel.target_part.blob
                 ctype = getattr(rel.target_part, "content_type", "image/png")
-                figures.append(Figure(index=len(figures),
-                                      ext=ctype.split("/")[-1], bytes=blob))
+                ext = ctype.split("/")[-1]
+                figures.append(_normalize_figure(
+                    Figure(index=len(figures), ext=ext, bytes=blob)))
             except Exception as e:  # noqa: BLE001 - one bad image, not a failure
                 logging.debug(f"Skipping unreadable image {rid}: {e}")
 
     return ParsedDocument(source=str(p), text="\n\n".join(text_parts),
                           tables=tables, figures=figures)
+
+
+def _normalize_figure(fig: Figure) -> Figure:
+    """Make a figure deliverable, or say why it is not.
+
+    Decodability is verified rather than inferred from the declared content
+    type, because the type lies in both directions. A corrupt or truncated
+    image stored as .png declares image/png and would pass a mime-only check
+    on its way to being rejected by the provider; conversely BMP/TIFF are
+    perfectly readable and only need re-encoding. One rule covers
+    unsupported formats, corrupt bytes and mislabelled files alike.
+
+    EMF/WMF — an Excel chart or SmartArt pasted into Word — are vector
+    metafiles Pillow cannot open, so they keep their slot in the numbering
+    and report why they are absent, which beats a silent gap.
+    """
+    try:
+        import io
+        from PIL import Image
+        im = Image.open(io.BytesIO(fig.bytes))
+        im.load()                      # force a real decode, not just a header
+        if fig.mime in SUPPORTED_IMAGE_MIMES:
+            return fig                 # decodes and is already deliverable
+        buf = io.BytesIO()
+        im.convert("RGB").save(buf, format="PNG")
+        return Figure(index=fig.index, ext="png", bytes=buf.getvalue(),
+                      note=f"converted from {fig.mime}")
+    except Exception as e:  # noqa: BLE001 - undeliverable is a normal outcome
+        logging.debug(f"Figure {fig.index + 1} not deliverable: {e}")
+        return Figure(index=fig.index, ext=fig.ext, bytes=fig.bytes,
+                      deliverable=False,
+                      note=f"{fig.mime} could not be decoded for display")
 
 
 def count_docx_figures(path) -> int:

--- a/scilink/parsers/extract.py
+++ b/scilink/parsers/extract.py
@@ -92,15 +92,26 @@ def extract_text(path: Union[str, Path], max_pages: int = None,
         info["n_ocr_pages"] = len(ocr_pages)
     elif ext == ".docx":
         try:
-            import docx
+            import docx  # noqa: F401 - checked here for a clear error
         except ImportError as e:
             raise ImportError(
                 "Reading .docx documents requires python-docx "
                 "(`pip install python-docx`)."
             ) from e
-        d = docx.Document(str(path))
-        info["n_paragraphs"] = len(d.paragraphs)
-        text = "\n".join(p.text for p in d.paragraphs)
+        # Tables were silently dropped here: paragraphs and tables are
+        # separate sequences in python-docx, so joining p.text lost every
+        # table in the document with nothing reporting the loss. The loader
+        # walks the body in order instead, so a table lands where the reader
+        # sees it. Figures are located and marked ([Figure N]) but not
+        # returned on this path — extract_document() carries the bytes for
+        # callers that can deliver images.
+        from .docx_document import count_docx_figures, load_docx
+        d = load_docx(path, include_figures=False)
+        import docx as _docx
+        info["n_paragraphs"] = len(_docx.Document(str(path)).paragraphs)
+        info["n_tables"] = len(d.tables)
+        info["n_figures"] = count_docx_figures(path)
+        text = d.composed()
     elif ext in (".md", ".txt", ".json", ".yaml", ".yml"):
         text = path.read_text(errors="replace")
     elif ext in (".csv", ".xlsx", ".xls"):
@@ -138,3 +149,25 @@ def extract_text(path: Union[str, Path], max_pages: int = None,
         while len(_EXTRACT_CACHE) > _EXTRACT_CACHE_MAX:
             _EXTRACT_CACHE.popitem(last=False)
     return info
+
+
+def extract_document(path: Union[str, Path], **kwargs):
+    """Like :func:`extract_text`, but keeps figures as image bytes.
+
+    Returns a ``ParsedDocument`` (text with ``[Figure N]`` / ``[Table N]``
+    markers, tables as markdown, figures as bytes) for ``.docx``. Every other
+    format returns a ``ParsedDocument`` carrying only the text
+    :func:`extract_text` produces, so a caller can treat all formats
+    uniformly and simply find ``figures`` empty.
+
+    Separate from ``extract_text`` on purpose: images are worth real tokens,
+    so a caller opts into carrying them rather than having every existing
+    text consumer start paying for them.
+    """
+    from .docx_document import ParsedDocument, load_docx
+
+    path = Path(path)
+    if path.suffix.lower() == ".docx":
+        return load_docx(path, include_figures=True)
+    info = extract_text(path, **kwargs)
+    return ParsedDocument(source=str(path), text=info.get("text", ""))

--- a/tests/test_docx_tables_and_figures.py
+++ b/tests/test_docx_tables_and_figures.py
@@ -1,0 +1,164 @@
+"""A Word document's tables and figures must survive being read.
+
+`extract_text` read a .docx as `"\\n".join(p.text for p in doc.paragraphs)`.
+python-docx exposes paragraphs and tables as separate sequences, so that join
+dropped every table in the document — silently, with nothing reporting the
+loss — and embedded figures were invisible entirely. A white paper whose
+methods sit in a table came back with the methods missing.
+
+The loader walks the document body in order, so a table lands where the reader
+sees it, and marks each embedded image `[Figure N]` at its exact position so a
+figure can be tied to the caption it belongs to. DOCX has no page concept;
+the marker is the only thing that carries that association.
+"""
+
+import re
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from scilink.parsers.docx_document import (
+    count_docx_figures, load_docx, rows_to_markdown)
+from scilink.parsers.extract import extract_document, extract_text
+
+docx = pytest.importorskip("docx")
+PIL = pytest.importorskip("PIL")
+
+
+@pytest.fixture(scope="module")
+def doc_with_everything():
+    from docx.shared import Inches
+    from PIL import Image
+
+    tmp = Path(tempfile.mkdtemp(prefix="docxfix_"))
+    img = tmp / "i.png"
+    Image.new("RGB", (60, 40), "navy").save(img)
+
+    d = docx.Document()
+    d.add_heading("Design Note", 0)
+    d.add_paragraph("Intro before any structure.")
+    t = d.add_table(rows=3, cols=3)
+    for r, row in enumerate([["Channel", "Observable", "Rate"],
+                             ["MZI", "phase | mass", "1 fps"],
+                             ["Raman", "speciation", "0.2 fps"]]):
+        for c, v in enumerate(row):
+            t.rows[r].cells[c].text = v
+    d.add_paragraph("Text AFTER the table.")
+    d.add_paragraph("The layout is shown here:")
+    d.add_picture(str(img), width=Inches(1))
+    d.add_paragraph("and the flow path here:")
+    d.add_picture(str(img), width=Inches(1))
+    p = tmp / "everything.docx"
+    d.save(p)
+    return p
+
+
+# ------------------------------------------------------------------ tables
+
+
+def test_table_content_is_no_longer_dropped(doc_with_everything):
+    """The regression: every cell used to vanish."""
+    text = extract_text(doc_with_everything)["text"]
+    for cell in ("Channel", "Observable", "Rate", "MZI", "Raman",
+                 "speciation", "0.2 fps"):
+        assert cell in text, f"{cell!r} was dropped"
+
+
+def test_a_table_lands_where_the_reader_sees_it(doc_with_everything):
+    """Joining paragraphs then tables would append it after the prose."""
+    text = extract_text(doc_with_everything)["text"]
+    assert text.index("[Table 1]") < text.index("Text AFTER the table.")
+
+
+def test_prose_around_the_table_survives(doc_with_everything):
+    text = extract_text(doc_with_everything)["text"]
+    assert "Intro before any structure." in text
+    assert "Text AFTER the table." in text
+
+
+def test_a_pipe_in_a_cell_cannot_break_the_table():
+    """An unescaped pipe would add a phantom column on that row only."""
+    md = rows_to_markdown([["a", "b"], ["x | y", "z"]])
+    assert r"x \| y" in md
+    # Count DELIMITERS — an escaped pipe is content, not a cell boundary.
+    delims = [len(re.findall(r"(?<!\\)\|", line)) for line in md.splitlines()]
+    assert delims == [3, 3, 3], delims
+
+
+def test_ragged_rows_are_padded_not_dropped():
+    md = rows_to_markdown([["a", "b", "c"], ["only one"]])
+    assert len(md.splitlines()) == 3          # header, rule, one body row
+    assert md.splitlines()[-1].count("|") == 4
+
+
+def test_counts_are_reported(doc_with_everything):
+    info = extract_text(doc_with_everything)
+    assert info["n_tables"] == 1
+    assert info["n_figures"] == 2
+
+
+# ----------------------------------------------------------------- figures
+
+
+def test_figures_are_marked_in_place_and_returned(doc_with_everything):
+    d = extract_document(doc_with_everything)
+    assert len(d.figures) == 2
+    # The marker must sit with the sentence that introduces it.
+    assert d.text.index("layout is shown here") < d.text.index("[Figure 1]")
+    assert d.text.index("[Figure 1]") < d.text.index("flow path here")
+    assert d.text.index("flow path here") < d.text.index("[Figure 2]")
+
+
+def test_marker_numbering_indexes_the_figure_list(doc_with_everything):
+    """`figures[N-1]` must BE the image `[Figure N]` refers to."""
+    d = extract_document(doc_with_everything)
+    for n, fig in enumerate(d.figures, start=1):
+        assert f"[Figure {n}]" in d.text
+        assert fig.index == n - 1
+        assert fig.bytes and fig.mime.startswith("image/")
+
+
+def test_figures_can_be_counted_without_decoding(doc_with_everything):
+    assert count_docx_figures(doc_with_everything) == 2
+
+
+def test_the_text_path_does_not_carry_image_bytes(doc_with_everything):
+    """extract_text stays cheap: markers yes, pixels no."""
+    d = load_docx(doc_with_everything, include_figures=False)
+    assert d.figures == []
+    assert "[Figure 1]" in d.text
+
+
+def test_base64_round_trips(doc_with_everything):
+    import base64
+    d = extract_document(doc_with_everything)
+    assert base64.b64decode(d.figures[0].to_base64()) == d.figures[0].bytes
+
+
+# ------------------------------------------------------------- other formats
+
+
+def test_non_docx_formats_return_an_empty_figure_list(tmp_path):
+    """A uniform shape so a caller need not branch on extension."""
+    md = tmp_path / "n.md"
+    md.write_text("# Note\n\nbody\n")
+    d = extract_document(md)
+    assert d.figures == [] and d.tables == []
+    assert "body" in d.text
+
+
+def test_a_document_with_neither_is_unchanged(tmp_path):
+    d = docx.Document()
+    d.add_heading("Plain", 0)
+    d.add_paragraph("No tables, no figures.")
+    p = tmp_path / "plain.docx"
+    d.save(p)
+
+    info = extract_text(p)
+    assert info["n_tables"] == 0 and info["n_figures"] == 0
+    assert info["text"].strip() == "Plain\n\nNo tables, no figures."
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_docx_tables_and_figures.py
+++ b/tests/test_docx_tables_and_figures.py
@@ -162,3 +162,102 @@ def test_a_document_with_neither_is_unchanged(tmp_path):
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
+
+
+# --------------------------------------------------- image format handling
+
+
+def test_bmp_and_tiff_are_converted_rather_than_shipped(tmp_path):
+    """A Word document carries scanned figures as BMP/TIFF routinely. The
+    delivery layer guesses mime from magic bytes and falls back to PNG, so
+    shipping one means a BMP arrives labelled PNG and breaks the request."""
+    from docx.shared import Inches
+    from PIL import Image
+    from scilink.parsers.docx_document import SUPPORTED_IMAGE_MIMES
+
+    d = docx.Document()
+    for fmt, ext in [("PNG", "png"), ("BMP", "bmp"), ("TIFF", "tif")]:
+        img = tmp_path / f"i.{ext}"
+        Image.new("RGB", (40, 30), "orange").save(img, fmt)
+        d.add_picture(str(img), width=Inches(0.4))
+    p = tmp_path / "formats.docx"
+    d.save(p)
+
+    figs = extract_document(p).figures
+    assert len(figs) == 3, "a figure was dropped, which would renumber the rest"
+    for f in figs:
+        assert f.mime in SUPPORTED_IMAGE_MIMES, f.mime
+        assert f.deliverable
+    assert figs[1].bytes.startswith(b"\x89PNG"), "BMP was not re-encoded"
+    assert "converted from image/bmp" in figs[1].note
+
+
+def test_an_unconvertible_figure_keeps_its_number(tmp_path):
+    """Dropping it would make [Figure 3] point at what was really figure 4 —
+    the exact mis-attribution the markers exist to prevent."""
+    from scilink.parsers.docx_document import Figure, _normalize_figure
+
+    bad = Figure(index=2, ext="x-emf", bytes=b"\x01\x00\x00\x00not-an-image")
+    out = _normalize_figure(bad)
+    assert out.index == 2, "renumbered"
+    assert out.deliverable is False
+    assert "could not be decoded" in out.note
+
+
+def test_a_supported_mime_is_still_verified_not_trusted(tmp_path):
+    """The declared type is a claim the bytes need not honour: a corrupt
+    file named .png declares image/png and would pass a mime-only check on
+    its way to being rejected by the provider."""
+    from scilink.parsers.docx_document import Figure, _normalize_figure
+
+    liar = Figure(index=0, ext="png",
+                  bytes=b"\x89PNG\r\n\x1a\n" + b"\x00" * 200)
+    out = _normalize_figure(liar)
+    assert out.deliverable is False, "a corrupt PNG was trusted on its label"
+
+
+def test_a_valid_supported_image_is_passed_through_untouched(tmp_path):
+    """Verification must not re-encode what is already fine."""
+    import io
+    from PIL import Image
+    from scilink.parsers.docx_document import Figure, _normalize_figure
+
+    buf = io.BytesIO()
+    Image.new("RGB", (20, 15), "teal").save(buf, "PNG")
+    raw = buf.getvalue()
+    out = _normalize_figure(Figure(index=0, ext="png", bytes=raw))
+    assert out.bytes is raw or out.bytes == raw, "needlessly re-encoded"
+    assert out.deliverable and out.note == ""
+
+
+def test_a_figure_inside_a_table_cell_is_found(tmp_path):
+    """Cells go through the same walker; an image in one must keep its place
+    in the global numbering rather than being skipped."""
+    from docx.shared import Inches
+    from PIL import Image
+
+    img = tmp_path / "c.png"
+    Image.new("RGB", (30, 20), "navy").save(img)
+
+    d = docx.Document()
+    d.add_paragraph("Before:")
+    d.add_picture(str(img), width=Inches(0.3))          # figure 1
+    t = d.add_table(rows=1, cols=2)
+    t.rows[0].cells[0].text = "caption"
+    t.rows[0].cells[1].paragraphs[0].add_run().add_picture(
+        str(img), width=Inches(0.3))                    # figure 2, in a cell
+    d.add_paragraph("After:")
+    d.add_picture(str(img), width=Inches(0.3))          # figure 3
+    p = tmp_path / "incell.docx"
+    d.save(p)
+
+    parsed = extract_document(p)
+    composed = parsed.composed()
+    assert len(parsed.figures) == 3, "the in-cell image was missed"
+    # The in-cell marker belongs in the CELL, not the body text — that says
+    # which cell holds the figure, which body placement could not.
+    assert "| caption | [Figure 2] |" in composed, composed
+    assert "[Figure 3]" in parsed.text, "numbering after the table broke"
+    # Numbering must stay global: the in-cell image consumes slot 2, so the
+    # paragraph image after the table is 3, not 2.
+    assert parsed.text.index("[Figure 1]") < parsed.text.index("[Figure 3]")

--- a/tests/test_view_document_figures.py
+++ b/tests/test_view_document_figures.py
@@ -78,10 +78,32 @@ def test_a_figure_heavy_document_reports_instead_of_attaching(tmp):
     assert "figures='on'" in note, "the agent must be told how to get them"
 
 
-def test_forcing_on_overrides_the_limit(tmp):
-    cap = _tools()
-    out = _call(cap, tmp / "many.docx", figures="on")
-    assert len(out.get("images_base64", [])) > 0
+def test_forcing_on_raises_the_limit_rather_than_nudging_it(tmp):
+    """'on' used to stop at the auto threshold, so it quietly meant
+    'on, up to 8'. Caught live, where the agent reported getting 8 of 20."""
+    out = _call(_tools(), tmp / "many.docx", figures="on")
+    n = len(out.get("images_base64", []))
+    assert n > 8, f"'on' still capped at the auto threshold ({n})"
+    assert n == 20, "all 20 fit under the hard ceiling and should arrive"
+
+
+def test_partial_delivery_is_stated_not_left_to_be_inferred(tmp):
+    """Past even the forced ceiling, some figures cannot be delivered.
+    Unsaid, the reply looks complete while the remaining [Figure N] markers
+    point at nothing."""
+    out = _call(_tools(), _doc(tmp / "atlas.docx", 30), figures="on")
+    n = len(out["images_base64"])
+    assert n < 30, "the hard ceiling did not bound the payload"
+    note = out.get("figures_attached", "")
+    assert f"{n} of 30" in note, note
+    assert "not delivered" in note
+
+
+def test_complete_delivery_says_nothing_extra(tmp):
+    """No note when everything arrived — silence means complete."""
+    out = _call(_tools(), _doc(tmp / "three.docx", 3), figures="on")
+    assert len(out["images_base64"]) == 3
+    assert "figures_attached" not in out
 
 
 def test_off_attaches_nothing_and_says_why(tmp):
@@ -125,3 +147,53 @@ def test_attached_images_are_valid_base64_png(tmp):
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
+
+
+def _corrupt_one_figure(tmp, name="broken.docx"):
+    """A .docx whose SECOND image is corrupt but still declares image/png —
+    the case a mime-only check cannot catch, since the type is a claim the
+    bytes do not honour."""
+    import zipfile
+    from docx.shared import Inches
+    from PIL import Image
+    src = tmp / "_src.docx"
+    d = docx.Document()
+    for colour in ("seagreen", "crimson", "royalblue"):     # distinct, or
+        img = tmp / f"{colour}.png"                          # python-docx
+        Image.new("RGB", (40, 30), colour).save(img)         # dedupes them
+        d.add_paragraph(f"{colour}:")
+        d.add_picture(str(img), width=Inches(0.4))
+    d.save(src)
+
+    out = tmp / name
+    zin, zout = zipfile.ZipFile(src), zipfile.ZipFile(out, "w")
+    media = sorted(n for n in zin.namelist() if n.startswith("word/media/"))
+    for n in zin.namelist():
+        data = zin.read(n)
+        if n == media[1]:
+            data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 400
+        zout.writestr(n, data)
+    zout.close(); zin.close()
+    return out
+
+
+def test_an_undeliverable_figure_is_named_not_silently_missing(tmp):
+    out = _call(_tools(), _corrupt_one_figure(tmp), figures="on")
+    notes = out.get("figures_undisplayable", [])
+    assert notes, "a broken figure vanished without explanation"
+    assert any("[Figure 2]" in n for n in notes), notes
+    assert any("could not be decoded" in n for n in notes), notes
+
+
+def test_the_good_figures_still_arrive_around_a_broken_one(tmp):
+    out = _call(_tools(), _corrupt_one_figure(tmp, "broken2.docx"), figures="on")
+    assert len(out["images_base64"]) == 2, "one bad image took the others down"
+
+
+def test_a_broken_figure_does_not_renumber_the_rest(tmp):
+    """If figure 2 were dropped, [Figure 3] in the text would point at the
+    image delivered second — the mis-attribution the markers prevent."""
+    from scilink.parsers.extract import extract_document
+    figs = extract_document(_corrupt_one_figure(tmp, "broken3.docx")).figures
+    assert [f.index for f in figs] == [0, 1, 2]
+    assert [f.deliverable for f in figs] == [True, False, True]

--- a/tests/test_view_document_figures.py
+++ b/tests/test_view_document_figures.py
@@ -1,0 +1,127 @@
+"""view_document decides whether figures are worth the context.
+
+Figures are worth real tokens, so attaching every one unconditionally would
+tax every document read. For DOCX the embedded images can be counted exactly
+without decoding them, so the decision is made on the true cost before paying
+it: a short note carrying a few diagrams gets them, an atlas of forty reports
+its count instead — and says so, rather than leaving the agent to wonder why
+the [Figure N] markers point at nothing.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+docx = pytest.importorskip("docx")
+PIL = pytest.importorskip("PIL")
+
+from scilink.agents.meta_agent.meta_orchestrator_tools import (  # noqa: E402
+    MetaOrchestratorTools)
+
+
+def _doc(path, n_figures, with_table=False):
+    from docx.shared import Inches
+    from PIL import Image
+    img = path.parent / "i.png"
+    Image.new("RGB", (40, 30), "navy").save(img)
+
+    d = docx.Document()
+    d.add_paragraph("Body text.")
+    if with_table:
+        t = d.add_table(rows=2, cols=2)
+        t.rows[0].cells[0].text = "k"
+        t.rows[0].cells[1].text = "v"
+    for i in range(n_figures):
+        d.add_paragraph(f"Caption {i + 1}:")
+        d.add_picture(str(img), width=Inches(0.5))
+    d.save(path)
+    return path
+
+
+def _tools():
+    t = MetaOrchestratorTools.__new__(MetaOrchestratorTools)
+    t.orch = SimpleNamespace(model=None)
+    cap = {}
+    t._register_tool = (
+        lambda func, name, description, parameters, required=None:
+        cap.update({name: func}))
+    MetaOrchestratorTools._register_all_tools(t)
+    return cap
+
+
+@pytest.fixture(scope="module")
+def tmp():
+    return Path(tempfile.mkdtemp(prefix="viewdoc_"))
+
+
+def _call(cap, path, **kw):
+    return json.loads(cap["view_document"]([str(path)], **kw))
+
+
+def test_a_few_figures_ride_along_automatically(tmp):
+    cap = _tools()
+    out = _call(cap, _doc(tmp / "few.docx", 3))
+    assert out["status"] == "success"
+    assert len(out.get("images_base64", [])) == 3
+    assert "figures_not_attached" not in out
+
+
+def test_a_figure_heavy_document_reports_instead_of_attaching(tmp):
+    cap = _tools()
+    out = _call(cap, _doc(tmp / "many.docx", 20))
+    assert "images_base64" not in out
+    note = out.get("figures_not_attached", "")
+    assert "20 embedded figure" in note, note
+    assert "figures='on'" in note, "the agent must be told how to get them"
+
+
+def test_forcing_on_overrides_the_limit(tmp):
+    cap = _tools()
+    out = _call(cap, tmp / "many.docx", figures="on")
+    assert len(out.get("images_base64", [])) > 0
+
+
+def test_off_attaches_nothing_and_says_why(tmp):
+    cap = _tools()
+    out = _call(cap, tmp / "few.docx", figures="off")
+    assert "images_base64" not in out
+    assert "figures='off'" in out.get("figures_not_attached", "")
+
+
+def test_a_document_without_figures_says_nothing_about_them(tmp):
+    cap = _tools()
+    out = _call(cap, _doc(tmp / "none.docx", 0))
+    assert "images_base64" not in out
+    assert "figures_not_attached" not in out, "no figures is not a warning"
+
+
+def test_tables_are_read_regardless_of_the_figure_policy(tmp):
+    cap = _tools()
+    p = _doc(tmp / "tbl.docx", 0, with_table=True)
+    out = _call(cap, p, figures="off")
+    assert out["documents"][0]["n_tables"] == 1
+    assert "| k | v |" in out["documents"][0]["text"]
+
+
+def test_the_cap_counts_across_all_requested_documents(tmp):
+    """Three documents of four figures each is twelve — over the limit."""
+    cap = _tools()
+    paths = [str(_doc(tmp / f"multi{i}.docx", 4)) for i in range(3)]
+    out = json.loads(cap["view_document"](paths))
+    assert "images_base64" not in out
+    assert "12 embedded figure" in out.get("figures_not_attached", "")
+
+
+def test_attached_images_are_valid_base64_png(tmp):
+    import base64
+    cap = _tools()
+    out = _call(cap, tmp / "few.docx", figures="on")
+    raw = base64.b64decode(out["images_base64"][0])
+    assert raw.startswith(b"\x89PNG"), "not a decodable image"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Reading a Word document threw away two of the things scientific documents
usually keep their content in: **every table, and every figure**. Silently —
nothing said anything was missing. A white paper whose methods sit in a table
came back with the methods gone, and a document built around its figures came
back as prose about pictures nobody could see.

Now tables are read where they sit in the document, and figures come back as
images you can actually look at, each marked in the text at the point it
appears so a figure can be tied to its caption.

**Figures ride along when they are worth it.** A short note with a few
diagrams gets them automatically; a forty-panel atlas reports how many it has
instead of spending the whole context on them, and says how to ask for them.
The count is exact rather than guessed, so the decision is made on the real
cost before paying it.

**Testing found three defects the first version had.** Asking for figures
explicitly quietly delivered only the first eight. Scanned figures and Excel
charts — stored as formats no vision model accepts — would have been sent
anyway and broken the request. And a corrupt image was trusted because its
filename said `.png`. All three are fixed, and the last one only surfaced
because building a test for the second one behaved unexpectedly.

The most important behaviour is what happens when a figure cannot be shown:
it keeps its number and says why. Tried live on a document with one broken
figure among three, the model read the two it could see, named the third as
unreadable, worked out correctly which delivered image belonged to which
caption, and refused to guess at the one it could not read.

<details>
<summary><b>Technical details</b></summary>

### The gap

`extract_text` read a .docx as `"\n".join(p.text for p in doc.paragraphs)`.
python-docx exposes paragraphs and tables as separate sequences, so that join
dropped every table; embedded images were never touched at all.

### Design (ported from the peerpanel document loader — same author, MIT)

**Body-order traversal.** `doc.element.body.iterchildren()` with
paragraph/table maps keyed on element id, so a table lands where the reader
sees it instead of appended after the prose. Cells go through the same
walker, so an image inside a cell keeps its place in the global numbering and
its marker renders in that cell (`| caption | [Figure 2] |`), which localises
it better than body placement could.

**Markers plus bytes.** Each `a:blip` emits `[Figure N]` at its exact
position and `figures[N-1]` is that image. DOCX has no page concept; the
marker is the only thing tying a figure to its caption.

**Two entry points.** `extract_text` gains tables, counts and markers but
carries no image bytes, so every existing consumer (KB ingestion, analysis,
simulation) keeps its cost. `extract_document` carries figures for callers
that can deliver them. Non-docx formats return the same shape with empty
lists.

**Delivery** reuses the existing `tool_media` `images_base64` contract.

### Policy

| | |
|---|---|
| `auto` (default) | attach iff total figures ≤ 8 across the call |
| `on` | attach up to a hard ceiling of 24 |
| `off` | text only |

Fewer delivered than exist → `figures_attached: "24 of 30 figures are
attached, in document order…"`. Nothing said when delivery is complete.
Undisplayable ones → `figures_undisplayable: ["[Figure 2] image/png could
not be decoded for display"]`.

Displayability is **verified, not inferred** — `Image.open()` + `im.load()`
to force a real decode. One rule covers unsupported formats, corrupt bytes
and mislabelled files; a valid supported image is passed through untouched.

### Validation

**31 offline tests.** Half assert what must *not* happen: a document with no
figures produces no warning; complete delivery says nothing extra; a valid
image is not needlessly re-encoded; a broken figure does not renumber the
rest.

**Four live rounds against real Bedrock**, with ground truth existing only in
the pixels (rendered text and shapes absent from the document text):

| Round | Covers | |
|---|---|---|
| 1 | tables, pixel-only figures, auto cap, plain doc | 11/11 |
| 2 | `'on'` after the fix; 24 of 30 partial delivery | 14/15¹ |
| 2b | auto path, prompts never mentioning figures | 1/1 |
| 3 | BMP-sourced, JPEG-sourced, in-cell, 4000×3000, mixed .docx+.md | 10/10 |
| 4 | one broken figure among three | 5/5 |

¹ a stale assertion of mine after the fix, diagnosed as a test artifact — the
agent had chosen `figures='on'` itself because the prompt asked about figure
contents. Verified it was not bypassing `auto` reflexively by inspecting the
actual tool-call arguments across all five calls.

Also verified: the real uploaded white paper that started this keeps all 21
substantive paragraphs and correctly reports 0 tables / 0 figures.

### Not included

PDF figures. peerpanel renders every page at 150 dpi because a review run is
one paper; `view_document` takes a list, and SciLink already has targeted
pdfplumber table extraction plus sparse-text OCR. Rasterising a 40-page
proposal ×3 is a different cost regime — left as a separate decision.

Headers, footers and text boxes are still not read on the docx path.

</details>
