### PR TITLE
MCP onboarding: shared credentials file, foreground narration by default, --print-mcp-json

### DIFF
--- a/scilink/cli/serve.py
+++ b/scilink/cli/serve.py
@@ -12,6 +12,54 @@ Usage::
 import argparse
 import os
 import sys
+from pathlib import Path
+
+
+def _print_mcp_json(args) -> int:
+    """Emit a client config entry for this server invocation.
+
+    The entry is secret-free by design: the server reads
+    ``~/.scilink/credentials.env`` at startup, so client configs never need
+    an env block. When ``uvx`` is on PATH the spec is zero-install (the
+    client machine needs uv, nothing else); otherwise it points at this
+    installation's ``scilink`` executable.
+    """
+    import json
+    import shutil
+
+    try:
+        from importlib.metadata import version as _pkg_version
+        _v = _pkg_version("scilink")
+    except Exception:  # noqa: BLE001 - editable/dev installs
+        _v = None
+
+    serve_args = ["serve", "--mode", args.mode, "--autonomy", args.autonomy]
+    if args.model:
+        serve_args += ["--model", args.model]
+    if args.session_dir:
+        serve_args += ["--session-dir", args.session_dir]
+    if args.transport == "sse":
+        entry = {"type": "sse", "url": f"http://{args.host}:{args.port}/sse"}
+        note = (f"# Start the server yourself:\n"
+                f"#   scilink serve {' '.join(serve_args[1:])} "
+                f"--transport sse --host {args.host} --port {args.port}")
+    elif shutil.which("uvx"):
+        entry = {"command": "uvx",
+                 "args": ["--from",
+                          f"scilink=={_v}" if _v else "scilink",
+                          "scilink"] + serve_args}
+        note = "# Zero-install spec: the client machine only needs uv."
+    else:
+        exe = shutil.which("scilink") or sys.argv[0]
+        entry = {"command": exe, "args": serve_args}
+        note = "# Points at this machine's scilink executable."
+    cred = Path.home() / ".scilink" / "credentials.env"
+    print(note, file=sys.stderr)
+    print(f"# LLM credentials: put KEY=VALUE lines in {cred}", file=sys.stderr)
+    print(f"# (loaded by the server at startup; {'present' if cred.exists() else 'NOT present yet'})",
+          file=sys.stderr)
+    print(json.dumps({"mcpServers": {"scilink": entry}}, indent=2))
+    return 0
 
 
 def main():
@@ -97,8 +145,22 @@ def main():
         default=None,
         help="FutureHouse/Edison API key for novelty assessment",
     )
+    parser.add_argument(
+        "--print-mcp-json",
+        action="store_true",
+        help=(
+            "Print a ready-to-paste .mcp.json entry for this server "
+            "configuration (Claude Desktop / Deep Agents style) and exit. "
+            "Uses a zero-install uvx spec when uvx is available; contains "
+            "no secrets — put LLM credentials in ~/.scilink/credentials.env "
+            "(KEY=VALUE lines), which the server loads at startup."
+        ),
+    )
 
     args = parser.parse_args()
+
+    if args.print_mcp_json:
+        return _print_mcp_json(args)
 
     # Resolve API key
     api_key = args.api_key

--- a/scilink/mcp_server.py
+++ b/scilink/mcp_server.py
@@ -476,6 +476,83 @@ def _ensure_headless_matplotlib() -> None:
         logging.warning(f"Could not enforce headless matplotlib backend: {exc}")
 
 
