### PR TITLE
Pin UTF-8 on the literature text path so Windows stops losing searches

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -40,6 +40,7 @@ from ..lit_agents.optimize_query_for_analysis import optimize_query_for_analysis
 from .recommendation_agent import RecommendationAgent
 from .feature_table import write_feature_table
 from ._locked_exec import CANDIDATES_DIR_NAME
+from ...utils.text_io import write_text_utf8
 from ...skills.loader import list_skills, list_all_skills, load_skill
 # Note: the simulation pipeline (`run_complete_workflow`) is imported lazily
 # inside `run_dft_workflow` to avoid pulling in the optional [sim] extras
@@ -3988,11 +3989,10 @@ class AnalysisOrchestratorTools:
             # same raw query → same file (re-runnable), different queries → different files.
             query_hash = hashlib.md5(query.encode("utf-8")).hexdigest()[:8]
             lit_path = self.orch.base_dir / f"literature_search_{query_hash}.md"
-            with open(lit_path, "w") as f:
-                f.write(f"# Literature Search Results\n\n**Draft query:** {query}\n")
-                if refined_query != query:
-                    f.write(f"**Refined query:** {refined_query}\n")
-                f.write(f"\n{content}")
+            header = f"# Literature Search Results\n\n**Draft query:** {query}\n"
+            if refined_query != query:
+                header += f"**Refined query:** {refined_query}\n"
+            write_text_utf8(lit_path, f"{header}\n{content}")
 
             print(f"  ✅ Literature search completed. Saved to {lit_path.name}")
 
@@ -4140,10 +4140,11 @@ class AnalysisOrchestratorTools:
             # Persist the search output (inspectable, same shape as search_literature).
             query_hash = hashlib.md5(query.encode("utf-8")).hexdigest()[:8]
             lit_path = self.orch.base_dir / f"interpretation_lit_{query_hash}.md"
-            with open(lit_path, "w") as f:
-                f.write(f"# Feature-Conditioned Literature (Channel B)\n\n"
-                        f"**Analysis:** {record.get('analysis_id')}\n"
-                        f"**Query:** {query}\n\n{content}")
+            write_text_utf8(
+                lit_path,
+                f"# Feature-Conditioned Literature (Channel B)\n\n"
+                f"**Analysis:** {record.get('analysis_id')}\n"
+                f"**Query:** {query}\n\n{content}")
 
             # 5. Tier-A refinement: text-in/text-out — revise the existing
             # interpretation against the literature. No pixel/state re-invoke.
@@ -4172,8 +4173,10 @@ class AnalysisOrchestratorTools:
 
             # Append the revised interpretation to the same document so the
             # revision is human-readable on disk, not only in session state.
-            with open(lit_path, "a") as f:
-                f.write("\n\n---\n\n## Literature-Refined Interpretation\n\n" + revised)
+            write_text_utf8(
+                lit_path,
+                "\n\n---\n\n## Literature-Refined Interpretation\n\n" + revised,
+                append=True)
 
             # Companion HTML next to the agent's original report (append-only:
             # a separate document, mirroring how assess_novelty writes its own
@@ -5690,7 +5693,7 @@ class AnalysisOrchestratorTools:
                 lit_dir.mkdir(parents=True, exist_ok=True)
                 ts = datetime.now().strftime("%Y%m%d_%H%M%S")
                 lit_path = lit_dir / f"provided_documents_{ts}.md"
-                lit_path.write_text(combined)
+                write_text_utf8(lit_path, combined)
             except Exception as e:
                 logging.error(f"read_document: could not save literature file: {e}")
             n_ocr = sum(info.get("n_ocr_pages", 0) for _, info in docs)

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -44,6 +44,7 @@ from ...skills._shared.curve_fitting_tools import (
 )
 from ._deprecation import normalize_params
 from ...skills.loader import load_skill
