### PR TITLE
Make UTF-8 the process default so non-ASCII output stops crashing Windows

### DIFF
--- a/scilink/agents/exp_agents/_locked_exec.py
+++ b/scilink/agents/exp_agents/_locked_exec.py
@@ -96,7 +96,7 @@ def stage_and_run(executor, script, primary_array, item_dir, *,
         np.save(item_dir / name, arr)
     if metadata:
         try:
-            with open(item_dir / meta_name, "w") as _fh:
+            with open(item_dir / meta_name, "w", encoding="utf-8") as _fh:
                 json.dump(metadata, _fh, indent=2, default=str)
         except Exception:
             pass   # sidecar is best-effort; never block execution on it

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1578,7 +1578,7 @@ class AnalysisOrchestratorAgent:
                 "graduated_skill_sources": self._graduated_skill_sources,
             }
 
-            with open(self.checkpoint_path, 'w') as f:
+            with open(self.checkpoint_path, 'w', encoding="utf-8") as f:
                 json.dump(checkpoint_data, f, indent=2)
 
             print(f"    ✅ Auto-checkpoint saved")
@@ -1884,7 +1884,7 @@ class AnalysisOrchestratorAgent:
             # Collapse any multimodal (image-bearing) tool messages back to plain
             # strings so chat_history.json keeps its shape and carries no base64.
             history_data = sanitize_history_images(history_data)
-            with open(self.history_path, 'w') as f:
+            with open(self.history_path, 'w', encoding="utf-8") as f:
                 json.dump(history_data, f, indent=2)
         except Exception as e:
             logging.warning(f"Failed to save history: {e}")

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -1665,7 +1665,7 @@ class AnalysisOrchestratorTools:
                     if metadata:
                         cpi_warning = self._replace_metadata(metadata)
                         output_path = self.orch.base_dir / "metadata.json"
