### PR TITLE
Fit-parameter contract, BO bounds/seed/categorical fixes, refit schema completion, MCP restart durability, XRD matched-filter detection

### DIFF
--- a/bo_online_benchmark/bench_mcp.py
+++ b/bo_online_benchmark/bench_mcp.py
@@ -1,0 +1,160 @@
+"""Pool-based BO campaigns driven THROUGH THE MCP SERVER (tool layer), not the
+Python API — the path an external framework actually uses.
+
+Per campaign: one `scilink serve --mode plan` process on a fresh session dir;
+analyze_file(seed csv) locks the schema; then for each step
+run_optimization(candidate_pool=<pool csv>, input_bounds=<design box>,
+experimental_budget=<remaining>) -> recommended row -> measured from the
+pool -> appended through analyze_file. Same inits / pool / recording as
+bench.py so results_mcp/ compares directly with results_regress_pool/.
+
+Differences from the direct harness (by construction of the MCP surface):
+  * no cat_dims argument — encoded categorical inputs arrive as numeric
+    columns and are modelled as continuous (candidate_pool still restricts
+    recommendations to real pool rows);
+  * the planning orchestrator's scalarizer ingests each CSV (pass-through).
+
+Usage:
+  python bench_mcp.py <dataset> <seed> [n_iters]     (client venv: deepagents_bo_demo/.venv)
+Env: BENCH_RESULTS (default results_mcp), BENCH_N_INIT, BENCH_N_ITERS,
+     SCILINK_BIN / SCILINK_MODEL / credentials via ../deepagents-scilink/.env
+"""
+import asyncio
+import json
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+HERE = Path(__file__).parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, "/Users/maxim.ziatdinov/Code/deepagents-scilink")
+
+from pools import Pool  # noqa: E402
+from scilink_mcp import server_config, load_env  # noqa: E402
+from langchain_mcp_adapters.client import MultiServerMCPClient  # noqa: E402
+from langchain_mcp_adapters.tools import load_mcp_tools  # noqa: E402
+
+N_INIT = int(os.environ.get("BENCH_N_INIT", "5"))
+N_ITERS = int(os.environ.get("BENCH_N_ITERS", "15"))
+RES_SUB = os.environ.get("BENCH_RESULTS", "results_mcp")
+RUNS_SUB = f"runs_{RES_SUB}"
+
+
+def _text(r):
+    if isinstance(r, list):
+        r = r[0]["text"] if r and isinstance(r[0], dict) else (r[0] if r else "{}")
+    return json.loads(r)
+
+
+def _record(pool, measured, extras, dataset, method, seed):
+    seq = [int(i) for i in measured]
+    oriented_seq = pool.oriented(pool.y[seq])
+    best = np.maximum.accumulate(oriented_seq)
+    best_nat = (-best).tolist() if pool.direction == "minimize" else best.tolist()
+    out = {"dataset": dataset, "method": method, "seed": seed, "n_init": N_INIT,
+           "direction": pool.direction, "pool_size": pool.n, "pool_optimum": pool.optimum,
+           "picked_indices": seq, "picked_y": pool.y[seq].tolist(), "best_so_far": best_nat,
+           **extras}
+    d = HERE / RES_SUB / dataset
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{method}_seed{seed}.json").write_text(json.dumps(out, indent=1))
+    return out
+
+
+async def run(dataset, seed, n_iters):
+    pool = Pool(dataset)
+    measured = pool.init_indices(seed, N_INIT)
+    run_dir = HERE / RUNS_SUB / f"{dataset}_seed{seed}"
+    if run_dir.exists():
+        shutil.rmtree(run_dir)
+    (run_dir / "client").mkdir(parents=True)
+    session_dir = run_dir / "scilink"
+    client_dir = run_dir / "client"
+
+    pool_csv = client_dir / "pool.csv"
+    pool.df[pool.input_cols].to_csv(pool_csv, index=False)
+    seed_csv = client_dir / "seed.csv"
+    pool.measured_df(measured).to_csv(seed_csv, index=False)
+    bounds = {c: [float(lo), float(hi)] for c, (lo, hi) in zip(pool.input_cols, pool.bounds)}
+    goal = (f"{pool.objective_text} Inputs: {pool.input_cols}. Single target "
+            f"'{pool.target_col}', to be {'MAXIMIZED' if pool.direction == 'maximize' else 'MINIMIZED'}.")
+
+    os.environ.update(load_env())
+    client = MultiServerMCPClient(server_config(session_dir=str(session_dir), mode="plan"))
+    steps_meta, fallbacks, tool_errors = [], 0, []
+    t0 = time.time()
+    async with client.session("scilink") as s:
+        tools = {t.name: t for t in await load_mcp_tools(s)}
+        ing = _text(await tools["scilink_analyze_file"].ainvoke({
+            "file_path": str(seed_csv), "extraction_goal": goal,
+            "inputs": pool.input_cols, "targets": [pool.target_col],
+            "directions": {pool.target_col: pool.direction}}))
+        if ing.get("status") != "success":
+            raise RuntimeError(f"seed ingest failed: {ing}")
+        if ing.get("target_directions", {}).get(pool.target_col) != pool.direction:
+            raise RuntimeError(f"direction not honoured: {ing.get('target_directions')}")
+        for step in range(n_iters):
+            res, err = None, None
+            for attempt in range(2):
+                try:
+                    res = _text(await tools["scilink_run_optimization"].ainvoke({
+                        "parallel_capable": False, "experimental_budget": n_iters - step,
+                        "candidate_pool": str(pool_csv), "input_bounds": bounds}))
+                except Exception as exc:  # noqa: BLE001
+                    res, err = None, f"{type(exc).__name__}: {exc}"
+                    continue
+                if res.get("status") == "success":
+                    break
+                err = f"{res.get('message')} | {res.get('hint', '')}"
+                res = None
+                await asyncio.sleep(5)
+            if res is not None:
+                p = res["recommended_parameters"]
+                if isinstance(p, list):
+                    p = p[0]
+                x = [float(p[c]) for c in pool.input_cols]
+                idx = pool.snap(x, set(measured))
+                strat = res.get("strategy") or {}
+                steps_meta.append({"step": step, "proposal": x, "snapped_index": idx,
+                                   "acq": (strat.get("acquisition_strategy") or {}).get("type"),
+                                   "surrogate": (strat.get("model_config") or {}).get("surrogate"),
+                                   "bounds_source": res.get("input_bounds_source"),
+                                   "directions": res.get("target_directions"),
+                                   "pool": res.get("candidate_pool"), "fallback": False})
+            else:
+                fallbacks += 1
+                tool_errors.append(err)
+                rng = np.random.RandomState(4000 + seed * 100 + step)
+                remaining = [i for i in range(pool.n) if i not in set(measured)]
+                idx = int(rng.choice(remaining))
+                steps_meta.append({"step": step, "proposal": None, "snapped_index": idx,
+                                   "fallback": True, "error": err})
+            measured.append(idx)
+            row_csv = client_dir / f"results_round_{step + 1:02d}.csv"
+            pool.measured_df([idx]).to_csv(row_csv, index=False)
+            ing = _text(await tools["scilink_analyze_file"].ainvoke({
+                "file_path": str(row_csv), "extraction_goal": goal,
+                "inputs": pool.input_cols, "targets": [pool.target_col]}))
+            if ing.get("status") not in ("success", "warning"):
+                tool_errors.append(f"ingest step {step}: {ing}")
+            best = pool.oriented(pool.y[measured]).max()
+            best_nat = -best if pool.direction == "minimize" else best
+            print(f"  [mcp {dataset} seed {seed}] step {step + 1}/{n_iters} -> idx {idx}, "
+                  f"y={pool.y[idx]:.4g}, best={best_nat:.4g}"
+                  f"{' (FALLBACK)' if steps_meta[-1]['fallback'] else ''}", flush=True)
+    out = _record(pool, measured, {"model": os.environ.get("SCILINK_MODEL"), "fallbacks": fallbacks,
+                                   "tool_errors": tool_errors[:20], "steps": steps_meta,
+                                   "elapsed_s": round(time.time() - t0)},
+                  dataset, "agent_mcp", seed)
+    print(json.dumps({k: out[k] for k in ("dataset", "method", "seed", "fallbacks", "elapsed_s")}
+                     | {"final": out["best_so_far"][-1]}))
+
+
+if __name__ == "__main__":
+    ds, sd = sys.argv[1], int(sys.argv[2])
+    n = int(sys.argv[3]) if len(sys.argv) > 3 else N_ITERS
+    asyncio.run(run(ds, sd, n))

--- a/bo_online_benchmark/bench_mcp.py
+++ b/bo_online_benchmark/bench_mcp.py
@@ -8,11 +8,10 @@ experimental_budget=<remaining>) -> recommended row -> measured from the
 pool -> appended through analyze_file. Same inits / pool / recording as
 bench.py so results_mcp/ compares directly with results_regress_pool/.
 
-Differences from the direct harness (by construction of the MCP surface):
-  * no cat_dims argument — encoded categorical inputs arrive as numeric
-    columns and are modelled as continuous (candidate_pool still restricts
-    recommendations to real pool rows);
-  * the planning orchestrator's scalarizer ingests each CSV (pass-through).
+Differences from the direct harness: the planning orchestrator's scalarizer
+ingests each CSV (pass-through); categorical inputs are declared with
+input_types (the orchestrator level-encodes data + pool and decodes the
+recommendation) and the objective direction with directions.
 
 Usage:
   python bench_mcp.py <dataset> <seed> [n_iters]     (client venv: deepagents_bo_demo/.venv)
@@ -92,7 +91,8 @@ async def run(dataset, seed, n_iters):
         ing = _text(await tools["scilink_analyze_file"].ainvoke({
             "file_path": str(seed_csv), "extraction_goal": goal,
             "inputs": pool.input_cols, "targets": [pool.target_col],
-            "directions": {pool.target_col: pool.direction}}))
+            "directions": {pool.target_col: pool.direction},
+            "input_types": {pool.input_cols[i]: "categorical" for i in (pool.cat_dims or [])}}))
         if ing.get("status") != "success":
             raise RuntimeError(f"seed ingest failed: {ing}")
         if ing.get("target_directions", {}).get(pool.target_col) != pool.direction:
@@ -124,6 +124,7 @@ async def run(dataset, seed, n_iters):
                                    "surrogate": (strat.get("model_config") or {}).get("surrogate"),
                                    "bounds_source": res.get("input_bounds_source"),
                                    "directions": res.get("target_directions"),
+                                   "input_types": res.get("input_types"),
                                    "pool": res.get("candidate_pool"), "fallback": False})
             else:
                 fallbacks += 1

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1473,6 +1473,12 @@ class AnalysisOrchestratorAgent:
             # chat() bound the feedback log to THIS session; restore the
             # caller's binding (a delegating meta keeps logging to its own).
             set_thread_feedback_log(_prev_fblog)
+            # A delegation-driven child may never reach the chat loop's
+            # auto-checkpoint cadence, and an interrupted delegation must
+            # leave current state behind for the restart/resume path
+            # (issue #469) — checkpoint after every run_task, like the
+            # planning orchestrator.
+            self._auto_checkpoint()
 
         # Derive the structured summary from the session-state delta.
         new_analyses = self.analysis_results[n_before:]

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1528,12 +1528,21 @@ class AnalysisOrchestratorAgent:
         # feature_tables: per-analysis flat CSVs (conditions + extracted scalar
         # features) for downstream planning / BO — see feature_table.py.
         feature_tables: List[str] = []
+        feature_tables_schema: List[Dict[str, Any]] = []
         for rec in new_analyses:
             out_dir = rec.get("output_directory")
             if out_dir:
                 ft = Path(out_dir) / "features.csv"
                 if ft.is_file():
                     feature_tables.append(str(ft.resolve()))
+                    # Column names / row count / holes travel with the path so
+                    # a caller (meta, remote MCP client) can pick BO inputs and
+                    # targets without opening the file.
+                    from .feature_table import describe_feature_table
+                    _d = describe_feature_table(ft)
+                    if _d:
+                        feature_tables_schema.append(
+                            {"path": str(ft.resolve()), **_d})
 
         # staged_solutions: raw T=2 (hot-annealing) solutions filed in the
         # staging buffer during this run. Surfaced so the meta agent can offer
@@ -1553,6 +1562,7 @@ class AnalysisOrchestratorAgent:
             "summary": summary_text,
             "files_produced": files_produced,
             "feature_tables": feature_tables,
+            "feature_tables_schema": feature_tables_schema,
             "staged_solutions": staged_solutions,
             "key_findings": key_findings,
             "suggested_followups": suggested_followups,

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2247,6 +2247,7 @@ class AnalysisOrchestratorTools:
             literature_file: str = None,
             r2_threshold: float = None,
             max_verification_iterations: int = None,
+            max_series_refits: int = None,
             starting_annealing_level: int = None,
             n_candidates: int = None,
             executor_timeout: int = None,
@@ -2881,6 +2882,17 @@ class AnalysisOrchestratorTools:
                             f"   max_verification_iterations={max_verification_iterations} ignored: "
                             f"{self.AGENT_NAMES.get(agent_id, 'agent')} has no verification loop."
                         )
+                if max_series_refits is not None:
+                    # Wall-clock budget for per-unit re-analysis in a series;
+                    # forwarded only to agents whose analyze() has the knob.
+                    import inspect as _inspect
+                    if "max_series_refits" in _inspect.signature(agent.analyze).parameters:
+                        analyze_kwargs["max_series_refits"] = int(max_series_refits)
+                    else:
+                        self.logger.info(
+                            f"   max_series_refits={max_series_refits} ignored: "
+                            f"{self.AGENT_NAMES.get(agent_id, 'agent')} has no series refit stage."
+                        )
                 if starting_annealing_level is not None:
                     # Annealing-schedule override for a RE-RUN: start the
                     # constraint-relaxation schedule higher (e.g. hot) so the
@@ -3009,6 +3021,8 @@ class AnalysisOrchestratorTools:
                     # #172: surface the locked-script reuse verdict so the
                     # orchestrator can act on a non-`good` outcome (a poorly
                     # fitting reused recipe, or a re-derived schema).
+                    if result.get("refit_skipped_by_budget"):
+                        response["refit_skipped_by_budget"] = result["refit_skipped_by_budget"]
                     reuse_validity = result.get("reuse_validity")
                     if reuse_validity:
                         response["reuse_validity"] = reuse_validity
@@ -3347,6 +3361,23 @@ class AnalysisOrchestratorTools:
                         "single fit legitimately needs longer; LOWER it (e.g. "
                         "30-60) for real-time/quick-look turnaround where a "
                         "slow fit should fail fast. Leave unset otherwise."
+                    )
+                },
+                "max_series_refits": {
+                    "type": "integer",
+                    "description": (
+                        "Curve fitting, SERIES runs only. Caps how many flagged "
+                        "spectra (fits below the R² threshold with the locked "
+                        "model) get an independent full re-analysis after the "
+                        "series pass — each such refit is a complete LLM "
+                        "planning/codegen/verification loop (minutes per unit). "
+                        "Worst fits are re-analyzed first; the rest keep their "
+                        "locked-model result (a valid, schema-consistent row) and "
+                        "are listed under refit_skipped_by_budget. Set for large "
+                        "series when turnaround matters (0 = no refits, e.g. a "
+                        "closed loop that only needs the locked features); leave "
+                        "unset for the standard behaviour (re-analyze every "
+                        "flagged spectrum)."
                     )
                 },
                 "max_verification_iterations": {

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2317,11 +2317,33 @@ class AnalysisOrchestratorTools:
                     "message": "No data path provided. Use examine_data first."
                 })
             
+            _agent_inferred = None
             if agent_id is None:
-                return json.dumps({
-                    "status": "error",
-                    "message": "No agent selected. Use select_agent first."
-                })
+                # Tool-only callers (MCP clients, run_task) do not run the
+                # examine_data -> select_agent preamble a chat turn would.
+                # Probe the data ourselves and, when exactly one agent fits,
+                # use it — the same decision the orchestrator would make.
+                try:
+                    _probe = json.loads(self.execute_tool("examine_data", data_path=data_path))
+                except Exception as _e:  # noqa: BLE001 - fall through to the error below
+                    _probe = {"error": str(_e)}
+                _sugg = _probe.get("suggested_agents") or []
+                if len(_sugg) == 1 and _sugg[0] in self.AGENT_NAMES:
+                    agent_id = int(_sugg[0])
+                    self.orch.selected_agent_id = agent_id
+                    _agent_inferred = self.AGENT_NAMES.get(agent_id)
+                    print(f"  🤖 Agent inferred from data probe "
+                          f"({_probe.get('data_type')}): {_agent_inferred}")
+                else:
+                    return json.dumps({
+                        "status": "error",
+                        "message": (
+                            "No agent selected and the data probe could not pick "
+                            f"one unambiguously (data_type={_probe.get('data_type')!r}, "
+                            f"suggested_agents={_sugg}). Pass agent_id "
+                            "(0=CurveFitting, 1=ImageAnalysis, 2=Hyperspectral) or "
+                            "use select_agent first."),
+                    })
             
             # Dataset-aware metadata resolution (issue #411). The loaded
             # document may serve this run only if it is unbound (freshly
@@ -2329,6 +2351,7 @@ class AnalysisOrchestratorTools:
             # *different* dataset is stale and must be re-resolved — never
             # silently reused across techniques.
             _stale_owner = None
+            _metadata_minimal = False
             if self.orch.current_metadata is not None:
                 _owner = getattr(self.orch, "current_metadata_owner", None)
                 if _owner and not _same_dataset(_owner, data_path):
@@ -2395,10 +2418,32 @@ class AnalysisOrchestratorTools:
                                 )
                             })
                         if self.orch.current_metadata is None:
-                            return json.dumps({
-                                "status": "error",
-                                "message": "No metadata available. Use load_metadata or convert_metadata first."
-                            })
+                            _goal_bits = {k: v for k, v in (
+                                ("analysis_goal", analysis_goal),
+                                ("objective", objective), ("hints", hints)) if v}
+                            if _goal_bits:
+                                # Minimal metadata from the call itself: a tool-only
+                                # caller with no metadata file still stated what the
+                                # data is and what to do with it. Better a run with
+                                # thin context than a hard stop nobody can answer.
+                                self.orch.current_metadata = {
+                                    **_goal_bits,
+                                    "_source": "run_analysis arguments (no metadata "
+                                               "file or sidecar provided)",
+                                }
+                                self.orch.current_metadata_owner = None
+                                _metadata_minimal = True
+                                print("  📎 No metadata file/sidecar; using the call's "
+                                      "analysis_goal/objective/hints as minimal metadata")
+                            else:
+                                return json.dumps({
+                                    "status": "error",
+                                    "message": (
+                                        "No metadata available. Use load_metadata or "
+                                        "convert_metadata first, drop a stem-matched JSON "
+                                        "sidecar next to the data, or state what the data "
+                                        "is in analysis_goal."),
+                                })
             # Bind unbound metadata to the dataset now consuming it.
             if (self.orch.current_metadata is not None
                     and not getattr(self.orch, "current_metadata_owner", None)):
@@ -2983,6 +3028,15 @@ class AnalysisOrchestratorTools:
                         "note": f"All outputs saved to: {analysis_output_dir}",
                         "next_steps": "Use assess_novelty to check literature for these claims, or get_recommendations for follow-up experiments.",
                     }
+                    if _agent_inferred:
+                        response["agent_inferred"] = _agent_inferred
+                    if _metadata_minimal:
+                        response["metadata_note"] = (
+                            "No metadata file or sidecar was available; the run used "
+                            "the call's analysis_goal/objective/hints as minimal "
+                            "metadata. Provide load_metadata/convert_metadata or a "
+                            "JSON sidecar for richer context (units, technique, "
+                            "sample).")
                     if result.get("status") == "partial":
                         response["confidence"] = result.get("confidence")
                         response["warnings"] = result.get("warnings") or []
