### PR TITLE
write_technical_document(style='memo'): one-page house memo with .docx twin

### DIFF
--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -1333,6 +1333,46 @@ portfolio names directions; benchwork is designed later, once one is chosen.
 """
 
 
+# One-page memo style for write_technical_document(style="memo"). A house
+# template distilled from a set of facility-design memos: header block, one
+# CORE line, a few short lead-in paragraphs, a decision at the end. Stated
+# as principles (what a memo IS), not as phrases to copy.
+TECHNICAL_MEMO_STYLE_RULES = """
+
+**THIS IS A ONE-PAGE TECHNICAL MEMO, NOT A REPORT.** Hard budget: the whole
+document is 350-500 words and reads on a single page. Drafts always run
+long, so write to 400 words and stop; a 400-word memo that omits a point
+is right, a 600-word one is not a memo. Density comes from cutting, not
+from compressing sentences.
+
+Shape (return it through the same "sections" contract):
+- FIRST section: heading "" (empty) — the header block, one line each in
+  this order: an italic one-line subtitle stating what the memo defines;
+  "**Purpose:** ..." (one sentence); "**Scope:** ..." (one sentence: what
+  is in, what is out — or "**Operating premise:** ..." when a working
+  assumption frames the memo); "**Date:** <today>"; then a blank line and
+  ONE bold line beginning "**CORE RULE**", "**CORE UNIT**", "**CORE
+  METRIC**" or "**CORE FRAMING**" (choose the one that fits) followed by
+  two spaces and the whole memo in one sentence.
+- Then 3-5 sections with short headings (three to six words). Each is
+  one to three paragraphs; a paragraph opens with a bold lead-in of one
+  to three words ending in a period ("**Role.** ...", "**Estimate
+  basis.** ...", "**Before and during.** ...") that names its point, then
+  two to four plain sentences. Bullets only for a genuine list of
+  parallel items; at most one small table, and only if the request has
+  a comparison an "At a glance" table serves.
+- LAST section is the decision: heading such as "Planning implication",
+  "Development approach" or "Common platform requirements" — what to do
+  next and what it commits the reader to, not a summary of the above.
+
+Do not add: an executive summary, background section, methods narrative,
+risks catalogue, references section (unless the context supplies real
+references you cite), or a closing summary. Every number carries its
+basis in the same sentence ("assumes", "at 2-5 episodes/week"). If the
+request asks for more than a memo can hold, cover what matters most and
+say in the Scope line what was left out.
+"""
+
 # Revision mode for write_technical_document. Authoring a fresh document and
 # revising one are different jobs: a revision must preserve everything it was
 # not asked to change, and must return the WHOLE document, because the tool

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -7389,8 +7389,12 @@ class OrchestratorTools:
             use_literature: bool = True,
             revise_path: str = None,
             literature_context: str = None,
+            style: str = "report",
         ):
             """Author a grounded technical document and save it.
+
+            style="memo" is the one-page house memo (header block, CORE
+            line, 3-5 lead-in sections, 350-550 words) with a .docx twin.
 
             Not a plan: no experiment schema, no campaign state, no plan
             report. A roadmap or estimate that went through the plan tool
@@ -7497,6 +7501,16 @@ class OrchestratorTools:
                                  else rp.stem.replace("_", " "))
                 doc_title = doc_title or (request[:70].strip()
                                           or "Technical document")
