### PR TITLE
Stop the meta agent burying its answer behind a routine checkpoint

### DIFF
--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -306,6 +306,8 @@ rather than fabricate a result).
   checked it (e.g. by reading the file) — e.g. do not state that a plan's
   HTML report "includes" the optimizer's diagnostic plots when those are
   separate image files in their own directory.
+- The user reads only your FINAL message of a turn, so put the answer there
+  and never end a turn with a housekeeping tool call after it.
 """
 
 

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -964,9 +964,10 @@ class MetaOrchestratorTools:
             description=(
                 "Save the meta session state (mode, delegation ledger, chat "
                 "history) to checkpoint.json so the session can be resumed "
-                "later. The state is also auto-saved periodically; call this "
-                "when the user asks to save/checkpoint the session, or before "
-                "they intend to stop."
+                "later. The state is ALREADY auto-saved every few turns, so "
+                "call this ONLY when the user asks to save/checkpoint the "
+                "session or says they are stopping — never as a routine "
+                "end-of-turn step."
             ),
             parameters={},
             required=[],


### PR DESCRIPTION
In a long meta session, the agent's replies suddenly went from full multi-paragraph syntheses to one-liners like "Checkpoint saved — 18 delegations preserved." It looked like the agent had stopped thinking. It hadn't: it was still writing the full answer every turn, but the answer was being shown in the wrong place — dimmed and indented above the tool log, styled as if it were the agent's internal reasoning — while the throwaway closing line became the visible reply.

The cause is that the agent had picked up a habit of saving a checkpoint at the end of every turn. Session state already saves itself automatically, so those saves did nothing except push the real answer out of view. This PR tells the agent not to save unless you actually ask it to, and states the underlying rule: the answer belongs in the last thing it says.

Two prompt-level lines change; no logic changes.

---

**Technical details**

`_handle_litellm_chat` (and its OpenAI twin) returns only the `content` of the first assistant message that comes back with no `tool_calls` (`meta_orchestrator.py:1962`). Any `content` accompanying a tool call goes to `_print_assistant_reasoning` (`meta_orchestrator.py:1870`), which prints it dim+italic as a `💭` block. So a turn shaped `synthesis + save_checkpoint → tool result → short closer` displays the closer as the response and demotes the synthesis to a thought.

Observed in a live 18-delegation planning session. From the point the model adopted the habit, every turn inverts:

| Turn | prose attached to `save_checkpoint` (shown as `💭`) | returned as the response |
|---|---|---|
| biotic-side tools | 4,329 chars | 694 chars |
| single-station catalysis | 4,834 chars | 132 chars |
| architecture duplication | 3,894 chars | 572 chars |
| architecture variant | 4,169 chars | 580 chars |
| consolidated memo | 2,992 chars | 976 chars |
| portable-rig architecture | 4,350 chars | 671 chars |

Before the habit set in, each turn's last message had no tool calls and ran 3.4k–5.6k chars. Nothing in the prompt requested per-turn checkpointing — it is in-context imitation, self-reinforcing once one turn ends that way, and redundant since `_auto_checkpoint` fires every `CHECKPOINT_INTERVAL = 10` turns (the session reached `message_count = 21`).

Changes:
- `meta_orchestrator_tools.py:964` — `save_checkpoint` description now leads with "ALREADY auto-saved", restricts the call to an explicit user request or a stated stop, and rules out the routine end-of-turn call. The old text ("call this when the user asks…, or before they intend to stop") was permissive enough to read a long session as an implicit reason.
- `meta_orchestrator.py:304` — one sentence in the prompt's RESPONSE STYLE block: the user reads only the final message, so the answer goes there and no housekeeping call follows it. This generalizes past checkpointing to any trailing tool call.

Verification: built the orchestrator and dumped `tools_for_model` to confirm the description the model actually receives; asserted the prompt line renders via `get_system_prompt`; `tests/test_meta_tool_dispatch_guards.py`, `tests/test_meta_fanout_robustness.py`, `tests/test_meta_simulation_delegation.py` pass (16 tests). No test asserted on the old description string.

Deliberately out of scope — two follow-ups worth noting:
- The planning orchestrator's own `save_checkpoint` description (`planning_agents/orchestrator_tools.py:5467`) instructs the model to "use this periodically during long campaigns (every 3-5 experiments)", and its chat loop has the same return shape, so standalone plan mode is more exposed to this than the meta was.
- The robust fix is in the display contract: accumulate assistant prose across loop iterations instead of returning only the final tool-free chunk, so no trailing tool call can ever demote substantive text. That is a behavior change across all four chat loops and belongs in its own PR.
