### PR TITLE
Add --skills flag to scilink plan

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -1,0 +1,117 @@
+# CLI reference
+
+Every command supports `--help` for its full flag list; this page covers the
+commands and the flags you'll actually reach for.
+
+## Commands
+
+| Command | What it starts |
+|---|---|
+| `scilink` | **Mission control** (the meta agent) — routes tasks across plan / analyze / simulate. Explicit form: `scilink explore` (alias `meta`) |
+| `scilink ui` | Mission control and all modes in the browser |
+| `scilink plan` | Planning session — experimental design, ideation, optimization |
+| `scilink analyze` | Analysis session — images, spectra, datacubes, curve series |
+| `scilink simulate` | Simulation session — structures, DFT, classical MD |
+| `scilink serve` | MCP server — expose SciLink's tools to another agent |
+| `scilink kb` | Manage named knowledge bases (see [knowledge_and_data.md](knowledge_and_data.md)) |
+| `scilink memory` | Manage persistent learned skills under `~/.scilink/` |
+| `scilink fetch-xrd-library` | Download the COD fingerprint library for XRD phase ID |
+
+## Mission control — `scilink` / `scilink explore`
+
+```bash
+scilink                                        # interactive, autopilot
+scilink explore --mode autonomous \
+    --message "Analyze ./stem.tif, then design a follow-up campaign"   # one-shot brief
+scilink explore --knowledge-dir produced-water # attach a named KB or path
+scilink explore --restore --session-dir ./meta_session_...             # resume
+```
+
+Key flags: `--mode {autopilot,autonomous}` (the meta agent has two levels, not
+three — a delegation must complete within a turn), `--message` (seed the first
+turn — the one-shot-brief entry point), `--knowledge-dir`, `--session-dir` /
+`--restore`, `--model` / `--base-url` / `--api-key`, `--embedding-model`,
+`--tools` / `--skills` / `--mcp`.
+
+## Specialist modes
+
+```bash
+scilink plan --autonomy autopilot --data-dir ./results --knowledge-dir ./papers
+scilink analyze --data ./sample.tif --metadata ./metadata.json
+scilink analyze --skills ./raman_skill.md --tools ./my_image_tools.py
+scilink simulate --mode autopilot --request "rutile TiO2 supercell with one O vacancy"
+```
+
+- **`plan`**: `--autonomy {co-pilot,autopilot,autonomous}`, `--data-dir`,
+  `--knowledge-dir` (path or KB name), `--code-dir`, `--embedding-model`,
+  `--tools`, `--skills`, `--mcp`.
+- **`analyze`**: `--data`, `--metadata`, `--mode {co-pilot,autopilot,autonomous}`,
+  `--session-dir`, `--agents`, `--skills`, `--tools`, `--mcp`.
+- **`simulate`**: `--mode {co-pilot,autopilot,autonomous}`, `--request`
+  (one-shot), `--session-dir`, `--tools`, `--skills`, `--mp-api-key`,
+  `--futurehouse-api-key`.
+
+Custom extensions: `--tools` (Python tool files) and `--skills` (markdown
+skill bundles) are accepted by all chat modes; `--mcp` (external MCP
+servers) by `analyze`, `plan`, and mission control. See
+[custom_tools_integration.md](custom_tools_integration.md) and
+[mcp_client_integration.md](mcp_client_integration.md).
+
+## MCP server — `scilink serve`
+
+```bash
+scilink serve --model claude-opus-4-6                 # stdio, autonomous
+scilink serve --mode analyze --autonomy co-pilot      # one mode, human-gated
+scilink serve --transport sse --host 127.0.0.1 --port 8000
+scilink serve --print-mcp-json                        # ready-to-paste client config
+```
+
+`--mode {analyze,plan,both,meta}` selects the exposed surface — `meta` serves
+mission control itself as a single delegation tool. See
+[connecting_agent_clients.md](connecting_agent_clients.md).
+
+## In-session slash commands
+
+Chat sessions accept slash commands alongside natural language. Common set:
+`/help`, `/tools`, `/files` (plan) or `/agents` (analyze), `/state` or
+`/status`, `/autonomy [level]` (plan) or `/mode [level]` (analyze),
+`/checkpoint`, `/schema` (analyze — metadata JSON schema), `/quit`.
+
+## Persistent memory — `scilink memory`
+
+Learned skills (graduated or distilled from sessions) live under `~/.scilink/`
+(override with `$SCILINK_HOME`), outside the installed package, so they
+survive upgrades and load on every future run:
+
+```bash
+scilink memory status | enable | disable    # opt-in switch
+scilink memory list                         # persisted skills
+scilink memory staged                       # raw solutions awaiting distillation
+scilink memory show <domain>/<name>         # print a skill's markdown
+scilink memory upgrade <domain>/<id> --into <domain>/<name>
+scilink memory consolidate <domain>/<technique>   # distill N staged into a new skill
+scilink memory promote <domain>/<name>      # make a provisional skill auto-routable
+scilink memory bank                         # proven-script bank; also bank-show
+```
+
+> **Docker:** `~/.scilink` inside a container is ephemeral — mount a volume
+> (`-v ~/.scilink:/home/scilinkuser/.scilink`, or set `SCILINK_HOME` to a
+> mounted path) or learned skills are lost when the container exits.
+
+## Sessions
+
+Every chat mode writes a timestamped session directory (override with
+`--session-dir`) holding the artifacts it produced plus `chat_history.json`,
+`checkpoint.json`, and a session log; checkpoints make sessions resumable, and
+a fixed `--session-dir` is how a restarted MCP server resumes its campaign.
+Mission-control sessions nest their specialists' sessions
+(`<meta_session>/analysis/`, `planning/`, `simulation/`) so each delegation's
+outputs stay isolated.
+
+## API keys
+
+Set the key matching your model provider — `ANTHROPIC_API_KEY`,
+`OPENAI_API_KEY`, or `GOOGLE_API_KEY` — or, for an OpenAI-compatible internal
+proxy, `SCILINK_API_KEY` together with `--base-url`. The proxy key is not a
+vendor credential; vendor endpoints reject it. MCP-server deployments can keep
+all of these in `~/.scilink/credentials.env` instead of the client config.

