### PR TITLE
Simulation orchestrator: edit_file / rename_file (#439 Tier 1)

### DIFF
--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -1416,6 +1416,156 @@ class SimulationOrchestratorTools:
         )
 
         # =====================================================================
+        # 10b. EDIT / RENAME FILE — surgical, byte-exact, no LLM regeneration
+        # =====================================================================
+        # Editable input/deck formats: "" covers extensionless VASP inputs
+        # (INCAR/POSCAR/KPOINTS/POTCAR); the rest are LAMMPS/QE decks and job
+        # scripts. On top of the shared text defaults.
+        _SIM_EDIT_SUFFIXES = {
+            "", ".lammps", ".data", ".in", ".param", ".mod", ".inc",
+            ".sbatch", ".pwi", ".lmp",
+        }
+
+        def edit_file(path: str, old_text: str = None, new_text: str = None,
+                      replace_all: bool = False, edits: list = None) -> str:
+            """Mechanical in-place edit of a generated input/deck file:
+            replace exact text snippets, one old/new pair or a batched `edits`
+            list applied atomically. For retuning several coupled parameters,
+            use apply_input_adjustments instead."""
+            print(f"  ⚡ Tool: Editing file '{path}'...")
+            try:
+                from ...utils.file_edit import (apply_surgical_edits,
+                                                 DEFAULT_EDITABLE_SUFFIXES)
+                if not edits:
+                    if old_text is None or new_text is None:
+                        return json.dumps({"status": "error", "message": (
+                            "Provide old_text+new_text or a non-empty edits "
+                            "list.")})
+                    edits = [{"old_text": old_text, "new_text": new_text,
+                              "replace_all": replace_all}]
+                root = Path(self.orch.base_dir).resolve()
+                rp = Path(path)
+                if not rp.is_absolute():
+                    rp = root / rp
+                rp = rp.resolve()
+                out = apply_surgical_edits(
+                    rp, edits, root=root, backup_dir=rp.parent,
+                    allowed_suffixes=DEFAULT_EDITABLE_SUFFIXES | _SIM_EDIT_SUFFIXES,
+                    too_large_message=(
+                        "Edit too large for edit_file. For a broader input "
+                        "change — retuning several coupled parameters, or "
+                        "regenerating a deck — use apply_input_adjustments. For "
+                        "a verbatim insertion, split the text at a unique "
+                        "boundary into consecutive smaller edit_file calls."),
+                )
+                if out["status"] == "success":
+                    n = out.get("n_edits", 1)
+                    print(f"    ✏️  Edited in place"
+                          f"{f' ({n} edits)' if n > 1 else ''}: {rp.name}")
+                return json.dumps(out)
+            except Exception as e:
+                logging.error(f"edit_file failed: {e}", exc_info=True)
+                return json.dumps({"status": "error", "message": str(e)})
+
+        self._register_tool(
+            func=edit_file,
+            name="edit_file",
+            description=(
+                "Surgically edit a generated input or deck file IN PLACE by "
+                "replacing exact text snippets — one INCAR tag, a timestep, a "
+                "thermostat damping, a pair_style cutoff. The canonical use is "
+                "'change ENCUT to 520 in this INCAR' without regenerating the "
+                "whole input. Copy old_text VERBATIM from the file (read it "
+                "first); each snippet is capped at 2000 characters. Several "
+                "changes to ONE file go in a single call as the `edits` list "
+                "(atomic, in order). Retuning several coupled parameters at "
+                "once, or a change that needs the input rebuilt, is "
+                "apply_input_adjustments' job, not this. A pre-edit backup is "
+                "kept automatically."
+            ),
+            parameters={
+                "path": {"type": "string", "description": (
+                    "Path of the file to edit — absolute, or relative to the "
+                    "session directory. Must be inside the session.")},
+                "old_text": {"type": "string", "description": (
+                    "Single-edit form: the exact snippet to replace, copied "
+                    "VERBATIM including whitespace. Must match exactly one "
+                    "place unless replace_all. Omit when passing `edits`.")},
+                "new_text": {"type": "string", "description": (
+                    "Single-edit form: the replacement text. Omit with "
+                    "`edits`.")},
+                "replace_all": {"type": "boolean", "description": (
+                    "Single-edit form: replace every occurrence instead of "
+                    "requiring a unique match. Default false.")},
+                "edits": {
+                    "type": "array",
+                    "items": {"type": "object", "properties": {
+                        "old_text": {"type": "string"},
+                        "new_text": {"type": "string"},
+                        "replace_all": {"type": "boolean"}},
+                        "required": ["old_text", "new_text"]},
+                    "description": (
+                        "Batched form: ALL changes for this file in one call, "
+                        "applied in order; all-or-nothing — if one edit fails "
+                        "to match, nothing is applied.")},
+            },
+            required=["path"],
+        )
+
+        def rename_file(path: str, new_name: str, copy: bool = False) -> str:
+            """Byte-exact rename (or copy) of a generated file within its own
+            directory — the content never passes through the model."""
+            print(f"  ⚡ Tool: {'Copying' if copy else 'Renaming'} "
+                  f"'{path}' → '{new_name}'...")
+            try:
+                from ...utils.file_edit import rename_or_copy_file
+                root = Path(self.orch.base_dir).resolve()
+                rp = Path(path)
+                if not rp.is_absolute():
+                    rp = root / rp
+                rp = rp.resolve()
+                safe = Path(new_name).name
+                if not safe:
+                    return json.dumps({"status": "error",
+                                       "message": "Invalid new_name."})
+                dest = (rp.parent / safe).resolve()
+                if dest == rp:
+                    return json.dumps({"status": "error", "message": (
+                        f"'{safe}' is already this file's name — nothing to "
+                        f"do.")})
+                out = rename_or_copy_file(rp, dest, root=root, copy=copy)
+                if out["status"] == "success":
+                    print(f"    📛 {'Copied' if copy else 'Renamed'}: "
+                          f"{Path(out['path']).name}")
+                return json.dumps(out)
+            except Exception as e:
+                logging.error(f"rename_file failed: {e}", exc_info=True)
+                return json.dumps({"status": "error", "message": str(e)})
+
+        self._register_tool(
+            func=rename_file,
+            name="rename_file",
+            description=(
+                "Rename or copy a generated file BYTE-EXACTLY within its own "
+                "directory — the content never passes through the model. Use "
+                "for a byte-exact rename (copy=false) or an exact duplicate "
+                "(copy=true); never reconstruct a file by regenerating it to "
+                "rename it, which risks perturbing the content."
+            ),
+            parameters={
+                "path": {"type": "string", "description": (
+                    "Path of the file to rename — absolute or relative to the "
+                    "session directory.")},
+                "new_name": {"type": "string", "description": (
+                    "The new bare filename (kept in the file's own "
+                    "directory).")},
+                "copy": {"type": "boolean", "description": (
+                    "Copy instead of rename (default false).")},
+            },
+            required=["path", "new_name"],
+        )
+
+        # =====================================================================
         # 11. LIST GENERATED STRUCTURES
         # =====================================================================
         def list_generated_structures() -> str:

