### PR TITLE
edit_file/rename_file: route oversize edits to one batched call; copy dead-end to relative path

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -5153,10 +5153,13 @@ class OrchestratorTools:
                         "revision use write_technical_document with "
                         "revise_path (whole-document rewrite under its "
                         "length guard). For a VERBATIM insertion, split "
-                        "the text at a unique boundary into consecutive "
-                        "smaller edit_file calls — do not rewrite the "
-                        "whole file with save_file, which keeps no "
-                        "backup and has no truncation guard."),
+                        "the text at unique boundaries into snippets under "
+                        "the cap and pass them TOGETHER as one `edits` "
+                        "list in a single call (each snippet inserted "
+                        "after the previous one) — not a chain of one-edit "
+                        "calls, which burns the turn's tool budget. Do not "
+                        "rewrite the whole file with save_file, which "
+                        "keeps no backup and has no truncation guard."),
                 )
                 if out["status"] != "success":
                     return json.dumps(out)
@@ -5300,6 +5303,21 @@ class OrchestratorTools:
                             f"writing, call again with copy=true — it lands "
                             f"in {out_dir}. To leave it where it is, "
                             f"reference it by a relative path instead.")})
+                    if copy:
+                        # The file is already in this delegation's folder;
+                        # the agent usually wanted it beside a document
+                        # that lives ELSEWHERE (an earlier delegation's).
+                        # A copy can only land here, so route to the
+                        # relative-path embed instead of a dead end.
+                        return json.dumps({"status": "error", "message": (
+                            f"'{safe_name}' already lives in this "
+                            f"delegation's folder ({dest.parent}); a copy "
+                            f"only ever lands here. To embed it in a "
+                            f"document stored in ANOTHER folder, do not "
+                            f"copy — reference it with a relative path "
+                            f"from that document's folder (e.g. "
+                            f"../{dest.parent.name}/{safe_name}); the "
+                            f"PDF twin resolves it.")})
                     return json.dumps({"status": "error", "message": (
                         f"'{safe_name}' is already this file's name in "
                         f"{dest.parent} — nothing to do. Give a different "

--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -1460,8 +1460,9 @@ class SimulationOrchestratorTools:
                         "Edit too large for edit_file. For a broader input "
                         "change — retuning several coupled parameters, or "
                         "regenerating a deck — use apply_input_adjustments. For "
-                        "a verbatim insertion, split the text at a unique "
-                        "boundary into consecutive smaller edit_file calls."),
+                        "a verbatim insertion, split the text at unique "
+                        "boundaries into snippets under the cap and pass "
+                        "them TOGETHER as one `edits` list in a single call."),
                 )
                 if out["status"] == "success":
                     n = out.get("n_edits", 1)

--- a/scilink/utils/file_edit.py
+++ b/scilink/utils/file_edit.py
@@ -46,8 +46,9 @@ DEFAULT_MAX_FILE_BYTES = 16 * 1024 * 1024
 _BINARY_SNIFF_BYTES = 8192
 
 DEFAULT_TOO_LARGE_MESSAGE = (
-    "Edit too large for edit_file — split the change at a unique boundary "
-    "into consecutive smaller edit_file calls."
+    "Edit too large for edit_file — split the change at unique boundaries "
+    "into smaller snippets and pass them TOGETHER as one `edits` list in a "
+    "single call, not as a chain of one-edit calls."
 )
 
 # The recovery route when a verbatim snippet guess misses. Parameterized

--- a/tests/test_edit_file_live.py
+++ b/tests/test_edit_file_live.py
@@ -526,11 +526,113 @@ def part10_readability_pass():
     check("p10 PDF twin refreshed", "PDF twin refreshed" in log)
 
 
