### PR TITLE
UI: reattach to a running session after a browser disconnect

### DIFF
--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -140,6 +140,15 @@ if st.query_params.get("reset"):
 
 inject_theme()
 init_session_state()
+
+# Keep the process-global session registry current while attached, so a
+# browser disconnect (new session_state on reconnect) can REATTACH to the
+# still-running agent thread instead of losing sight of it.
+from scilink.ui import registry as _session_registry  # noqa: E402
+
+if st.session_state.agent_initialized and st.session_state.session_dir:
+    _session_registry.sync_from(st.session_state)
+
 render_sidebar()
 
 
@@ -704,6 +713,44 @@ if not st.session_state.agent_initialized:
         # the error invisible behind the dimmed sidebar.
         st.rerun()
 
+    # ── Reattach banner: live sessions in THIS server process ──
+    # A dropped connection gives the reconnected page a fresh session_state
+    # while the agent thread keeps running; offer to pick it back up. This is
+    # reference reattachment, not checkpoint resume — nothing is re-created.
+    _live = _session_registry.live_entries()
+    if _live:
+        _status_label = {
+            "running": "🟢 running",
+            "awaiting input": "🟠 awaiting your input",
+            "finished": "🔵 finished — result not yet shown",
+            "idle": "⚪ idle (in memory)",
+        }
+        _bl, _bc, _br = st.columns([1, 2, 1])
+        with _bc:
+            st.info("This server has live session(s) from a previous "
+                    "connection — reattach to continue where it left off.")
+            for _e in _live:
+                _name = Path(_e["session_dir"]).name
+                _cfg = _e["config"]
+                _desc = " · ".join(x for x in (
+                    _e.get("app_mode"), _cfg.get("model"),
+                    f"{_e['n_messages']} messages") if x)
+                _c1, _c2 = st.columns([3, 1])
+                with _c1:
+                    st.markdown(f"**{_name}**  \n"
+                                f"{_status_label.get(_e['status'], _e['status'])}"
+                                f"{' · ' + _desc if _desc else ''}")
+                with _c2:
+                    if st.button("Reattach", key=f"reattach_{_e['session_dir']}",
+                                 type="primary"):
+                        if _session_registry.attach_to(
+                                st.session_state, _e["session_dir"]):
+                            st.rerun()
+                        else:
+                            st.warning("That session is no longer in memory — "
+                                       "use Resume from checkpoint instead.")
+            st.divider()
+
     # ── Normal welcome screen ────────────────────────────────
     col_l, col_c, col_r = st.columns([1, 2, 1])
     with col_c:
@@ -941,6 +988,15 @@ else:
                 # Strip markdown image tags with local file paths — images are
                 # rendered separately via st.image() from _find_new_images()
                 content = re.sub(r"!\[[^\]]*\]\([^)]+\)\n?", "", content).strip()