+from ...utils.text_io import read_text_utf8
 
 from .instruct import (
     FITTING_INTERPRETATION_INSTRUCTIONS,
@@ -906,7 +907,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         if literature_file:
             lit_p = Path(literature_file)
             if lit_p.is_file():
-                state["literature_context"] = lit_p.read_text()
+                state["literature_context"] = read_text_utf8(lit_p)
                 # Record provenance so the result reflects that literature
                 # was consulted — the in-pipeline LiteratureSearchController
                 # is skipped on this path and never populates literature_files.

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -25,6 +25,7 @@ from ...skills._shared.image_processor import load_image, convert_numpy_to_jpeg_
 from ...skills._shared.curve_fitting_tools import load_curve_data, plot_curve_to_bytes
 from ...executors import require_sandbox_approval
 from ...skills.loader import load_skill
+from ...utils.text_io import read_text_utf8
 
 from ._deprecation import normalize_params
 
@@ -374,7 +375,7 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         if literature_file:
             lit_p = Path(literature_file)
             if lit_p.is_file():
-                literature_context = lit_p.read_text()
+                literature_context = read_text_utf8(lit_p)
                 literature_files = {"provided_file": str(lit_p)}
                 self.logger.info(f"📚 Loaded literature context from {lit_p.name}")
             else:

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -47,6 +47,7 @@ from ...skills._shared.image_analysis_tools import (
 )
 from ._deprecation import normalize_params
 from ...skills.loader import load_skill
+from ...utils.text_io import read_text_utf8
 
 from .instruct import (
     IMAGE_ANALYSIS_INTERPRETATION_INSTRUCTIONS,
@@ -588,7 +589,7 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         if literature_file:
             lit_p = Path(literature_file)
             if lit_p.is_file():
-                state["literature_context"] = lit_p.read_text()
+                state["literature_context"] = read_text_utf8(lit_p)
                 # Record provenance so the result reflects that literature
                 # was consulted — the in-pipeline LiteratureSearchController
                 # is skipped on this path and never populates literature_files.

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -28,6 +28,7 @@ from .instruct import (
     SCREEN_DATABASE_CODEGEN_PROMPT,
 )
 from ..lit_agents.optimize_query import optimize_search_query, is_molecule_design_objective
+from ...utils.text_io import read_text_utf8, write_text_utf8
 from ...skills.loader import list_skills, load_skill
 
 
@@ -448,7 +449,7 @@ class OrchestratorTools:
         if not base.is_file():
             return None
         n = int(m.group("n"))
-        text = base.read_text()
+        text = read_text_utf8(base)
         sections = OrchestratorTools._split_literature_sections(text)
         for _q, chunk in sections:
             hm = _LIT_QUESTION_RE.match(chunk)
@@ -488,7 +489,7 @@ class OrchestratorTools:
                           f"question that file does not contain — skipped")
                 return sec
             p = Path(s)
-            return p.read_text() if p.is_file() else None
+            return read_text_utf8(p) if p.is_file() else None
 
         items = value if isinstance(value, list) else [value]
         pieces = []
@@ -632,7 +633,7 @@ class OrchestratorTools:
                 lines.append("")
 
         path = self._output_dir() / "ideation_report.md"
-        path.write_text("\n".join(lines))
+        write_text_utf8(path, "\n".join(lines))
         from .user_interface import format_path, record_deliverable
         record_deliverable(self.orch.base_dir, path,
                            "Ideation report — all candidate directions",
@@ -982,7 +983,7 @@ class OrchestratorTools:
         topics = []
         for p in self._campaign_literature_files():
             try:
-                sections = self._split_literature_sections(p.read_text())
+                sections = self._split_literature_sections(read_text_utf8(p))
             except Exception as exc:  # noqa: BLE001 - the index is advisory
                 logging.debug(f"Literature topic scan failed for {p}: {exc}")
                 continue
@@ -1020,7 +1021,7 @@ class OrchestratorTools:
         if not files:
             return None
         if len(files) == 1:
-            text = files[0].read_text()
+            text = read_text_utf8(files[0])
             return {"text": text, "files": [files[0].name],
                     "n_files": 1, "dropped": []}
         chunks = []  # (file_name, question, chunk_text)
@@ -1028,7 +1029,7 @@ class OrchestratorTools:
         dup_dropped = []
         for p in files:
             for question, chunk in self._split_literature_sections(
-                    p.read_text()):
+                    read_text_utf8(p)):
                 key = chunk.strip()
                 if key in seen_content:
                     dup_dropped.append((p.name, question))
@@ -1155,7 +1156,7 @@ class OrchestratorTools:
         )
         text = self._maybe_embed_workflow_diagram(text, self._output_dir())
         wp_path = self._output_dir() / "white_paper.md"