+# A ~6 KB, six-paragraph section: three times the per-snippet cap, so it
+# cannot go in as one edit — it must go in as ONE batched `edits` call.
+def _big_section():
+    paras = []
+    for i in range(1, 7):
+        paras.append(
+            f"**Layer {i} — MARKER-L{i}X.** " + (
+                "This paragraph is part of a verbatim insertion whose total "
+                "length is deliberately far above the per-snippet cap of the "
+                "surgical editor, so that a faithful transcription cannot fit "
+                "in a single old/new pair and the agent must decide how to "
+                "split it. The correct move is a single batched call whose "
+                "edits list carries the paragraphs in order, each anchored on "
+                "the previous one; the wrong move is a chain of one-edit calls "
+                "that burns the turn's tool budget one paragraph at a time. "
+            ) * 3)
+    return "## Role of AI/ML/Agents\n\n" + "\n\n".join(paras)
+
+
+def part11_big_insertion_batched():
+    print("\n=== 11. oversized verbatim INSERTION goes in as ONE batched call ===")
+    run = BASE / "p11"
+    orch = _seed_session(run, {"report.md": REPORT}, with_pdf=("report.md",))
+    base = Path(orch.base_dir)
+    section = _big_section()
+    assert len(section) > 5000
+
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        orch.chat(
+            "Insert the following new section into report.md VERBATIM "
+            "(do not paraphrase, shorten, or reflow it), placed "
+            "immediately BEFORE the '## Approach' heading. Leave every "
+            "other part of the document exactly as it is:\n\n" + section)
+    log = buf.getvalue()
+
+    text = (base / "report.md").read_text()
+    check("p11 all six paragraphs landed",
+          all(f"MARKER-L{i}X" in text for i in range(1, 7)))
+    check("p11 placed before Approach, other sections intact",
+          text.find("MARKER-L6X") < text.find("## Approach")
+          and "![Campaign workflow]" in text and "rocking-curve width" in text)
+    n_edit_calls = log.count("Tool: Editing file")
+    n_too_large = log.count("Edit too large")
+    print(f"    edit_file calls: {n_edit_calls}, too-large rejections: {n_too_large}")
+    used_revision = "Revised IN PLACE" in log
+    check("p11 batched: at most 3 edit_file calls (was: 11 live), or revision",
+          used_revision or (1 <= n_edit_calls <= 3))
+    check("p11 no save_file rewrite", "Tool: Saving file" not in log)
+    check("p11 PDF twin refreshed (log)", "PDF twin refreshed" in log)
+
+
+def part12_embed_into_earlier_delegation():
+    print("\n=== 12. figure HERE, document in an EARLIER delegation: relative embed ===")
+    run = BASE / "p12"
+    orch = _seed_session(run, {})
+    base = Path(orch.base_dir)
+    d01 = base / "delegations" / "01_author_white_paper"
+    d02 = base / "delegations" / "02_add_ai_loop_figure"
+    d01.mkdir(parents=True)
+    d02.mkdir(parents=True)
+    _write_png(d01 / "campaign_workflow.png", "navy")
+    _write_png(d02 / "ai_loop.png", "teal")
+    doc = d01 / "white_paper.md"
+    doc.write_text(REPORT.replace("old_diagram.png", "campaign_workflow.png"))
+    from scilink.utils.md_to_pdf import markdown_to_pdf
+    markdown_to_pdf(doc)
+    orch._active_output_subdir = d02
+
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        orch.chat(
+            f"The figure {d02 / 'ai_loop.png'} was rendered in this "
+            "delegation. Embed it in white_paper.md (the document from "
+            "delegation 01) as a new figure at the end of the Motivation "
+            "section, with the caption 'Figure 2 — AI loop.', so that the "
+            "reference resolves and the PDF twin carries it. Do not alter "
+            "any other prose.")
+    log = buf.getvalue()
+
+    text = doc.read_text()
+    check("p12 document references the figure", "ai_loop.png" in text)
+    ref = next((l for l in text.splitlines() if "ai_loop.png" in l), "")
+    resolves = False
+    m = __import__("re").search(r"\((.*?ai_loop\.png)\)", ref)
+    if m:
+        resolves = (d01 / m.group(1)).resolve().exists() \
+            or Path(m.group(1)).exists()
+    check("p12 reference resolves from the document's folder", resolves)
+    check("p12 no phantom copy of the doc in delegation 02",
+          not (d02 / "white_paper.md").exists())
+    check("p12 caption present", "Figure 2" in text)
+    check("p12 no save_file rewrite", "Tool: Saving file" not in log)
+    check("p12 PDF twin refreshed (log)", "PDF twin refreshed" in log)
+    n_calls = log.count("Tool: ")
+    print(f"    tool calls this turn: {n_calls}")
+    check("p12 finished within budget (no iteration cap)",
+          "Maximum tool iterations" not in log)
+
+
 PARTS = {"1": part1_mechanical_swap, "2": part2_content_revision,
          "3": part3_replace_all, "4": part4_delegation_layout,
          "5": part5_disambiguation, "6": part6_cap_fallback,
          "7": part7_sandbox_honesty, "8": part8_html_edit,
-         "9": part9_rename, "10": part10_readability_pass}
+         "9": part9_rename, "10": part10_readability_pass,
+         "11": part11_big_insertion_batched,
+         "12": part12_embed_into_earlier_delegation}
 
 if __name__ == "__main__":
     want = sys.argv[1:] or sorted(PARTS)