+                # If another attached view of this session already consumed
+                # this completion (reattach can briefly leave two observers),
+                # do not append the same turn twice — just clear the task.
+                _msgs = st.session_state.chat_messages
+                if (_msgs and _msgs[-1].get("role") == "assistant"
+                        and _msgs[-1].get("content") == content):
+                    st.session_state.chat_task = ChatTask()
+                    st.rerun(scope="app")
+                    return
                 new_images = _find_new_images()
                 new_reports = _find_new_html_reports()
                 new_docs = _find_new_md_documents()

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -1242,6 +1242,13 @@ def resume_session(
 
 
 def _reset_session() -> None:
+    # This session is being torn down deliberately — drop its registry entry
+    # so the welcome screen does not offer to reattach to a dead run.
+    try:
+        from scilink.ui import registry as _session_registry
+        _session_registry.unregister(st.session_state.get("session_dir"))
+    except Exception:  # noqa: BLE001 - teardown must not fail
+        pass
     # Stop the agent thread if it's still running
     task = st.session_state.get("chat_task")
     if task and task.is_running:

--- a/scilink/ui/registry.py
+++ b/scilink/ui/registry.py
@@ -1,0 +1,96 @@
+"""Process-global registry of live UI sessions — survives browser disconnects.
+
+Streamlit ties ``st.session_state`` to the browser's WebSocket session: when
+the viewer's connection drops (laptop offline, lid closed), the server keeps
+running the agent thread, but the reconnected page gets a FRESH session_state
+with no handle to it — the run looks lost even though it is alive (observed
+with the server under ``screen`` on another machine).
+
+This module keeps the handles at PROCESS scope. Modules are imported once per
+Streamlit server process, so ``_SESSIONS`` outlives any browser session. The
+app syncs its state here on every run while attached; the welcome screen
+offers to REATTACH when it finds an entry whose work is still running or
+whose finished result was never shown.
+
+Entries hold live references (agent, ChatTask, the chat_messages list), so a
+reattached page continues the same objects the background thread mutates —
+including a pending human-feedback request. Nothing is persisted; a server
+restart is the (separate) checkpoint-resume path.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Mapping, Optional
+
+# The session_state keys that constitute an attachable session. chat_messages
+# is shared BY REFERENCE so appends after reattach mutate the same list.
+SESSION_KEYS = ("agent", "agent_config", "chat_messages", "chat_task",
+                "known_images", "app_mode")
+
+_SESSIONS: Dict[str, Dict[str, Any]] = {}
+
+
+def sync_from(state: Mapping[str, Any]) -> None:
+    """Mirror the attached session's handles into the registry.
+
+    Called once per script run while a session is attached — reruns are
+    frequent, so this also keeps reassigned objects (a fresh ChatTask each
+    turn) current. Cheap: reference copies only.
+    """
+    sdir = state.get("session_dir")
+    if not sdir:
+        return
+    entry = _SESSIONS.setdefault(str(sdir), {})
+    for k in SESSION_KEYS:
+        entry[k] = state.get(k)
+    entry["updated_at"] = time.time()
+
+
+def attach_to(state, session_dir: str) -> bool:
+    """Copy a registry entry's handles into ``state`` (a new browser session).
+
+    Returns False when the entry is gone (e.g. the server restarted)."""
+    entry = _SESSIONS.get(str(session_dir))
+    if entry is None:
+        return False
+    for k in SESSION_KEYS:
+        state[k] = entry.get(k)
+    state["session_dir"] = str(session_dir)
+    state["agent_initialized"] = True
+    return True
+
+
+def unregister(session_dir: Optional[str]) -> None:
+    if session_dir:
+        _SESSIONS.pop(str(session_dir), None)
+
+
+def status_of(entry: Mapping[str, Any]) -> str:
+    """'awaiting input' | 'running' | 'finished' (result never shown) | 'idle'."""
+    task = entry.get("chat_task")
+    if task is not None:
+        if getattr(task, "is_running", False):
+            if getattr(task, "feedback_request", None) is not None:
+                return "awaiting input"
+            return "running"
+        if (getattr(task, "result", None) is not None
+                or getattr(task, "error", None) is not None):
+            return "finished"
+    return "idle"
+
+
+def live_entries() -> List[Dict[str, Any]]:
+    """Entries worth offering a reattach for, most recent first.
+
+    'idle' entries are included too: after a completed turn the task is
+    consumed and replaced, but the session (agent + history) is still only
+    alive in this process — reattaching beats resuming from checkpoint."""
+    out = []
+    for sdir, entry in _SESSIONS.items():
+        out.append({"session_dir": sdir, "status": status_of(entry),
+                    "updated_at": entry.get("updated_at", 0.0),
+                    "config": entry.get("agent_config") or {},
+                    "app_mode": entry.get("app_mode"),
+                    "n_messages": len(entry.get("chat_messages") or [])})
+    out.sort(key=lambda e: e["updated_at"], reverse=True)
+    return out

--- a/tests/test_ui_reattach_apptest.py
+++ b/tests/test_ui_reattach_apptest.py
@@ -1,0 +1,87 @@
+"""End-to-end reattach through Streamlit's AppTest harness.
+
+Simulates the real failure: an agent turn is running in a background thread
+when the browser session is lost. A NEW AppTest run (fresh session_state,
+same process) must show the reattach banner; clicking it must hand the new
+session the live task, whose completion then lands in the chat.
+"""
+import time
+
+import pytest
+
+pytest.importorskip("streamlit.testing.v1")
+from streamlit.testing.v1 import AppTest  # noqa: E402
+
+from scilink.ui import registry  # noqa: E402
+from scilink.ui.state import ChatTask  # noqa: E402
+
+APP = "scilink/ui/app.py"
+TIMEOUT = 60
+
+
+class _StubAgent:
+    model = "stub-model"
+    base_dir = "."
+
+
+def _seed_running_entry(tmp_path):
+    registry._SESSIONS.clear()
+    task = ChatTask(is_running=True)
+    sdir = tmp_path / "meta_session_20990101_000000"
+    sdir.mkdir()
+    registry.sync_from({
+        "session_dir": str(sdir), "agent": _StubAgent(),
+        "agent_config": {"model": "stub-model", "mode": "autonomous"},
+        "chat_messages": [{"role": "user", "content": "long job please"}],
+        "chat_task": task, "known_images": set(), "app_mode": "meta",
+    })
+    return sdir, task
+
+
+def test_banner_lists_live_session_and_reattaches(tmp_path):
+    sdir, task = _seed_running_entry(tmp_path)
+    at = AppTest.from_file(APP, default_timeout=TIMEOUT).run()
+
+    # Fresh session (disconnected browser): welcome screen with the banner
+    assert not at.session_state["agent_initialized"]
+    assert any("live session" in str(i.value) for i in at.info)
+    btns = [b for b in at.button if b.key == f"reattach_{sdir}"]
+    assert btns, "reattach button not rendered"
+
+    at2 = btns[0].click().run()
+    assert at2.session_state["agent_initialized"] is True
+    assert at2.session_state["session_dir"] == str(sdir)
+    assert at2.session_state["chat_task"] is task
+    assert at2.session_state["chat_messages"][0]["content"] == "long job please"
+
+
+def test_completion_after_reattach_lands_in_chat(tmp_path):
+    sdir, task = _seed_running_entry(tmp_path)
+    at = AppTest.from_file(APP, default_timeout=TIMEOUT).run()
+    at = [b for b in at.button if b.key == f"reattach_{sdir}"][0].click().run()
+
+    # the "background thread" finishes while attached
+    task.result = "the long answer"
+    task.verbose_log = "log"
+    task.is_running = False
+    time.sleep(0.1)
+    at = at.run()   # monitor fragment consumes the completion
+
+    msgs = at.session_state["chat_messages"]
+    assert any(m.get("role") == "assistant" and m.get("content") == "the long answer"
+               for m in msgs)
+    fresh = at.session_state["chat_task"]
+    assert fresh is not task and not fresh.is_running
+
+    # duplicate-consumption guard: a second observer holding the old task
+    at.session_state["chat_task"] = task
+    at = at.run()
+    n = sum(1 for m in at.session_state["chat_messages"]
+            if m.get("role") == "assistant" and m.get("content") == "the long answer")
+    assert n == 1
+
+
+def test_no_banner_without_live_sessions():
+    registry._SESSIONS.clear()
+    at = AppTest.from_file(APP, default_timeout=TIMEOUT).run()
+    assert not any("live session" in str(i.value) for i in at.info)

--- a/tests/test_ui_session_registry.py
+++ b/tests/test_ui_session_registry.py
@@ -1,0 +1,106 @@
+"""UI session registry: reattach a live run after a browser disconnect.
+
+The registry is plain Python (dict state), so the disconnect scenario is
+simulated directly: session A syncs, its "browser" vanishes (nothing to do —
+the registry is process-scoped), a fresh state B attaches and must receive
+the SAME live objects the background thread mutates.
+"""
+import threading
+
+from scilink.ui import registry
+from scilink.ui.state import ChatTask, FeedbackRequest
+
+
+def setup_function(_):
+    registry._SESSIONS.clear()
+
+
+def _state(sdir="s1", **over):
+    st = {"session_dir": sdir, "agent": object(), "agent_config": {"model": "m"},
+          "chat_messages": [{"role": "user", "content": "hi"}],
+          "chat_task": ChatTask(), "known_images": set(), "app_mode": "meta"}
+    st.update(over)
+    return st
+
+
+def test_sync_and_reattach_share_live_objects():
+    a = _state()
+    a["chat_task"].is_running = True
+    registry.sync_from(a)
+
+    b = {}  # fresh browser session after the disconnect
+    assert registry.attach_to(b, "s1")
+    assert b["agent"] is a["agent"]
+    assert b["chat_task"] is a["chat_task"]
+    assert b["chat_messages"] is a["chat_messages"]
+    assert b["agent_initialized"] is True and b["session_dir"] == "s1"
+
+    # the background thread finishes while only B is attached
+    a["chat_task"].result = "done"
+    a["chat_task"].is_running = False
+    assert b["chat_task"].result == "done"
+
+
+def test_sync_tracks_reassigned_task():
+    a = _state()
+    registry.sync_from(a)
+    fresh = ChatTask(is_running=True)
+    a["chat_task"] = fresh                # new turn starts
+    registry.sync_from(a)                 # next script run syncs
+    b = {}
+    registry.attach_to(b, "s1")
+    assert b["chat_task"] is fresh
+
+
+def test_status_of_all_states():
+    t = ChatTask()
+    assert registry.status_of({"chat_task": t}) == "idle"
+    t.is_running = True
+    assert registry.status_of({"chat_task": t}) == "running"
+    t.feedback_request = FeedbackRequest(prompt="ok?")
+    assert registry.status_of({"chat_task": t}) == "awaiting input"
+    t.is_running = False
+    t.feedback_request = None
+    t.result = "r"
+    assert registry.status_of({"chat_task": t}) == "finished"
+    assert registry.status_of({}) == "idle"
+
+
+def test_live_entries_sorted_and_described():
+    registry.sync_from(_state("s_old"))
+    registry.sync_from(_state("s_new", chat_messages=[{}, {}, {}]))
+    entries = registry.live_entries()
+    assert [e["session_dir"] for e in entries] == ["s_new", "s_old"]
+    assert entries[0]["n_messages"] == 3
+    assert entries[0]["config"] == {"model": "m"}
+
+
+def test_unregister_and_missing_attach():
+    registry.sync_from(_state())
+    registry.unregister("s1")
+    assert registry.live_entries() == []
+    assert registry.attach_to({}, "s1") is False
+    registry.unregister(None)  # no-op, no raise
+
+
+def test_pending_feedback_survives_reattach():
+    a = _state()
+    a["chat_task"].is_running = True
+    req = FeedbackRequest(prompt="approve the plan?")
+    a["chat_task"].feedback_request = req
+    registry.sync_from(a)
+    b = {}
+    registry.attach_to(b, "s1")
+    # B answers; the blocked agent thread (waiting on the SAME event) wakes
+    got = {}
+    waiter = threading.Thread(target=lambda: got.setdefault("r", (req.event.wait(2), req.response)))
+    waiter.start()
+    b["chat_task"].feedback_request.response = "yes"
+    b["chat_task"].feedback_request.event.set()
+    waiter.join()
+    assert got["r"] == (True, "yes")
+
+
+def test_sync_without_session_dir_is_noop():
+    registry.sync_from({"agent": object()})
+    assert registry.live_entries() == []


### PR DESCRIPTION
## Summary

If you drive the GUI from another machine and your connection drops, the agent keeps working (the server lives on, e.g. under `screen`), but the reloaded page no longer knows about the run: Streamlit binds its per-page state to the browser's WebSocket session, so a reconnect gets a fresh, empty state while the background thread — and its eventual result — are orphaned in the server process.

Now the server remembers. On reconnect, the welcome screen shows a banner listing the live session(s) held by the process — with status: 🟢 running, 🟠 awaiting your input, 🔵 finished (result not yet shown), ⚪ idle — and a **Reattach** button. Reattaching hands the new page the *same* live objects: the ongoing turn continues streaming, a pending approve/feedback prompt reappears and still unblocks the waiting agent thread, and a turn that finished while you were offline is delivered on arrival. Full chat history comes along (it lives in the same process), so nothing is re-created and no checkpoint restore is needed. A server restart is still the existing resume-from-checkpoint path.

## Technical details

- `scilink/ui/registry.py` (new): process-global `_SESSIONS` keyed by session dir; entries hold references (agent, `ChatTask`, the `chat_messages` list, config). `sync_from(state)` runs once per script run while attached (reference copies only), so reassigned objects — the fresh `ChatTask` each turn — stay current. `attach_to(state, sdir)` copies the handles into a new session_state; `status_of` / `live_entries` / `unregister` complete the API.
- `app.py`: sync hook after `init_session_state()`; reattach banner at the top of the welcome screen; duplicate-consumption guard in the completion branch of the monitor fragment (a briefly doubled observer — old tab plus reattached tab — cannot append the same assistant turn twice).
- `sidebar.py`: `_reset_session` unregisters the entry so a deliberately ended session is not offered for reattach.

**Verification**
- 7 unit tests on the registry (shared live objects across "disconnect", reassigned-task tracking, status states, ordering, unregister, a feedback `threading.Event` answered from the reattached side unblocking a waiter).
- 3 end-to-end tests through `streamlit.testing.v1.AppTest` booting the real `app.py`: fresh session shows the banner and the button; clicking it transfers the live task and history; a completion after reattach lands in chat exactly once (dedupe guard exercised with a second stale observer); no banner when the registry is empty.
- Headless `streamlit run` boot smoke (HTTP 200).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>