-                        with open(output_path, 'w') as f:
+                        with open(output_path, 'w', encoding="utf-8") as f:
                             json.dump(metadata, f, indent=2)
 
                         result = {
@@ -1692,7 +1692,7 @@ class AnalysisOrchestratorTools:
             elif text_input:
                 # Create temporary file and convert
                 temp_path = self.orch.base_dir / "temp_metadata_input.txt"
-                with open(temp_path, 'w') as f:
+                with open(temp_path, 'w', encoding="utf-8") as f:
                     f.write(text_input)
                 
                 try:
@@ -1709,7 +1709,7 @@ class AnalysisOrchestratorTools:
                     if metadata:
                         cpi_warning = self._replace_metadata(metadata)
                         output_path = self.orch.base_dir / "metadata.json"
-                        with open(output_path, 'w') as f:
+                        with open(output_path, 'w', encoding="utf-8") as f:
                             json.dump(metadata, f, indent=2)
 
                         result = {
@@ -1878,7 +1878,7 @@ class AnalysisOrchestratorTools:
 
                                     cpi_warning = self._replace_metadata(synthesized)
                                     output_path = self.orch.base_dir / "metadata.json"
-                                    with open(output_path, 'w') as f:
+                                    with open(output_path, 'w', encoding="utf-8") as f:
                                         json.dump(synthesized, f, indent=2)
                                     print(
                                         f"    Synthesized global metadata from "
@@ -2720,7 +2720,7 @@ class AnalysisOrchestratorTools:
 
                 # === Save metadata copy for traceability ===
                 metadata_copy_path = analysis_output_dir / "metadata_used.json"
-                with open(metadata_copy_path, 'w') as f:
+                with open(metadata_copy_path, 'w', encoding="utf-8") as f:
                     json.dump({
                         "analysis_id": analysis_id,
                         "data_path": data_path,
@@ -3521,7 +3521,7 @@ class AnalysisOrchestratorTools:
                     "graduated_skill_sources": self.orch._graduated_skill_sources,
                 }
 
-                with open(self.orch.checkpoint_path, 'w') as f:
+                with open(self.orch.checkpoint_path, 'w', encoding="utf-8") as f:
                     json.dump(checkpoint_data, f, indent=2)
 
                 return json.dumps({
@@ -3807,7 +3807,7 @@ class AnalysisOrchestratorTools:
                 r["series_variable"] = str(svar)
                 try:
                     (self.orch.results_dir / "reconciled_series_result.json").write_text(
-                        json.dumps(r, default=str))
+                        json.dumps(r, default=str), encoding="utf-8")
                 except Exception:
                     pass
                 # Attach the reconciled figure so the orchestrator LLM sees the
@@ -4218,7 +4218,7 @@ class AnalysisOrchestratorTools:
                         f"<div class='analysis-text'>{paras}</div>"
                         "<div class='footer'>Post-fit revision (feature-conditioned "
                         "literature); the original report is unchanged.</div>"
-                        "</div></body></html>")
+                        "</div></body></html>", encoding="utf-8")
                 except Exception as e:
                     logging.warning(f"Companion revision HTML failed: {e}")
                     report_html = None
@@ -4606,7 +4606,7 @@ class AnalysisOrchestratorTools:
             
             # 7. Save Results to file
             output_file = lit_output_dir / "novelty_report.json"
-            with open(output_file, "w") as f:
+            with open(output_file, "w", encoding="utf-8") as f:
                 json.dump({
                     "analysis_id": record.get("analysis_id"),
                     **novelty_assessment
@@ -4752,7 +4752,7 @@ class AnalysisOrchestratorTools:
             # 7. Persist sidecar JSON for parity with the standalone runner
             output_file = out_dir / "dft_recommendations.json"
             try:
-                with open(output_file, 'w') as f:
+                with open(output_file, 'w', encoding="utf-8") as f:
                     json.dump({
                         "reasoning": reasoning,
                         "recommendations": recommendations,
@@ -5153,7 +5153,7 @@ class AnalysisOrchestratorTools:
             knowledge_dir = self.orch.base_dir / "knowledge"
             knowledge_dir.mkdir(parents=True, exist_ok=True)
             knowledge_file = knowledge_dir / f"{entry['id']}.json"
-            with open(knowledge_file, 'w') as f:
+            with open(knowledge_file, 'w', encoding="utf-8") as f:
                 json.dump(entry, f, indent=2)
 
             response = {

--- a/scilink/agents/exp_agents/base_agent.py
+++ b/scilink/agents/exp_agents/base_agent.py
@@ -1260,7 +1260,7 @@ class BaseAnalysisAgent(LLMAgentMixin, ABC):
         """Persist state to disk."""
         state_file = self.output_dir / self._get_state_filename()
         try:
-            with open(state_file, 'w') as f:
+            with open(state_file, 'w', encoding="utf-8") as f:
                 json.dump(self.state, f, indent=2, default=str)
         except Exception as e:
             self.logger.warning(f"Failed to save {self.agent_type} state: {e}")

--- a/scilink/agents/exp_agents/controllers/base_controllers.py
+++ b/scilink/agents/exp_agents/controllers/base_controllers.py
@@ -58,12 +58,12 @@ class LiteratureSearchController:
             os.makedirs(lit_dir, exist_ok=True)
 
             query_path = os.path.join(lit_dir, "search_query.txt")
-            with open(query_path, "w") as f:
+            with open(query_path, "w", encoding="utf-8") as f:
                 f.write(query)
             saved_files["query_file"] = query_path
 
             report_path = os.path.join(lit_dir, "literature_report.md")
-            with open(report_path, "w") as f:
+            with open(report_path, "w", encoding="utf-8") as f:
                 f.write(report)
             saved_files["report_file"] = report_path
         except Exception as e:

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -2675,7 +2675,7 @@ def _write_series_fit_results(output_dir, state, series_results, quality_setting
         "results": serializable_results,
     }
     results_path = output_dir / "series_fit_results.json"
-    with open(results_path, "w") as f:
+    with open(results_path, "w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2, default=str)
     return str(results_path)
 
@@ -5395,7 +5395,7 @@ Return JSON with:
                             / CANDIDATES_DIR_NAME / f"cand_{attempt:02d}"
                         )
                         cdir.mkdir(parents=True, exist_ok=True)
-                        with open(cdir / "attempt_result.json", "w") as f:
+                        with open(cdir / "attempt_result.json", "w", encoding="utf-8") as f:
                             json.dump({
                                 "attempt": attempt,
                                 "score": candidates[-1]["score"],
@@ -6453,7 +6453,7 @@ Return JSON with:
                         r["deviation_sigma"] = flag_info.get("deviation_sigma")
                 
                 flagged_report_path = self.output_dir / "flagged_spectra.json"
-                with open(flagged_report_path, 'w') as f:
+                with open(flagged_report_path, 'w', encoding="utf-8") as f:
                     json.dump({
                         "timestamp": datetime.now().isoformat(),
                         "r2_threshold": self.r2_threshold,
@@ -7394,7 +7394,7 @@ Return JSON with:
             script = "import matplotlib\nmatplotlib.use('Agg')\n" + script
         
         script_path = self.output_dir / "trend_analysis.py"
-        with open(script_path, 'w') as f:
+        with open(script_path, 'w', encoding="utf-8") as f:
             f.write(script)
         result = self.executor.execute_script(script, working_dir=str(self.output_dir))
         return result.get("status") == "success", result.get("stdout", ""), result.get("message", "")

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -3027,7 +3027,7 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
             recs = state.get("dynamic_analysis_records") or []
             if recs:
                 _rec_path = Path(output_dir) / "dynamic_analysis_records.json"
-                _rec_path.write_text(json.dumps(recs, indent=1, default=str))
+                _rec_path.write_text(json.dumps(recs, indent=1, default=str), encoding="utf-8")
                 self.logger.info(
                     f"   📄 {len(recs)} per-target record(s) persisted: "
                     f"{_rec_path.name}")

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -4307,7 +4307,7 @@ Return JSON with:
                             / CANDIDATES_DIR_NAME / f"cand_{attempt:02d}"
                         )
                         cdir.mkdir(parents=True, exist_ok=True)
-                        with open(cdir / "attempt_result.json", "w") as f:
+                        with open(cdir / "attempt_result.json", "w", encoding="utf-8") as f:
                             json.dump({
                                 "attempt": attempt,
                                 "score": candidates[-1]["score"],
@@ -5622,7 +5622,7 @@ Return JSON: {{"change_type": "cosmetic" | "analytical" | "rewrite", \
                         r["flag_details"] = flag_info.get("details")
 
                 flagged_report_path = self.output_dir / "flagged_images.json"
-                with open(flagged_report_path, 'w') as f:
+                with open(flagged_report_path, 'w', encoding="utf-8") as f:
                     json.dump({
                         "timestamp": datetime.now().isoformat(),
                         "outlier_sigma": self.outlier_sigma,
@@ -5684,7 +5684,7 @@ Return JSON: {{"change_type": "cosmetic" | "analytical" | "rewrite", \
 
         # Save series results
         results_path = self.output_dir / "series_analysis_results.json"
-        with open(results_path, 'w') as f:
+        with open(results_path, 'w', encoding="utf-8") as f:
             serializable_results = []
             for r in series_results:
                 r_copy = {
@@ -6660,7 +6660,7 @@ Return JSON with:
             script = "import matplotlib\nmatplotlib.use('Agg')\n" + script
 
         script_path = self.output_dir / "trend_analysis.py"
-        with open(script_path, 'w') as f:
+        with open(script_path, 'w', encoding="utf-8") as f:
             f.write(script)
         result = self.executor.execute_script(
             script, working_dir=str(self.output_dir)

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -1041,7 +1041,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # dict (they were previously written before the hooks and silently
         # missing from the file).
         results_path = self.output_dir / "analysis_results.json"
-        with open(results_path, 'w') as f:
+        with open(results_path, 'w', encoding="utf-8") as f:
             serializable = self._make_serializable(final_results)
             json.dump(serializable, f, indent=2, default=str)
 

--- a/scilink/agents/exp_agents/feature_table.py
+++ b/scilink/agents/exp_agents/feature_table.py
@@ -187,7 +187,7 @@ def write_feature_table(output_dir) -> Optional[str]:
                 if key not in columns:
                     columns.append(key)
         dest = output_dir / "features.csv"
-        with open(dest, "w", newline="") as fh:
+        with open(dest, "w", newline="", encoding="utf-8") as fh:
             writer = csv.DictWriter(fh, fieldnames=columns)
             writer.writeheader()
             for row in rows:

--- a/scilink/agents/exp_agents/human_feedback.py
+++ b/scilink/agents/exp_agents/human_feedback.py
@@ -86,7 +86,7 @@ class SimpleFeedbackCollector:
             }
         }
         
-        with open(log_file, 'w') as f:
+        with open(log_file, 'w', encoding="utf-8") as f:
             json.dump(log_data, f, indent=2)
         
         self.logger.info(f"Feedback log saved: {log_file}")

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -572,7 +572,7 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 "extracted_features": feats,
             }
             path = self.output_dir / "analysis_results.json"
-            with open(path, "w") as fh:
+            with open(path, "w", encoding="utf-8") as fh:
                 json.dump(payload, fh, indent=2, default=str)
             self.logger.info(
                 f"   📄 Numeric features persisted for downstream fusion: "

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -740,7 +740,7 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
 
         # Save final merged results
         results_path = self.output_dir / "analysis_results.json"
-        with open(results_path, "w") as f:
+        with open(results_path, "w", encoding="utf-8") as f:
             serializable = self._make_serializable(final_results)
             json.dump(serializable, f, indent=2, default=str)
 

--- a/scilink/agents/exp_agents/preprocess.py
+++ b/scilink/agents/exp_agents/preprocess.py
@@ -480,7 +480,7 @@ class HyperspectralPreprocessingAgent(BaseUtilityAgent):
         final_script = script_bundle.get("final_script", "# No script was returned.")
         script_save_path = os.path.join(self.output_dir, "custom_preprocessing_script.py")
         try:
-            with open(script_save_path, "w") as f:
+            with open(script_save_path, "w", encoding="utf-8") as f:
                 f.write(f"# --- SciLink Auto-Generated Preprocessing Script ---\n")
                 f.write(f"# Original Instruction: {instruction}\n")
                 f.write(f"# --------------------------------------------------\n\n")
@@ -970,7 +970,7 @@ class CurvePreprocessingAgent(BaseUtilityAgent):
                 # Save the final script and return the good data
                 final_script = script_bundle.get("final_script", "# No script was returned.")
                 try:
-                    with open(script_save_path, "w") as f:
+                    with open(script_save_path, "w", encoding="utf-8") as f:
                         f.write(f"# --- SciLink Auto-Generated 1D Preprocessing Script ---\n")
                         f.write(f"# Original Instruction: {instruction}\n")
                         f.write(f"# Final Validation: {assessment['critique']}\n")

--- a/scilink/agents/lit_agents/novelty_scorer.py
+++ b/scilink/agents/lit_agents/novelty_scorer.py
@@ -446,7 +446,7 @@ def save_enhanced_novelty_results(assessment: Dict[str, Any], output_dir: str,
             }
         }
         
-        with open(output_path, 'w') as f:
+        with open(output_path, 'w', encoding="utf-8") as f:
             json.dump(enhanced_assessment, f, indent=2, default=str)
         
         logger.info(f"Enhanced novelty assessment saved to: {output_path}")

--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -1637,7 +1637,7 @@ def _run_fusion_codegen(orch, ok: List[dict], branch_numerics: Dict[str, Any],
         # same way; it is best-effort.)
         try:
             script_path.write_text(best_script, encoding="utf-8")
-            with open(numerics_path, "w") as fh:
+            with open(numerics_path, "w", encoding="utf-8") as fh:
                 json.dump(best["results"], fh, indent=2, default=str)
         except Exception as e:  # noqa: BLE001
             logger.warning(f"fusion codegen: could not restore artifacts: {e}")
@@ -2174,7 +2174,7 @@ def fuse_delegations(orch, indices: List[int], focus: Optional[str] = None) -> s
         "novelty": novelty,
     }
     try:
-        with open(report_path, "w") as fh:
+        with open(report_path, "w", encoding="utf-8") as fh:
             json.dump(fused, fh, indent=2, default=str)
     except Exception as e:  # noqa: BLE001
         logger.warning(f"could not write fusion report: {e}")

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1581,7 +1581,7 @@ class MetaOrchestratorAgent:
                     "knowledge_dir": str(self.knowledge_dir) if self.knowledge_dir else None,
                 }
                 tmp_path = self.checkpoint_path.with_suffix(".json.tmp")
-                with open(tmp_path, 'w') as f:
+                with open(tmp_path, 'w', encoding="utf-8") as f:
                     json.dump(checkpoint_data, f, indent=2, default=str)
                 os.replace(tmp_path, self.checkpoint_path)
             print(f"    ✅ Auto-checkpoint saved")
@@ -1670,7 +1670,7 @@ class MetaOrchestratorAgent:
         try:
             history_data = [m for m in self.messages if m["role"] != "system"]
             history_data = sanitize_history_images(history_data)
-            with open(self.history_path, 'w') as f:
+            with open(self.history_path, 'w', encoding="utf-8") as f:
                 json.dump(history_data, f, indent=2)
         except Exception as e:
             logging.warning(f"Failed to save history: {e}")

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -1226,7 +1226,7 @@ class MetaOrchestratorTools:
                     continue
                 scalars = {k: v for k, v in cond.items()
                            if isinstance(v, (int, float, str, bool))}
-                sidecar.write_text(json.dumps(scalars, indent=2))
+                sidecar.write_text(json.dumps(scalars, indent=2), encoding="utf-8")
                 written.append(str(sidecar))
             return json.dumps({
                 "status": "success" if written or skipped else "error",

--- a/scilink/agents/planning_agents/base_agent.py
+++ b/scilink/agents/planning_agents/base_agent.py
@@ -175,7 +175,7 @@ class BaseAgent(ABC):
         """
         state_file = self.output_dir / self._get_state_filename()
         try:
-            with open(state_file, 'w') as f:
+            with open(state_file, 'w', encoding="utf-8") as f:
                 json.dump(self.state, f, indent=2)
         except Exception as e:
             logging.warning(f"Failed to save {self.agent_type} state: {e}")

--- a/scilink/agents/planning_agents/bo_agent.py
+++ b/scilink/agents/planning_agents/bo_agent.py
@@ -238,7 +238,7 @@ class OptimizationAgent(BaseAgent):
     def _save_history(self, entry: Dict):
         history = self._load_history()
         history.append(entry)
-        with open(self.history_file, 'w') as f: json.dump(history, f, indent=2)
+        with open(self.history_file, 'w', encoding="utf-8") as f: json.dump(history, f, indent=2)
 
     def _validate_config(self, config: Dict, fidelity_declared: bool = False,
                          extra_surrogates: Optional[set] = None,
@@ -1166,7 +1166,7 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
         if is_retry:
             print(f"  - 🔄 Re-run detected (same {len(df)} data points). Replacing previous step.")
             history.pop()
-            with open(self.history_file, 'w') as f:
+            with open(self.history_file, 'w', encoding="utf-8") as f:
                 json.dump(history, f, indent=2)
 
         # Compute budget context

--- a/scilink/agents/planning_agents/diagram_agent.py
+++ b/scilink/agents/planning_agents/diagram_agent.py
@@ -240,7 +240,7 @@ class DiagramAgent(BaseAgent):
                     "error": "no valid render within attempt budget",
                     "attempts": attempts}
 
-        mmd_path.write_text(code)
+        mmd_path.write_text(code, encoding="utf-8")
         return {"status": "success", "png_path": str(png_path),
                 "mmd_path": str(mmd_path), "code": code,
                 "attempts": attempts, "qc_rounds": qc_rounds,

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -2275,7 +2275,7 @@ class OrchestratorTools:
 
                 # Save
                 output_path = self._output_dir() / "plan.json"
-                with open(output_path, 'w') as f:
+                with open(output_path, 'w', encoding="utf-8") as f:
                     json.dump(plan, f, indent=2)
 
                 # Persist external grounding that arrived without a literature
@@ -2757,7 +2757,7 @@ class OrchestratorTools:
                 
                 # Save
                 output_path = self._output_dir() / "plan.json"
-                with open(output_path, 'w') as f:
+                with open(output_path, 'w', encoding="utf-8") as f:
                     json.dump(updated_plan, f, indent=2)
                 
                 # Regenerate HTML
@@ -3060,7 +3060,7 @@ class OrchestratorTools:
 
                 # Save
                 output_path = self._output_dir() / "plan.json"
-                with open(output_path, 'w') as f:
+                with open(output_path, 'w', encoding="utf-8") as f:
                     json.dump(plan, f, indent=2)
 
                 # Generate HTML
@@ -3149,7 +3149,7 @@ class OrchestratorTools:
 
                 # Save
                 output_path = self._output_dir() / "plan.json"
-                with open(output_path, 'w') as f:
+                with open(output_path, 'w', encoding="utf-8") as f:
                     json.dump(plan, f, indent=2)
 
                 # Generate HTML
@@ -3227,7 +3227,7 @@ class OrchestratorTools:
                 
                 # Save
                 output_path = self._output_dir() / "plan_refined.json"
-                with open(output_path, 'w') as f:
+                with open(output_path, 'w', encoding="utf-8") as f:
                     json.dump(updated_plan, f, indent=2)
                 
                 # Regenerate HTML
@@ -3812,7 +3812,7 @@ class OrchestratorTools:
                     'hash': current_hash,
                     'timestamp': datetime.now().isoformat()
                 }
-                with open(self.orch.analyzed_files_path, 'w') as f:
+                with open(self.orch.analyzed_files_path, 'w', encoding="utf-8") as f:
                     json.dump(self.orch.analyzed_files, f, indent=2)
                 
                 df_final = pd.read_csv(self.orch.bo_data_path)
@@ -4187,7 +4187,7 @@ class OrchestratorTools:
                                 'row_count': 1, 'hash': current_hash,
                                 'timestamp': datetime.now().isoformat()
                             }
-                        with open(self.orch.analyzed_files_path, 'w') as f:
+                        with open(self.orch.analyzed_files_path, 'w', encoding="utf-8") as f:
                             json.dump(self.orch.analyzed_files, f, indent=2)
 
                         df_final = pd.read_csv(self.orch.bo_data_path)
@@ -4222,7 +4222,7 @@ class OrchestratorTools:
                     'hash': current_hash,
                     'timestamp': datetime.now().isoformat()
                 }
-            with open(self.orch.analyzed_files_path, 'w') as f:
+            with open(self.orch.analyzed_files_path, 'w', encoding="utf-8") as f:
                 json.dump(self.orch.analyzed_files, f, indent=2)
 
             df_final = pd.read_csv(self.orch.bo_data_path)
@@ -5430,7 +5430,7 @@ class OrchestratorTools:
             }
             
             try:
-                with open(checkpoint_path, 'w') as f:
+                with open(checkpoint_path, 'w', encoding="utf-8") as f:
                     json.dump(state, f, indent=2)
                 
                 print(f"    💾 Checkpoint saved: {checkpoint_path}")
@@ -6355,7 +6355,7 @@ class OrchestratorTools:
                     )
                     # Log raw response for debugging
                     raw_log_path = debug_dir / f"kq_dir_raw_{abs(hash(query)) % 10000:04d}_a{attempt}.txt"
-                    raw_log_path.write_text(response.text)
+                    raw_log_path.write_text(response.text, encoding="utf-8")
                     # LLM returns JSON: {"code": "...TODO lines..."}
                     result, parse_error = parse_json_from_response(response)
                     if parse_error or not result or "code" not in result:
@@ -6374,7 +6374,7 @@ class OrchestratorTools:
                     return json.dumps({"status": "error", "message": f"Code generation failed: {e}"})
 
                 script_path = scripts_dir / f"kq_dir_{Path(dir_path).name}_{abs(hash(query)) % 10000:04d}.py"
-                script_path.write_text(code)
+                script_path.write_text(code, encoding="utf-8")
                 print(f"    - Running: {script_path.name} (attempt {attempt + 1})")
 
                 try:
@@ -6527,7 +6527,7 @@ class OrchestratorTools:
 
                 # Write and execute script
                 script_path = scripts_dir / f"kq_{Path(target_path).stem}_{abs(hash(query)) % 10000:04d}.py"
-                script_path.write_text(code)
+                script_path.write_text(code, encoding="utf-8")
                 print(f"    - Running: {script_path.name} (attempt {attempt + 1})")
 
                 try:
@@ -6753,7 +6753,7 @@ class OrchestratorTools:
                         [current_prompt],
                         generation_config={"temperature": 0.0},
                     )
-                    (debug_dir / f"screen_{safe_name}_{hash_str}_a{attempt}.txt").write_text(response.text)
+                    (debug_dir / f"screen_{safe_name}_{hash_str}_a{attempt}.txt").write_text(response.text, encoding="utf-8")
                     parsed, parse_error = parse_json_from_response(response)
                     if parse_error or not parsed or "code" not in parsed:
                         body = _extract_code_block(response.text) or response.text.strip()
@@ -6786,7 +6786,7 @@ class OrchestratorTools:
                 except Exception as e:
                     return json.dumps({"status": "error", "message": f"Codegen failed: {e}"})
 
-                script_path.write_text(code)
+                script_path.write_text(code, encoding="utf-8")
                 print(f"    - Running: {script_path.name} (attempt {attempt + 1}/{max_retries})")
 
                 try:
@@ -6826,7 +6826,7 @@ class OrchestratorTools:
                         "script_path": str(script_path),
                         "attempts_used": attempt + 1,
                     }
-                    result_path.write_text(json.dumps(full, indent=2, default=str))
+                    result_path.write_text(json.dumps(full, indent=2, default=str), encoding="utf-8")
                     print(
                         f"    - ✅ Screened: {full['n_passed']} of {full['n_scanned']} "
                         f"passed; saved {result_path.name}"
@@ -7002,7 +7002,7 @@ class OrchestratorTools:
             knowledge_dir = self.orch.base_dir / "knowledge"
             knowledge_dir.mkdir(parents=True, exist_ok=True)
             knowledge_file = knowledge_dir / f"{entry['id']}.json"
-            with open(knowledge_file, 'w') as f:
+            with open(knowledge_file, 'w', encoding="utf-8") as f:
                 json.dump(entry, f, indent=2)
 
             response = {
@@ -7541,7 +7541,7 @@ class OrchestratorTools:
                         while bak.exists():
                             n += 1
                             bak = d / f"{rp.stem}.before_revision{n}{rp.suffix}"
-                        bak.write_text(current or "")
+                        bak.write_text(current or "", encoding="utf-8")
                         # Listed (not starred) so the replaced version shows
                         # up in the files block rather than only on disk.
                         # Under the meta this is the delegation slug; in a
@@ -7582,7 +7582,7 @@ class OrchestratorTools:
                 if not revise_path:
                     text = self._maybe_embed_workflow_diagram(
                         text, out.parent, stem=f"{out.stem}_workflow")
-                out.write_text(text)
+                out.write_text(text, encoding="utf-8")
                 # A revised document's exported PDF twin (the white paper's
                 # forwarded copy) must not keep serving the pre-revision
                 # content; re-export is deterministic, so it does not touch

--- a/scilink/agents/planning_agents/planning_agent.py
+++ b/scilink/agents/planning_agents/planning_agent.py
@@ -471,7 +471,7 @@ class PlanningAgent(BaseAgent):
             logging.warning(f"Literature compaction skipped: {e}")
             payload = self.state
         try:
-            with open(state_file, 'w') as f:
+            with open(state_file, 'w', encoding="utf-8") as f:
                 json.dump(payload, f, indent=2)
         except Exception as e:
             logging.warning(f"Failed to save {self.agent_type} state: {e}")

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -1556,7 +1556,7 @@ class PlanningOrchestratorAgent:
                 "custom_skills": self._custom_skills,
             }
             
-            with open(self.checkpoint_path, 'w') as f:
+            with open(self.checkpoint_path, 'w', encoding="utf-8") as f:
                 json.dump(checkpoint_data, f, indent=2)
             
             print(f"    ✅ Auto-checkpoint saved")
@@ -1890,7 +1890,7 @@ class PlanningOrchestratorAgent:
             # Filter out system messages for saved history
             history_data = [m for m in self.messages if m["role"] != "system"]
             
-            with open(self.history_path, 'w') as f: 
+            with open(self.history_path, 'w', encoding="utf-8") as f: 
                 json.dump(history_data, f, indent=2)
                 
         except Exception as e:

--- a/scilink/agents/planning_agents/user_interface.py
+++ b/scilink/agents/planning_agents/user_interface.py
@@ -38,7 +38,7 @@ def record_deliverable(base_dir: Any, path: Any, title: str = "",
                  "deliverable": bool(deliverable)}
         entries = [e for e in entries if e.get("path") != entry["path"]]
         entries.append(entry)
-        manifest.write_text(json.dumps(entries, indent=2))
+        manifest.write_text(json.dumps(entries, indent=2), encoding="utf-8")
     except Exception:  # noqa: BLE001 - bookkeeping must never break a tool
         pass
 

--- a/scilink/agents/sim_agents/_ase_runner.py
+++ b/scilink/agents/sim_agents/_ase_runner.py
@@ -243,6 +243,6 @@ if __name__ == "__main__":
     content = (header + body).replace("{script}", script_name)
     os.makedirs(working_dir, exist_ok=True)
     path = os.path.join(working_dir, script_name)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write(content)
     return path

--- a/scilink/agents/sim_agents/_engine_inputs.py
+++ b/scilink/agents/sim_agents/_engine_inputs.py
@@ -191,7 +191,7 @@ def _orthogonalize_zero_tilt(data_file: str) -> None:
                 pass
         out.append(ln)
     if changed:
-        with open(data_file, "w") as fh:
+        with open(data_file, "w", encoding="utf-8") as fh:
             fh.writelines(out)
 
 

--- a/scilink/agents/sim_agents/base_agent.py
+++ b/scilink/agents/sim_agents/base_agent.py
@@ -317,7 +317,7 @@ class SimulationAgent(ABC):
             "Return ONLY the file. No markdown."
         )
         updated = self._clean_output(self._generate_text(prompt))
-        script_path.write_text(updated)
+        script_path.write_text(updated, encoding="utf-8")
         self.logger.info(f"Refined: {script_path}")
         return {
             "script_path": str(script_path),
@@ -350,7 +350,7 @@ class SimulationAgent(ABC):
             "Return ONLY the file. No markdown."
         )
         fixed = self._clean_output(self._generate_text(prompt))
-        script_path.write_text(fixed)
+        script_path.write_text(fixed, encoding="utf-8")
         self.logger.info(f"Fixed: {script_path}")
         return {
             "script_path": str(script_path),

--- a/scilink/agents/sim_agents/base_analysis_agent.py
+++ b/scilink/agents/sim_agents/base_analysis_agent.py
@@ -281,7 +281,7 @@ class BaseAnalysisAgent(ABC):
         exec_result = self.executor.execute_script(
             script_content=code, working_dir=str(self.output_dir))
         if exec_result.get("status") == "success":
-            (self.output_dir / f"{slug}.py").write_text(code)
+            (self.output_dir / f"{slug}.py").write_text(code, encoding="utf-8")
             parsed = self._extract_json(exec_result.get("stdout", ""))
             if parsed is not None:
                 # The script RAN and returned its JSON answer — whether it reports

--- a/scilink/agents/sim_agents/cluster_executor.py
+++ b/scilink/agents/sim_agents/cluster_executor.py
@@ -192,7 +192,7 @@ class ClusterExecutor(Executor):
         # Materialize inputs locally too — gives the local snapshot the inputs
         # and serves as the upload source.
         for name, contents in (input_files or {}).items():
-            (run_path / name).write_text(contents)
+            (run_path / name).write_text(contents, encoding="utf-8")
 
         self._ensure_connected()
         sched = self._resolve_scheduler()
@@ -207,7 +207,7 @@ class ClusterExecutor(Executor):
             resources=self.resources, setup=self.setup,
             stdout_file=_STDOUT, stderr_file=_STDERR, rc_file=_RC,
         )
-        (run_path / self.job_script_name).write_text(script)
+        (run_path / self.job_script_name).write_text(script, encoding="utf-8")
         self.conn.upload(
             str(run_path / self.job_script_name),
             f"{remote_dir}/{self.job_script_name}",
@@ -216,8 +216,8 @@ class ClusterExecutor(Executor):
         try:
             job_id = sched.submit(self.job_script_name, work_dir=remote_dir)
         except Exception as exc:  # noqa: BLE001 — surface as an executor error
-            (run_path / _STDERR).write_text(f"Job submission failed: {exc}")
-            (run_path / _RC).write_text("submit_error")
+            (run_path / _STDERR).write_text(f"Job submission failed: {exc}", encoding="utf-8")
+            (run_path / _RC).write_text("submit_error", encoding="utf-8")
             return {
                 "status": "error", "output_dir": str(run_path),
                 "returncode": None, "error": f"Job submission failed: {exc}",
@@ -233,9 +233,9 @@ class ClusterExecutor(Executor):
                 sched.cancel(job_id)
                 self._download_outputs(remote_dir, run_path)
                 (run_path / _STDERR).write_text(
-                    f"Job {job_id} exceeded {self.timeout}s wall-clock; cancelled."
+                    f"Job {job_id} exceeded {self.timeout}s wall-clock; cancelled.", encoding="utf-8"
                 )
-                (run_path / _RC).write_text("timeout")
+                (run_path / _RC).write_text("timeout", encoding="utf-8")
                 return {
                     "status": "error", "output_dir": str(run_path),
                     "returncode": None,

--- a/scilink/agents/sim_agents/force_field_agent.py
+++ b/scilink/agents/sim_agents/force_field_agent.py
@@ -511,7 +511,7 @@ class ForceFieldAgent:
                 k: v for k, v in result.items()
                 if isinstance(v, (str, int, float, bool, list, dict, type(None)))
             }
-            with open(summary_file, "w") as f:
+            with open(summary_file, "w", encoding="utf-8") as f:
                 json.dump(serializable, f, indent=2)
         except Exception as e:
             self.logger.warning(f"Could not save pipeline summary: {e}")
@@ -954,7 +954,7 @@ Provide a brief summary of what the results mean and any actions needed.
         inpcrd = os.path.join(self.working_dir, "system.inpcrd")
         lines += ["check SYS", f"saveamberparm SYS {prmtop} {inpcrd}", "quit"]
         script_path = os.path.join(self.working_dir, "system_tleap.in")
-        with open(script_path, "w") as f:
+        with open(script_path, "w", encoding="utf-8") as f:
             f.write("\n".join(lines) + "\n")
         return script_path
 
@@ -1120,7 +1120,7 @@ Provide a brief summary of what the results mean and any actions needed.
         }
 
         selection_file = os.path.join(self.working_dir, "force_field_selection.json")
-        with open(selection_file, 'w') as f:
+        with open(selection_file, 'w', encoding="utf-8") as f:
             json.dump(result, f, indent=2)
 
         return result
@@ -1253,7 +1253,7 @@ Provide a brief summary of what the results mean and any actions needed.
 
         param_file = os.path.join(self.working_dir, "parameter_info.json")
         try:
-            with open(param_file, 'w') as f:
+            with open(param_file, 'w', encoding="utf-8") as f:
                 serializable_params = {
                     k: v for k, v in params.items()
                     if k not in ["raw_data", "quantum_results"]
@@ -1339,7 +1339,7 @@ Provide a brief summary of what the results mean and any actions needed.
             header = parameter_info.get("input_header", "")
             if header:
                 header_file = os.path.join(self.working_dir, "ff_params.lammps")
-                with open(header_file, 'w') as f:
+                with open(header_file, 'w', encoding="utf-8") as f:
                     f.write(header)
                 return {"main": header_file}
             # Fall through to LLM-based generation if header is missing
@@ -1351,7 +1351,7 @@ Provide a brief summary of what the results mean and any actions needed.
 
         files = {}
         param_file = os.path.join(self.working_dir, "ff_params.lammps")
-        with open(param_file, 'w') as f:
+        with open(param_file, 'w', encoding="utf-8") as f:
             f.write(param_content["main"])
         files["main"] = param_file
 
@@ -1359,7 +1359,7 @@ Provide a brief summary of what the results mean and any actions needed.
             for name, content in param_content["additional"].items():
                 if content:
                     add_file = os.path.join(self.working_dir, f"{name}.lammps")
-                    with open(add_file, 'w') as f:
+                    with open(add_file, 'w', encoding="utf-8") as f:
                         f.write(content)
                     files[name] = add_file
 
@@ -2439,7 +2439,7 @@ Include only the JSON response with no additional text.
             charge_assignments=charge_assignments, data_info=data_info
         )
         charge_info_file = os.path.join(self.working_dir, "charge_assignments.json")
-        with open(charge_info_file, 'w') as f:
+        with open(charge_info_file, 'w', encoding="utf-8") as f:
             json.dump({
                 "charge_assignments": charge_assignments,
                 "validation": validation,
@@ -3193,7 +3193,7 @@ Return JSON mapping type ID to charge:
                     except (ValueError, IndexError):
                         pass
             new_lines.append(line)
-        with open(output_file, 'w') as f:
+        with open(output_file, 'w', encoding="utf-8") as f:
             f.writelines(new_lines)
         self.logger.info(f"Wrote data file with charges: {output_file} ({charges_written} atoms)")
         if charges_written == 0:
@@ -3443,7 +3443,7 @@ Return JSON mapping type ID to charge:
                     except (ValueError, IndexError):
                         pass
             new_lines.append(line); i += 1
-        with open(output_file, 'w') as f:
+        with open(output_file, 'w', encoding="utf-8") as f:
             f.writelines(new_lines)
         self.logger.info(f"Split {len(new_type_info)} atom types, total now: {new_type_counter}")
         return output_file
@@ -3546,7 +3546,7 @@ Return JSON:
             if corrected_ff and corrected_ff.strip() != current_ff.strip():
                 backup_path = ff_params_path + f".before_quality_{stage}"
                 shutil.copy2(ff_params_path, backup_path)
-                with open(ff_params_path, 'w') as f:
+                with open(ff_params_path, 'w', encoding="utf-8") as f:
                     f.write(corrected_ff)
                 changes = result.get("changes", [])
                 return True, {"summary": f"{len(changes)} parameter changes: {diagnosis[:80]}", "diagnosis": diagnosis, "changes": changes, "backup": backup_path}
@@ -3620,7 +3620,7 @@ Return JSON:
             shutil.copy2(data_file, backup_path)
             self._write_data_file_with_charges(data_file, data_file, int_charges, data_info)
             new_validation = self._validate_charge_assignments(int_charges, data_info)
-            with open(charge_file, 'w') as f:
+            with open(charge_file, 'w', encoding="utf-8") as f:
                 json.dump({
                     "charge_assignments": {str(k): v for k, v in int_charges.items()},
                     "validation": new_validation,

--- a/scilink/agents/sim_agents/lammps_analysis.py
+++ b/scilink/agents/sim_agents/lammps_analysis.py
@@ -259,7 +259,7 @@ class LAMMPSAnalysisAgent:
     
                     # Save code
                     code_path = self.output_dir / f"quality_check_{check_name}.py"
-                    with open(code_path, 'w') as f:
+                    with open(code_path, 'w', encoding="utf-8") as f:
                         f.write(code)
     
                     # Execute
@@ -306,7 +306,7 @@ class LAMMPSAnalysisAgent:
     
             # Save assessment
             assessment_path = self.output_dir / f"quality_assessment_{stage}.json"
-            with open(assessment_path, 'w') as f:
+            with open(assessment_path, 'w', encoding="utf-8") as f:
                 json.dump(assessment, f, indent=2, default=str)
     
             self.logger.info(f"Quality assessment: {assessment.get('status', 'unknown')}")
@@ -410,7 +410,7 @@ class LAMMPSAnalysisAgent:
     
                     # Save code
                     code_path = self.output_dir / f"analysis_{name}.py"
-                    with open(code_path, 'w') as f:
+                    with open(code_path, 'w', encoding="utf-8") as f:
                         f.write(code)
     
                     # Execute
@@ -1179,7 +1179,7 @@ Return ONLY JSON.
             html_content = html_content.strip()
             
             # Save report
-            with open(report_path, 'w') as f:
+            with open(report_path, 'w', encoding="utf-8") as f:
                 f.write(html_content)
             
             self.logger.info(f"HTML report generated: {report_path}")
@@ -1205,7 +1205,7 @@ Return ONLY JSON.
             
             # Fallback HTML report
             fallback_html = self._generate_fallback_report(research_goal, results, figures)
-            with open(report_path, 'w') as f:
+            with open(report_path, 'w', encoding="utf-8") as f:
                 f.write(fallback_html)
             
             return str(report_path)
@@ -1412,7 +1412,7 @@ Return ONLY JSON.
         
         # Save Dockerfile
         dockerfile_path = self.output_dir / "Dockerfile.analysis"
-        with open(dockerfile_path, 'w') as f:
+        with open(dockerfile_path, 'w', encoding="utf-8") as f:
             f.write(dockerfile_content)
         
         self.logger.info(f"Custom Dockerfile generated: {dockerfile_path}")
@@ -1458,7 +1458,7 @@ Return ONLY JSON.
         build_script_content = '\n'.join(script_lines)
         
         script_path = self.output_dir / "build_scilink_analysis.sbatch"
-        with open(script_path, 'w') as f:
+        with open(script_path, 'w', encoding="utf-8") as f:
             f.write(build_script_content)
         
         os.chmod(script_path, 0o755)
@@ -1605,7 +1605,7 @@ Return ONLY JSON.
         try:
             # Save code to file
             code_path = self.output_dir / f"{analysis_name}.py"
-            with open(code_path, 'w') as f:
+            with open(code_path, 'w', encoding="utf-8") as f:
                 f.write(code)
             
             # Execute using ScriptExecutor
@@ -1773,7 +1773,7 @@ Return ONLY JSON.
                 if corrected_code and corrected_code.strip() != code.strip():
                     # Save refined code
                     refined_path = self.output_dir / f"{analysis_name}_refined_{attempt}.py"
-                    with open(refined_path, 'w') as f:
+                    with open(refined_path, 'w', encoding="utf-8") as f:
                         f.write(corrected_code)
     
                     # Execute refined code

--- a/scilink/agents/sim_agents/lammps_orchestrator.py
+++ b/scilink/agents/sim_agents/lammps_orchestrator.py
@@ -240,7 +240,7 @@ class LAMMPSOrchestrator:
                     
                     # Save error details for this attempt
                     error_log_path = self.working_dir / f"error_details_{stage_name}_attempt{attempt}.txt"
-                    with open(error_log_path, 'w') as f:
+                    with open(error_log_path, 'w', encoding="utf-8") as f:
                         f.write(f"Stage: {stage_name}\n")
                         f.write(f"Attempt: {attempt}\n")
                         f.write(f"Script: {stage_script_path}\n")
@@ -572,7 +572,7 @@ class LAMMPSOrchestrator:
             
             # Create comprehensive error log for the updater
             combined_log = self.working_dir / "log_for_correction.lammps"
-            with open(combined_log, 'w') as f:
+            with open(combined_log, 'w', encoding="utf-8") as f:
                 f.write(log_content)
                 if stderr_content:
                     f.write("\n\n# === STDERR FROM LAMMPS EXECUTION ===\n")
@@ -702,7 +702,7 @@ class LAMMPSOrchestrator:
             # SAVE ANALYSIS TO FILE
             # ============================================================
             analysis_path = self.working_dir / f"error_analysis_{Path(script_path).stem}.json"
-            with open(analysis_path, 'w') as f:
+            with open(analysis_path, 'w', encoding="utf-8") as f:
                 json.dump(analysis, f, indent=2)
             print(f"     💾 Analysis saved: {analysis_path.name}")
             
@@ -762,7 +762,7 @@ class LAMMPSOrchestrator:
             attempt_num = len(list(self.working_dir.glob(f"{base_name}_corrected_*.lammps"))) + 1
             new_script_path = self.working_dir / f"{base_name}_corrected_{attempt_num}.lammps"
             
-            with open(new_script_path, 'w') as f:
+            with open(new_script_path, 'w', encoding="utf-8") as f:
                 f.write(corrected_script)
             
             correction_info = {
@@ -971,7 +971,7 @@ class LAMMPSOrchestrator:
                 attempt_num = len(list(self.working_dir.glob(f"{base_name}_quality_*.lammps"))) + 1
                 new_script_path = self.working_dir / f"{base_name}_quality_{attempt_num}.lammps"
                 
-                with open(new_script_path, 'w') as f:
+                with open(new_script_path, 'w', encoding="utf-8") as f:
                     f.write(corrected_script)
                 
                 corrections_made.append(("script", {"new_script": str(new_script_path)}))
@@ -1078,7 +1078,7 @@ class LAMMPSOrchestrator:
         """
         report_path = self.working_dir / "simulation_orchestration_report.md"
         
-        with open(report_path, 'w') as f:
+        with open(report_path, 'w', encoding="utf-8") as f:
             f.write("# Supervised Simulation Report\n\n")
             f.write(f"**Working Directory:** `{self.working_dir}`\n\n")
             

--- a/scilink/agents/sim_agents/lammps_utils.py
+++ b/scilink/agents/sim_agents/lammps_utils.py
@@ -278,7 +278,7 @@ $all delete
 exit
 '''
 
-        with open(script_path, 'w') as f:
+        with open(script_path, 'w', encoding="utf-8") as f:
             f.write(script_content)
         
         return script_path
@@ -454,7 +454,7 @@ exit
             )
         
         # Step 5: Write fixed data file
-        with open(data_file, 'w') as f:
+        with open(data_file, 'w', encoding="utf-8") as f:
             f.writelines(new_lines)
         
         self.logger.info(f"Wrote fixed data file: {data_file}")
@@ -492,7 +492,7 @@ $all delete
 exit
 '''
         
-        with open(script_path, 'w') as f:
+        with open(script_path, 'w', encoding="utf-8") as f:
             f.write(script_content)
             
         self._run_vmd_script(script_path)
@@ -534,7 +534,7 @@ exit
         with open(input_pdb, 'r') as f_in:
             content = f_in.readlines()
             
-        with open(output_pdb, 'w') as f_out:
+        with open(output_pdb, 'w', encoding="utf-8") as f_out:
             f_out.write(cryst_line)
             f_out.writelines(content)
             

--- a/scilink/agents/sim_agents/md_simulation_agent.py
+++ b/scilink/agents/sim_agents/md_simulation_agent.py
@@ -388,14 +388,14 @@ class MDSimulationAgent(SimulationAgent):
             )
 
         script_path = self.working_dir / "run.lammps"
-        script_path.write_text(script)
+        script_path.write_text(script, encoding="utf-8")
 
         validation = self._validate(str(script_path), system_info, plan)
 
         if not validation.get("valid", True) and validation.get("errors"):
             self.logger.warning("Validation failed, fixing...")
             script = self._attempt_fix(script, validation["errors"], plan)
-            script_path.write_text(script)
+            script_path.write_text(script, encoding="utf-8")
             validation = self._validate(str(script_path), system_info, plan)
 
         readme = self._generate_readme(
@@ -727,7 +727,7 @@ class MDSimulationAgent(SimulationAgent):
                     "Analysis realizability: %s (no resolution)", c.message)
                 return script, info
             res = self.tools_module.split_shared_types(**c.resolution["kwargs"])
-            with open(structure_file, "w") as fh:
+            with open(structure_file, "w", encoding="utf-8") as fh:
                 fh.write(res["data_file_text"])
             self.logger.info(
                 "Analysis realizability: split shared types so %s are distinct",
@@ -816,7 +816,7 @@ class MDSimulationAgent(SimulationAgent):
         # Validate a representative member (the placeholder is already resolved).
         rep_files = stages[0]["members"][0]["input_files"]
         rep_path = self.working_dir / entry
-        rep_path.write_text(rep_files[entry])
+        rep_path.write_text(rep_files[entry], encoding="utf-8")
         validation = self._validate(str(rep_path), info, plan)
         readme = self._generate_readme(goal, desc, info, plan, str(rep_path))
 
@@ -923,7 +923,7 @@ class MDSimulationAgent(SimulationAgent):
             content = self._clean_and_fix(content, plan)
             entry = f"run_{name}.lammps"
             path = self.working_dir / entry
-            path.write_text(content)
+            path.write_text(content, encoding="utf-8")
             stage_scripts[name] = str(path)
             steps.append({"name": name, "entry_file": entry, "script": content})
 
@@ -1000,7 +1000,7 @@ class MDSimulationAgent(SimulationAgent):
 
     def _generate_readme(self, goal, desc, info, plan, script_path):
         p = self.working_dir / "README.md"
-        with open(p, "w") as f:
+        with open(p, "w", encoding="utf-8") as f:
             f.write(f"# MD Simulation: {desc}\n\n")
             f.write(f"**Skill**: {self.skill_name or 'none'}\n\n")
             f.write(f"## Goal\n{goal}\n\n")

--- a/scilink/agents/sim_agents/mlip_agent.py
+++ b/scilink/agents/sim_agents/mlip_agent.py
@@ -406,7 +406,7 @@ Return JSON:
             **run,        # run_path, runner, task, notes, ...
         }
 
-        with open(os.path.join(self.working_dir, "deployment.json"), "w") as f:
+        with open(os.path.join(self.working_dir, "deployment.json"), "w", encoding="utf-8") as f:
             json.dump(
                 {k: v for k, v in result.items()
                  if isinstance(v, (str, int, float, bool, list, dict, type(None)))},
@@ -562,7 +562,7 @@ Return JSON:
 
         # Save
         report_file = os.path.join(self.working_dir, "quality_report.json")
-        with open(report_file, "w") as f:
+        with open(report_file, "w", encoding="utf-8") as f:
             json.dump(result, f, indent=2, default=str)
 
         return result
@@ -1158,7 +1158,7 @@ Return JSON:
         }
 
         # Save
-        with open(os.path.join(self.working_dir, "finetune_result.json"), "w") as f:
+        with open(os.path.join(self.working_dir, "finetune_result.json"), "w", encoding="utf-8") as f:
             json.dump(
                 {k: v for k, v in result.items()
                  if isinstance(v, (str, int, float, bool, list, dict, type(None)))},

--- a/scilink/agents/sim_agents/molecular_qc_agent.py
+++ b/scilink/agents/sim_agents/molecular_qc_agent.py
@@ -373,7 +373,7 @@ class MolecularQCAgent:
         try:
             for filename, content in input_files.items():
                 path = os.path.join(output_dir, filename)
-                with open(path, 'w') as f:
+                with open(path, 'w', encoding="utf-8") as f:
                     f.write(content)
                 saved[filename] = path
             return saved

--- a/scilink/agents/sim_agents/packmol_agent.py
+++ b/scilink/agents/sim_agents/packmol_agent.py
@@ -445,7 +445,7 @@ class PackmolGeneratorAgent:
                 final_script = script_content.format(output_filename=output_filename)
                 
                 script_path = os.path.join(self.working_dir, "input.inp")
-                with open(script_path, "w") as f:
+                with open(script_path, "w", encoding="utf-8") as f:
                     f.write(final_script)
                 
                 self.logger.info(f"PACKMOL script written to: {script_path}")

--- a/scilink/agents/sim_agents/periodic_dft_agent.py
+++ b/scilink/agents/sim_agents/periodic_dft_agent.py
@@ -468,7 +468,7 @@ class PeriodicDFTAgent:
         try:
             for filename, content in input_files.items():
                 path = os.path.join(output_dir, filename)
-                with open(path, 'w') as f:
+                with open(path, 'w', encoding="utf-8") as f:
                     f.write(content)
                 saved[filename] = path
             return saved
@@ -619,7 +619,7 @@ class PeriodicDFTAgent:
         improved_paths = {}
         for filename, content in result["input_files"].items():
             path = os.path.join(output_dir, f"{filename}_improved")
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding="utf-8") as f:
                 f.write(content)
             improved_paths[filename] = path
 

--- a/scilink/agents/sim_agents/reference_measurement.py
+++ b/scilink/agents/sim_agents/reference_measurement.py
@@ -83,7 +83,7 @@ def _pack_pure_box(smiles: str, n_molecules: int, init_density: float,
             f"tolerance 2.0\nseed 12345\nfiletype xyz\noutput {packed}\n"
             f"structure {single}\n  number {n_molecules}\n"
             f"  inside box 1. 1. 1. {L - 1:.3f} {L - 1:.3f} {L - 1:.3f}\n"
-            "end structure\n"
+            "end structure\n", encoding="utf-8"
         )
         with open(inp) as fh:
             subprocess.run(["packmol"], stdin=fh, cwd=str(work), check=True,

--- a/scilink/agents/sim_agents/refinement.py
+++ b/scilink/agents/sim_agents/refinement.py
@@ -226,7 +226,7 @@ class LocalExecutor(Executor):
         run_path.mkdir(parents=True, exist_ok=True)
 
         for name, contents in (input_files or {}).items():
-            (run_path / name).write_text(contents)
+            (run_path / name).write_text(contents, encoding="utf-8")
 
         logger.info("LocalExecutor: running %r in %s", run_command, run_dir)
         try:
@@ -240,9 +240,9 @@ class LocalExecutor(Executor):
             )
         except subprocess.TimeoutExpired as e:
             (run_path / self.STDERR_FILE).write_text(
-                f"Timed out after {self.timeout}s\n{e}"
+                f"Timed out after {self.timeout}s\n{e}", encoding="utf-8"
             )
-            (run_path / self.RETURNCODE_FILE).write_text("timeout")
+            (run_path / self.RETURNCODE_FILE).write_text("timeout", encoding="utf-8")
             return {
                 "status": "error",
                 "output_dir": str(run_path),
@@ -250,8 +250,8 @@ class LocalExecutor(Executor):
                 "error": f"Run timed out after {self.timeout}s",
             }
         except (OSError, FileNotFoundError) as e:
-            (run_path / self.STDERR_FILE).write_text(str(e))
-            (run_path / self.RETURNCODE_FILE).write_text("launch_error")
+            (run_path / self.STDERR_FILE).write_text(str(e), encoding="utf-8")
+            (run_path / self.RETURNCODE_FILE).write_text("launch_error", encoding="utf-8")
             return {
                 "status": "error",
                 "output_dir": str(run_path),
@@ -259,9 +259,9 @@ class LocalExecutor(Executor):
                 "error": f"Could not launch run command: {e}",
             }
 
-        (run_path / self.STDOUT_FILE).write_text(proc.stdout or "")
-        (run_path / self.STDERR_FILE).write_text(proc.stderr or "")
-        (run_path / self.RETURNCODE_FILE).write_text(str(proc.returncode))
+        (run_path / self.STDOUT_FILE).write_text(proc.stdout or "", encoding="utf-8")
+        (run_path / self.STDERR_FILE).write_text(proc.stderr or "", encoding="utf-8")
+        (run_path / self.RETURNCODE_FILE).write_text(str(proc.returncode), encoding="utf-8")
         return {
             "status": "completed",
             "output_dir": str(run_path),
@@ -732,7 +732,7 @@ def _run_dry_run_gate(phase, executor, run_critic, ctx, prepare, entry,
         out_dir = result.get("output_dir", dry_dir)
         # Put the REAL deck where the critic judges, so a fix patches the full
         # deck (run lengths preserved), not the run-0 twin.
-        with open(os.path.join(out_dir, entry), "w") as fh:
+        with open(os.path.join(out_dir, entry), "w", encoding="utf-8") as fh:
             fh.write(real_deck)
         # Coverage is a static (goal, deck) check independent of setup success:
         # the trimmed twin never exercises observables, so a deck that starts

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -746,7 +746,7 @@ class SimulationOrchestratorAgent:
         """Persist conversation history to disk."""
         try:
             history_data = [m for m in self.messages if m["role"] != "system"]
-            with open(self.history_path, "w") as f:
+            with open(self.history_path, "w", encoding="utf-8") as f:
                 json.dump(history_data, f, indent=2)
         except Exception as e:
             self.logger.warning(f"Failed to save history: {e}")
@@ -778,7 +778,7 @@ class SimulationOrchestratorAgent:
                 "message_count": self.message_count,
                 "saved_at": datetime.now().isoformat(),
             }
-            with open(self.checkpoint_path, "w") as f:
+            with open(self.checkpoint_path, "w", encoding="utf-8") as f:
                 json.dump(ck, f, indent=2, default=str)
             self.last_checkpoint_message_count = self.message_count
             print(f"    ✅ Auto-checkpoint saved")

--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -1628,7 +1628,7 @@ class SimulationOrchestratorTools:
                     extra_directives=extra_directives,
                 )
                 local_script = Path(record["structure_dir"]) / "job.sh"
-                local_script.write_text(script_content)
+                local_script.write_text(script_content, encoding="utf-8")
                 remote_script = f"{remote_dir}/job.sh"
                 conn.upload(str(local_script), remote_script)
 
@@ -2001,7 +2001,7 @@ class SimulationOrchestratorTools:
                 else Path(record["structure_dir"]) / "final_report.md"
             )
             try:
-                out_path.write_text(report_text)
+                out_path.write_text(report_text, encoding="utf-8")
             except Exception as e:
                 return json.dumps({"status": "error", "message": f"Failed to write report: {e}"})
 

--- a/scilink/agents/sim_agents/structure_pipeline.py
+++ b/scilink/agents/sim_agents/structure_pipeline.py
@@ -509,7 +509,7 @@ class StructurePipeline:
         try:
             log_content = self.log_capture.getvalue()
             log_path = os.path.join(self.output_dir, "workflow_log.txt")
-            with open(log_path, 'w') as f:
+            with open(log_path, 'w', encoding="utf-8") as f:
                 f.write(f"SciLink Workflow Log\n")
                 f.write(f"{'='*30}\n\n")
                 f.write(log_content)

--- a/scilink/agents/sim_agents/vasp_agent.py
+++ b/scilink/agents/sim_agents/vasp_agent.py
@@ -123,12 +123,12 @@ class VaspInputAgent(PeriodicDFTAgent):
             try:
                 if "incar" in result:
                     p = os.path.join(output_dir, "INCAR")
-                    with open(p, "w") as f:
+                    with open(p, "w", encoding="utf-8") as f:
                         f.write(result["incar"])
                     saved["INCAR"] = p
                 if "kpoints" in result:
                     p = os.path.join(output_dir, "KPOINTS")
-                    with open(p, "w") as f:
+                    with open(p, "w", encoding="utf-8") as f:
                         f.write(result["kpoints"])
                     saved["KPOINTS"] = p
             except Exception as e:
@@ -140,7 +140,7 @@ class VaspInputAgent(PeriodicDFTAgent):
 
         if result.get("config_changes"):
             log_path = os.path.join(output_dir, "config_changes.log")
-            with open(log_path, "w") as f:
+            with open(log_path, "w", encoding="utf-8") as f:
                 f.write("# Changes applied by VASPProjectConfig\n")
                 for change in result["config_changes"]:
                     f.write(f"  {change}\n")

--- a/scilink/agents/sim_agents/vasp_config.py
+++ b/scilink/agents/sim_agents/vasp_config.py
@@ -58,7 +58,7 @@ class VASPConfig:
             "default_params": self.default_params,
             "potcar_map": self.potcar_map,
         }
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
     
     def apply_to_incar(self, incar_text: str) -> dict:

--- a/scilink/agents/sim_agents/vasp_input_validator.py
+++ b/scilink/agents/sim_agents/vasp_input_validator.py
@@ -192,7 +192,7 @@ Analyze the literature review and suggest specific parameter adjustments if need
 
         try:
             report_path = os.path.join(output_dir, "incar_validation_report.json")
-            with open(report_path, 'w') as f:
+            with open(report_path, 'w', encoding="utf-8") as f:
                 json.dump(validation_result, f, indent=2, default=str)
             saved_files["validation_report"] = report_path
 
@@ -200,12 +200,12 @@ Analyze the literature review and suggest specific parameter adjustments if need
                     validation_result.get("revised_incar")):
 
                 revised_path = os.path.join(output_dir, "INCAR_revised")
-                with open(revised_path, 'w') as f:
+                with open(revised_path, 'w', encoding="utf-8") as f:
                     f.write(validation_result["revised_incar"])
                 saved_files["revised_incar"] = revised_path
 
                 summary_path = os.path.join(output_dir, "incar_adjustments.txt")
-                with open(summary_path, 'w') as f:
+                with open(summary_path, 'w', encoding="utf-8") as f:
                     f.write("INCAR Parameter Adjustments\n")
                     f.write("=" * 30 + "\n\n")
                     f.write(f"Overall Assessment: {validation_result.get('overall_assessment', 'N/A')}\n\n")

--- a/scilink/cli/main.py
+++ b/scilink/cli/main.py
@@ -10,6 +10,9 @@ import os
 # Set on the re-exec'd child so a restart that fails to take UTF-8 mode warns
 # once instead of forking forever.
 _UTF8_REEXEC_FLAG = "SCILINK_UTF8_RESTARTED"
+# Carries the launcher's argv[0] across the restart so usage strings keep
+# saying "scilink" rather than the path to this module.
+_ARGV0_ENV = "SCILINK_ARGV0"
 
 
 def get_terminal_color_support():
@@ -141,22 +144,29 @@ def ensure_utf8_mode() -> None:
     if encoding == "utf8":
         return
 
+    # Warnings go to stderr, never stdout: under `scilink serve` stdout IS the
+    # MCP transport, and a stray line there corrupts the protocol.
+    def warn(message: str) -> None:
+        print(f"  ⚠️  {message} Non-ASCII output may fail to save — set "
+              f"PYTHONUTF8=1 before launching scilink.", file=sys.stderr)
+
     # A failed re-exec must not spawn another one.
     if os.environ.get(_UTF8_REEXEC_FLAG):
-        print(f"  ⚠️  Locale encoding is {encoding or 'unknown'}, not UTF-8, and "
-              f"the automatic restart did not take. Non-ASCII output may fail "
-              f"to save — set PYTHONUTF8=1 before launching scilink.")
+        warn(f"Locale encoding is {encoding or 'unknown'}, not UTF-8, and the "
+             f"automatic restart did not take.")
         return
 
-    env = dict(os.environ, PYTHONUTF8="1", **{_UTF8_REEXEC_FLAG: "1"})
+    # `-m` gives the child argv[0] = .../cli/main.py, which would surface as
+    # the program name in every usage string; carry the real one across.
+    env = dict(os.environ, PYTHONUTF8="1",
+               **{_UTF8_REEXEC_FLAG: "1", _ARGV0_ENV: sys.argv[0]})
     cmd = [sys.executable, "-X", "utf8", "-m", "scilink.cli.main", *sys.argv[1:]]
     try:
         completed = subprocess.run(cmd, env=env)
     except KeyboardInterrupt:
         sys.exit(130)
     except Exception as e:  # noqa: BLE001 - never block startup on this
-        print(f"  ⚠️  Could not restart under UTF-8 ({e}). Non-ASCII output may "
-              f"fail to save — set PYTHONUTF8=1 before launching scilink.")
+        warn(f"Could not restart under UTF-8 ({e}).")
         return
     sys.exit(completed.returncode)
 
@@ -167,6 +177,11 @@ def main():
     # Before anything else: a non-UTF-8 locale silently breaks every write of
     # model-generated text, so correct it while a restart is still cheap.
     ensure_utf8_mode()
+
+    # In a restarted process, present the launcher's name, not this module's
+    # path — every subcommand builds its argparse prog from sys.argv[0].
+    if os.environ.get(_ARGV0_ENV):
+        sys.argv[0] = os.environ[_ARGV0_ENV]
 
     # Skip logo for MCP server mode (stdout is the transport)
     if len(sys.argv) >= 2 and sys.argv[1] == 'serve':

--- a/scilink/cli/main.py
+++ b/scilink/cli/main.py
@@ -7,6 +7,10 @@ Routes to different agent types: plan, simulate, analyze
 import sys
 import os
 
+# Set on the re-exec'd child so a restart that fails to take UTF-8 mode warns
+# once instead of forking forever.
+_UTF8_REEXEC_FLAG = "SCILINK_UTF8_RESTARTED"
+
 
 def get_terminal_color_support():
     """
@@ -110,9 +114,60 @@ def print_gradient_logo():
     
     print()
 
+def ensure_utf8_mode() -> None:
+    """Restart under Python's UTF-8 mode when the locale encoding cannot hold
+    scientific text.
+
+    `open()` writes in the locale encoding unless told otherwise. On a
+    Western-European Windows install that is cp1252, which has no subscript,
+    no arrow and no superscript minus — so persisting a literature answer or
+    a technical document raises UnicodeEncodeError and loses the work. There
+    are ~190 text writes across the package; pinning each one is a treadmill,
+    and it would still leave third-party writers broken.
+
+    UTF-8 mode fixes all of them at once, but it can only be enabled before
+    the interpreter starts — hence the re-exec. This is a no-op wherever the
+    locale is already UTF-8 (every Linux and macOS install, and a Windows one
+    with the UTF-8 beta option enabled), so it cannot perturb a working
+    setup. Library and notebook users bypass this entry point; for them the
+    explicit `encoding=` at each write site is what carries the fix.
+    """
+    import locale
+    import subprocess
+
+    if sys.flags.utf8_mode:
+        return
+    encoding = (locale.getpreferredencoding(False) or "").lower().replace("-", "")
+    if encoding == "utf8":
+        return
+
+    # A failed re-exec must not spawn another one.
+    if os.environ.get(_UTF8_REEXEC_FLAG):
+        print(f"  ⚠️  Locale encoding is {encoding or 'unknown'}, not UTF-8, and "
+              f"the automatic restart did not take. Non-ASCII output may fail "
+              f"to save — set PYTHONUTF8=1 before launching scilink.")
+        return
+
+    env = dict(os.environ, PYTHONUTF8="1", **{_UTF8_REEXEC_FLAG: "1"})
+    cmd = [sys.executable, "-X", "utf8", "-m", "scilink.cli.main", *sys.argv[1:]]
+    try:
+        completed = subprocess.run(cmd, env=env)
+    except KeyboardInterrupt:
+        sys.exit(130)
+    except Exception as e:  # noqa: BLE001 - never block startup on this
+        print(f"  ⚠️  Could not restart under UTF-8 ({e}). Non-ASCII output may "
+              f"fail to save — set PYTHONUTF8=1 before launching scilink.")
+        return
+    sys.exit(completed.returncode)
+
+
 def main():
     """Main CLI entry point with subcommands"""
-    
+
+    # Before anything else: a non-UTF-8 locale silently breaks every write of
+    # model-generated text, so correct it while a restart is still cheap.
+    ensure_utf8_mode()
+
     # Skip logo for MCP server mode (stdout is the transport)
     if len(sys.argv) >= 2 and sys.argv[1] == 'serve':
         from scilink.cli.serve import main as serve_main

--- a/scilink/cli/prepare_ff.py
+++ b/scilink/cli/prepare_ff.py
@@ -319,7 +319,7 @@ savepdb x {pdb_path.resolve()}
 quit
 """
     script_path = output_dir / "_build_test.in"
-    script_path.write_text(tleap_script)
+    script_path.write_text(tleap_script, encoding="utf-8")
 
     result = subprocess.run(
         ["tleap", "-f", str(script_path)],
@@ -461,7 +461,7 @@ def _run_preparation(
     }
 
     prep_file = output_path / "preparation.json"
-    with open(prep_file, "w") as f:
+    with open(prep_file, "w", encoding="utf-8") as f:
         json.dump(result, f, indent=2, default=str)
 
     # ── Print summary ─────────────────────────────────────────────

--- a/scilink/knowledge/kb_store.py
+++ b/scilink/knowledge/kb_store.py
@@ -221,7 +221,7 @@ def _write_manifest(kb_dir: Path, **fields) -> Dict[str, Any]:
     manifest = read_manifest(kb_dir) or {}
     manifest.update(fields)
     manifest["updated_at"] = datetime.now().isoformat(timespec="seconds")
-    (kb_dir / MANIFEST_NAME).write_text(json.dumps(manifest, indent=2))
+    (kb_dir / MANIFEST_NAME).write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     return manifest
 
 

--- a/scilink/skills/_shared/_graduation.py
+++ b/scilink/skills/_shared/_graduation.py
@@ -386,7 +386,7 @@ def graduate_to_skill_file(
     # Loader-style bundles include __init__.py; harmless for path-loaded
     # skills, but keeps the layout consistent with built-ins.
     (skill_dir / "__init__.py").touch()
-    skill_path.write_text(skill_content)
+    skill_path.write_text(skill_content, encoding="utf-8")
 
     word_count = len(skill_content.split())
     warning = None

--- a/scilink/skills/_shared/_memory.py
+++ b/scilink/skills/_shared/_memory.py
@@ -158,7 +158,7 @@ def promote_memory(
         # No frontmatter left; drop the fence entirely.
         new_text = body.lstrip("\n")
 
-    md.write_text(new_text)
+    md.write_text(new_text, encoding="utf-8")
 
     moved_to = None
     if to_domain and to_domain != domain:
@@ -211,7 +211,7 @@ def demote_memory(domain: str, name: str, *, root: Optional[Path] = None) -> Dic
         allow_unicode=True,
         width=10_000,
     ).strip()
-    md.write_text(f"---\n{frontmatter}\n---\n{body}")
+    md.write_text(f"---\n{frontmatter}\n---\n{body}", encoding="utf-8")
     return {
         "status": "success",
         "name": name,
@@ -257,8 +257,8 @@ def edit_memory(domain: str, name: str, content: str, *,
                 "message": "The skill needs at least one '## section' heading."}
 
     backup = md.with_name(md.name + ".bak")
-    backup.write_text(md.read_text())
-    md.write_text(content)
+    backup.write_text(md.read_text(), encoding="utf-8")
+    md.write_text(content, encoding="utf-8")
     return {"status": "success", "path": str(md), "backup_path": str(backup)}
 
 
@@ -291,7 +291,7 @@ def fork_builtin(domain: str, name: str, *, root: Optional[Path] = None) -> Dict
                             f"({dest_md}); upgrade or prune that copy.")}
     dest_dir.mkdir(parents=True, exist_ok=True)
     (dest_dir / "__init__.py").touch()
-    dest_md.write_text(src_md.read_text())
+    dest_md.write_text(src_md.read_text(), encoding="utf-8")
     sibling_tools = sorted(
         f.name for f in src_md.parent.glob("*.py") if f.name != "__init__.py")
     return {

--- a/scilink/skills/_shared/_script_bank.py
+++ b/scilink/skills/_shared/_script_bank.py
@@ -127,7 +127,7 @@ def add_record(domain: str, record: Dict[str, Any], *, root: Optional[Path] = No
             ):
                 rec["outcome"]["best_metric"] = metric
         rec["updated_at"] = now
-        path.write_text(json.dumps(rec, indent=2, default=str))
+        path.write_text(json.dumps(rec, indent=2, default=str), encoding="utf-8")
         return {"id": rec["id"], "action": "updated"}
 
     warn_if_ephemeral_store()
@@ -143,7 +143,7 @@ def add_record(domain: str, record: Dict[str, Any], *, root: Optional[Path] = No
         "stats": {"n_successes": 1, "n_retrievals": 0},
         **record,
     }
-    (d / f"{rid}.json").write_text(json.dumps(payload, indent=2, default=str))
+    (d / f"{rid}.json").write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
     return {"id": rid, "action": "created"}
 
 
@@ -636,7 +636,7 @@ def mark_retrieved(domain: str, rid: str, *, root: Optional[Path] = None) -> Non
         rec = json.loads(f.read_text())
         stats = rec.setdefault("stats", {})
         stats["n_retrievals"] = int(stats.get("n_retrievals", 0)) + 1
-        f.write_text(json.dumps(rec, indent=2, default=str))
+        f.write_text(json.dumps(rec, indent=2, default=str), encoding="utf-8")
     except Exception:
         pass
 
@@ -662,7 +662,7 @@ def record_success(domain: str, rid: str, session: Optional[str] = None,
                 sessions.append(session)
                 del sessions[:-_MAX_SESSIONS]
         rec["updated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
-        f.write_text(json.dumps(rec, indent=2, default=str))
+        f.write_text(json.dumps(rec, indent=2, default=str), encoding="utf-8")
     except Exception:
         pass
 
@@ -831,7 +831,7 @@ def promote_to_staging(domain: str, rid: str, technique: Optional[str] = None,
     rec["promoted_reason"] = provenance
     rec["updated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
     (_domain_dir(domain, root=root) / f"{rid}.json").write_text(
-        json.dumps(rec, indent=2, default=str))
+        json.dumps(rec, indent=2, default=str), encoding="utf-8")
     return {"status": "success", "staged_id": sid, "technique": label,
             "domain": domain, "bank_id": rid}
 

--- a/scilink/skills/_shared/_staging.py
+++ b/scilink/skills/_shared/_staging.py
@@ -99,7 +99,7 @@ def stage_solution(
     d.mkdir(parents=True, exist_ok=True)
     sid = uuid.uuid4().hex[:8]
     payload = {"id": sid, "domain": domain, "technique": technique, **record}
-    (d / f"{sid}.json").write_text(json.dumps(payload, indent=2, default=str))
+    (d / f"{sid}.json").write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
     return sid
 
 
@@ -162,7 +162,7 @@ def relabel_staged(domain: str, sid: str, technique: str, *,
         return {"status": "error", "message": "Empty technique label."}
     rec["technique"] = label
     (_domain_dir(domain, root=root) / f"{sid}.json").write_text(
-        json.dumps(rec, indent=2, default=str))
+        json.dumps(rec, indent=2, default=str), encoding="utf-8")
     return {"status": "success", "technique": label, "id": sid}
 
 
@@ -541,9 +541,9 @@ def apply_skill_upgrade(
     # Back up the current version (single last-version undo; .bak is ignored by
     # the loader, which only discovers <name>.md).
     backup = target_md.with_name(target_md.name + ".bak")
-    backup.write_text(target_md.read_text())
+    backup.write_text(target_md.read_text(), encoding="utf-8")
     (target_md.parent / "__init__.py").touch()
-    target_md.write_text(proposed_content)
+    target_md.write_text(proposed_content, encoding="utf-8")
     removed = remove_staged(domain, staged_ids, root=root)
     return {
         "status": "success",

--- a/scilink/skills/_shared/mlip_tools.py
+++ b/scilink/skills/_shared/mlip_tools.py
@@ -726,7 +726,7 @@ def _mace_train(
 
     # Write config
     config_path = os.path.join(model_dir, "config.json")
-    with open(config_path, "w") as f:
+    with open(config_path, "w", encoding="utf-8") as f:
         json.dump(config, f, indent=2)
 
     # Build CLI
@@ -744,7 +744,7 @@ def _mace_train(
 
     logger.info(f"Starting MACE training ({model_name})...")
 
-    with open(stdout_log, "w") as out, open(stderr_log, "w") as err:
+    with open(stdout_log, "w", encoding="utf-8") as out, open(stderr_log, "w", encoding="utf-8") as err:
         proc = subprocess.run(
             cli, stdout=out, stderr=err,
             cwd=working_dir,
@@ -965,10 +965,10 @@ LREAL = Auto
 LWAVE = .FALSE.
 LCHARG = .FALSE.
 """
-    with open(os.path.join(calc_dir, "INCAR"), "w") as f:
+    with open(os.path.join(calc_dir, "INCAR"), "w", encoding="utf-8") as f:
         f.write(incar)
 
-    with open(os.path.join(calc_dir, "KPOINTS"), "w") as f:
+    with open(os.path.join(calc_dir, "KPOINTS"), "w", encoding="utf-8") as f:
         f.write(f"Automatic\n0\nGamma\n{kpoints[0]} {kpoints[1]} {kpoints[2]}\n0 0 0\n")
 
 
@@ -978,7 +978,7 @@ def _write_cp2k_inputs(atoms, calc_dir, settings):
 
     ase.io.write(os.path.join(calc_dir, "structure.xyz"), atoms, format="xyz")
     # Minimal template — user should customize
-    with open(os.path.join(calc_dir, "cp2k.inp"), "w") as f:
+    with open(os.path.join(calc_dir, "cp2k.inp"), "w", encoding="utf-8") as f:
         f.write("# CP2K input template — customize for your system\n")
         f.write("# Structure: structure.xyz\n")
 

--- a/scilink/skills/_shared/sam.py
+++ b/scilink/skills/_shared/sam.py
@@ -354,7 +354,7 @@ def save_sam_visualization(
         # Save parameters to companion file
         params_filename = f"{stage}_cycle{cycle:02d}_params_{timestamp}.txt"
         params_filepath = os.path.join(output_dir, params_filename)
-        with open(params_filepath, 'w') as f:
+        with open(params_filepath, 'w', encoding="utf-8") as f:
             f.write(f"Stage: {stage}\n")
             f.write(f"Cycle: {cycle}\n")
             f.write(f"Particle Count: {particle_count}\n")

--- a/scilink/skills/_shared/series_reduction.py
+++ b/scilink/skills/_shared/series_reduction.py
@@ -225,7 +225,7 @@ def reduce_curves(curves: list, controls=None, control_source: str = "index",
         if out_dir:
             os.makedirs(out_dir, exist_ok=True)
             jpath = os.path.join(out_dir, "reduction.json")
-            with open(jpath, "w") as fh:
+            with open(jpath, "w", encoding="utf-8") as fh:
                 json.dump({**out, "score1": score1.tolist(),
                            "controls": controls.tolist()}, fh, indent=2)
             out["reduction_json_path"] = jpath

--- a/scilink/skills/exafs_simulation/exafs_workflow/feff_tools.py
+++ b/scilink/skills/exafs_simulation/exafs_workflow/feff_tools.py
@@ -296,7 +296,7 @@ def generate_feff_inputs_from_trajectory(
             ipots_string=ipots_string,
             atoms_string=atoms_string,
         )
-        (subdir / "feff.inp").write_text(inp_content)
+        (subdir / "feff.inp").write_text(inp_content, encoding="utf-8")
 
     neighborhoods_path = output_dir / f"neighborhoods_{target_atom}.xyz"
     write(str(neighborhoods_path), carved_regions, format="extxyz")
@@ -389,7 +389,7 @@ def average_chi(directory: str, savefile: str) -> dict[str, Any]:
 
     paired = np.vstack((k_common, chi_mean)).T
     output_file = f"{savefile}-chi_avg.dat"
-    with open(output_file, "w") as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         f.writelines([" ".join(row) + "\n" for row in paired.astype(str)])
 
     return {

--- a/scilink/skills/force_field/amber/amber.py
+++ b/scilink/skills/force_field/amber/amber.py
@@ -368,7 +368,7 @@ def generate_tleap_script(
     ]
 
     script_path = os.path.join(working_dir, f"{output_prefix}_tleap.in")
-    with open(script_path, "w") as f:
+    with open(script_path, "w", encoding="utf-8") as f:
         f.write("\n".join(lines) + "\n")
 
     logger.info(f"tleap script → {script_path}")
@@ -578,7 +578,7 @@ def _write_lammps_data(system, output_path: str):
     valid_impropers = [i for i in impropers if i.type is not None]
 
     # ── Write the file ───────────────────────────────────────────
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         # Header
         f.write("LAMMPS data file via ParmEd/SciLink\n\n")
         f.write(f"{len(atoms)} atoms\n")

--- a/scilink/skills/force_field/openff/build_interchange.py
+++ b/scilink/skills/force_field/openff/build_interchange.py
@@ -185,7 +185,7 @@ def build_interchange(components: List[Dict[str, Any]],
     # OpenFF Interchange (>=0.5, pydantic v2) serializes via model_dump_json;
     # the engine writer reloads with Interchange.model_validate_json. Both run in
     # the same [ff] env, so the round-trip is version-safe.
-    with open(out, "w") as fh:
+    with open(out, "w", encoding="utf-8") as fh:
         fh.write(interchange.model_dump_json())
 
     return {

--- a/scilink/skills/loader.py
+++ b/scilink/skills/loader.py
@@ -138,7 +138,7 @@ def set_memory_enabled(enabled: bool) -> Path:
     cfg = _read_config()
     cfg["memory_enabled"] = bool(enabled)
     p = _config_path()
-    p.write_text(json.dumps(cfg, indent=2))
+    p.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
     return p
 
 

--- a/scilink/skills/molecular_dynamics/lammps/lammps.py
+++ b/scilink/skills/molecular_dynamics/lammps/lammps.py
@@ -1509,7 +1509,7 @@ def run_with_potential(
 
     os.makedirs(working_dir, exist_ok=True)
     path = os.path.join(working_dir, "in.lammps")
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write(head + body)
     return path
 

--- a/scilink/skills/structure_matching/xrd/_gsas_engine.py
+++ b/scilink/skills/structure_matching/xrd/_gsas_engine.py
@@ -201,7 +201,7 @@ def simulate_gsas(
     # Work inside a scratch dir: GSAS-II writes a .gpx project + temp files.
     with tempfile.TemporaryDirectory() as tmpd:
         instprm = os.path.join(tmpd, "auto.instprm")
-        with open(instprm, "w") as fh:
+        with open(instprm, "w", encoding="utf-8") as fh:
             fh.write(_INSTPRM_TEMPLATE.format(lam=lam))
 
         # Normalize the CIF to explicit P1 (if pymatgen is available) so an
@@ -355,7 +355,7 @@ def rietveld_refine(
         esd = np.sqrt(np.maximum(y, 1.0))
         np.savetxt(xy, np.column_stack([x, y, esd]), fmt="%.6f")
         instf = os.path.join(td, "auto.instprm")
-        with open(instf, "w") as fh:
+        with open(instf, "w", encoding="utf-8") as fh:
             fh.write(_INSTPRM_TEMPLATE.format(lam=lam))
 
         gpx = G2sc.G2Project(newgpx=os.path.join(td, "riet.gpx"))
@@ -631,12 +631,12 @@ def lebail_fit(
     with tempfile.TemporaryDirectory() as td:
         cif = os.path.join(td, "lebail.cif")
         a, b, c_, al, be, ga = (float(v) for v in vals)
-        with open(cif, "w") as fh:
+        with open(cif, "w", encoding="utf-8") as fh:
             fh.write(_LEBAIL_CIF.format(a=a, b=b, c=c_, al=al, be=be, ga=ga, sg=sg))
         xy = os.path.join(td, "data.xy")
         np.savetxt(xy, np.column_stack([x, y, np.sqrt(np.maximum(y, 1.0))]), fmt="%.6f")
         instf = os.path.join(td, "auto.instprm")
-        with open(instf, "w") as fh:
+        with open(instf, "w", encoding="utf-8") as fh:
             fh.write(_INSTPRM_TEMPLATE.format(lam=lam))
 
         gpx = G2sc.G2Project(newgpx=os.path.join(td, "lb.gpx"))
@@ -1100,7 +1100,7 @@ def rietveld_refine_multiphase(
         np.savetxt(xy, np.column_stack([x, y, np.sqrt(np.maximum(y, 1.0))]),
                    fmt="%.6f")
         instf = os.path.join(td, "auto.instprm")
-        with open(instf, "w") as fh:
+        with open(instf, "w", encoding="utf-8") as fh:
             fh.write(_INSTPRM_TEMPLATE.format(lam=lam))
 
         gpx = G2sc.G2Project(newgpx=os.path.join(td, "riet.gpx"))

--- a/scilink/skills/structure_matching/xrd/search_structures.py
+++ b/scilink/skills/structure_matching/xrd/search_structures.py
@@ -323,7 +323,7 @@ def _materialize_cifs(
             continue
         path = output_dir / f"{cand.source}_{cand.id}.cif"
         try:
-            with open(path, "w") as f:
+            with open(path, "w", encoding="utf-8") as f:
                 f.write(struct.to(fmt="cif"))
             cand.structure_path = str(path)
         except Exception as e:

--- a/scilink/tracing.py
+++ b/scilink/tracing.py
@@ -95,7 +95,7 @@ def record(model: str,
     try:
         line = json.dumps(rec, default=str)
         with _lock:
-            with open(path, "a") as fh:
+            with open(path, "a", encoding="utf-8") as fh:
                 fh.write(line + "\n")
     except Exception:
         # Tracing must never break a generation.

--- a/scilink/ui/components/wizard_state.py
+++ b/scilink/ui/components/wizard_state.py
@@ -75,7 +75,7 @@ def _load() -> Dict[str, Dict[str, Any]]:
 def _save(data: Dict[str, Dict[str, Any]]) -> None:
     try:
         _STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
-        _STATE_PATH.write_text(json.dumps(data, indent=2))
+        _STATE_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
     except Exception as exc:
         logging.warning("Could not write %s: %s", _STATE_PATH, exc)
 

--- a/scilink/ui/session_meta.py
+++ b/scilink/ui/session_meta.py
@@ -44,7 +44,7 @@ def save_session_name(session_dir, name: str, named_by: str) -> bool:
         return False
     meta.update({"name": name[:80], "named_by": named_by})
     try:
-        _meta_path(session_dir).write_text(json.dumps(meta, indent=1))
+        _meta_path(session_dir).write_text(json.dumps(meta, indent=1), encoding="utf-8")
         return True
     except OSError:
         return False

--- a/scilink/utils/available_software.py
+++ b/scilink/utils/available_software.py
@@ -357,7 +357,7 @@ class AvailableSoftware:
         """Write the state to YAML, returning the path written."""
         p = Path(path) if path else _yaml_path()
         p.parent.mkdir(parents=True, exist_ok=True)
-        with open(p, "w") as f:
+        with open(p, "w", encoding="utf-8") as f:
             yaml.safe_dump(
                 self._data, f, sort_keys=True, default_flow_style=False
             )

--- a/scilink/utils/file_edit.py
+++ b/scilink/utils/file_edit.py
@@ -188,13 +188,13 @@ def apply_surgical_edits(
         backup_dir.mkdir(parents=True, exist_ok=True)
         bak = backup_dir / f"{rp.stem}.before_edit{rp.suffix}"
         if not bak.exists():
-            bak.write_text(current)
+            bak.write_text(current, encoding="utf-8")
             created = True
     except Exception as e:  # noqa: BLE001 - never block the edit
         logging.warning(f"Pre-edit copy failed: {e}")
         bak = None
 
-    rp.write_text(res["text"])
+    rp.write_text(res["text"], encoding="utf-8")
     return {
         "status": "success",
         "path": str(rp),

--- a/scilink/utils/file_prep.py
+++ b/scilink/utils/file_prep.py
@@ -617,7 +617,7 @@ def split_pickled_metadata_only(input_path, paths: dict, logger=None):
     if not meta:
         return None  # empty container — nothing to emit, report via normal path
     meta_out = Path(paths["metadata_out"])
-    meta_out.write_text(json.dumps(meta, indent=2, default=str))
+    meta_out.write_text(json.dumps(meta, indent=2, default=str), encoding="utf-8")
     json.loads(meta_out.read_text())  # self-check: valid JSON round-trip
     if logger:
         logger.info(f"✅ Metadata-only split (deterministic): {meta_out}")

--- a/tests/test_utf8_process_mode.py
+++ b/tests/test_utf8_process_mode.py
@@ -1,0 +1,164 @@
+"""Process-wide UTF-8: the entry-point guard and the no-unencoded-writes rule.
+
+Round one pinned the encoding on the literature path; the crash simply moved
+downstream to the next writer that had never named an encoding. There are
+~190 such writes, so the fix has to be categorical rather than per-site:
+every text write states UTF-8 (checked here for the whole package), and the
+CLI additionally restarts under UTF-8 mode so reads, third-party writers and
+anything added later are covered too.
+"""
+import ast
+import pathlib
+import sys
+
+import pytest
+
+import importlib
+
+# scilink/cli/__init__.py does `from .main import main`, which rebinds the
+# attribute `main` on the package to the FUNCTION — so both
+# `from scilink.cli import main` and `import scilink.cli.main as m` hand back
+# the function, not the module. Go through importlib to get the module.
+cli_main = importlib.import_module("scilink.cli.main")
+
+
+PACKAGE = pathlib.Path(__file__).resolve().parents[1] / "scilink"
+
+
+def _unencoded_text_writes():
+    """Every text-mode write in the package that does not name an encoding."""
+    offenders = []
+    for path in sorted(PACKAGE.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - would fail elsewhere first
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if any(kw.arg == "encoding" for kw in node.keywords):
+                continue
+            rel = path.relative_to(PACKAGE.parent)
+            if isinstance(node.func, ast.Name) and node.func.id == "open":
+                mode = (
+                    node.args[1].value
+                    if len(node.args) > 1 and isinstance(node.args[1], ast.Constant)
+                    else next((kw.value.value for kw in node.keywords
+                               if kw.arg == "mode"
+                               and isinstance(kw.value, ast.Constant)), "r")
+                )
+                mode = str(mode)
+                if "b" not in mode and any(c in mode for c in "wax"):
+                    offenders.append(f"{rel}:{node.lineno} open({mode!r})")
+            elif (isinstance(node.func, ast.Attribute)
+                  and node.func.attr == "write_text"):
+                offenders.append(f"{rel}:{node.lineno} write_text")
+    return offenders
+
+
+def test_no_text_write_in_the_package_omits_its_encoding():
+    """The categorical rule, enforced package-wide.
+
+    A bare `open(p, 'w')` inherits the locale encoding, which is cp1252 on a
+    Western-European Windows install — where the scientific characters this
+    codebase routinely produces cannot be encoded at all. Name the encoding
+    (or use scilink.utils.text_io) and this passes.
+    """
+    offenders = _unencoded_text_writes()
+    assert not offenders, (
+        f"{len(offenders)} text write(s) without encoding=; these crash on a "
+        f"cp1252 Windows locale:\n  " + "\n  ".join(offenders[:25])
+    )
+
+
+# ------------------------------------------------------------ the CLI guard
+
+class _FakeCompleted:
+    def __init__(self, returncode=0):
+        self.returncode = returncode
+
+
+@pytest.fixture
+def utf8_probe(monkeypatch):
+    """Drive ensure_utf8_mode's inputs and capture whether it re-execs."""
+    calls = {}
+
+    def fake_run(cmd, env=None, **kw):
+        calls["cmd"] = cmd
+        calls["env"] = env
+        return _FakeCompleted(0)
+
+    import subprocess
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.delenv("SCILINK_UTF8_RESTARTED", raising=False)
+    return calls
+
+
+def _pretend_locale(monkeypatch, encoding, utf8_mode=0):
+    import locale
+    monkeypatch.setattr(locale, "getpreferredencoding", lambda *a: encoding)
+    monkeypatch.setattr(
+        sys, "flags",
+        type("F", (), {**{f: getattr(sys.flags, f) for f in dir(sys.flags)
+                          if not f.startswith("_")},
+                       "utf8_mode": utf8_mode})(),
+    )
+
+
+@pytest.mark.parametrize("encoding", ["UTF-8", "utf-8", "utf8"])
+def test_noop_when_the_locale_is_already_utf8(monkeypatch, utf8_probe, encoding):
+    """Linux and macOS must be untouched — no restart, no output."""
+    _pretend_locale(monkeypatch, encoding)
+    cli_main.ensure_utf8_mode()
+    assert "cmd" not in utf8_probe
+
+
+def test_noop_when_already_running_in_utf8_mode(monkeypatch, utf8_probe):
+    _pretend_locale(monkeypatch, "cp1252", utf8_mode=1)
+    cli_main.ensure_utf8_mode()
+    assert "cmd" not in utf8_probe
+
+
+def test_restarts_under_utf8_on_a_cp1252_locale(monkeypatch, utf8_probe):
+    _pretend_locale(monkeypatch, "cp1252")
+    monkeypatch.setattr(sys, "argv", ["scilink", "plan", "--data-dir", "x"])
+    with pytest.raises(SystemExit) as exc:
+        cli_main.ensure_utf8_mode()
+    assert exc.value.code == 0
+    cmd = utf8_probe["cmd"]
+    assert cmd[0] == sys.executable
+    assert "-X" in cmd and "utf8" in cmd
+    assert cmd[-3:] == ["plan", "--data-dir", "x"]  # argv preserved
+    assert utf8_probe["env"]["PYTHONUTF8"] == "1"
+    assert utf8_probe["env"]["SCILINK_UTF8_RESTARTED"] == "1"
+
+
+def test_child_exit_code_propagates(monkeypatch, utf8_probe):
+    import subprocess
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _FakeCompleted(3))
+    _pretend_locale(monkeypatch, "cp1252")
+    with pytest.raises(SystemExit) as exc:
+        cli_main.ensure_utf8_mode()
+    assert exc.value.code == 3
+
+
+def test_does_not_restart_twice(monkeypatch, utf8_probe, capsys):
+    """The re-exec flag is the loop breaker: warn once, then carry on."""
+    _pretend_locale(monkeypatch, "cp1252")
+    monkeypatch.setenv("SCILINK_UTF8_RESTARTED", "1")
+    cli_main.ensure_utf8_mode()  # must return, not exit
+    assert "cmd" not in utf8_probe
+    assert "PYTHONUTF8" in capsys.readouterr().out
+
+
+def test_a_failed_restart_does_not_block_startup(monkeypatch, capsys):
+    import subprocess
+
+    def boom(*a, **k):
+        raise OSError("no exec for you")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    monkeypatch.delenv("SCILINK_UTF8_RESTARTED", raising=False)
+    _pretend_locale(monkeypatch, "cp1252")
+    cli_main.ensure_utf8_mode()  # returns rather than raising
+    assert "PYTHONUTF8" in capsys.readouterr().out

--- a/tests/test_utf8_process_mode.py
+++ b/tests/test_utf8_process_mode.py
@@ -131,6 +131,9 @@ def test_restarts_under_utf8_on_a_cp1252_locale(monkeypatch, utf8_probe):
     assert cmd[-3:] == ["plan", "--data-dir", "x"]  # argv preserved
     assert utf8_probe["env"]["PYTHONUTF8"] == "1"
     assert utf8_probe["env"]["SCILINK_UTF8_RESTARTED"] == "1"
+    # `-m` would otherwise make argv[0] the module path, which every
+    # subcommand's argparse turns into the program name in its usage line.
+    assert utf8_probe["env"]["SCILINK_ARGV0"] == "scilink"
 
 
 def test_child_exit_code_propagates(monkeypatch, utf8_probe):
@@ -148,7 +151,10 @@ def test_does_not_restart_twice(monkeypatch, utf8_probe, capsys):
     monkeypatch.setenv("SCILINK_UTF8_RESTARTED", "1")
     cli_main.ensure_utf8_mode()  # must return, not exit
     assert "cmd" not in utf8_probe
-    assert "PYTHONUTF8" in capsys.readouterr().out
+    captured = capsys.readouterr()
+    # stdout is the MCP transport under `scilink serve` — warn on stderr only.
+    assert "PYTHONUTF8" in captured.err
+    assert captured.out == ""
 
 
 def test_a_failed_restart_does_not_block_startup(monkeypatch, capsys):
@@ -161,4 +167,17 @@ def test_a_failed_restart_does_not_block_startup(monkeypatch, capsys):
     monkeypatch.delenv("SCILINK_UTF8_RESTARTED", raising=False)
     _pretend_locale(monkeypatch, "cp1252")
     cli_main.ensure_utf8_mode()  # returns rather than raising
-    assert "PYTHONUTF8" in capsys.readouterr().out
+    captured = capsys.readouterr()
+    assert "PYTHONUTF8" in captured.err
+    assert captured.out == ""
+
+
+def test_restored_argv0_keeps_the_program_name_in_usage(monkeypatch):
+    """The child restores argv[0] so `--help` still says "scilink"."""
+    monkeypatch.setenv("SCILINK_ARGV0", "scilink")
+    monkeypatch.setattr(sys, "argv", ["/site-packages/scilink/cli/main.py", "help"])
+    _pretend_locale(monkeypatch, "cp1252", utf8_mode=1)  # already restarted
+    import io, contextlib
+    with contextlib.redirect_stdout(io.StringIO()):
+        cli_main.main()
+    assert sys.argv[0].startswith("scilink")


### PR DESCRIPTION
The previous fix stopped the literature search from crashing on a Windows machine — and the crash immediately reappeared one step later, in the next place SciLink tried to save text. Same cause, different file: this time a superscript minus (as in "kJ mol⁻¹") instead of an arrow.

That is the signature of a problem that cannot be fixed one file at a time. SciLink saves text in 188 different places, and none of them said which encoding to use, so each one inherits the machine's default. On an affected Windows setup that default cannot represent the characters scientific writing is made of, so whichever save runs next is the one that fails. Fixing them individually just moves the crash.

So this change fixes the category rather than the instance, in two layers. Every place SciLink saves text now says UTF-8 explicitly. And when launched from the command line on a machine whose default cannot handle scientific characters, SciLink now restarts itself in UTF-8 mode automatically — which also covers reading files back, code from other libraries, and anything added in future.

Nothing changes on macOS or Linux, or on a Windows machine already set to UTF-8: the restart is skipped entirely, and the saves produce byte-identical files. A test now fails if anyone adds a save that omits its encoding, so this cannot start over a third time.

Users on an affected machine no longer need to set `PYTHONUTF8=1` by hand.

---

**Technical details**

Round one (#455) pinned `encoding="utf-8"` on the literature path. The user upgraded, confirmed the fix was loaded, and hit `UnicodeEncodeError: 'charmap' codec can't encode character '⁻'` from a different writer — the literature text now survives its own save and flows downstream into a document writer that had never named an encoding. An AST sweep found **188 unencoded text writes across 69 files**.

**Layer 1 — every text write names its encoding.** Applied mechanically via AST (`open()` in a text write mode, and `Path.write_text()`), inserting `encoding="utf-8"` before the closing paren, with trailing-comma and multi-line call handling. 188 sites, 69 files. This is provably inert where the locale is already UTF-8.

**Layer 2 — `ensure_utf8_mode()` at the CLI entry** (`scilink/cli/main.py`, called first thing in `main()`). Layer 1 only covers the encode direction in our own code; reads, third-party writers and future call sites remain locale-bound. Python's UTF-8 mode fixes all of them, but is settable only before interpreter start, so the guard re-execs `[sys.executable, "-X", "utf8", "-m", "scilink.cli.main", *argv[1:]]` with `PYTHONUTF8=1` and propagates the child's exit code.

Three guards, because a startup hook that misfires is worse than the bug:
- returns immediately when `locale.getpreferredencoding(False)` is already UTF-8 — Linux and macOS never reach the re-exec;
- returns immediately when `sys.flags.utf8_mode` is set;
- `SCILINK_UTF8_RESTARTED` in the child's env breaks any restart loop: a second pass warns once and continues rather than forking again.

A failed `subprocess.run` warns and returns instead of aborting startup. `KeyboardInterrupt` exits 130. Stdio is inherited rather than piped, so the interactive chat loop and the `serve` MCP stdio transport are unaffected.

**Verification**

- End-to-end under a forced non-UTF-8 locale (`LC_ALL=en_US.ISO8859-1`): `python -m scilink.cli.main help` runs exactly once (no double execution, no loop), and the interpreter the guard spawns reports `utf8_mode = 1`, `open()` default `utf-8`, and successfully performs a **bare** `open(p,'w').write("kJ mol⁻¹ ; CO₂ ; → ; ≥")` — the exact write shape that was crashing.
- 9 new tests in `tests/test_utf8_process_mode.py`: the no-op paths, argv preservation, env contents, exit-code propagation, the anti-loop flag, and graceful degradation when the restart fails.
- A package-wide AST test asserts no text write anywhere in `scilink/` omits `encoding=`. This is the guard against a third round.
- Full offline suite run twice, once on this branch and once on `main` with the branch stashed, using identical arguments: **the failure sets are identical** — 33 pre-existing failures/errors on both, none new. 1635 passed here vs 1626 on `main`, the difference being the 9 new tests.

**Pre-existing, not touched:** those 33 come from stale tests (`test_curve_fitting_orient_and_adapt.py` references a removed method), missing optional deps (`test_mp_resolver.py`, `test_simulation_orchestrator.py`), and golden-file drift. Separately, 75 test files call `sys.exit()` at module scope, which makes pytest abort collection with INTERNALERROR, and `tests/test_amber_skill/` and `tests/test_lammps_skill/` share the basename `test_skill_loading.py`, which collides without `__init__.py`. Both are why the suite can't be run in one shot today; worth cleaning up separately.

**Known gap:** reads still default to the locale encoding outside the CLI guard, so a library or notebook user on a cp1252 machine could now hit the mirror error (`'utf-8' codec can't decode`) when loading a file an older version wrote. `scilink.utils.text_io.read_text_utf8` already handles that ladder and is the migration target for read sites — a follow-up.