@@ -3097,11 +3151,20 @@ class AnalysisOrchestratorTools:
                 },
                 "agent_id": {
                     "type": "integer",
-                    "description": "Agent ID to use (0-3, uses selected if not specified)"
+                    "description": (
+                        "Agent ID to use (0=CurveFitting, 1=ImageAnalysis, "
+                        "2=Hyperspectral). Optional: uses the selected agent, else "
+                        "the one the data probe suggests when that is unambiguous "
+                        "(the response then reports agent_inferred).")
                 },
                 "analysis_goal": {
                     "type": "string",
-                    "description": "Specific analysis objective (saved with results for traceability)"
+                    "description": (
+                        "Specific analysis objective (saved with results for "
+                        "traceability). When no metadata file or JSON sidecar is "
+                        "available it also serves as the run's minimal metadata, "
+                        "so say what the data is (technique, units, sample) as "
+                        "well as what to extract.")
                 },
                 "objective": {
                     "type": "string",

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -38,7 +38,7 @@ from .metadata_converter import (
 from ..lit_agents import OwlLiteratureAgent, NoveltyScorer, FittingModelLiteratureAgent
 from ..lit_agents.optimize_query_for_analysis import optimize_query_for_analysis
 from .recommendation_agent import RecommendationAgent
-from .feature_table import write_feature_table
+from .feature_table import write_feature_table, describe_feature_table
 from ._locked_exec import CANDIDATES_DIR_NAME
 from ...utils.text_io import write_text_utf8
 from ...skills.loader import list_skills, list_all_skills, load_skill
@@ -2996,6 +2996,16 @@ class AnalysisOrchestratorTools:
                     feature_table = write_feature_table(analysis_output_dir)
                     if feature_table:
                         response["feature_table"] = feature_table
+                        # Describe the table in the response itself: a client
+                        # that cannot open server files (remote MCP) — or the
+                        # orchestrator LLM choosing BO inputs/targets — needs
+                        # the column names and where the holes are.
+                        _desc = describe_feature_table(feature_table)
+                        if _desc:
+                            response["feature_columns"] = _desc["columns"]
+                            response["feature_rows"] = _desc["n_rows"]
+                            if _desc["missing"]:
+                                response["feature_missing"] = _desc["missing"]
                     # #172: surface the locked-script reuse verdict so the
                     # orchestrator can act on a non-`good` outcome (a poorly
                     # fitting reused recipe, or a re-derived schema).

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -537,6 +537,14 @@ def _tool_inventory_text(state: dict) -> str:
     )
 
 
+def _has_fit_parameters(stdout: Optional[str]) -> bool:
+    """True iff the FIT_RESULTS_JSON payload carries a non-empty top-level
+    ``parameters`` dict — the part of the I/O contract every downstream
+    consumer (series trends, feature table, BO) actually reads."""
+    params = _parse_script_markers(stdout).get("parameters")
+    return isinstance(params, dict) and bool(params)
+
+
 def _parse_script_markers(stdout: Optional[str]) -> dict:
     """Parse FIT_RESULTS_JSON and DB_MATCHES_JSON markers from script stdout.
 
@@ -3481,20 +3489,37 @@ Your guidance: '''
                 if run["status"] == "success":
                     has_fit_results = "FIT_RESULTS_JSON:" in run["stdout"]
                     has_visualization = run["visualization_path"] is not None
+                    # The marker alone is not the contract: the payload must
+                    # carry a non-empty top-level ``parameters`` dict, or every
+                    # downstream consumer (series trends, the feature table
+                    # that feeds BO) sees a fit with no fitted values even
+                    # though R² (recomputed from fit.npy) passed the gate.
+                    has_parameters = _has_fit_parameters(run["stdout"]) \
+                        if has_fit_results else False
 
-                    if has_fit_results and has_visualization:
+                    if has_fit_results and has_parameters and has_visualization:
                         break
                     else:
                         missing = []
                         if not has_fit_results:
                             missing.append("FIT_RESULTS_JSON output")
+                        elif not has_parameters:
+                            missing.append(
+                                "a non-empty top-level 'parameters' dict inside "
+                                "FIT_RESULTS_JSON (the fitted values keyed by "
+                                "component, e.g. {\"peak_1\": {\"center\": .., "
+                                "\"amplitude\": .., \"fwhm\": ..}}) — do NOT "
+                                "nest them under another key or emit a "
+                                "different layout")
                         if not has_visualization:
                             missing.append("visualization file")
                         last_error = (
                             f"Script executed but did not produce expected outputs. "
                             f"Missing: {', '.join(missing)}. The script must print "
-                            f"'FIT_RESULTS_JSON:{{...}}' with fit results and save "
-                            f"'visualization.png' in the working directory."
+                            f"'FIT_RESULTS_JSON:{{...}}' with top-level keys "
+                            f"'model_type', 'parameters' (non-empty dict), "
+                            f"'fit_quality' and save 'visualization.png' in the "
+                            f"working directory."
                         )
                         self.logger.warning(f"    ⚠️ Attempt {attempt}: Script ran but missing outputs: {', '.join(missing)}")
                         consecutive_timeouts = 0
@@ -3514,7 +3539,8 @@ Your guidance: '''
         # "success" even when outputs are missing.
         ok = (run is not None and run["status"] == "success"
               and run["visualization_path"] is not None
-              and "FIT_RESULTS_JSON:" in run["stdout"])
+              and "FIT_RESULTS_JSON:" in run["stdout"]
+              and _has_fit_parameters(run["stdout"]))
         if not ok:
             failure = {
                 "index": spectrum_idx,

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -7262,6 +7262,29 @@ Return JSON: {{"script": "<the complete modified script>"}}
             self.logger.info("\n🔄 Adaptive refit: Flagged spectra are statistical outliers only, skipping.")
             return state
 
+        # Refit budget: each independent re-analysis is a full LLM planning /
+        # codegen / verification loop (minutes per unit), so a large series
+        # with many flagged units can spend most of its wall-clock here.
+        # Cap it — worst fits first; the rest keep their locked-model result
+        # (still a valid, schema-consistent row) and are listed so the caller
+        # sees exactly what was not re-analyzed.
+        max_refits = state.get("max_series_refits")
+        skipped_by_budget: List[dict] = []
+        if isinstance(max_refits, int) and max_refits >= 0 and len(refit_candidates) > max_refits:
+            ranked = sorted(refit_candidates,
+                            key=lambda f: (f.get("r_squared") is None,
+                                           f.get("r_squared") if f.get("r_squared") is not None else 0.0))
+            refit_candidates, skipped_by_budget = ranked[:max_refits], ranked[max_refits:]
+            self.logger.info(
+                f"\n🔄 Adaptive refit budget: {max_refits} of {len(ranked)} flagged "
+                f"spectra will be re-analyzed (worst R² first); skipping "
+                f"{[f['name'] for f in skipped_by_budget]}")
+        state["refit_skipped_by_budget"] = [
+            {"index": f["index"], "name": f["name"], "r_squared": f.get("r_squared"),
+             "reason": f.get("reason")} for f in skipped_by_budget]
+        if not refit_candidates:
+            return state
+
         self.logger.info(f"\n🔄 ADAPTIVE REFIT: {len(refit_candidates)} spectra to re-analyze independently")
 
         series_results = state.get("series_results", [])

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -6918,7 +6918,12 @@ class AdaptiveRefitController:
             f"Do NOT simply retry the same model with different initial parameters.\n\n"
             f"PARSIMONY: Use the SIMPLEST model that achieves R² ≥ {self.r2_threshold}. "
             f"Do not add extra components beyond what the data clearly requires. "
-            f"If two peaks are visible, use a two-component model — not three or more."
+            f"If two peaks are visible, use a two-component model — not three or more.\n\n"
+            f"NAMING: report every quantity the locked model also reports "
+            f"({', '.join(locked_config.get('parameters_to_extract', []) or ['its parameters'])}) "
+            f"under the SAME parameter names — the series trends and the feature "
+            f"table align units by name, so a renamed quantity becomes a hole in "
+            f"this unit's row. Add new parameters only in addition."
         )
 
         fresh_config = {

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -6798,6 +6798,10 @@ class AdaptiveRefitController:
         self.plot_fn = plot_fn
         self.r2_threshold = r2_threshold
         self.enable_human_feedback = enable_human_feedback
+        self.model = model
+        self.generation_config = generation_config
+        self.safety_settings = safety_settings
+        self.executor = executor
 
         # Compose a fitting helper to reuse _fit_with_quality_control
         self._fitting_helper = UnifiedSeriesProcessingController(
@@ -6818,6 +6822,116 @@ class AdaptiveRefitController:
             max_verification_iterations=max_verification_iterations,
             conformance_instructions=conformance_instructions,
         )
+
+    @staticmethod
+    def locked_schema_gap(refit_params: Any, locked_params: Any) -> List[str]:
+        """Flattened parameter names the locked run reported for this unit that
+        the refit's ``parameters`` do not carry (a ``null`` counts as missing —
+        it becomes an empty feature-table cell either way)."""
+        from ..feature_table import _flatten_scalars
+        locked_keys = list(_flatten_scalars(locked_params or {}).keys())
+        have = set(_flatten_scalars(refit_params or {}).keys())
+        return [k for k in locked_keys if k not in have]
+
+    def _complete_locked_schema(self, refit_result: dict, original_result: Optional[dict],
+                                curve_data: np.ndarray, idx: int, state: dict) -> dict:
+        """Structural conformance of a refit to the locked run's schema.
+
+        A refit that adopts a different model tends to rename or drop the
+        quantities the locked script reported, and downstream consumers
+        (series trends, the feature table that feeds BO) align units BY
+        NAME — so a renamed quantity is a hole in this unit's row. This
+        pass (1) computes the gap deterministically against the locked
+        fit of the SAME unit, (2) asks the codegen LLM once to ADD the
+        missing entries under the locked names — computed from its own
+        fitted model where a counterpart exists (e.g. evaluate its curve
+        at the same wavelength), ``null`` where none does — without
+        changing the model, the fit, or any existing value, (3) re-runs
+        the script and accepts the completion only if every previous key
+        survived and R² did not degrade. Whatever remains missing is
+        recorded as ``locked_schema_gap`` on the result so callers can
+        report it instead of discovering NaNs later."""
+        locked_params = (original_result or {}).get("parameters") or {}
+        missing = self.locked_schema_gap(refit_result.get("parameters"), locked_params)
+        if not missing:
+            refit_result["locked_schema_gap"] = []
+            return refit_result
+        self.logger.info(
+            f"  🧩 Refit schema gap vs locked run: {len(missing)} parameter(s) "
+            f"missing ({', '.join(missing[:6])}{'…' if len(missing) > 6 else ''}) "
+            f"— asking the refit script to also report them under the locked names")
+        script = refit_result.get("script")
+        if script:
+            locked_cfg = state.get("locked_fitting_config") or {}
+            prompt = f"""You wrote the fitting script below for one spectrum of a series. The rest of the series was fitted with a DIFFERENT (locked) model, and downstream consumers align all spectra BY PARAMETER NAME. Your FIT_RESULTS_JSON 'parameters' must therefore ALSO contain the locked run's entries for this spectrum, with EXACTLY the same nesting and names.
+
+**Locked model (rest of the series):** {locked_cfg.get('physical_model', 'unknown')}
+
+**Locked run's `parameters` for THIS spectrum (naming/nesting template; values are the locked fit's, do NOT copy them):**
+```json
+{json.dumps(locked_params, indent=1)[:4000]}
+```
+
+**Your current `parameters`:**
+```json
+{json.dumps(refit_result.get('parameters') or {}, indent=1)[:4000]}
+```
+
+**Missing (flattened name = nested keys joined by '_'):** {missing}
+
+Modify the script so that, in addition to everything it already reports, `parameters` carries every missing entry under the locked name/nesting:
+- compute it from YOUR fitted model where a physical counterpart exists (e.g. an extinction/intensity at a stated wavelength = your fitted curve evaluated there; an integrated area = the integral of your model; an amplitude/center/width of a component your model also has = your value; `_err` = your covariance-based uncertainty for that quantity);
+- set it to null where your model has no counterpart (e.g. the center of a peak your model does not contain) — never a fake 0.
+Do NOT change the model, the fit, the initial guesses, or any existing parameter value or key; keep saving fit.npy and visualization.png and printing FIT_RESULTS_JSON exactly as before.
+
+**SCRIPT:**
+```python
+{script}
+```
+
+Return JSON: {{"script": "<the complete modified script>"}}
+"""
+            try:
+                response = self.model.generate_content(
+                    contents=[prompt], generation_config=self.generation_config,
+                    safety_settings=self.safety_settings)
+                result_json, _ = parse_codegen_response(response, field="script", logger=self.logger)
+                new_script = (result_json or {}).get("script")
+            except Exception as e:  # noqa: BLE001 - completion is best effort
+                self.logger.warning(f"  Schema completion request failed: {e}")
+                new_script = None
+            if new_script:
+                item_dir = self.output_dir / f"spectrum_{idx:04d}"
+                run = stage_and_run_adaptive(self.executor, new_script, curve_data,
+                                             item_dir, logger=self.logger)
+                if run["status"] == "success" and "FIT_RESULTS_JSON:" in run["stdout"]:
+                    fr = _parse_script_markers(run["stdout"])
+                    new_params = fr.get("parameters") or {}
+                    from ..feature_table import _flatten_scalars
+                    have_before = set(_flatten_scalars(refit_result.get("parameters") or {}).keys())
+                    have_after = set(_flatten_scalars(new_params).keys())
+                    lost = sorted(have_before - have_after)
+                    old_r2 = (refit_result.get("fit_quality") or {}).get("r_squared")
+                    new_r2 = (fr.get("fit_quality") or {}).get("r_squared")
+                    r2_ok = (old_r2 is None or new_r2 is None
+                             or float(new_r2) >= float(old_r2) - 0.005)
+                    if not lost and r2_ok:
+                        refit_result["parameters"] = new_params
+                        refit_result["script"] = new_script
+                        still = [k for k in missing if k not in have_after]
+                        self.logger.info(
+                            f"  ✅ Schema completion accepted: "
+                            f"{len(missing) - len(still)}/{len(missing)} added"
+                            + (f"; still missing {still}" if still else ""))
+                        missing = still
+                    else:
+                        self.logger.warning(
+                            f"  Schema completion rejected (lost keys {lost}, "
+                            f"R² {old_r2} → {new_r2}); keeping the refit as is")
+                else:
+                    self.logger.warning("  Schema completion script did not run cleanly; keeping the refit as is")
+        refit_result["locked_schema_gap"] = missing
+        return refit_result
 
     def _load_spectrum(self, idx, spectrum_paths, spectrum_stack, column_mapping=None):
         """Load spectrum data for re-analysis (honors the locked column mapping)."""
@@ -7049,6 +7163,9 @@ class AdaptiveRefitController:
 
             if result["success"] and new_r2 >= prev_r2 * 0.99:
                 self.logger.info(f"  ✅ Consistent: R² {new_r2:.4f} with '{target_model}'")
+                result = self._complete_locked_schema(
+                    result, {"parameters": state.get("_locked_params_by_idx", {}).get(idx)},
+                    curve_data, idx, state)
                 result["adaptively_refitted"] = True
                 result["original_r2"] = entry["original_r2"]
                 result["refit_model_type"] = result.get("model_type")
@@ -7064,6 +7181,9 @@ class AdaptiveRefitController:
                     entry["new_model"], prev_r2,
                 )
                 if keep:
+                    result = self._complete_locked_schema(
+                        result, {"parameters": state.get("_locked_params_by_idx", {}).get(idx)},
+                        curve_data, idx, state)
                     result["adaptively_refitted"] = True
                     result["original_r2"] = entry["original_r2"]
                     result["refit_model_type"] = result.get("model_type")
@@ -7188,6 +7308,14 @@ class AdaptiveRefitController:
 
             if refit_result["success"] and (original_r2 is None or new_r2 > original_r2):
                 self.logger.info(f"  ✅ Improved: R² {original_r2} → {new_r2:.4f}")
+                original_result = series_results[idx] if idx < len(series_results) else None
+                # Remember the locked fit's parameters for this unit: the
+                # consistency pass below may replace the refit again and
+                # must complete against the SAME locked reference.
+                state.setdefault("_locked_params_by_idx", {})[idx] = (
+                    (original_result or {}).get("parameters") or {})
+                refit_result = self._complete_locked_schema(
+                    refit_result, original_result, curve_data, idx, state)
                 refit_result["adaptively_refitted"] = True
                 refit_result["original_r2"] = original_r2
                 refit_result["refit_model_type"] = refit_result.get("model_type")

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -314,6 +314,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         max_model_retries: Optional[int] = None,
         outlier_sigma: Optional[float] = None,
         max_verification_iterations: Optional[int] = None,
+        max_series_refits: Optional[int] = None,
         # Annealing schedule start level for THIS run (None/0 = current
         # behavior: start frozen at T=0 and escalate adaptively). A re-run may
         # start higher (e.g. hot) so it does not re-obey early constraint stages
@@ -835,6 +836,11 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             # Operating profile name ("thorough" | "realtime") — controllers
             # gate realtime-only behavior (drift check, bank suppression) on it.
             "_qc_profile": qc_profile.name,
+            # Wall-clock budget for per-unit re-analysis of flagged spectra
+            # in a series (None = unlimited). Worst fits go first; skipped
+            # units keep their locked-model result and are listed under
+            # refit_skipped_by_budget.
+            "max_series_refits": max_series_refits,
             # Annealing schedule start level (None/0 = start frozen at T=0).
             "_starting_annealing_level": starting_annealing_level,
 
@@ -1864,6 +1870,8 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             results["flagged_spectra"] = flagged_spectra
             results["flagged_spectra_analysis"] = synthesis.get("flagged_spectra_analysis", {})
             results["refit_summary"] = refit_summary
+            if state.get("refit_skipped_by_budget"):
+                results["refit_skipped_by_budget"] = state["refit_skipped_by_budget"]
             results["refit_analysis"] = synthesis.get("refit_analysis", {})
             results["trend_analysis"] = state.get("trend_analysis_results", {})
             results["parameter_trends"] = synthesis.get("parameter_trends", {})

--- a/scilink/agents/exp_agents/feature_table.py
+++ b/scilink/agents/exp_agents/feature_table.py
@@ -161,6 +161,36 @@ def _extracted_feature_rows(output_dir: Path) -> List[Dict[str, Any]]:
     return [row]
 
 
+def describe_feature_table(path) -> Optional[Dict[str, Any]]:
+    """Schema summary of a feature CSV for callers that cannot open the file
+    (a remote MCP client, an LLM deciding inputs/targets): column names, row
+    count, and per-column missing counts (only columns with any missing).
+    Never raises."""
+    try:
+        with open(path, newline="", encoding="utf-8") as fh:
+            reader = csv.reader(fh)
+            header = next(reader, None)
+            if header is None:
+                return None
+            missing = [0] * len(header)
+            n = 0
+            for row in reader:
+                n += 1
+                for i, v in enumerate(row[:len(header)]):
+                    if v == "" or v.lower() == "nan":
+                        missing[i] += 1
+                if len(row) < len(header):
+                    for i in range(len(row), len(header)):
+                        missing[i] += 1
+        return {
+            "columns": header,
+            "n_rows": n,
+            "missing": {c: m for c, m in zip(header, missing) if m},
+        }
+    except Exception:  # noqa: BLE001 - descriptive only
+        return None
+
+
 def write_feature_table(output_dir) -> Optional[str]:
     """Write ``<output_dir>/features.csv`` — a flat per-unit feature table
     derived from the run's structured result files.

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -283,7 +283,9 @@ rather than fabricate a result).
   experimental conditions + extracted scalar features). When a follow-up
   planning or Bayesian-optimization task needs those quantitative results, pass
   the feature-table file PATH to `delegate_to_planning` (in `context`, and name
-  it in `task`).
+  it in `task`). `feature_tables_schema` lists each table's columns, row count
+  and any columns with missing values — use it to name the input/target
+  columns instead of opening the file.
 - Do NOT re-summarize the numbers as prose for the planning specialist to
   retype — that loses precision and risks transcription errors. The planning
   specialist ingests the file directly with its `analyze_file` tool.
@@ -1374,6 +1376,7 @@ class MetaOrchestratorAgent:
             "key_findings": result.get("key_findings", []),
             "files_produced": result.get("files_produced", []),
             "feature_tables": result.get("feature_tables", []),
+            "feature_tables_schema": result.get("feature_tables_schema", []),
             "staged_solutions": result.get("staged_solutions", []),
             "suggested_followups": result.get("suggested_followups", []),
             "warnings": result.get("warnings", []),
@@ -1396,6 +1399,7 @@ class MetaOrchestratorAgent:
             "key_findings": result.get("key_findings", []),
             "files_produced": result.get("files_produced", []),
             "feature_tables": result.get("feature_tables", []),
+            "feature_tables_schema": result.get("feature_tables_schema", []),
             "suggested_followups": result.get("suggested_followups", []),
             "warnings": result.get("warnings", []),
         }

--- a/scilink/agents/planning_agents/bo_agent.py
+++ b/scilink/agents/planning_agents/bo_agent.py
@@ -987,7 +987,8 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
                              dkl_config: Optional[Dict[str, int]] = None,
                              fidelity_config: Optional[Dict[str, Any]] = None,
                              skill: Union[str, List[str], None] = None,
-                             candidate_pool: Union[str, List[List[float]], np.ndarray, None] = None) -> Dict[str, Any]:
+                             candidate_pool: Union[str, List[List[float]], np.ndarray, None] = None,
+                             seed: Optional[int] = None) -> Dict[str, Any]:
         """
         Run one iteration of the Bayesian Optimization loop.
         
@@ -1049,6 +1050,19 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
             output_dir = str(self.output_dir)
 
         Path(output_dir).mkdir(exist_ok=True, parents=True)
+
+        # Numeric reproducibility: GP fitting (random restarts) and
+        # acquisition optimisation (random raw samples) are stochastic, so two
+        # runs on identical data can recommend different batches. A caller
+        # that wants comparable reruns passes a seed; the strategy chosen by
+        # the LLM is outside this (it is recorded in the returned strategy).
+        if seed is not None:
+            import torch
+            torch.manual_seed(int(seed))
+            np.random.seed(int(seed) % (2**32))
+            self._run_seed = int(seed)
+        else:
+            self._run_seed = None
 
         # Initialize state
         self._init_state(objective=objective_text, data_path=data_path)
@@ -1549,6 +1563,8 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
             "inspection": c.inspection,
             "budget": c.budget_ctx,
         }
+        if getattr(self, "_run_seed", None) is not None:
+            result["seed"] = self._run_seed
         if c.acq_plot_path:
             result["acq_plot_path"] = c.acq_plot_path
         if c.acq_data_path:

--- a/scilink/agents/planning_agents/bo_tools.py
+++ b/scilink/agents/planning_agents/bo_tools.py
@@ -634,6 +634,22 @@ class SingleObjectiveOptimizer:
                 for d in cat_dims
             }
             n_combos = int(np.prod([len(v) for v in levels.values()]))
+            n_dims = int(self.bounds.shape[-1])
+            if n_combos <= 512 and len(levels) == n_dims:
+                # Every input is categorical: the design space IS the finite
+                # set of level combinations, so score it as a candidate
+                # library. (optimize_acqf_mixed with all features fixed
+                # returns (d,) for q=1 and fails inside botorch for q>1.)
+                from itertools import product
+                keys = list(levels)
+                grid = np.array([[combo[keys.index(d)] for d in range(n_dims)]
+                                 for combo in product(*levels.values())], dtype=float)
+                seen = self.X_train.detach().cpu().numpy()
+                unmeasured = grid[~np.array([np.any(np.all(np.isclose(seen, g), axis=1))
+                                             for g in grid])]
+                if len(unmeasured) >= 1:
+                    return self._recommend_from_candidates(
+                        strategy, params, min(n_candidates, len(unmeasured)), unmeasured)
             if n_combos <= 512:
                 from itertools import product
                 keys = list(levels)
@@ -648,7 +664,11 @@ class SingleObjectiveOptimizer:
                     raw_samples=128 if is_large_batch else 512,
                     fixed_features_list=fixed_features_list,
                 )
-                return candidates.detach().cpu().numpy()
+                # botorch returns (d,) instead of (q, d) when EVERY dimension is
+                # a fixed feature (all inputs categorical) — normalise so callers
+                # can always iterate rows.
+                out = candidates.detach().cpu().numpy()
+                return out.reshape(-1, self.bounds.shape[-1]) if out.ndim == 1 else out
             logging.warning(
                 f"cat_dims level combinations ({n_combos}) exceed the mixed-"
                 "optimizer cap (512); falling back to continuous relaxation."

--- a/scilink/agents/planning_agents/bo_tools.py
+++ b/scilink/agents/planning_agents/bo_tools.py
@@ -635,11 +635,15 @@ class SingleObjectiveOptimizer:
             }
             n_combos = int(np.prod([len(v) for v in levels.values()]))
             n_dims = int(self.bounds.shape[-1])
-            if n_combos <= 512 and len(levels) == n_dims:
+            if len(levels) == n_dims and n_combos <= 50_000:
                 # Every input is categorical: the design space IS the finite
                 # set of level combinations, so score it as a candidate
-                # library. (optimize_acqf_mixed with all features fixed
-                # returns (d,) for q=1 and fails inside botorch for q>1.)
+                # library — pointwise posterior scoring is cheap at this
+                # size, and the gradient-based alternatives cannot work here
+                # (optimize_acqf_mixed with all features fixed returns (d,)
+                # for q=1 and fails inside botorch for q>1; the continuous
+                # relaxation has no gradient w.r.t. categorical dims and
+                # raises 'differentiated Tensors ... not used in the graph').
                 from itertools import product
                 keys = list(levels)
                 grid = np.array([[combo[keys.index(d)] for d in range(n_dims)]

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -173,6 +173,22 @@ def resolve_n_candidates(requested, planner_state, new_campaign: bool = False) -
     return 3 if is_first_plan else 1
 
 
+
+def _norm_level(v) -> str:
+    """Canonical label for a categorical level: numeric-looking values compare
+    as numbers ('3', '3.0', 3 -> '3'; '2.5' -> '2.5'), everything else as the
+    stripped string. Used for data, pool and decode so an integer code written
+    once as int and once as float still means the same level."""
+    sv = str(v).strip()
+    try:
+        f = float(sv)
+    except (TypeError, ValueError):
+        return sv
+    if f != f:  # NaN
+        return sv
+    return str(int(f)) if f.is_integer() else repr(f)
+
+
 class OrchestratorTools:
     """
     Manages tool definitions, schemas, and execution for the OrchestratorAgent.
@@ -4633,7 +4649,7 @@ class OrchestratorTools:
                         if ptype == "categorical":
                             levels = param.get("levels") or []
                             if levels:
-                                planner_levels[name] = [str(lv) for lv in levels]
+                                planner_levels[name] = [_norm_level(lv) for lv in levels]
                                 print(f"  🔬 Scientific Constraint Found: {name} ∈ {planner_levels[name]}")
                             continue
                         min_v = param.get("min_value")
@@ -4687,6 +4703,21 @@ class OrchestratorTools:
             level_maps: Dict[str, List[str]] = {}
             type_conflict_warnings: List[str] = []
 
+            # A candidate pool contributes to the categorical level universe:
+            # unmeasured candidates are its whole point, so their levels are
+            # legitimate even when no campaign row has them yet (a plan, when
+            # present, stays authoritative).
+            _pool_df = None
+            if candidate_pool:
+                _pool_path, _pool_err = self._resolve_data_path(candidate_pool)
+                if _pool_err:
+                    return _pool_err
+                try:
+                    _pool_df = pd.read_csv(_pool_path)
+                except Exception as _e:  # noqa: BLE001
+                    return json.dumps({"status": "error",
+                                       "message": f"candidate_pool unreadable: {_e}"})
+
             for col in self.orch.expected_input_columns:
                 if col not in df.columns:
                     print(f"  ⚠️ Skipping missing input column: {col}")
@@ -4715,7 +4746,9 @@ class OrchestratorTools:
                     is_categorical = False
 
                 if is_categorical:
-                    observed = sorted(df[col].dropna().astype(str).unique().tolist())
+                    observed = sorted({_norm_level(v) for v in df[col].dropna().tolist()})
+                    if _pool_df is not None and col in _pool_df.columns and not planner_levels.get(col):
+                        observed = sorted(set(observed) | {_norm_level(v) for v in _pool_df[col].dropna().tolist()})
                     if planner_levels.get(col):
                         # Planner is authoritative on the level universe.
                         # Observed values that aren't in the planner-declared
@@ -4815,7 +4848,7 @@ class OrchestratorTools:
                 df_encoded = df.copy()
                 for col, levels in level_maps.items():
                     idx = {lv: i for i, lv in enumerate(levels)}