--- a/docs/custom_tools_integration.md
+++ b/docs/custom_tools_integration.md
@@ -52,7 +52,7 @@ Two things to know about the factory:
 - **The first parameter name decides what the orchestrator passes you.** Names like `image`, `data`, or `array` mean "load the current file and pass it as a NumPy array (or a pandas DataFrame for CSV)." Names like `data_path`, `path`, or `file` mean "just pass the file path as a string."
 - **Add an `output_dir` keyword argument** if your tool wants to save plots or data files. The orchestrator auto-injects the session's `results/custom_tools/` directory so your outputs land next to the other session results.
 
-Working examples live in `examples/custom_image_tools.py` and `examples/custom_stats_tools.py`.
+The file above is the complete contract — a `tool_schemas` list plus a `create_tool_functions` factory in one `.py` file.
 
 ## Step 2: register your tool
 
@@ -67,7 +67,7 @@ scilink analyze --tools ./preprocess.py ./morphology.py
 
 ### Web UI
 
-In the Streamlit UI, open the **Tools & Agents** tab and upload your `.py` file under **Custom Tools**. Registered tools appear with their descriptions and remain available for the session.
+In the Streamlit UI, open the **Tools** tab and upload your `.py` file under **Upload Tools**. Registered tools appear with their descriptions and remain available for the session.
 
 ### Programmatic
 
@@ -174,7 +174,7 @@ If you'd rather be explicit than trust the hint, just say so in chat: *"now exam
 
 Custom tools are the lightest extension. SciLink also supports two heavier ones:
 
-- **`--agents ./my_agent.py`** — register a full analysis agent with its own `analyze()` method. Useful when the workflow is more involved than a single function. See `examples/custom_peak_agent.py` and `examples/custom_outlier_agent.py`.
+- **`--agents ./my_agent.py`** — register a full analysis agent with its own `analyze()` method. Useful when the workflow is more involved than a single function. The file contains one or more `BaseAnalysisAgent` subclasses; all subclasses found are registered automatically.
 - **`--skills ./my_skill.md`** — register a markdown skill file that built-in agents can load via the `skill` parameter of `run_analysis`. Useful for encoding domain-specific fitting or analysis recipes as guidance.
 
 All three flags combine in one command:
