### PR TITLE
feat: deterministic geometry-consistency check for MolecularQC decks (#400)

### DIFF
--- a/scilink/agents/sim_agents/molecular_qc_agent.py
+++ b/scilink/agents/sim_agents/molecular_qc_agent.py
@@ -349,6 +349,39 @@ class MolecularQCAgent:
         if "entry_file" not in result and len(result["input_files"]) == 1:
             result["entry_file"] = next(iter(result["input_files"]))
 
+        # ── deterministic geometry-consistency check (fail loud) ──────
+        # The deck's inline geometry is LLM-transcribed from the structure; a
+        # dropped atom or wrong element would run to completion on the wrong
+        # system. Compare composition against the source and fail generation on
+        # a mismatch. Engine-neutral: resolved from the active skill bundle, so
+        # a QC engine without this tool simply skips it.
+        try:
+            from ...skills._shared._registry import get_tool_function
+            try:
+                geom_check = get_tool_function(
+                    "check_geometry_consistency", active_skills=[software]
+                )
+            except LookupError:
+                geom_check = None
+            if geom_check is not None:
+                check = geom_check(
+                    input_files=result["input_files"],
+                    structure_file=structure_file,
+                )
+                result["geometry_check"] = check
+                if check.get("status") == "mismatch":
+                    return {
+                        "status": "error",
+                        "message": (
+                            "Generated deck geometry is inconsistent with the "
+                            "source structure: " + check.get("reason", "")
+                        ),
+                        "geometry_check": check,
+                        "raw_result": result,
+                    }
+        except Exception as exc:
+            self.logger.warning("geometry consistency check failed: %s", exc)
+
         result["status"] = "success"
         result["software"] = software
         return result

--- a/scilink/skills/molecular_qc/nwchem/nwchem_geometry.py
+++ b/scilink/skills/molecular_qc/nwchem/nwchem_geometry.py
@@ -18,44 +18,68 @@ from typing import Any, Dict, List, Optional
 
 from ..._shared._spec import ToolSpec
 
-# Non-atom lines that can appear inside a `geometry` block.
+# Plain non-atom directive lines that can appear inside a `geometry` block.
 _GEOMETRY_DIRECTIVES = {
-    "units", "symmetry", "zcoord", "zmatrix", "load", "system", "adjust",
-    "autosym", "noautosym", "autoz", "noautoz", "center", "nocenter", "print",
+    "units", "autosym", "noautosym", "autoz", "noautoz", "center", "nocenter",
+    "print", "system", "adjust",
 }
+# Sub-directives whose presence means the block is NOT a plain Cartesian list we
+# can count atom-for-atom (internal coords, external/loaded coords, nested
+# blocks with their own `end`). We skip the check rather than risk a false fail.
+_NONCARTESIAN = {"zmatrix", "zcoord", "load", "constraints"}
+# NWChem placeholders that are not physical atoms (ghost / dummy centers).
+_GHOST_DUMMY = {"x", "bq"}
 _ELEMENT_RE = re.compile(r"^([A-Z][a-z]?)")
 
 
-def _parse_geometry_elements(deck: str) -> Optional[List[str]]:
-    """Element symbols from the first ``geometry ... end`` block.
+def _parse_geometry_block(deck: str) -> Optional[Dict[str, Any]]:
+    """Parse the first ``geometry ... end`` block.
 
-    Each atom line is ``<Element> <x> <y> <z>``; directive lines (``units``,
-    ``symmetry``, ``zcoord``, …) inside the block are skipped. Returns ``None``
-    when the deck has no parseable geometry block.
+    Returns ``None`` when there is no geometry block, otherwise
+    ``{"elements": [...], "reliable": bool, "note": str}``. ``reliable`` is
+    ``False`` when the block uses a form we cannot safely count atom-for-atom (a
+    Z-matrix, external/loaded coordinates, or a non-C1 symmetry group that may
+    list only the asymmetric unit) — the caller then skips instead of failing.
     """
     in_block = False
     elements: List[str] = []
     for raw in deck.splitlines():
         line = raw.split("#", 1)[0].strip()
+        toks = line.split()
         if not in_block:
-            if line.lower().startswith("geometry"):
+            if toks and toks[0].lower() == "geometry":   # whole-word match
                 in_block = True
             continue
-        low = line.lower()
-        if low == "end" or low.startswith("end "):
-            return elements
-        if not line:
+        if not toks:
             continue
-        first = line.split()[0]
-        if first.lower().rstrip(":") in _GEOMETRY_DIRECTIVES:
+        head = toks[0].lower().rstrip(":")
+        if head == "end":
+            return {"elements": elements, "reliable": True, "note": ""}
+        if head in _NONCARTESIAN:
+            return {"elements": [], "reliable": False,
+                    "note": f"geometry uses `{head}` (non-Cartesian / external "
+                            "coordinates); atom-count check skipped"}
+        if head == "symmetry":
+            grp = toks[1].lower() if len(toks) > 1 else "c1"
+            if grp not in ("c1", ""):
+                return {"elements": [], "reliable": False,
+                        "note": f"geometry declares symmetry `{grp}`; the block "
+                                "may list only the asymmetric unit — check skipped"}
             continue
-        parts = line.split()
-        if len(parts) < 4:            # an atom line needs an element + x y z
+        if head in _GEOMETRY_DIRECTIVES:
             continue
-        m = _ELEMENT_RE.match(first)  # strip tags/charges: "O1" -> "O"
-        if m:
-            elements.append(m.group(1))
-    return elements if in_block else None
+        if len(toks) < 4:                 # an atom line needs an element + x y z
+            continue
+        m = _ELEMENT_RE.match(toks[0])    # strip tags/charges: "O1" -> "O"
+        if not m:
+            continue
+        el = m.group(1)
+        if el.lower() in _GHOST_DUMMY:    # ghost/dummy: not a physical atom
+            continue
+        elements.append(el)
+    # Block opened but no explicit `end` — use what we parsed.
+    return ({"elements": elements, "reliable": True, "note": ""}
+            if in_block else None)
 
 
 def _source_elements(structure_file: str) -> Optional[List[str]]:
@@ -79,16 +103,19 @@ def check_geometry_consistency(*, input_files: Dict[str, str],
       * ``skipped``  — no parseable geometry block, or the structure file can't
                        be read (never block on an inapplicable case).
     """
-    deck_elems: Optional[List[str]] = None
+    parsed: Optional[Dict[str, Any]] = None
     for content in (input_files or {}).values():
         if isinstance(content, str):
-            parsed = _parse_geometry_elements(content)
-            if parsed is not None:
-                deck_elems = parsed
+            block = _parse_geometry_block(content)
+            if block is not None:
+                parsed = block
                 break
-    if deck_elems is None:
+    if parsed is None:
         return {"status": "skipped",
                 "reason": "no parseable `geometry` block in the deck"}
+    if not parsed["reliable"]:
+        return {"status": "skipped", "reason": parsed["note"]}
+    deck_elems = parsed["elements"]
 
     src_elems = _source_elements(structure_file)
     if src_elems is None:

--- a/scilink/skills/molecular_qc/nwchem/nwchem_geometry.py
+++ b/scilink/skills/molecular_qc/nwchem/nwchem_geometry.py
@@ -1,0 +1,142 @@
+"""Deterministic geometry-consistency check for NWChem decks (issue #400).
+
+The deck's inline ``geometry ... end`` block is transcribed from the source
+structure by the LLM; a dropped atom or a wrong element yields a deck that runs
+to completion on the *wrong* system — the run succeeds, the output parses, and
+the answer is simply for a different molecule. This module parses that block and
+compares it against the source structure file on atom count and per-element
+composition, so a silent transcription error fails generation loudly.
+
+No LLM, cheap, engine-specific: it lives in the NWChem skill bundle and the
+agent resolves it through the registry (the agent names no parser).
+"""
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Any, Dict, List, Optional
+
+from ..._shared._spec import ToolSpec
+
+# Non-atom lines that can appear inside a `geometry` block.
+_GEOMETRY_DIRECTIVES = {
+    "units", "symmetry", "zcoord", "zmatrix", "load", "system", "adjust",
+    "autosym", "noautosym", "autoz", "noautoz", "center", "nocenter", "print",
+}
+_ELEMENT_RE = re.compile(r"^([A-Z][a-z]?)")
+
+
+def _parse_geometry_elements(deck: str) -> Optional[List[str]]:
+    """Element symbols from the first ``geometry ... end`` block.
+
+    Each atom line is ``<Element> <x> <y> <z>``; directive lines (``units``,
+    ``symmetry``, ``zcoord``, …) inside the block are skipped. Returns ``None``
+    when the deck has no parseable geometry block.
+    """
+    in_block = False
+    elements: List[str] = []
+    for raw in deck.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not in_block:
+            if line.lower().startswith("geometry"):
+                in_block = True
+            continue
+        low = line.lower()
+        if low == "end" or low.startswith("end "):
+            return elements
+        if not line:
+            continue
+        first = line.split()[0]
+        if first.lower().rstrip(":") in _GEOMETRY_DIRECTIVES:
+            continue
+        parts = line.split()
+        if len(parts) < 4:            # an atom line needs an element + x y z
+            continue
+        m = _ELEMENT_RE.match(first)  # strip tags/charges: "O1" -> "O"
+        if m:
+            elements.append(m.group(1))
+    return elements if in_block else None
+
+
+def _source_elements(structure_file: str) -> Optional[List[str]]:
+    try:
+        from ase.io import read as ase_read
+        atoms = ase_read(structure_file)
+        return list(atoms.get_chemical_symbols())
+    except Exception:
+        return None
+
+
+def check_geometry_consistency(*, input_files: Dict[str, str],
+                               structure_file: str,
+                               **_ignored: Any) -> Dict[str, Any]:
+    """Compare a generated deck's geometry to the source structure.
+
+    Returns a status dict:
+      * ``ok``       — atom count and per-element composition match;
+      * ``mismatch`` — they differ (fail loud; a wrong-system deck is
+                       unrecoverable downstream);
+      * ``skipped``  — no parseable geometry block, or the structure file can't
+                       be read (never block on an inapplicable case).
+    """
+    deck_elems: Optional[List[str]] = None
+    for content in (input_files or {}).values():
+        if isinstance(content, str):
+            parsed = _parse_geometry_elements(content)
+            if parsed is not None:
+                deck_elems = parsed
+                break
+    if deck_elems is None:
+        return {"status": "skipped",
+                "reason": "no parseable `geometry` block in the deck"}
+
+    src_elems = _source_elements(structure_file)
+    if src_elems is None:
+        return {"status": "skipped",
+                "reason": f"could not read source structure {structure_file!r}"}
+
+    deck_comp, src_comp = Counter(deck_elems), Counter(src_elems)
+    if deck_comp == src_comp:
+        return {"status": "ok", "n_atoms": len(deck_elems),
+                "composition": dict(sorted(deck_comp.items()))}
+
+    reasons: List[str] = []
+    if len(deck_elems) != len(src_elems):
+        reasons.append(f"atom count {len(deck_elems)} (deck) vs "
+                       f"{len(src_elems)} (source)")
+    per_el = [f"{el}: {deck_comp.get(el, 0)} vs {src_comp.get(el, 0)}"
+              for el in sorted(set(deck_comp) | set(src_comp))
+              if deck_comp.get(el, 0) != src_comp.get(el, 0)]
+    if per_el:
+        reasons.append("per-element counts (deck vs source) — " + ", ".join(per_el))
+    return {
+        "status": "mismatch",
+        "reason": "; ".join(reasons),
+        "deck_composition": dict(sorted(deck_comp.items())),
+        "source_composition": dict(sorted(src_comp.items())),
+    }
+
+
+TOOL_SPEC = ToolSpec(
+    name="check_geometry_consistency",
+    description=(
+        "Deterministically verify that a generated NWChem deck's inline "
+        "geometry block matches the source structure file on atom count and "
+        "per-element composition, catching a silent LLM transcription error "
+        "(a dropped atom or wrong element) that would otherwise run to "
+        "completion on the wrong system."
+    ),
+    parameters={
+        "input_files": {"type": "object",
+                        "description": "{filename: contents} of the generated deck"},
+        "structure_file": {"type": "string",
+                           "description": "the source structure the deck was generated from"},
+    },
+    required=["input_files", "structure_file"],
+    signature=("check_geometry_consistency(*, input_files, structure_file) -> "
+               "dict(status='ok'|'mismatch'|'skipped', ...)"),
+    import_line=("from scilink.skills.molecular_qc.nwchem.nwchem_geometry "
+                 "import check_geometry_consistency"),
+    agents=["simulation"],
+    returns="status dict; a 'mismatch' fails generation loudly",
+)

--- a/scilink/skills/molecular_qc/nwchem/nwchem_geometry.py
+++ b/scilink/skills/molecular_qc/nwchem/nwchem_geometry.py
@@ -29,7 +29,24 @@ _GEOMETRY_DIRECTIVES = {
 _NONCARTESIAN = {"zmatrix", "zcoord", "load", "constraints"}
 # NWChem placeholders that are not physical atoms (ghost / dummy centers).
 _GHOST_DUMMY = {"x", "bq"}
-_ELEMENT_RE = re.compile(r"^([A-Z][a-z]?)")
+# Leading 1-2 letters of an atom-line token. Case-insensitive (NWChem element
+# tags are case-insensitive, so `o` is a legal atom line); normalized with
+# `.capitalize()` and checked against the real element symbols below.
+_ELEMENT_RE = re.compile(r"^([A-Za-z]{1,2})")
+
+_SYMBOLS_CACHE = None
+
+
+def _is_element(symbol: str) -> bool:
+    """Whether ``symbol`` (already capitalized) is a real chemical element."""
+    global _SYMBOLS_CACHE
+    if _SYMBOLS_CACHE is None:
+        try:
+            from ase.data import chemical_symbols
+            _SYMBOLS_CACHE = frozenset(chemical_symbols)
+        except Exception:
+            _SYMBOLS_CACHE = frozenset()
+    return symbol in _SYMBOLS_CACHE
 
 
 def _parse_geometry_block(deck: str) -> Optional[Dict[str, Any]]:
@@ -68,15 +85,23 @@ def _parse_geometry_block(deck: str) -> Optional[Dict[str, Any]]:
             continue
         if head in _GEOMETRY_DIRECTIVES:
             continue
+        # An atom line: element symbol + coordinates. Element tags are
+        # case-insensitive, so normalize; a ghost/dummy centre is excluded; and
+        # a >=4-token line whose leading token is NOT a real element cannot be
+        # counted — skip the whole check rather than silently drop the line (a
+        # dropped line would fail a correct deck loudly, the very failure this
+        # module promises to avoid).
         if len(toks) < 4:                 # an atom line needs an element + x y z
             continue
-        m = _ELEMENT_RE.match(toks[0])    # strip tags/charges: "O1" -> "O"
-        if not m:
-            continue
-        el = m.group(1)
-        if el.lower() in _GHOST_DUMMY:    # ghost/dummy: not a physical atom
-            continue
-        elements.append(el)
+        m = _ELEMENT_RE.match(toks[0])    # tag/charge-tolerant: "O1"/"o" -> "O"
+        sym = m.group(1).capitalize() if m else None
+        if sym is not None and sym.lower() in _GHOST_DUMMY:
+            continue                      # ghost/dummy: not a physical atom
+        if sym is None or not _is_element(sym):
+            return {"elements": [], "reliable": False,
+                    "note": f"unrecognized atom line in geometry block: "
+                            f"{line[:60]!r}"}
+        elements.append(sym)
     # Block opened but no explicit `end` — use what we parsed.
     return ({"elements": elements, "reliable": True, "note": ""}
             if in_block else None)

--- a/tests/test_molecular_qc_geometry_check.py
+++ b/tests/test_molecular_qc_geometry_check.py
@@ -1,0 +1,130 @@
+"""Tests for the deterministic NWChem geometry-consistency check (issue #400)."""
+import textwrap
+
+import pytest
+
+from scilink.skills.molecular_qc.nwchem.nwchem_geometry import (
+    check_geometry_consistency,
+)
+
+_CO2_XYZ = textwrap.dedent("""\
+    3
+    CO2
+    O 0.0 0.0 0.0
+    C 0.0 0.0 1.16
+    O 0.0 0.0 2.32
+""")
+
+_DECK_OK = textwrap.dedent("""\
+    title "co2"
+    geometry units angstrom
+      symmetry c1
+      O 0.0 0.0 0.0
+      C 0.0 0.0 1.16
+      O 0.0 0.0 2.32
+    end
+    task scf energy
+""")
+
+# One oxygen dropped from the deck.
+_DECK_DROPPED = textwrap.dedent("""\
+    geometry units angstrom
+      O 0.0 0.0 0.0
+      C 0.0 0.0 1.16
+    end
+""")
+
+# Carbon transcribed as nitrogen.
+_DECK_WRONG_EL = textwrap.dedent("""\
+    geometry units angstrom
+      O 0.0 0.0 0.0
+      N 0.0 0.0 1.16
+      O 0.0 0.0 2.32
+    end
+""")
+
+_DECK_NO_GEOM = "task scf energy\n"
+
+
+@pytest.fixture
+def co2_xyz(tmp_path):
+    p = tmp_path / "co2.xyz"
+    p.write_text(_CO2_XYZ)
+    return str(p)
+
+
+def test_matching_deck_ok(co2_xyz):
+    r = check_geometry_consistency(input_files={"m.nw": _DECK_OK},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "ok"
+    assert r["n_atoms"] == 3
+    assert r["composition"] == {"C": 1, "O": 2}
+
+
+def test_dropped_atom_mismatch(co2_xyz):
+    r = check_geometry_consistency(input_files={"m.nw": _DECK_DROPPED},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "mismatch"
+    assert "atom count 2" in r["reason"]
+    assert r["deck_composition"] == {"C": 1, "O": 1}
+    assert r["source_composition"] == {"C": 1, "O": 2}
+
+
+def test_wrong_element_mismatch(co2_xyz):
+    r = check_geometry_consistency(input_files={"m.nw": _DECK_WRONG_EL},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "mismatch"
+    # same atom count, but composition differs (N appears, one C missing)
+    assert "N:" in r["reason"] and "C:" in r["reason"]
+
+
+def test_no_geometry_block_skipped(co2_xyz):
+    r = check_geometry_consistency(input_files={"m.nw": _DECK_NO_GEOM},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "skipped"
+
+
+def test_unreadable_structure_skipped():
+    r = check_geometry_consistency(input_files={"m.nw": _DECK_OK},
+                                   structure_file="/no/such/file.xyz")
+    assert r["status"] == "skipped"
+
+
+def test_composition_is_order_independent(co2_xyz):
+    reordered = textwrap.dedent("""\
+        geometry units angstrom
+          C 0.0 0.0 1.16
+          O 0.0 0.0 2.32
+          O 0.0 0.0 0.0
+        end
+    """)
+    r = check_geometry_consistency(input_files={"m.nw": reordered},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "ok"
+
+
+def test_registry_resolves_the_tool():
+    from scilink.skills._shared._registry import get_tool_function
+    fn = get_tool_function("check_geometry_consistency", active_skills=["nwchem"])
+    assert callable(fn)
+
+
+def test_agent_fails_loud_on_mismatch(co2_xyz, monkeypatch):
+    """generate_inputs returns status='error' when the deck drops an atom."""
+    from scilink.agents.sim_agents.molecular_qc_agent import MolecularQCAgent
+
+    # base_url set -> no vendor-credential check at construction; no network.
+    agent = MolecularQCAgent(api_key="dummy", base_url="http://localhost:0")
+
+    class _Resp:
+        text = "ignored"
+
+    monkeypatch.setattr(agent.model, "generate_content",
+                        lambda *a, **k: _Resp())
+    monkeypatch.setattr(agent, "_parse_response",
+                        lambda text: {"input_files": {"co2.nw": _DECK_DROPPED}})
+
+    result = agent.generate_inputs(structure_file=co2_xyz, request="scf energy")
+    assert result["status"] == "error"
+    assert "inconsistent" in result["message"]
+    assert result["geometry_check"]["status"] == "mismatch"

--- a/tests/test_molecular_qc_geometry_check.py
+++ b/tests/test_molecular_qc_geometry_check.py
@@ -103,6 +103,53 @@ def test_composition_is_order_independent(co2_xyz):
     assert r["status"] == "ok"
 
 
+def test_symmetry_group_skipped(co2_xyz):
+    """A non-C1 symmetry group may list only the asymmetric unit -> skip, not fail."""
+    deck = textwrap.dedent("""\
+        geometry units angstrom
+          symmetry d2h
+          O 0.0 0.0 0.0
+        end
+    """)
+    r = check_geometry_consistency(input_files={"m.nw": deck},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "skipped"
+    assert "symmetry" in r["reason"]
+
+
+def test_zmatrix_skipped(co2_xyz):
+    """A Z-matrix geometry isn't a plain Cartesian list -> skip, not false-fail."""
+    deck = textwrap.dedent("""\
+        geometry
+          zmatrix
+            O
+            C 1 1.16
+            O 1 1.16 2 180.0
+          end
+        end
+    """)
+    r = check_geometry_consistency(input_files={"m.nw": deck},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "skipped"
+    assert "zmatrix" in r["reason"]
+
+
+def test_ghost_atoms_excluded(co2_xyz):
+    """BSSE ghost (bq) / dummy centers are not physical atoms -> excluded, still ok."""
+    deck = textwrap.dedent("""\
+        geometry units angstrom
+          O  0.0 0.0 0.0
+          C  0.0 0.0 1.16
+          O  0.0 0.0 2.32
+          Bq 5.0 5.0 5.0
+        end
+    """)
+    r = check_geometry_consistency(input_files={"m.nw": deck},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "ok"
+    assert r["composition"] == {"C": 1, "O": 2}
+
+
 def test_registry_resolves_the_tool():
     from scilink.skills._shared._registry import get_tool_function
     fn = get_tool_function("check_geometry_consistency", active_skills=["nwchem"])

--- a/tests/test_molecular_qc_geometry_check.py
+++ b/tests/test_molecular_qc_geometry_check.py
@@ -150,6 +150,50 @@ def test_ghost_atoms_excluded(co2_xyz):
     assert r["composition"] == {"C": 1, "O": 2}
 
 
+def test_lowercase_deck_ok(co2_xyz):
+    """NWChem element tags are case-insensitive — a lowercase deck is valid."""
+    deck = textwrap.dedent("""\
+        geometry units angstrom
+          o 0.0 0.0 0.0
+          c 0.0 0.0 1.16
+          o 0.0 0.0 2.32
+        end
+    """)
+    r = check_geometry_consistency(input_files={"m.nw": deck},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "ok"
+    assert r["composition"] == {"C": 1, "O": 2}
+
+
+def test_mixed_case_element_ok(co2_xyz):
+    """`CL`, `cl`, `Cl` all normalize to the same element."""
+    deck = textwrap.dedent("""\
+        geometry units angstrom
+          O 0.0 0.0 0.0
+          C 0.0 0.0 1.16
+          o 0.0 0.0 2.32
+        end
+    """)
+    r = check_geometry_consistency(input_files={"m.nw": deck},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "ok" and r["composition"] == {"C": 1, "O": 2}
+
+
+def test_unrecognized_atom_line_skipped(co2_xyz):
+    """A >=4-token line that doesn't parse as a real element -> skip, not fail."""
+    deck = textwrap.dedent("""\
+        geometry units angstrom
+          O  0.0 0.0 0.0
+          Zz 0.0 0.0 1.16
+          O  0.0 0.0 2.32
+        end
+    """)
+    r = check_geometry_consistency(input_files={"m.nw": deck},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "skipped"
+    assert "unrecognized" in r["reason"]
+
+
 def test_registry_resolves_the_tool():
     from scilink.skills._shared._registry import get_tool_function
     fn = get_tool_function("check_geometry_consistency", active_skills=["nwchem"])


### PR DESCRIPTION
Closes #400.

The NWChem deck's inline `geometry` block is LLM-transcribed from the source structure (`molecular_qc_agent.py` injects the structure as raw text and the model copies it into `geometry ... end`). A silent transcription error — a dropped atom, a wrong element — produces a deck that runs to completion on the **wrong** system: the run succeeds, the output parses, the answer is for a different molecule. Every other failure mode has a guard; this one didn't.

## What this adds
A deterministic, no-LLM, **fail-loud** check after deck generation.

- **New skill-bundle tool** `skills/molecular_qc/nwchem/nwchem_geometry.py` — `check_geometry_consistency(input_files, structure_file)` parses the deck's first `geometry ... end` block (element = first token per atom line; skips in-block directives like `units`/`symmetry`/`zcoord`) and compares **atom count** and **per-element composition** against the ASE-read structure. Returns `ok` / `mismatch` / `skipped`.
- **`MolecularQCAgent.generate_inputs`** resolves it through the registry (`active_skills=[software]`) after the deck is assembled and, on `mismatch`, returns an error status dict — generation fails loudly. `ok`/`skipped` proceed (a `skipped` covers no-geometry-block or unreadable-structure, so it never blocks an inapplicable case); a QC engine without the tool no-ops, matching the existing advisory syntax hook.
- **Engine-neutral:** the agent names no parser; a future QC engine adds its own bundle tool of the same name.

## Testing
`tests/test_molecular_qc_geometry_check.py` (8 cases, all passing): matching deck → `ok`; dropped atom / wrong element → `mismatch`; no geometry block / unreadable structure → `skipped`; reordered atoms → `ok`; registry resolution; and an agent-level test asserting `generate_inputs` returns `status="error"` on a mismatched deck.

## Scope note
Parses the first geometry block (QC decks are single-system); multi-fragment or nested-directive decks fall to `skipped` rather than a false failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)