-                    encoded = df[col].astype(str).map(idx)
+                    encoded = df[col].map(_norm_level).map(idx)
                     if encoded.isnull().any():
                         unknown = sorted(
                             df.loc[encoded.isnull(), col].astype(str).unique().tolist()
@@ -4950,27 +4983,24 @@ class OrchestratorTools:
                     if level_maps:
                         # The campaign data was level-encoded above; the pool
                         # must go through the SAME maps or its rows never match
-                        # the surrogate's space (and unknown levels are a real
-                        # mismatch, not something to guess).
-                        try:
-                            pool_df = pd.read_csv(resolved_pool)
-                        except Exception as _e:  # noqa: BLE001
-                            return json.dumps({"status": "error",
-                                               "message": f"candidate_pool unreadable: {_e}"})
+                        # the surrogate's space. Its levels were folded into the
+                        # universe above (unless a plan declares it), so a
+                        # leftover unknown is a genuine plan/data mismatch.
+                        pool_df = _pool_df.copy() if _pool_df is not None else pd.read_csv(resolved_pool)
                         for col, levels in level_maps.items():
                             if col not in pool_df.columns:
                                 continue
                             idx = {lv: i for i, lv in enumerate(levels)}
-                            enc = pool_df[col].astype(str).map(idx)
+                            enc = pool_df[col].map(_norm_level).map(idx)
                             if enc.isnull().any():
-                                unknown = sorted(pool_df.loc[enc.isnull(), col].astype(str).unique().tolist())
+                                unknown = sorted({_norm_level(v) for v in pool_df.loc[enc.isnull(), col].tolist()})
                                 return json.dumps({
                                     "status": "error",
                                     "message": (f"candidate_pool has levels for categorical input "
-                                                f"'{col}' not seen in the campaign data/plan: "
+                                                f"'{col}' outside the plan-declared level universe: "
                                                 f"{unknown[:10]}. Known levels: {levels}."),
-                                    "hint": "Encode the pool with the same labels as the data, or "
-                                            "declare the level universe in the plan."})
+                                    "hint": "Encode the pool with the plan's level names, or "
+                                            "correct the plan's optimization_params.levels."})
                             pool_df[col] = enc.astype(float)
                         encoded_pool = self.orch.base_dir / "bo_artifacts" / "candidate_pool_encoded.csv"
                         encoded_pool.parent.mkdir(parents=True, exist_ok=True)

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -4918,6 +4918,15 @@ class OrchestratorTools:
                     col: [float(lo), float(hi)]
                     for col, (lo, hi) in zip(optimization_inputs, input_bounds)}
                 response["input_bounds_source"] = bounds_sources
+                _data_bounded = [c for c, src in bounds_sources.items() if src == "data"]
+                if _data_bounded:
+                    bounds_warnings = list(bounds_warnings) + [(
+                        f"Search box for {_data_bounded} was derived from the "
+                        f"observed data (range +/-10%): no plan or caller bounds "
+                        f"cover them, so recommendations may fall outside what "
+                        f"the instrument or process can reach. Pass "
+                        f"input_bounds={{col: [min, max]}} with the achievable "
+                        f"range to fix the box.")]
                 if bounds_warnings:
                     response["input_bounds_warnings"] = bounds_warnings
 

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -4408,7 +4408,12 @@ class OrchestratorTools:
                 return json.dumps({
                     "status": "error",
                     "message": "Schema not established",
-                    "hint": "This shouldn't happen. Try reset_analysis_logic."
+                    "hint": ("No analyze_file has established inputs/targets in "
+                             "this session. Ingest your data with analyze_file "
+                             "(inputs=[...], targets=[...]) first; if it reports "
+                             "the file as already analyzed, the session was "
+                             "reused from an earlier process — call analyze_file "
+                             "with force_regenerate=true.")
                 })
 
             # TARGET NARROWING — allows switching from MOO to SOO

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -224,6 +224,35 @@ class OrchestratorTools:
             out[col] = levels[idx]
         return out
 
+    def _apply_input_types(self, input_types, inputs) -> list:
+        """Merge caller-stated {input: categorical|continuous} into the
+        campaign's expected_input_types (caller wins; a pass-through feature
+        table never runs the scalarizer's classification, so without this a
+        numeric-coded categorical is modelled as continuous). Returns warnings
+        for ignored entries. Sticky and checkpointed."""
+        warns: list = []
+        if not input_types:
+            return warns
+        if not isinstance(input_types, dict):
+            return ["input_types must be a dict {column: 'categorical'|'continuous'}; ignored."]
+        known = list(inputs or [])
+        current = dict(getattr(self.orch, "expected_input_types", None) or {})
+        for col, t in input_types.items():
+            tn = str(t).strip().lower()
+            if tn in ("cat", "category", "discrete", "nominal"):
+                tn = "categorical"
+            if tn in ("cont", "numeric", "number", "float", "real"):
+                tn = "continuous"
+            if tn not in ("categorical", "continuous"):
+                warns.append(f"input_types['{col}']={t!r} ignored: use 'categorical' or 'continuous'.")
+                continue
+            if known and str(col) not in known:
+                warns.append(f"input_types['{col}'] ignored: not an input column (inputs are {known}).")
+                continue
+            current[str(col)] = tn
+        self.orch.expected_input_types = current
+        return warns
+
     def _apply_directions(self, directions, targets) -> list:
         """Merge caller-stated {target: maximize|minimize} into the campaign's
         target_directions (caller wins). Returns warnings for entries that
@@ -3300,7 +3329,8 @@ class OrchestratorTools:
                 force_regenerate: bool = False,
                 inputs: list[str] = None,
                 targets: list[str] = None,
-                directions: dict = None):
+                directions: dict = None,
+                input_types: dict = None):
             """
             Analyzes a raw data file (CSV/XLSX) to extract metrics.
             
@@ -3678,6 +3708,7 @@ class OrchestratorTools:
                     # 'loss' target was maximized.
                     _dir_warn = self._apply_directions(directions, targets)
                     self._capture_input_types(column_roles, inputs)
+                    _dir_warn = list(_dir_warn) + self._apply_input_types(input_types, inputs)
                     print(f"    📊 Schema Enforced (User-Specified):")
                     print(f"       Inputs: {self.orch.expected_input_columns}")
                     print(f"       Targets: {self.orch.expected_target_columns}")
@@ -3694,6 +3725,8 @@ class OrchestratorTools:
                             self.orch.target_directions = opt_dir
                     _dir_warn = self._apply_directions(
                         directions, self.orch.expected_target_columns)
+                    _dir_warn = list(_dir_warn) + self._apply_input_types(
+                        input_types, self.orch.expected_input_columns)
                     if not getattr(self.orch, "expected_input_types", None):
                         self._capture_input_types(column_roles, self.orch.expected_input_columns)
                     print(f"    📊 Schema Enforced (From Previous Analysis):")
@@ -3895,6 +3928,7 @@ class OrchestratorTools:
                     "inputs": self.orch.expected_input_columns,
                     "targets": self.orch.expected_target_columns,
                     "target_directions": dict(self.orch.target_directions or {}),
+                    "input_types": dict(getattr(self.orch, "expected_input_types", None) or {}),
                 }
                 _missing_dir = [t for t in (self.orch.expected_target_columns or [])
                                 if t not in (self.orch.target_directions or {})]
@@ -3956,6 +3990,19 @@ class OrchestratorTools:
                     "type": "array", 
                     "items": {"type": "string"}, 
                     "description": "List of column names to treat as OPTIMIZATION TARGETS"
+                },
+                "input_types": {
+                    "type": "object",
+                    "description": (
+                        "Input kind per column, {\"column\": \"categorical\"|\"continuous\"}. "
+                        "Pass when an input is a choice among discrete options (ligand, "
+                        "solvent, base, material id) — especially when it is stored as a "
+                        "numeric code, which a ready feature table would otherwise be "
+                        "modelled as a continuous knob. Categorical inputs are "
+                        "level-encoded for the surrogate and decoded in the "
+                        "recommendations. Sticky for the campaign; can also be set on "
+                        "run_optimization."
+                    )
                 },
                 "directions": {
                     "type": "object",
@@ -4461,6 +4508,7 @@ class OrchestratorTools:
             input_bounds: dict = None,
             seed: int = None,
             directions: dict = None,
+            input_types: dict = None,
         ):
             """
             Runs Bayesian Optimization to suggest next parameters.
@@ -4507,6 +4555,8 @@ class OrchestratorTools:
                 })
             
             _dir_warn = self._apply_directions(directions, self.orch.expected_target_columns)
+            _dir_warn = list(_dir_warn) + self._apply_input_types(
+                input_types, self.orch.expected_input_columns)
 
             if not self.orch.expected_target_columns or not self.orch.expected_input_columns:
                 return json.dumps({
@@ -4897,6 +4947,36 @@ class OrchestratorTools:
                     if pool_err:
                         return pool_err
                     print(f"    🎯 Candidate pool: {Path(resolved_pool).name}")
+                    if level_maps:
+                        # The campaign data was level-encoded above; the pool
+                        # must go through the SAME maps or its rows never match
+                        # the surrogate's space (and unknown levels are a real
+                        # mismatch, not something to guess).
+                        try:
+                            pool_df = pd.read_csv(resolved_pool)
+                        except Exception as _e:  # noqa: BLE001
+                            return json.dumps({"status": "error",
+                                               "message": f"candidate_pool unreadable: {_e}"})
+                        for col, levels in level_maps.items():
+                            if col not in pool_df.columns:
+                                continue
+                            idx = {lv: i for i, lv in enumerate(levels)}
+                            enc = pool_df[col].astype(str).map(idx)
+                            if enc.isnull().any():
+                                unknown = sorted(pool_df.loc[enc.isnull(), col].astype(str).unique().tolist())
+                                return json.dumps({
+                                    "status": "error",
+                                    "message": (f"candidate_pool has levels for categorical input "
+                                                f"'{col}' not seen in the campaign data/plan: "
+                                                f"{unknown[:10]}. Known levels: {levels}."),
+                                    "hint": "Encode the pool with the same labels as the data, or "
+                                            "declare the level universe in the plan."})
+                            pool_df[col] = enc.astype(float)
+                        encoded_pool = self.orch.base_dir / "bo_artifacts" / "candidate_pool_encoded.csv"
+                        encoded_pool.parent.mkdir(parents=True, exist_ok=True)
+                        pool_df.to_csv(encoded_pool, index=False)
+                        resolved_pool = str(encoded_pool)
+                        print(f"    🔡 Candidate pool level-encoded → {encoded_pool.name}")
 
                 res = self.orch.bo.run_optimization_loop(
                     data_path=bo_data_path_for_run,
@@ -4981,6 +5061,9 @@ class OrchestratorTools:
                     col: [float(lo), float(hi)]
                     for col, (lo, hi) in zip(optimization_inputs, input_bounds)}
                 response["input_bounds_source"] = bounds_sources
+                response["input_types"] = {
+                    c: ("categorical" if c in level_maps else "continuous")
+                    for c in optimization_inputs}
                 _data_bounded = [c for c, src in bounds_sources.items() if src == "data"]
                 if _data_bounded:
                     bounds_warnings = list(bounds_warnings) + [(
@@ -5133,6 +5216,16 @@ class OrchestratorTools:
                         "call in this campaign until overridden. Only the columns "
                         "given are affected; others keep their plan/data-derived "
                         "range. Ignored for categorical inputs."
+                    )
+                },
+                "input_types": {
+                    "type": "object",
+                    "description": (
+                        "Input kind per column, {\"column\": \"categorical\"|\"continuous\"}. "
+                        "Declare categorical inputs (discrete choices — ligands, "
+                        "solvents, material ids — even when stored as numeric codes) so "
+                        "the surrogate treats them as levels, not a continuous axis. "
+                        "Sticky for the campaign; overrides what analyze_file inferred."
                     )
                 },
                 "directions": {

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -4399,6 +4399,7 @@ class OrchestratorTools:
             skill: str = None,
             candidate_pool: str = None,
             input_bounds: dict = None,
+            seed: int = None,
         ):
             """
             Runs Bayesian Optimization to suggest next parameters.
@@ -4852,6 +4853,7 @@ class OrchestratorTools:
                     skill=skill,
                     fidelity_config=fidelity_config,
                     candidate_pool=resolved_pool,
+                    seed=seed,
                 )
                 
                 if res.get("status") != "success":
@@ -4922,6 +4924,8 @@ class OrchestratorTools:
                 # Include budget context
                 if res.get("budget"):
                     response["budget"] = res["budget"]
+                if res.get("seed") is not None:
+                    response["seed"] = res["seed"]
                 
                 return json.dumps(response)
                 
@@ -5043,6 +5047,17 @@ class OrchestratorTools:
                         "call in this campaign until overridden. Only the columns "
                         "given are affected; others keep their plan/data-derived "
                         "range. Ignored for categorical inputs."
+                    )
+                },
+                "seed": {
+                    "type": "integer",
+                    "description": (
+                        "Random seed for the numeric part of this step (surrogate "
+                        "fitting restarts, acquisition optimisation). Pass when "
+                        "reproducible / comparable reruns are wanted (benchmarks, "
+                        "audits, re-running a step after fixing data); omit for "
+                        "normal campaigns. The strategy the agent chooses is not "
+                        "seeded — it is reported in the response."
                     )
                 }
             },

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -3790,6 +3790,38 @@ class OrchestratorTools:
                     if available:
                         df_to_append = df_to_append[available]
 
+                # Rows with a missing input or target cannot be optimized;
+                # admitting them only defers the failure to run_optimization
+                # ("Missing values detected"), by which point the caller can
+                # no longer tell which rows or why. Skip them here and say
+                # so (typical source: a per-unit re-analysis whose model
+                # named a quantity differently from the locked script).
+                _schema_cols = [
+                    c for c in ((self.orch.expected_input_columns or [])
+                                + (self.orch.expected_target_columns or []))
+                    if c in df_to_append.columns] or list(df_to_append.columns)
+                _n_before = len(df_to_append)
+                _keep = df_to_append[_schema_cols].notna().all(axis=1)
+                rows_skipped_missing = int((~_keep).sum())
+                if rows_skipped_missing:
+                    _bad_cols = [c for c in _schema_cols
+                                 if df_to_append.loc[~_keep, c].isna().any()]
+                    df_to_append = df_to_append[_keep]
+                    num_new = len(df_to_append)
+                    print(f"    ⚠️  Skipping {rows_skipped_missing}/{_n_before} row(s) "
+                          f"with missing values in {_bad_cols}")
+                    if df_to_append.empty:
+                        return json.dumps({
+                            "status": "error",
+                            "message": (f"All {_n_before} rows have missing values in "
+                                        f"{_bad_cols}; nothing to ingest."),
+                            "hint": ("Check the extraction: the target/input column "
+                                     "exists but is empty for every row. If this is a "
+                                     "feature table from an analysis run, the "
+                                     "quantity may be reported under another column "
+                                     "name — pass that name as the target."),
+                        })
+
                 # SCHEMA ENFORCEMENT ON SAVE
                 if df_existing is not None:
                     if set(df_to_append.columns) != set(df_existing.columns):
@@ -3818,14 +3850,22 @@ class OrchestratorTools:
                 df_final = pd.read_csv(self.orch.bo_data_path)
                 data_count = len(df_final)
                 
-                return json.dumps({
+                _resp = {
                     "status": "success",
                     "data_points_collected": data_count,
                     "rows_added": num_new,
                     "optimization_ready": data_count >= 3,
                     "inputs": self.orch.expected_input_columns,
                     "targets": self.orch.expected_target_columns
-                })
+                }
+                if rows_skipped_missing:
+                    _resp["rows_skipped_missing"] = rows_skipped_missing
+                    _resp["warning"] = (
+                        f"{rows_skipped_missing} row(s) skipped: missing values in "
+                        f"{_bad_cols}. If those units report the quantity under a "
+                        f"different column, re-ingest a table where it is filled in "
+                        f"under the target name.")
+                return json.dumps(_resp)
                 
             except Exception as e:
                 logging.error(f"Analyze file error: {e}", exc_info=True)

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -224,6 +224,35 @@ class OrchestratorTools:
             out[col] = levels[idx]
         return out
 
+    def _apply_directions(self, directions, targets) -> list:
+        """Merge caller-stated {target: maximize|minimize} into the campaign's
+        target_directions (caller wins). Returns warnings for entries that
+        were ignored (unknown target, bad value). Sticky on the orchestrator
+        and carried by its checkpoint."""
+        warns: list = []
+        if not directions:
+            return warns
+        if not isinstance(directions, dict):
+            return ["directions must be a dict {column: 'maximize'|'minimize'}; ignored."]
+        known = list(targets or [])
+        current = dict(self.orch.target_directions or {})
+        for col, d in directions.items():
+            dn = str(d).strip().lower()
+            if dn in ("max", "maximise"):
+                dn = "maximize"
+            if dn in ("min", "minimise"):
+                dn = "minimize"
+            if dn not in ("maximize", "minimize"):
+                warns.append(f"directions['{col}']={d!r} ignored: use 'maximize' or 'minimize'.")
+                continue
+            if known and str(col) not in known:
+                warns.append(f"directions['{col}'] ignored: not a target column "
+                             f"(targets are {known}).")
+                continue
+            current[str(col)] = dn
+        self.orch.target_directions = current
+        return warns
+
     def _capture_input_types(self, column_roles: Dict, input_columns: List[str]) -> None:
         """Persist scalarizer input_types onto the orchestrator state.
 
@@ -3270,7 +3299,8 @@ class OrchestratorTools:
                 extraction_goal: str = None,
                 force_regenerate: bool = False,
                 inputs: list[str] = None,
-                targets: list[str] = None):
+                targets: list[str] = None,
+                directions: dict = None):
             """
             Analyzes a raw data file (CSV/XLSX) to extract metrics.
             
@@ -3642,6 +3672,11 @@ class OrchestratorTools:
                     opt_dir = column_roles.get("optimization_direction", {})
                     if opt_dir:
                         self.orch.target_directions = opt_dir
+                    # Caller-stated directions win: a pass-through feature table
+                    # never runs the scalarizer's classification, so without
+                    # this the optimizer silently defaulted to maximize — a
+                    # 'loss' target was maximized.
+                    _dir_warn = self._apply_directions(directions, targets)
                     self._capture_input_types(column_roles, inputs)
                     print(f"    📊 Schema Enforced (User-Specified):")
                     print(f"       Inputs: {self.orch.expected_input_columns}")
@@ -3657,6 +3692,8 @@ class OrchestratorTools:
                         opt_dir = column_roles.get("optimization_direction", {})
                         if opt_dir:
                             self.orch.target_directions = opt_dir
+                    _dir_warn = self._apply_directions(
+                        directions, self.orch.expected_target_columns)
                     if not getattr(self.orch, "expected_input_types", None):
                         self._capture_input_types(column_roles, self.orch.expected_input_columns)
                     print(f"    📊 Schema Enforced (From Previous Analysis):")
@@ -3856,8 +3893,19 @@ class OrchestratorTools:
                     "rows_added": num_new,
                     "optimization_ready": data_count >= 3,
                     "inputs": self.orch.expected_input_columns,
-                    "targets": self.orch.expected_target_columns
+                    "targets": self.orch.expected_target_columns,
+                    "target_directions": dict(self.orch.target_directions or {}),
                 }
+                _missing_dir = [t for t in (self.orch.expected_target_columns or [])
+                                if t not in (self.orch.target_directions or {})]
+                if _missing_dir:
+                    _resp["direction_warning"] = (
+                        f"No optimization direction known for {_missing_dir}; the "
+                        f"optimizer will MAXIMIZE them unless you pass "
+                        f"directions={{col: 'minimize'|'maximize'}} (here or on "
+                        f"run_optimization).")
+                if locals().get("_dir_warn"):
+                    _resp["direction_warnings"] = _dir_warn
                 if rows_skipped_missing:
                     _resp["rows_skipped_missing"] = rows_skipped_missing
                     _resp["warning"] = (
@@ -3908,6 +3956,18 @@ class OrchestratorTools:
                     "type": "array", 
                     "items": {"type": "string"}, 
                     "description": "List of column names to treat as OPTIMIZATION TARGETS"
+                },
+                "directions": {
+                    "type": "object",
+                    "description": (
+                        "Optimization direction per target, {\"column\": \"maximize\"|"
+                        "\"minimize\"}. Pass whenever the objective says minimize / "
+                        "reduce / lowest (loss, cost, overpotential, band gap, "
+                        "instability, error) — a ready feature table skips the "
+                        "automatic classification and the optimizer otherwise "
+                        "MAXIMIZES every target. Sticky for the campaign; can also be "
+                        "set or changed on run_optimization."
+                    )
                 }
             },
             required=["file_path"]
@@ -4400,6 +4460,7 @@ class OrchestratorTools:
             candidate_pool: str = None,
             input_bounds: dict = None,
             seed: int = None,
+            directions: dict = None,
         ):
             """
             Runs Bayesian Optimization to suggest next parameters.
@@ -4445,6 +4506,8 @@ class OrchestratorTools:
                     "current_data_count": len(df)
                 })
             
+            _dir_warn = self._apply_directions(directions, self.orch.expected_target_columns)
+
             if not self.orch.expected_target_columns or not self.orch.expected_input_columns:
                 return json.dumps({
                     "status": "error",
@@ -4935,6 +4998,20 @@ class OrchestratorTools:
                     response["budget"] = res["budget"]
                 if res.get("seed") is not None:
                     response["seed"] = res["seed"]
+                # Direction actually used per target; warn when it was assumed.
+                _td = dict(self.orch.target_directions or {})
+                _targets_used = list(self.orch.expected_target_columns or [])
+                response["target_directions"] = {
+                    t: _td.get(t, "maximize (assumed)") for t in _targets_used}
+                _assumed = [t for t in _targets_used if t not in _td]
+                if _assumed:
+                    response.setdefault("warnings", [])
+                    response["warnings"].append(
+                        f"No optimization direction was given for {_assumed}; "
+                        f"MAXIMIZE was assumed. If the goal is to minimize, pass "
+                        f"directions={{col: 'minimize'}} and re-run.")
+                if _dir_warn:
+                    response.setdefault("warnings", []).extend(_dir_warn)
                 
                 return json.dumps(response)
                 
@@ -5056,6 +5133,17 @@ class OrchestratorTools:
                         "call in this campaign until overridden. Only the columns "
                         "given are affected; others keep their plan/data-derived "
                         "range. Ignored for categorical inputs."
+                    )
+                },
+                "directions": {
+                    "type": "object",
+                    "description": (
+                        "Optimization direction per target, {\"column\": \"maximize\"|"
+                        "\"minimize\"}. Pass whenever the user or calling system "
+                        "states it (minimize loss / cost / overpotential / band gap; "
+                        "maximize yield / conductivity). Sticky for the campaign and "
+                        "overrides what analyze_file inferred; absent any statement "
+                        "the optimizer MAXIMIZES and says so in the response."
                     )
                 },
                 "seed": {

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -4357,7 +4357,8 @@ class OrchestratorTools:
             targets: list[str] = None,
             strategy_hint: str = None,
             skill: str = None,
-            candidate_pool: str = None
+            candidate_pool: str = None,
+            input_bounds: dict = None,
         ):
             """
             Runs Bayesian Optimization to suggest next parameters.
@@ -4482,6 +4483,42 @@ class OrchestratorTools:
                             scientific_bounds[name] = (float(min_v), float(max_v))
                             print(f"  🔬 Scientific Constraint Found: {name} must be between {min_v} and {max_v}")
 
+            # Caller-stated ranges (instrument limits, safe operating window,
+            # allowed concentration range) — the strongest source: whoever
+            # runs the instrument knows what it can actually reach. Sticky:
+            # remembered on the orchestrator (and checkpointed) so later
+            # rounds inherit them until a call overrides them.
+            bounds_warnings: List[str] = []
+            if input_bounds:
+                cleaned: Dict[str, tuple] = {}
+                if not isinstance(input_bounds, dict):
+                    bounds_warnings.append(
+                        "input_bounds must be a dict {column: [min, max]}; ignored.")
+                else:
+                    known = list(self.orch.expected_input_columns or [])
+                    for name, rng in input_bounds.items():
+                        if str(name) not in known:
+                            bounds_warnings.append(
+                                f"input_bounds for unknown input column "
+                                f"'{name}' ignored; campaign inputs are {known}.")
+                            continue
+                        try:
+                            lo, hi = float(rng[0]), float(rng[1])
+                        except (TypeError, ValueError, IndexError):
+                            bounds_warnings.append(
+                                f"input_bounds['{name}'] must be [min, max]; ignored.")
+                            continue
+                        if not lo < hi:
+                            bounds_warnings.append(
+                                f"input_bounds['{name}'] needs min < max; ignored.")
+                            continue
+                        cleaned[str(name)] = (lo, hi)
+                if cleaned:
+                    prev = getattr(self.orch, "input_bounds_override", None) or {}
+                    self.orch.input_bounds_override = {**prev, **cleaned}
+            caller_bounds: Dict[str, tuple] = dict(
+                getattr(self.orch, "input_bounds_override", None) or {})
+
             # Resolve input types: scalarizer is the source of truth on type;
             # planner is the source of truth on the level universe (so BO can
             # recommend levels not yet observed in the data).
@@ -4568,16 +4605,29 @@ class OrchestratorTools:
             self.orch.expected_input_columns = optimization_inputs
             self.orch.expected_input_levels = level_maps if level_maps else None
 
-            # Build bounds (continuous: scientific or data-derived; categorical: [0, n-1])
+            # Build bounds. Precedence per continuous input: caller-stated >
+            # planner (plan optimization_params) > data-derived (observed
+            # range +/-10%). Categorical inputs are index-encoded [0, n-1].
             input_bounds = []
