### PR TITLE
feat: route surgical input-file edits in the sim orchestrator prompt (#439 Tier 1)

### DIFF
--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -162,6 +162,14 @@ inside `generate_structure` when MP_API_KEY is available.
 - When a user request contains parameters you had to infer (polymorph
   choice, default supercell, etc.), say so explicitly so they can confirm
   or override.
+- For a small, exact change to an existing input file — `ENCUT = 520` in an
+  INCAR, a timestep or temperature in a LAMMPS deck — use `edit_file` (a
+  byte-exact surgical edit that leaves everything else untouched), NOT
+  `apply_input_adjustments`. Reserve `apply_input_adjustments` for a larger or
+  physics-changing revision that retunes several coupled settings at once (it
+  regenerates the inputs and can perturb parameters you did not mean to change);
+  `edit_file`'s cap-exceeded hint points you there when a change is too big for a
+  surgical edit. Use `rename_file` to change a filename byte-exactly.
 """
 
 

--- a/tests/test_sim_orchestrator_edit_routing.py
+++ b/tests/test_sim_orchestrator_edit_routing.py
@@ -1,0 +1,20 @@
+"""The simulation orchestrator's system prompt routes surgical input edits to
+`edit_file` and larger revisions to `apply_input_adjustments` (#439 Tier 1)."""
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scilink.agents.sim_agents.simulation_orchestrator import (  # noqa: E402
+    _SYSTEM_PROMPT_BODY)
+
+
+def test_system_prompt_routes_surgical_edits():
+    body = _SYSTEM_PROMPT_BODY.lower()
+    # Both tools are named, and the guidance distinguishes them.
+    assert "edit_file" in body
+    assert "apply_input_adjustments" in body
+    assert "surgical" in body or "byte-exact" in body
+    # The canonical example (a small exact input change) is present.
+    assert "encut" in body


### PR DESCRIPTION
Completes **Tier 1** of #439.

The `edit_file` / `rename_file` machinery for the simulation orchestrator already landed in `f5d30d8c` — the wrappers, tool specs, the VASP-aware extensionless-suffix policy (`_SIM_EDIT_SUFFIXES`), the cap-hint routing to `apply_input_adjustments`, and the targeted tests (INCAR `ENCUT` edit + backup, `.png`/binary/out-of-sandbox refusal, byte-exact rename — all green). The one piece missing was item-4 from the discussion: the **routing narrative in the orchestrator's system prompt**. `edit_file` wasn't mentioned there, so the model was never told when to prefer a surgical edit over regeneration.

## Change
One Conventions bullet in `SimulationOrchestratorAgent`'s system prompt:
- a **small, exact** input-file change (`ENCUT = 520` in an INCAR, a timestep/temperature in a LAMMPS deck) → `edit_file` (byte-exact, leaves everything else untouched);
- a **larger or physics-changing** revision that retunes several coupled settings → `apply_input_adjustments` (regenerates, and can perturb parameters you didn't mean to change); the `edit_file` cap-hint points there;
- `rename_file` to change a filename byte-exactly.

## Test
`tests/test_sim_orchestrator_edit_routing.py` asserts the system prompt names both tools, distinguishes them (surgical/byte-exact), and includes the canonical `ENCUT` example. The existing targeted orchestrator tests remain 9/9.

## Not in this PR (per the discussion)
Tier 2 (`SimulationAnalysisAgent` on the shared codegen QC engine — after #405, with a seam check) and Tier 3 (deck bank — a design doc first, with the observable-requirements contract as the guardrail, UC2 as first campaign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)