### PR TITLE
write_technical_document: images in source_files route instead of crashing

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -7447,8 +7447,17 @@ class OrchestratorTools:
 
                 # Prior documents the agent names — this is how a revision or
                 # a merge builds on what the session already wrote instead of
-                # re-deriving it.
-                sources, missing = [], []
+                # re-deriving it. Text documents only: a freshly rendered
+                # diagram PNG passed here read as raw bytes and the
+                # UnicodeDecodeError killed the whole authoring call (live).
+                # Images enter documents BY REFERENCE (![...](path) in the
+                # text — the PDF exporter already resolves them), so a
+                # non-text source is refused with that routing hint instead
+                # of crashing or being silently dropped.
+                _text_suffixes = {".md", ".txt", ".json", ".yaml", ".yml",
+                                  ".csv", ".py", ".html", ".mmd", ".tex",
+                                  ".rst", ""}
+                sources, missing, non_text = [], [], []
                 for raw in (source_files or "").split(","):
                     raw = raw.strip()
                     if not raw:
@@ -7456,18 +7465,22 @@ class OrchestratorTools:
                     fp = Path(raw)
                     if not fp.is_absolute():
                         fp = self._output_dir() / raw
-                    if fp.exists():
-                        sources.append(f"### {fp.name}\n{fp.read_text()}")
-                    else:
+                    if not fp.exists():
                         # The agent names its own earlier file; that file
                         # lives in a SIBLING delegation directory, so search
                         # the session root by basename before giving up.
                         hits = sorted(Path(self.orch.base_dir).rglob(fp.name))
-                        if hits:
-                            sources.append(f"### {hits[0].name}\n"
-                                           + hits[0].read_text())
-                        else:
+                        if not hits:
                             missing.append(raw)
+                            continue
+                        fp = hits[0]
+                    if fp.suffix.lower() not in _text_suffixes:
+                        non_text.append(fp.name)
+                        continue
+                    # errors="replace": a stray non-UTF-8 byte in an
+                    # otherwise-text file must not kill authoring either.
+                    sources.append(f"### {fp.name}\n"
+                                   f"{fp.read_text(errors='replace')}")
 
                 # A revision inherits the document's OWN name: falling back
                 # to the request titled the deliverable with the instruction
@@ -7599,6 +7612,14 @@ class OrchestratorTools:
                        "sources_used": len(sources)}
                 if missing:
                     res["source_files_not_found"] = missing