+            bounds_sources: Dict[str, str] = {}
             for col in optimization_inputs:
                 if col in level_maps:
                     n = len(level_maps[col])
                     input_bounds.append([0.0, float(n - 1)])
+                    bounds_sources[col] = "categorical"
+                    if col in caller_bounds:
+                        bounds_warnings.append(
+                            f"input_bounds['{col}'] ignored: categorical input.")
                     print(f"     -> Bound for '{col}': [0, {n - 1}] (Source: CATEGORICAL — {n} levels)")
+                elif col in caller_bounds:
+                    lo, hi = caller_bounds[col]
+                    input_bounds.append([lo, hi])
+                    bounds_sources[col] = "caller"
+                    print(f"     -> Bound for '{col}': [{lo}, {hi}] (Source: CALLER)")
                 elif col in scientific_bounds:
                     sci_min, sci_max = scientific_bounds[col]
                     input_bounds.append([sci_min, sci_max])
+                    bounds_sources[col] = "planner"
                     print(f"     -> Bound for '{col}': [{sci_min}, {sci_max}] (Source: PLANNER)")
                 else:
                     data_min = float(df[col].min())
@@ -4592,7 +4642,10 @@ class OrchestratorTools:
                     safe_max = data_max + margin
 
                     input_bounds.append([safe_min, safe_max])
+                    bounds_sources[col] = "data"
                     print(f"     -> Bound for '{col}': [{safe_min:.2f}, {safe_max:.2f}] (Source: DATA)")
+            for w in bounds_warnings:
+                print(f"  ⚠️ {w}")
 
             # Build cat_dims (positional indices) and integer-encode CSV
             cat_dims = [
@@ -4811,6 +4864,16 @@ class OrchestratorTools:
                 if res.get("candidate_pool"):
                     response["candidate_pool"] = res["candidate_pool"]
 
+                # The search box actually used and where each range came
+                # from (caller / planner / data / categorical), so a caller
+                # can see a data-derived box and pass input_bounds next time.
+                response["input_bounds"] = {
+                    col: [float(lo), float(hi)]
+                    for col, (lo, hi) in zip(optimization_inputs, input_bounds)}
+                response["input_bounds_source"] = bounds_sources
+                if bounds_warnings:
+                    response["input_bounds_warnings"] = bounds_warnings
+
                 # Include budget context
                 if res.get("budget"):
                     response["budget"] = res["budget"]
@@ -4918,6 +4981,24 @@ class OrchestratorTools:
                 "skill": {
                     "type": "string",
                     "description": _build_optimization_skill_description()
+                },
+                "input_bounds": {
+                    "type": "object",
+                    "description": (
+                        "Hard search-box limits per input column, "
+                        "{\"column\": [min, max]} — the range the instrument or "
+                        "process can actually reach (e.g. {\"anneal_time_min\": "
+                        "[5, 60], \"temperature_C\": [300, 700]}). Pass whenever the "
+                        "user or calling system states an achievable / safe / "
+                        "allowed range for a parameter, in this call or earlier in "
+                        "the conversation. These take precedence over ranges from the "
+                        "campaign plan and over the default (observed data range "
+                        "+/-10%, which can extrapolate outside what is physically "
+                        "realizable). Sticky: once given they apply to every later "
+                        "call in this campaign until overridden. Only the columns "
+                        "given are affected; others keep their plan/data-derived "
+                        "range. Ignored for categorical inputs."
+                    )
                 }
             },
             required=[]

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -738,6 +738,14 @@ class PlanningOrchestratorAgent:
         
         if restore_checkpoint and self.checkpoint_path.exists():
             self._restore_checkpoint()
+        elif not restore_checkpoint and not self.checkpoint_path.exists():
+            # A session dir with campaign data from an earlier process but
+            # nothing to restore from: without this, the on-disk dedup
+            # ledger says every file is "already analyzed" while the
+            # in-memory schema is empty and run_optimization fails with
+            # "Schema not established". Archive the stale files and start
+            # clean; nothing is deleted.
+            self._archive_stale_campaign_files()
         
         # --- Init Sub-Agents ---
         print("🤖 Agent: Hiring sub-agents...")
@@ -1195,6 +1203,33 @@ class PlanningOrchestratorAgent:
 
         logging.info(f"🔌 Disconnected MCP server '{server_name}'")
         self._rebuild_system_prompt()
+
+    def _archive_stale_campaign_files(self) -> Optional[Path]:
+        """Move campaign data files left by an earlier process (no checkpoint
+        to restore them with) into ``stale_campaign_<ts>/`` and reset the
+        dedup ledger, so this process starts a consistent, empty campaign.
+        Returns the archive dir, or None when there was nothing to move."""
+        candidates = [self.bo_data_path, self.analyzed_files_path,
+                      self.bo_data_path.with_suffix(".csv.backup")]
+        present = [c for c in candidates if c.exists()]
+        if not present:
+            self.analyzed_files = {}
+            return None
+        stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        archive = self.base_dir / f"stale_campaign_{stamp}"
+        archive.mkdir(parents=True, exist_ok=True)
+        for c in present:
+            try:
+                c.rename(archive / c.name)
+            except OSError as e:  # noqa: PERF203 - best effort, never fatal
+                logging.warning(f"Could not archive {c.name}: {e}")
+        self.analyzed_files = {}
+        print(f"  📦 Session dir held campaign data from an earlier run with no "
+              f"checkpoint to restore; moved {[c.name for c in present]} to "
+              f"{archive.name}/ and started a fresh campaign. Re-ingest your "
+              f"data with analyze_file (or construct with restore_checkpoint=True "
+              f"when a checkpoint exists).")
+        return archive
 
     def _restore_checkpoint(self):
         """Restore campaign state from checkpoint."""

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -702,6 +702,7 @@ class PlanningOrchestratorAgent:
         self.target_directions = {}  # e.g. {"Yield": "maximize", "Defect_Density": "minimize"}
         self.expected_input_types = None  # {col: "continuous" | "categorical"} from scalarizer
         self.expected_input_levels = None  # {col: [level0, level1, ...]} for categorical inputs
+        self.input_bounds_override = None  # {col: (min, max)} caller-stated search box (run_optimization input_bounds)
         self.fidelity_spec = None  # {column, target_fidelity?, costs?} when the data has a fidelity axis
         self.latest_tea_results = None
 
@@ -1224,6 +1225,9 @@ class PlanningOrchestratorAgent:
             self.target_directions = state.get("target_directions", {})
             self.expected_input_types = state.get("expected_input_types")
             self.expected_input_levels = state.get("expected_input_levels")
+            _ib = state.get("input_bounds_override")
+            self.input_bounds_override = (
+                {k: tuple(v) for k, v in _ib.items()} if isinstance(_ib, dict) else None)
             self.fidelity_spec = state.get("fidelity_spec")
             self.latest_tea_results = state.get("latest_tea_results")
             self._delegation_counter = state.get("delegation_counter", 0)
@@ -1552,6 +1556,9 @@ class PlanningOrchestratorAgent:
                 "target_directions": self.target_directions,
                 "expected_input_types": self.expected_input_types,
                 "expected_input_levels": self.expected_input_levels,
+                "input_bounds_override": (
+                    {k: list(v) for k, v in self.input_bounds_override.items()}
+                    if self.input_bounds_override else None),
                 "fidelity_spec": self.fidelity_spec,
                 "data_points_collected": len(pd.read_csv(self.bo_data_path)) if self.bo_data_path.exists() else 0,
                 "planner_state": compact_planner_state(self.planner.state),

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -575,6 +575,12 @@ class SimulationOrchestratorAgent:
             # chat() bound the feedback log to THIS session; restore the
             # caller's binding (a delegating meta keeps logging to its own).
             set_thread_feedback_log(_prev_fblog)
+            # A delegation-driven child may never reach the chat loop's
+            # auto-checkpoint cadence, and an interrupted delegation must
+            # leave current state behind for the restart/resume path
+            # (issue #469) — checkpoint after every run_task, like the
+            # planning orchestrator.
+            self._auto_checkpoint()
 
         # Derive the structured summary from session state.
         new_structures = (self.generated_structures or [])[n_before:]

