### PR TITLE
Make base_agent._generate_json robust to an empty/garbled completion

### DIFF
--- a/scilink/agents/sim_agents/base_agent.py
+++ b/scilink/agents/sim_agents/base_agent.py
@@ -192,23 +192,45 @@ class SimulationAgent(ABC):
     # LLM HELPERS
     # ================================================================
 
-    def _generate_json(self, prompt: str) -> Dict[str, Any]:
-        try:
+    def _generate_json(self, prompt: str, _attempts: int = 3) -> Dict[str, Any]:
+        """Generate a JSON object from the model, robust to a bad completion.
+
+        An occasional empty or non-JSON response — a proxy hiccup, a
+        content-filter stop, a stray prose wrapper — otherwise raises on the
+        first try and aborts the whole generation, which is expensive mid-workflow
+        (it burns the caller's retry budget without ever reaching the real work).
+        So retry a few times, nudging explicitly for JSON on the retries, and
+        salvage an embedded object before giving up.
+        """
+        attempts = max(1, _attempts)
+        last_err: Any = None
+        for i in range(attempts):
+            p = prompt if i == 0 else (
+                prompt + "\n\nRespond with ONLY a single valid JSON object — "
+                "no prose, no code fences.")
             response = self.model.generate_content(
-                prompt,
+                p,
                 generation_config={"response_mime_type": "application/json"},
             )
-            return json.loads(response.text)
-        except json.JSONDecodeError as e:
-            self.logger.error(f"JSON parse failed: {e}")
-            text = response.text
-            match = re.search(r'\{.*\}', text, re.DOTALL)
-            if match:
+            text = (getattr(response, "text", None) or "").strip()
+            if text:
                 try:
-                    return json.loads(match.group(0))
-                except Exception:
-                    pass
-            raise ValueError(f"Could not parse JSON: {e}")
+                    return json.loads(text)
+                except json.JSONDecodeError as e:
+                    last_err = e
+                    match = re.search(r'\{.*\}', text, re.DOTALL)
+                    if match:
+                        try:
+                            return json.loads(match.group(0))
+                        except json.JSONDecodeError as e2:
+                            last_err = e2
+            else:
+                last_err = ValueError("empty model response")
+            self.logger.warning(
+                "JSON parse attempt %d/%d failed (%s); retrying",
+                i + 1, attempts, last_err)
+        self.logger.error(f"JSON parse failed after {attempts} attempts: {last_err}")
+        raise ValueError(f"Could not parse JSON after {attempts} attempts: {last_err}")
 
     def _generate_text(self, prompt: str) -> str:
         response = self.model.generate_content(prompt)

--- a/tests/test_md_agent_smoke.py
+++ b/tests/test_md_agent_smoke.py
@@ -80,8 +80,52 @@ def test_md_agent_assembly():
         print(f"    analyze_system  = {info['atom_count']} atoms, {info['elements']}")
 
 
+def test_generate_json_retries_empty_response():
+    """base_agent._generate_json rides through an empty/garbled completion
+    instead of aborting the whole generation on the first bad response (an
+    empty proxy completion otherwise burned the caller's retry budget)."""
+    import types
+    from scilink.agents.sim_agents import MDSimulationAgent
+
+    with tempfile.TemporaryDirectory() as td:
+        agent = MDSimulationAgent(working_dir=td, skill="lammps", **_agent_kwargs())
+
+        # empty twice, then valid JSON -> returns the parsed object, no raise
+        calls = {"n": 0}
+
+        def _gen(prompt, generation_config=None):
+            calls["n"] += 1
+            txt = "" if calls["n"] < 3 else '{"ok": true}'
+            return types.SimpleNamespace(text=txt)
+
+        agent.model = types.SimpleNamespace(generate_content=_gen)
+        assert agent._generate_json("x") == {"ok": True}
+        assert calls["n"] == 3
+
+        # an object embedded in prose is salvaged
+        agent.model = types.SimpleNamespace(
+            generate_content=lambda p, generation_config=None:
+                types.SimpleNamespace(text='sure: {"a": 1} done'))
+        assert agent._generate_json("x") == {"a": 1}
+
+        # persistently empty -> raises AFTER the retry budget, not on attempt 1
+        agent.model = types.SimpleNamespace(
+            generate_content=lambda p, generation_config=None:
+                types.SimpleNamespace(text=""))
+        try:
+            agent._generate_json("x")
+            raise AssertionError("should raise after exhausting retries")
+        except ValueError:
+            pass
+
+        print("  _generate_json: retries empty / salvages / raises after budget: OK")
+
+
 if __name__ == "__main__":
-    print("=== smoke: MDSimulationAgent(skill='lammps') ===")
+    print("=== smoke 1: MDSimulationAgent(skill='lammps') ===")
     test_md_agent_assembly()
     print()
-    print("Smoke passed.")
+    print("=== smoke 2: _generate_json robustness ===")
+    test_generate_json_retries_empty_response()
+    print()
+    print("All smokes passed.")


### PR DESCRIPTION
Follow-up to #485 — this fix was pushed to the #485 branch *after* it merged, so it didn't make it into `main`. Re-submitting it cleanly on top of current `main` (cherry-pick of the stranded commit; the `test_md_agent_smoke` reconciliation drops the `LAMMPSSimulationAgent` backward-compat test that #484 already removed).

## Why
End-to-end testing of #485 (in-allocation MD) showed `run_simulation` still never executing — the failure was **upstream of the executor**. `MDSimulationAgent`'s deck-generation LLM call occasionally returns an **empty completion** (`JSON parse failed: Expecting value: line 1 column 1 (char 0)` = empty string — a proxy/content-filter hiccup, not the `response_mime_type` config, which `_map_gen_config` silently drops). `base_agent._generate_json` did `json.loads(response.text)` and **raised on the first bad response**, with only a regex fallback that can't rescue an empty string. That abort propagated up, the specialist burned its iteration budget re-issuing `run_simulation` (proliferating workdirs), and it never reached the `LocalExecutor` path.

## Fix
`_generate_json` now retries a few times (default 3), nudging explicitly for JSON on the retries and salvaging an embedded object before giving up, instead of aborting on one bad completion. Since `_run_workflow_once` returns `failed_input_generation` (does not raise), a run that now succeeds records its structure, so `run_simulation`'s reuse also stops the dir proliferation.

## Verification
`test_md_agent_smoke.py` gains a `_generate_json` regression test: rides through empty completions (returns on the 3rd call), salvages a prose-wrapped object, and raises only after the retry budget. Suite passes; `import scilink` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)