@@ -183,4 +183,4 @@ All three flags combine in one command:
 scilink analyze --tools ./preprocess.py --agents ./my_agent.py --skills ./raman.md
 ```
 
-The **Tools & Agents** tab in the web UI supports all three as well.
+In the web UI, custom tools upload via the **Tools** tab and custom skills via the **Skills** tab; custom agents are CLI/API only. The flags are not analyze-only either: `scilink plan`, `scilink simulate`, and `scilink explore` also accept both `--tools` and `--skills`.

--- a/scilink/cli/plan.py
+++ b/scilink/cli/plan.py
@@ -144,6 +144,15 @@ Supported Models:
         )
     )
 
+    parser.add_argument(
+        '--skills',
+        type=str,
+        nargs='+',
+        dest='skill_files',
+        metavar='SKILL_FILE',
+        help='Path(s) to custom skill .md files.'
+    )
+
     # MCP server arguments
     parser.add_argument(
         '--mcp',
@@ -237,6 +246,7 @@ Supported Models:
         'knowledge_dir': args.knowledge_dir,
         'code_dir': args.code_dir,
         'tool_files': args.tool_files,
+        'skill_files': args.skill_files,
         'mcp_servers': args.mcp_servers,
     }
     
@@ -272,6 +282,7 @@ class OrchestratorPlayground:
         self.knowledge_dir = None
         self.code_dir = None
         self._tool_files = self.config.get('tool_files')
+        self._skill_files = self.config.get('skill_files')
         self._mcp_servers = self.config.get('mcp_servers')
         
     def _infer_provider(self, model_name: str) -> tuple:
@@ -461,6 +472,10 @@ class OrchestratorPlayground:
         if self._tool_files:
             self._load_custom_tools(self._tool_files)
 
+        # === REGISTER CUSTOM SKILLS ===
+        if self._skill_files:
+            self._register_custom_skills(self._skill_files)
+
         # === CONNECT MCP SERVERS ===
         if self._mcp_servers:
             self._connect_mcp_servers(self._mcp_servers)
@@ -569,6 +584,17 @@ class OrchestratorPlayground:
             self.agent.register_tools(schemas, factory)
             count = sum(1 for s in schemas if s.get('type') == 'function')
             print(f"   ✅ Registered {count} tool(s) from {path.name}")
+
+    def _register_custom_skills(self, skill_files: list) -> None:
+        """Register user-supplied .md skill bundles into the orchestrator."""
+        for file_path in skill_files:
+            path = Path(file_path).resolve()
+            print(f"\n📖 Registering custom skill: {path}")
+            try:
+                name = self.agent.register_skill(str(path))
+                print(f"   ✅ Registered skill '{name}'")
+            except Exception as e:
+                print(f"   ❌ Failed to register {path.name}: {e}")
 
     def _connect_mcp_servers(self, mcp_configs: list) -> None:
         """Parse MCP server configs and connect to each."""


### PR DESCRIPTION
## Summary

`scilink plan` was the only chat mode without a `--skills` flag — you could supply custom markdown skill bundles to `analyze`, `simulate`, and `explore` from the CLI, but not to plan mode. This adds it, so custom skills can be supplied the same way everywhere.

The change is CLI-only: the backend seam already existed (`PlanningOrchestratorAgent.register_skill`), the same mechanism the skill-graduation path uses. Plan-mode skills are knowledge-only by convention (markdown, no per-skill tools), which fits a runtime-supplied bundle exactly.

Usage:

```bash
scilink plan --skills ./my_planning_skill.md
scilink plan --skills ./skill_a.md ./skill_b.md
```

Each registered skill's name is logged at startup; a missing or unreadable file is a per-file warning, not a startup failure.

<details>
<summary>Technical details</summary>

- `scilink/cli/plan.py`: added `--skills SKILL_FILE [...]` → `skill_files`, threaded through the config dict, and added `_register_custom_skills()` (calls `register_skill` per file), invoked in `setup()` right after custom-tool loading. Mirrors the wiring in `scilink/cli/simulate.py`.
- Docs: `docs/cli_reference.md` and `docs/custom_tools_integration.md` updated so the per-mode `--tools`/`--skills` split lists plan under `--skills`.
- Out of scope (per the issue): `--mcp` on `scilink simulate`.

Note: `plan` follows `simulate`'s per-file-warning behavior rather than `analyze`'s upfront `parser.error` validation — an intentional difference matching the issue spec.

Closes #487.
</details>