### PR TITLE
Move ion parameter guidance into the Planning section, and cover trivalent

### DIFF
--- a/scilink/skills/force_field/amber/amber.md
+++ b/scilink/skills/force_field/amber/amber.md
@@ -78,14 +78,23 @@ water model, and the right set depends on the ion's CHARGE.
 | Trivalent (Al3+, Fe3+, lanthanides) | Li-Merz **12-6-4** | 12-6 is worst here; charge-induced polarisation dominates |
 
 Decision rule: For monovalent ions use Joung-Cheatham matched to the water
-model. For divalent and trivalent cations use the Li-Merz **12-6-4** set
-whenever the research goal involves coordination number, hydration structure,
-ion-water distances, or binding free energies — the r^-4 term represents
-charge-induced dipole and is what lets one parameter set reproduce hydration
-free energy and coordination geometry simultaneously. A plain 12-6 set is
-acceptable only when the ion is a spectator (bulk neutralising counter-ions).
-Never leave a multivalent cation on a generic point-charge Lennard-Jones
-model when its coordination is what is being measured.
+model. For divalent and trivalent cations the Li-Merz **12-6-4** set is the
+physically right answer whenever the research goal involves coordination
+number, hydration structure, ion-water distances, or binding free energies —
+the r^-4 term represents charge-induced dipole and is what lets one parameter
+set reproduce hydration free energy and coordination geometry simultaneously.
+A plain 12-6 set is fine when the ion is a spectator (bulk neutralising
+counter-ions).
+
+**12-6-4 needs a C4 term this pipeline does not currently carry.** The AMBER
+to LAMMPS route here is `lj/charmm/coul/long` / `lj/cut/coul/long`, both 12-6
+forms, and the ParmEd conversion does not transport `LENNARD_JONES_CCOEF`.
+Selecting 12-6-4 where it cannot be implemented is worse than not selecting
+it: the run proceeds on plain 12-6 while carrying parameters fitted on the
+assumption that C4 is present. So when the workflow cannot implement C4,
+choose the 12-6 set fitted to the ION-OXYGEN DISTANCE rather than the
+HFE-fitted one — the goals above are structural — and record both the
+substitution and its consequence for the target observable in `cautions`.
 
 ### Charge method selection for small molecules
 

--- a/scilink/skills/force_field/amber/amber.md
+++ b/scilink/skills/force_field/amber/amber.md
@@ -19,8 +19,8 @@ convert to a LAMMPS data file that embeds all coefficients and charges.
 - Carbohydrates / glycans: GLYCAM06j-1
 - Small organic molecules, ligands, solvents: GAFF2 (preferred) or GAFF
 - Solvated systems with explicit water: TIP3P, SPC/E, OPC, TIP4P-Ew
-- Monovalent ions (Na+, K+, Cl-): Joung-Cheatham (auto-loaded with water model)
-- Divalent ions (Mg2+, Ca2+, Zn2+): 12-6 LJ sets from Aqvist or Li-Merz
+- Ions, monovalent through trivalent — see "Ion parameter selection" under
+  Planning
 
 ### When NOT to use AMBER
 
@@ -65,6 +65,27 @@ file is needed -- the read_data command loads everything.
 
 Decision rule: Use OPC with ff19SB. Use TIP3P with ff14SB. Avoid TIP4P
 in LAMMPS unless specifically needed (virtual site handling adds complexity).
+
+### Ion parameter selection
+
+Ion parameters are a separate choice from the biomolecular force field and the
+water model, and the right set depends on the ion's CHARGE.
+
+| Ion charge | Recommended set | Notes |
+|---|---|---|
+| Monovalent (Na+, K+, Li+, Cl-, Br-) | Joung-Cheatham | Auto-loaded with the water model; matched per water model |
+| Divalent (Mg2+, Ca2+, Zn2+, Cu2+, ...) | Li-Merz **12-6-4**, else Li-Merz/Aqvist 12-6 | A 12-6 set is fitted to EITHER the hydration free energy OR the ion-oxygen distance, not both |
+| Trivalent (Al3+, Fe3+, lanthanides) | Li-Merz **12-6-4** | 12-6 is worst here; charge-induced polarisation dominates |
+
+Decision rule: For monovalent ions use Joung-Cheatham matched to the water
+model. For divalent and trivalent cations use the Li-Merz **12-6-4** set
+whenever the research goal involves coordination number, hydration structure,
+ion-water distances, or binding free energies — the r^-4 term represents
+charge-induced dipole and is what lets one parameter set reproduce hydration
+free energy and coordination geometry simultaneously. A plain 12-6 set is
+acceptable only when the ion is a spectator (bulk neutralising counter-ions).
+Never leave a multivalent cation on a generic point-charge Lennard-Jones
+model when its coordination is what is being measured.
 
 ### Charge method selection for small molecules
 


### PR DESCRIPTION
The AMBER skill's ion guidance never reaches the decision it is meant to inform.

`_select_optimal_force_field()` injects `_get_skill_context(section="planning")`, and the ion bullets live under `## Overview`. Loading the skill shows it directly:

```
overview   1487 chars | Joung=True  Merz=True  Aqvist=True
planning   3608 chars | Joung=False Merz=False Aqvist=False
```

`_get_skill_context` returns the requested section or `""` — there's no fallback to overview. Ion selection is also the only *selection* decision filed under Overview: water-model and charge-method selection are already in Planning, each with a `Decision rule:`, and the agent handles both reliably (it picks SPC/E correctly every time).

## Measurement

Aqueous Ca²⁺, Zn²⁺ and Al³⁺, coordination-number goal, 3 runs each, `claude-opus-4-8`. Counting whether the answer names a real ion parameter set:

| arm | names a set | recommends 12-6-4 |
|---|---|---|
| no skill loaded | 1/9 | — |
| skill loaded, guidance in Overview | 4/9 | **0/9** |
| skill loaded, guidance in Planning (this PR) | **8/9** | **4/9** |

Loading the skill helps somewhat; moving the guidance into the injected section is what actually lands it, and is the only arm that produces a 12-6-4 recommendation at all.

Without it, answers are generic for systems where coordination number is the requested observable — "non-bonded ion model", "12-6 point-charge", "monovalent/divalent ion LJ parameters".

## Changes

Docs only, one file, 23 insertions.

- Ion guidance moves to Planning as its own subsection, in the same table + `Decision rule:` style as its neighbours. Overview keeps a one-line pointer.
- **Trivalent ions added.** The old text covered "Mg2+, Ca2+, Zn2+" only. Al³⁺ went 0/3 → 3/3, all three naming 12-6-4.
- The rule distinguishes when 12-6-4 matters — coordination number, hydration structure, binding free energies, where a 12-6 set can be fitted to the hydration free energy *or* the ion–oxygen distance but not both — from when plain 12-6 is fine (spectator counter-ions).

n=9 per arm is small, but the effect is large and the mechanism was verified directly rather than inferred.

## Separate, not addressed here

`_auto_select_skill()` runs *after* `_select_optimal_force_field()`, and 4 of 6 construction sites — including `simulation_pipeline.py:484` — never pass `skill=`. So on those paths no skill is loaded at all when the force field is chosen. That's a code change and a different discussion; happy to open it separately if useful.

Found while building force-field coverage for the benchmark suite, which had none.