-        wp_path.write_text(text)
+        write_text_utf8(wp_path, text)
         from .user_interface import format_path, record_deliverable
         record_deliverable(self.orch.base_dir, wp_path,
                            "White paper", deliverable=True)
@@ -1760,9 +1761,9 @@ class OrchestratorTools:
                     _n += 1
                     lit_path = (self._output_dir()
                                 / f"literature_search_{label}_{_n}.md")
-                with open(lit_path, 'w') as f:
-                    f.write(f"# Literature Search Results ({label})\n\n")
-                    f.write(content)
+                write_text_utf8(
+                    lit_path,
+                    f"# Literature Search Results ({label})\n\n{content}")
                 self._record_literature_file(
                     lit_path, label=label,
                     questions=[objectives[oi]
@@ -1897,7 +1898,7 @@ class OrchestratorTools:
                         meta[str(Path(e["path"]).resolve())] = e
                 out_files = []
                 for p in files:
-                    text = p.read_text()
+                    text = read_text_utf8(p)
                     entry = meta.get(str(p.resolve()), {})
                     reg_qs = entry.get("questions") or []
                     chunks = self._split_literature_sections(text)
@@ -2006,9 +2007,10 @@ class OrchestratorTools:
 
                 # Save to file
                 mol_path = self._output_dir() / "molecule_design.md"
-                with open(mol_path, 'w') as f:
-                    f.write("# Molecular Design & Synthesis Planning Results\n\n")
-                    f.write(mol_res['content'])
+                write_text_utf8(
+                    mol_path,
+                    "# Molecular Design & Synthesis Planning Results\n\n"
+                    + mol_res['content'])
 
                 print(f"  ✅ Molecules query completed. Saved to {mol_path.name}")
 
@@ -2283,9 +2285,10 @@ class OrchestratorTools:
                 # originally motivated this save is removed.)
                 if not literature_context and plan.get("literature_search"):
                     lit_path = self._output_dir() / "literature_search.md"
-                    with open(lit_path, 'w') as f:
-                        f.write("# Literature Search Results\n\n")
-                        f.write(plan["literature_search"])
+                    write_text_utf8(
+                        lit_path,
+                        "# Literature Search Results\n\n"
+                        + plan["literature_search"])
                     self._record_literature_file(lit_path)
                     saved_extras.append(str(lit_path))
 
@@ -2542,7 +2545,7 @@ class OrchestratorTools:
             print("  ⚡ Tool: Generating white paper...")
             try:
                 wp_path = self._write_white_paper(audience_context)
-                text = Path(wp_path).read_text()
+                text = read_text_utf8(wp_path)
                 return json.dumps({
                     "status": "success",
                     "white_paper": str(wp_path),
@@ -2890,7 +2893,8 @@ class OrchestratorTools:
                 ext_ctx = None
                 if literature_context:
                     lp = Path(literature_context)
-                    ext_ctx = lp.read_text() if lp.is_file() else literature_context
+                    ext_ctx = (read_text_utf8(lp) if lp.is_file()
+                               else literature_context)
                     print(f"    📚 Literature context from: {lp.name if lp.is_file() else 'inline text'}")
 
                 res = self.orch.planner.perform_technoeconomic_analysis(

--- a/scilink/utils/text_io.py
+++ b/scilink/utils/text_io.py
@@ -1,0 +1,86 @@
+"""UTF-8 text I/O — the encoding this codebase assumes everywhere but states
+nowhere.
+
+`open()`, `Path.read_text()` and `Path.write_text()` all fall back to the
+*locale* encoding when no `encoding=` is given. On Linux and macOS that is
+UTF-8, so the omission is invisible. On a Windows machine with a Western
+European locale it is cp1252, which cannot encode the characters scientific
+prose is actually made of — subscripts, arrows, Greek letters, the minus
+sign. Persisting a literature answer that contains a single "→" therefore
+raises `UnicodeEncodeError: 'charmap' codec can't encode character` and, in
+the reported case, discarded a completed 13-minute Edison search.
+
+These helpers state the encoding. On any UTF-8 system they are byte-for-byte
+identical to the bare calls they replace — including newline translation,
+which is left at the platform default so Windows keeps writing CRLF — and
+only change behaviour where the bare call would have raised.
+
+Reads are deliberately tolerant. A markdown file written by an EARLIER
+SciLink run on a cp1252 machine is not valid UTF-8, so a strict UTF-8 read
+would newly fail on artifacts that used to load fine. `read_text_utf8`
+therefore tries UTF-8, falls back to the locale encoding, and only then
+degrades to a lossy read — warning at each step down rather than failing.
+
+Consumers today: the literature text path (search results, molecule design,
+white paper, ideation report, provided documents) across the planning and
+analysis orchestrators and the three analysis agents. Any other site that
+persists or reloads model-generated prose should move here too.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+
+def write_text_utf8(path: Any, text: str, *, append: bool = False) -> Path:
+    """Write ``text`` to ``path`` as UTF-8, creating or truncating it.
+
+    Args:
+        path: Destination file.
+        text: Content to write.
+        append: Append instead of truncating.
+
+    Returns:
+        The destination as a ``Path``.
+    """
+    p = Path(path)
+    # newline is left at the default so line-ending behaviour is unchanged
+    # on every platform; only the codec is being pinned here.
+    with open(p, "a" if append else "w", encoding="utf-8") as f:
+        f.write(text)
+    return p
+
+
+def read_text_utf8(path: Any) -> str:
+    """Read ``path`` as UTF-8, degrading rather than failing on legacy files.
+
+    Falls back to the locale encoding for files an older SciLink wrote under
+    a non-UTF-8 locale, then to a lossy UTF-8 read; each step down is logged.
+
+    Args:
+        path: File to read.
+
+    Returns:
+        The file's text.
+    """
+    p = Path(path)
+    try:
+        return p.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        pass
+
+    try:
+        text = p.read_text()
+        logging.warning(
+            f"{p.name} is not valid UTF-8 — read using the locale encoding. "
+            f"It was likely written by an older SciLink run on a non-UTF-8 "
+            f"system; re-generating it will store UTF-8."
+        )
+        return text
+    except UnicodeDecodeError:
+        logging.warning(
+            f"{p.name} decodes under neither UTF-8 nor the locale encoding — "
+            f"reading it lossily; some characters will be replaced."
+        )
+        return p.read_text(encoding="utf-8", errors="replace")

--- a/tests/test_text_io_encoding.py
+++ b/tests/test_text_io_encoding.py
@@ -1,0 +1,202 @@
+"""UTF-8 text I/O helpers and the literature path that now uses them.
+
+The bug these guard against: `open(path, 'w')` with no `encoding=` writes in
+the locale encoding, so on a cp1252 Windows machine persisting a literature
+answer containing "→" raised UnicodeEncodeError and discarded a completed
+Edison search. The two properties that matter are (1) writes are UTF-8
+regardless of locale and (2) nothing changes on a system that was already
+UTF-8 — so the byte-identity test below is as load-bearing as the fix.
+"""
+import ast
+import locale
+import logging
+from pathlib import Path
+
+import pytest
+
+from scilink.utils.text_io import read_text_utf8, write_text_utf8
+
+
+# The characters that actually broke it live, plus the general suspects.
+SCIENTIFIC_TEXT = (
+    "# Literature Search Results (hypothesis_context)\n\n"
+    "Kr/Xe sieving in CO₂-activated MOFs; ΔH ≥ 30 kJ mol⁻¹; "
+    "aperture → 4 Å; −196 °C; μ-pore; α-phase.\n"
+)
+
+
+# ---------------------------------------------------------------- write side
+
+def test_write_is_utf8_regardless_of_locale(tmp_path):
+    p = write_text_utf8(tmp_path / "lit.md", SCIENTIFIC_TEXT)
+    assert p.read_bytes().decode("utf-8") == SCIENTIFIC_TEXT
+
+
+def test_write_survives_the_character_that_broke_it(tmp_path):
+    # U+2192 at the reported crash, U+2082 at the one before it.
+    for ch in ("→", "₂", "−", "≥", "Å"):
+        p = write_text_utf8(tmp_path / f"c_{ord(ch)}.md", f"x {ch} y")
+        assert ch in p.read_text(encoding="utf-8")
+
+
+def test_append_extends_rather_than_truncates(tmp_path):
+    p = tmp_path / "lit.md"
+    write_text_utf8(p, "first ₂\n")
+    write_text_utf8(p, "second →\n", append=True)
+    assert p.read_text(encoding="utf-8") == "first ₂\nsecond →\n"
+
+
+def test_append_creates_a_missing_file(tmp_path):
+    p = write_text_utf8(tmp_path / "new.md", "only →", append=True)
+    assert p.read_text(encoding="utf-8") == "only →"
+
+
+def test_returns_a_path(tmp_path):
+    assert write_text_utf8(str(tmp_path / "x.md"), "t") == tmp_path / "x.md"
+
+
+# --------------------------------------------- no-op on an already-UTF-8 OS
+
+@pytest.mark.skipif(
+    (locale.getpreferredencoding(False) or "").lower().replace("-", "")
+    not in ("utf8",),
+    reason="byte-identity only claimed where the locale was already UTF-8",
+)
+@pytest.mark.parametrize("text", [
+    "",
+    "plain ascii\n",
+    SCIENTIFIC_TEXT,
+    "trailing newlines\n\n\n",
+    "embedded\r\ncrlf\r\n",
+    "no trailing newline",
+])
+def test_byte_identical_to_the_bare_call_it_replaces(tmp_path, text):
+    """The fix must not alter working behaviour on Linux/macOS.
+
+    Same bytes, including newline translation — which is why the helper
+    leaves `newline` at the platform default instead of pinning it.
+    """
+    before = tmp_path / "before.md"
+    with open(before, "w") as f:  # what the code did prior to the fix
+        f.write(text)
+    after = write_text_utf8(tmp_path / "after.md", text)
+    assert after.read_bytes() == before.read_bytes()
+
+
+@pytest.mark.skipif(
+    (locale.getpreferredencoding(False) or "").lower().replace("-", "")
+    not in ("utf8",),
+    reason="byte-identity only claimed where the locale was already UTF-8",
+)
+def test_append_byte_identical_to_the_bare_call(tmp_path):
+    before, after = tmp_path / "b.md", tmp_path / "a.md"
+    for target, writer in ((before, None), (after, write_text_utf8)):
+        for chunk in ("head ₂\n", "tail →\n"):
+            if writer is None:
+                with open(target, "a") as f:
+                    f.write(chunk)
+            else:
+                writer(target, chunk, append=True)
+    assert after.read_bytes() == before.read_bytes()
+
+
+# ----------------------------------------------------------------- read side
+
+def test_read_roundtrips_what_write_produced(tmp_path):
+    p = write_text_utf8(tmp_path / "lit.md", SCIENTIFIC_TEXT)
+    assert read_text_utf8(p) == SCIENTIFIC_TEXT
+
+
+def test_read_recovers_a_legacy_cp1252_file_on_a_cp1252_host(
+        tmp_path, monkeypatch, caplog):
+    """Artifacts an older SciLink wrote on Windows must still load there.
+
+    An em dash is byte 0x97 in cp1252, which is not valid UTF-8 — so a
+    strict read would newly break files that used to open fine. The locale
+    rung is what recovers them, simulated here so the Windows behaviour is
+    covered from any host.
+    """
+    real_read_text = Path.read_text
+
+    def locale_is_cp1252(self, encoding=None, *a, **kw):
+        return real_read_text(self, encoding=encoding or "cp1252", *a, **kw)
+
+    monkeypatch.setattr(Path, "read_text", locale_is_cp1252)
+
+    p = tmp_path / "legacy.md"
+    p.write_bytes("cost — high".encode("cp1252"))
+    with caplog.at_level(logging.WARNING):
+        text = read_text_utf8(p)
+    assert text == "cost — high"  # em dash recovered exactly, not mangled
+    assert any("not valid UTF-8" in r.message for r in caplog.records)
+
+
+def test_read_of_a_legacy_file_never_raises_on_a_utf8_host(tmp_path, caplog):
+    """Cross-machine, the encoding is unknowable — degrade, do not crash.
+
+    Bare `read_text()` raised UnicodeDecodeError here, so lossy-with-warning
+    is strictly better than what it replaces.
+    """
+    p = tmp_path / "legacy.md"
+    p.write_bytes("cost — high".encode("cp1252"))
+    with caplog.at_level(logging.WARNING):
+        text = read_text_utf8(p)
+    assert "cost" in text and "high" in text
+    assert caplog.records
+
+
+def test_read_degrades_lossily_rather_than_raising(tmp_path, caplog):
+    p = tmp_path / "binary.md"
+    p.write_bytes(b"start \xff\xfe\xfd end")
+    with caplog.at_level(logging.WARNING):
+        text = read_text_utf8(p)
+    assert "start" in text and "end" in text
+
+
+def test_read_accepts_str_paths(tmp_path):
+    p = write_text_utf8(tmp_path / "lit.md", "text →")
+    assert read_text_utf8(str(p)) == "text →"
+
+
+# --------------------------------------------------- the literature path itself
+
+LITERATURE_IO_MODULES = [
+    "scilink/agents/planning_agents/orchestrator_tools.py",
+    "scilink/agents/exp_agents/analysis_orchestrator_tools.py",
+]
+
+
+@pytest.mark.parametrize("rel", LITERATURE_IO_MODULES)
+def test_no_unencoded_writes_left_in_the_literature_writers(rel):
+    """Every markdown write in these modules names its encoding.
+
+    Regression guard: the reported crash was one such call. JSON writes are
+    exempt — `json.dump` defaults to ensure_ascii=True, so they are already
+    cp1252-safe, and there are many of them.
+    """
+    src = (Path(__file__).resolve().parents[1] / rel).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    offenders = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "open"):
+            continue
+        mode = (node.args[1].value
+                if len(node.args) > 1 and isinstance(node.args[1], ast.Constant)
+                else "r")
+        if not any(m in str(mode) for m in ("w", "a", "x")):
+            continue
+        if any(kw.arg == "encoding" for kw in node.keywords):
+            continue
+        target = getattr(node.args[0], "id", None) if node.args else None
+        if target in ("lit_path", "mol_path"):
+            offenders.append((rel, node.lineno, target))
+    assert not offenders, f"unencoded literature writes remain: {offenders}"
+
+
+def test_literature_writers_import_the_helper():
+    for rel in LITERATURE_IO_MODULES:
+        src = (Path(__file__).resolve().parents[1] / rel).read_text(
+            encoding="utf-8")
+        assert "from ...utils.text_io import" in src, rel


### PR DESCRIPTION
A Windows user ran a literature search, waited the full 13 minutes for it to come back, and got an error instead of results. The search itself had worked perfectly — the answer arrived intact. What failed was saving it to disk: the answer contained an arrow character (→), and on that machine SciLink was writing the file in an encoding that has no arrow in it. The write crashed, the completed answer was thrown away, and each retry paid the 13 minutes again for the same outcome.

This happens on Windows machines set to a Western European locale, and it affects any file where SciLink saves prose that came from a model — literature results, molecule design output, white papers, ideation reports, documents you upload. Scientific writing is full of characters that encoding cannot represent: subscripts (₂), arrows, Greek letters, ≥, the minus sign. Any one of them is enough. macOS and Linux were never affected, because their default is already the encoding SciLink needed all along.

The fix tells those files, explicitly, to save as UTF-8. Nothing changes on macOS or Linux — the files come out byte-for-byte identical, which the tests check directly. Files saved by an older version on an affected Windows machine still open fine.

Reported against 0.0.58 (current release); `main` was affected too.

---

**Technical details**

`open()`, `Path.write_text()` and `Path.read_text()` fall back to `locale.getpreferredencoding(False)` when no `encoding=` is passed — cp1252 on a Western European Windows install. The reported traceback:

```
File "...\scilink\agents\planning_agents\orchestrator_tools.py", line 1349, in search_literature
    f.write(content)
File "...\Lib\encodings\cp1252.py", line 19, in encode
UnicodeEncodeError: 'charmap' codec can't encode character '→' in position 2612
```

The failure lands *after* the Edison call returns, and the tool's broad `except Exception` (`orchestrator_tools.py:1799`) converts it into `{"status": "error"}` — so a completed multi-minute search is discarded rather than partially salvaged. Verbose logs confirm stdout was never the problem: every emoji `print()` in the same tool succeeded (real Windows console, UTF-16 path), which also means `PYTHONIOENCODING=utf-8` would not have helped — it governs only the standard streams, not `open()`. `PYTHONUTF8=1` is the only environment-side workaround that works, and it remains a valid stopgap for users on a released build.

**Changes**

New `scilink/utils/text_io.py` — `write_text_utf8(path, text, *, append=False)` and `read_text_utf8(path)`. The literature text path now routes through it:

| Site | File |
|---|---|
| `search_literature` result (the reported crash) | `planning_agents/orchestrator_tools.py:1761` |
| plan-embedded `literature_search.md` | `planning_agents/orchestrator_tools.py:2285` |
| `query_molecules` output | `planning_agents/orchestrator_tools.py:2007` |
| ideation report / white paper | `planning_agents/orchestrator_tools.py:633`, `:1156` |
| analysis-mode `search_literature` | `exp_agents/analysis_orchestrator_tools.py:3989` |
| Channel-B literature + refinement append | `exp_agents/analysis_orchestrator_tools.py:4140`, `:4173` |
| `read_document` provided-documents file | `exp_agents/analysis_orchestrator_tools.py:5693` |
| the 11 reads that load those files back | planning tools ×8, curve/image/hyperspectral agents ×3 |

**Two design points worth reviewing**

*Writes leave `newline` at the platform default.* Pinning `newline=""` would have switched Windows from CRLF to LF — a silent behaviour change in a bug fix. Only the codec is pinned, so output is byte-identical wherever the locale was already UTF-8; `test_byte_identical_to_the_bare_call_it_replaces` asserts this against the exact pre-fix call, across empty / ASCII / scientific / CRLF / no-trailing-newline inputs, for both truncate and append.

*Reads are tolerant, not strict.* A markdown file written by an earlier run on a cp1252 machine is not valid UTF-8 (an em dash is byte 0x97), so a strict UTF-8 read would newly fail on artifacts that used to load. `read_text_utf8` tries UTF-8, falls back to the locale encoding, then degrades to a lossy read, logging at each step down. The cp1252-host recovery rung is tested by monkeypatching `Path.read_text`, so the Windows behaviour is covered from any host.

**Not changed, deliberately**

JSON writes. `json.dump` defaults to `ensure_ascii=True` and `ensure_ascii` appears nowhere in the tree, so every checkpoint, campaign registry and deliverables manifest is pure ASCII and already cp1252-safe. That asymmetry is exactly why Windows sessions mostly work and only markdown writers explode.

The remaining ~219 unencoded write sites across the package are out of scope here; `text_io` is the landing place as they get migrated. The 25 `subprocess(..., text=True)` calls without `encoding=` are the same class of bug on the decode side (a generated script printing "CO₂" would break the parent on Windows) and want their own PR.

**Verification**

- 20 new tests in `tests/test_text_io_encoding.py`, including an AST guard that no unencoded literature write can reappear in either orchestrator tools module.
- Ran the pre-fix statement and the fix side by side under a forced non-UTF-8 locale (`LC_ALL=en_US.ISO8859-1`): the old line reproduces the reported failure on the same character (`'latin-1' codec can't encode character '→'`), the new one writes and round-trips correctly.
- 94 tests pass across the literature, ideation and planning-campaign suites, plus `test_literature_no_overwrite.py` 7/7 — which exercises the fixed writer directly (collision suffixing, content intact).
- Two pre-existing failures on `main` are unrelated and unchanged: `test_literature_no_overwrite.py` raises `SystemExit` at import so it breaks pytest collection (runs clean as a script), and `test_curve_fitting_orient_and_adapt.py` has 5 setup errors from a stale reference to a removed method. Both verified against `main` with the branch stashed.