--- a/tests/test_rename_copy_across_delegations.py
+++ b/tests/test_rename_copy_across_delegations.py
@@ -94,7 +94,10 @@ def test_copy_of_a_file_already_here_under_the_same_name_is_refused(tmp_path):
                                         copy=True))
 
     assert out["status"] == "error"
-    assert "already this file's name" in out["message"]
+    # Routing, not a dead end: a copy can only land here, so the agent is
+    # told to embed by relative path from the other document's folder.
+    assert "relative path" in out["message"]
+    assert "../09_consolidate/campaign_workflow.png" in out["message"]
     assert fig.exists()
 
 


### PR DESCRIPTION
## Summary

Two tool-message fixes that stop the planning agent from burning its 20-iteration turn budget on file housekeeping. Observed live: a meta delegation asked to add a section and a diagram to an existing white paper hit "Maximum tool iterations reached" — the section and figure had landed, but the figure never got embedded in the document.

**What went wrong**
- `edit_file`'s "too large" error told the agent to split an oversize verbatim insertion into *consecutive smaller edit_file calls* — contradicting the tool spec, which asks for one batched `edits` list. The agent obeyed the error: 11 calls (2 rejected, then one paragraph per call) for a single six-paragraph section.
- `rename_file(copy=true)` on a figure already in the current delegation folder returned "already this file's name — nothing to do". A copy can only land in the current folder by design, so when the *document* lives in an earlier delegation this was a dead end, and the agent spent its last iterations trying to work around it.

**Fix**
- Too-large message (shared default in `utils/file_edit.py`, planning, sim) now says: split into snippets under the cap and pass them TOGETHER as one `edits` list in a single call.
- The copy-into-own-folder case now routes to a relative-path reference from the other document's folder (`../<folder>/<file>`), keeping the deliberate "destination is never agent-chosen" design.

## Technical details

- `scilink/utils/file_edit.py` — `DEFAULT_TOO_LARGE_MESSAGE` reworded.
- `scilink/agents/planning_agents/orchestrator_tools.py` — planning `edit_file` too-large message reworded; `rename_file` gains a `copy`-specific branch on `rp == dest` with the relative-path routing.
- `scilink/agents/sim_agents/simulation_orchestrator_tools.py` — sim `edit_file` too-large message reworded.
- `tests/test_rename_copy_across_delegations.py` — same-name-copy test now asserts the routing message.
- `tests/test_edit_file_live.py` — new p11 (6 KB verbatim insertion) and p12 (figure here, document in an earlier delegation).

**Verification**
- Offline: 49/49 (`test_rename_copy_across_delegations`, `test_edit_file_tool`, `test_file_edit_utility`).
- Live on Bedrock Opus 4.8, 12/12: p11 lands the section in **one** `edit_file` call carrying a 6-item `edits` list (was 11 calls), 0 rejections; p12 hits the copy message, follows it, and embeds `../02_…/ai_loop.png` in the delegation-01 document in 4 tool calls, PDF twin refreshed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>