+                if non_text:
+                    res["source_files_skipped"] = non_text
+                    res["source_files_note"] = (
+                        f"{', '.join(non_text)}: not text — an image or "
+                        "other binary cannot be inlined as source text. To "
+                        "include a figure, reference it IN the document "
+                        "body instead: ![caption](<filename>) — the "
+                        "renderer resolves it from the file's directory.")
                 if declined_topics:
                     res["literature_declined"] = {
                         "available_sections": declined_topics,
@@ -7668,10 +7689,13 @@ class OrchestratorTools:
                 "source_files": {
                     "type": "string",
                     "description": (
-                        "Comma-separated files this document should build on "
-                        "— a roadmap you are revising, two documents you are "
-                        "merging. Names of files in the session are resolved "
-                        "for you. Omit for a fresh document."
+                        "Comma-separated TEXT files this document should "
+                        "build on — a roadmap you are revising, two "
+                        "documents you are merging. Names of files in the "
+                        "session are resolved for you. Do NOT list images "
+                        "here: a figure goes in the document body by "
+                        "reference (![caption](file.png)). Omit for a "
+                        "fresh document."
                     ),
                 },
                 "literature_context": {

--- a/tests/test_technical_document_tool.py
+++ b/tests/test_technical_document_tool.py
@@ -355,3 +355,78 @@ def test_an_explicit_title_still_wins(tmp_path, monkeypatch):
     out = json.loads(t.functions_map["write_technical_document"](
         request="rename it", title="New Name", revise_path=str(orig)))
     assert out["title"] == "New Name"
+
+
+# ── source_files: text only, images by reference ─────────────────────
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n" + b"\x00" * 24
+
+
+def test_an_image_source_is_refused_with_routing_not_a_crash(
+        tmp_path, monkeypatch):
+    """Live: the delegation passed its freshly rendered workflow PNG in
+    source_files; the bare read_text() hit the 0x89 PNG magic byte and
+    the UnicodeDecodeError killed the WHOLE authoring call."""
+    d = tmp_path / "delegations" / "04_revise"
+    png = d.parent / "03_render" / "campaign_workflow.png"
+    png.parent.mkdir(parents=True)
+    png.write_bytes(PNG_MAGIC)
+    notes = d.parent / "03_render" / "notes.md"
+    notes.write_text("# Notes\n\nplan prose\n")
+
+    cap = {}
+    t = _doc_tool(tmp_path, monkeypatch, SECTIONS, cap)
+    OrchestratorTools._register_all_tools(t)
+    out = json.loads(t.functions_map["write_technical_document"](
+        request="PoC design doc", filename="poc.md",
+        source_files=f"{png}, {notes}", use_literature=False))
+
+    assert out["status"] == "success"                 # no crash
+    assert out["sources_used"] == 1                   # the text file
+    assert out["source_files_skipped"] == ["campaign_workflow.png"]
+    note = out["source_files_note"]
+    assert "![" in note and "cannot be inlined" in note
+    assert "plan prose" in cap["source_documents"]    # text source flowed
+
+
+def test_sibling_resolution_also_guards_binary(tmp_path, monkeypatch):
+    """The bare-name rglob fallback read the sibling file too — same
+    guard must apply on that path."""
+    d = tmp_path / "delegations" / "04_revise"
+    png = tmp_path / "delegations" / "01_a" / "diagram.png"
+    png.parent.mkdir(parents=True)
+    png.write_bytes(PNG_MAGIC)
+
+    t = _doc_tool(tmp_path, monkeypatch, SECTIONS)
+    OrchestratorTools._register_all_tools(t)
+    out = json.loads(t.functions_map["write_technical_document"](
+        request="doc", filename="d.md",
+        source_files="diagram.png", use_literature=False))
+    assert out["status"] == "success"
+    assert out["source_files_skipped"] == ["diagram.png"]
+
+
+def test_stray_bytes_in_a_text_source_do_not_kill_authoring(
+        tmp_path, monkeypatch):
+    d = tmp_path / "delegations" / "04_revise"
+    d.mkdir(parents=True, exist_ok=True)
+    weird = d / "log.txt"
+    weird.write_bytes(b"valid prose\x89here\n")
+
+    cap = {}
+    t = _doc_tool(tmp_path, monkeypatch, SECTIONS, cap)
+    OrchestratorTools._register_all_tools(t)
+    out = json.loads(t.functions_map["write_technical_document"](
+        request="doc", filename="d.md",
+        source_files=str(weird), use_literature=False))
+    assert out["status"] == "success" and out["sources_used"] == 1
+    assert "valid prose" in cap["source_documents"]
+
+
+def test_source_files_schema_says_text_only():
+    src = Path("scilink/agents/planning_agents/orchestrator_tools.py"
+               ).read_text()
+    i = src.index('"source_files"')
+    desc = src[i:i + 700]
+    assert "TEXT files" in desc
+    assert "![caption](file.png)" in desc


### PR DESCRIPTION
## Summary

Observed live: a planning delegation rendered its workflow diagram and then called `write_technical_document` with the PNG listed in `source_files` — a perfectly sensible intent ("build the document on the plan *and* the diagram"). The ingestion loop did a bare `read_text()` on it, hit the PNG magic byte (`0x89`), and the `UnicodeDecodeError` killed the entire authoring call — no document, no partial result, just a traceback.

The gap: nothing told the model images don't belong in `source_files`, and inlining image bytes as source text could never be what anyone wants. Images enter documents **by reference** (`![caption](path)` in the body), which the PDF exporter already resolves.

Three-part fix, same shape as the session's other routing repairs:
- The `source_files` loop (including the sibling-delegation basename fallback, which shared the bare read) guards by text suffix: a non-text source is skipped and reported back as `source_files_skipped` plus a routing note — *"an image cannot be inlined as source text; reference it in the document body: `![caption](file.png)`"*. Not a crash, not a silent drop — the model does the right thing on the next call.
- Text reads use `errors="replace"`, so a stray non-UTF-8 byte in an otherwise-text file can't kill authoring either.
- The `source_files` parameter description now says TEXT files only, images by reference.

Validation: offline 23/23 (`tests/test_technical_document_tool.py` — image refused with the routing note while the text source still flows to the author, the fallback path guarded, a stray-byte text file surviving, schema check). Live on Bedrock Opus 4.8, replaying the trace's shape — "author a memo building on notes.md AND the campaign_workflow.png diagram" — the run completes with the notes ingested as source text and the diagram embedded by reference in the written document; the agent's reply even explains that the reference resolves from the file's directory.