+def _load_shared_credentials() -> list:
+    """Load ``~/.scilink/credentials.env`` (KEY=VALUE lines) into the process
+    environment with setdefault semantics — an explicitly set variable always
+    wins. Lets every MCP client config stay secret-free: put the LLM
+    credentials in ONE file instead of into each client's .mcp.json."""
+    path = Path.home() / ".scilink" / "credentials.env"
+    loaded = []
+    if not path.exists():
+        return loaded
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            k, v = k.strip(), v.strip().strip('"').strip("'")
+            if k and v and k not in os.environ:
+                os.environ[k] = v
+                loaded.append(k)
+        if loaded:
+            logging.info(f"Loaded credentials from {path}: {loaded}")
+    except Exception as exc:  # noqa: BLE001 - never block serving
+        logging.warning(f"Could not read {path}: {exc}")
+    return loaded
+
+
+# ── Foreground narration (log-message notifications) ────────────────────
+# Foreground tool calls used to be silent until the final JSON (stdout must
+# stay clean for the stdio transport). The captured narration is now also
+# streamed to the client as MCP `notifications/message` entries while the
+# call runs, so any client that renders log notifications shows live
+# progress with no background-job dance. Disable: SCILINK_MCP_NARRATION=0.
+import contextvars as _contextvars
+
+_MCP_SESSION: "_contextvars.ContextVar" = _contextvars.ContextVar(
+    "scilink_mcp_session", default=None)
+
+_NARRATION_POLL_S = 1.0
+_NARRATION_MAX_PER_POLL = 50
+
+
+def _narration_enabled() -> bool:
+    return os.environ.get("SCILINK_MCP_NARRATION", "1").lower() not in (
+        "0", "false", "no", "off")
+
+
+async def _to_thread_streaming(fn, *args) -> str:
+    """Run a captured executor (signature ``fn(*args, log_lines)``) in a
+    worker thread; while it runs, forward newly captured narration lines to
+    the client as info-level log notifications. Notification failures stop
+    the streaming but never affect the call."""
+    if not _narration_enabled():
+        return await asyncio.to_thread(fn, *args, None)
+    lines: list = []          # plain list: append-only, no maxlen truncation
+    task = asyncio.ensure_future(asyncio.to_thread(fn, *args, lines))
+    session = _MCP_SESSION.get()
+    sent = 0
+    while True:
+        done = task.done()
+        if session is not None and len(lines) > sent:
+            batch = lines[sent:sent + _NARRATION_MAX_PER_POLL]
+            sent += len(batch)
+            for line in batch:
+                if not str(line).strip():
+                    continue
+                try:
+                    await session.send_log_message(
+                        "info", str(line), logger="scilink")
+                except Exception:  # noqa: BLE001 - client gone / no support
+                    session = None
+                    break
+        if done:
+            break
+        await asyncio.sleep(_NARRATION_POLL_S)
+    return task.result()
+
+
 def create_server(
     *,
     api_key: str = None,
@@ -506,6 +583,7 @@ def create_server(
     server = Server("scilink")
 
     _ensure_headless_matplotlib()
+    _load_shared_credentials()
     import threading as _threading
 
     # ── State (initialized lazily on first tool list) ────────────────
@@ -852,6 +930,13 @@ def create_server(
         name: str, arguments: dict
     ) -> List[types.TextContent]:
         _ensure_initialized()
+        # Session handle for foreground narration (log-message
+        # notifications). Best effort: absent a request context we just
+        # run silently, exactly as before.
+        try:
+            _MCP_SESSION.set(server.request_context.session)
+        except Exception:  # noqa: BLE001
+            _MCP_SESSION.set(None)
 
         # Handle the respond tool
         if name == "scilink_respond":
@@ -951,7 +1036,7 @@ def create_server(
                 }),
             )]
 
-        result = await asyncio.to_thread(
+        result = await _to_thread_streaming(
             _execute_tool_captured, orch.tools, original_name, arguments,
             state, None,
         )
@@ -1486,8 +1571,8 @@ async def _handle_orchestrate_meta(
             }),
         )]
 
-    result = await asyncio.to_thread(_execute_meta_chat_captured, orch,
-                                     prompt, autonomy_str, state, None)
+    result = await _to_thread_streaming(_execute_meta_chat_captured, orch,
+                                        prompt, autonomy_str, state, None)
     return [types.TextContent(type="text", text=result)]
 
 
