### PR TITLE
Human-in-the-loop as first-class state: chokepoint, channels, durable log, MCP answers

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1349,6 +1349,12 @@ class AnalysisOrchestratorAgent:
 
     def chat(self, user_input: str) -> str:
         """Main chat interface with robust function calling support."""
+        # Bind this turn's human-feedback prompts to the session's
+        # durable feedback log (nested child chats rebind to their own;
+        # run_task restores the caller's binding on exit).
+        from ...hitl import set_thread_feedback_log as _set_fblog
+        from pathlib import Path as _P
+        _set_fblog(str(_P(self.base_dir) / "feedback_log.jsonl"))
         self.message_count += 1
         self._last_chat_hit_iter_cap = False
 
@@ -1436,6 +1442,8 @@ class AnalysisOrchestratorAgent:
         run_mode = autonomy if autonomy is not None else AnalysisMode.AUTONOMOUS
         original_mode = self.analysis_mode
         original_max_iter = self.max_iterations
+        from ...hitl import get_thread_feedback_log, set_thread_feedback_log
+        _prev_fblog = get_thread_feedback_log()
         try:
             self.set_analysis_mode(run_mode)
             if max_iterations is not None:
@@ -1462,6 +1470,9 @@ class AnalysisOrchestratorAgent:
             # Always restore the original mode, even if chat() raised.
             self.set_analysis_mode(original_mode)
             self.max_iterations = original_max_iter
+            # chat() bound the feedback log to THIS session; restore the
+            # caller's binding (a delegating meta keeps logging to its own).
+            set_thread_feedback_log(_prev_fblog)
 
         # Derive the structured summary from the session-state delta.
         new_analyses = self.analysis_results[n_before:]

--- a/scilink/agents/exp_agents/controllers/base_controllers.py
+++ b/scilink/agents/exp_agents/controllers/base_controllers.py
@@ -4,6 +4,8 @@ import textwrap
 from typing import Any, Callable, Optional
 import json
 
+from ....hitl import request_human_feedback
+
 
 # Generic Tier-A synthesis re-entry instructions (issue #322). Deliberately
 # modality-neutral: the payload critique + surfaced features carry the
@@ -301,7 +303,11 @@ class IterativeFeedbackController:
         print("-" * 80)
         
         try:
-            user_feedback = input("\n🤔 Your feedback to adjust the targets/plan (or press Enter to accept): ").strip()
+            user_feedback = request_human_feedback(
+                "\n🤔 Your feedback to adjust the targets/plan (or press Enter to accept): ",
+                kind="review_plan",
+                origin={"stage": "preprocess_plan"},
+            ).strip()
         except KeyboardInterrupt:
             self.logger.warning("User interrupted feedback. Accepting original decision.")
             return state

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -40,6 +40,7 @@ from .._locked_exec import (
 from .._qc_engine import CodegenQCEngine, QCEngineSpec, QCItemContext
 from ....utils.codegen_parse import parse_codegen_response
 from ....utils.synthesis_parse import salvage_synthesis_from_response
+from ....hitl import request_human_feedback
 
 # Canonical fitted-curve output the fit script saves alongside visualization.png.
 # Best-effort: when present it powers controller-side residual diagnostics; when
@@ -1919,7 +1920,11 @@ class CurveFittingPlanningController:
 
     def _get_human_feedback(self, state: dict) -> dict:
         self._display_plan(state)
-        feedback = input("\n🤔 Your feedback (or Enter to accept): ").strip()
+        feedback = request_human_feedback(
+            "\n🤔 Your feedback (or Enter to accept): ",
+            kind="review_plan",
+            origin={"stage": "fitting_plan"},
+        ).strip()
         
         if feedback == "":
             print("✅ Plan accepted.")
@@ -4257,9 +4262,13 @@ Return JSON with the refined fitting approach:
             example_threshold=self.r2_threshold - self._r2_soft_margin(self.r2_threshold),
         )
         print(prompt)
-        
-        feedback = input("\nYour input: ").strip()
-        
+
+        feedback = request_human_feedback(
+            "\nYour input: ",
+            kind="review_fit",
+            origin={"stage": "poor_fit_review"},
+        ).strip()
+
         if not feedback:
             print("No feedback provided. Proceeding with best available fit.")
             return None
@@ -4324,9 +4333,13 @@ Return JSON with the refined fitting approach:
         print("  • Type feedback to modify the fitting approach (e.g., 'add baseline', ")
         print("    'use Voigt instead of Gaussian', 'fit two peaks instead of one')")
         print("-" * 60)
-        
-        feedback = input("\n🤔 Your feedback (or Enter to accept): ").strip()
-        
+
+        feedback = request_human_feedback(
+            "\n🤔 Your feedback (or Enter to accept): ",
+            kind="review_fit",
+            origin={"stage": "fit_review"},
+        ).strip()
+
         # Clean up the review file - it's only for user viewing during this step
         if review_viz_path and review_viz_path.exists():
             try:
@@ -4348,9 +4361,14 @@ Return JSON with the refined fitting approach:
         print("Options:")
         print(f"  • Type 'keep' to use the user-guided fit anyway (R² = {user_r2:.4f})")
         print(f"  • Press Enter to revert to original fit (R² = {original_r2:.4f})")
-        
-        response = input("\nYour choice: ").strip().lower()
-        
+
+        response = request_human_feedback(
+            "\nYour choice: ",
+            kind="keep_or_revert",
+            options=["keep", ""],
+            origin={"stage": "user_guided_fit"},
+        ).strip().lower()
+
         if response == 'keep':
             print("✅ Keeping user-guided fit.")
             return True
@@ -5653,9 +5671,11 @@ Return JSON with:
             print("-" * 60)
 
             for _ in range(3):
