### PR TITLE
fix: derive structure_class from scale in the one-shot pipeline (#474)

### DIFF
--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -1003,10 +1003,16 @@ class SimulationOrchestratorTools:
                     "type": "string",
                     "description": (
                         "Optional structure-class override ('crystal' | "
-                        "'molecular' | 'condensed' | 'biomolecular'). Omit to "
-                        "derive it from the scale (molecular_dynamics -> "
-                        "condensed, periodic_dft -> crystal); set it explicitly "
-                        "for a biomolecular MD system."
+                        "'molecular' | 'condensed' | 'biomolecular'). Omit and it "
+                        "is derived from the scale, where the molecular_dynamics "
+                        "default 'condensed' means a liquid / solution / solvated "
+                        "box. MD also covers crystalline and biomolecular systems, "
+                        "and the derived default is wrong for those — so SET IT "
+                        "EXPLICITLY from the task: 'crystal' for a crystalline "
+                        "solid, a melt-from-crystal, or a slab interface (e.g. "
+                        "melting Cu, Li diffusion in LiCoO2, water on a TiO2 slab); "
+                        "'biomolecular' for a protein. periodic_dft derives "
+                        "'crystal', molecular_qc derives 'molecular'."
                     ),
                 },
                 "max_run_cycles": {

--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -861,6 +861,7 @@ class SimulationOrchestratorTools:
         # =====================================================================
         def run_simulation(description: str, run_command: str = None,
                            scale: str = None, software: str = None,
+                           structure_class: str = None,
                            max_refinement_cycles: int = 4,
                            max_run_cycles: int = 3,
                            run_timeout: int = 3600) -> str:
@@ -910,6 +911,7 @@ class SimulationOrchestratorTools:
                 result = run_complete_workflow(
                     description,
                     scale=scale, software=software,
+                    structure_class=structure_class,
                     output_dir=str(workdir),
                     api_key=self.orch.api_key, base_url=self.orch.base_url,
                     model_name=self.orch.model_name,
@@ -996,6 +998,16 @@ class SimulationOrchestratorTools:
                     "type": "string",
                     "description": ("Optional engine override "
                                     "('vasp' | 'lammps'); routed if omitted."),
+                },
+                "structure_class": {
+                    "type": "string",
+                    "description": (
+                        "Optional structure-class override ('crystal' | "
+                        "'molecular' | 'condensed' | 'biomolecular'). Omit to "
+                        "derive it from the scale (molecular_dynamics -> "
+                        "condensed, periodic_dft -> crystal); set it explicitly "
+                        "for a biomolecular MD system."
+                    ),
                 },
                 "max_run_cycles": {
                     "type": "integer",

--- a/scilink/agents/sim_agents/simulation_pipeline.py
+++ b/scilink/agents/sim_agents/simulation_pipeline.py
@@ -53,6 +53,18 @@ _DEFAULT_ENGINE = {
 }
 
 
+# Default structure class per scale, used when the caller does not specify one.
+# A classical-MD run is a liquid / solvated / condensed-phase box, NOT a crystal
+# (issue #474): building and validating it under the crystal rubric applies the
+# wrong packing guidance and validation criteria. Periodic DFT is crystalline;
+# molecular QC is a finite molecule. Explicit callers still win (None sentinel).
+_SCALE_STRUCTURE_CLASS = {
+    "periodic_dft": "crystal",
+    "molecular_qc": "molecular",
+    "molecular_dynamics": "condensed",
+}
+
+
 def _generate_classical_md_inputs(
     *, software, structure_file, request, output_dir, api_key, base_url,
     model_name, force_field_files, staged, required_observables,
@@ -409,7 +421,7 @@ def _run_workflow_once(
     scale: str = "periodic_dft",
     software: Optional[str] = None,
     method: str = "llm",
-    structure_class: str = "crystal",
+    structure_class: Optional[str] = None,
     output_dir: str = "simulation_workflow_output",
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
@@ -444,7 +456,10 @@ def _run_workflow_once(
             foundation agent's generation; a named backend (e.g.
             ``"atomate2"``) resolves to a skill-bundle generation tool.
         structure_class: Structure-class hint forwarded to structure
-            generation.
+            generation. When ``None`` (the default) it is derived from ``scale``
+            (``molecular_dynamics`` -> ``condensed``, ``periodic_dft`` ->
+            ``crystal``, ``molecular_qc`` -> ``molecular``); an explicit value
+            wins, so a biomolecular MD run can still pass ``"biomolecular"``.
         output_dir: Directory for all generated files.
         api_key, base_url, model_name: LLM credentials.
         futurehouse_api_key: Optional FutureHouse key enabling
@@ -492,6 +507,12 @@ def _run_workflow_once(
     """
     software = software or _DEFAULT_ENGINE.get(scale)
     os.makedirs(output_dir, exist_ok=True)
+    # Derive the structure class from the scale when the caller didn't set one,
+    # so a classical-MD run builds/validates as a condensed system rather than a
+    # crystal (issue #474). An explicit structure_class always wins.
+    if structure_class is None:
+        structure_class = _SCALE_STRUCTURE_CLASS.get(scale, "crystal")
+
     result: Dict[str, Any] = {
         "user_request": user_request,
         "scale": scale,

--- a/scilink/agents/sim_agents/simulation_pipeline.py
+++ b/scilink/agents/sim_agents/simulation_pipeline.py
@@ -54,14 +54,22 @@ _DEFAULT_ENGINE = {
 
 
 # Default structure class per scale, used when the caller does not specify one.
-# A classical-MD run is a liquid / solvated / condensed-phase box, NOT a crystal
-# (issue #474): building and validating it under the crystal rubric applies the
-# wrong packing guidance and validation criteria. Periodic DFT is crystalline;
-# molecular QC is a finite molecule. Explicit callers still win (None sentinel).
+# For MD, ``condensed`` is the *liquids / solutions* default: a solvated box built
+# and validated under the crystal rubric gets the wrong packing guidance and
+# validation criteria (issue #474). It is only a default — since #432 the MD scale
+# also absorbs crystalline solids, melts-from-crystal, and slab interfaces, and
+# those must be built as ``crystal``; the caller (an LLM reading the
+# ``structure_class`` description) sets it explicitly for those. Periodic DFT is
+# crystalline; molecular QC is a finite molecule. Explicit callers always win
+# (None sentinel). ``machine_learning_potentials`` is a deprecated MLIP-as-scale
+# shim that this module treats as an MD task, so it shares MD's ``condensed``
+# default deliberately (rather than falling through to ``crystal``); a crystalline
+# MLIP-MD run passes ``structure_class="crystal"`` the same way classical MD does.
 _SCALE_STRUCTURE_CLASS = {
     "periodic_dft": "crystal",
     "molecular_qc": "molecular",
     "molecular_dynamics": "condensed",
+    "machine_learning_potentials": "condensed",
 }
 
 
@@ -457,9 +465,13 @@ def _run_workflow_once(
             ``"atomate2"``) resolves to a skill-bundle generation tool.
         structure_class: Structure-class hint forwarded to structure
             generation. When ``None`` (the default) it is derived from ``scale``
-            (``molecular_dynamics`` -> ``condensed``, ``periodic_dft`` ->
-            ``crystal``, ``molecular_qc`` -> ``molecular``); an explicit value
-            wins, so a biomolecular MD run can still pass ``"biomolecular"``.
+            (``periodic_dft`` -> ``crystal``, ``molecular_qc`` -> ``molecular``,
+            ``molecular_dynamics`` -> ``condensed``). The MD default of
+            ``condensed`` is the *liquids / solutions* case; pass an explicit
+            value for the others the MD scale now covers (since #432):
+            ``"crystal"`` for a crystalline solid, a melt-from-crystal, or a
+            slab interface, and ``"biomolecular"`` for a protein. An explicit
+            value always wins.
         output_dir: Directory for all generated files.
         api_key, base_url, model_name: LLM credentials.
         futurehouse_api_key: Optional FutureHouse key enabling
@@ -509,7 +521,9 @@ def _run_workflow_once(
     os.makedirs(output_dir, exist_ok=True)
     # Derive the structure class from the scale when the caller didn't set one,
     # so a classical-MD run builds/validates as a condensed system rather than a
-    # crystal (issue #474). An explicit structure_class always wins.
+    # crystal (issue #474). This is only the default for the scale's typical case
+    # (liquids for MD); crystalline-solid / slab MD and biomolecular MD rely on
+    # the caller passing structure_class explicitly. An explicit value always wins.
     if structure_class is None:
         structure_class = _SCALE_STRUCTURE_CLASS.get(scale, "crystal")
 

--- a/tests/test_structure_class_from_scale.py
+++ b/tests/test_structure_class_from_scale.py
@@ -1,0 +1,72 @@
+"""structure_class is derived from scale when unset (issue #474).
+
+A classical-MD run must build/validate as a condensed system, not a crystal.
+We stub StructurePipeline to capture the structure_class the pipeline passes it,
+returning a non-success result so the pipeline stops right after structure gen.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import scilink.agents.sim_agents.simulation_pipeline as sp  # noqa: E402
+import scilink.agents.sim_agents.structure_pipeline as spmod  # noqa: E402
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    seen = {}
+
+    class FakeStructurePipeline:
+        def __init__(self, **kw):
+            self.api_key = kw.get("api_key")
+            self.base_url = kw.get("base_url")
+
+        def generate_and_validate(self, request, structure_class=None):
+            seen["structure_class"] = structure_class
+            return {"status": "stopped"}   # non-success -> pipeline returns early
+
+    monkeypatch.setattr(spmod, "StructurePipeline", FakeStructurePipeline)
+    return seen
+
+
+def _run(captured, tmp_path, **kw):
+    sp._run_workflow_once(
+        user_request="an aqueous NaCl electrolyte box",
+        output_dir=str(tmp_path), api_key="k", base_url="http://localhost:0",
+        **kw)
+    return captured["structure_class"]
+
+
+def test_md_derives_condensed(captured, tmp_path):
+    assert _run(captured, tmp_path, scale="molecular_dynamics") == "condensed"
+
+
+def test_periodic_dft_derives_crystal(captured, tmp_path):
+    assert _run(captured, tmp_path, scale="periodic_dft") == "crystal"
+
+
+def test_molecular_qc_derives_molecular(captured, tmp_path):
+    assert _run(captured, tmp_path, scale="molecular_qc") == "molecular"
+
+
+def test_explicit_class_wins(captured, tmp_path):
+    # A biomolecular MD system can still opt out of the condensed default.
+    got = _run(captured, tmp_path, scale="molecular_dynamics",
+               structure_class="biomolecular")
+    assert got == "biomolecular"
+
+
+def test_unknown_scale_defaults_crystal(captured, tmp_path):
+    assert _run(captured, tmp_path, scale="something_new") == "crystal"
+
+
+def test_run_complete_workflow_threads_class(captured, tmp_path):
+    # The public entry point passes structure_class through to the derivation.
+    sp.run_complete_workflow(
+        "an aqueous NaCl electrolyte box", scale="molecular_dynamics",
+        output_dir=str(tmp_path), api_key="k", base_url="http://localhost:0")
+    assert captured["structure_class"] == "condensed"

--- a/tests/test_structure_class_from_scale.py
+++ b/tests/test_structure_class_from_scale.py
@@ -60,6 +60,21 @@ def test_explicit_class_wins(captured, tmp_path):
     assert got == "biomolecular"
 
 
+def test_explicit_crystal_wins_for_crystalline_md(captured, tmp_path):
+    # Crystalline-solid / slab MD (which the MD scale absorbs since #432) is
+    # built as a crystal when the caller says so, not the condensed default.
+    got = _run(captured, tmp_path, scale="molecular_dynamics",
+               structure_class="crystal")
+    assert got == "crystal"
+
+
+def test_mlip_shim_derives_condensed(captured, tmp_path):
+    # The deprecated machine_learning_potentials scale is treated as an MD task,
+    # so it deliberately shares MD's condensed default (not a crystal fall-through).
+    assert _run(captured, tmp_path,
+                scale="machine_learning_potentials") == "condensed"
+
+
 def test_unknown_scale_defaults_crystal(captured, tmp_path):
     assert _run(captured, tmp_path, scale="something_new") == "crystal"
 


### PR DESCRIPTION
Closes #474.

The one-shot `run_simulation` path hardcoded `structure_class="crystal"` in `_run_workflow_once` regardless of `scale`, so a classical-MD run of a solvated / condensed-phase system (explicit water + ions) was built **and validated** under the `crystal` skill and rubric — the condensed-phase packing guidance and validation criteria were never applied. The two-step `plan_structure` → `generate_structure` path could set the class; the one-shot path couldn't.

## Fix
- **`_run_workflow_once`**: `structure_class` defaults to `None` and is derived from `scale` via `_SCALE_STRUCTURE_CLASS` (`molecular_dynamics → condensed`, `periodic_dft → crystal`, `molecular_qc → molecular`; unknown → `crystal`). An **explicit `structure_class` still wins**, so a biomolecular MD run can pass `"biomolecular"`. `run_complete_workflow` already threads it via `**kwargs`.
- **`run_simulation` tool**: exposes an optional `structure_class` override (signature + tool spec) and passes it through, so a caller can override the derived default.

## Tests
`tests/test_structure_class_from_scale.py` (6): scale→class derivation for each scale, explicit override wins, unknown-scale fallback to crystal, and the public `run_complete_workflow` passthrough — all by stubbing `StructurePipeline` to capture the class it receives.

## Scope note
The derivation is a deterministic scale→class default (a strict improvement over the crystal hardcode). Running `StructurePlanner` inside the one-shot path to pick the class from the description (e.g. condensed vs biomolecular MD) is a possible follow-up; explicit callers and the two-step path already cover that today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)