@@ -1561,8 +1646,8 @@ async def _handle_orchestrate(
             }),
         )]
 
-    result = await asyncio.to_thread(_execute_run_task_captured, orch,
-                                     prompt, autonomy_str, state, None)
+    result = await _to_thread_streaming(_execute_run_task_captured, orch,
+                                        prompt, autonomy_str, state, None)
     return [types.TextContent(type="text", text=result)]
 
 
@@ -1740,7 +1825,7 @@ async def _handle_respond(
                 }),
             )]
 
-        result = await asyncio.to_thread(
+        result = await _to_thread_streaming(
             _execute_tool_captured, orch.tools, action.tool_name,
             action.kwargs, state, None,
         )

--- a/tests/test_mcp_onboarding.py
+++ b/tests/test_mcp_onboarding.py
@@ -1,0 +1,114 @@
+"""Onboarding + narration features: shared credentials file, foreground
+narration streaming, --print-mcp-json."""
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp")
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+
+from scilink.mcp_server import (  # noqa: E402
+    _load_shared_credentials, _to_thread_streaming, _MCP_SESSION,
+)
+
+
+def test_credentials_setdefault(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    d = tmp_path / ".scilink"; d.mkdir()
+    (d / "credentials.env").write_text(
+        "# comment\nAWS_BEARER_TOKEN_BEDROCK=abc123\n"
+        'QUOTED_KEY="qv"\nALREADY_SET=from_file\nBADLINE\n=novalue\n')
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+    monkeypatch.setenv("ALREADY_SET", "from_env")
+    loaded = _load_shared_credentials()
+    assert set(loaded) == {"AWS_BEARER_TOKEN_BEDROCK", "QUOTED_KEY"}
+    assert os.environ["AWS_BEARER_TOKEN_BEDROCK"] == "abc123"
+    assert os.environ["QUOTED_KEY"] == "qv"
+    assert os.environ["ALREADY_SET"] == "from_env"     # explicit env wins
+
+
+def test_credentials_missing_file_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert _load_shared_credentials() == []
+
+
+class _FakeSession:
+    def __init__(self): self.msgs = []
+    async def send_log_message(self, level, data, logger=None, **kw):
+        self.msgs.append((level, data, logger))
+
+
+def _worker(a, b, log_lines):
+    for i in range(3):
+        if log_lines is not None:
+            log_lines.append(f"step {i}")
+        time.sleep(0.4)
+    return json.dumps({"status": "success", "sum": a + b})
+
+
+def test_narration_streams_lines():
+    sess = _FakeSession()
+    tok = _MCP_SESSION.set(sess)
+    try:
+        out = asyncio.run(_to_thread_streaming(_worker, 1, 2))
+    finally:
+        _MCP_SESSION.reset(tok)
+    assert json.loads(out)["sum"] == 3
+    assert [m[1] for m in sess.msgs] == ["step 0", "step 1", "step 2"]
+    assert all(m[0] == "info" and m[2] == "scilink" for m in sess.msgs)
+
+
+def test_narration_disabled_and_no_session_are_silent(monkeypatch):
+    monkeypatch.setenv("SCILINK_MCP_NARRATION", "0")
+    out = asyncio.run(_to_thread_streaming(_worker, 2, 3))
+    assert json.loads(out)["sum"] == 5
+    monkeypatch.delenv("SCILINK_MCP_NARRATION")
+    tok = _MCP_SESSION.set(None)
+    try:
+        out = asyncio.run(_to_thread_streaming(_worker, 3, 4))
+    finally:
+        _MCP_SESSION.reset(tok)
+    assert json.loads(out)["sum"] == 7
+
+
+class _DyingSession(_FakeSession):
+    async def send_log_message(self, *a, **k):
+        await super().send_log_message(*a, **k)
+        if len(self.msgs) >= 1:
+            raise RuntimeError("client gone")
+
+
+def test_notification_failure_never_breaks_the_call():
+    sess = _DyingSession()
+    tok = _MCP_SESSION.set(sess)
+    try:
+        out = asyncio.run(_to_thread_streaming(_worker, 5, 6))
+    finally:
+        _MCP_SESSION.reset(tok)
+    assert json.loads(out)["sum"] == 11
+    assert len(sess.msgs) == 1          # stopped streaming after the failure
+
+
+def test_print_mcp_json_forms():
+    env = dict(os.environ)
+    r = subprocess.run([sys.executable, "-m", "scilink.cli.main", "serve",
+                        "--print-mcp-json", "--mode", "both",
+                        "--model", "m", "--session-dir", "/tmp/x"],
+                       capture_output=True, text=True, env=env, timeout=120)
+    assert r.returncode == 0, r.stderr[-400:]
+    cfg = json.loads(r.stdout)
+    e = cfg["mcpServers"]["scilink"]
+    assert "env" not in e                      # secret-free by design
+    assert "serve" in e["args"] and "--model" in e["args"]
+    assert "credentials.env" in r.stderr
+    r = subprocess.run([sys.executable, "-m", "scilink.cli.main", "serve",
+                        "--print-mcp-json", "--transport", "sse", "--port", "8123"],
+                       capture_output=True, text=True, env=env, timeout=120)
+    e = json.loads(r.stdout)["mcpServers"]["scilink"]
+    assert e == {"type": "sse", "url": "http://127.0.0.1:8123/sse"}


### PR DESCRIPTION
## Summary

Makes SciLink painless to hook into MCP clients (Deep Agents CLI/`dcode`, Claude Desktop, or any framework). Driving SciLink from a live `deepagents-code` session surfaced three friction points; each gets a first-class fix:

- **Credentials once, not per client.** The server now loads `~/.scilink/credentials.env` (plain `KEY=VALUE`) at startup with setdefault semantics — an explicitly exported variable always wins. Client configs (`.mcp.json` etc.) no longer need `env` blocks with secrets.
- **Narration by default.** Foreground tool calls used to be silent until the final JSON (stdout must stay clean for the stdio transport). The captured narration now also streams to the client as MCP `notifications/message` entries (info level, logger `scilink`) while the call runs — clients that render log notifications show live progress with no background-job dance. Opt out with `SCILINK_MCP_NARRATION=0`. Applied on all four foreground paths (granular tools, orchestrate analysis/planning, meta, approval-resume); a notification failure stops the stream, never the call.
- **One-command client setup.** `scilink serve --print-mcp-json` prints a ready-to-paste, secret-free `.mcp.json` entry: a zero-install `uvx` spec when `uvx` is on PATH (`uvx --from scilink==<version> scilink serve …` — verified working against the 0.0.64 release), an executable-path fallback otherwise, and the `{"type": "sse", "url": …}` form when invoked with `--transport sse`. stderr notes point at the credentials file.

## Technical details

- `mcp_server.py`: `_load_shared_credentials()` (called in `create_server()`); `_MCP_SESSION` contextvar set at `call_tool` entry; `_to_thread_streaming()` wraps the existing `*_captured` executors, polling their `log_lines` buffer every 1 s and forwarding up to 50 lines per poll via `session.send_log_message`.
- `cli/serve.py`: `--print-mcp-json` flag + `_print_mcp_json()` (version via `importlib.metadata`, dev installs fall back to an unpinned spec).

## Validation

- Offline: `tests/test_mcp_onboarding.py` 6/6 (setdefault/quoting/malformed lines; streaming order; disabled/no-session silence; dying-client isolation; both `--print-mcp-json` forms secret-free). All MCP suites 35/35.
- Live: logging-callback stdio client received 37 narration notifications during a foreground ingest + BO call (including the BO strategy lines); a server spawned with every AWS/LLM variable stripped completed a Bedrock BO run from the credentials file alone; deepagents example 02 end-to-end unchanged (0 errors, +40 % over seed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