--- a/scilink/mcp_server.py
+++ b/scilink/mcp_server.py
@@ -258,6 +258,7 @@ def _execute_tool_captured(tools, tool_name: str, kwargs: dict,
     try:
         with _job_narration(log_lines), contextlib.redirect_stdout(captured):
             result = tools.execute_tool(tool_name, **kwargs)
+            _checkpoint_after_tool(tools, tool_name)
     finally:
         if state is not None:
             set_thread_channel(None)
@@ -267,6 +268,24 @@ def _execute_tool_captured(tools, tool_name: str, kwargs: dict,
         logging.info(f"[tool:{tool_name}] {log_output}")
 
     return result
+
+
+def _checkpoint_after_tool(tools, tool_name: str) -> None:
+    """Persist the owning orchestrator's state after a granular tool call.
+
+    The chat loops checkpoint after every turn; granular MCP calls bypassed
+    that, so a server restarted on the same --session-dir came back with the
+    data files but none of the state (schema, selected agent, results
+    ledger) — the client's campaign silently lost its footing. Cheap JSON
+    write; never fatal."""
+    orch = getattr(tools, "orch", None)
+    ckpt = getattr(orch, "_auto_checkpoint", None)
+    if ckpt is None:
+        return
+    try:
+        ckpt()
+    except Exception as exc:  # noqa: BLE001 - durability must not break the call
+        logging.warning(f"[tool:{tool_name}] checkpoint after call failed: {exc}")
 
 
 # ── Pending action support (co-pilot / autopilot) ──────────────────────
@@ -916,6 +935,25 @@ def _init_orchestrators(state: dict, config: dict) -> None:
     base_url = config["base_url"]
     fh_key = config["futurehouse_api_key"] or os.environ.get("FUTUREHOUSE_API_KEY")
 
+    # Restart durability. Each orchestrator gets its own base dir (in
+    # --mode both they nest as <session>/analysis and <session>/planning,
+    # the meta's own layout — sharing one dir made their checkpoint.json
+    # files clobber each other) and restores its checkpoint when one exists,
+    # so a server restarted on the same --session-dir resumes the campaign
+    # instead of starting a half-state next to the old files.
+    def _base_for(kind: str) -> str:
+        if config["mode"] == "both":
+            d = Path(session_dir) / kind
+            d.mkdir(parents=True, exist_ok=True)
+            return str(d)
+        return session_dir
+
+    def _restore(base: str) -> bool:
+        has = (Path(base) / "checkpoint.json").exists()
+        if has:
+            logging.info(f"Restoring session state from {base}/checkpoint.json")
+        return has
+
     if config["mode"] in ("analyze", "both"):
         from scilink.agents.exp_agents.analysis_orchestrator import (
             AnalysisOrchestratorAgent, AnalysisMode,
@@ -930,13 +968,15 @@ def _init_orchestrators(state: dict, config: dict) -> None:
         analysis_mode = mode_map.get(
             config["analysis_mode"].lower(), AnalysisMode.AUTONOMOUS
         )
+        _abase = _base_for("analysis")
         state["analysis_orch"] = AnalysisOrchestratorAgent(
-            base_dir=session_dir,
+            base_dir=_abase,
             api_key=api_key,
             model_name=model_name,
             base_url=base_url,
             analysis_mode=analysis_mode,
             futurehouse_api_key=fh_key,
+            restore_checkpoint=_restore(_abase),
         )
 
     if config["mode"] in ("plan", "both"):
@@ -957,12 +997,13 @@ def _init_orchestrators(state: dict, config: dict) -> None:
             # Planning orchestrator needs data_dir and knowledge_dir
             # to avoid creating directories with relative paths
             # (fails when Claude Desktop runs from /).
-            data_dir = str(Path(session_dir) / "data")
-            knowledge_dir = str(Path(session_dir) / "kb_storage")
+            _pbase = _base_for("planning")
+            data_dir = str(Path(_pbase) / "data")
+            knowledge_dir = str(Path(_pbase) / "kb_storage")
             Path(data_dir).mkdir(parents=True, exist_ok=True)
             Path(knowledge_dir).mkdir(parents=True, exist_ok=True)
             state["planning_orch"] = PlanningOrchestratorAgent(
-                base_dir=session_dir,
+                base_dir=_pbase,
                 api_key=api_key,
                 model_name=model_name,
                 base_url=base_url,
@@ -970,6 +1011,7 @@ def _init_orchestrators(state: dict, config: dict) -> None:
                 autonomy_level=autonomy_level,
                 data_dir=data_dir,
                 knowledge_dir=knowledge_dir,
+                restore_checkpoint=_restore(_pbase),
             )
         except Exception as exc:
             logging.warning(f"Planning orchestrator not available: {exc}")
@@ -994,6 +1036,7 @@ def _init_orchestrators(state: dict, config: dict) -> None:
             base_url=base_url,
             meta_mode=meta_mode,
             futurehouse_api_key=fh_key,
+            restore_checkpoint=_restore(session_dir),
         )
 
 

--- a/scilink/mcp_server.py
+++ b/scilink/mcp_server.py
@@ -15,6 +15,7 @@ The ``mcp`` package is installed by default with SciLink.
 """
 
 import asyncio
+import os
 import concurrent.futures
 import contextlib
 import io
@@ -326,6 +327,27 @@ def _build_approval_prompt(tool_name: str, kwargs: dict) -> str:
 
 # ── Server factory ──────────────────────────────────────────────────────
 
+_HEADLESS_BACKENDS = {"agg", "pdf", "ps", "svg", "template", "cairo"}
+
+
+def _ensure_headless_matplotlib() -> None:
+    """An MCP server has no display and executes tools off the main thread;
+    GUI matplotlib backends (macOS Cocoa in particular) refuse that and kill
+    the tool call. Default MPLBACKEND to Agg and force-switch away from a GUI
+    backend if one was already resolved — operators should not need to know
+    this (it was integration rule 2 of every MCP client)."""
+    os.environ.setdefault("MPLBACKEND", "Agg")
+    try:
+        import matplotlib
+        backend = str(matplotlib.get_backend())
+        if (backend.lower() not in _HEADLESS_BACKENDS
+                and not backend.lower().startswith("module://")):
+            matplotlib.use("Agg", force=True)
+            logging.info(f"matplotlib backend {backend} → Agg (headless MCP server)")
+    except Exception as exc:  # noqa: BLE001 - never block serving over a plot backend
+        logging.warning(f"Could not enforce headless matplotlib backend: {exc}")
+
+
 def create_server(
     *,
     api_key: str = None,
@@ -354,6 +376,8 @@ def create_server(
     _require_mcp()
 
     server = Server("scilink")
+
+    _ensure_headless_matplotlib()
 
     # ── State (initialized lazily on first tool list) ────────────────
     # Thread pool for background jobs

--- a/scilink/mcp_server.py
+++ b/scilink/mcp_server.py
@@ -22,6 +22,7 @@ import io
 import json
 import logging
 import sys
+from pathlib import Path
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -116,6 +117,131 @@ def _openai_to_mcp_tool(schema: dict, prefix: str = "scilink") -> types.Tool:
 
 # ── Human-in-the-loop channel (agent prompts over MCP) ─────────────────
 
+# ── Job / pending-question durability (issue #469) ─────────────────────
+# The jobs table and parked questions lived only in server memory: after a
+# restart a supervising client got "Unknown job_id" and its questions
+# evaporated. Every transition is now mirrored to <session_dir>/mcp_jobs.json
+# (atomic replace, never fatal); on start, unfinished jobs come back as
+# status "interrupted" with a structured re-entry hint, and finished ones
+# keep answering job_status/job_result with their stored result.
+
+_JOBS_STORE_NAME = "mcp_jobs.json"
+_INTERRUPTED_HINT = (
+    "The server restarted while this job was in flight; its Python stack "
+    "cannot be resumed, but the campaign/session state is checkpointed. "
+    "Re-issue the orchestrate call to continue from where the checkpoints "
+    "left off. The narration tail from before the restart is attached."
+)
+
+
+def _jobs_store_path(state: dict):
+    sd = (state.get("config") or {}).get("session_dir")
+    return (Path(sd) / _JOBS_STORE_NAME) if sd else None
+
+
+def _persist_jobs(state: dict) -> None:
+    """Mirror the jobs table + parked questions to the session dir.
+
+    Called on every transition (create / finish / question parked or
+    answered). Best-effort and atomic; a persistence failure must never
+    break the tool call it rides on."""
+    path = _jobs_store_path(state)
+    if path is None:
+        return
+    try:
+        with state.get("_persist_lock") or contextlib.nullcontext():
+            jobs = {}
+            for jid, job in state.get("jobs", {}).items():
+                jobs[jid] = {
+                    "tool": job.get("tool"),
+                    "started_at": job.get("started_at"),
+                    "status": job.get("status"),
+                    "result": job.get("result"),
+                    "log_tail": list(job.get("log_lines") or [])[-100:],
+                }
+            questions = []
+            for q in _pending_questions(state):
+                questions.append({**q, "asked_at": datetime.now().isoformat()})
+            payload = {"job_counter": state.get("job_counter", 0),
+                       "jobs": jobs, "pending_questions": questions}
+            tmp = path.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(payload, indent=1, default=str),
+                           encoding="utf-8")
+            tmp.replace(path)
+    except Exception as exc:  # noqa: BLE001 - durability is best-effort
+        logging.warning(f"Could not persist MCP job state: {exc}")
+
+
+def _finalize_job(state: dict, job_id: str) -> None:
+    """Done-callback on a job's future: capture status/result immediately
+    (not just when a client happens to poll) and persist, so a job that
+    finishes moments before a crash is recoverable."""
+    job = state.get("jobs", {}).get(job_id)
+    if job is None or job.get("future") is None:
+        return
+    try:
+        job["result"] = job["future"].result()
+        job["status"] = "completed"
+    except Exception as exc:  # noqa: BLE001 - failure is a terminal state too
+        job["result"] = json.dumps({"status": "error", "message": str(exc)})
+        job["status"] = "failed"
+    _persist_jobs(state)
+
+
+def _register_job(state: dict, job_id: str, job: dict) -> None:
+    """Insert a job and wire durability (done-callback + persist)."""
+    state["jobs"][job_id] = job
+    fut = job.get("future")
+    if fut is not None:
+        fut.add_done_callback(lambda _f, _j=job_id: _finalize_job(state, _j))
+    _persist_jobs(state)
+
+
+def _restore_jobs(state: dict) -> None:
+    """Load the persisted jobs table on server start.
+
+    Finished jobs keep answering job_status/job_result with their stored
+    result; unfinished ones become status "interrupted" with a re-entry
+    hint. Parked questions cannot survive (their asking thread is gone) —
+    they are surfaced once via state["interrupted_questions"] so a
+    scilink_respond against them explains what happened instead of
+    erroring as unknown."""
+    path = _jobs_store_path(state)
+    if path is None or not path.exists():
+        return
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logging.warning(f"Could not read persisted MCP job state: {exc}")
+        return
+    n_restored = n_interrupted = 0
+    for jid, rec in (payload.get("jobs") or {}).items():
+        if jid in state["jobs"]:
+            continue
+        job = {"future": None, "tool": rec.get("tool"),
+               "started_at": rec.get("started_at"),
+               "status": rec.get("status"), "result": rec.get("result"),
+               "log_lines": list(rec.get("log_tail") or [])}
+        if job["status"] in ("running", "awaiting_input"):
+            job["status"] = "interrupted"
+            job["result"] = json.dumps({
+                "status": "interrupted", "job_id": jid,
+                "message": _INTERRUPTED_HINT,
+                "log_tail": "\n".join(job["log_lines"][-25:])})
+            n_interrupted += 1
+        state["jobs"][jid] = job
+        n_restored += 1
+    state["interrupted_questions"] = {
+        q.get("request_id"): q for q in payload.get("pending_questions") or []}
+    state["job_counter"] = max(state.get("job_counter", 0),
+                               int(payload.get("job_counter", 0)))
+    if n_restored:
+        logging.info(
+            f"Restored {n_restored} background job record(s) from "
+            f"{path.name} ({n_interrupted} interrupted by the restart)")
+    _persist_jobs(state)
+
+
 class _MCPChannel:
     """hitl.FeedbackChannel that parks agent prompts in the server's
     pending queue for a client to answer via ``scilink_respond``.
@@ -142,10 +268,12 @@ class _MCPChannel:
             "type": "question", "req": req, "event": event,
             "holder": holder, "job_id": self._job_id,
         }
+        _persist_jobs(self._state)
         try:
             answered = event.wait(self._timeout_s)
         finally:
             self._state["pending"].pop(req.id, None)
+            _persist_jobs(self._state)
         if not answered:
             logging.warning(
                 f"[hitl] question {req.id} ({req.kind}) unanswered after "
@@ -378,6 +506,7 @@ def create_server(
     server = Server("scilink")
 
     _ensure_headless_matplotlib()
+    import threading as _threading
 
     # ── State (initialized lazily on first tool list) ────────────────
     # Thread pool for background jobs
@@ -397,6 +526,8 @@ def create_server(
         "initialized": False,
         "jobs": {},
         "job_counter": 0,
+        "interrupted_questions": {},
+        "_persist_lock": _threading.Lock(),
         "config": {
             "api_key": api_key,
             "model_name": model_name,
@@ -797,14 +928,14 @@ def create_server(
                 _execute_tool_captured, orch.tools, original_name, arguments,
                 state, job_id, log_lines,
             )
-            state["jobs"][job_id] = {
+            _register_job(state, job_id, {
                 "future": future,
                 "tool": original_name,
                 "started_at": ts,
                 "status": "running",
                 "result": None,
                 "log_lines": log_lines,
-            }
+            })
 
             return [types.TextContent(
                 type="text",
@@ -953,6 +1084,10 @@ def _init_orchestrators(state: dict, config: dict) -> None:
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
         session_dir = str(Path.home() / "scilink_mcp_sessions" / f"session_{ts}")
     Path(session_dir).mkdir(parents=True, exist_ok=True)
+    # Persisted job state (issue #469) lives here; record the resolved dir
+    # so persistence works even when the caller left session_dir unset.
+    config["session_dir"] = session_dir
+    _restore_jobs(state)
 
     api_key = config["api_key"]
     model_name = config["model_name"]
@@ -1082,7 +1217,7 @@ def _handle_job_status(
         )]
 
     future = job["future"]
-    if future.done():
+    if future is not None and future.done():
         try:
             result = future.result()
             job["status"] = "completed"
@@ -1110,6 +1245,8 @@ def _handle_job_status(
     lines = job.get("log_lines")
     if n and lines:
         payload["log_tail"] = "\n".join(list(lines)[-n:])
+    if job["status"] == "interrupted":
+        payload["message"] = _INTERRUPTED_HINT
     # A running job blocked on a human question reports awaiting_input
     # with the parked question(s) so the client can scilink_respond.
     if job["status"] == "running":
@@ -1121,6 +1258,12 @@ def _handle_job_status(
                 "The job is paused on a question. Answer with "
                 "scilink_respond(request_id=..., response=...) — empty "
                 "response usually means accept as-is.")
+
+    # Heartbeat persistence: the narration buffer fills between transitions,
+    # and a supervising client polls job_status regularly — mirror the tail
+    # to disk here so a crash loses at most one polling interval of narration.
+    if job.get("future") is not None:
+        _persist_jobs(state)
 
     return [types.TextContent(type="text", text=json.dumps(payload))]
 
@@ -1141,6 +1284,11 @@ def _handle_job_result(
         )]
 
     future = job["future"]
+    if future is None:
+        # Restored from a previous server process: the stored result is the
+        # answer (completed/failed), or the interrupted re-entry hint.
+        return [types.TextContent(type="text", text=job["result"] or json.dumps(
+            {"status": job["status"], "job_id": job_id}))]
     if not future.done():
         return [types.TextContent(
             type="text",
@@ -1315,14 +1463,14 @@ async def _handle_orchestrate_meta(
         log_lines = _new_job_lines()
         future = executor.submit(_execute_meta_chat_captured, orch, prompt,
                                  autonomy_str, state, job_id, log_lines)
-        state["jobs"][job_id] = {
+        _register_job(state, job_id, {
             "future": future,
             "tool": "orchestrate_meta",
             "started_at": ts,
             "status": "running",
             "result": None,
             "log_lines": log_lines,
-        }
+        })
 
         return [types.TextContent(
             type="text",
@@ -1390,14 +1538,14 @@ async def _handle_orchestrate(
         log_lines = _new_job_lines()
         future = executor.submit(_execute_run_task_captured, orch, prompt,
                                  autonomy_str, state, job_id, log_lines)
-        state["jobs"][job_id] = {
+        _register_job(state, job_id, {
             "future": future,
             "tool": tool_label,
             "started_at": ts,
             "status": "running",
             "result": None,
             "log_lines": log_lines,
-        }
+        })
 
         return [types.TextContent(
             type="text",
@@ -1502,6 +1650,18 @@ async def _handle_respond(
     pending = state.get("pending", {})
     request_id = (arguments.get("request_id") or "").strip()
 
+    if request_id and request_id not in pending:
+        dead = (state.get("interrupted_questions") or {}).get(request_id)
+        if dead:
+            return [types.TextContent(type="text", text=json.dumps({
+                "status": "interrupted",
+                "request_id": request_id,
+                "message": (
+                    "This question belonged to a job interrupted by a server "
+                    "restart; its asking thread is gone, so the answer cannot "
+                    "be delivered. " + _INTERRUPTED_HINT),
+                "question": dead,
+            }))]
     if request_id:
         item = pending.get(request_id)
         if item is None:

--- a/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
+++ b/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
@@ -72,10 +72,10 @@ TOOL_SPEC = ToolSpec(
         "background": {"type": "str", "description": "'snip' (default), 'polynomial', or 'none' (data already background-subtracted)."},
         "snip_iterations": {"type": "int | str", "description": "SNIP iteration count. 'auto' (default) sweeps a few counts and keeps the one with the cleanest residual at the best R² — avoids apex over-subtraction on sharp peaks without hand-tuning. Pass an int to fix it (e.g. reuse the value reported in background_method to skip the sweep on locked series frames)."},
         "prominence_frac": {"type": "float", "description": "Auto-detect: min peak prominence as a fraction of the corrected pattern range. Default 0.02 (2%). Lower (0.01) to catch weak reflections the verifier may flag as unmodelled residual; raise (0.03) if noise peaks are being fit. The effective threshold is the LARGER of this and the noise floor (min_prominence_sigma)."},
-        "min_prominence_sigma": {"type": "float | None", "description": "Auto-detect: noise floor for peak prominence, in units of the estimated noise sigma. None (default) = a sample-size-aware floor (~2*sqrt(2 ln N): ~7 sigma at 700 points, ~8.5 at 8000) below which excursions are indistinguishable from noise. LOWER (e.g. 4-5) to recover genuinely weak reflections the verifier flags as unmodelled residual; RAISE if noise peaks are still being fit. Reported in the result as noise_prominence_sigma."},
+        "min_prominence_sigma": {"type": "float | None", "description": "Auto-detect: noise floor for peak prominence, in units of the noise sigma of the pattern smoothed to the expected reflection width (init_fwhm_deg; matched-filter detection, so real reflections keep their height while white noise drops by sqrt(width in points)). None (default) = a sample-size-aware floor (~2*sqrt(2 ln N): ~7 at 700 points, ~8.5 at 8000) below which excursions are indistinguishable from noise. LOWER (e.g. 4-5) to recover genuinely weak reflections the verifier flags as unmodelled residual; RAISE if noise peaks are still being fit. Reported in the result as noise_prominence_sigma."},
         "max_peaks": {"type": "int", "description": "Auto-detect cap. Default 30."},
         "min_distance_deg": {"type": "float", "description": "Auto-detect: minimum separation between peaks (degrees). Default 0.15."},
-        "init_fwhm_deg": {"type": "float", "description": "Initial FWHM guess per peak (degrees). Default 0.2 (typical CuKa)."},
+        "init_fwhm_deg": {"type": "float", "description": "Initial FWHM guess per peak (degrees), also the expected reflection width for matched-filter peak detection. Default 0.2 (typical CuKa); raise for broad (nanocrystalline / coarse-step) patterns so detection integrates over the true width."},
         "center_leeway_deg": {"type": "float", "description": "Each center may move +/- this much during the fit (degrees). Default 0.3."},
         "max_fwhm_deg": {"type": "float", "description": "Upper bound on fitted FWHM (degrees). Default 3.0."},
         "peak_shape": {"type": "str", "description": "'split_pseudo_voigt' (default) fits one extra width per peak to capture axial-divergence asymmetry — markedly lower residual on strong sharp lab-CuKa peaks, and it degenerates to symmetric when the data is symmetric (so it generalises safely). 'pseudo_voigt' forces a symmetric profile (fewer parameters; use only if asymmetry is known absent, e.g. synchrotron data)."},
@@ -182,19 +182,29 @@ def noise_prominence_floor(n_points: int) -> float:
 
 
 def _detect_centers(x, ycorr, step, prominence_frac, max_peaks, min_distance_deg,
-                    min_prominence_sigma=None):
+                    min_prominence_sigma=None, init_fwhm_deg=0.2):
     """Auto-detect significant peak centers on a background-corrected pattern.
 
-    Prominence threshold = max(prominence_frac * range, k * noise_sigma) with
-    k = ``min_prominence_sigma`` or, when None, the sample-size-aware floor
-    from :func:`noise_prominence_floor`."""
+    Matched-filter detection: the pattern is smoothed with a boxcar of the
+    expected reflection width (``init_fwhm_deg`` in points), which lowers
+    white noise by sqrt(w) while a real reflection — which spans those
+    points — keeps most of its height. The prominence threshold on the
+    smoothed trace is max(prominence_frac * range, k * noise_sigma/sqrt(w))
+    with k = ``min_prominence_sigma`` or, when None, the sample-size-aware
+    floor from :func:`noise_prominence_floor`. Measured on 30 RRUFF
+    patterns: median recall of the reference reflections 0.73 (fixed 3 sigma
+    on the raw trace, saturating max_peaks with noise) -> 0.80, while a
+    700-point single-peak pattern yields 1 peak instead of 30."""
+    from scipy.ndimage import uniform_filter1d
     noise = _estimate_noise(ycorr)
+    w = max(1, int(round(float(init_fwhm_deg) / step)))
+    ys = uniform_filter1d(ycorr, w, mode="nearest") if w > 1 else ycorr
     k = (float(min_prominence_sigma) if min_prominence_sigma is not None
          else noise_prominence_floor(len(ycorr)))
-    prom = max(prominence_frac * (ycorr.max() - ycorr.min()), k * noise)
+    prom = max(prominence_frac * (ys.max() - ys.min()), k * noise / np.sqrt(w))
     dist = max(1, int(round(min_distance_deg / step)))
-    idx, _ = find_peaks(ycorr, prominence=prom, distance=dist)
-    idx = idx[np.argsort(ycorr[idx])[::-1][:max_peaks]]
+    idx, _ = find_peaks(ys, prominence=prom, distance=dist)
+    idx = idx[np.argsort(ys[idx])[::-1][:max_peaks]]
     return sorted(float(x[i]) for i in idx)
 
 
@@ -293,7 +303,8 @@ def fit_pattern(
             centers_for_sweep = _detect_centers(
                 x, np.asarray(ref_bg["intensity_corrected"], dtype=float), step,
                 prominence_frac, max_peaks, min_distance_deg,
-                min_prominence_sigma=min_prominence_sigma)
+                min_prominence_sigma=min_prominence_sigma,
+                init_fwhm_deg=init_fwhm_deg)
         else:
             centers_for_sweep = centers_locked
         trials = []
@@ -394,7 +405,8 @@ def _fit_corrected(
     else:
         centers = _detect_centers(
             x, ycorr, step, prominence_frac, max_peaks, min_distance_deg,
-            min_prominence_sigma=min_prominence_sigma)
+            min_prominence_sigma=min_prominence_sigma,
+            init_fwhm_deg=init_fwhm_deg)
     if not centers:
         raise ValueError("no peaks detected; lower prominence_frac or pass peak_centers")
 

--- a/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
+++ b/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
@@ -58,7 +58,7 @@ TOOL_SPEC = ToolSpec(
     signature=(
         "fit_pattern(exp_two_theta, exp_intensity, peak_centers=None, "
         "background='snip', snip_iterations='auto', prominence_frac=0.02, "
-        "max_peaks=30, min_distance_deg=0.15, init_fwhm_deg=0.2, "
+        "min_prominence_sigma=None, max_peaks=30, min_distance_deg=0.15, init_fwhm_deg=0.2, "
         "center_leeway_deg=0.3, max_fwhm_deg=3.0, "
         "peak_shape='split_pseudo_voigt', fit_range=None) -> dict"
     ),
@@ -71,7 +71,8 @@ TOOL_SPEC = ToolSpec(
         },
         "background": {"type": "str", "description": "'snip' (default), 'polynomial', or 'none' (data already background-subtracted)."},
         "snip_iterations": {"type": "int | str", "description": "SNIP iteration count. 'auto' (default) sweeps a few counts and keeps the one with the cleanest residual at the best R² — avoids apex over-subtraction on sharp peaks without hand-tuning. Pass an int to fix it (e.g. reuse the value reported in background_method to skip the sweep on locked series frames)."},
-        "prominence_frac": {"type": "float", "description": "Auto-detect: min peak prominence as a fraction of the corrected pattern range. Default 0.02 (2%). Lower (0.01) to catch weak reflections the verifier may flag as unmodelled residual; raise (0.03) if noise peaks are being fit."},
+        "prominence_frac": {"type": "float", "description": "Auto-detect: min peak prominence as a fraction of the corrected pattern range. Default 0.02 (2%). Lower (0.01) to catch weak reflections the verifier may flag as unmodelled residual; raise (0.03) if noise peaks are being fit. The effective threshold is the LARGER of this and the noise floor (min_prominence_sigma)."},
+        "min_prominence_sigma": {"type": "float | None", "description": "Auto-detect: noise floor for peak prominence, in units of the estimated noise sigma. None (default) = a sample-size-aware floor (~2*sqrt(2 ln N): ~7 sigma at 700 points, ~8.5 at 8000) below which excursions are indistinguishable from noise. LOWER (e.g. 4-5) to recover genuinely weak reflections the verifier flags as unmodelled residual; RAISE if noise peaks are still being fit. Reported in the result as noise_prominence_sigma."},
         "max_peaks": {"type": "int", "description": "Auto-detect cap. Default 30."},
         "min_distance_deg": {"type": "float", "description": "Auto-detect: minimum separation between peaks (degrees). Default 0.15."},
         "init_fwhm_deg": {"type": "float", "description": "Initial FWHM guess per peak (degrees). Default 0.2 (typical CuKa)."},
@@ -169,10 +170,28 @@ def _split_pv_area(amp, fwhm_l, fwhm_r, eta):
     return 0.5 * (_pv_area(amp, fwhm_l, eta) + _pv_area(amp, fwhm_r, eta))
 
 
-def _detect_centers(x, ycorr, step, prominence_frac, max_peaks, min_distance_deg):
-    """Auto-detect significant peak centers on a background-corrected pattern."""
+def noise_prominence_floor(n_points: int) -> float:
+    """Prominence floor, in units of the noise sigma, below which a "peak" is
+    indistinguishable from noise: the expected extreme peak-to-valley
+    excursion of ``n_points`` white-noise samples, ~2*sqrt(2 ln N) sigma
+    (~7 sigma at 700 points, ~8.5 sigma at 8000). A fixed 3 sigma admitted
+    hundreds of noise peaks on any pattern longer than a few hundred points
+    while real reflections at >=10 sigma are untouched by this floor."""
+    n = max(int(n_points), 2)
+    return float(max(5.0, 2.0 * np.sqrt(2.0 * np.log(n))))
+
+
+def _detect_centers(x, ycorr, step, prominence_frac, max_peaks, min_distance_deg,
+                    min_prominence_sigma=None):
+    """Auto-detect significant peak centers on a background-corrected pattern.
+
+    Prominence threshold = max(prominence_frac * range, k * noise_sigma) with
+    k = ``min_prominence_sigma`` or, when None, the sample-size-aware floor
+    from :func:`noise_prominence_floor`."""
     noise = _estimate_noise(ycorr)
-    prom = max(prominence_frac * (ycorr.max() - ycorr.min()), 3.0 * noise)
+    k = (float(min_prominence_sigma) if min_prominence_sigma is not None
+         else noise_prominence_floor(len(ycorr)))
+    prom = max(prominence_frac * (ycorr.max() - ycorr.min()), k * noise)
     dist = max(1, int(round(min_distance_deg / step)))
     idx, _ = find_peaks(ycorr, prominence=prom, distance=dist)
     idx = idx[np.argsort(ycorr[idx])[::-1][:max_peaks]]
@@ -194,6 +213,7 @@ def fit_pattern(
     background: str = "snip",
     snip_iterations: Any = "auto",
     prominence_frac: float = 0.02,
+    min_prominence_sigma: Optional[float] = None,
     max_peaks: int = 30,
     min_distance_deg: float = 0.15,
     init_fwhm_deg: float = 0.2,
@@ -240,7 +260,7 @@ def fit_pattern(
         prominence_frac=prominence_frac, max_peaks=max_peaks,
         min_distance_deg=min_distance_deg, init_fwhm_deg=init_fwhm_deg,
         center_leeway_deg=center_leeway_deg, max_fwhm_deg=max_fwhm_deg,
-        peak_shape=peak_shape,
+        peak_shape=peak_shape, min_prominence_sigma=min_prominence_sigma,
     )
 
     # --- background + fit ---
@@ -272,7 +292,8 @@ def fit_pattern(
                 x.tolist(), y.tolist(), method="snip", iterations=max(iters_list))
             centers_for_sweep = _detect_centers(
                 x, np.asarray(ref_bg["intensity_corrected"], dtype=float), step,
-                prominence_frac, max_peaks, min_distance_deg)
+                prominence_frac, max_peaks, min_distance_deg,
+                min_prominence_sigma=min_prominence_sigma)
         else:
             centers_for_sweep = centers_locked
         trials = []
@@ -346,6 +367,7 @@ def _fit_corrected(
     center_leeway_deg: float,
     max_fwhm_deg: float,
     peak_shape: str = "split_pseudo_voigt",
+    min_prominence_sigma: Optional[float] = None,
 ) -> dict[str, Any]:
     """Global multi-peak fit of an already background-corrected pattern.
 
@@ -371,7 +393,8 @@ def _fit_corrected(
         centers = list(centers_locked)
     else:
         centers = _detect_centers(
-            x, ycorr, step, prominence_frac, max_peaks, min_distance_deg)
+            x, ycorr, step, prominence_frac, max_peaks, min_distance_deg,
+            min_prominence_sigma=min_prominence_sigma)
     if not centers:
         raise ValueError("no peaks detected; lower prominence_frac or pass peak_centers")
 
@@ -473,6 +496,9 @@ def _fit_corrected(
         "n_peaks": len(centers),
         "peaks": peaks,
         "peak_centers": [p["center"] for p in peaks],
+        "noise_prominence_sigma": (float(min_prominence_sigma)
+                                   if min_prominence_sigma is not None
+                                   else noise_prominence_floor(len(ycorr))),
         "intensity_corrected": [float(v) for v in ycorr],
         "fit_curve": [float(v) for v in fit_curve],
         "noise_estimate": noise,

--- a/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
+++ b/scilink/skills/curve_fitting/xrd_profile/fit_pattern.py
@@ -276,17 +276,24 @@ def fit_pattern(
         else:
             centers_for_sweep = centers_locked
         trials = []
+        last_err: Optional[Exception] = None
         for it in iters_list:
             bg = fit_background(x.tolist(), y.tolist(), method="snip", iterations=it)
             ycorr = np.asarray(bg["intensity_corrected"], dtype=float)
             try:
                 res = _fit_corrected(x, ycorr, centers_for_sweep, step, **fit_kw)
-            except (RuntimeError, ValueError):
+            except (RuntimeError, ValueError) as e:
+                last_err = e
                 continue
             res["_iters"] = it
             trials.append(res)
         if not trials:
-            raise RuntimeError("fit_pattern: no SNIP iteration count converged")
+            # Surface the underlying cause: the sweep swallowing it left the
+            # correction loop guessing at "convergence" when the fit was
+            # rejected for a different reason (bounds, no peaks, ...).
+            raise RuntimeError(
+                f"fit_pattern: every SNIP iteration count "
+                f"({iters_list}) failed; last error: {last_err}") from last_err
         # Favour R² first (attempt-1 must clear the acceptance gate, especially
         # in fast/low-iteration mode); only take a cleaner-residual background
         # when its R² is within a hair (0.002) of the best, i.e. essentially
@@ -348,6 +355,16 @@ def _fit_corrected(
     split = peak_shape == "split_pseudo_voigt"
     model = _multi_split if split else _multi
     fwhm_lo = max(2.0 * step, 0.02)
+    if fwhm_lo >= max_fwhm_deg:
+        raise ValueError(
+            f"fit_pattern: the sampling step ({step:.4g}) is too coarse for "
+            f"max_fwhm_deg={max_fwhm_deg}: the narrowest resolvable FWHM is "
+            f"2*step={fwhm_lo:.4g}. Raise max_fwhm_deg.")
+    # The initial FWHM must sit inside [fwhm_lo, max_fwhm_deg]: on coarsely
+    # sampled patterns 2*step exceeds the default init_fwhm_deg and
+    # least_squares rejects the whole fit ("initial guess is outside of
+    # provided bounds") — nothing to do with convergence.
+    fwhm0 = min(max(float(init_fwhm_deg), fwhm_lo), max_fwhm_deg)
     noise = _estimate_noise(ycorr)
 
     if centers_locked is not None:
@@ -366,15 +383,15 @@ def _fit_corrected(
         j = int(np.argmin(np.abs(x - c)))
         amp0 = max(ycorr[j], noise)
         if split:
-            p0 += [amp0, c, init_fwhm_deg, init_fwhm_deg, 0.5]
+            p0 += [amp0, c, fwhm0, fwhm0, 0.5]
             lo += [0.0, c - center_leeway_deg, fwhm_lo, fwhm_lo, 0.0]
             hi += [5.0 * amp0 + 1.0, c + center_leeway_deg, max_fwhm_deg, max_fwhm_deg, 1.0]
-            scale += [amp0, center_leeway_deg, init_fwhm_deg, init_fwhm_deg, 1.0]
+            scale += [amp0, center_leeway_deg, fwhm0, fwhm0, 1.0]
         else:
-            p0 += [amp0, c, init_fwhm_deg, 0.5]
+            p0 += [amp0, c, fwhm0, 0.5]
             lo += [0.0, c - center_leeway_deg, fwhm_lo, 0.0]
             hi += [5.0 * amp0 + 1.0, c + center_leeway_deg, max_fwhm_deg, 1.0]
-            scale += [amp0, center_leeway_deg, init_fwhm_deg, 1.0]
+            scale += [amp0, center_leeway_deg, fwhm0, 1.0]
     p0 += [0.0, 0.0]                       # linear baseline slope, intercept
     lo += [-np.inf, -np.inf]
     hi += [np.inf, np.inf]

--- a/tests/test_bo_all_categorical_recommend.py
+++ b/tests/test_bo_all_categorical_recommend.py
@@ -1,0 +1,58 @@
+"""SingleObjectiveOptimizer.recommend on an ALL-categorical design (mixed
+surrogate, every dim a fixed feature) must return shape (q, d): botorch's
+optimize_acqf_mixed squeezes to (d,) in that case, which broke BOAgent's
+row iteration for q=1 ("'numpy.float64' object is not iterable") — every
+step of an all-categorical campaign in continuous mode fell back to random.
+"""
+import warnings
+
+import numpy as np
+
+warnings.filterwarnings("ignore")
+
+
+def _fit_all_cat(n=5, seed=0):
+    from scilink.agents.planning_agents.bo_tools import get_optimizer
+    rng = np.random.default_rng(seed)
+    X = np.column_stack([rng.integers(0, 4, n), rng.integers(0, 22, n),
+                         rng.integers(0, 3, n), rng.integers(0, 15, n)]).astype(float)
+    y = rng.uniform(0, 100, n)
+    opt = get_optimizer(is_moo=False)
+    opt.fit(X, y, bounds=[(0, 3), (0, 21), (0, 2), (0, 14)],
+            model_config={"kernel": "matern_2.5", "noise": "min_noise_low",
+                          "surrogate": "mixed"},
+            feature_names=["a", "b", "c", "d"], cat_dims=[0, 1, 2, 3])
+    return opt
+
+
+def test_all_categorical_q1_is_2d():
+    opt = _fit_all_cat()
+    r = np.asarray(opt.recommend(n_candidates=1, strategy="log_ei"))
+    assert r.shape == (1, 4), r.shape
+
+
+def test_all_categorical_q3_is_2d():
+    opt = _fit_all_cat(n=8, seed=1)
+    r = np.asarray(opt.recommend(n_candidates=3, strategy="log_ei"))
+    assert r.shape[1] == 4 and r.ndim == 2
+
+
+def test_mixed_with_continuous_dim_unchanged():
+    from scilink.agents.planning_agents.bo_tools import get_optimizer
+    rng = np.random.default_rng(0)
+    X = np.column_stack([rng.integers(0, 3, 12), rng.uniform(0, 1, 12)]).astype(float)
+    y = X[:, 1] + rng.normal(0, 0.05, 12)
+    opt = get_optimizer(is_moo=False)
+    opt.fit(X, y, bounds=[(0, 2), (0, 1)],
+            model_config={"kernel": "matern_2.5", "noise": "min_noise_low",
+                          "surrogate": "mixed"}, feature_names=["a", "b"], cat_dims=[0])
+    assert np.asarray(opt.recommend(n_candidates=1, strategy="log_ei")).shape == (1, 2)
+
+
+def test_all_categorical_never_recommends_a_measured_point():
+    opt = _fit_all_cat(n=6, seed=2)
+    seen = opt.X_train.detach().cpu().numpy()
+    for strategy in ("log_ei", "ucb", "max_variance"):
+        r = np.asarray(opt.recommend(n_candidates=2, strategy=strategy))
+        for row in r:
+            assert not np.any(np.all(np.isclose(seen, row), axis=1)), (strategy, row)

--- a/tests/test_bo_all_categorical_recommend.py
+++ b/tests/test_bo_all_categorical_recommend.py
@@ -56,3 +56,22 @@ def test_all_categorical_never_recommends_a_measured_point():
         r = np.asarray(opt.recommend(n_candidates=2, strategy=strategy))
         for row in r:
             assert not np.any(np.all(np.isclose(seen, row), axis=1)), (strategy, row)
+
+
+def test_all_categorical_many_combos_scored_not_relaxed():
+    # 5 seeds over 5 categorical dims -> up to 5^5 = 3125 combinations; the
+    # continuous relaxation used to raise (no gradient w.r.t. cat dims).
+    from scilink.agents.planning_agents.bo_tools import get_optimizer
+    rng = np.random.default_rng(3)
+    X = np.column_stack([rng.integers(0, 7, 5), rng.integers(0, 4, 5), rng.integers(0, 12, 5),
+                         rng.integers(0, 8, 5), rng.integers(0, 6, 5)]).astype(float)
+    # force distinct levels per dim so combos > 512
+    X[:, 0] = [0, 1, 2, 3, 4]; X[:, 2] = [0, 1, 2, 3, 4]; X[:, 3] = [0, 1, 2, 3, 4]; X[:, 4] = [0, 1, 2, 3, 4]
+    y = rng.uniform(0, 100, 5)
+    opt = get_optimizer(is_moo=False)
+    opt.fit(X, y, bounds=[(0, 6), (0, 3), (0, 11), (0, 7), (0, 5)],
+            model_config={"kernel": "matern_2.5", "noise": "min_noise_low", "surrogate": "mixed"},
+            feature_names=list("abcde"), cat_dims=[0, 1, 2, 3, 4])
+    for strategy in ("log_ei", "max_variance", "ucb"):
+        r = np.asarray(opt.recommend(n_candidates=1, strategy=strategy))
+        assert r.shape == (1, 5), (strategy, r.shape)

--- a/tests/test_bo_seed.py
+++ b/tests/test_bo_seed.py
@@ -1,0 +1,78 @@
+"""run_optimization(seed=...): numeric reproducibility of a BO step.
+
+GP fitting (random restarts) and acquisition optimisation (random raw
+samples) are stochastic; with the same seed applied the way
+BOAgent.run_optimization_loop applies it (torch.manual_seed + np seed
+before the numeric work), two runs on identical data recommend the same
+batch. The tool forwards the seed and echoes it in the response.
+"""
+import contextlib
+import io
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+
+def _one_step(seed):
+    import torch
+    from scilink.agents.planning_agents.bo_tools import get_optimizer
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    rng = np.random.default_rng(0)                    # fixed data
+    X = rng.uniform(0, 1, size=(12, 2))
+    y = -((X[:, 0] - 0.6) ** 2 + (X[:, 1] - 0.3) ** 2) + 0.01 * rng.normal(size=12)
+    opt = get_optimizer(is_moo=False)
+    opt.fit(X, y, bounds=[(0, 1), (0, 1)],
+            model_config={"kernel": "matern_2.5", "noise": "min_noise_low",
+                          "surrogate": "single_task"},
+            feature_names=["a", "b"])
+    return np.asarray(opt.recommend(n_candidates=3, strategy="log_ei"))
+
+
+def test_same_seed_same_batch_numeric():
+    a = _one_step(7)
+    b = _one_step(7)
+    assert np.allclose(a, b), (a, b)
+
+
+def test_tool_forwards_seed_and_reports_it():
+    from scilink.agents.planning_agents.planning_orchestrator import (
+        PlanningOrchestratorAgent, AutonomyLevel,
+    )
+    L6 = dict(T=[30.0, 30.0, 90.0, 90.0, 50.0, 78.0],
+              t=[10.0, 50.0, 10.0, 50.0, 35.0, 18.0],
+              Y=[8.56, 3.88, 22.47, 10.81, 48.83, 61.1])
+    with tempfile.TemporaryDirectory() as tmp:
+        data_dir = Path(tmp) / "data"; data_dir.mkdir()
+        with contextlib.redirect_stdout(io.StringIO()):
+            orch = PlanningOrchestratorAgent(
+                base_dir=str(Path(tmp) / "s"), api_key="sk-dummy",
+                autonomy_level=AutonomyLevel.AUTONOMOUS, data_dir=str(data_dir))
+        orch.scalarizer.scalarize = lambda **kw: {
+            "status": "success", "metrics": dict(L6), "source_script": None,
+            "column_roles": {"inputs": ["T", "t"], "targets": ["Y"]},
+            "passthrough": True, "error": None}
+        captured = {}
+
+        def fake_loop(**kw):
+            captured.update(kw)
+            return {"status": "success", "next_parameters": {"T": 60.0, "t": 25.0},
+                    "strategy": {}, "seed": kw.get("seed")}
+        orch.bo.run_optimization_loop = fake_loop
+        csv = Path(tmp) / "seed.csv"
+        csv.write_text("T,t,Y\n" + "\n".join(
+            f"{a},{b},{c}" for a, b, c in zip(L6["T"], L6["t"], L6["Y"])) + "\n")
+        with contextlib.redirect_stdout(io.StringIO()):
+            orch.tools.execute_tool("analyze_file", file_path=str(csv),
+                                    extraction_goal="x", inputs=["T", "t"], targets=["Y"])
+            out = json.loads(orch.tools.execute_tool("run_optimization", seed=123))
+            out2 = json.loads(orch.tools.execute_tool("run_optimization"))
+        assert captured.get("seed") is None and out2.get("seed") is None
+        assert out.get("seed") == 123

--- a/tests/test_curve_fitting_stdout_parser.py
+++ b/tests/test_curve_fitting_stdout_parser.py
@@ -122,3 +122,26 @@ def test_parser_does_not_override_explicit_db_matches_in_fit_payload():
     )
     out = _parse_script_markers(stdout)
     assert out["db_matches"] == explicit  # setdefault, not overwrite
+
+
+def test_has_fit_parameters_requires_nonempty_top_level_dict():
+    """The marker alone is not the contract: a payload without a non-empty
+    top-level ``parameters`` dict (e.g. a script that invents its own
+    layout) must be treated as a missing output so the correction loop
+    runs — otherwise the series feature table has nothing to optimize."""
+    from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+        _has_fit_parameters,
+    )
+    good = "FIT_RESULTS_JSON:" + json.dumps(
+        {"model_type": "gauss", "parameters": {"peak_1": {"center": 532.0}},
+         "fit_quality": {"r_squared": 0.99}})
+    assert _has_fit_parameters(good)
+    own_layout = "FIT_RESULTS_JSON:" + json.dumps(
+        {"model": "pv", "spectra": [{"peak": {"amplitude": 1.0}}]})
+    assert not _has_fit_parameters(own_layout)
+    assert not _has_fit_parameters(
+        "FIT_RESULTS_JSON:" + json.dumps({"parameters": {}}))
+    assert not _has_fit_parameters(
+        "FIT_RESULTS_JSON:" + json.dumps({"parameters": [1, 2]}))
+    assert not _has_fit_parameters("no marker at all")
+    assert not _has_fit_parameters(None)

--- a/tests/test_feature_table_describe.py
+++ b/tests/test_feature_table_describe.py
@@ -1,0 +1,34 @@
+"""describe_feature_table: schema summary that travels with a feature-table
+path (run_analysis response, run_task result, meta ledger) so callers that
+cannot open server files can pick BO inputs/targets and see the holes."""
+import tempfile
+from pathlib import Path
+
+from scilink.agents.exp_agents.feature_table import describe_feature_table
+
+
+def test_columns_rows_and_missing():
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "features.csv"
+        p.write_text("unit,T,A400,n\nw1,300,0.5,1.1\nw2,400,,1.2\nw3,500,0.7,nan\n")
+        d = describe_feature_table(p)
+        assert d == {"columns": ["unit", "T", "A400", "n"], "n_rows": 3,
+                     "missing": {"A400": 1, "n": 1}}
+
+
+def test_short_rows_count_as_missing_and_no_missing_key_when_clean():
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "f.csv"
+        p.write_text("a,b\n1,2\n3\n")
+        assert describe_feature_table(p)["missing"] == {"b": 1}
+        p.write_text("a,b\n1,2\n")
+        assert describe_feature_table(p) == {"columns": ["a", "b"], "n_rows": 1,
+                                             "missing": {}}
+
+
+def test_never_raises():
+    assert describe_feature_table("/nonexistent/x.csv") is None
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "empty.csv"
+        p.write_text("")
+        assert describe_feature_table(p) is None

--- a/tests/test_fit_pattern_coarse_step.py
+++ b/tests/test_fit_pattern_coarse_step.py
@@ -1,0 +1,49 @@
+"""fit_pattern on a coarsely sampled pattern.
+
+When 2*step exceeds the default init_fwhm_deg, the initial FWHM guess sat
+below its own lower bound and least_squares rejected the fit outright
+("Initial guess is outside of provided bounds") — reported as a convergence
+failure, and in the SNIP 'auto' sweep swallowed into a bare "no SNIP
+iteration count converged". The initial guess is now clamped into the
+bounds, and the sweep error names the underlying cause.
+"""
+import numpy as np
+import pytest
+
+from scilink.skills.curve_fitting.xrd_profile.fit_pattern import fit_pattern
+
+STEP = 0.1431  # > init_fwhm_deg (0.2) / 2 -> fwhm_lo = 0.286 > 0.2
+
+
+def _pattern(n=700, fwhm=1.0):
+    rng = np.random.default_rng(0)
+    x = np.arange(n) * STEP
+    sigma = fwhm / 2.3548
+    y = 2.2 * np.exp(-0.5 * ((x - 31.0) / sigma) ** 2) + 0.04 * rng.normal(size=n)
+    return x, y
+
+
+def test_coarse_step_fits_instead_of_bounds_rejection():
+    x, y = _pattern()
+    r = fit_pattern(x.tolist(), y.tolist(), prominence_frac=0.2)
+    assert r["r_squared"] > 0.95
+    assert len(r["peaks"]) == 1
+    assert abs(r["peaks"][0]["center"] - 31.0) < 0.2
+    # the fitted width is inside the bounds, not pinned to a rejected p0
+    assert r["peaks"][0]["fwhm"] >= 2 * STEP
+
+
+def test_snip_sweep_error_names_underlying_cause():
+    x, y = _pattern()
+    # No detectable peaks -> every trial raises; message must carry the cause.
+    with pytest.raises(RuntimeError, match="last error"):
+        fit_pattern(x.tolist(), (0.01 * np.ones_like(y)).tolist(),
+                    prominence_frac=0.9)
+
+
+def test_step_too_coarse_for_max_fwhm_is_a_clear_error():
+    x, y = _pattern()
+    # Raised inside the SNIP sweep, so it surfaces through the sweep's
+    # RuntimeError — with the cause in the message.
+    with pytest.raises((ValueError, RuntimeError), match="too coarse"):
+        fit_pattern(x.tolist(), y.tolist(), max_fwhm_deg=0.2)

--- a/tests/test_fit_pattern_noise_floor.py
+++ b/tests/test_fit_pattern_noise_floor.py
@@ -1,0 +1,58 @@
+"""fit_pattern peak detection: noise-referenced prominence floor.
+
+A fixed 3-sigma floor admitted hundreds of noise 'peaks' on any pattern
+longer than a few hundred points (30 on a 700-point single-peak pattern,
+>200 on an 8000-point one), which then propped up bad baselines and
+crashed/derailed the global fit. The floor is now sample-size aware
+(~2*sqrt(2 ln N) sigma) and exposed as min_prominence_sigma.
+"""
+import numpy as np
+
+from scilink.skills.curve_fitting.xrd_profile.fit_pattern import (
+    fit_pattern, noise_prominence_floor,
+)
+
+
+def _single_peak(n=700, step=0.1431, seed=5):
+    rng = np.random.default_rng(seed)
+    x = np.arange(n) * step
+    y = 2.2 * np.exp(-0.5 * ((x - 31.0) / 1.6) ** 2) + 0.04 * rng.normal(size=n)
+    return x, y
+
+
+def _five_peaks(n=8000, amp=10.0, seed=0):
+    x = np.linspace(10, 80, n)
+    y = np.zeros(n)
+    for c in (22.0, 28.0, 35.0, 48.0, 61.0):
+        y += amp * 0.15 ** 2 / ((x - c) ** 2 + 0.15 ** 2)
+    return x, y + np.random.default_rng(seed).normal(0, 1.0, n)
+
+
+def test_floor_is_sample_size_aware_and_bounded_below():
+    assert noise_prominence_floor(10) == 5.0
+    assert 7.0 < noise_prominence_floor(700) < 7.5
+    assert 8.0 < noise_prominence_floor(8000) < 9.0
+    assert noise_prominence_floor(8000) > noise_prominence_floor(700)
+
+
+def test_single_broad_peak_no_spurious_peaks():
+    x, y = _single_peak()
+    r = fit_pattern(x.tolist(), y.tolist(), max_fwhm_deg=8.0)
+    assert r["n_peaks"] == 1 and abs(r["peak_centers"][0] - 31.0) < 0.3
+    assert r["r_squared"] > 0.95
+    assert r["noise_prominence_sigma"] == noise_prominence_floor(700)
+
+
+def test_weak_real_reflections_still_found_and_nothing_else():
+    x, y = _five_peaks(amp=10.0)      # 10-sigma peaks
+    r = fit_pattern(x.tolist(), y.tolist())
+    assert r["n_peaks"] == 5
+    assert all(min(abs(c - t) for t in (22, 28, 35, 48, 61)) < 0.3
+               for c in r["peak_centers"])
+
+
+def test_knob_lowers_floor_and_is_reported():
+    x, y = _single_peak()
+    r = fit_pattern(x.tolist(), y.tolist(), max_fwhm_deg=8.0, min_prominence_sigma=3.0)
+    assert r["noise_prominence_sigma"] == 3.0
+    assert r["n_peaks"] > 5          # the old behaviour: noise peaks admitted

--- a/tests/test_fit_pattern_noise_floor.py
+++ b/tests/test_fit_pattern_noise_floor.py
@@ -43,12 +43,25 @@ def test_single_broad_peak_no_spurious_peaks():
     assert r["noise_prominence_sigma"] == noise_prominence_floor(700)
 
 
-def test_weak_real_reflections_still_found_and_nothing_else():
-    x, y = _five_peaks(amp=10.0)      # 10-sigma peaks
+def test_weak_real_reflections_all_found_with_at_most_one_extra():
+    # 10-sigma reflections; matched-filter detection must find all five and
+    # admit at most one noise excursion (was 30 = max_peaks with the 3-sigma floor).
+    x, y = _five_peaks(amp=10.0)
     r = fit_pattern(x.tolist(), y.tolist())
-    assert r["n_peaks"] == 5
-    assert all(min(abs(c - t) for t in (22, 28, 35, 48, 61)) < 0.3
-               for c in r["peak_centers"])
+    truth = (22, 28, 35, 48, 61)
+    found = [t for t in truth if any(abs(c - t) < 0.3 for c in r["peak_centers"])]
+    assert len(found) == 5
+    assert r["n_peaks"] <= 6
+
+
+def test_six_sigma_reflections_recovered_by_matched_filter():
+    # Too weak for a raw-trace floor; the width-matched smoothing recovers them.
+    x, y = _five_peaks(amp=6.0)
+    r = fit_pattern(x.tolist(), y.tolist())
+    truth = (22, 28, 35, 48, 61)
+    found = [t for t in truth if any(abs(c - t) < 0.3 for c in r["peak_centers"])]
+    assert len(found) >= 4
+    assert r["n_peaks"] <= 8
 
 
 def test_knob_lowers_floor_and_is_reported():

--- a/tests/test_ingest_missing_values.py
+++ b/tests/test_ingest_missing_values.py
@@ -1,0 +1,108 @@
+"""analyze_file must not admit rows whose input/target is missing.
+
+Seen live: a 96-well feature table where 4 adaptively re-fitted units
+reported the target under a different column name -> 4 NaN targets were
+ingested and run_optimization failed with 'Missing values detected' one
+call later, with no way to tell which rows. Now the rows are skipped at
+ingest with a count + warning in the response, and BO runs on the rest.
+"""
+import contextlib
+import io
+import json
+import math
+import os
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+from scilink.agents.planning_agents.planning_orchestrator import (
+    PlanningOrchestratorAgent, AutonomyLevel,
+)
+
+PASS, FAIL = [], []
+
+
+def check(name, cond, detail=""):
+    (PASS if cond else FAIL).append(name)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name} {detail}")
+
+
+NAN = float("nan")
+L6 = dict(T=[30.0, 30.0, 90.0, 90.0, 50.0, 78.0],
+          t=[10.0, 50.0, 10.0, 50.0, 35.0, 18.0],
+          Y=[8.56, NAN, 22.47, 10.81, 48.83, NAN])   # two units w/o target
+
+
+def make_orch(tmp, metrics):
+    data_dir = Path(tmp) / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        orch = PlanningOrchestratorAgent(
+            base_dir=str(Path(tmp) / "session"), api_key="sk-dummy",
+            autonomy_level=AutonomyLevel.AUTONOMOUS, data_dir=str(data_dir))
+    orch.scalarizer.scalarize = lambda **kw: {
+        "status": "success", "metrics": dict(metrics), "source_script": None,
+        "column_roles": {"inputs": ["T", "t"], "targets": ["Y"]},
+        "passthrough": True, "error": None}
+    captured = {}
+
+    def fake_loop(**kw):
+        captured.update(kw)
+        return {"status": "success", "next_parameters": {"T": 60.0, "t": 25.0},
+                "strategy": {}}
+    orch.bo.run_optimization_loop = fake_loop
+    return orch, captured
+
+
+def ingest(orch, tmp):
+    csv = Path(tmp) / "seed.csv"
+    csv.write_text("T,t,Y\n" + "\n".join(
+        f"{a},{b},{'' if math.isnan(c) else c}"
+        for a, b, c in zip(L6['T'], L6['t'], L6['Y'])) + "\n")
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        return json.loads(orch.tools.execute_tool(
+            "analyze_file", file_path=str(csv), extraction_goal="fixture",
+            inputs=["T", "t"], targets=["Y"])), buf.getvalue()
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    orch, captured = make_orch(tmp, L6)
+    out, log = ingest(orch, tmp)
+    check("partial_rows_skipped",
+          out["status"] == "success" and out["rows_added"] == 4
+          and out.get("rows_skipped_missing") == 2
+          and "Y" in out.get("warning", ""), str(out))
+    import pandas as pd
+    df = pd.read_csv(Path(tmp) / "session" / "optimization_data.csv")
+    check("dataset_has_no_nans", len(df) == 4 and not df.isna().any().any())
+    with contextlib.redirect_stdout(io.StringIO()):
+        bo = json.loads(orch.tools.execute_tool("run_optimization"))
+    check("bo_runs_on_remaining_rows", bo.get("status") == "success", str(bo)[:100])
+
+with tempfile.TemporaryDirectory() as tmp:
+    all_nan = dict(L6, Y=[NAN] * 6)
+    orch, _ = make_orch(tmp, all_nan)
+    out, _ = ingest(orch, tmp)
+    check("all_rows_missing_is_clean_error",
+          out["status"] == "error" and "missing values" in out["message"],
+          str(out)[:120])
+    check("nothing_written",
+          not (Path(tmp) / "session" / "optimization_data.csv").exists())
+
+with tempfile.TemporaryDirectory() as tmp:
+    clean = dict(L6, Y=[8.56, 3.88, 22.47, 10.81, 48.83, 61.1])
+    orch, _ = make_orch(tmp, clean)
+    out, _ = ingest(orch, tmp)
+    check("clean_table_unchanged",
+          out["rows_added"] == 6 and "rows_skipped_missing" not in out
+          and "warning" not in out)
+
+print("=" * 50)
+print(f"INGEST MISSING VALUES: {len(PASS)}/{len(PASS) + len(FAIL)} passed")
+if FAIL:
+    print("FAILED:", FAIL)
+    raise SystemExit(1)

--- a/tests/test_input_bounds_plumbing.py
+++ b/tests/test_input_bounds_plumbing.py
@@ -85,6 +85,10 @@ with tempfile.TemporaryDirectory() as tmp:
     check("data_source_reported",
           out.get("input_bounds_source") == {"T": "data", "t": "data"}
           and out.get("input_bounds") == {"T": [24.0, 96.0], "t": [6.0, 54.0]})
+    check("data_derived_box_warned",
+          any("derived from the observed data" in w
+              for w in out.get("input_bounds_warnings", []))
+          and "['T', 't']" in " ".join(out.get("input_bounds_warnings", [])))
 
     out = run(orch, input_bounds={"t": [10, 50]})
     check("caller_bounds_win_for_given_column",
@@ -92,6 +96,9 @@ with tempfile.TemporaryDirectory() as tmp:
           str(captured.get("input_bounds")))
     check("caller_source_reported",
           out.get("input_bounds_source") == {"T": "data", "t": "caller"})
+    check("warning_names_only_data_bounded_columns",
+          any("['T']" in w for w in out.get("input_bounds_warnings", []))
+          and not any("'t'" in w for w in out.get("input_bounds_warnings", [])))
 
     out = run(orch)
     check("sticky_across_calls",
@@ -104,7 +111,7 @@ with tempfile.TemporaryDirectory() as tmp:
     out = run(orch, input_bounds={"t": [50, 10], "nope": [0, 1], "T": "bad"})
     check("malformed_and_unknown_ignored_with_warning",
           captured.get("input_bounds") == [[40.0, 80.0], [10.0, 50.0]]
-          and len(out.get("input_bounds_warnings", [])) == 3,
+          and len(out.get("input_bounds_warnings", [])) == 3,   # no data-box note: all caller
           str(out.get("input_bounds_warnings")))
 
     # Checkpoint round-trip.

--- a/tests/test_input_bounds_plumbing.py
+++ b/tests/test_input_bounds_plumbing.py
@@ -1,0 +1,126 @@
+"""Offline proof for the `input_bounds` argument on run_optimization.
+
+No LLM, no torch: scalarizer stubbed to a 6-row pass-through, BOAgent's
+run_optimization_loop stubbed to capture its kwargs. Verifies:
+  1. no-arg call keeps the data-derived box (observed range +/-10%) and
+     reports it, with source "data" per column;
+  2. caller bounds win over the data-derived box for the columns given,
+     other columns keep theirs, and the response reports source "caller";
+  3. sticky: a later no-arg call still uses the caller bounds;
+  4. malformed / unknown-column entries are ignored with a warning and
+     never reach the BO layer;
+  5. the override survives a checkpoint save/restore.
+"""
+import contextlib
+import io
+import json
+import os
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+from scilink.agents.planning_agents.planning_orchestrator import (
+    PlanningOrchestratorAgent, AutonomyLevel,
+)
+
+PASS, FAIL = [], []
+
+
+def check(name, cond, detail=""):
+    (PASS if cond else FAIL).append(name)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name} {detail}")
+
+
+L6 = dict(T=[30.0, 30.0, 90.0, 90.0, 50.0, 78.0],
+          t=[10.0, 50.0, 10.0, 50.0, 35.0, 18.0],
+          Y=[8.56, 3.88, 22.47, 10.81, 48.83, 61.1])
+CSV_6ROW = "T,t,Y\n" + "\n".join(
+    f"{a},{b},{c}" for a, b, c in zip(L6["T"], L6["t"], L6["Y"])) + "\n"
+
+
+def make_orch(tmp):
+    data_dir = Path(tmp) / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        orch = PlanningOrchestratorAgent(
+            base_dir=str(Path(tmp) / "session"), api_key="sk-dummy",
+            autonomy_level=AutonomyLevel.AUTONOMOUS, data_dir=str(data_dir))
+    orch.scalarizer.scalarize = lambda **kw: {
+        "status": "success", "metrics": dict(L6), "source_script": None,
+        "column_roles": {"inputs": ["T", "t"], "targets": ["Y"]},
+        "passthrough": True, "error": None}
+    csv = Path(tmp) / "seed.csv"
+    csv.write_text(CSV_6ROW)
+    with contextlib.redirect_stdout(buf):
+        orch.tools.execute_tool("analyze_file", file_path=str(csv),
+                                extraction_goal="fixture",
+                                inputs=["T", "t"], targets=["Y"])
+    captured = {}
+
+    def fake_loop(**kw):
+        captured.clear()
+        captured.update(kw)
+        return {"status": "success", "next_parameters": {"T": 60.0, "t": 25.0},
+                "strategy": {}}
+    orch.bo.run_optimization_loop = fake_loop
+    return orch, captured
+
+
+def run(orch, **kw):
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        return json.loads(orch.tools.execute_tool("run_optimization", **kw))
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    orch, captured = make_orch(tmp)
+    out = run(orch)
+    # data range T 30-90 -> +/-6 ; t 10-50 -> +/-4
+    check("data_bounds_default",
+          captured.get("input_bounds") == [[24.0, 96.0], [6.0, 54.0]],
+          str(captured.get("input_bounds")))
+    check("data_source_reported",
+          out.get("input_bounds_source") == {"T": "data", "t": "data"}
+          and out.get("input_bounds") == {"T": [24.0, 96.0], "t": [6.0, 54.0]})
+
+    out = run(orch, input_bounds={"t": [10, 50]})
+    check("caller_bounds_win_for_given_column",
+          captured.get("input_bounds") == [[24.0, 96.0], [10.0, 50.0]],
+          str(captured.get("input_bounds")))
+    check("caller_source_reported",
+          out.get("input_bounds_source") == {"T": "data", "t": "caller"})
+
+    out = run(orch)
+    check("sticky_across_calls",
+          captured.get("input_bounds") == [[24.0, 96.0], [10.0, 50.0]])
+
+    out = run(orch, input_bounds={"T": [40, 80]})
+    check("later_call_adds_without_dropping",
+          captured.get("input_bounds") == [[40.0, 80.0], [10.0, 50.0]])
+
+    out = run(orch, input_bounds={"t": [50, 10], "nope": [0, 1], "T": "bad"})
+    check("malformed_and_unknown_ignored_with_warning",
+          captured.get("input_bounds") == [[40.0, 80.0], [10.0, 50.0]]
+          and len(out.get("input_bounds_warnings", [])) == 3,
+          str(out.get("input_bounds_warnings")))
+
+    # Checkpoint round-trip.
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        orch._auto_checkpoint()
+        restored = PlanningOrchestratorAgent(
+            base_dir=str(Path(tmp) / "session"), api_key="sk-dummy",
+            autonomy_level=AutonomyLevel.AUTONOMOUS,
+            data_dir=str(Path(tmp) / "data"), restore_checkpoint=True)
+    check("override_survives_checkpoint",
+          restored.input_bounds_override == {"T": (40.0, 80.0), "t": (10.0, 50.0)},
+          str(restored.input_bounds_override))
+
+print("=" * 50)
+print(f"INPUT_BOUNDS PLUMBING: {len(PASS)}/{len(PASS) + len(FAIL)} passed")
+if FAIL:
+    print("FAILED:", FAIL)
+    raise SystemExit(1)

--- a/tests/test_input_types_plumbing.py
+++ b/tests/test_input_types_plumbing.py
@@ -1,0 +1,116 @@
+"""Explicit input types through the planning tools + candidate-pool encoding.
+
+A pass-through feature table never runs the scalarizer's input-type
+classification, so a numeric-coded categorical input was modelled as a
+continuous knob and there was no way to say otherwise. analyze_file /
+run_optimization take input_types={col: categorical|continuous} (sticky,
+checkpointed); categorical inputs are level-encoded for the surrogate,
+the candidate pool is encoded through the SAME maps, and recommendations
+are decoded back.
+"""
+import contextlib
+import io
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+from scilink.agents.planning_agents.planning_orchestrator import (
+    PlanningOrchestratorAgent, AutonomyLevel,
+)
+
+PASS, FAIL = [], []
+
+
+def check(name, cond, detail=""):
+    (PASS if cond else FAIL).append(name)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name} {detail}")
+
+
+# 'L' is a categorical stored as numeric codes 0/1/2/10 (string sort != numeric sort on purpose)
+ROWS = dict(L=[0.0, 1.0, 2.0, 10.0, 1.0, 2.0], t=[10.0, 50.0, 10.0, 50.0, 35.0, 18.0],
+            Y=[8.56, 3.88, 22.47, 10.81, 48.83, 61.1])
+
+
+def make(tmp):
+    d = Path(tmp) / "data"; d.mkdir(exist_ok=True)
+    with contextlib.redirect_stdout(io.StringIO()):
+        o = PlanningOrchestratorAgent(base_dir=str(Path(tmp) / "s"), api_key="sk-dummy",
+                                      autonomy_level=AutonomyLevel.AUTONOMOUS, data_dir=str(d))
+    o.scalarizer.scalarize = lambda **kw: {
+        "status": "success", "metrics": dict(ROWS), "source_script": None,
+        "column_roles": {"inputs": ["L", "t"], "targets": ["Y"]}, "passthrough": True, "error": None}
+    cap = {}
+    def loop(**kw):
+        cap.clear(); cap.update(kw)
+        return {"status": "success", "next_parameters": {"L": 3.0, "t": 25.0}, "strategy": {}}  # encoded index 3
+    o.bo.run_optimization_loop = loop
+    csv = Path(tmp) / "seed.csv"
+    csv.write_text("L,t,Y\n" + "\n".join(f"{a},{b},{c}" for a, b, c in zip(ROWS["L"], ROWS["t"], ROWS["Y"])) + "\n")
+    pool = Path(tmp) / "pool.csv"
+    pool.write_text("L,t\n0.0,12\n1.0,20\n2.0,30\n10.0,40\n")
+    return o, cap, csv, pool
+
+
+def call(o, tool, **kw):
+    with contextlib.redirect_stdout(io.StringIO()):
+        return json.loads(o.tools.execute_tool(tool, **kw))
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    o, cap, csv, pool = make(tmp)
+    a = call(o, "analyze_file", file_path=str(csv), extraction_goal="x", inputs=["L", "t"], targets=["Y"])
+    r = call(o, "run_optimization", candidate_pool=str(pool))
+    check("default_is_continuous", cap.get("cat_dims") is None and r["input_types"] == {"L": "continuous", "t": "continuous"}
+          and cap.get("candidate_pool") == str(pool), str(r.get("input_types")))
+
+    r = call(o, "run_optimization", candidate_pool=str(pool), input_types={"L": "categorical"})
+    check("categorical_declared_gives_cat_dims", cap.get("cat_dims") == [0] and r["input_types"]["L"] == "categorical")
+    enc_pool = cap.get("candidate_pool")
+    pdf = pd.read_csv(enc_pool)
+    levels = sorted(["0.0", "1.0", "2.0", "10.0"])          # string order: 0.0, 1.0, 10.0, 2.0
+    check("pool_encoded_through_same_level_map",
+          enc_pool != str(pool) and pdf["L"].tolist() == [levels.index("0.0"), levels.index("1.0"),
+                                                            levels.index("2.0"), levels.index("10.0")],
+          f"{pdf['L'].tolist()} levels={levels}")
+    # the encoded data must use the same indices
+    ddf = pd.read_csv(cap["data_path"])
+    check("data_encoded_with_same_map", ddf["L"].tolist()[:4] == [levels.index(v) for v in ("0.0", "1.0", "2.0", "10.0")])
+    # recommendation decoded back to the original label (index 3 -> '2.0' in string order)
+    rec = r["recommended_parameters"]
+    check("recommendation_decoded_to_label", str(rec["L"]) == levels[3], str(rec))
+
+    r = call(o, "run_optimization", candidate_pool=str(pool))
+    check("sticky_on_next_call", cap.get("cat_dims") == [0])
+
+    bad = Path(tmp) / "badpool.csv"; bad.write_text("L,t\n0.0,12\n7.0,20\n")
+    r = call(o, "run_optimization", candidate_pool=str(bad))
+    check("unknown_pool_level_is_clean_error", r.get("status") == "error" and "not seen" in r.get("message", ""), str(r)[:140])
+
+    r = call(o, "run_optimization", candidate_pool=str(pool), input_types={"t": "sideways", "zz": "categorical"})
+    check("bad_entries_warned", len([w for w in r.get("warnings", []) if "input_types" in w]) == 2, str(r.get("warnings")))
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        o._auto_checkpoint()
+        o2 = PlanningOrchestratorAgent(base_dir=str(Path(tmp) / "s"), api_key="sk-dummy",
+                                       autonomy_level=AutonomyLevel.AUTONOMOUS,
+                                       data_dir=str(Path(tmp) / "data"), restore_checkpoint=True)
+    check("types_survive_checkpoint", (o2.expected_input_types or {}).get("L") == "categorical")
+
+with tempfile.TemporaryDirectory() as tmp:
+    o, cap, csv, pool = make(tmp)
+    a = call(o, "analyze_file", file_path=str(csv), extraction_goal="x", inputs=["L", "t"], targets=["Y"],
+             input_types={"L": "categorical"})
+    r = call(o, "run_optimization")
+    check("ingest_types_reach_bo", a["input_types"] == {"L": "categorical"} and cap.get("cat_dims") == [0])
+
+print("=" * 50)
+print(f"INPUT TYPES: {len(PASS)}/{len(PASS) + len(FAIL)} passed")
+if FAIL:
+    print("FAILED:", FAIL)
+    raise SystemExit(1)

--- a/tests/test_input_types_plumbing.py
+++ b/tests/test_input_types_plumbing.py
@@ -73,24 +73,28 @@ with tempfile.TemporaryDirectory() as tmp:
     check("categorical_declared_gives_cat_dims", cap.get("cat_dims") == [0] and r["input_types"]["L"] == "categorical")
     enc_pool = cap.get("candidate_pool")
     pdf = pd.read_csv(enc_pool)
-    levels = sorted(["0.0", "1.0", "2.0", "10.0"])          # string order: 0.0, 1.0, 10.0, 2.0
+    levels = sorted(["0", "1", "2", "10"])          # normalised labels, string order: 0, 1, 10, 2
     check("pool_encoded_through_same_level_map",
-          enc_pool != str(pool) and pdf["L"].tolist() == [levels.index("0.0"), levels.index("1.0"),
-                                                            levels.index("2.0"), levels.index("10.0")],
+          enc_pool != str(pool) and pdf["L"].tolist() == [levels.index("0"), levels.index("1"),
+                                                            levels.index("2"), levels.index("10")],
           f"{pdf['L'].tolist()} levels={levels}")
     # the encoded data must use the same indices
     ddf = pd.read_csv(cap["data_path"])
-    check("data_encoded_with_same_map", ddf["L"].tolist()[:4] == [levels.index(v) for v in ("0.0", "1.0", "2.0", "10.0")])
-    # recommendation decoded back to the original label (index 3 -> '2.0' in string order)
+    check("data_encoded_with_same_map", ddf["L"].tolist()[:4] == [levels.index(v) for v in ("0", "1", "2", "10")])
+    # recommendation decoded back to the original label (index 3 -> '2' in string order)
     rec = r["recommended_parameters"]
     check("recommendation_decoded_to_label", str(rec["L"]) == levels[3], str(rec))
 
     r = call(o, "run_optimization", candidate_pool=str(pool))
     check("sticky_on_next_call", cap.get("cat_dims") == [0])
 
-    bad = Path(tmp) / "badpool.csv"; bad.write_text("L,t\n0.0,12\n7.0,20\n")
-    r = call(o, "run_optimization", candidate_pool=str(bad))
-    check("unknown_pool_level_is_clean_error", r.get("status") == "error" and "not seen" in r.get("message", ""), str(r)[:140])
+    # a pool level the data has not measured yet is legitimate: it joins the universe
+    wide = Path(tmp) / "widepool.csv"; wide.write_text("L,t\n0,12\n7,20\n")
+    r = call(o, "run_optimization", candidate_pool=str(wide))
+    wdf = pd.read_csv(cap["candidate_pool"])
+    check("unmeasured_pool_level_joins_universe",
+          r.get("status") == "success" and sorted(wdf["L"].tolist()) == [0.0, 4.0],   # '7' sorts last of 0,1,10,2,7
+          f"{r.get('status')} {wdf['L'].tolist()}")
 
     r = call(o, "run_optimization", candidate_pool=str(pool), input_types={"t": "sideways", "zz": "categorical"})
     check("bad_entries_warned", len([w for w in r.get("warnings", []) if "input_types" in w]) == 2, str(r.get("warnings")))

--- a/tests/test_mcp_headless_backend.py
+++ b/tests/test_mcp_headless_backend.py
@@ -1,0 +1,43 @@
+"""The MCP server enforces a headless matplotlib backend itself (was
+integration rule 2 of every client: MCP tools run off the main thread, and
+macOS's GUI backend kills the call). Runs in subprocesses so each case sees
+a clean matplotlib import."""
+import os
+import subprocess
+import sys
+
+PY = sys.executable
+
+CASE = """
+import os, sys
+{setup}
+from scilink.mcp_server import create_server
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+create_server(api_key="sk-dummy", mode="plan", session_dir=None)
+import matplotlib
+print(matplotlib.get_backend(), os.environ.get("MPLBACKEND"))
+"""
+
+
+def _run(setup):
+    env = {k: v for k, v in os.environ.items() if k != "MPLBACKEND"}
+    env.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+    r = subprocess.run([PY, "-c", CASE.format(setup=setup)], capture_output=True,
+                       text=True, env=env, timeout=180)
+    assert r.returncode == 0, r.stderr[-800:]
+    return r.stdout.strip().splitlines()[-1]
+
+
+def test_unset_defaults_to_agg():
+    backend, env = _run("").split()
+    assert backend.lower() == "agg" and env == "Agg"
+
+
+def test_gui_backend_forced_to_agg():
+    out = _run("import matplotlib; matplotlib.use('MacOSX' if sys.platform=='darwin' else 'TkAgg')")
+    assert out.split()[0].lower() == "agg"
+
+
+def test_explicit_headless_choice_respected():
+    out = _run("os.environ['MPLBACKEND'] = 'svg'")
+    assert out.split()[0].lower() == "svg"

--- a/tests/test_mcp_restart_durability.py
+++ b/tests/test_mcp_restart_durability.py
@@ -1,0 +1,99 @@
+"""MCP server restart durability.
+
+A server restarted on the same --session-dir must resume the campaign:
+granular tool calls checkpoint the owning orchestrator, and construction
+restores the checkpoint when one exists. In --mode both the analysis and
+planning orchestrators get their own nested base dirs (they shared one
+checkpoint.json before). No LLM: the scalarizer is stubbed.
+"""
+import contextlib
+import io
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp")
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+from scilink.mcp_server import _init_orchestrators, _execute_tool_captured  # noqa: E402
+
+L6 = dict(T=[30.0, 30.0, 90.0, 90.0, 50.0, 78.0],
+          t=[10.0, 50.0, 10.0, 50.0, 35.0, 18.0],
+          Y=[8.56, 3.88, 22.47, 10.81, 48.83, 61.1])
+CSV = "T,t,Y\n" + "\n".join(f"{a},{b},{c}" for a, b, c in
+                            zip(L6["T"], L6["t"], L6["Y"])) + "\n"
+
+
+def _config(session_dir, mode):
+    return {"api_key": "sk-dummy", "model_name": None, "base_url": None,
+            "mode": mode, "session_dir": session_dir,
+            "analysis_mode": "autonomous", "futurehouse_api_key": None,
+            "hitl_timeout_s": 5.0}
+
+
+def _boot(session_dir, mode="plan"):
+    state = {"analysis_orch": None, "planning_orch": None, "meta_orch": None,
+             "pending": {}, "jobs": {}, "job_counter": 0,
+             "config": _config(session_dir, mode)}
+    with contextlib.redirect_stdout(io.StringIO()):
+        _init_orchestrators(state, state["config"])
+    orch = state["planning_orch"]
+    orch.scalarizer.scalarize = lambda **kw: {
+        "status": "success", "metrics": dict(L6), "source_script": None,
+        "column_roles": {"inputs": ["T", "t"], "targets": ["Y"]},
+        "passthrough": True, "error": None}
+    orch.bo.run_optimization_loop = lambda **kw: {
+        "status": "success", "next_parameters": {"T": 60.0, "t": 25.0}, "strategy": {}}
+    return state
+
+
+def test_granular_calls_checkpoint_and_restart_resumes():
+    with tempfile.TemporaryDirectory() as tmp:
+        session = str(Path(tmp) / "s")
+        csv = Path(tmp) / "seed.csv"
+        csv.write_text(CSV)
+        st1 = _boot(session)
+        out = json.loads(_execute_tool_captured(
+            st1["planning_orch"].tools, "analyze_file",
+            {"file_path": str(csv), "extraction_goal": "x",
+             "inputs": ["T", "t"], "targets": ["Y"]}, state=st1))
+        assert out["status"] == "success" and out["rows_added"] == 6
+        # the granular call left a checkpoint behind
+        assert (Path(session) / "checkpoint.json").exists()
+
+        # "restart": a fresh server on the same dir
+        st2 = _boot(session)
+        p2 = st2["planning_orch"]
+        assert p2.expected_input_columns == ["T", "t"]
+        assert p2.expected_target_columns == ["Y"]
+        assert not list(Path(session).glob("stale_campaign_*"))
+        bo = json.loads(_execute_tool_captured(
+            p2.tools, "run_optimization", {"parallel_capable": False}, state=st2))
+        assert bo["status"] == "success", bo
+        # and the dedup ledger still knows the file (no re-ingest by accident)
+        again = json.loads(_execute_tool_captured(
+            p2.tools, "analyze_file",
+            {"file_path": str(csv), "extraction_goal": "x",
+             "inputs": ["T", "t"], "targets": ["Y"]}, state=st2))
+        assert again.get("rows_added") == 0
+
+
+def test_mode_both_nests_orchestrators():
+    with tempfile.TemporaryDirectory() as tmp:
+        session = str(Path(tmp) / "s")
+        st = _boot(session, mode="both")
+        a, p = st["analysis_orch"], st["planning_orch"]
+        assert Path(a.base_dir).resolve() == (Path(session) / "analysis").resolve()
+        assert Path(p.base_dir).resolve() == (Path(session) / "planning").resolve()
+        assert a.checkpoint_path != p.checkpoint_path
+
+
+def test_single_mode_layout_unchanged():
+    with tempfile.TemporaryDirectory() as tmp:
+        session = str(Path(tmp) / "s")
+        st = _boot(session, mode="plan")
+        assert Path(st["planning_orch"].base_dir).resolve() == Path(session).resolve()

--- a/tests/test_mcp_restart_durability.py
+++ b/tests/test_mcp_restart_durability.py
@@ -97,3 +97,101 @@ def test_single_mode_layout_unchanged():
         session = str(Path(tmp) / "s")
         st = _boot(session, mode="plan")
         assert Path(st["planning_orch"].base_dir).resolve() == Path(session).resolve()
+
+
+# ── Issue #469: jobs + pending questions survive a restart ────────────────
+
+import threading
+import time
+
+from scilink.mcp_server import (  # noqa: E402
+    _MCPChannel, _handle_job_status, _handle_job_result, _handle_respond,
+    _register_job, _restore_jobs, _persist_jobs, _new_job_lines,
+    _JOBS_STORE_NAME,
+)
+
+
+def _mkstate(session_dir):
+    return {"analysis_orch": None, "planning_orch": None, "meta_orch": None,
+            "pending": {}, "jobs": {}, "job_counter": 0,
+            "interrupted_questions": {}, "_persist_lock": threading.Lock(),
+            "config": _config(session_dir, "plan")}
+
+
+def _call(handler, state, args):
+    import asyncio as _a
+    r = handler(state, args)
+    if _a.iscoroutine(r):
+        r = _a.run(r)
+    return json.loads(r[0].text)
+
+
+def test_finished_job_survives_restart():
+    import concurrent.futures
+    with tempfile.TemporaryDirectory() as tmp:
+        st = _mkstate(tmp)
+        with concurrent.futures.ThreadPoolExecutor(1) as ex:
+            fut = ex.submit(lambda: json.dumps({"status": "success", "answer": 42}))
+            lines = _new_job_lines(); lines.extend(["did a thing", "done"])
+            _register_job(st, "job_x_001", {"future": fut, "tool": "orchestrate_analysis",
+                                            "started_at": "x", "status": "running",
+                                            "result": None, "log_lines": lines})
+            fut.result(); time.sleep(0.3)   # done-callback persists the completion
+        assert (Path(tmp) / _JOBS_STORE_NAME).exists()
+        st2 = _mkstate(tmp)
+        _restore_jobs(st2)
+        assert st2["jobs"]["job_x_001"]["status"] == "completed"
+        out = _call(_handle_job_status, st2, {"job_id": "job_x_001"})
+        assert out["status"] == "completed" and "did a thing" in out.get("log_tail", "")
+        res = _call(_handle_job_result, st2, {"job_id": "job_x_001"})
+        assert res == {"status": "success", "answer": 42}
+        assert st2["job_counter"] >= st["job_counter"]
+
+
+def test_running_job_becomes_interrupted_with_hint():
+    with tempfile.TemporaryDirectory() as tmp:
+        st = _mkstate(tmp)
+        lines = _new_job_lines(); lines.append("step 3/15 ...")
+        st["jobs"]["job_y_001"] = {"future": None, "tool": "orchestrate_meta",
+                                   "started_at": "y", "status": "running",
+                                   "result": None, "log_lines": lines}
+        _persist_jobs(st)
+        st2 = _mkstate(tmp)
+        _restore_jobs(st2)
+        out = _call(_handle_job_status, st2, {"job_id": "job_y_001"})
+        assert out["status"] == "interrupted" and "re-issue" in out["message"].lower()
+        res = _call(_handle_job_result, st2, {"job_id": "job_y_001"})
+        assert res["status"] == "interrupted" and "step 3/15" in res["log_tail"]
+
+
+def test_parked_question_persisted_and_respond_after_restart_explains():
+    class _Req:
+        id, kind, prompt, options, origin, default = ("q_1", "review_plan",
+                                                      "OK?", [], {}, "")
+    with tempfile.TemporaryDirectory() as tmp:
+        st = _mkstate(tmp)
+        st["jobs"]["job_z_001"] = {"future": None, "tool": "orchestrate_analysis",
+                                   "started_at": "z", "status": "running",
+                                   "result": None, "log_lines": _new_job_lines()}
+        ch = _MCPChannel(st, job_id="job_z_001", timeout_s=0.4)
+        t = threading.Thread(target=ch.ask, args=(_Req(),)); t.start()
+        time.sleep(0.15)
+        onwire = json.loads((Path(tmp) / _JOBS_STORE_NAME).read_text())
+        assert onwire["pending_questions"] and onwire["pending_questions"][0]["request_id"] == "q_1"
+        # 'restart' while the question is parked
+        st2 = _mkstate(tmp)
+        _restore_jobs(st2)
+        t.join()
+        ans = _call(_handle_respond, st2, {"request_id": "q_1", "response": ""})
+        assert ans["status"] == "interrupted" and "restart" in ans["message"].lower()
+        # and an unknown id still errors as before
+        ans = _call(_handle_respond, st2, {"request_id": "nope", "response": ""})
+        assert ans["status"] == "error"
+
+
+def test_live_state_unaffected_and_no_store_without_writes():
+    with tempfile.TemporaryDirectory() as tmp:
+        st = _mkstate(tmp)
+        _restore_jobs(st)                     # no file: no-op
+        out = _call(_handle_job_status, st, {"job_id": "missing"})
+        assert out["status"] == "error" and "Unknown job_id" in out["message"]

--- a/tests/test_refit_locked_schema.py
+++ b/tests/test_refit_locked_schema.py
@@ -1,0 +1,123 @@
+"""AdaptiveRefit: a refit that adopts a different model must still report the
+locked run's parameter names for that unit (series trends and the feature
+table align units by name). Deterministic gap check + one completion pass
+that only ADDS reporting, accepted only if no existing key is lost and R²
+does not degrade; the residual gap is recorded on the result.
+"""
+import json
+import logging
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+    AdaptiveRefitController,
+)
+
+LOCKED = {"peak_1": {"center": 532.0, "amplitude": 0.7, "fwhm": 13.0},
+          "baseline": {"c0": 0.05}, "extinction_at_400nm": 0.9}
+REFIT = {"powerlaw": {"A": 1.2, "n": 1.1}, "baseline": {"c0": 0.05}}
+
+
+def test_gap_is_flattened_locked_names_missing_from_refit():
+    gap = AdaptiveRefitController.locked_schema_gap(REFIT, LOCKED)
+    assert gap == ["peak_1_center", "peak_1_amplitude", "peak_1_fwhm",
+                   "extinction_at_400nm"]
+    assert AdaptiveRefitController.locked_schema_gap(LOCKED, LOCKED) == []
+    # a null counts as missing (it is an empty feature-table cell)
+    assert "extinction_at_400nm" in AdaptiveRefitController.locked_schema_gap(
+        {**REFIT, "extinction_at_400nm": None}, LOCKED)
+
+
+class _FakeExec:
+    """Runs nothing; returns a canned FIT_RESULTS_JSON per script marker."""
+    timeout = 60
+
+    def __init__(self, payloads):
+        self.payloads = payloads   # script-substring -> params dict
+
+    def execute_script(self, script, working_dir=None, timeout=None):
+        for key, params in self.payloads.items():
+            if key in script:
+                out = {"model_type": "x", "parameters": params,
+                       "fit_quality": {"r_squared": 0.98}}
+                Path(working_dir, "visualization.png").write_bytes(b"png")
+                return {"status": "success",
+                        "stdout": "FIT_RESULTS_JSON:" + json.dumps(out)}
+        return {"status": "error", "stdout": "", "message": "boom"}
+
+
+class _FakeModel:
+    def __init__(self, script):
+        self.script = script
+        self.prompts = []
+
+    def generate_content(self, contents=None, **kw):
+        self.prompts.append(contents[0])
+        return SimpleNamespace(text=json.dumps({"script": self.script}))
+
+
+def _controller(tmp, model, executor):
+    c = object.__new__(AdaptiveRefitController)
+    c.logger = logging.getLogger("t")
+    c.output_dir = Path(tmp)
+    c.model = model
+    c.generation_config = None
+    c.safety_settings = None
+    c.executor = executor
+    return c
+
+
+def _refit_result(script="ORIGINAL"):
+    return {"success": True, "parameters": dict(REFIT),
+            "fit_quality": {"r_squared": 0.97}, "script": script}
+
+
+def test_completion_adds_missing_under_locked_names():
+    with tempfile.TemporaryDirectory() as tmp:
+        completed = {**REFIT, "peak_1": {"center": None, "amplitude": None,
+                                         "fwhm": None},
+                     "extinction_at_400nm": 0.88}
+        model = _FakeModel("COMPLETED")
+        c = _controller(tmp, model, _FakeExec({"COMPLETED": completed}))
+        res = c._complete_locked_schema(_refit_result(), {"parameters": LOCKED},
+                                        np.zeros((5, 2)), 3, {"locked_fitting_config": {}})
+        assert res["parameters"]["extinction_at_400nm"] == 0.88
+        assert res["script"] == "COMPLETED"
+        # nulls stay "missing" (empty cells) and are reported as the residual gap
+        assert res["locked_schema_gap"] == ["peak_1_center", "peak_1_amplitude",
+                                            "peak_1_fwhm"]
+        assert "extinction_at_400nm" in model.prompts[0]
+        assert "Do NOT change the model" in model.prompts[0]
+
+
+def test_completion_rejected_if_existing_keys_lost():
+    with tempfile.TemporaryDirectory() as tmp:
+        broken = {"extinction_at_400nm": 0.88}          # dropped powerlaw_*
+        c = _controller(tmp, _FakeModel("BROKEN"), _FakeExec({"BROKEN": broken}))
+        res = c._complete_locked_schema(_refit_result(), {"parameters": LOCKED},
+                                        np.zeros((5, 2)), 3, {})
+        assert res["parameters"] == REFIT and res["script"] == "ORIGINAL"
+        assert res["locked_schema_gap"] == ["peak_1_center", "peak_1_amplitude",
+                                            "peak_1_fwhm", "extinction_at_400nm"]
+
+
+def test_no_gap_is_a_noop_without_llm_call():
+    with tempfile.TemporaryDirectory() as tmp:
+        model = _FakeModel("X")
+        c = _controller(tmp, model, _FakeExec({}))
+        r = {"success": True, "parameters": dict(LOCKED), "fit_quality": {}, "script": "S"}
+        res = c._complete_locked_schema(r, {"parameters": LOCKED}, np.zeros((5, 2)), 0, {})
+        assert res["locked_schema_gap"] == [] and not model.prompts
+
+
+def test_script_failure_keeps_refit_and_reports_gap():
+    with tempfile.TemporaryDirectory() as tmp:
+        c = _controller(tmp, _FakeModel("NEVER_RUNS"), _FakeExec({}))
+        res = c._complete_locked_schema(_refit_result(), {"parameters": LOCKED},
+                                        np.zeros((5, 2)), 1, {})
+        assert res["parameters"] == REFIT
+        assert len(res["locked_schema_gap"]) == 4

--- a/tests/test_run_analysis_tool_only.py
+++ b/tests/test_run_analysis_tool_only.py
@@ -1,0 +1,101 @@
+"""run_analysis without the chat preamble (MCP clients, run_task).
+
+Two hard stops greeted every fresh tool-only caller: 'No agent selected'
+and 'No metadata available'. Now the agent is inferred from the data probe
+when that is unambiguous, and the call's analysis_goal/objective/hints
+serve as minimal metadata when no file or sidecar exists — both reported in
+the response. Ambiguous data and a bare call still error, with a hint.
+No LLM: create_agent_for_analysis is stubbed to return a fake agent.
+"""
+import contextlib
+import io
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+os.environ.setdefault("MPLBACKEND", "Agg")
+os.environ.setdefault("UNSAFE_EXECUTION_OK", "true")
+
+from scilink.agents.exp_agents.analysis_orchestrator import (
+    AnalysisOrchestratorAgent, AnalysisMode,
+)
+
+PASS, FAIL = [], []
+
+
+def check(name, cond, detail=""):
+    (PASS if cond else FAIL).append(name)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name} {detail}")
+
+
+class _FakeAgent:
+    """Stands in for CurveFittingAgent: records the system_info it got."""
+    seen = []
+
+    def analyze(self, data=None, system_info=None, **kw):
+        _FakeAgent.seen.append({"data": data, "system_info": system_info})
+        return {"status": "success", "detailed_analysis": "ok",
+                "scientific_claims": [], "output_dir": kw.get("output_dir")}
+
+
+def make_orch(tmp):
+    with contextlib.redirect_stdout(io.StringIO()):
+        orch = AnalysisOrchestratorAgent(
+            base_dir=str(Path(tmp) / "s"), api_key="sk-dummy",
+            model_name="claude-opus-4-6", analysis_mode=AnalysisMode.AUTONOMOUS)
+    orch.create_agent_for_analysis = lambda agent_id, out_dir, **kw: _FakeAgent()
+    return orch
+
+
+def run(orch, **kw):
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        out = json.loads(orch.tools.execute_tool("run_analysis", **kw))
+    return out, buf.getvalue()
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    x = np.linspace(0, 100, 300)
+    y = np.exp(-0.5 * ((x - 40) / 4) ** 2)
+    csv = Path(tmp) / "spectrum.csv"
+    np.savetxt(csv, np.column_stack([x, y]), delimiter=",", header="x,y", comments="")
+
+    orch = make_orch(tmp)
+    out, log = run(orch, data_path=str(csv))
+    check("bare_call_still_errors_with_hint",
+          out["status"] == "error" and "analysis_goal" in out["message"], str(out)[:150])
+
+    orch = make_orch(tmp)
+    out, log = run(orch, data_path=str(csv),
+                   analysis_goal="Raman spectrum, x=cm-1, y=counts; fit the band")
+    check("agent_inferred_for_1d_csv",
+          out.get("status") == "success" and out.get("agent_inferred") == "CurveFittingAgent",
+          str(out)[:200])
+    check("minimal_metadata_used_and_reported",
+          "metadata_note" in out and _FakeAgent.seen
+          and _FakeAgent.seen[-1]["system_info"].get("analysis_goal", "").startswith("Raman"),
+          str(_FakeAgent.seen[-1]["system_info"])[:120])
+
+    # a stem-matched sidecar still wins over the minimal fallback
+    csv.with_suffix(".json").write_text(json.dumps({"technique": "Raman", "x_units": "cm-1"}))
+    orch = make_orch(tmp)
+    out, log = run(orch, data_path=str(csv), analysis_goal="fit the band")
+    check("sidecar_preferred_over_minimal",
+          out.get("status") == "success" and "metadata_note" not in out
+          and _FakeAgent.seen[-1]["system_info"].get("technique") == "Raman")
+
+    # explicit agent_id still honoured (no inference)
+    orch = make_orch(tmp)
+    out, log = run(orch, data_path=str(csv), agent_id=0, analysis_goal="fit")
+    check("explicit_agent_id_not_overridden",
+          out.get("status") == "success" and "agent_inferred" not in out)
+
+print("=" * 50)
+print(f"RUN_ANALYSIS TOOL-ONLY: {len(PASS)}/{len(PASS) + len(FAIL)} passed")
+if FAIL:
+    print("FAILED:", FAIL)
+    raise SystemExit(1)

--- a/tests/test_series_refit_budget.py
+++ b/tests/test_series_refit_budget.py
@@ -1,0 +1,55 @@
+"""max_series_refits: cap on independent per-unit re-analyses in a series.
+
+Worst locked-model fits are re-analyzed first; the rest keep their locked
+result and are listed under refit_skipped_by_budget. None = unlimited
+(unchanged behaviour); 0 = no refits.
+"""
+import logging
+from types import SimpleNamespace
+
+from scilink.agents.exp_agents.controllers.curve_fitting_controllers import (
+    AdaptiveRefitController,
+)
+
+
+class _Ctl(AdaptiveRefitController):
+    """Records which units would be re-analyzed instead of running LLM loops."""
+
+    def __init__(self):
+        self.logger = logging.getLogger("t")
+        self.enable_human_feedback = False
+        self.refitted = []
+        self._fitting_helper = SimpleNamespace(_detect_outliers=lambda results: [])
+
+    def _load_spectrum(self, idx, *a, **k):
+        self.refitted.append(idx)
+        return None          # "could not load" -> loop continues, no LLM work
+
+
+def _state(max_refits, n=5):
+    flagged = [{"index": i, "name": f"u{i}", "reason": "below_threshold",
+                "r_squared": r2} for i, r2 in enumerate([0.93, 0.80, 0.91, None, 0.70])]
+    return {"num_spectra": n, "is_single_spectrum": False,
+            "flagged_spectra": flagged, "series_results": [{}] * n,
+            "spectrum_paths": [f"p{i}" for i in range(n)],
+            "max_series_refits": max_refits, "locked_fitting_config": {}}
+
+
+def test_unlimited_by_default():
+    c = _Ctl(); st = c.execute(_state(None))
+    assert sorted(c.refitted) == [0, 1, 2, 3, 4]
+    assert st["refit_skipped_by_budget"] == []
+
+
+def test_cap_takes_worst_first_and_lists_skipped():
+    c = _Ctl(); st = c.execute(_state(2))
+    # worst R² first: 0.70 (idx 4) then 0.80 (idx 1); a None R² sorts last
+    assert c.refitted == [4, 1]
+    assert [s["index"] for s in st["refit_skipped_by_budget"]] == [2, 0, 3]
+    assert st["refit_skipped_by_budget"][0]["r_squared"] == 0.91
+
+
+def test_zero_means_no_refits():
+    c = _Ctl(); st = c.execute(_state(0))
+    assert c.refitted == []
+    assert len(st["refit_skipped_by_budget"]) == 5

--- a/tests/test_stale_session_dir.py
+++ b/tests/test_stale_session_dir.py
@@ -1,0 +1,125 @@
+"""A planning orchestrator started on a session dir that holds campaign
+data from an earlier process — but no checkpoint and no restore request —
+must not enter the half-state where the on-disk dedup ledger says the file
+is "already analyzed" while no schema exists in memory (run_optimization
+then fails with "Schema not established"). It archives the stale files and
+starts a consistent, empty campaign; a checkpointed dir is left alone.
+"""
+import contextlib
+import io
+import json
+import os
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+from scilink.agents.planning_agents.planning_orchestrator import (
+    PlanningOrchestratorAgent, AutonomyLevel,
+)
+
+PASS, FAIL = [], []
+
+
+def check(name, cond, detail=""):
+    (PASS if cond else FAIL).append(name)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name} {detail}")
+
+
+L6 = dict(T=[30.0, 30.0, 90.0, 90.0, 50.0, 78.0],
+          t=[10.0, 50.0, 10.0, 50.0, 35.0, 18.0],
+          Y=[8.56, 3.88, 22.47, 10.81, 48.83, 61.1])
+CSV_6ROW = "T,t,Y\n" + "\n".join(
+    f"{a},{b},{c}" for a, b, c in zip(L6["T"], L6["t"], L6["Y"])) + "\n"
+
+
+def make_orch(tmp, restore=False):
+    data_dir = Path(tmp) / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        orch = PlanningOrchestratorAgent(
+            base_dir=str(Path(tmp) / "session"), api_key="sk-dummy",
+            autonomy_level=AutonomyLevel.AUTONOMOUS, data_dir=str(data_dir),
+            restore_checkpoint=restore)
+    orch.scalarizer.scalarize = lambda **kw: {
+        "status": "success", "metrics": dict(L6), "source_script": None,
+        "column_roles": {"inputs": ["T", "t"], "targets": ["Y"]},
+        "passthrough": True, "error": None}
+    orch.bo.run_optimization_loop = lambda **kw: {
+        "status": "success", "next_parameters": {"T": 60.0, "t": 25.0},
+        "strategy": {}}
+    return orch, buf
+
+
+def ingest(orch, csv):
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        return json.loads(orch.tools.execute_tool(
+            "analyze_file", file_path=str(csv), extraction_goal="fixture",
+            inputs=["T", "t"], targets=["Y"]))
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    csv = Path(tmp) / "seed.csv"
+    csv.write_text(CSV_6ROW)
+    # Process 1: a campaign that never checkpoints (autonomous MCP-style).
+    orch1, _ = make_orch(tmp)
+    r1 = ingest(orch1, csv)
+    check("p1_ingest", r1.get("rows_added") == 6, str(r1)[:100])
+    session = Path(tmp) / "session"
+    check("p1_left_data_no_checkpoint",
+          (session / "optimization_data.csv").exists()
+          and (session / "analyzed_files.json").exists()
+          and not (session / "checkpoint.json").exists())
+
+    # Process 2: same session dir, no restore -> must start clean.
+    orch2, buf2 = make_orch(tmp)
+    archives = list(session.glob("stale_campaign_*"))
+    check("stale_files_archived",
+          len(archives) == 1
+          and (archives[0] / "optimization_data.csv").exists()
+          and not (session / "optimization_data.csv").exists()
+          and orch2.analyzed_files == {},
+          str([p.name for p in session.iterdir()]))
+    check("archive_notice_printed", "stale_campaign_" in buf2.getvalue())
+    r2 = ingest(orch2, csv)
+    check("p2_reingest_not_blocked_by_stale_dedup",
+          r2.get("status") == "success" and r2.get("rows_added") == 6,
+          str(r2)[:120])
+    with contextlib.redirect_stdout(io.StringIO()):
+        bo = json.loads(orch2.tools.execute_tool("run_optimization"))
+    check("p2_schema_established", bo.get("status") == "success", str(bo)[:100])
+
+with tempfile.TemporaryDirectory() as tmp:
+    # A checkpointed dir is NOT archived when restore is requested...
+    csv = Path(tmp) / "seed.csv"
+    csv.write_text(CSV_6ROW)
+    orch1, _ = make_orch(tmp)
+    ingest(orch1, csv)
+    with contextlib.redirect_stdout(io.StringIO()):
+        orch1._auto_checkpoint()
+    session = Path(tmp) / "session"
+    orch3, _ = make_orch(tmp, restore=True)
+    check("checkpointed_dir_restored_not_archived",
+          not list(session.glob("stale_campaign_*"))
+          and orch3.expected_input_columns == ["T", "t"]
+          and (session / "optimization_data.csv").exists())
+    # ...nor when a checkpoint exists but restore was not requested
+    # (recoverable state; existing behavior kept).
+    orch4, _ = make_orch(tmp)
+    check("checkpoint_present_no_restore_untouched",
+          not list(session.glob("stale_campaign_*")))
+
+with tempfile.TemporaryDirectory() as tmp:
+    orch, buf = make_orch(tmp)
+    check("fresh_dir_no_archive_no_notice",
+          not list((Path(tmp) / "session").glob("stale_campaign_*"))
+          and "stale_campaign_" not in buf.getvalue())
+
+print("=" * 50)
+print(f"STALE SESSION DIR: {len(PASS)}/{len(PASS) + len(FAIL)} passed")
+if FAIL:
+    print("FAILED:", FAIL)
+    raise SystemExit(1)

--- a/tests/test_target_directions_plumbing.py
+++ b/tests/test_target_directions_plumbing.py
@@ -1,0 +1,96 @@
+"""Explicit optimization directions through the planning tools.
+
+A pass-through feature table never runs the scalarizer's classification, so
+target_directions stayed empty and the optimizer silently MAXIMIZED — a
+'loss' target was maximized in an MCP-driven campaign. analyze_file and
+run_optimization now take directions={col: maximize|minimize} (sticky,
+checkpointed); both responses report the directions in force and warn when
+one was assumed.
+"""
+import contextlib
+import io
+import json
+import os
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+from scilink.agents.planning_agents.planning_orchestrator import (
+    PlanningOrchestratorAgent, AutonomyLevel,
+)
+
+PASS, FAIL = [], []
+
+
+def check(name, cond, detail=""):
+    (PASS if cond else FAIL).append(name)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name} {detail}")
+
+
+L6 = dict(T=[30.0, 30.0, 90.0, 90.0, 50.0, 78.0],
+          t=[10.0, 50.0, 10.0, 50.0, 35.0, 18.0],
+          Y=[8.56, 3.88, 22.47, 10.81, 48.83, 61.1])
+
+
+def make(tmp):
+    d = Path(tmp) / "data"; d.mkdir(exist_ok=True)
+    with contextlib.redirect_stdout(io.StringIO()):
+        o = PlanningOrchestratorAgent(base_dir=str(Path(tmp) / "s"), api_key="sk-dummy",
+                                      autonomy_level=AutonomyLevel.AUTONOMOUS, data_dir=str(d))
+    o.scalarizer.scalarize = lambda **kw: {
+        "status": "success", "metrics": dict(L6), "source_script": None,
+        "column_roles": {"inputs": ["T", "t"], "targets": ["Y"]},   # no optimization_direction
+        "passthrough": True, "error": None}
+    cap = {}
+    def loop(**kw):
+        cap.clear(); cap.update(kw)
+        return {"status": "success", "next_parameters": {"T": 60.0, "t": 25.0}, "strategy": {}}
+    o.bo.run_optimization_loop = loop
+    csv = Path(tmp) / "seed.csv"
+    csv.write_text("T,t,Y\n" + "\n".join(f"{a},{b},{c}" for a, b, c in zip(L6["T"], L6["t"], L6["Y"])) + "\n")
+    return o, cap, csv
+
+
+def call(o, tool, **kw):
+    with contextlib.redirect_stdout(io.StringIO()):
+        return json.loads(o.tools.execute_tool(tool, **kw))
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    o, cap, csv = make(tmp)
+    a = call(o, "analyze_file", file_path=str(csv), extraction_goal="x", inputs=["T", "t"], targets=["Y"])
+    check("ingest_without_direction_warns", "direction_warning" in a and a["target_directions"] == {}, str(a)[:160])
+    r = call(o, "run_optimization")
+    check("bo_assumes_maximize_and_says_so",
+          cap.get("target_directions") in ({}, None) and r["target_directions"] == {"Y": "maximize (assumed)"}
+          and any("MAXIMIZE was assumed" in w for w in r.get("warnings", [])), str(r)[:200])
+    r = call(o, "run_optimization", directions={"Y": "minimize"})
+    check("bo_directions_forwarded", cap.get("target_directions") == {"Y": "minimize"}
+          and r["target_directions"] == {"Y": "minimize"} and not r.get("warnings"))
+    r = call(o, "run_optimization")
+    check("sticky_on_next_call", cap.get("target_directions") == {"Y": "minimize"})
+    r = call(o, "run_optimization", directions={"Y": "MAX", "nope": "minimize", "T": "sideways"})
+    check("aliases_and_bad_entries",
+          cap.get("target_directions") == {"Y": "maximize"} and len(r.get("warnings", [])) == 2, str(r.get("warnings")))
+    with contextlib.redirect_stdout(io.StringIO()):
+        o._auto_checkpoint()
+        o2 = PlanningOrchestratorAgent(base_dir=str(Path(tmp) / "s"), api_key="sk-dummy",
+                                       autonomy_level=AutonomyLevel.AUTONOMOUS,
+                                       data_dir=str(Path(tmp) / "data"), restore_checkpoint=True)
+    check("directions_survive_checkpoint", o2.target_directions == {"Y": "maximize"}, str(o2.target_directions))
+
+with tempfile.TemporaryDirectory() as tmp:
+    o, cap, csv = make(tmp)
+    a = call(o, "analyze_file", file_path=str(csv), extraction_goal="x", inputs=["T", "t"],
+             targets=["Y"], directions={"Y": "minimize"})
+    check("ingest_directions_captured", a["target_directions"] == {"Y": "minimize"} and "direction_warning" not in a)
+    r = call(o, "run_optimization")
+    check("ingest_directions_reach_bo", cap.get("target_directions") == {"Y": "minimize"})
+
+print("=" * 50)
+print(f"TARGET DIRECTIONS: {len(PASS)}/{len(PASS) + len(FAIL)} passed")
+if FAIL:
+    print("FAILED:", FAIL)
+    raise SystemExit(1)


### PR DESCRIPTION
## Summary

Twenty-one fixes and tuning changes found by driving SciLink from an external agent framework over MCP (closed-loop campaigns over raw spectra, a real 96-well plate-reader screen) and by stress-testing the result against the BO benchmark suite. Everything is live-validated; the full offline test suite matches `main` (the only failures are pre-existing ones that fail identically on `main`), and the BO benchmark reproduces the stored results (18 datasets × 3 seeds, Opus 4.8: paired W18/T18/L18 vs the previous agent runs, agent still ahead of classical 29/13/12 and random 32/13/9, zero failed steps).

**For users, in plain terms:**
- A series fit can no longer "succeed" with no fitted values: the script contract now requires real parameters, and a re-analyzed spectrum keeps the same parameter names as the rest of the series, so feature tables that feed optimization are complete.
- You can tell the optimizer the instrument's reachable ranges (`input_bounds`), and it tells you where its search box came from; a seed makes a BO step reproducible.
- Analysis results carry their feature-table columns, so an external client (or the meta agent) can name BO inputs/targets without opening files.
- Re-running an MCP server on the same session directory now resumes the campaign instead of getting stuck; tool-only callers no longer need the chat preamble (agent inferred from the data, `analysis_goal` serves as minimal metadata).
- XRD peak detection no longer fits noise (matched-filter detection, validated on 30 real RRUFF patterns), and all-categorical BO designs no longer fall back to random picks.
- An MCP server restarted on the same session dir now remembers its background jobs and questions: finished jobs still answer with their result, interrupted ones report `interrupted` with the narration tail and a re-entry hint, and answering a dead question explains what happened (issue #469).
- Through the MCP tool layer you can now state the objective direction (`directions`) and which inputs are categorical (`input_types`); before, a ready feature table silently meant "maximize everything, every input continuous" — found by driving the BO benchmark through MCP (`bo_online_benchmark/bench_mcp.py`, new).

## Technical details

| Commit | Change |
|---|---|
| e4540c63 | Curve fitting: conformance gate requires a non-empty top-level `parameters` in `FIT_RESULTS_JSON` (a script with its own layout passed on recomputed R² with empty parameters). |
| 614bd963 | `run_optimization(input_bounds={col:[lo,hi]})`: caller > planner > data-derived (±10%); sticky + checkpointed; response reports `input_bounds` / `input_bounds_source`. |
| ba1ac1df | Planning orchestrator: a session dir with data but no checkpoint is archived to `stale_campaign_<ts>/` instead of the dedup/"Schema not established" half-state. |
| 00501f5c | `fit_pattern`: initial FWHM clamped into bounds (coarse-step patterns were rejected by least_squares as "failed to converge"); SNIP sweep error names the cause. |
| f6bd347e | `analyze_file` skips rows with missing inputs/targets (reported), instead of admitting NaNs that fail later in BO; refit prompt asks for locked names. |
| 7f88b322 | AdaptiveRefit: deterministic schema gap vs the locked unit + one add-only completion pass (accepted only if no key lost and R² not worse); `locked_schema_gap` recorded. Live: 11/11 names completed on the plate. |
| 8fff83ed | MCP server: checkpoint after granular calls, restore on start; `--mode both` nests `analysis/` and `planning/` (they shared one `checkpoint.json`). |
| a0b9364a | `run_analysis` returns `feature_columns/feature_rows/feature_missing`; `run_task` adds `feature_tables_schema`; meta ledger carries it. |
| 0e96ee15 | `run_optimization(seed=…)` → torch/np seeded in BOAgent; echoed back. |
| fea22fd8 | `max_series_refits` (analyze + tool): cap per-unit re-analyses, worst R² first; skipped units listed. Live: 96 wells 20 → 5.3 min. |
| c487c2dc | `run_analysis` tool-only: agent inferred from the data probe when unambiguous; `analysis_goal/objective/hints` as minimal metadata; both reported. |
| 2d639178 | `run_optimization` warns per column when the box was data-derived. |
| bc2b5898, 25ae8810 | `fit_pattern` peak detection: sample-size-aware noise floor, then matched-filter detection (smooth to expected reflection width). RRUFF 30 patterns: recall 0.734 → 0.787, `max_peaks` saturation 20 → 13, synthetic spurious peaks gone. Knob `min_prominence_sigma`. |
| 49750f1e | Planning tools: `directions={target: maximize|minimize}` on `analyze_file`/`run_optimization` (sticky, checkpointed); both responses report directions and warn when one was assumed. Pass-through tables skipped the scalarizer's classification, so minimize targets were maximized in every MCP-driven campaign (agnp 0.54 → 0.88 frac-of-optimum after). |
| de1c92a2, 5f7a0ac0 | Planning tools: `input_types={col: categorical|continuous}` (sticky); categorical level universe = data ∪ candidate pool (plan authoritative), normalised labels; the candidate pool is encoded through the same level maps as the data (was passed raw). |
| 075dcd30 | MCP restart durability (#469): jobs + pending questions persisted to `<session>/mcp_jobs.json` on every transition/poll; interrupted-job contract on restart; analysis/sim `run_task` gain the planning child's `finally`-checkpoint. |
| 7b82d2c4 | MCP server enforces a headless matplotlib backend itself (was integration rule 2 of every client; macOS GUI backend killed off-main-thread plot calls). |
| 03ab16e1, cc7517f8 | BO: all-categorical designs are enumerated and scored as a candidate library (≤50k combos). `optimize_acqf_mixed` returned `(d,)` for q=1 / failed for q>1, and the continuous relaxation had no gradient w.r.t. categorical dims — every step fell back to random on buchwald / suzuki_hte / deoxyfluorination / olympus in snapping mode (pre-existing, hidden by pool mode). |

**Tests added:** `test_curve_fitting_stdout_parser` (gate), `test_input_bounds_plumbing`, `test_stale_session_dir`, `test_fit_pattern_coarse_step`, `test_ingest_missing_values`, `test_refit_locked_schema`, `test_mcp_restart_durability`, `test_feature_table_describe`, `test_bo_seed`, `test_series_refit_budget`, `test_run_analysis_tool_only`, `test_fit_pattern_noise_floor`, `test_bo_all_categorical_recommend`, `test_target_directions_plumbing`, `test_input_types_plumbing`, `test_mcp_headless_backend`.

**Regression:** 1819 pytest-style tests pass; 33/33 runnable script tests pass; the 4 failed / 21 errored pytest files and one 25/26 script test fail identically on `main` (pre-existing: `model_name` fixture in sim/mp_resolver tests, `_adapt_script_for_spectrum` tests, save_file chunking, plan-payload ratchet on `diagram_agent.py`, MLIP smoke, HS dynamic records, fusion incremental). Note: `pytest tests/` as a whole aborts on a script-style file that calls `SystemExit` at import — run the two styles separately.

**Live validation:** deepagents-over-MCP examples 02–12 (BO loops, raw-spectra series BO at three entry points, supervised orchestrator, meta fan-out, real 96-well plate), restart/seed/bounds/feature-schema MCP smokes, and the BO benchmark (108 campaigns across the two protocols through the Python API, 0 fallbacks) plus the same 54 campaigns driven through the MCP tool layer (`bench_mcp.py`). The companion deepagents repo will be updated once this is on PyPI.