-                response = input(
+                response = request_human_feedback(
                     f"\nYour choice (Enter = accept candidate "
-                    f"{winner['attempt']}): "
+                    f"{winner['attempt']}): ",
+                    kind="bestofn_select",
+                    origin={"stage": "bestofn_join"},
                 ).strip()
 
                 if not response:
@@ -6927,7 +6947,11 @@ class AdaptiveRefitController:
         print("  • Press Enter to keep the independent results as-is")
         print("-" * 60)
 
-        response = input("\n🤔 Your choice: ").strip()
+        response = request_human_feedback(
+            "\n🤔 Your choice: ",
+            kind="consensus_select",
+            origin={"stage": "series_consensus"},
+        ).strip()
         if not response:
             print("✅ Keeping independent refit results.")
             return None
@@ -7040,7 +7064,12 @@ class AdaptiveRefitController:
         print(f"  • Type 'consensus' to use '{consensus_model}' for consistency")
         print(f"  • Press Enter to keep '{original_model}'")
 
-        response = input("\nYour choice: ").strip().lower()
+        response = request_human_feedback(
+            "\nYour choice: ",
+            kind="keep_or_revert",
+            options=["consensus", ""],
+            origin={"stage": "consistency_result"},
+        ).strip().lower()
         if response == "consensus":
             print(f"✅ Using consensus model for [{idx}] {name}")
             return True

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -42,6 +42,7 @@ from .._locked_exec import (
 from .._qc_engine import CodegenQCEngine, QCEngineSpec, QCItemContext
 from ....utils.codegen_parse import parse_codegen_response
 from ....utils.synthesis_parse import salvage_synthesis_from_response
+from ....hitl import request_human_feedback
 
 
 # Anthropic's API rejects images over 5 MB. Cap below that with headroom
@@ -1154,7 +1155,11 @@ class ImagePlanningController:
 
     def _get_human_feedback(self, state: dict) -> dict:
         self._display_plan(state)
-        feedback = input("\nYour feedback (or Enter to accept): ").strip()
+        feedback = request_human_feedback(
+            "\nYour feedback (or Enter to accept): ",
+            kind="review_plan",
+            origin={"stage": "analysis_plan"},
+        ).strip()
 
         if feedback == "":
             print("Plan accepted.")
@@ -3220,7 +3225,11 @@ Return JSON with the refined analysis approach:
         )
         print(prompt)
 
-        feedback = input("\nYour input: ").strip()
+        feedback = request_human_feedback(
+            "\nYour input: ",
+            kind="review_result",
+            origin={"stage": "poor_quality_review"},
+        ).strip()
 
         if not feedback:
             print("No feedback provided. Proceeding with best available result.")
@@ -3282,7 +3291,11 @@ Return JSON with the refined analysis approach:
         print("  - Type feedback to modify the analysis approach")
         print("-" * 60)
 
-        feedback = input("\nYour feedback (or Enter to accept): ").strip()
+        feedback = request_human_feedback(
+            "\nYour feedback (or Enter to accept): ",
+            kind="review_result",
+            origin={"stage": "result_review"},
+        ).strip()
 
         if review_viz_path and review_viz_path.exists():
             try:
@@ -3313,7 +3326,12 @@ Return JSON with the refined analysis approach:
         print(f"  - Type 'keep' to use the user-guided result anyway (score = {user_score:.2f})")
         print(f"  - Press Enter to revert to original result (score = {original_score:.2f})")
 
-        response = input("\nYour choice: ").strip().lower()
+        response = request_human_feedback(
+            "\nYour choice: ",
+            kind="keep_or_revert",
+            options=["keep", ""],
+            origin={"stage": "user_guided_result"},
+        ).strip().lower()
 
         if response == 'keep':
             print("Keeping user-guided result.")
@@ -4582,9 +4600,11 @@ Return JSON with:
             print("-" * 60)
 
             for _ in range(3):
-                response = input(
+                response = request_human_feedback(
                     f"\nYour choice (Enter = accept candidate "
-                    f"{winner['attempt']}): "
+                    f"{winner['attempt']}): ",
+                    kind="bestofn_select",
+                    origin={"stage": "bestofn_join"},
                 ).strip()
 
                 if not response:
@@ -6107,7 +6127,11 @@ class ImageAdaptiveRefitController:
         print("  - Press Enter to keep the independent results as-is")
         print("-" * 60)
 
-        response = input("\nYour choice: ").strip()
+        response = request_human_feedback(
+            "\nYour choice: ",
+            kind="consensus_select",
+            origin={"stage": "series_consensus"},
+        ).strip()
         if not response:
             print("Keeping independent refit results.")
             return None
@@ -6272,7 +6296,12 @@ class ImageAdaptiveRefitController:
         )
         print(f"  - Press Enter to keep '{original_pipeline}'")
 
-        response = input("\nYour choice: ").strip().lower()
+        response = request_human_feedback(
+            "\nYour choice: ",
+            kind="keep_or_revert",
+            options=["consensus", ""],
+            origin={"stage": "consistency_result"},
+        ).strip().lower()
         if response == "consensus":
             print(f"Using consensus pipeline for [{idx}] {name}")
             return True

--- a/scilink/agents/exp_agents/human_feedback.py
+++ b/scilink/agents/exp_agents/human_feedback.py
@@ -4,6 +4,8 @@ import textwrap
 from typing import Dict, Any, Optional
 from datetime import datetime
 
+from ...hitl import request_human_feedback
+
 
 
 
@@ -45,7 +47,11 @@ class SimpleFeedbackCollector:
         
         try:
             # Single, clear prompt that accepts feedback directly
-            feedback_text = input("\n🤔 Your feedback (or press Enter to use analysis as-is): ").strip()
+            feedback_text = request_human_feedback(
+                "\n🤔 Your feedback (or press Enter to use analysis as-is): ",
+                kind="review_result",
+                origin={"stage": "analysis_review"},
+            ).strip()
             
             if not feedback_text:
                 print("✅ No feedback provided. Using analysis as-is.")
@@ -239,7 +245,11 @@ class IterationFeedbackMixin:
         print("-" * 80)
         
         # Prompt for feedback
-        user_feedback = input("\n🤔 Your feedback to adjust the targets/refinement (or press Enter to continue as-is): ").strip()
+        user_feedback = request_human_feedback(
+            "\n🤔 Your feedback to adjust the targets/refinement (or press Enter to continue as-is): ",
+            kind="review_plan",
+            origin={"stage": "iteration_feedback"},
+        ).strip()
         
         if not user_feedback:
             print("✅ No feedback provided. Continuing with current targets.")

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -35,6 +35,7 @@ import numpy as np
 from .base_agent import BaseAnalysisAgent, AnalysisInput
 from .human_feedback import SimpleFeedbackMixin
 from ...executors import ScriptExecutor, require_sandbox_approval
+from ...hitl import request_human_feedback
 from ..lit_agents.literature_agent import FittingModelLiteratureAgent
 from .pipelines.image_analysis_pipelines import create_unified_image_analysis_pipeline
 from .controllers.image_analysis_controllers import compute_image_statistics
@@ -1241,9 +1242,12 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         print("─" * 60)
 
         try:
-            response = input(
+            response = request_human_feedback(
                 "Proceed with deeper analysis? "
-                "(yes / skip / or provide guidance): "
+                "(yes / skip / or provide guidance): ",
+                kind="confirm",
+                options=["yes", "skip"],
+                origin={"stage": "tier2_escalation"},
             ).strip()
         except EOFError:
             return True, None

--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -547,7 +547,11 @@ def _confirm_fanout(orch, verdict: dict, fanout_set: List[str],
     if n > FANOUT_SOFT_CAP:
         lines.append(f"  ⚠️  {n}-way mesh exceeds the soft cap ({FANOUT_SOFT_CAP}) "
                      "— this is expensive.")
-    lines.append("  Branches run AUTONOMOUSLY (no per-branch approval pauses).")
+    if _branch_hitl_enabled(orch):
+        lines.append("  Branches will PAUSE for approvals (served one at a "
+                     "time, labeled per branch).")
+    else:
+        lines.append("  Branches run AUTONOMOUSLY (no per-branch approval pauses).")
     lines.append("=" * 78)
     print("\n".join(lines))
 
@@ -571,6 +575,31 @@ def _confirm_fanout(orch, verdict: dict, fanout_set: List[str],
 # ======================================================================
 # Branch execution
 # ======================================================================
+
+def _branch_hitl_enabled(orch) -> bool:
+    """Per-branch human-in-the-loop is OPT-IN (default off).
+
+    When ``orch.fanout_branch_hitl`` is truthy AND the meta has a human
+    attached, branches keep the meta's autonomy level and their prompts are
+    queued to the coordinator instead of being suppressed. Default-off
+    preserves the historical contract: branches run AUTONOMOUS.
+    """
+    return bool(getattr(orch, "fanout_branch_hitl", False)) \
+        and orch._enable_human_feedback
+
+
+class _BranchChannel:
+    """Tags a branch's requests with its label, then parks them on the
+    shared queue for the coordinator to serve."""
+
+    def __init__(self, queue_channel, label: str) -> None:
+        self._qch = queue_channel
+        self._label = label
+
+    def ask(self, req):
+        req.origin.setdefault("branch_label", self._label)
+        return self._qch.ask(req)
+
 
 def _make_ephemeral_analysis_child(orch, base_dir: Path):
     """Build an isolated, one-shot analysis orchestrator for one branch.
@@ -721,7 +750,8 @@ def _mesh_task(branch: dict, companions: List[dict]) -> str:
 
 
 def _run_one_branch(orch, branch: dict, companions: List[dict],
-                    entry: dict) -> None:
+                    entry: dict, queue_channel=None,
+                    branch_autonomy=None) -> None:
     """Execute a single fan-out branch into its preallocated ledger slot.
 
     Each worker touches ONLY its own ``entry`` dict, so there is no shared
@@ -744,6 +774,10 @@ def _run_one_branch(orch, branch: dict, companions: List[dict],
                   branch.get("label") or slug)
     entry["_started_at"] = time.monotonic()
     entry["_branch_tid"] = threading.get_ident()
+    if queue_channel is not None:
+        from ...hitl import set_thread_channel
+        set_thread_channel(_BranchChannel(
+            queue_channel, branch.get("label") or slug))
     try:
         try:
             from ..exp_agents.analysis_orchestrator import AnalysisMode
@@ -751,7 +785,8 @@ def _run_one_branch(orch, branch: dict, companions: List[dict],
             result = child.run_task(
                 _mesh_task(branch, companions),
                 context=branch.get("context"),
-                autonomy=AnalysisMode.AUTONOMOUS,
+                autonomy=(branch_autonomy if branch_autonomy is not None
+                          else AnalysisMode.AUTONOMOUS),
             )
         except Exception as e:  # noqa: BLE001
             logger.exception(f"fan-out branch {index} failed: {e}")
@@ -759,6 +794,9 @@ def _run_one_branch(orch, branch: dict, companions: List[dict],
                       "key_findings": [], "files_produced": [],
                       "suggested_followups": [], "warnings": []}
     finally:
+        if queue_channel is not None:
+            from ...hitl import set_thread_channel
+            set_thread_channel(None)
         _release_branch(mem_key)
     if entry.get("timed_out"):
         logger.warning(
@@ -996,12 +1034,23 @@ def run_fanout(orch, branches: List[dict],
     # No context manager: an abandoned (timed-out) branch thread cannot be
     # killed, and `with` would join it — the pool is shut down without
     # waiting instead (#358).
+    # Per-branch HITL (opt-in): branches keep the meta's autonomy and their
+    # prompts are parked on a queue the coordinator serves serially below.
+    queue_channel = None
+    branch_autonomy = None
+    if _branch_hitl_enabled(orch):
+        from ...hitl import QueueChannel
+        from ..exp_agents.analysis_orchestrator import AnalysisMode
+        queue_channel = QueueChannel()
+        branch_autonomy = AnalysisMode[orch.meta_mode.name]
+
     pool = ThreadPoolExecutor(max_workers=max_workers)
     try:
         fut_label, fut_entry = {}, {}
         for i in range(n_total):
             fut = pool.submit(_run_one_branch, orch, run_branches[i],
-                              branch_companions[i], entries[i])
+                              branch_companions[i], entries[i],
+                              queue_channel, branch_autonomy)
             fut_label[fut] = run_branches[i]["label"]
             fut_entry[fut] = entries[i]
         # Wait with a periodic heartbeat so the user can see the parallel run is
@@ -1020,6 +1069,11 @@ def run_fanout(orch, branches: List[dict],
             t0 = time.monotonic()
             done, pending = wait(pending, timeout=_FANOUT_POLL_S)
             since_tick += time.monotonic() - t0
+            if queue_channel is not None:
+                # Serve queued branch prompts through the coordinator's own
+                # channel (console prompt / UI modal), one at a time.
+                if queue_channel.serve_pending():
+                    since_tick = 0.0  # a served prompt shows the run is alive
             for f in done:
                 f.result()  # _run_one_branch never raises; just surfaces oddities
                 print(f"  ✅ analysis branch finished: {fut_label[f]}  "

--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -46,6 +46,8 @@ from concurrent.futures import ThreadPoolExecutor, wait
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ...hitl import request_human_feedback
+
 logger = logging.getLogger("meta_agent.fanout")
 
 # Concurrency + sizing. The complementary SET (post-gate) is what these bound,
@@ -550,7 +552,13 @@ def _confirm_fanout(orch, verdict: dict, fanout_set: List[str],
     print("\n".join(lines))
 
     try:
-        ans = input("\n🤔 Launch this parallel analysis? [y/N]: ").strip().lower()
+        ans = request_human_feedback(
+            "\n🤔 Launch this parallel analysis? [y/N]: ",
+            kind="confirm",
+            options=["y", "n"],
+            default="n",
+            origin={"stage": "fanout_confirm"},
+        ).strip().lower()
     except (EOFError, KeyboardInterrupt):
         # No usable input channel in a mode that expects one → do not fire an
         # expensive parallel op on a guess.

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1686,6 +1686,12 @@ class MetaOrchestratorAgent:
 
     def chat(self, user_input: str) -> str:
         """Main chat interface with robust function calling support."""
+        # Bind this turn's human-feedback prompts to the session's
+        # durable feedback log (nested child chats rebind to their own;
+        # run_task restores the caller's binding on exit).
+        from ...hitl import set_thread_feedback_log as _set_fblog
+        from pathlib import Path as _P
+        _set_fblog(str(_P(self.base_dir) / "feedback_log.jsonl"))
         self.message_count += 1
         self._last_chat_hit_iter_cap = False
 

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -1282,6 +1282,12 @@ class PlanningOrchestratorAgent:
 
     def chat(self, user_input: str) -> str:
         """Main chat interface with robust function calling support."""
+        # Bind this turn's human-feedback prompts to the session's
+        # durable feedback log (nested child chats rebind to their own;
+        # run_task restores the caller's binding on exit).
+        from ...hitl import set_thread_feedback_log as _set_fblog
+        from pathlib import Path as _P
+        _set_fblog(str(_P(self.base_dir) / "feedback_log.jsonl"))
         self.message_count += 1
         self._last_chat_hit_iter_cap = False
         
@@ -1399,6 +1405,8 @@ class PlanningOrchestratorAgent:
         run_level = autonomy if autonomy is not None else AutonomyLevel.AUTONOMOUS
         original_level = self.autonomy_level
         original_max_iter = self.max_iterations
+        from ...hitl import get_thread_feedback_log, set_thread_feedback_log
+        _prev_fblog = get_thread_feedback_log()
         try:
             self.set_autonomy_level(run_level)
             if max_iterations is not None:
@@ -1425,6 +1433,9 @@ class PlanningOrchestratorAgent:
             # Always restore the original level, even if chat() raised.
             self.set_autonomy_level(original_level)
             self.max_iterations = original_max_iter
+            # chat() bound the feedback log to THIS session; restore the
+            # caller's binding (a delegating meta keeps logging to its own).
+            set_thread_feedback_log(_prev_fblog)
             # _active_output_subdir is scoped to this call; clear it so a
             # later direct chat() on the same instance writes to base_dir.
             self._active_output_subdir = None

--- a/scilink/agents/planning_agents/scalarizer_agent.py
+++ b/scilink/agents/planning_agents/scalarizer_agent.py
@@ -9,6 +9,7 @@ from typing import Dict, Any, Optional, List
 import PIL.Image as PIL_Image
 
 from ...auth import get_internal_proxy_key
+from ...hitl import request_human_feedback
 from ...wrappers.openai_wrapper import OpenAIAsGenerativeModel
 from ...wrappers.litellm_wrapper import LiteLLMGenerativeModel
 from ...executors import require_sandbox_approval
@@ -674,7 +675,11 @@ class ScalarizerAgent(BaseAgent):
                     print(f"    • {col}: [{preview}]")
                 print(f"  Plot: {exec_res['plot_path']}")
                 print("-" * 60)
-                user_fb = input("> Press [ENTER] to confirm or type feedback: ").strip()
+                user_fb = request_human_feedback(
+                    "> Press [ENTER] to confirm or type feedback: ",
+                    kind="review_metrics",
+                    origin={"stage": "scalarizer_review"},
+                ).strip()
                 
                 if user_fb:
                     human_feedback_collected = user_fb

--- a/scilink/agents/planning_agents/user_interface.py
+++ b/scilink/agents/planning_agents/user_interface.py
@@ -4,6 +4,8 @@ import re
 import textwrap
 from pathlib import Path
 
+from ...hitl import request_human_feedback
+
 DELIVERABLES_MANIFEST = "deliverables.json"
 
 
@@ -522,7 +524,11 @@ def get_candidate_selection(n_candidates: int, judge_pick: int) -> int:
     print(f"• Or type a candidate number (1-{n_candidates}) to choose a "
           "different plan.")
 
-    reply = input(f"\n> Selection (ENTER to accept plan candidate {judge_pick}): ").strip()
+    reply = request_human_feedback(
+        f"\n> Selection (ENTER to accept plan candidate {judge_pick}): ",
+        kind="plan_candidate_select",
+        origin={"stage": "plan_candidates"},
+    ).strip()
 
     if reply.isdigit() and 1 <= int(reply) <= n_candidates:
         return int(reply)
@@ -546,7 +552,11 @@ def get_user_feedback() -> Optional[str]:
     print("• To REVISE (e.g. address the caveats, or your own changes): "
           "Type instructions and press [ENTER].")
     
-    feedback = input("\n> Instruction: ").strip()
+    feedback = request_human_feedback(
+        "\n> Instruction: ",
+        kind="approve_or_revise",
+        origin={"stage": "plan_review"},
+    ).strip()
     
     if not feedback:
         return None # User accepted the plan
@@ -577,7 +587,11 @@ def get_dataset_description(filename: str) -> str:
     print("• Option 2: Type a brief description (e.g., 'Yield results from Suzuki coupling').")
 
     try:
-        return input("\n> Context: ").strip()
+        return request_human_feedback(
+            "\n> Context: ",
+            kind="dataset_description",
+            origin={"stage": "missing_metadata", "filename": str(filename)},
+        ).strip()
     except (EOFError, KeyboardInterrupt, OSError):
         print("  - ℹ️  No interactive session to answer; continuing without "
               "metadata (the parser will infer from headers).")

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -449,6 +449,12 @@ class SimulationOrchestratorAgent:
 
     def chat(self, user_input: str) -> str:
         """Interactive chat — used by the CLI and UI."""
+        # Bind this turn's human-feedback prompts to the session's
+        # durable feedback log (nested child chats rebind to their own;
+        # run_task restores the caller's binding on exit).
+        from ...hitl import set_thread_feedback_log as _set_fblog
+        from pathlib import Path as _P
+        _set_fblog(str(_P(self.base_dir) / "feedback_log.jsonl"))
         # ── Console display features not yet wired here (parity TODO) ──────────
         # Analysis, meta, and planning distinguish three console output classes;
         # this orchestrator currently emits only structural logs. To bring it to
@@ -538,6 +544,8 @@ class SimulationOrchestratorAgent:
         run_mode = autonomy if autonomy is not None else SimulationMode.AUTONOMOUS
         original_mode = self.simulation_mode
         original_max_iter = self.max_iterations
+        from ...hitl import get_thread_feedback_log, set_thread_feedback_log
+        _prev_fblog = get_thread_feedback_log()
         try:
             self.set_simulation_mode(run_mode)
             if max_iterations is not None:
@@ -564,6 +572,9 @@ class SimulationOrchestratorAgent:
             # Always restore the original mode, even if chat() raised.
             self.set_simulation_mode(original_mode)
             self.max_iterations = original_max_iter
+            # chat() bound the feedback log to THIS session; restore the
+            # caller's binding (a delegating meta keeps logging to its own).
+            set_thread_feedback_log(_prev_fblog)
 
         # Derive the structured summary from session state.
         new_structures = (self.generated_structures or [])[n_before:]

--- a/scilink/agents/sim_agents/utils.py
+++ b/scilink/agents/sim_agents/utils.py
@@ -438,29 +438,6 @@ def save_generated_script(script_content: str, description: str, attempt: int, o
         return None
     
 
-def ask_user_proceed_or_refine(validation_feedback, structure_file):
-    """Ask user whether to proceed with current structure or attempt refinement."""
-    import sys
-    
-    print(f"\n--- Validation Issues Found ---")
-    issues = validation_feedback.get('all_identified_issues', [])
-    for i, issue in enumerate(issues, 1):
-        print(f"  {i}. {issue}")
-    
-    print(f"\nOptions:")
-    print(f"  [p] PROCEED - Use current structure: {structure_file}")
-    print(f"  [r] REFINE   - Attempt to fix issues")
-    
-    while True:
-        try:
-            choice = input("Choice [p/r]: ").strip().lower()
-            if choice in ['p', 'proceed']: return 'proceed'
-            elif choice in ['r', 'refine']: return 'refine'
-            else: print("Please enter 'p' or 'r'")
-        except (KeyboardInterrupt, EOFError):
-            return 'refine'
-
-
 def generate_structure_views(structure_path: str, output_dir: str = None) -> Dict[str, str]:
     """Render PNG views of a structure for the validator and the user.
 

--- a/scilink/cli/serve.py
+++ b/scilink/cli/serve.py
@@ -59,6 +59,15 @@ def main():
         help="Session directory for outputs (default: auto-generated)",
     )
     parser.add_argument(
+        "--hitl-timeout",
+        type=float,
+        default=1800.0,
+        help=(
+            "Seconds an agent question waits for scilink_respond before "
+            "falling back to its default answer (default: 1800)"
+        ),
+    )
+    parser.add_argument(
         "--transport",
         type=str,
         choices=["stdio", "sse"],
@@ -131,6 +140,7 @@ def main():
         session_dir=args.session_dir,
         analysis_mode=args.autonomy,
         futurehouse_api_key=args.futurehouse_key,
+        hitl_timeout_s=args.hitl_timeout,
     )
 
     # Initialize orchestrators eagerly so tools/list responds instantly.

--- a/scilink/hitl.py
+++ b/scilink/hitl.py
@@ -1,0 +1,148 @@
+"""Human-in-the-loop chokepoint.
+
+Every agent-level human-feedback prompt in SciLink routes through
+``request_human_feedback`` instead of calling ``input()`` directly. The
+default channel simply calls ``builtins.input`` (resolved at call time, so
+front-ends that intercept ``builtins.input`` keep working), which makes the
+console behavior byte-identical to the pre-chokepoint code. Front-ends can
+install richer channels — process-wide via ``set_default_channel`` or for
+the current thread via ``set_thread_channel`` — to serve prompts through a
+UI, a queue, or a remote transport.
+
+Out of scope by design: CLI session-bootstrap/REPL prompts, destructive-op
+confirmations in ``scilink memory`` / ``scilink kb``, and the sandbox
+consent prompt in ``executors.py`` (TTY-gated security surface). Those are
+not agent decision points and keep calling ``input()`` directly.
+"""
+
+from __future__ import annotations
+
+import builtins
+import itertools
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+__all__ = [
+    "FeedbackRequest",
+    "FeedbackChannel",
+    "ConsoleChannel",
+    "request_human_feedback",
+    "get_channel",
+    "set_default_channel",
+    "set_thread_channel",
+    "use_channel",
+]
+
+_counter = itertools.count(1)
+
+
+def _next_id() -> str:
+    return f"q_{int(time.time())}_{next(_counter):04d}"
+
+
+@dataclass
+class FeedbackRequest:
+    """A structured human-feedback question.
+
+    ``kind`` identifies the decision type so channels can render the right
+    surface (a radio for ``bestofn_select``, buttons for ``confirm``, a text
+    box for ``free_text``) without sniffing the prompt string. ``default``
+    is the answer that means "accept as-is" — for almost every SciLink
+    prompt that is the empty string (press Enter). ``origin`` carries
+    routing metadata (agent label, pipeline stage, fan-out branch thread
+    id) and must stay JSON-serializable.
+    """
+
+    prompt: str
+    kind: str = "free_text"
+    options: Optional[List[str]] = None
+    default: str = ""
+    context: str = ""
+    origin: Dict[str, Any] = field(default_factory=dict)
+    id: str = field(default_factory=_next_id)
+    created_at: float = field(default_factory=time.time)
+
+
+@runtime_checkable
+class FeedbackChannel(Protocol):
+    def ask(self, req: FeedbackRequest) -> str:  # pragma: no cover - protocol
+        ...
+
+
+class ConsoleChannel:
+    """Blocking console prompt — the process default.
+
+    Calls ``builtins.input`` dynamically so a front-end that monkeypatches
+    ``builtins.input`` (the Streamlit UI does, until it installs a channel
+    of its own) still intercepts every prompt.
+    """
+
+    def ask(self, req: FeedbackRequest) -> str:
+        return builtins.input(req.prompt)
+
+
+_default_channel: FeedbackChannel = ConsoleChannel()
+_thread_local = threading.local()
+
+
+def set_default_channel(channel: Optional[FeedbackChannel]) -> None:
+    """Install the process-wide channel (``None`` restores the console)."""
+    global _default_channel
+    _default_channel = channel if channel is not None else ConsoleChannel()
+
+
+def set_thread_channel(channel: Optional[FeedbackChannel]) -> None:
+    """Install (or with ``None`` clear) the channel for the current thread.
+
+    Thread-local overrides win over the process default; fan-out branches
+    and UI worker threads use this so concurrent prompts route to their
+    own owner instead of colliding on one console.
+    """
+    _thread_local.channel = channel
+
+
+@contextmanager
+def use_channel(channel: FeedbackChannel):
+    """Scoped thread-local channel override."""
+    previous = getattr(_thread_local, "channel", None)
+    _thread_local.channel = channel
+    try:
+        yield channel
+    finally:
+        _thread_local.channel = previous
+
+
+def get_channel() -> FeedbackChannel:
+    channel = getattr(_thread_local, "channel", None)
+    return channel if channel is not None else _default_channel
+
+
+def request_human_feedback(
+    prompt: str,
+    *,
+    kind: str = "free_text",
+    options: Optional[List[str]] = None,
+    default: str = "",
+    context: str = "",
+    origin: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Ask the human a question through the active feedback channel.
+
+    Returns the raw answer string exactly as ``input()`` would (no
+    stripping — call sites keep their own normalization so behavior stays
+    identical). Exceptions from the channel (``EOFError``,
+    ``KeyboardInterrupt``, stop signals) propagate to the call site, which
+    keeps its existing fallback handling.
+    """
+    req = FeedbackRequest(
+        prompt=prompt,
+        kind=kind,
+        options=options,
+        default=default,
+        context=context,
+        origin=origin or {},
+    )
+    return get_channel().ask(req)

--- a/scilink/hitl.py
+++ b/scilink/hitl.py
@@ -19,16 +19,18 @@ from __future__ import annotations
 
 import builtins
 import itertools
+import queue as _queue_mod
 import threading
 import time
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
 __all__ = [
     "FeedbackRequest",
     "FeedbackChannel",
     "ConsoleChannel",
+    "QueueChannel",
     "request_human_feedback",
     "get_channel",
     "set_default_channel",
@@ -82,6 +84,60 @@ class ConsoleChannel:
 
     def ask(self, req: FeedbackRequest) -> str:
         return builtins.input(req.prompt)
+
+
+class QueueChannel:
+    """Parks requests from concurrent worker threads for serial serving.
+
+    Worker threads (fan-out branches) install this as their thread channel;
+    ``ask`` enqueues the request and blocks until a coordinator thread —
+    the one that owns the human — answers it via ``serve_pending``, which
+    relays each queued request through the coordinator's own active
+    channel (console prompt, UI modal, ...) one at a time.
+
+    ``timeout_s`` bounds how long a worker waits for an answer; on timeout
+    the request's ``default`` answer is returned so an unattended branch
+    degrades to accept-as-is instead of hanging forever.
+    """
+
+    def __init__(self, timeout_s: Optional[float] = None) -> None:
+        self._queue: _queue_mod.Queue = _queue_mod.Queue()
+        self.timeout_s = timeout_s
+
+    def ask(self, req: FeedbackRequest) -> str:
+        event = threading.Event()
+        holder: Dict[str, str] = {}
+        self._queue.put((req, holder, event))
+        if not event.wait(self.timeout_s):
+            holder.setdefault("answer", req.default)
+        return holder.get("answer", req.default)
+
+    def serve_pending(self, through: Optional[FeedbackChannel] = None) -> int:
+        """Serve every queued request now; returns how many were answered.
+
+        Called periodically from the coordinator's wait loop. A label from
+        ``origin['branch_label']`` is prefixed onto the prompt so the human
+        knows which branch is asking. If the serving channel raises (EOF,
+        stop, interrupt), the waiting worker is unblocked with the
+        request's default answer before the exception propagates.
+        """
+        served = 0
+        while True:
+            try:
+                req, holder, event = self._queue.get_nowait()
+            except _queue_mod.Empty:
+                return served
+            label = req.origin.get("branch_label")
+            to_serve = (replace(req, prompt=f"\n[branch: {label}]{req.prompt}")
+                        if label else req)
+            try:
+                holder["answer"] = (through or get_channel()).ask(to_serve)
+            except BaseException:
+                holder.setdefault("answer", req.default)
+                event.set()
+                raise
+            event.set()
+            served += 1
 
 
 _default_channel: FeedbackChannel = ConsoleChannel()

--- a/scilink/hitl.py
+++ b/scilink/hitl.py
@@ -36,6 +36,9 @@ __all__ = [
     "set_default_channel",
     "set_thread_channel",
     "use_channel",
+    "set_thread_feedback_log",
+    "get_thread_feedback_log",
+    "use_feedback_log",
 ]
 
 _counter = itertools.count(1)
@@ -176,6 +179,69 @@ def get_channel() -> FeedbackChannel:
     return channel if channel is not None else _default_channel
 
 
+# --------------------------------------------------------------- durability
+
+def set_thread_feedback_log(path) -> None:
+    """Bind this thread's prompts to a session feedback log.
+
+    ``path`` is the JSONL file (conventionally
+    ``<session>/feedback_log.jsonl``); every request asked on this thread
+    is appended at ask time and again at answer time, and a
+    ``pending_question.json`` sidecar next to the log marks the question
+    currently awaiting an answer (removed once answered — if a run dies
+    while blocked, the sidecar says what it was waiting for). ``None``
+    unbinds. Orchestrators bind their session file around each chat turn.
+    """
+    _thread_local.feedback_log = path
+
+
+def get_thread_feedback_log():
+    return getattr(_thread_local, "feedback_log", None)
+
+
+@contextmanager
+def use_feedback_log(path):
+    """Scoped thread-local feedback-log binding (re-entrant safe)."""
+    previous = get_thread_feedback_log()
+    _thread_local.feedback_log = path
+    try:
+        yield
+    finally:
+        _thread_local.feedback_log = previous
+
+
+def _append_record(path, record: Dict[str, Any]) -> None:
+    """Best-effort append — the log must never break the prompt itself."""
+    import json
+
+    try:
+        p = __import__("pathlib").Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with open(p, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _write_pending(path, req: FeedbackRequest) -> None:
+    import json
+
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump({"id": req.id, "kind": req.kind, "prompt": req.prompt,
+                       "origin": req.origin, "asked_at": req.created_at},
+                      f, ensure_ascii=False, default=str)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _clear_pending(path) -> None:
+    try:
+        __import__("pathlib").Path(path).unlink(missing_ok=True)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def request_human_feedback(
     prompt: str,
     *,
@@ -201,4 +267,31 @@ def request_human_feedback(
         context=context,
         origin=origin or {},
     )
-    return get_channel().ask(req)
+    log = get_thread_feedback_log()
+    pending = None
+    if log:
+        from pathlib import Path as _Path
+
+        _append_record(log, {"id": req.id, "event": "asked",
+                             "kind": req.kind, "prompt": req.prompt,
+                             "options": req.options, "default": req.default,
+                             "origin": req.origin, "t": req.created_at})
+        pending = _Path(log).parent / "pending_question.json"
+        _write_pending(pending, req)
+    try:
+        answer = get_channel().ask(req)
+    except BaseException as exc:
+        if log:
+            _append_record(log, {
+                "id": req.id, "event": "interrupted",
+                "error": type(exc).__name__,
+                "elapsed_s": round(time.time() - req.created_at, 3)})
+        raise
+    finally:
+        if pending is not None:
+            _clear_pending(pending)
+    if log:
+        _append_record(log, {
+            "id": req.id, "event": "answered", "answer": answer,
+            "elapsed_s": round(time.time() - req.created_at, 3)})
+    return answer

--- a/scilink/mcp_server.py
+++ b/scilink/mcp_server.py
@@ -105,13 +105,79 @@ def _openai_to_mcp_tool(schema: dict, prefix: str = "scilink") -> types.Tool:
     )
 
 
+# ── Human-in-the-loop channel (agent prompts over MCP) ─────────────────
+
+class _MCPChannel:
+    """hitl.FeedbackChannel that parks agent prompts in the server's
+    pending queue for a client to answer via ``scilink_respond``.
+
+    The asking worker thread blocks on an event with a mandatory timeout;
+    on timeout the request's declared default answer is returned so an
+    unattended run degrades to accept-as-is instead of hanging a tool
+    call forever. ``job_id`` ties questions to their background job so
+    ``scilink_job_status`` can report ``awaiting_input``.
+    """
+
+    def __init__(self, state: dict, job_id: str = None,
+                 timeout_s: float = 1800.0) -> None:
+        self._state = state
+        self._job_id = job_id
+        self._timeout_s = timeout_s
+
+    def ask(self, req) -> str:
+        import threading
+
+        event = threading.Event()
+        holder: dict = {}
+        self._state["pending"][req.id] = {
+            "type": "question", "req": req, "event": event,
+            "holder": holder, "job_id": self._job_id,
+        }
+        try:
+            answered = event.wait(self._timeout_s)
+        finally:
+            self._state["pending"].pop(req.id, None)
+        if not answered:
+            logging.warning(
+                f"[hitl] question {req.id} ({req.kind}) unanswered after "
+                f"{self._timeout_s}s — using its default answer")
+            return req.default
+        return holder.get("answer", req.default)
+
+
+def _pending_questions(state: dict, job_id: str = None) -> list:
+    """Structured list of parked agent questions (optionally per job)."""
+    out = []
+    for rid, item in list(state.get("pending", {}).items()):
+        if item.get("type") != "question":
+            continue
+        if job_id is not None and item.get("job_id") != job_id:
+            continue
+        req = item["req"]
+        out.append({"request_id": rid, "kind": req.kind,
+                    "prompt": req.prompt, "options": req.options,
+                    "origin": req.origin, "job_id": item.get("job_id")})
+    return out
+
+
 # ── Stdout capture ──────────────────────────────────────────────────────
 
-def _execute_tool_captured(tools, tool_name: str, kwargs: dict) -> str:
+def _execute_tool_captured(tools, tool_name: str, kwargs: dict,
+                           state: dict = None, job_id: str = None) -> str:
     """Execute a tool while capturing stdout so it doesn't corrupt stdio MCP transport."""
+    from scilink.hitl import set_thread_channel
+
+    if state is not None:
+        set_thread_channel(_MCPChannel(
+            state, job_id=job_id,
+            timeout_s=state["config"].get("hitl_timeout_s", 1800.0)))
     captured = io.StringIO()
-    with contextlib.redirect_stdout(captured):
-        result = tools.execute_tool(tool_name, **kwargs)
+    try:
+        with contextlib.redirect_stdout(captured):
+            result = tools.execute_tool(tool_name, **kwargs)
+    finally:
+        if state is not None:
+            set_thread_channel(None)
 
     log_output = captured.getvalue().strip()
     if log_output:
@@ -167,6 +233,7 @@ def create_server(
     session_dir: str = None,
     analysis_mode: str = "autonomous",
     futurehouse_api_key: str = None,
+    hitl_timeout_s: float = 1800.0,
 ) -> "Server":
     """Create and return a configured MCP Server instance.
 
@@ -193,7 +260,13 @@ def create_server(
     state: Dict[str, Any] = {
         "analysis_orch": None,
         "planning_orch": None,
-        "pending_action": None,
+        # Pending items awaiting a client's scilink_respond, keyed by
+        # request id. Two shapes: {"type": "tool_approval", "action":
+        # PendingAction} for gated tool calls, and {"type": "question",
+        # "req": FeedbackRequest, "event": ..., "holder": ..., "job_id":
+        # ...} for agent prompts parked by _MCPChannel. A queue, not a
+        # slot — concurrent questions never overwrite each other.
+        "pending": {},
         "initialized": False,
         "jobs": {},
         "job_counter": 0,
@@ -205,6 +278,7 @@ def create_server(
             "session_dir": session_dir,
             "analysis_mode": analysis_mode,
             "futurehouse_api_key": futurehouse_api_key,
+            "hitl_timeout_s": hitl_timeout_s,
         },
     }
 
@@ -277,9 +351,13 @@ def create_server(
         tools.append(types.Tool(
             name="scilink_respond",
             description=(
-                "Send a response to a pending SciLink action that requires "
-                "human approval. Only needed in co-pilot or autopilot mode. "
-                "Call this after receiving a 'needs_input' status from another tool."
+                "Answer a pending SciLink request. Two cases: (1) a tool "
+                "approval from co-pilot/autopilot mode ('needs_input' "
+                "status) — respond 'yes'/'approve' to proceed or anything "
+                "else to cancel; (2) an agent question surfaced while a "
+                "job runs ('awaiting_input' in scilink_job_status) — the "
+                "response text is delivered verbatim as the answer (empty "
+                "string usually means accept as-is)."
             ),
             inputSchema={
                 "type": "object",
@@ -287,8 +365,17 @@ def create_server(
                     "response": {
                         "type": "string",
                         "description": (
-                            "User's response: 'yes'/'approve' to proceed, "
-                            "'no'/'reject' to cancel, or free-text feedback."
+                            "The answer. For tool approvals: 'yes'/'approve' "
+                            "to proceed, anything else cancels. For agent "
+                            "questions: delivered verbatim ('' = accept)."
+                        ),
+                    },
+                    "request_id": {
+                        "type": "string",
+                        "description": (
+                            "Which pending request to answer (from the "
+                            "'needs_input' payload or scilink_job_status). "
+                            "Optional when exactly one request is pending."
                         ),
                     },
                 },
@@ -483,16 +570,22 @@ def create_server(
         # Co-pilot / autopilot: intercept tools that need approval
         if _needs_approval(original_name, autonomy):
             prompt = _build_approval_prompt(original_name, arguments)
-            state["pending_action"] = PendingAction(
-                tool_name=original_name,
-                kwargs=arguments,
-                prompt=prompt,
-                context={"orch_key": orch_key},
-            )
+            state["job_counter"] += 1
+            request_id = f"act_{state['job_counter']:04d}"
+            state["pending"][request_id] = {
+                "type": "tool_approval",
+                "action": PendingAction(
+                    tool_name=original_name,
+                    kwargs=arguments,
+                    prompt=prompt,
+                    context={"orch_key": orch_key},
+                ),
+            }
             return [types.TextContent(
                 type="text",
                 text=json.dumps({
                     "status": "needs_input",
+                    "request_id": request_id,
                     "message": prompt,
                     "tool": original_name,
                     "arguments": arguments,
@@ -508,7 +601,8 @@ def create_server(
             job_id = f"job_{ts}_{state['job_counter']:03d}"
 
             future = _executor.submit(
-                _execute_tool_captured, orch.tools, original_name, arguments
+                _execute_tool_captured, orch.tools, original_name, arguments,
+                state, job_id,
             )
             state["jobs"][job_id] = {
                 "future": future,
@@ -533,7 +627,8 @@ def create_server(
             )]
 
         result = await asyncio.to_thread(
-            _execute_tool_captured, orch.tools, original_name, arguments
+            _execute_tool_captured, orch.tools, original_name, arguments,
+            state, None,
         )
 
         return [types.TextContent(type="text", text=result)]
@@ -758,15 +853,25 @@ def _handle_job_status(
                 "status": "error", "message": str(exc),
             })
 
-    return [types.TextContent(
-        type="text",
-        text=json.dumps({
-            "job_id": job_id,
-            "status": job["status"],
-            "tool": job["tool"],
-            "started_at": job["started_at"],
-        }),
-    )]
+    payload = {
+        "job_id": job_id,
+        "status": job["status"],
+        "tool": job["tool"],
+        "started_at": job["started_at"],
+    }
+    # A running job blocked on a human question reports awaiting_input
+    # with the parked question(s) so the client can scilink_respond.
+    if job["status"] == "running":
+        questions = _pending_questions(state, job_id=job_id)
+        if questions:
+            payload["status"] = "awaiting_input"
+            payload["questions"] = questions
+            payload["message"] = (
+                "The job is paused on a question. Answer with "
+                "scilink_respond(request_id=..., response=...) — empty "
+                "response usually means accept as-is.")
+
+    return [types.TextContent(type="text", text=json.dumps(payload))]
 
 
 def _handle_job_result(
@@ -824,6 +929,56 @@ def _execute_chat_captured(orch, prompt: str) -> str:
     return result
 
 
+def _execute_run_task_captured(orch, prompt: str, autonomy_str: str,
+                               state: dict = None,
+                               job_id: str = None) -> str:
+    """Execute orch.run_task() under the server's autonomy, stdout captured.
+
+    Returns the structured run_task contract as JSON, with the legacy chat
+    text preserved in the ``response`` field (run_task's ``summary`` IS the
+    chat return string) so clients that read the text keep working. The
+    per-call ``autonomy`` override means co-pilot/autopilot serving works
+    without mutating the orchestrator's resting mode, and prompts raised
+    mid-run park in the server's pending queue via the thread channel.
+    """
+    from scilink.hitl import set_thread_channel
+
+    level_name = {"co-pilot": "CO_PILOT", "co_pilot": "CO_PILOT",
+                  "copilot": "CO_PILOT", "autopilot": "AUTOPILOT",
+                  "autonomous": "AUTONOMOUS"}.get(
+                      (autonomy_str or "autonomous").lower(), "AUTONOMOUS")
+    mode_enum = type(orch).__module__  # resolved below per orchestrator
+    if "planning_orchestrator" in mode_enum:
+        from scilink.agents.planning_agents.planning_orchestrator import (
+            AutonomyLevel as _Level,
+        )
+    else:
+        from scilink.agents.exp_agents.analysis_orchestrator import (
+            AnalysisMode as _Level,
+        )
+    autonomy = _Level[level_name]
+
+    if state is not None:
+        set_thread_channel(_MCPChannel(
+            state, job_id=job_id,
+            timeout_s=state["config"].get("hitl_timeout_s", 1800.0)))
+    captured = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(captured):
+            res = orch.run_task(prompt, autonomy=autonomy)
+    finally:
+        if state is not None:
+            set_thread_channel(None)
+
+    log_output = captured.getvalue().strip()
+    if log_output:
+        logging.info(f"[orchestrate] {log_output}")
+
+    out = dict(res)
+    out["response"] = res.get("summary", "")
+    return json.dumps(out, default=str)
+
+
 async def _handle_orchestrate(
     state: dict, name: str, arguments: dict, executor
 ) -> List["types.TextContent"]:
@@ -861,12 +1016,15 @@ async def _handle_orchestrate(
     run_in_background = arguments.pop("background", False)
     tool_label = name.replace("scilink_", "")
 
+    autonomy_str = state["config"]["analysis_mode"]
+
     if run_in_background:
         state["job_counter"] += 1
         ts = _dt.now().strftime("%Y%m%d_%H%M%S")
         job_id = f"job_{ts}_{state['job_counter']:03d}"
 
-        future = executor.submit(_execute_chat_captured, orch, prompt)
+        future = executor.submit(_execute_run_task_captured, orch, prompt,
+                                 autonomy_str, state, job_id)
         state["jobs"][job_id] = {
             "future": future,
             "tool": tool_label,
@@ -889,7 +1047,8 @@ async def _handle_orchestrate(
             }),
         )]
 
-    result = await asyncio.to_thread(_execute_chat_captured, orch, prompt)
+    result = await asyncio.to_thread(_execute_run_task_captured, orch,
+                                     prompt, autonomy_str, state, None)
     return [types.TextContent(type="text", text=result)]
 
 
@@ -913,8 +1072,36 @@ def _handle_set_autonomy(
     old_mode = state["config"]["analysis_mode"]
     state["config"]["analysis_mode"] = new_mode
 
-    # Clear any pending action from the previous mode
-    state["pending_action"] = None
+    # Propagate to the LIVE orchestrators too — the server-side gate and
+    # the agents' own human-feedback behavior must agree (previously this
+    # only mutated the config dict, leaving the orchestrators in their
+    # construction-time mode).
+    _level_name = {"co-pilot": "CO_PILOT", "autopilot": "AUTOPILOT",
+                   "autonomous": "AUTONOMOUS"}[new_mode]
+    if state.get("analysis_orch") is not None:
+        try:
+            from scilink.agents.exp_agents.analysis_orchestrator import (
+                AnalysisMode,
+            )
+            state["analysis_orch"].set_analysis_mode(
+                AnalysisMode[_level_name])
+        except Exception as exc:  # noqa: BLE001
+            logging.warning(f"set_autonomy: analysis orch not updated: {exc}")
+    if state.get("planning_orch") is not None:
+        try:
+            from scilink.agents.planning_agents.planning_orchestrator import (
+                AutonomyLevel,
+            )
+            state["planning_orch"].set_autonomy_level(
+                AutonomyLevel[_level_name])
+        except Exception as exc:  # noqa: BLE001
+            logging.warning(f"set_autonomy: planning orch not updated: {exc}")
+
+    # Clear pending tool approvals from the previous mode; parked agent
+    # questions belong to running jobs and stay answerable.
+    for rid in [r for r, it in state.get("pending", {}).items()
+                if it.get("type") == "tool_approval"]:
+        state["pending"].pop(rid, None)
 
     return [types.TextContent(
         type="text",
@@ -937,22 +1124,78 @@ def _handle_set_autonomy(
 async def _handle_respond(
     state: dict, arguments: dict
 ) -> List["types.TextContent"]:
-    """Handle user response to a pending action."""
-    pending = state.get("pending_action")
-    if pending is None:
+    """Answer a pending tool approval or a parked agent question."""
+    pending = state.get("pending", {})
+    request_id = (arguments.get("request_id") or "").strip()
+
+    if request_id:
+        item = pending.get(request_id)
+        if item is None:
+            return [types.TextContent(
+                type="text",
+                text=json.dumps({
+                    "status": "error",
+                    "message": f"Unknown request_id: {request_id}",
+                    "pending": _pending_questions(state) + [
+                        {"request_id": rid, "kind": "tool_approval",
+                         "tool": it["action"].tool_name}
+                        for rid, it in pending.items()
+                        if it.get("type") == "tool_approval"],
+                }),
+            )]
+    elif len(pending) == 1:
+        request_id, item = next(iter(pending.items()))
+    elif not pending:
         return [types.TextContent(
             type="text",
             text=json.dumps({
                 "status": "error",
-                "message": "No pending action to respond to.",
+                "message": "No pending request to respond to.",
+            }),
+        )]
+    else:
+        return [types.TextContent(
+            type="text",
+            text=json.dumps({
+                "status": "error",
+                "message": ("Multiple requests pending — pass request_id "
+                            "to pick one."),
+                "pending": _pending_questions(state) + [
+                    {"request_id": rid, "kind": "tool_approval",
+                     "tool": it["action"].tool_name}
+                    for rid, it in pending.items()
+                    if it.get("type") == "tool_approval"],
             }),
         )]
 
-    response = arguments.get("response", "").strip().lower()
-    state["pending_action"] = None
+    raw_response = arguments.get("response", "")
+
+    # Agent question: deliver the response VERBATIM — free text is the
+    # answer (the asking code interprets it), never an implicit cancel.
+    if item.get("type") == "question":
+        item["holder"]["answer"] = raw_response
+        item["event"].set()
+        # The asking thread pops the entry itself on wake-up.
+        return [types.TextContent(
+            type="text",
+            text=json.dumps({
+                "status": "answered",
+                "request_id": request_id,
+                "kind": item["req"].kind,
+                "message": ("Answer delivered; the run resumes. Poll "
+                            "scilink_job_status for progress if this was "
+                            "a background job."),
+            }),
+        )]
+
+    # Tool approval: keyword gate (unchanged semantics), but a cancel now
+    # echoes the feedback instead of silently discarding it.
+    action = item["action"]
+    state["pending"].pop(request_id, None)
+    response = raw_response.strip().lower()
 
     if response in ("yes", "y", "approve", "ok", "proceed"):
-        orch_key = pending.context.get("orch_key", "analysis_orch")
+        orch_key = action.context.get("orch_key", "analysis_orch")
         orch = state.get(orch_key)
         if orch is None:
             return [types.TextContent(
@@ -964,19 +1207,22 @@ async def _handle_respond(
             )]
 
         result = await asyncio.to_thread(
-            _execute_tool_captured, orch.tools, pending.tool_name, pending.kwargs
+            _execute_tool_captured, orch.tools, action.tool_name,
+            action.kwargs, state, None,
         )
         return [types.TextContent(type="text", text=result)]
 
-    else:
-        return [types.TextContent(
-            type="text",
-            text=json.dumps({
-                "status": "cancelled",
-                "message": f"Action cancelled by user: {response}",
-                "tool": pending.tool_name,
-            }),
-        )]
+    return [types.TextContent(
+        type="text",
+        text=json.dumps({
+            "status": "cancelled",
+            "message": f"Action cancelled by user: {raw_response}",
+            "tool": action.tool_name,
+            "note": ("Free-text feedback on a tool approval cancels the "
+                     "call — re-issue the tool call with adjusted "
+                     "arguments to apply the feedback."),
+        }),
+    )]
 
 
 # ── Server runner ────────────────────────────────────────────────────────

--- a/scilink/mcp_server.py
+++ b/scilink/mcp_server.py
@@ -160,10 +160,85 @@ def _pending_questions(state: dict, job_id: str = None) -> list:
     return out
 
 
+# ── Per-job narration buffer (real-time log_tail for job_status) ───────
+
+class _JobLogHandler(logging.Handler):
+    """Streams this job's log records into its bounded line buffer.
+
+    Thread-scoped via ``log_context.effective_thread`` (same mapping the
+    UI panel uses), so narration from worker threads the job spawns
+    (best-of-N candidates, fan-out branches) lands in the right job's
+    buffer while concurrent jobs stay separated.
+    """
+
+    def __init__(self, lines, root_thread_id: int) -> None:
+        super().__init__(level=logging.INFO)
+        self._lines = lines
+        self._root_tid = root_thread_id
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            from scilink.utils.log_context import effective_thread
+            if effective_thread(record.thread) != self._root_tid:
+                return
+            self._lines.append(record.getMessage())
+        except Exception:  # noqa: BLE001 — never break the run over the tail
+            pass
+
+
+class _TeeIO(io.StringIO):
+    """StringIO that also appends complete lines to the job's buffer."""
+
+    def __init__(self, lines) -> None:
+        super().__init__()
+        self._lines = lines
+        self._partial = ""
+
+    def write(self, s: str) -> int:
+        try:
+            self._partial += s
+            while "\n" in self._partial:
+                line, self._partial = self._partial.split("\n", 1)
+                if line.strip():
+                    self._lines.append(line)
+        except Exception:  # noqa: BLE001
+            pass
+        return super().write(s)
+
+
+class _job_narration:
+    """Context manager: route this thread's narration into ``lines``."""
+
+    def __init__(self, lines) -> None:
+        self._lines = lines
+        self._handler = None
+
+    def __enter__(self):
+        if self._lines is not None:
+            import threading
+
+            self._handler = _JobLogHandler(self._lines,
+                                           threading.get_ident())
+            logging.getLogger().addHandler(self._handler)
+        return self
+
+    def __exit__(self, *exc):
+        if self._handler is not None:
+            logging.getLogger().removeHandler(self._handler)
+        return False
+
+
+def _new_job_lines():
+    from collections import deque
+
+    return deque(maxlen=400)
+
+
 # ── Stdout capture ──────────────────────────────────────────────────────
 
 def _execute_tool_captured(tools, tool_name: str, kwargs: dict,
-                           state: dict = None, job_id: str = None) -> str:
+                           state: dict = None, job_id: str = None,
+                           log_lines=None) -> str:
     """Execute a tool while capturing stdout so it doesn't corrupt stdio MCP transport."""
     from scilink.hitl import set_thread_channel
 
@@ -171,9 +246,9 @@ def _execute_tool_captured(tools, tool_name: str, kwargs: dict,
         set_thread_channel(_MCPChannel(
             state, job_id=job_id,
             timeout_s=state["config"].get("hitl_timeout_s", 1800.0)))
-    captured = io.StringIO()
+    captured = _TeeIO(log_lines) if log_lines is not None else io.StringIO()
     try:
-        with contextlib.redirect_stdout(captured):
+        with _job_narration(log_lines), contextlib.redirect_stdout(captured):
             result = tools.execute_tool(tool_name, **kwargs)
     finally:
         if state is not None:
@@ -388,7 +463,9 @@ def create_server(
             name="scilink_job_status",
             description=(
                 "Check the status of a background job started with "
-                "background=true. Returns 'running', 'completed', or 'failed'."
+                "background=true. Returns 'running', 'awaiting_input', "
+                "'completed', or 'failed', plus a log_tail of the job's "
+                "recent narration so progress is visible in real time."
             ),
             inputSchema={
                 "type": "object",
@@ -396,6 +473,13 @@ def create_server(
                     "job_id": {
                         "type": "string",
                         "description": "The job ID returned by the original tool call.",
+                    },
+                    "tail_lines": {
+                        "type": "integer",
+                        "description": (
+                            "How many recent narration lines to include as "
+                            "log_tail (default 25, max 200, 0 to omit)."
+                        ),
                     },
                 },
                 "required": ["job_id"],
@@ -600,9 +684,10 @@ def create_server(
             ts = datetime.now().strftime("%Y%m%d_%H%M%S")
             job_id = f"job_{ts}_{state['job_counter']:03d}"
 
+            log_lines = _new_job_lines()
             future = _executor.submit(
                 _execute_tool_captured, orch.tools, original_name, arguments,
-                state, job_id,
+                state, job_id, log_lines,
             )
             state["jobs"][job_id] = {
                 "future": future,
@@ -610,6 +695,7 @@ def create_server(
                 "started_at": ts,
                 "status": "running",
                 "result": None,
+                "log_lines": log_lines,
             }
 
             return [types.TextContent(
@@ -859,6 +945,17 @@ def _handle_job_status(
         "tool": job["tool"],
         "started_at": job["started_at"],
     }
+    # Real-time narration tail: the job's recent log/print lines, so any
+    # MCP client (including remote transports with no stderr access) can
+    # watch progress in-band while the job runs.
+    try:
+        n = int(arguments.get("tail_lines", 25))
+    except (TypeError, ValueError):
+        n = 25
+    n = max(0, min(200, n))
+    lines = job.get("log_lines")
+    if n and lines:
+        payload["log_tail"] = "\n".join(list(lines)[-n:])
     # A running job blocked on a human question reports awaiting_input
     # with the parked question(s) so the client can scilink_respond.
     if job["status"] == "running":
@@ -931,7 +1028,8 @@ def _execute_chat_captured(orch, prompt: str) -> str:
 
 def _execute_run_task_captured(orch, prompt: str, autonomy_str: str,
                                state: dict = None,
-                               job_id: str = None) -> str:
+                               job_id: str = None,
+                               log_lines=None) -> str:
     """Execute orch.run_task() under the server's autonomy, stdout captured.
 
     Returns the structured run_task contract as JSON, with the legacy chat
@@ -962,9 +1060,9 @@ def _execute_run_task_captured(orch, prompt: str, autonomy_str: str,
         set_thread_channel(_MCPChannel(
             state, job_id=job_id,
             timeout_s=state["config"].get("hitl_timeout_s", 1800.0)))
-    captured = io.StringIO()
+    captured = _TeeIO(log_lines) if log_lines is not None else io.StringIO()
     try:
-        with contextlib.redirect_stdout(captured):
+        with _job_narration(log_lines), contextlib.redirect_stdout(captured):
             res = orch.run_task(prompt, autonomy=autonomy)
     finally:
         if state is not None:
@@ -1023,14 +1121,16 @@ async def _handle_orchestrate(
         ts = _dt.now().strftime("%Y%m%d_%H%M%S")
         job_id = f"job_{ts}_{state['job_counter']:03d}"
 
+        log_lines = _new_job_lines()
         future = executor.submit(_execute_run_task_captured, orch, prompt,
-                                 autonomy_str, state, job_id)
+                                 autonomy_str, state, job_id, log_lines)
         state["jobs"][job_id] = {
             "future": future,
             "tool": tool_label,
             "started_at": ts,
             "status": "running",
             "result": None,
+            "log_lines": log_lines,
         }
 
         return [types.TextContent(

--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -503,42 +503,72 @@ def _parse_plan_candidate_review(context: str, prompt: str):
     return ordered, pick
 
 
-def _run_agent_chat(task: ChatTask, agent, user_input: str) -> None:
-    """Target for the background thread."""
-    import logging
+class _UIChannel:
+    """hitl.FeedbackChannel that publishes prompts to the Streamlit UI.
 
-    original_input = builtins.input
-    _metadata_cache: dict[str, str] = {}
+    Carries the structured kind/options/origin through to the widget
+    chooser; the metadata auto-reply cache keys on ``origin['filename']``
+    when the prompt came through the chokepoint, with the legacy
+    context-regex fallback for stray raw ``input()`` calls.
+    """
 
-    def _streamlit_input(prompt: str = "") -> str:
-        if task.stopped:
-            raise AgentStoppedError("Agent stopped by user")
-        context = cap.getvalue()
-        # Auto-reply for repeated metadata prompts (same file asked twice)
-        if "Context" in prompt and "MISSING METADATA" in context:
+    def __init__(self, task: ChatTask, cap) -> None:
+        self._task = task
+        self._cap = cap
+        self._metadata_cache: dict[str, str] = {}
+
+    def _metadata_key(self, hreq, context: str):
+        if hreq.kind == "dataset_description" and hreq.origin.get("filename"):
+            return str(hreq.origin["filename"])
+        if "Context" in hreq.prompt and "MISSING METADATA" in context:
             import re
             m = re.search(r"MISSING METADATA FOR:\s*(.+)", context)
             if m:
-                fname = m.group(1).strip()
-                if fname in _metadata_cache:
-                    return _metadata_cache[fname]
-        req = FeedbackRequest(prompt=prompt, context=context)
+                return m.group(1).strip()
+        return None
+
+    def ask(self, hreq) -> str:
+        task = self._task
+        if task.stopped:
+            raise AgentStoppedError("Agent stopped by user")
+        context = self._cap.getvalue()
+        # Auto-reply for repeated metadata prompts (same file asked twice)
+        key = self._metadata_key(hreq, context)
+        if key is not None and key in self._metadata_cache:
+            return self._metadata_cache[key]
+        req = FeedbackRequest(
+            prompt=hreq.prompt, context=context,
+            kind=hreq.kind, options=hreq.options, origin=dict(hreq.origin),
+        )
         task.feedback_request = req
         req.event.wait()
         task.feedback_request = None
         if task.stopped:
             raise AgentStoppedError("Agent stopped by user")
         response = req.response or ""
-        # Cache metadata descriptions so repeated prompts auto-reply
-        if "Context" in prompt and "MISSING METADATA" in context:
-            import re
-            m = re.search(r"MISSING METADATA FOR:\s*(.+)", context)
-            if m:
-                _metadata_cache[m.group(1).strip()] = response
+        if key is not None:
+            self._metadata_cache[key] = response
         return response
+
+
+def _run_agent_chat(task: ChatTask, agent, user_input: str) -> None:
+    """Target for the background thread."""
+    import logging
+
+    from scilink import hitl as _hitl
+
+    original_input = builtins.input
 
     cap = OutputCapture()
     task.live_capture = cap
+
+    channel = _UIChannel(task, cap)
+
+    def _streamlit_input(prompt: str = "") -> str:
+        # Raw-input fallback: covers third-party code and agent worker
+        # threads (fan-out branches, best-of-N workers) that bypass the
+        # thread-local channel. Same UI slot, generic free-text request.
+        return channel.ask(_hitl.FeedbackRequest(prompt=prompt))
 
     # Route logging output through the capture buffer so that
     # logging.info() messages (used by the verification-correction
@@ -585,6 +615,7 @@ def _run_agent_chat(task: ChatTask, agent, user_input: str) -> None:
 
     try:
         builtins.input = _streamlit_input
+        _hitl.set_thread_channel(channel)
         with cap:
             result = agent.chat(user_input)
         if not task.stopped:
@@ -599,6 +630,7 @@ def _run_agent_chat(task: ChatTask, agent, user_input: str) -> None:
             task.verbose_log = cap.getvalue()
     finally:
         builtins.input = original_input
+        _hitl.set_thread_channel(None)
         root_logger.removeHandler(log_handler)
         task.live_capture = None
         if not task.stopped:
@@ -998,8 +1030,11 @@ else:
                             with st.expander(f"📄 {fname}", expanded=len(code_files) == 1):
                                 st.code(content, language="python")
     
-                _is_fanout_confirm = ("parallel multi-dataset analysis"
-                                      in (req.context or "").lower())
+                _is_fanout_confirm = (
+                    req.origin.get("stage") == "fanout_confirm"
+                    or "parallel multi-dataset analysis"
+                    in (req.context or "").lower()
+                )
                 if _is_fanout_confirm:
                     _render_fanout_confirm(req.context)
                 elif req.context:
@@ -1059,7 +1094,11 @@ else:
                 # the buffer accumulates all stdout from the session.
                 _ctx_tail = (req.context or "")[-1500:]
                 _prompt = req.prompt or ""
-                _is_keep_revert = "revert to original" in _ctx_tail.lower()
+                _is_keep_revert = (
+                    (req.kind == "keep_or_revert"
+                     and (req.options or [""])[0] == "keep")
+                    or "revert to original" in _ctx_tail.lower()
+                )
                 # Best-of-N candidate review: parse the candidate list so we can
                 # render a radio selector (scales to any N, unlike one button
                 # per candidate). None -> falls through to the generic text box.
@@ -1067,7 +1106,8 @@ else:
                 # Plan-mode best-of-N: same radio UX, its own parser/markers.
                 _plan_cand_data = _parse_plan_candidate_review(req.context or "", _prompt)
                 # (_is_fanout_confirm computed above, before the context render)
-                if "Context" in _prompt or "MISSING METADATA" in _ctx_tail:
+                if (req.kind == "dataset_description"
+                        or "Context" in _prompt or "MISSING METADATA" in _ctx_tail):
                     _input_label = "Describe your data (optional):"
                     _submit_label = "Submit description"
                     _accept_label = "Skip (let agent guess)"
@@ -1079,7 +1119,7 @@ else:
                     _input_label = "Your plan feedback (optional):"
                     _submit_label = "Request changes"
                     _accept_label = "Approve plan"
-                elif "SCALARIZER REVIEW" in _ctx_tail:
+                elif req.kind == "review_metrics" or "SCALARIZER REVIEW" in _ctx_tail:
                     _input_label = "Your extraction feedback (optional):"
                     _submit_label = "Request changes"
                     _accept_label = "Approve extraction"

--- a/scilink/ui/state.py
+++ b/scilink/ui/state.py
@@ -9,11 +9,20 @@ import streamlit as st
 
 @dataclass
 class FeedbackRequest:
-    """A pending input() call from the agent thread waiting for the user."""
+    """A pending human-feedback request from the agent thread.
+
+    ``kind``/``options``/``origin`` mirror the structured fields of
+    ``scilink.hitl.FeedbackRequest`` when the prompt arrives through the
+    chokepoint; a stray raw ``input()`` (third-party code) produces the
+    defaults, and the widget chooser falls back to prompt/context sniffing.
+    """
     prompt: str = ""
-    context: str = ""  # stdout captured before the input() call
+    context: str = ""  # stdout captured before the prompt
     response: Optional[str] = None
     event: threading.Event = field(default_factory=threading.Event)
+    kind: str = ""
+    options: Optional[list] = None
+    origin: dict = field(default_factory=dict)
 
 
 @dataclass

--- a/tests/test_hitl_channels.py
+++ b/tests/test_hitl_channels.py
@@ -1,0 +1,184 @@
+"""Phase-1 channel tests: QueueChannel handshake and the UI channel contract."""
+
+import threading
+import time
+
+import pytest
+
+from scilink.hitl import (
+    FeedbackRequest,
+    QueueChannel,
+    set_default_channel,
+    set_thread_channel,
+)
+
+
+class StubChannel:
+    def __init__(self, answer=""):
+        self.answer = answer
+        self.requests = []
+
+    def ask(self, req):
+        self.requests.append(req)
+        return self.answer
+
+
+@pytest.fixture(autouse=True)
+def _reset_channels():
+    yield
+    set_default_channel(None)
+    set_thread_channel(None)
+
+
+def test_queue_channel_serves_worker_through_coordinator_channel():
+    qch = QueueChannel()
+    coordinator = StubChannel(answer="approved")
+    results = {}
+
+    def worker():
+        set_thread_channel(qch)
+        results["answer"] = qch.ask(FeedbackRequest(
+            prompt="\nYour choice: ", kind="review_plan",
+            origin={"branch_label": "raman"},
+        ))
+
+    t = threading.Thread(target=worker)
+    t.start()
+    # Coordinator loop: poll until the request lands, then serve it.
+    deadline = time.time() + 5
+    served = 0
+    while served == 0 and time.time() < deadline:
+        served = qch.serve_pending(through=coordinator)
+        time.sleep(0.01)
+    t.join(timeout=5)
+    assert served == 1
+    assert results["answer"] == "approved"
+    (req,) = coordinator.requests
+    # Branch label is prefixed onto the served prompt.
+    assert req.prompt.startswith("\n[branch: raman]")
+    assert req.origin["branch_label"] == "raman"
+
+
+def test_queue_channel_serves_multiple_serially():
+    qch = QueueChannel()
+    coordinator = StubChannel(answer="")
+    threads = [
+        threading.Thread(target=lambda i=i: qch.ask(FeedbackRequest(
+            prompt=f"p{i}", origin={"branch_label": f"b{i}"})))
+        for i in range(3)
+    ]
+    for t in threads:
+        t.start()
+    deadline = time.time() + 5
+    total = 0
+    while total < 3 and time.time() < deadline:
+        total += qch.serve_pending(through=coordinator)
+        time.sleep(0.01)
+    for t in threads:
+        t.join(timeout=5)
+    assert total == 3
+    assert len(coordinator.requests) == 3
+
+
+def test_queue_channel_timeout_returns_default():
+    qch = QueueChannel(timeout_s=0.05)
+    answer = qch.ask(FeedbackRequest(prompt="p", default="n"))
+    assert answer == "n"  # nobody served → default, no hang
+
+
+def test_queue_channel_unblocks_worker_when_serving_raises():
+    qch = QueueChannel()
+
+    class StopChannel:
+        def ask(self, req):
+            raise KeyboardInterrupt
+
+    results = {}
+
+    def worker():
+        results["answer"] = qch.ask(FeedbackRequest(prompt="p", default="skip"))
+
+    t = threading.Thread(target=worker)
+    t.start()
+    time.sleep(0.05)
+    with pytest.raises(KeyboardInterrupt):
+        qch.serve_pending(through=StopChannel())
+    t.join(timeout=5)
+    assert results["answer"] == "skip"
+
+
+def test_ui_channel_handshake_carries_kind_and_options():
+    """The UI channel publishes a structured request to the task slot and
+    returns the widget's response after the event fires."""
+    streamlit = pytest.importorskip("streamlit")  # noqa: F841
+    from scilink.ui.app import _UIChannel
+
+    class Cap:
+        def getvalue(self):
+            return "captured context"
+
+    class Task:
+        stopped = False
+        feedback_request = None
+
+    task = Task()
+    ch = _UIChannel(task, Cap())
+    out = {}
+
+    def agent_thread():
+        out["answer"] = ch.ask(FeedbackRequest(
+            prompt="\nYour choice: ", kind="bestofn_select",
+            options=["1", "2"], origin={"stage": "bestofn_join"},
+        ))
+
+    t = threading.Thread(target=agent_thread)
+    t.start()
+    deadline = time.time() + 5
+    while task.feedback_request is None and time.time() < deadline:
+        time.sleep(0.01)
+    req = task.feedback_request
+    assert req is not None
+    assert req.kind == "bestofn_select"
+    assert req.options == ["1", "2"]
+    assert req.origin["stage"] == "bestofn_join"
+    assert req.context == "captured context"
+    req.response = "2"
+    req.event.set()
+    t.join(timeout=5)
+    assert out["answer"] == "2"
+    assert task.feedback_request is None
+
+
+def test_ui_channel_metadata_cache_keys_on_origin_filename():
+    pytest.importorskip("streamlit")
+    from scilink.ui.app import _UIChannel
+
+    class Cap:
+        def getvalue(self):
+            return ""
+
+    class Task:
+        stopped = False
+        feedback_request = None
+
+    task = Task()
+    ch = _UIChannel(task, Cap())
+
+    def answer_first():
+        deadline = time.time() + 5
+        while task.feedback_request is None and time.time() < deadline:
+            time.sleep(0.01)
+        task.feedback_request.response = "XRD powder pattern"
+        task.feedback_request.event.set()
+
+    t = threading.Thread(target=answer_first)
+    t.start()
+    req = FeedbackRequest(prompt="\n> Context: ", kind="dataset_description",
+                          origin={"filename": "run1.csv"})
+    assert ch.ask(req) == "XRD powder pattern"
+    t.join(timeout=5)
+    # Second ask for the same file auto-replies from the cache — no publish.
+    req2 = FeedbackRequest(prompt="\n> Context: ", kind="dataset_description",
+                           origin={"filename": "run1.csv"})
+    assert ch.ask(req2) == "XRD powder pattern"
+    assert task.feedback_request is None

--- a/tests/test_hitl_chokepoint.py
+++ b/tests/test_hitl_chokepoint.py
@@ -1,0 +1,202 @@
+"""Phase-0 chokepoint tests: scilink.hitl routing + the no-raw-input gate."""
+
+import builtins
+import re
+import threading
+from pathlib import Path
+
+import pytest
+
+from scilink import hitl
+from scilink.hitl import (
+    ConsoleChannel,
+    FeedbackRequest,
+    request_human_feedback,
+    set_default_channel,
+    set_thread_channel,
+    use_channel,
+)
+
+SCILINK_ROOT = Path(hitl.__file__).parent
+
+
+class StubChannel:
+    def __init__(self, answer=""):
+        self.answer = answer
+        self.requests = []
+
+    def ask(self, req):
+        self.requests.append(req)
+        return self.answer
+
+
+@pytest.fixture(autouse=True)
+def _reset_channels():
+    yield
+    set_default_channel(None)
+    set_thread_channel(None)
+
+
+# ---------------------------------------------------------------- core API
+
+def test_console_channel_calls_builtins_input_with_exact_prompt(monkeypatch):
+    seen = {}
+
+    def fake_input(prompt=""):
+        seen["prompt"] = prompt
+        return "  hello  "
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+    answer = request_human_feedback("\n🤔 Your feedback (or Enter to accept): ")
+    # Raw return — no stripping in the chokepoint (call sites strip).
+    assert answer == "  hello  "
+    assert seen["prompt"] == "\n🤔 Your feedback (or Enter to accept): "
+
+
+def test_console_channel_resolves_input_at_call_time(monkeypatch):
+    """A front-end that monkeypatches builtins.input (the Streamlit UI)
+    must keep intercepting prompts after the chokepoint migration."""
+    monkeypatch.setattr(builtins, "input", lambda prompt="": "patched")
+    assert ConsoleChannel().ask(FeedbackRequest(prompt="x")) == "patched"
+
+
+def test_request_metadata_reaches_channel():
+    stub = StubChannel(answer="ok")
+    set_default_channel(stub)
+    out = request_human_feedback(
+        "p: ", kind="bestofn_select", options=["1", "2"], default="",
+        context="ctx", origin={"stage": "s"},
+    )
+    assert out == "ok"
+    (req,) = stub.requests
+    assert req.kind == "bestofn_select"
+    assert req.options == ["1", "2"]
+    assert req.context == "ctx"
+    assert req.origin == {"stage": "s"}
+    assert req.id.startswith("q_")
+
+
+def test_thread_local_channel_wins_and_clears():
+    default = StubChannel(answer="default")
+    local = StubChannel(answer="local")
+    set_default_channel(default)
+    set_thread_channel(local)
+    assert request_human_feedback("p") == "local"
+    set_thread_channel(None)
+    assert request_human_feedback("p") == "default"
+
+
+def test_use_channel_scopes_and_restores():
+    outer = StubChannel(answer="outer")
+    inner = StubChannel(answer="inner")
+    set_thread_channel(outer)
+    with use_channel(inner):
+        assert request_human_feedback("p") == "inner"
+    assert request_human_feedback("p") == "outer"
+
+
+def test_thread_isolation():
+    set_default_channel(StubChannel(answer="main-default"))
+    results = {}
+
+    def worker():
+        set_thread_channel(StubChannel(answer="worker-local"))
+        results["worker"] = request_human_feedback("p")
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+    assert results["worker"] == "worker-local"
+    assert request_human_feedback("p") == "main-default"
+
+
+def test_channel_exceptions_propagate():
+    class EOFChannel:
+        def ask(self, req):
+            raise EOFError
+
+    set_default_channel(EOFChannel())
+    with pytest.raises(EOFError):
+        request_human_feedback("p")
+
+
+# ------------------------------------------------------- converted call sites
+
+def test_get_user_feedback_routes_through_chokepoint():
+    from scilink.agents.planning_agents import user_interface
+
+    stub = StubChannel(answer="")
+    set_default_channel(stub)
+    assert user_interface.get_user_feedback() is None
+    (req,) = stub.requests
+    assert req.kind == "approve_or_revise"
+
+    stub2 = StubChannel(answer="revise it")
+    set_default_channel(stub2)
+    assert user_interface.get_user_feedback() == "revise it"
+
+
+def test_get_dataset_description_routes_and_keeps_eof_fallback():
+    from scilink.agents.planning_agents import user_interface
+
+    stub = StubChannel(answer=" my dataset ")
+    set_default_channel(stub)
+    assert user_interface.get_dataset_description("f.csv") == "my dataset"
+    (req,) = stub.requests
+    assert req.kind == "dataset_description"
+    assert req.origin["filename"] == "f.csv"
+
+    class EOFChannel:
+        def ask(self, req):
+            raise EOFError
+
+    set_default_channel(EOFChannel())
+    assert user_interface.get_dataset_description("f.csv") == ""
+
+
+# ------------------------------------------------------------- the grep gate
+
+# Files allowed to call input() directly: CLI bootstrap/REPL prompts,
+# destructive-op confirms, and the TTY-gated sandbox consent.
+_ALLOWED_RAW_INPUT = {
+    "cli/plan.py", "cli/analyze.py", "cli/simulate.py", "cli/meta.py",
+    "cli/memory.py", "cli/kb.py", "executors.py", "hitl.py",
+}
+
+_INPUT_CALL = re.compile(r"(?<![\w.])input\s*\(")
+
+
+def _strip_strings_and_comments(source: str) -> str:
+    import io
+    import tokenize
+
+    skip = {tokenize.STRING, tokenize.COMMENT}
+    # Python 3.12+ tokenizes f-string text separately; skip it too so prose
+    # like "3 input(s):" inside an f-string doesn't trip the gate.
+    for name in ("FSTRING_START", "FSTRING_MIDDLE", "FSTRING_END"):
+        if hasattr(tokenize, name):
+            skip.add(getattr(tokenize, name))
+    out = []
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            if tok.type in skip:
+                continue
+            out.append(tok.string)
+    except tokenize.TokenizeError:
+        return source
+    return " ".join(out)
+
+
+def test_no_raw_input_outside_allowed_files():
+    offenders = []
+    for py in SCILINK_ROOT.rglob("*.py"):
+        rel = py.relative_to(SCILINK_ROOT).as_posix()
+        if rel in _ALLOWED_RAW_INPUT or rel.startswith("ui/"):
+            continue
+        code = _strip_strings_and_comments(py.read_text(encoding="utf-8"))
+        if _INPUT_CALL.search(code):
+            offenders.append(rel)
+    assert offenders == [], (
+        f"raw input() call in {offenders} — route through "
+        "scilink.hitl.request_human_feedback instead"
+    )

--- a/tests/test_hitl_durability.py
+++ b/tests/test_hitl_durability.py
@@ -1,0 +1,150 @@
+"""Phase-2 durability tests: feedback log, pending sidecar, timeout policy."""
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from scilink.hitl import (
+    FeedbackRequest,
+    QueueChannel,
+    request_human_feedback,
+    set_default_channel,
+    set_thread_channel,
+    set_thread_feedback_log,
+    get_thread_feedback_log,
+    use_feedback_log,
+)
+
+
+class StubChannel:
+    def __init__(self, answer=""):
+        self.answer = answer
+
+    def ask(self, req):
+        return self.answer
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    yield
+    set_default_channel(None)
+    set_thread_channel(None)
+    set_thread_feedback_log(None)
+
+
+def _records(log: Path):
+    return [json.loads(line) for line in log.read_text().splitlines()]
+
+
+def test_log_records_asked_and_answered(tmp_path):
+    log = tmp_path / "feedback_log.jsonl"
+    set_default_channel(StubChannel(answer="looks good"))
+    with use_feedback_log(log):
+        out = request_human_feedback(
+            "p: ", kind="review_plan", default="", origin={"stage": "s"})
+    assert out == "looks good"
+    recs = _records(log)
+    assert [r["event"] for r in recs] == ["asked", "answered"]
+    assert recs[0]["kind"] == "review_plan"
+    assert recs[0]["id"] == recs[1]["id"]
+    assert recs[1]["answer"] == "looks good"
+    assert "elapsed_s" in recs[1]
+    # pending sidecar cleared after the answer
+    assert not (tmp_path / "pending_question.json").exists()
+
+
+def test_pending_sidecar_exists_while_blocked(tmp_path):
+    log = tmp_path / "feedback_log.jsonl"
+    sidecar = tmp_path / "pending_question.json"
+    observed = {}
+
+    class InspectingChannel:
+        def ask(self, req):
+            observed["pending"] = json.loads(sidecar.read_text())
+            return "ok"
+
+    set_default_channel(InspectingChannel())
+    with use_feedback_log(log):
+        request_human_feedback("p: ", kind="confirm", origin={"stage": "x"})
+    assert observed["pending"]["kind"] == "confirm"
+    assert observed["pending"]["origin"] == {"stage": "x"}
+    assert not sidecar.exists()
+
+
+def test_interrupted_prompt_is_recorded_and_sidecar_cleared(tmp_path):
+    log = tmp_path / "feedback_log.jsonl"
+
+    class EOFChannel:
+        def ask(self, req):
+            raise EOFError
+
+    set_default_channel(EOFChannel())
+    with use_feedback_log(log):
+        with pytest.raises(EOFError):
+            request_human_feedback("p: ", kind="review_fit")
+    recs = _records(log)
+    assert [r["event"] for r in recs] == ["asked", "interrupted"]
+    assert recs[1]["error"] == "EOFError"
+    assert not (tmp_path / "pending_question.json").exists()
+
+
+def test_no_binding_means_no_files(tmp_path, monkeypatch):
+    set_default_channel(StubChannel(answer="x"))
+    monkeypatch.chdir(tmp_path)
+    assert request_human_feedback("p: ") == "x"
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_nested_rebinding_restores_caller(tmp_path):
+    """The run_task pattern: child chat rebinds; caller binding restored."""
+    meta_log = tmp_path / "meta" / "feedback_log.jsonl"
+    child_log = tmp_path / "child" / "feedback_log.jsonl"
+    set_default_channel(StubChannel(answer=""))
+
+    set_thread_feedback_log(str(meta_log))            # meta chat entry
+    prev = get_thread_feedback_log()                  # run_task saves
+    set_thread_feedback_log(str(child_log))           # child chat entry
+    request_human_feedback("child prompt: ", kind="review_plan")
+    set_thread_feedback_log(prev)                     # run_task finally
+    request_human_feedback("meta prompt: ", kind="confirm")
+
+    assert [r["kind"] for r in _records(child_log)
+            if r["event"] == "asked"] == ["review_plan"]
+    assert [r["kind"] for r in _records(meta_log)
+            if r["event"] == "asked"] == ["confirm"]
+
+
+def test_queue_channel_timeout_policy_with_log(tmp_path):
+    """An unattended queued prompt times out to its default AND the log
+    still records the answered event with the default answer."""
+    log = tmp_path / "feedback_log.jsonl"
+    set_thread_channel(QueueChannel(timeout_s=0.05))
+    with use_feedback_log(log):
+        out = request_human_feedback("p: ", kind="confirm", default="n")
+    assert out == "n"
+    recs = _records(log)
+    assert recs[-1]["event"] == "answered"
+    assert recs[-1]["answer"] == "n"
+
+
+def test_thread_isolated_logs(tmp_path):
+    set_default_channel(StubChannel(answer=""))
+    log_a = tmp_path / "a.jsonl"
+    log_b = tmp_path / "b.jsonl"
+
+    def worker():
+        set_thread_feedback_log(str(log_b))
+        request_human_feedback("wp: ", kind="review_fit")
+
+    set_thread_feedback_log(str(log_a))
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join(timeout=5)
+    request_human_feedback("mp: ", kind="review_plan")
+    assert [r["kind"] for r in _records(log_a)
+            if r["event"] == "asked"] == ["review_plan"]
+    assert [r["kind"] for r in _records(log_b)
+            if r["event"] == "asked"] == ["review_fit"]

--- a/tests/test_mcp_hitl.py
+++ b/tests/test_mcp_hitl.py
@@ -1,0 +1,213 @@
+"""Phase-3 MCP HITL tests: pending queue, verbatim answers, awaiting_input,
+set_autonomy propagation, run_task routing. All offline — handlers are
+exercised directly with a fabricated server state."""
+
+import asyncio
+import json
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from scilink.mcp_server import (  # noqa: E402
+    PendingAction,
+    _MCPChannel,
+    _execute_run_task_captured,
+    _handle_job_status,
+    _handle_respond,
+    _handle_set_autonomy,
+    _pending_questions,
+)
+from scilink.hitl import FeedbackRequest  # noqa: E402
+
+
+def _state(mode="co-pilot", timeout=5.0):
+    return {
+        "analysis_orch": None,
+        "planning_orch": None,
+        "pending": {},
+        "jobs": {},
+        "job_counter": 0,
+        "config": {"analysis_mode": mode, "hitl_timeout_s": timeout},
+    }
+
+
+def _respond(state, **kwargs):
+    (content,) = asyncio.run(_handle_respond(state, kwargs))
+    return json.loads(content.text)
+
+
+# ------------------------------------------------------------ question flow
+
+def test_question_answered_verbatim():
+    state = _state()
+    ch = _MCPChannel(state, job_id="job_1", timeout_s=10)
+    req = FeedbackRequest(prompt="Approve plan? ", kind="review_plan",
+                          default="")
+    out = {}
+
+    t = threading.Thread(target=lambda: out.setdefault("a", ch.ask(req)))
+    t.start()
+    deadline = time.time() + 5
+    while not state["pending"] and time.time() < deadline:
+        time.sleep(0.01)
+    assert req.id in state["pending"]
+
+    res = _respond(state, response="use three peaks instead",
+                   request_id=req.id)
+    t.join(timeout=5)
+    assert res["status"] == "answered"
+    assert res["kind"] == "review_plan"
+    # Free text is the ANSWER, delivered verbatim — not a cancel.
+    assert out["a"] == "use three peaks instead"
+    assert state["pending"] == {}
+
+
+def test_respond_without_id_when_single_pending():
+    state = _state()
+    ch = _MCPChannel(state, timeout_s=10)
+    req = FeedbackRequest(prompt="q ", kind="confirm", default="n")
+    out = {}
+    t = threading.Thread(target=lambda: out.setdefault("a", ch.ask(req)))
+    t.start()
+    while not state["pending"]:
+        time.sleep(0.01)
+    res = _respond(state, response="")
+    t.join(timeout=5)
+    assert res["status"] == "answered"
+    assert out["a"] == ""
+
+
+def test_multiple_pending_requires_request_id():
+    state = _state()
+    state["pending"]["q_a"] = {
+        "type": "question", "req": FeedbackRequest(prompt="a", kind="confirm"),
+        "event": threading.Event(), "holder": {}, "job_id": None}
+    state["pending"]["q_b"] = {
+        "type": "question", "req": FeedbackRequest(prompt="b", kind="confirm"),
+        "event": threading.Event(), "holder": {}, "job_id": None}
+    res = _respond(state, response="yes")
+    assert res["status"] == "error"
+    ids = {q["request_id"] for q in res["pending"]}
+    assert ids == {"q_a", "q_b"}
+
+
+def test_channel_timeout_returns_default():
+    state = _state()
+    ch = _MCPChannel(state, timeout_s=0.05)
+    assert ch.ask(FeedbackRequest(prompt="q", default="n")) == "n"
+    assert state["pending"] == {}
+
+
+# ----------------------------------------------------------- tool approvals
+
+def test_two_approvals_do_not_overwrite():
+    state = _state()
+    for n, tool in enumerate(("run_analysis", "run_optimization")):
+        state["job_counter"] += 1
+        state["pending"][f"act_{n}"] = {
+            "type": "tool_approval",
+            "action": PendingAction(tool, {}, "p", {"orch_key": "analysis_orch"}),
+        }
+    assert len(state["pending"]) == 2  # queue, not slot
+
+
+def test_free_text_on_approval_cancels_with_echo():
+    state = _state()
+    state["pending"]["act_1"] = {
+        "type": "tool_approval",
+        "action": PendingAction("run_analysis", {}, "p",
+                                {"orch_key": "analysis_orch"}),
+    }
+    res = _respond(state, response="please use the raman skill",
+                   request_id="act_1")
+    assert res["status"] == "cancelled"
+    assert "please use the raman skill" in res["message"]
+    assert "note" in res  # feedback not silently discarded
+
+
+# ------------------------------------------------------------- job status
+
+def test_job_status_reports_awaiting_input():
+    class NeverDone:
+        def done(self):
+            return False
+
+    state = _state()
+    state["jobs"]["job_9"] = {"future": NeverDone(), "tool": "orchestrate",
+                              "started_at": "t", "status": "running",
+                              "result": None}
+    req = FeedbackRequest(prompt="Approve? ", kind="review_plan")
+    state["pending"][req.id] = {"type": "question", "req": req,
+                                "event": threading.Event(), "holder": {},
+                                "job_id": "job_9"}
+    (content,) = _handle_job_status(state, {"job_id": "job_9"})
+    payload = json.loads(content.text)
+    assert payload["status"] == "awaiting_input"
+    assert payload["questions"][0]["request_id"] == req.id
+    assert payload["questions"][0]["kind"] == "review_plan"
+    assert _pending_questions(state, job_id="other") == []
+
+
+# ----------------------------------------------------------- set_autonomy
+
+def test_set_autonomy_propagates_to_live_orchestrators():
+    calls = {}
+
+    class AnalysisStub:
+        def set_analysis_mode(self, mode):
+            calls["analysis"] = mode
+
+    class PlanningStub:
+        def set_autonomy_level(self, level):
+            calls["planning"] = level
+
+    state = _state(mode="autonomous")
+    state["analysis_orch"] = AnalysisStub()
+    state["planning_orch"] = PlanningStub()
+    state["pending"]["act_1"] = {
+        "type": "tool_approval",
+        "action": PendingAction("run_analysis", {}, "p", {})}
+    q = FeedbackRequest(prompt="q", kind="confirm")
+    state["pending"][q.id] = {"type": "question", "req": q,
+                              "event": threading.Event(), "holder": {},
+                              "job_id": "job_1"}
+
+    (content,) = _handle_set_autonomy(state, {"mode": "co-pilot"})
+    payload = json.loads(content.text)
+    assert payload["status"] == "success"
+    from scilink.agents.exp_agents.analysis_orchestrator import AnalysisMode
+    from scilink.agents.planning_agents.planning_orchestrator import (
+        AutonomyLevel,
+    )
+    assert calls["analysis"] == AnalysisMode.CO_PILOT
+    assert calls["planning"] == AutonomyLevel.CO_PILOT
+    # Approvals cleared; parked agent questions kept (they belong to jobs).
+    assert "act_1" not in state["pending"]
+    assert q.id in state["pending"]
+
+
+# ------------------------------------------------------- run_task routing
+
+def test_orchestrate_routes_through_run_task_with_autonomy():
+    seen = {}
+
+    class OrchStub:
+        def run_task(self, prompt, autonomy=None):
+            seen["autonomy"] = autonomy
+            return {"status": "success", "task": prompt,
+                    "summary": "the chat text", "files_produced": [],
+                    "key_findings": ["f1"], "suggested_followups": [],
+                    "warnings": []}
+
+    state = _state(mode="co-pilot")
+    out = json.loads(_execute_run_task_captured(
+        OrchStub(), "do the thing", "co-pilot", state, None))
+    from scilink.agents.exp_agents.analysis_orchestrator import AnalysisMode
+    assert seen["autonomy"] == AnalysisMode.CO_PILOT
+    # Structured contract + legacy text field.
+    assert out["status"] == "success"
+    assert out["key_findings"] == ["f1"]
+    assert out["response"] == "the chat text"

--- a/tests/test_mcp_log_tail.py
+++ b/tests/test_mcp_log_tail.py
@@ -1,0 +1,119 @@
+"""log_tail streaming in scilink_job_status — offline tests."""
+
+import json
+import logging
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from scilink.mcp_server import (  # noqa: E402
+    _TeeIO,
+    _execute_run_task_captured,
+    _handle_job_status,
+    _new_job_lines,
+)
+
+
+def _state():
+    return {"pending": {}, "jobs": {}, "job_counter": 0,
+            "config": {"analysis_mode": "autonomous", "hitl_timeout_s": 5}}
+
+
+def test_teeio_splits_lines_and_keeps_stream():
+    lines = _new_job_lines()
+    t = _TeeIO(lines)
+    t.write("hello ")
+    t.write("world\npartial")
+    assert list(lines) == ["hello world"]
+    t.write(" done\n")
+    assert list(lines) == ["hello world", "partial done"]
+    assert t.getvalue() == "hello world\npartial done\n"
+
+
+def test_run_task_narration_lands_in_buffer_thread_scoped():
+    lines = _new_job_lines()
+    other_thread_noise = []
+
+    class OrchStub:
+        def run_task(self, prompt, autonomy=None):
+            logging.getLogger("SomeAgent").info("Fitting spectrum ...")
+            logging.getLogger("SomeAgent").info("Fit approved (R2=0.99)")
+            print("plan accepted")
+            return {"status": "success", "summary": "ok",
+                    "files_produced": [], "key_findings": [],
+                    "suggested_followups": [], "warnings": []}
+
+    def noise():
+        # Concurrent logging from an unrelated thread must NOT leak in.
+        for _ in range(20):
+            logging.getLogger("Other").info("unrelated narration")
+            other_thread_noise.append(1)
+            time.sleep(0.005)
+
+    prev_level = logging.getLogger().level
+    logging.getLogger().setLevel(logging.INFO)
+    try:
+        t = threading.Thread(target=noise)
+        t.start()
+        out = _execute_run_task_captured(OrchStub(), "task", "autonomous",
+                                         _state(), "job_x", lines)
+        t.join()
+    finally:
+        logging.getLogger().setLevel(prev_level)
+
+    assert json.loads(out)["status"] == "success"
+    joined = "\n".join(lines)
+    assert "Fitting spectrum" in joined
+    assert "Fit approved" in joined
+    assert "plan accepted" in joined
+    assert "unrelated narration" not in joined
+
+
+def test_job_status_returns_bounded_log_tail():
+    class NeverDone:
+        def done(self):
+            return False
+
+    state = _state()
+    lines = _new_job_lines()
+    for i in range(50):
+        lines.append(f"line {i}")
+    state["jobs"]["j1"] = {"future": NeverDone(), "tool": "t",
+                           "started_at": "ts", "status": "running",
+                           "result": None, "log_lines": lines}
+
+    (content,) = _handle_job_status(state, {"job_id": "j1"})
+    payload = json.loads(content.text)
+    tail = payload["log_tail"].splitlines()
+    assert len(tail) == 25 and tail[-1] == "line 49"  # default 25, newest last
+
+    (content,) = _handle_job_status(state, {"job_id": "j1", "tail_lines": 5})
+    assert json.loads(content.text)["log_tail"].splitlines() == [
+        f"line {i}" for i in range(45, 50)]
+
+    (content,) = _handle_job_status(state, {"job_id": "j1", "tail_lines": 0})
+    assert "log_tail" not in json.loads(content.text)
+
+    (content,) = _handle_job_status(state, {"job_id": "j1",
+                                            "tail_lines": 10_000})
+    assert len(json.loads(content.text)["log_tail"].splitlines()) == 50
+
+
+def test_job_status_backcompat_without_buffer():
+    class Done:
+        def done(self):
+            return True
+
+        def result(self):
+            return "the result"
+
+    state = _state()
+    state["jobs"]["j2"] = {"future": Done(), "tool": "t", "started_at": "ts",
+                           "status": "running", "result": None}
+    (content,) = _handle_job_status(state, {"job_id": "j2"})
+    payload = json.loads(content.text)
+    assert payload["status"] == "completed"
+    assert "log_tail" not in payload


### PR DESCRIPTION
## Summary

Today, whenever a SciLink agent wants your opinion mid-run — approve a fitting plan, pick a best-of-N candidate, review extracted metrics — it stops and waits for you to type into the terminal. That works at the keyboard, but the question itself is invisible everywhere else: parallel fan-out branches must silence their questions entirely, nothing records what was asked or answered, and an external agent driving SciLink over MCP can never see or answer a question at all.

This PR makes the question itself a first-class object. Every human-feedback prompt now flows through one chokepoint that knows what kind of decision is being asked, who is asking, and what "accept as-is" means. From there:

- **The console and UI behave exactly as before** — same prompts, same buttons.
- **Parallel branches can now pause for your approval** (opt-in): their questions queue up and are presented one at a time, labeled by branch, instead of being suppressed.
- **Every session keeps a record** (`feedback_log.jsonl`) of what was asked, what you answered, and how long you took — and if a run dies while waiting, a sidecar file says what it was waiting for.
- **Remote agents can answer questions over MCP**: a background job pauses with `awaiting_input`, the client sees the structured question, answers via `scilink_respond`, and the run resumes. This is the LangGraph-style interrupt/resume experience, without adopting a graph runtime — and it fixes three existing MCP bugs along the way (a second question silently overwriting the first, free-text feedback discarded as a cancel, and the autonomy switch not reaching the live agents).
- **You can watch SciLink work in real time from any client**: while a background job runs, `scilink_job_status` now returns a `log_tail` of the orchestrator's recent narration (tool calls, fit progress, verifier verdicts) — so a remote agent or dashboard sees live progress through the protocol itself, not just at completion.

Each phase was live-validated end-to-end (co-pilot curve fit; per-branch fan-out approvals; durable log; full co-pilot-over-MCP loop with a real `scilink serve` child), and all defaults are behavior-preserving: console byte-identical, fan-out branches autonomous unless opted in, autonomous MCP serving unchanged.

---

<details>
<summary><b>Technical details</b></summary>

### Commit 1 — chokepoint (`scilink/hitl.py`)
`request_human_feedback(prompt, kind, options, default, context, origin)` builds a `FeedbackRequest` and delegates to the active channel (thread-local override, else process default). The default `ConsoleChannel` calls `builtins.input` **at call time**, so console behavior is byte-identical and front-ends that monkeypatch `builtins.input` kept working throughout the migration. All 22 gated `input()` sites converted (curve/image controllers, base controller, tier-2 escalation, planning `user_interface`, scalarizer, feedback mixins, fan-out confirm). CLI bootstrap/REPL prompts, destructive-op confirms, and the TTY-gated sandbox consent intentionally stay raw. Dead `ask_user_proceed_or_refine` removed. A tokenizer-based test gate asserts no raw `input()` outside the allowed files (skips f-string text on py3.12).

### Commit 2 — channels
- `_UIChannel` (`ui/app.py`): installed thread-locally for the chat thread; publishes structured requests to `task.feedback_request` (`ui/state.py` gains additive `kind`/`options`/`origin` fields). Widget dispatch gets kind-based fast paths with the existing prompt/context sniffing retained as fallback; the `builtins.input` monkeypatch stays as a raw-input safety net for third-party code and worker threads, delegating to the same channel. Metadata auto-reply cache keys on `origin['filename']` with the legacy regex fallback.
- `QueueChannel` (`hitl.py`): workers park requests; the coordinator thread serves them serially through its own channel, prompts prefixed `[branch: <label>]`. Fan-out wires it behind `orch.fanout_branch_hitl` (**default off**): when enabled with a human attached, branches keep the meta's autonomy instead of hardcoded `AUTONOMOUS` (`fanout.py:587/:746` paths), and the coordinator's wait loop drains the queue each poll.

### Commit 3 — durable record
The chokepoint appends to `<session>/feedback_log.jsonl` at ask time and at answer/interrupt time, and maintains a `pending_question.json` sidecar while blocked. Binding is thread-local: each orchestrator binds its session file at `chat()` entry; `run_task` restores the caller's binding in `finally`, so a delegating meta logs to its own session while children (and fan-out branches) log to theirs. Recording is best-effort and can never break a prompt; unbound threads are a no-op.

### Commit 4 — MCP
- `state["pending"]` is a dict keyed by request id, holding both tool approvals and parked agent questions — queue, not slot.
- `_MCPChannel` is installed around every tool / orchestrate execution; questions block the worker with a mandatory timeout (`--hitl-timeout`, default 1800 s) falling back to the question's declared default.
- `scilink_respond` gains optional `request_id` (not needed when exactly one request is pending). Agent questions receive the response **verbatim** ('' = accept); the approve-keyword gate applies only to tool approvals, and a cancel echoes the feedback with an explicit note.
- `scilink_job_status` reports `awaiting_input` with the structured question(s) for a blocked job.
- `scilink_set_autonomy` now also calls the live orchestrators' mode setters (enum lookup by *name*, since `AutonomyLevel` and `AnalysisMode` disagree on the co-pilot value string).
- `orchestrate_*` routes through `run_task` (per-call autonomy, structured `status`/`files_produced`/`key_findings` contract) with the legacy chat text preserved in a `response` field — the one client-visible shape change.

### Commit 5 — real-time job narration (`log_tail`)
Each background job carries a bounded narration buffer fed by a thread-scoped `logging` handler (keyed via `log_context.effective_thread`, so concurrent jobs and their worker threads stay separated) plus a tee on the captured stdout. `scilink_job_status` returns the last N lines as `log_tail` (`tail_lines` param, default 25, max 200, `0` to omit). Additive — jobs without a buffer and existing clients are unaffected. Live-validated: 97 unique narration lines streamed over 26 in-flight polls of a running co-pilot job.

### Testing
- Offline: 36 tests across `test_hitl_chokepoint.py`, `test_hitl_channels.py`, `test_hitl_durability.py`, `test_mcp_hitl.py`; plus scalarizer-passthrough 14/14, analyze_file shapes 9/9, candidate-pool 4/4, fan-out/fusion suites. `test_fusion_incremental.py` fails 25/26 identically on the base commit (pre-existing).
- Live (Gemini): co-pilot curve fit through the chokepoint (R²=0.9915); real UI chat path driven headlessly with structured requests; 2-branch fan-out with per-branch approvals served serially; durable log + sidecar verified in a real session; full co-pilot-over-MCP loop against a real stdio `scilink serve` child (`awaiting_input` → `scilink_respond` → completed structured result).

- Stress campaign (all passed): mixed pending types + free-text corrections that changed the fit (2→3 Gaussians as instructed); unattended-timeout fallback (exactly at the configured deadline); live `set_autonomy` switch; Stop during a pending prompt (clean interrupt, logged); console revision loop; UI fan-out with labeled per-branch approvals; and every orchestrator — meta sequential delegation (per-session logs correct), planning in-agent prompts (Bedrock), simulation no-regression, and a meta-mediated analysis→BO hand-off ending in one connected report.
- Real deepagents/LangChain stack: the autonomous closed-loop BO campaign reproduces the pre-change protocol exactly (11 tool calls, zero `needs_input`, 61.1→87.5%), and in autopilot the deep agent handled the `needs_input` → `scilink_respond` approval cycles unprompted.
- Known pre-existing limitations surfaced while testing (not introduced here): the planning orchestrator's *chat* tool schemas are rejected by Gemini's function-declaration validator (drive planning with Claude models, as the demos do), and the sim stack's Gemini path expects Vertex credentials.

### Not in this PR
Restart durability (plan Phase 4 — coupled to mid-fan-out resume) and the MCP elicitation fast path (client adapters lack support; the polling contract is the baseline). Plan doc: `hitl_durable_feedback_plan.md`.

</details>