--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -1451,6 +1451,11 @@ class SimulationOrchestratorTools:
                 out = apply_surgical_edits(
                     rp, edits, root=root, backup_dir=rp.parent,
                     allowed_suffixes=DEFAULT_EDITABLE_SUFFIXES | _SIM_EDIT_SUFFIXES,
+                    not_found_message=(
+                        "the snippet must match the file byte for byte. "
+                        "For periodic_dft, apply_input_adjustments retunes "
+                        "tags without needing an exact match and is the "
+                        "route to take when a verbatim guess misses."),
                     too_large_message=(
                         "Edit too large for edit_file. For a broader input "
                         "change — retuning several coupled parameters, or "
@@ -1475,8 +1480,8 @@ class SimulationOrchestratorTools:
                 "replacing exact text snippets — one INCAR tag, a timestep, a "
                 "thermostat damping, a pair_style cutoff. The canonical use is "
                 "'change ENCUT to 520 in this INCAR' without regenerating the "
-                "whole input. Copy old_text VERBATIM from the file (read it "
-                "first); each snippet is capped at 2000 characters. Several "
+                "whole input. Copy old_text VERBATIM from the file; each "
+                "snippet is capped at 2000 characters. Several "
                 "changes to ONE file go in a single call as the `edits` list "
                 "(atomic, in order). Retuning several coupled parameters at "
                 "once, or a change that needs the input rebuilt, is "

--- a/scilink/utils/file_edit.py
+++ b/scilink/utils/file_edit.py
@@ -230,6 +230,19 @@ def apply_surgical_edits(
                 "message": (f"{rp.name} is not valid UTF-8 text — refusing "
                             "to edit it as text.")}
 
+    # The old read_text() path normalized newlines on read; the strict
+    # decode above does not, so an \n-authored old_text would never match
+    # a CRLF file. Match and edit in \n form — snippets included, so an
+    # \r\n inside new_text can't survive into the re-expansion below —
+    # then restore the file's own convention on the way out.
+    uses_crlf = "\r\n" in current
+    if uses_crlf:
+        current = current.replace("\r\n", "\n")
+        edits = [{**e, **{k: e[k].replace("\r\n", "\n")
+                          for k in ("old_text", "new_text")
+                          if isinstance(e.get(k), str)}}
+                 for e in edits]
+
     res = apply_snippet_edits(current, edits, max_len=max_len,
                               too_large_message=too_large_message,
                               not_found_message=not_found_message)
@@ -255,7 +268,12 @@ def apply_surgical_edits(
         logging.warning(f"Pre-edit copy failed: {e}")
         bak = None
 
-    rp.write_text(res["text"], encoding="utf-8")
+    text = res["text"]
+    if uses_crlf:
+        text = text.replace("\n", "\r\n")
+    # newline="" so the newlines above reach the disk as-is — the default
+    # translation would expand each \r\n to \r\r\n on Windows.
+    rp.write_text(text, encoding="utf-8", newline="")
     return {
         "status": "success",
         "path": str(rp),

--- a/scilink/utils/file_edit.py
+++ b/scilink/utils/file_edit.py
@@ -10,15 +10,17 @@ wrappers: relative-path resolution, deliverable recording, transcript
 prints, and the routing text in error hints (each mode names ITS OWN
 alternative tool for oversized edits).
 
-Consumers today: the planning orchestrator's `edit_file`. Analysis and
-simulation orchestrators are the intended follow-ups — note that VASP
-inputs (POSCAR / INCAR / KPOINTS) are extensionless, which is why the
-suffix policy is a parameter: include "" in `allowed_suffixes` to permit
-extensionless files.
+Consumers today: the planning and simulation orchestrators' `edit_file`;
+the analysis orchestrator is the intended follow-up. VASP inputs (POSCAR /
+INCAR / KPOINTS) are extensionless, which is why the suffix policy is a
+parameter: include "" in `allowed_suffixes` to permit extensionless files.
+Doing so widens the gate past what a name can decide, so the size and
+binary/UTF-8 content guards below carry the rest of that decision.
 """
 from __future__ import annotations
 
 import logging
+import shutil
 from pathlib import Path
 from typing import Any, Dict, Optional, Set, Tuple
 
@@ -31,9 +33,29 @@ DEFAULT_EDITABLE_SUFFIXES: Set[str] = {
 # Surgical means SMALL — see module docstring.
 DEFAULT_MAX_SNIPPET_LEN = 2000
 
+# The suffix allowlist cannot carry the whole "is this editable" decision
+# once "" is in it: VASP writes its INPUTS extensionless (INCAR, POSCAR,
+# KPOINTS) and its OUTPUTS extensionless too (WAVECAR, CHGCAR, WAVEDER),
+# and the two are indistinguishable by name. So content and size are
+# checked as well — a NUL in the first few KB means binary, and a file
+# past the byte cap is a run artifact rather than a deck under edit.
+# CHGCAR is the case that needs both: it is ASCII, so only the cap stops
+# it. Cap chosen to clear the largest plausible text deck (a LAMMPS
+# .data for a few hundred thousand atoms) by a wide margin.
+DEFAULT_MAX_FILE_BYTES = 16 * 1024 * 1024
+_BINARY_SNIFF_BYTES = 8192
+
 DEFAULT_TOO_LARGE_MESSAGE = (
     "Edit too large for edit_file — split the change at a unique boundary "
     "into consecutive smaller edit_file calls."
+)
+
+# The recovery route when a verbatim snippet guess misses. Parameterized
+# for the same reason as `too_large_message`: each mode names a surface it
+# actually has (planning has read_file; simulate does not).
+DEFAULT_NOT_FOUND_MESSAGE = (
+    "read_file the document and copy the snippet verbatim, "
+    "whitespace included."
 )
 
 
@@ -43,6 +65,7 @@ def apply_snippet_edits(
     *,
     max_len: int = DEFAULT_MAX_SNIPPET_LEN,
     too_large_message: str = DEFAULT_TOO_LARGE_MESSAGE,
+    not_found_message: str = DEFAULT_NOT_FOUND_MESSAGE,
 ) -> Dict[str, Any]:
     """Atomically apply a SEQUENCE of exact-snippet replacements to text.
 
@@ -90,9 +113,8 @@ def apply_snippet_edits(
                           "edits. Nothing was applied.") if batch else ""
             return {"status": "error", "failed_edit": i + 1,
                     "message": (
-                        f"{label}old_text not found — read_file the "
-                        "document and copy the snippet verbatim, "
-                        f"whitespace included.{batch_note}")}
+                        f"{label}old_text not found — "
+                        f"{not_found_message}{batch_note}")}
         if n > 1 and not ra:
             batch_note = (" Nothing was applied." if batch else "")
             return {"status": "error", "failed_edit": i + 1,
@@ -133,7 +155,9 @@ def apply_surgical_edits(
     backup_dir: Path,
     max_len: int = DEFAULT_MAX_SNIPPET_LEN,
     allowed_suffixes: Set[str] = DEFAULT_EDITABLE_SUFFIXES,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
     too_large_message: str = DEFAULT_TOO_LARGE_MESSAGE,
+    not_found_message: str = DEFAULT_NOT_FOUND_MESSAGE,
     root_label: str = "session directory",
 ) -> Dict[str, Any]:
     """Apply an atomic batch of exact-snippet edits to `path`, guarded and
@@ -146,10 +170,13 @@ def apply_surgical_edits(
     ``status: "error"`` (plus ``message``, and ``failed_edit`` when a
     specific edit failed). Never raises for expected failures.
 
-    Path guards: sandbox (inside `root`), existence, suffix allowlist.
-    Per-edit guards live in :func:`apply_snippet_edits` (all-or-nothing);
-    `too_large_message` is the mode's routing hint — it should name that
-    mode's alternative tool.
+    Path guards: sandbox (inside `root`), existence, suffix allowlist,
+    byte cap, and a binary/UTF-8 content check. The last two exist because
+    a mode that allows "" (extensionless VASP inputs) thereby also matches
+    extensionless run OUTPUTS — see `DEFAULT_MAX_FILE_BYTES`. Per-edit
+    guards live in :func:`apply_snippet_edits` (all-or-nothing);
+    `too_large_message` and `not_found_message` are the mode's routing
+    hints — each should name a surface that mode actually has.
 
     Backup: ONE per file per `backup_dir` — ``<stem>.before_edit<suffix>``
     holds the state before this backup dir's FIRST edit of the file, and
@@ -175,9 +202,37 @@ def apply_surgical_edits(
                 "message": (f"'{rp.suffix}' is not an editable text "
                             f"format ({shown}).")}
 
-    current = rp.read_text(errors="replace")
+    size = rp.stat().st_size
+    if size > max_file_bytes:
+        return {"status": "error",
+                "message": (
+                    f"{rp.name} is {size / (1024 * 1024):.1f} MB, over the "
+                    f"{max_file_bytes // (1024 * 1024)} MB in-place edit cap "
+                    "— a file this size is a run output, not an editable "
+                    "input.")}
+    # Bytes, then a STRICT decode. read_text(errors="replace") here does not
+    # merely mangle the edit — it rewrites every undecodable byte in the
+    # whole file as U+FFFD and reports success, so refusing is the only safe
+    # answer once the file is not text.
+    try:
+        raw = rp.read_bytes()
+    except OSError as e:
+        return {"status": "error",
+                "message": f"Could not read {rp.name}: {e}"}
+    if b"\x00" in raw[:_BINARY_SNIFF_BYTES]:
+        return {"status": "error",
+                "message": (f"{rp.name} is a binary file — refusing to "
+                            "edit it as text.")}
+    try:
+        current = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return {"status": "error",
+                "message": (f"{rp.name} is not valid UTF-8 text — refusing "
+                            "to edit it as text.")}
+
     res = apply_snippet_edits(current, edits, max_len=max_len,
-                              too_large_message=too_large_message)
+                              too_large_message=too_large_message,
+                              not_found_message=not_found_message)
     if res["status"] != "success":
         return res
 
@@ -188,13 +243,16 @@ def apply_surgical_edits(
         backup_dir.mkdir(parents=True, exist_ok=True)
         bak = backup_dir / f"{rp.stem}.before_edit{rp.suffix}"
         if not bak.exists():
-            bak.write_text(current)
+            # copyfile, not write_text(current): the backup is the only
+            # route back from a bad edit, so it must be the file's bytes
+            # rather than a re-encoding of what we decoded from them.
+            shutil.copyfile(rp, bak)
             created = True
     except Exception as e:  # noqa: BLE001 - never block the edit
         logging.warning(f"Pre-edit copy failed: {e}")
         bak = None
 
-    rp.write_text(res["text"])
+    rp.write_text(res["text"], encoding="utf-8")
     return {
         "status": "success",
         "path": str(rp),
@@ -226,8 +284,6 @@ def rename_or_copy_file(
     one exists and the destination twin is free), preserving the
     twins-never-go-stale invariant across renames.
     """
-    import shutil
-
     src, dest, root = Path(src), Path(dest), Path(root).resolve()
     for label, p in (("path", src), ("new path", dest)):
         if root not in p.parents:

--- a/tests/test_file_edit_utility.py
+++ b/tests/test_file_edit_utility.py
@@ -109,6 +109,37 @@ def test_undecodable_text_is_refused_not_replaced(tmp_path):
     assert f.read_bytes() == original
 
 
+def test_crlf_file_matches_lf_snippet_and_keeps_crlf(tmp_path):
+    """read_text() normalized newlines for free; the strict decode must too,
+    or \\n-authored snippets never match Windows-written files."""
+    f = tmp_path / "doc.md"
+    original = b"line one\r\nENCUT = 400\r\nline three\r\n"
+    f.write_bytes(original)
+    out = edit(f, "ENCUT = 400\nline three", "ENCUT = 520\nline three",
+               root=tmp_path)
+    assert out["status"] == "success"
+    assert f.read_bytes() == b"line one\r\nENCUT = 520\r\nline three\r\n"
+    assert Path(out["previous_version"]).read_bytes() == original
+
+
+def test_crlf_in_new_text_cannot_double_the_carriage_return(tmp_path):
+    f = tmp_path / "doc.md"
+    f.write_bytes(b"alpha\r\nbeta\r\n")
+    out = edit(f, "alpha", "alpha\r\nextra", root=tmp_path)
+    assert out["status"] == "success"
+    assert f.read_bytes() == b"alpha\r\nextra\r\nbeta\r\n"
+
+
+def test_lf_file_stays_lf_byte_for_byte(tmp_path):
+    """newline='' on the write — the platform default would emit \\r\\n
+    for every \\n on Windows, silently converting LF files."""
+    f = tmp_path / "doc.md"
+    f.write_bytes(b"alpha\nbeta\n")
+    out = edit(f, "beta", "gamma", root=tmp_path)
+    assert out["status"] == "success"
+    assert f.read_bytes() == b"alpha\ngamma\n"
+
+
 def test_file_byte_cap(tmp_path):
     """CHGCAR is ASCII, so size is the only thing that classifies it."""
     chgcar = tmp_path / "CHGCAR"

--- a/tests/test_file_edit_utility.py
+++ b/tests/test_file_edit_utility.py
@@ -68,6 +68,73 @@ def test_suffix_policy_is_configurable_for_extensionless_vasp(tmp_path):
     assert incar.read_text() == "ENCUT = 520\n"
 
 
+def test_not_found_uses_the_callers_routing_hint(tmp_path):
+    f = tmp_path / "doc.md"
+    f.write_text("alpha\n")
+    out = edit(f, "beta", "gamma", root=tmp_path)
+    assert "read_file the document" in out["message"]     # default kept
+
+    out = edit(f, "beta", "gamma", root=tmp_path,
+               not_found_message="USE-MODE-SPECIFIC-TOOL")
+    assert out["status"] == "error"
+    assert out["message"] == "old_text not found — USE-MODE-SPECIFIC-TOOL"
+    assert f.read_text() == "alpha\n"
+
+
+# Admitting "" to the suffix set admits extensionless run OUTPUTS along
+# with the VASP inputs it was meant for. These three pin the guards that
+# carry the decision a filename no longer can.
+
+def test_binary_extensionless_file_is_refused(tmp_path):
+    """The live repro: a WAVECAR is extensionless, so only content stops it."""
+    wavecar = tmp_path / "WAVECAR"
+    original = b"\x00\x01\x02ENCUT = 400\xff\xfe binary tail"
+    wavecar.write_bytes(original)
+    out = edit(wavecar, "ENCUT = 400", "ENCUT = 520", root=tmp_path,
+               allowed_suffixes=DEFAULT_EDITABLE_SUFFIXES | {""})
+    assert out["status"] == "error"
+    assert "binary" in out["message"]
+    assert wavecar.read_bytes() == original        # not one byte touched
+    assert not (tmp_path / "backups").exists()     # and no lossy "backup"
+
+
+def test_undecodable_text_is_refused_not_replaced(tmp_path):
+    """No NUL, still not UTF-8 — errors='replace' would have rewritten it."""
+    f = tmp_path / "deck.txt"
+    original = "pair_style lj/cut 10.0\n".encode() + b"\xff\xfe latin tail"
+    f.write_bytes(original)
+    out = edit(f, "10.0", "12.0", root=tmp_path)
+    assert out["status"] == "error"
+    assert "UTF-8" in out["message"]
+    assert f.read_bytes() == original
+
+
+def test_file_byte_cap(tmp_path):
+    """CHGCAR is ASCII, so size is the only thing that classifies it."""
+    chgcar = tmp_path / "CHGCAR"
+    chgcar.write_text("ENCUT = 400\n" + "0.1 " * 3000)
+    suffixes = DEFAULT_EDITABLE_SUFFIXES | {""}
+    out = edit(chgcar, "400", "520", root=tmp_path,
+               allowed_suffixes=suffixes, max_file_bytes=1024)
+    assert out["status"] == "error"
+    assert "run output" in out["message"]
+    assert "ENCUT = 400" in chgcar.read_text()
+
+    out = edit(chgcar, "400", "520", root=tmp_path,
+               allowed_suffixes=suffixes)          # default cap clears it
+    assert out["status"] == "success"
+
+
+def test_backup_is_byte_exact(tmp_path):
+    """The backup is the only route back, so it copies bytes."""
+    f = tmp_path / "doc.md"
+    f.write_bytes("héllo — em dash\n".encode())
+    out = edit(f, "héllo", "hallo", root=tmp_path)
+    assert out["status"] == "success"
+    assert Path(out["previous_version"]).read_bytes() == \
+        "héllo — em dash\n".encode()
+
+
 def test_chain_origin_backup_only(tmp_path):
     f = tmp_path / "doc.md"
     f.write_text("v1\n")

--- a/tests/test_simulation_orchestrator.py
+++ b/tests/test_simulation_orchestrator.py
@@ -227,12 +227,28 @@ def test_2b_edit_and_rename_file(model_name: str):
         assert incar.read_text().startswith("ENCUT = 520")
         assert (sd / "INCAR.before_edit").exists()   # pre-edit backup kept
 
-        # 2. a non-text artifact is refused
+        # 2. a non-text artifact is refused by the suffix gate
         (sd / "view.png").write_bytes(b"x")
         r = json.loads(orch.tools.execute_tool(
             "edit_file", path=str(sd / "view.png"),
             old_text="a", new_text="b"))
         assert r["status"] == "error"
+
+        # 2b. an extensionless run OUTPUT is refused on CONTENT — the suffix
+        # gate cannot help here, because admitting "" for INCAR/POSCAR
+        # admits WAVECAR/CHGCAR/WAVEDER from the download path too.
+        out = sd / "outputs"
+        out.mkdir(exist_ok=True)
+        wavecar = out / "WAVECAR"
+        original = b"\x00\x01\x02ENCUT = 400\xff\xfe binary tail"
+        wavecar.write_bytes(original)
+        r = json.loads(orch.tools.execute_tool(
+            "edit_file", path=str(wavecar),
+            old_text="ENCUT = 400", new_text="ENCUT = 520"))
+        assert r["status"] == "error", r
+        assert "binary" in r["message"]
+        assert wavecar.read_bytes() == original          # bytes intact
+        assert not (out / "WAVECAR.before_edit").exists()  # no lossy backup
 
         # 3. a path outside the session is refused (sandbox)
         r = json.loads(orch.tools.execute_tool(

--- a/tests/test_simulation_orchestrator.py
+++ b/tests/test_simulation_orchestrator.py
@@ -93,10 +93,15 @@ EXPECTED_TOOLS = {
     "validate_structure",
     "generate_dft_inputs",
     "run_complete_dft_workflow",
+    "run_simulation",
+    "run_mlip_simulation",
+    "run_exafs_workflow",
     "refine_structure",
     "view_structure",
     "validate_inputs",
     "apply_input_adjustments",
+    "edit_file",
+    "rename_file",
     "list_generated_structures",
     "analyze_output",
     "route_simulation",
@@ -202,6 +207,46 @@ def test_2_tool_error_paths(model_name: str):
         assert r["status"] == "error"
 
         print("   ✅ All error paths return structured JSON")
+
+
+def test_2b_edit_and_rename_file(model_name: str):
+    """edit_file / rename_file: surgical, sandboxed, extensionless-VASP aware."""
+    from pathlib import Path
+    with tempfile.TemporaryDirectory() as td:
+        orch = _make_orch(model_name, td + "/sim")
+        sd = Path(orch.base_dir) / "structures" / "mp"
+        sd.mkdir(parents=True, exist_ok=True)
+        incar = sd / "INCAR"                       # extensionless VASP input
+        incar.write_text("ENCUT = 400\nISMEAR = 0\n")
+
+        # 1. the canonical case: change ENCUT in place, no regeneration
+        r = json.loads(orch.tools.execute_tool(
+            "edit_file", path=str(incar),
+            old_text="ENCUT = 400", new_text="ENCUT = 520"))
+        assert r["status"] == "success", r
+        assert incar.read_text().startswith("ENCUT = 520")
+        assert (sd / "INCAR.before_edit").exists()   # pre-edit backup kept
+
+        # 2. a non-text artifact is refused
+        (sd / "view.png").write_bytes(b"x")
+        r = json.loads(orch.tools.execute_tool(
+            "edit_file", path=str(sd / "view.png"),
+            old_text="a", new_text="b"))
+        assert r["status"] == "error"
+
+        # 3. a path outside the session is refused (sandbox)
+        r = json.loads(orch.tools.execute_tool(
+            "edit_file", path="/etc/hosts",
+            old_text="localhost", new_text="x"))
+        assert r["status"] == "error"
+
+        # 4. byte-exact rename within the file's own directory
+        r = json.loads(orch.tools.execute_tool(
+            "rename_file", path=str(incar), new_name="INCAR.bak"))
+        assert r["status"] == "success", r
+        assert (sd / "INCAR.bak").exists()
+
+        print("   ✅ edit_file/rename_file: surgical, sandboxed, VASP-aware")
 
 
 def test_3_post_run_analysis_synthetic(model_name: str):
@@ -863,6 +908,7 @@ def integration_1_hpc_slurm(model_name: str):
 TARGETED_TESTS = [
     ("Orchestrator constructs",                test_1_orchestrator_constructs),
     ("Tool error paths",                       test_2_tool_error_paths),
+    ("edit_file / rename_file",                test_2b_edit_and_rename_file),
     ("Post-run analysis (synthetic)",          test_3_post_run_analysis_synthetic),
     ("Mode switching",                         test_4_mode_switching),
     ("run_task without LLM",                   test_5_run_task_without_llm),


### PR DESCRIPTION
Tier 1 of #439 — brings the surgical-edit machinery to the simulation side.

`edit_file` / `rename_file` wrappers on the simulation orchestrator over the shared `scilink/utils/file_edit.py` core, same shape as the planning adoption (#427). The canonical case is *"change ENCUT to 520 in this INCAR"* without an LLM-mediated regeneration round — `apply_input_adjustments` today is overkill for a single value and can perturb other settings while it's in there.

### What's added
- **`edit_file`** — atomic exact-snippet edits (single `old_text`/`new_text` or a batched `edits` list), 2000-char per-snippet cap, sandboxed to the session directory, pre-edit backup kept. The editable-suffix set extends the shared text defaults with `""` (extensionless VASP `INCAR`/`POSCAR`/`KPOINTS`/`POTCAR`) and the LAMMPS/QE deck extensions (`.lammps`, `.data`, `.in`, `.param`, `.mod`, `.inc`, `.sbatch`, `.pwi`, `.lmp`). The cap-error routing hint points at `apply_input_adjustments`, per the issue.
- **`rename_file`** — byte-exact rename/copy within the file's own directory; content never passes through the model.

All the guards (sandbox, size cap, suffix allowlist, backup) live in the shared core — these are thin wrappers owning path resolution + the sim routing hint.

### Tests
`edit_file`/`rename_file` exercised through `execute_tool`: an extensionless `INCAR` ENCUT edit (+ backup created), a non-text artifact refused, an out-of-sandbox path refused, and a rename. Also completes the stale `EXPECTED_TOOLS` set — `run_simulation` / `run_mlip_simulation` / `run_exafs_workflow` were registered but unlisted, which was already failing `test_1_orchestrator_constructs` on main. **9/9 targeted tests pass.**

Tiers 2 (SimulationAnalysisAgent → shared QC engine, after #405 + a seam review) and 3 (deck bank) are tracked separately in #439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)