+                memo = (style or "report").strip().lower() == "memo"
+                # A memo has a hard length budget. The prompt states it; the
+                # guard enforces it with ONE re-ask that names the overshoot,
+                # then ships with a warning rather than looping.
+                MEMO_MAX_WORDS = 600
+                date_note = None
+                if memo:
+                    from datetime import datetime as _dt
+                    date_note = (f"## TODAY (for the memo's Date line): "
+                                 f"{_dt.now():%B %-d, %Y}")
                 result = author_technical_document(
                     request=request,
                     kb_docs=planner.kb_docs,
@@ -7504,10 +7518,13 @@ class OrchestratorTools:
                     generation_config=planner.generation_config,
                     external_context=lit,
                     source_documents=("\n\n".join(sources) if sources else None),
+                    additional_context=date_note,
                     skill_context=planner._build_skill_context("planning"),
                     revise_document=current,
-                    task_name=("Technical Document (revision)" if current
-                               else "Technical Document"),
+                    style="memo" if memo else "report",
+                    task_name=(("Technical Memo" if memo
+                                else "Technical Document")
+                               + (" (revision)" if current else "")),
                 )
                 if result.get("error"):
                     return json.dumps({"status": "error",
@@ -7517,8 +7534,37 @@ class OrchestratorTools:
                     return json.dumps({
                         "status": "error",
                         "message": "The author returned no sections."})
-
                 text = document_to_markdown(doc_title, sections)
+                n_words = len(text.split())
+                if memo and n_words > MEMO_MAX_WORDS:
+                    # Structural support for the length rule: condense
+                    # passes over the DRAFT ALONE (no sources, no
+                    # retrieval) — at most two, each keeping the shorter
+                    # text. If they fail or it is still long, the draft
+                    # ships with a warning; the guard never fails the call.
+                    from .planning_rag import condense_memo
+                    for _pass in range(2):
+                        print(f"    ✂️  Memo draft is {n_words} words — over "
+                              f"the one-page budget; condensing")
+                        tight = condense_memo(text, planner.model,
+                                              planner.generation_config,
+                                              max_words=400)
+                        tsecs = ([] if not isinstance(tight, dict)
+                                 or tight.get("error")
+                                 else (tight.get("sections") or []))
+                        if not tsecs:
+                            print("    ⚠️  Condense pass failed; keeping "
+                                  "the draft")
+                            break
+                        ttext = document_to_markdown(doc_title, tsecs)
+                        tn = len(ttext.split())
+                        if tn >= n_words:
+                            # A "condense" that grew is a failed pass.
+                            break
+                        text, sections, n_words = ttext, tsecs, tn
+                        print(f"    ✂️  Condensed to {tn} words")
+                        if n_words <= MEMO_MAX_WORDS:
+                            break
                 if revise_path:
                     out = rp
                     # Revising in place crosses delegation isolation, which
@@ -7558,7 +7604,7 @@ class OrchestratorTools:
                     # A revision that came back shorter than the original is
                     # nearly always the model summarising instead of
                     # revising. Refuse rather than overwrite the good copy.
-                    if len(text) < 0.5 * len(current or ""):
+                    if not memo and len(text) < 0.5 * len(current or ""):
                         return json.dumps({
                             "status": "error",
                             "message": (
@@ -7579,10 +7625,23 @@ class OrchestratorTools:
                 # white paper does. Skipped on a revision: the document
                 # already has its figure, and a second pass would append a
                 # duplicate section.
-                if not revise_path:
+                if not revise_path and not memo:
                     text = self._maybe_embed_workflow_diagram(
                         text, out.parent, stem=f"{out.stem}_workflow")
                 out.write_text(text, encoding="utf-8")
+                # The memo's circulating form is .docx (house style: label,
+                # header block, Heading 1 sections). Deterministic, no LLM.
+                docx_path = None
+                if memo:
+                    try:
+                        from ...utils.md_to_docx import markdown_to_docx
+                        docx_path = markdown_to_docx(out)
+                        print(f"    📝 Memo .docx: {format_path(docx_path)}")
+                        record_deliverable(self.orch.base_dir, docx_path,
+                                           f"{doc_title} (.docx)",
+                                           deliverable=True)
+                    except Exception as e:  # noqa: BLE001 - never block the write
+                        logging.warning(f"Memo .docx export failed: {e}")
                 # A revised document's exported PDF twin (the white paper's
                 # forwarded copy) must not keep serving the pre-revision
                 # content; re-export is deterministic, so it does not touch
@@ -7612,6 +7671,8 @@ class OrchestratorTools:
                        "sections": [s.get("heading") for s in sections
                                     if isinstance(s, dict)],
                        "words": len(text.split()),
+                       "style": "memo" if memo else "report",
+                       "docx": (str(docx_path) if docx_path else None),
                        "literature_used": bool(lit),
                        "sources_used": len(sources)}
                 if missing:
@@ -7624,6 +7685,13 @@ class OrchestratorTools:
                         "include a figure, reference it IN the document "
                         "body instead: ![caption](<filename>) — the "
                         "renderer resolves it from the file's directory.")
+                if memo and len(text.split()) > MEMO_MAX_WORDS:
+                    res["length_warning"] = (
+                        f"Memo is {len(text.split())} words after "
+                        f"condensing; the one-page budget is ~550. Do NOT "
+                        f"add content. If it must be shorter, name what to "
+                        f"cut in a revise_path pass with style='memo'; "
+                        f"otherwise ship it as is.")
                 if declined_topics:
                     res["literature_declined"] = {
                         "available_sections": declined_topics,
@@ -7646,7 +7714,11 @@ class OrchestratorTools:
                 "Author a grounded technical DOCUMENT and save it as the "
                 "deliverable: a roadmap, staging or build plan, cost or "
                 "footprint estimate, consolidation memo, brief, summary or "
-                "review. USE THIS — not generate_initial_plan — whenever the "
+                "review. For a ONE-PAGE memo / one-pager / brief — a "
+                "'short memo on X', 'one page for the director' — pass "
+                "style='memo': the house memo template (header block, one "
+                "CORE line, 3-5 lead-in sections, 350-550 words) with a "
+                ".docx twin. USE THIS — not generate_initial_plan — whenever the "
                 "user says 'plan' in the everyday sense of a course of "
                 "action ('plan how we build the facility', 'outline the "
                 "stages', 'estimate the space we need'). "
@@ -7746,6 +7818,23 @@ class OrchestratorTools:
                         "current delegation folder instead, and a save_file "
                         "call truncates what is already there. Omit for a new "
                         "document; `filename` is ignored when this is set."
+                    ),
+                },
+                "style": {
+                    "type": "string",
+                    "enum": ["report", "memo"],
+                    "description": (
+                        "'report' (default): unconstrained document — white "
+                        "paper, roadmap, review. 'memo': ONE-PAGE technical "
+                        "memo in the house template — header block "
+                        "(subtitle, Purpose, Scope, Date), one CORE line, "
+                        "3-5 short sections of bold-lead-in paragraphs, a "
+                        "closing decision section, 350-550 words, exported "
+                        "as .md + .docx. Use whenever the user asks for a "
+                        "memo, one-pager, brief or 'a page on'. With "
+                        "revise_path, style='memo' CONDENSES the existing "
+                        "document into a memo (the verbatim-revision rule "
+                        "yields to the length budget)."
                     ),
                 },
             },

--- a/scilink/agents/planning_agents/planning_rag.py
+++ b/scilink/agents/planning_agents/planning_rag.py
@@ -24,6 +24,7 @@ from .instruct import (
     IDEATION_AUTHOR_OVERRIDE,
     IDEATION_OUTPUT_RULES,
     TECHNICAL_DOCUMENT_INSTRUCTIONS,
+    TECHNICAL_MEMO_STYLE_RULES,
     IDEATION_PORTFOLIO_INSTRUCTIONS,
     PORTFOLIO_REFINEMENT_RULES,
     IDEATION_PORTFOLIO_INSTRUCTIONS_FALLBACK,
@@ -1075,6 +1076,13 @@ def refine_code_with_feedback(result: Dict[str, Any],
         print(f"    - ❌ Error during code refinement: {e}")
         return result
 
+MEMO_REVISION_OVERRIDE = """
+**Memo revision override.** Because the target is a one-page memo, the
+"return everything verbatim" rule above yields to the memo budget: keep the
+substance and any real references, but condense to the memo shape.
+"""
+
+
 def author_technical_document(request: str,
                               kb_docs: Any,
                               model: Any,
@@ -1085,9 +1093,14 @@ def author_technical_document(request: str,
                               additional_context: Optional[str] = None,
                               skill_context: Optional[str] = None,
                               revise_document: Optional[str] = None,
+                              style: str = "report",
                               task_name: str = "Technical Document"
                               ) -> Dict[str, Any]:
     """Author a grounded technical document (roadmap, estimate, memo, brief).
+
+    ``style="memo"`` appends the one-page memo template rules (header
+    block, CORE line, 3-5 lead-in sections, 350-550 words); the default
+    ``"report"`` is the unconstrained document.
 
     Same retrieval path as plan generation, different contract: the model
     returns SECTIONS, not an experiment. Sections rather than one markdown
@@ -1112,6 +1125,16 @@ def author_technical_document(request: str,
     if revise_document:
         _instr += TECHNICAL_DOCUMENT_REVISION_RULES
         _fallback += TECHNICAL_DOCUMENT_REVISION_RULES
+    if style == "memo":
+        # After the revision rules on purpose: a memo revision keeps the
+        # memo's shape, and condensing a long document INTO a memo is a
+        # legitimate revision — the memo budget then overrides "return
+        # everything verbatim".
+        _instr += TECHNICAL_MEMO_STYLE_RULES
+        _fallback += TECHNICAL_MEMO_STYLE_RULES
+        if revise_document:
+            _instr += MEMO_REVISION_OVERRIDE
+            _fallback += MEMO_REVISION_OVERRIDE
     result = run_rag(
         query=request,
         instructions=_instr,
@@ -1127,6 +1150,48 @@ def author_technical_document(request: str,
     if not isinstance(result, dict):
         return {"error": f"Document generation returned {type(result).__name__}"}
     return result
+
+
+MEMO_CONDENSE_INSTRUCTIONS = """
+You are tightening a ONE-PAGE technical memo that came back too long. The
+draft is given below in full. Return the SAME memo condensed to the word
+budget stated in the objective — same header block (subtitle, Purpose,
+Scope, Date), the same single CORE line, 3-5 sections of bold-lead-in
+paragraphs, the same closing decision section. Cut by dropping the
+paragraphs, bullets and sections that matter least and by removing
+restatement; do not compress sentences into clause chains, do not add
+anything, keep every real citation you keep a claim for.
+
+Return a JSON object with a "sections" list; each entry has "heading" (the
+header block keeps heading "") and "body" (markdown). Return ONLY the JSON.
+"""
+
+
+def condense_memo(draft_markdown: str,
+                  model: Any,
+                  generation_config: Any,
+                  *,
+                  max_words: int = 400,
+                  task_name: str = "Technical Memo (condense)"
+                  ) -> Dict[str, Any]:
+    """Tighten an over-budget memo draft — the draft ALONE, no retrieval,
+    no source documents.
+
+    Structural support for the memo length rule: re-asking the RAG author
+    re-injects the full source corpus and the draft comes back long again
+    (live: 788 → 639 → still over). Condensing a finished draft is a
+    narrower task the model does reliably.
+    """
+    return run_rag(
+        query=(f"Condense the memo below to NO MORE THAN {max_words} words "
+               f"(count them), keeping its shape."),
+        instructions=MEMO_CONDENSE_INSTRUCTIONS + TECHNICAL_MEMO_STYLE_RULES,
+        kb=None,
+        model=model,
+        generation_config=generation_config,
+        additional_context="## THE DRAFT MEMO (condense THIS):\n" + draft_markdown,
+        task_name=task_name,
+    )
 
 
 def document_to_markdown(title: str, sections: List[Dict[str, Any]]) -> str:

--- a/scilink/utils/md_to_docx.py
+++ b/scilink/utils/md_to_docx.py
@@ -1,0 +1,147 @@
+"""Markdown → .docx for one-page technical memos.
+
+A deliberately small converter for the memo shape produced by
+``write_technical_document(style="memo")``: a title, a header block of
+bold-labelled lines, ``## `` sections, paragraphs with ``**bold**`` runs,
+``- `` bullets and simple pipe tables. It is not a general markdown
+renderer — a white paper keeps its PDF twin; the memo additionally gets
+the .docx that is what actually circulates.
+
+Deterministic and LLM-free, like ``md_to_pdf``.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+_INLINE = re.compile(r"(\*\*[^*]+\*\*|\*[^*]+\*|`[^`]+`)")
+
+
+def _add_runs(par, text: str) -> None:
+    """Emit ``text`` into ``par`` honouring **bold**, *italic*, `code`."""
+    for tok in _INLINE.split(text):
+        if not tok:
+            continue
+        if tok.startswith("**") and tok.endswith("**"):
+            r = par.add_run(tok[2:-2]); r.bold = True
+        elif tok.startswith("*") and tok.endswith("*"):
+            r = par.add_run(tok[1:-1]); r.italic = True
+        elif tok.startswith("`") and tok.endswith("`"):
+            r = par.add_run(tok[1:-1]); r.font.name = "Consolas"
+        else:
+            par.add_run(tok)
+
+
+def _split_table(lines: List[str]) -> Optional[List[List[str]]]:
+    rows = []
+    for ln in lines:
+        cells = [c.strip() for c in ln.strip().strip("|").split("|")]
+        if all(re.fullmatch(r":?-{2,}:?", c) for c in cells if c):
+            continue  # separator row
+        rows.append(cells)
+    return rows or None
+
+
+def markdown_to_docx(md_path: Path, label: str = "TECHNICAL MEMO",
+                     docx_path: Optional[Path] = None) -> Path:
+    """Render ``md_path`` to a .docx twin (same stem) and return its path.
+
+    Layout: US Letter, 1-inch margins, 11-pt body; a bold small-caps
+    ``label`` line above the title; ``## `` headings as Heading 1;
+    ``**Bold.**`` lead-ins preserved as bold runs.
+    """
+    from docx import Document
+    from docx.shared import Pt, Inches
+
+    md_path = Path(md_path)
+    out = Path(docx_path) if docx_path else md_path.with_suffix(".docx")
+    text = md_path.read_text(encoding="utf-8", errors="replace")
+
+    doc = Document()
+    sec = doc.sections[0]
+    sec.page_width, sec.page_height = Inches(8.5), Inches(11)
+    for side in ("left_margin", "right_margin", "top_margin", "bottom_margin"):
+        setattr(sec, side, Inches(1))
+    normal = doc.styles["Normal"]
+    normal.font.name = "Calibri"
+    normal.font.size = Pt(11)
+    normal.paragraph_format.space_after = Pt(6)
+
+    lines = text.splitlines()
+    i, first_h1_done = 0, False
+    para_buf: List[str] = []
+
+    def flush_para():
+        nonlocal para_buf
+        if para_buf:
+            p = doc.add_paragraph()
+            _add_runs(p, " ".join(s.strip() for s in para_buf))
+            para_buf = []
+
+    while i < len(lines):
+        ln = lines[i]
+        s = ln.strip()
+        if not s:
+            flush_para(); i += 1; continue
+        if s.startswith("# ") and not first_h1_done:
+            flush_para()
+            lab = doc.add_paragraph(); r = lab.add_run(label); r.bold = True
+            lab.paragraph_format.space_after = Pt(0)
+            t = doc.add_paragraph(); r = t.add_run(s[2:].strip())
+            r.bold = True; r.font.size = Pt(15)
+            first_h1_done = True
+            i += 1; continue
+        m = re.match(r"^(#{1,6})\s+(.*)$", s)
+        if m:
+            flush_para()
+            level = 1 if len(m.group(1)) <= 2 else min(len(m.group(1)) - 1, 3)
+            doc.add_heading(m.group(2).strip(), level=level)
+            i += 1; continue
+        if s.startswith("|"):
+            flush_para()
+            j = i
+            while j < len(lines) and lines[j].strip().startswith("|"):
+                j += 1
+            rows = _split_table(lines[i:j])
+            if rows:
+                ncol = max(len(r) for r in rows)
+                tbl = doc.add_table(rows=len(rows), cols=ncol)
+                tbl.style = "Table Grid"
+                for ri, row in enumerate(rows):
+                    for ci in range(ncol):
+                        cell = tbl.cell(ri, ci)
+                        cell.text = ""
+                        _add_runs(cell.paragraphs[0],
+                                  row[ci] if ci < len(row) else "")
+                        if ri == 0:
+                            for r in cell.paragraphs[0].runs:
+                                r.bold = True
+                doc.add_paragraph()
+            i = j; continue
+        if re.match(r"^[-*+]\s+", s):
+            flush_para()
+            p = doc.add_paragraph(style="List Bullet")
+            _add_runs(p, re.sub(r"^[-*+]\s+", "", s))
+            i += 1; continue
+        if re.match(r"^\d+[.)]\s+", s):
+            flush_para()
+            p = doc.add_paragraph(style="List Number")
+            _add_runs(p, re.sub(r"^\d+[.)]\s+", "", s))
+            i += 1; continue
+        if s.startswith("!["):  # images: skip in a memo docx
+            flush_para(); i += 1; continue
+        # A header-block line ("**Purpose:** ...", "*subtitle*", "**CORE RULE** ...")
+        # stands alone; ordinary prose lines are joined into one paragraph.
+        if re.match(r"^(\*\*[^*]+\*\*|\*[^*]+\*)", s) and (
+                s.startswith("**CORE") or re.match(r"^\*\*[A-Za-z ]+:\*\*", s)
+                or (s.startswith("*") and not s.startswith("**") and s.endswith("*"))):
+            flush_para()
+            p = doc.add_paragraph(); _add_runs(p, s)
+            p.paragraph_format.space_after = Pt(2)
+            i += 1; continue
+        para_buf.append(s)
+        i += 1
+    flush_para()
+    doc.save(out)
+    return out

--- a/tests/test_memo_style_document.py
+++ b/tests/test_memo_style_document.py
@@ -1,0 +1,188 @@
+"""write_technical_document(style="memo"): one-page memo routing.
+
+Offline: the author is stubbed. Checks the style flag reaches the author,
+the length guard re-asks once and then ships with a warning, memo
+revisions bypass the shrink guard, no workflow diagram is appended, and
+the .docx twin renders the house layout.
+"""
+import json
+from pathlib import Path
+
+from docx import Document
+
+from scilink.agents.planning_agents import orchestrator_tools as ot
+from scilink.agents.planning_agents import planning_rag as ot_rag
+from scilink.utils.md_to_docx import markdown_to_docx
+from tests.test_edit_file_tool import make_tools
+
+HEADER = ("*One-line subtitle*\n\n**Purpose:** Define X.\n**Scope:** Y only.\n"
+          "**Date:** August 17, 2026\n\n**CORE RULE**  One sentence.")
+
+
+def _memo_sections(n_words_body=60):
+    body = " ".join(["word"] * n_words_body)
+    return [{"heading": "", "body": HEADER},
+            {"heading": "Scientific role", "body": f"**Role.** {body}"},
+            {"heading": "Planning implication", "body": f"**Stage it.** {body}"}]
+
+
+def _stub_author(monkeypatch, drafts):
+    """Successive calls return successive drafts; records the kwargs."""
+    calls = []
+
+    def fake(request, kb_docs, model, generation_config, **kw):
+        calls.append(kw)
+        idx = min(len(calls) - 1, len(drafts) - 1)
+        return {"sections": drafts[idx]}
+    monkeypatch.setattr(ot, "author_technical_document", fake)
+    return calls
+
+
+def test_memo_style_reaches_author_and_exports_docx(tmp_path, monkeypatch):
+    tools, cap, deleg = make_tools(tmp_path)
+    tools._maybe_embed_workflow_diagram = lambda text, d, stem=None: text + "\nDIAGRAM\n"
+    calls = _stub_author(monkeypatch, [_memo_sections()])
+
+    out = json.loads(cap["write_technical_document"](
+        request="one page on X", filename="x_memo.md", title="X memo",
+        use_literature=False, style="memo"))
+
+    assert out["status"] == "success"
+    assert calls[0]["style"] == "memo"
+    assert "TODAY" in (calls[0]["additional_context"] or "")
+    assert out["style"] == "memo"
+    md = Path(out["path"])
+    assert "DIAGRAM" not in md.read_text(), "memos get no auto workflow diagram"
+    docx = Path(out["docx"])
+    assert docx.exists() and docx.suffix == ".docx"
+    d = Document(docx)
+    texts = [p.text for p in d.paragraphs]
+    assert texts[0] == "TECHNICAL MEMO"
+    assert texts[1] == "X memo"
+    assert any(p.style.name == "Heading 1" and p.text == "Scientific role"
+               for p in d.paragraphs)
+    lead = next(p for p in d.paragraphs if p.text.startswith("Role."))
+    assert lead.runs[0].bold and lead.runs[0].text == "Role."
+
+
+def test_report_style_is_unchanged(tmp_path, monkeypatch):
+    tools, cap, deleg = make_tools(tmp_path)
+    tools._maybe_embed_workflow_diagram = lambda text, d, stem=None: text + "\nDIAGRAM\n"
+    calls = _stub_author(monkeypatch, [_memo_sections()])
+    out = json.loads(cap["write_technical_document"](
+        request="a roadmap", filename="r.md", use_literature=False))
+    assert out["status"] == "success" and out["style"] == "report"
+    assert calls[0]["style"] == "report" and calls[0]["additional_context"] is None
+    assert out["docx"] is None
+    assert "DIAGRAM" in Path(out["path"]).read_text()
+
+
+def _stub_condense(monkeypatch, result):
+    calls = []
+
+    def fake(draft, model, generation_config, **kw):
+        calls.append((draft, kw))
+        return result
+    monkeypatch.setattr(ot_rag, "condense_memo", fake)
+    return calls
+
+
+def test_memo_length_guard_condenses_over_budget_draft(tmp_path, monkeypatch):
+    tools, cap, deleg = make_tools(tmp_path)
+    tools._maybe_embed_workflow_diagram = lambda text, d, stem=None: text
+    calls = _stub_author(monkeypatch, [_memo_sections(500)])
+    ccalls = _stub_condense(monkeypatch, {"sections": _memo_sections(50)})
+    out = json.loads(cap["write_technical_document"](
+        request="one page", filename="m.md", use_literature=False,
+        style="memo"))
+    assert len(calls) == 1, "the RAG author is not re-asked"
+    assert len(ccalls) == 1 and "word word" in ccalls[0][0]
+    assert ccalls[0][1]["max_words"] == 400
+    assert out["status"] == "success" and "length_warning" not in out
+    assert out["words"] < 200
+
+
+def test_memo_condense_failure_ships_draft_with_warning(tmp_path, monkeypatch):
+    tools, cap, deleg = make_tools(tmp_path)
+    tools._maybe_embed_workflow_diagram = lambda text, d, stem=None: text
+    _stub_author(monkeypatch, [_memo_sections(500)])
+    _stub_condense(monkeypatch, {"error": "JSON Parsing Error"})
+    out = json.loads(cap["write_technical_document"](
+        request="one page", filename="m.md", use_literature=False,
+        style="memo"))
+    assert out["status"] == "success" and "length_warning" in out
+    assert Path(out["path"]).exists() and Path(out["docx"]).exists()
+
+
+def test_memo_condense_that_grew_is_discarded(tmp_path, monkeypatch):
+    tools, cap, deleg = make_tools(tmp_path)
+    tools._maybe_embed_workflow_diagram = lambda text, d, stem=None: text
+    _stub_author(monkeypatch, [_memo_sections(500)])
+    _stub_condense(monkeypatch, {"sections": _memo_sections(900)})
+    out = json.loads(cap["write_technical_document"](
+        request="one page", filename="m.md", use_literature=False,
+        style="memo"))
+    assert out["status"] == "success" and "length_warning" in out
+    assert out["words"] < 1200  # the 500-word draft, not the 900-word one
+
+
+def test_memo_revision_may_condense_a_long_document(tmp_path, monkeypatch):
+    tools, cap, deleg = make_tools(tmp_path)
+    tools._maybe_embed_workflow_diagram = lambda text, d, stem=None: text
+    long_doc = tmp_path / "delegations" / "01_x" / "white_paper.md"
+    long_doc.parent.mkdir(parents=True)
+    long_doc.write_text("# White paper\n\n" + ("## S\n\n" + "prose " * 400 + "\n\n") * 5)
+    calls = _stub_author(monkeypatch, [_memo_sections()])
+
+    out = json.loads(cap["write_technical_document"](
+        request="condense to a memo", revise_path=str(long_doc),
+        use_literature=False, style="memo"))
+
+    assert out["status"] == "success", out
+    assert calls[0]["revise_document"] and calls[0]["style"] == "memo"
+    assert out["words"] < 200 and out["revised_in_place"]
+    assert Path(out["docx"]).exists()
+    assert list(deleg.glob("white_paper.before_revision*"))
+
+
+def test_report_revision_still_refuses_shrinkage(tmp_path, monkeypatch):
+    tools, cap, deleg = make_tools(tmp_path)
+    tools._maybe_embed_workflow_diagram = lambda text, d, stem=None: text
+    long_doc = tmp_path / "delegations" / "01_x" / "white_paper.md"
+    long_doc.parent.mkdir(parents=True)
+    long_doc.write_text("# White paper\n\n" + ("## S\n\n" + "prose " * 400 + "\n\n") * 5)
+    _stub_author(monkeypatch, [_memo_sections()])
+    out = json.loads(cap["write_technical_document"](
+        request="tighten", revise_path=str(long_doc), use_literature=False))
+    assert out["status"] == "error" and "Revision aborted" in out["message"]
+
+
+def test_docx_converter_tables_bullets_and_header_lines(tmp_path):
+    md = tmp_path / "m.md"
+    md.write_text("# T\n\n**Purpose:** p.\n\n**CORE UNIT**  u.\n\n## A\n\n"
+                  "- one\n- two\n\n| Track | Out |\n|---|---|\n| 1 | traj |\n")
+    out = markdown_to_docx(md)
+    d = Document(out)
+    styles = [p.style.name for p in d.paragraphs]
+    assert styles.count("List Bullet") == 2
+    assert len(d.tables) == 1 and d.tables[0].cell(1, 1).text == "traj"
+    purpose = next(p for p in d.paragraphs if p.text.startswith("Purpose:"))
+    assert purpose.runs[0].bold
+
+
+def test_memo_condense_runs_a_second_pass_when_still_long(tmp_path, monkeypatch):
+    tools, cap, deleg = make_tools(tmp_path)
+    tools._maybe_embed_workflow_diagram = lambda text, d, stem=None: text
+    _stub_author(monkeypatch, [_memo_sections(500)])
+    outs = [{"sections": _memo_sections(350)}, {"sections": _memo_sections(120)}]
+    calls = []
+
+    def fake(draft, model, generation_config, **kw):
+        calls.append(draft)
+        return outs[min(len(calls) - 1, 1)]
+    monkeypatch.setattr(ot_rag, "condense_memo", fake)
+    out = json.loads(cap["write_technical_document"](
+        request="one page", filename="m.md", use_literature=False,
+        style="memo"))
+    assert len(calls) == 2
+    assert out["words"] < 400 and "length_warning" not in out

--- a/tests/test_memo_style_live.py
+++ b/tests/test_memo_style_live.py
@@ -1,0 +1,175 @@
+"""Live: write_technical_document(style="memo") on Bedrock.
+
+Run: python tests/test_memo_style_live.py [1 2 3]
+1 — "one-page memo" from a source white paper: routing picks style=memo
+    unprompted; shape, budget, .docx checked.
+2 — memo with no source and no literature: grounding honesty, still memo.
+3 — condense a long white paper INTO a memo in place (revise_path).
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+BASE = Path("tests/_memo_style_live_runs").resolve()
+SRC_WP = Path("meta_session_20260817_162104/planning/delegations/"
+              "01_propose_a_killer_proof_of_concept_use_ca/white_paper.md")
+
+results = {}
+
+
+def check(name, cond):
+    results[name] = bool(cond)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+
+class Tee(io.StringIO):
+    def write(self, s):
+        sys.__stdout__.write(s)
+        return super().write(s)
+
+
+def _seed(run_dir: Path):
+    from scilink.agents.planning_agents.planning_orchestrator import (
+        PlanningOrchestratorAgent, AutonomyLevel)
+    if run_dir.exists():
+        shutil.rmtree(run_dir)
+    (run_dir / "data").mkdir(parents=True)
+    orch = PlanningOrchestratorAgent(
+        objective="Chemical Dynamics Observation & Control platform design",
+        base_dir=str(run_dir / "session"), api_key=None, model_name=MODEL,
+        autonomy_level=AutonomyLevel.AUTONOMOUS, data_dir=str(run_dir / "data"))
+    return orch
+
+
+def _memo_shape_checks(tag, md: Path, docx: Path | None, log: str):
+    text = md.read_text()
+    words = len(text.split())
+    print(f"    {tag}: {words} words; sections: "
+          f"{[l for l in text.splitlines() if l.startswith('## ')]}")
+    check(f"{tag} tool called with style=memo", '"style": "memo"' in log
+          or "style='memo'" in log or "Technical Memo" in log)
+    check(f"{tag} within one-page budget (<=600 words)", words <= 600)
+    check(f"{tag} not trivially short (>=250 words)", words >= 250)
+    check(f"{tag} header block: Purpose + Date lines",
+          re.search(r"\*\*Purpose:\*\*", text) and re.search(r"\*\*Date:\*\*", text))
+    check(f"{tag} Date line carries the injected date",
+          re.search(r"\*\*Date:\*\*\s*August 1[78], 2026", text))
+    check(f"{tag} one CORE line", len(re.findall(r"\*\*CORE [A-Z]+\*\*", text)) == 1)
+    n_sec = len([l for l in text.splitlines() if l.startswith("## ")])
+    check(f"{tag} 3-5 sections", 3 <= n_sec <= 5)
+    check(f"{tag} bold lead-ins used",
+          len(re.findall(r"^\*\*[A-Z][^*]{1,40}\.\*\* ", text, re.M)) >= 3)
+    check(f"{tag} no References/Executive Summary section",
+          not re.search(r"^## (References|Executive Summary|Summary)\s*$", text, re.M))
+    check(f"{tag} no auto workflow diagram", "workflow" not in text.lower()
+          or "![" not in text)
+    check(f"{tag} .docx twin exists", docx is not None and docx.exists())
+    if docx and docx.exists():
+        from docx import Document
+        d = Document(docx)
+        paras = [p for p in d.paragraphs if p.text.strip()]
+        check(f"{tag} docx opens with TECHNICAL MEMO label",
+              paras and paras[0].text == "TECHNICAL MEMO")
+        check(f"{tag} docx has Heading 1 sections",
+              sum(p.style.name == "Heading 1" for p in paras) == n_sec)
+    return text
+
+
+def part1_memo_from_source():
+    print("\n=== 1. one-page memo from a source white paper ===")
+    run = BASE / "p1"
+    orch = _seed(run)
+    base = Path(orch.base_dir)
+    shutil.copy(SRC_WP, base / "white_paper.md")
+
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        orch.chat(
+            "Write a one-page technical memo for the directorate that "
+            "distils white_paper.md: what the proof-of-concept is, why "
+            "state-triggered control benchmarked against a yoked clock is "
+            "the decisive test, and what it commits us to in year one. "
+            "Base it on white_paper.md; no new literature search.")
+    log = buf.getvalue()
+    mds = [p for p in base.rglob("*.md") if p.name != "white_paper.md"
+           and "before_" not in p.name]
+    check("p1 a new memo file was written", len(mds) >= 1)
+    if not mds:
+        return
+    md = max(mds, key=lambda p: p.stat().st_mtime)
+    docx = md.with_suffix(".docx")
+    text = _memo_shape_checks("p1", md, docx, log)
+    check("p1 grounded in source (mentions yoked)", "yoked" in text.lower())
+    check("p1 no save_file authoring", "Tool: Saving file" not in log)
+
+
+def part2_memo_no_source():
+    print("\n=== 2. memo phrasing, no source, no literature ===")
+    run = BASE / "p2"
+    orch = _seed(run)
+    base = Path(orch.base_dir)
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        orch.chat(
+            "Give me a short memo (one page) defining how a quantum-sensing "
+            "track could be added to an operando materials platform "
+            "without changing its scientific objective: role, candidate "
+            "capability families, relationship to the existing workflow, "
+            "and a staged development approach. Skip literature search; "
+            "mark what is assumption.")
+    log = buf.getvalue()
+    mds = [p for p in base.rglob("*.md") if "before_" not in p.name]
+    check("p2 a memo file was written", len(mds) >= 1)
+    if not mds:
+        return
+    md = max(mds, key=lambda p: p.stat().st_mtime)
+    text = _memo_shape_checks("p2", md, md.with_suffix(".docx"), log)
+    check("p2 assumptions marked", re.search(r"assum", text, re.I) is not None)
+
+
+def part3_condense_in_place():
+    print("\n=== 3. condense the white paper INTO a memo in place ===")
+    run = BASE / "p3"
+    orch = _seed(run)
+    base = Path(orch.base_dir)
+    d01 = base / "delegations" / "01_white_paper"
+    d02 = base / "delegations" / "02_condense"
+    d01.mkdir(parents=True); d02.mkdir(parents=True)
+    doc = d01 / "white_paper.md"
+    shutil.copy(SRC_WP, doc)
+    n_before = len(doc.read_text().split())
+    orch._active_output_subdir = d02
+    buf = Tee()
+    with contextlib.redirect_stdout(buf):
+        orch.chat(
+            f"Condense {doc} in place into a one-page technical memo — "
+            "same file, memo format. Keep the yoked-clock benchmark as the "
+            "core idea.")
+    log = buf.getvalue()
+    text = _memo_shape_checks("p3", doc, doc.with_suffix(".docx"), log)
+    print(f"    p3: {n_before} words -> {len(text.split())} words")
+    check("p3 revised in place (same path)", "Revised IN PLACE" in log)
+    check("p3 pre-revision copy kept in delegation 02",
+          list(d02.glob("white_paper.before_revision*")))
+    check("p3 was NOT refused as shrinkage", "Revision aborted" not in log)
+
+
+PARTS = {"1": part1_memo_from_source, "2": part2_memo_no_source,
+         "3": part3_condense_in_place}
+
+if __name__ == "__main__":
+    for k in (sys.argv[1:] or sorted(PARTS)):
+        PARTS[k]()
+    print("\n" + "=" * 60)
+    npass = sum(results.values())
+    for name, ok in results.items():
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name}")
+    print(f"\n{npass}/{len(results)} checks passed")
+    sys.exit(0 if npass == len(results) else 1)


### PR DESCRIPTION
## Summary

Asking the planning agent for "a one-page memo" produced a multi-page white paper: `write_technical_document` had no notion of length or format. This adds `style="memo"` — the one-page technical memo in the house template used for facility-design memos — and exports it as `.md` + `.docx`.

**What a memo looks like** (distilled from a set of existing memos): a header block (italic subtitle, **Purpose:**, **Scope:** or **Operating premise:**, **Date:**), one bold **CORE RULE / UNIT / METRIC / FRAMING** line stating the whole memo in a sentence, 3–5 short sections of bold-lead-in paragraphs ("**Role.** …"), a closing decision section ("Planning implication"), 350–550 words. No executive summary, background, risks catalogue or references section unless real references are supplied.

**How to use:** "write a one-page memo on X", "give me a page for the director", "condense white_paper.md into a memo" — the agent selects `style="memo"` itself (verified live, unprompted). Works for fresh documents and for `revise_path` (condense an existing long document in place).

## Technical details

- `instruct.py` — `TECHNICAL_MEMO_STYLE_RULES` (principles of the shape, not phrases).
- `planning_rag.py` — `author_technical_document(style=...)` appends the memo rules (after the revision rules; a `MEMO_REVISION_OVERRIDE` lets a memo revision condense rather than "return everything verbatim"); new `condense_memo()` — a draft-only pass (`kb=None`, no sources) used as the length enforcer.
- `orchestrator_tools.py` — `style` param + schema enum; today's date injected for the Date line; up to two condense passes when the draft exceeds 600 words, keeping the shorter text, never failing the call (ships with `length_warning` otherwise); memo revisions bypass the 50%-shrink guard; no auto workflow diagram on memos; `.docx` twin recorded as a deliverable; result carries `style` and `docx`.
- `utils/md_to_docx.py` — small deterministic markdown→docx for the memo shape (label, title, header lines, Heading 1, bold lead-ins, bullets, simple tables; Letter, 1" margins).
- Tests: `tests/test_memo_style_document.py` (9 offline: routing, report path unchanged, condense/fallback/grow-discard/second-pass, revision bypass, shrink guard still on for reports, docx converter); `tests/test_memo_style_live.py` (Bedrock harness).

**Why condense rather than re-ask:** the RAG author, re-asked with a lower target, re-reads the whole source and stays long (live 788 → 639 → still over). Condensing the finished draft alone is a narrower task the model does reliably (838 → 617, 601 → 524, 930 → 582); a second pass covers the tail.

**Verification**
- Offline: 9/9 new + 23/23 `test_technical_document_tool` + 49/49 edit/rename suites.
- Live on Bedrock Opus 4.8, 47/47: (1) memo distilled from a 4k-word white paper → 571 words, header block, one CORE line, 3 sections, grounded citations carried, .docx; (2) memo with no source and no literature → 581 words, assumptions marked; (3) condense the white paper in place → 4252 → 561 words, pre-revision copy kept in the editing delegation, not refused as shrinkage.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>