### PR TITLE
Fix two LAMMPS validate_script false positives (#409)

### DIFF
--- a/scilink/skills/molecular_dynamics/lammps/lammps.py
+++ b/scilink/skills/molecular_dynamics/lammps/lammps.py
@@ -868,9 +868,13 @@ def validate_script(
     commands_seen: set = set()
     command_order: List[str] = []
 
-    # Track thermostat/barostat per group
-    npt_groups: set = set()
-    nvt_groups: set = set()
+    # Track integrator fixes over their lifecycle (fix … / unfix …) so a
+    # legitimate sequential deck — NPT equilibrate, unfix, then NVT produce on
+    # the same group — is not flagged. `active_integrators` maps fix-ID ->
+    # (group, family); a conflict is recorded only when an nvt and an npt/nph
+    # fix are active on the same group at the same time.
+    active_integrators: Dict[str, tuple] = {}
+    integrator_conflict: set = set()
 
     for line in lines:
         stripped = line.strip()
@@ -899,14 +903,21 @@ def validate_script(
         elif keyword == "run":
             result["has_run"] = True
         elif keyword == "fix" and len(parts) >= 4:
+            fix_id = parts[1]
             group = parts[2]
             style = parts[3].lower()
             if "shake" in style or "rattle" in style:
                 result["has_shake"] = True
-            if style in ("npt", "nph"):
-                npt_groups.add(group)
-            elif style == "nvt":
-                nvt_groups.add(group)
+            if style in ("npt", "nph", "nvt"):
+                family = "nvt" if style == "nvt" else "npt"
+                # Conflict only if a DIFFERENT-family integrator is already
+                # active on this same group (i.e. never unfixed).
+                for a_group, a_family in active_integrators.values():
+                    if a_group == group and a_family != family:
+                        integrator_conflict.add(group)
+                active_integrators[fix_id] = (group, family)
+        elif keyword == "unfix" and len(parts) >= 2:
+            active_integrators.pop(parts[1], None)
 
     errors = result["errors"]
     warnings = result["warnings"]
@@ -1059,9 +1070,10 @@ def validate_script(
                     break
 
     # nvt + npt on same group
-    overlap = npt_groups & nvt_groups
-    if overlap:
-        errors.append(f"fix nvt and fix npt both on group(s): {overlap}")
+    if integrator_conflict:
+        errors.append(
+            f"fix nvt and fix npt both active on group(s): {integrator_conflict}"
+        )
 
     # ── Unit-aware parameter ranges ──
     ts = result["timestep"]
@@ -1108,9 +1120,19 @@ def validate_script(
                 pass
 
     # ── Unresolved templates ──
-    templates = re.findall(r'\$\{[a-z_]+\}|\{[a-z_]+\}', content, re.IGNORECASE)
-    if templates:
-        errors.append(f"Unresolved template variables: {sorted(set(templates))}")
+    # Scan CODE only — comments legitimately mention ${var} (e.g. a note about a
+    # variable) and must not be flagged. A ${name} whose `name` has a
+    # `variable name …` definition in the deck is a valid LAMMPS variable
+    # reference, not an unrendered template. A bare {name} is not LAMMPS syntax,
+    # so it is always suspect (an unrendered template placeholder).
+    code = "\n".join(ln.split("#", 1)[0] for ln in lines)
+    defined_vars = set(re.findall(
+        r"(?mi)^\s*variable\s+([A-Za-z_]\w*)\b", code))
+    referenced = set(re.findall(r"\$\{([A-Za-z_]\w*)\}", code))
+    braces = set(re.findall(r"(?<!\$)\{([A-Za-z_]\w*)\}", code))
+    unresolved = sorted((referenced - defined_vars) | braces)
+    if unresolved:
+        errors.append(f"Unresolved template variables: {unresolved}")
 
     # ── Force field completeness ──
     if system_info:

--- a/tests/test_lammps_skill/conftest.py
+++ b/tests/test_lammps_skill/conftest.py
@@ -359,6 +359,32 @@ timestep 0.001
 run 50000
 """
 
+# Legitimate sequential ensembles: NPT equilibration, unfix, then NVT production
+# on the SAME group — must not be flagged as nvt+npt-on-all. Also references a
+# defined `variable scale` as v_scale and only *mentions* ${scale} in a comment
+# — must not be flagged as an unresolved template. (Regression for #409.)
+VALID_SEQUENTIAL_NVT_NPT_SCRIPT = """\
+units real
+atom_style full
+boundary p p p
+read_data system.data
+pair_style lj/cut/coul/long 10.0
+kspace_style pppm 1.0e-4
+fix SHAKE all shake 1.0e-5 100 0 m 1.008
+timestep 1.0
+
+# NPT equilibration, then hand off to NVT production on the same group
+fix NPT all npt temp 298.15 298.15 100.0 iso 1.0 1.0 1000.0
+run 1000
+unfix NPT
+
+fix NVT all nvt temp 298.15 298.15 100.0
+# reference the LAMMPS variable with v_scale, not the unresolved ${scale} template
+variable scale equal vol/(1.3806504e-23*298.15)
+variable visc equal trap(f_SACF[3])*v_scale
+run 1000
+"""
+
 # ── Error scripts (each has exactly one known problem) ──
 
 ERROR_KSPACE_WITH_EAM = """\
@@ -560,6 +586,7 @@ def fixtures_dir(tmp_path):
         "valid_ionic.lammps": VALID_IONIC_SCRIPT,
         "valid_slab.lammps": VALID_SLAB_SCRIPT,
         "valid_create_atoms.lammps": VALID_CREATE_ATOMS_SCRIPT,
+        "valid_sequential_nvt_npt.lammps": VALID_SEQUENTIAL_NVT_NPT_SCRIPT,
     }
     for name, content in valid_scripts.items():
         (script_dir / name).write_text(content)

--- a/tests/test_lammps_skill/test_lammps_tools.py
+++ b/tests/test_lammps_skill/test_lammps_tools.py
@@ -335,6 +335,23 @@ class TestValidateScriptErrors:
         assert r["valid"] is False
         assert any("timestep" in e.lower() for e in r["errors"])
 
+    # ── Regression: #409 false positives on correct sequential-ensemble decks ──
+    def test_sequential_nvt_npt_no_conflict(self, script_dir):
+        # NPT equilibrate -> unfix -> NVT produce on the same group is valid;
+        # the overlap check must model unfix, not just co-occurrence.
+        r = lammps_tools.validate_script(
+            str(script_dir / "valid_sequential_nvt_npt.lammps"))
+        assert not any("nvt" in e.lower() and "npt" in e.lower()
+                       for e in r["errors"]), r["errors"]
+
+    def test_defined_var_and_comment_not_flagged_as_template(self, script_dir):
+        # ${scale} only appears in a comment, and `variable scale` is defined and
+        # used as v_scale — neither is an unrendered template.
+        r = lammps_tools.validate_script(
+            str(script_dir / "valid_sequential_nvt_npt.lammps"))
+        assert not any("template" in e.lower() or "unresolved" in e.lower()
+                       for e in r["errors"]), r["errors"]
+
     def test_nonexistent_file(self):
         r = lammps_tools.validate_script("/no/such/file.lammps")
         assert r["valid"] is False


### PR DESCRIPTION
Closes #409.

`validate_script` reported two spurious errors on physically correct decks. The gate is fail-open so runs still proceed, but the simulate pipeline treats them as validation failures and burns refinement cycles "fixing" a deck that was already right — surfaced live on the UC2 electrolyte runs, where a combined minimize→NPT→unfix→NVT deck tripped both on every member.

### 1. nvt/npt overlap ignored `unfix`

The check accumulated every `fix … npt/nvt` group across the whole file and flagged any group appearing under both, with nothing consuming `unfix`. So a legitimate sequential deck — NPT equilibrate, `unfix`, then NVT produce on the same group — read as if both integrators ran simultaneously.

Now the parse loop tracks the fix lifecycle: an `active_integrators` map (fix-ID → group, family) updated on `fix`/`unfix`, and a conflict is recorded only when an nvt and an npt/nph fix are active on the **same group at the same time**.

### 2. Unresolved-template scan hit comments and valid variables

The regex ran over the entire file, comments included, and rejected `${name}` even when a `variable name …` defined it — so a comment merely *mentioning* `${scale}`, next to a defined `variable scale` used as `v_scale`, was flagged.

Now it scans **code only** (strips `#` comments), exempts a `${name}` that has a `variable` definition in the deck, and still flags a bare `{name}` (not LAMMPS syntax) as an unrendered placeholder.

### Verification
- Both true positives still fire: nvt+npt **simultaneously** active on `all`; `${temperature}` with no definition.
- The real UC2 decks (combined `run.lammps` + the staged `run_equilibration`/`run_production`) now validate with **zero errors**.
- Adds a sequential-ensemble regression fixture + two tests. **100 LAMMPS-skill tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)