### PR TITLE
Expose simulation agents over MCP (scilink serve --mode simulate)

### DIFF
--- a/scilink/cli/serve.py
+++ b/scilink/cli/serve.py
@@ -89,12 +89,15 @@ def main():
     parser.add_argument(
         "--mode",
         type=str,
-        choices=["analyze", "plan", "both", "meta"],
+        choices=["analyze", "plan", "simulate", "both", "meta"],
         default="both",
         help=(
-            "Which tool sets to expose (default: both). 'meta' exposes "
-            "SciLink's meta orchestrator instead — one surface that routes "
-            "across the specialists, with parallel multi-modal fan-out + "
+            "Which tool sets to expose (default: both, i.e. analyze+plan). "
+            "'simulate' exposes the simulation tools (structure building, "
+            "engine inputs, run + refine; DFT/MD/MLIP) as a standalone "
+            "surface. 'meta' exposes SciLink's meta orchestrator instead — "
+            "one surface that routes across the specialists (analysis, "
+            "planning, simulation), with parallel multi-modal fan-out + "
             "fusion and cross-mode delegation."
         ),
     )

--- a/scilink/mcp_server.py
+++ b/scilink/mcp_server.py
@@ -51,6 +51,10 @@ _COPILOT_APPROVAL_TOOLS = {
     "get_recommendations", "run_optimization", "generate_initial_plan",
     "generate_implementation_code", "run_economic_analysis",
     "discard_plan",
+    # Simulation-mode tools that build/run a calculation (expensive; co-pilot
+    # gates them, as it does the analysis/planning run tools).
+    "run_simulation", "run_complete_dft_workflow", "run_mlip_simulation",
+    "run_exafs_workflow", "submit_simulation_job",
     # Meta-mode granular delegations (each one launches a full specialist
     # workflow — co-pilot gates them; in autopilot they run and the
     # children's own questions surface via awaiting_input instead).
@@ -58,6 +62,8 @@ _COPILOT_APPROVAL_TOOLS = {
 }
 _AUTOPILOT_APPROVAL_TOOLS = {
     "run_analysis", "run_optimization", "discard_plan",
+    # High-impact simulation execution (real engine / HPC time).
+    "run_simulation", "run_complete_dft_workflow",
 }
 
 # Tools that support optional background execution via ``background=true``.
@@ -81,9 +87,19 @@ _BACKGROUND_CAPABLE_TOOLS = {
     "orchestrate_analysis",
     "orchestrate_planning",
     "orchestrate_meta",
+    "orchestrate_simulation",
     "delegate_to_analysis",
     "delegate_to_planning",
     "delegate_to_simulation",
+    # Simulation tools with long engine / DFT / MD / HPC runtimes — a blocking
+    # call would routinely exceed a client's tool-call timeout.
+    "run_simulation",
+    "run_complete_dft_workflow",
+    "run_mlip_simulation",
+    "run_exafs_workflow",
+    "analyze_output",
+    "submit_simulation_job",
+    "generate_final_report",
 }
 
 
@@ -694,6 +710,7 @@ def create_server(
     state: Dict[str, Any] = {
         "analysis_orch": None,
         "planning_orch": None,
+        "simulation_orch": None,
         "meta_orch": None,
         # Pending items awaiting a client's scilink_respond, keyed by
         # request id. Two shapes: {"type": "tool_approval", "action":
@@ -752,6 +769,15 @@ def create_server(
                         mcp_name = f"scilink_plan_{fn_name}"
                     tool_map[mcp_name] = ("planning_orch", fn_name)
 
+        # Simulation is a standalone mode (its tools are never registered
+        # alongside analysis/planning), so plain `scilink_` names — no
+        # collision handling needed.
+        if state["simulation_orch"]:
+            for schema in state["simulation_orch"].tools.openai_schemas:
+                fn_name = schema.get("function", {}).get("name", "")
+                if fn_name:
+                    tool_map[f"scilink_{fn_name}"] = ("simulation_orch", fn_name)
+
         if state["meta_orch"]:
             for schema in state["meta_orch"].tools.openai_schemas:
                 fn_name = schema.get("function", {}).get("name", "")
@@ -787,6 +813,10 @@ def create_server(
                 else:
                     prefix = "scilink"
                 tools.append(_openai_to_mcp_tool(schema, prefix=prefix))
+
+        if state["simulation_orch"]:
+            for schema in state["simulation_orch"].tools.openai_schemas:
+                tools.append(_openai_to_mcp_tool(schema, prefix="scilink"))
 
         if state["meta_orch"]:
             for schema in state["meta_orch"].tools.openai_schemas:
@@ -979,6 +1009,47 @@ def create_server(
                 },
             ))
 
+        if state["simulation_orch"]:
+            tools.append(types.Tool(
+                name="scilink_orchestrate_simulation",
+                description=(
+                    "Delegate a complete simulation workflow to SciLink's "
+                    "simulation orchestrator. Send a natural-language prompt and "
+                    "the orchestrator handles the entire flow: routing to the right "
+                    "scale/engine, building and validating the atomic structure, "
+                    "generating engine inputs, running the calculation, and "
+                    "refining it to convergence — engine-neutral across periodic "
+                    "DFT (VASP/QE), classical MD (LAMMPS), and ML-potential MD. Best "
+                    "for a full task where SciLink's domain expertise should drive "
+                    "the workflow; use background=true, as a real run can take "
+                    "minutes to hours."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "description": (
+                                "Natural-language instruction for the simulation "
+                                "orchestrator, e.g. 'Build a rutile TiO2 supercell "
+                                "with one oxygen vacancy and generate a spin-polarized "
+                                "VASP relaxation.'"
+                            ),
+                        },
+                        "background": {
+                            "type": "boolean",
+                            "description": (
+                                "If true, run in the background and return a job_id "
+                                "immediately. Recommended for most requests. Use "
+                                "scilink_job_status and scilink_job_result to poll "
+                                "and retrieve results. Default: false."
+                            ),
+                        },
+                    },
+                    "required": ["prompt"],
+                },
+            ))
+
         if state["meta_orch"]:
             tools.append(types.Tool(
                 name="scilink_orchestrate_meta",
@@ -1054,7 +1125,9 @@ def create_server(
             return _handle_job_result(state, arguments)
 
         # Handle orchestrator-level chat tools
-        if name in ("scilink_orchestrate_analysis", "scilink_orchestrate_planning"):
+        if name in ("scilink_orchestrate_analysis",
+                    "scilink_orchestrate_planning",
+                    "scilink_orchestrate_simulation"):
             return await _handle_orchestrate(
                 state, name, arguments, _executor
             )
@@ -1361,6 +1434,39 @@ def _init_orchestrators(state: dict, config: dict) -> None:
         except Exception as exc:
             logging.warning(f"Planning orchestrator not available: {exc}")
 
+    if config["mode"] == "simulate":
+        # Standalone simulation surface (structure + inputs + run + refine,
+        # engine-neutral). Guarded like the planning block: the sim package
+        # pulls the optional `[sim]` extra (ase/pymatgen/…), so a checkout
+        # without it must not break `scilink serve` — it just won't offer the
+        # simulate mode.
+        try:
+            from scilink.agents.sim_agents.simulation_orchestrator import (
+                SimulationOrchestratorAgent, SimulationMode,
+            )
+            sim_mode_map = {
+                "co-pilot": SimulationMode.CO_PILOT,
+                "co_pilot": SimulationMode.CO_PILOT,
+                "copilot": SimulationMode.CO_PILOT,
+                "autopilot": SimulationMode.AUTOPILOT,
+                "autonomous": SimulationMode.AUTONOMOUS,
+            }
+            sim_mode = sim_mode_map.get(
+                config["analysis_mode"].lower(), SimulationMode.AUTONOMOUS
+            )
+            _sbase = _base_for("simulation")
+            state["simulation_orch"] = SimulationOrchestratorAgent(
+                base_dir=_sbase,
+                api_key=api_key,
+                model_name=model_name,
+                base_url=base_url,
+                simulation_mode=sim_mode,
+                futurehouse_api_key=fh_key,
+                restore_checkpoint=_restore(_sbase),
+            )
+        except Exception as exc:
+            logging.warning(f"Simulation orchestrator not available: {exc}")
+
     if config["mode"] == "meta":
         # The meta is its own surface (it constructs and routes to its
         # specialist children internally) — exposed INSTEAD of the
@@ -1538,6 +1644,10 @@ def _execute_run_task_captured(orch, prompt: str, autonomy_str: str,
         from scilink.agents.planning_agents.planning_orchestrator import (
             AutonomyLevel as _Level,
         )
+    elif "simulation_orchestrator" in mode_enum:
+        from scilink.agents.sim_agents.simulation_orchestrator import (
+            SimulationMode as _Level,
+        )
     else:
         from scilink.agents.exp_agents.analysis_orchestrator import (
             AnalysisMode as _Level,
@@ -1684,20 +1794,25 @@ async def _handle_orchestrate(
     """Handle orchestrator-level chat tools."""
     from datetime import datetime as _dt
 
-    orch_key = (
-        "analysis_orch" if name == "scilink_orchestrate_analysis"
-        else "planning_orch"
-    )
+    orch_key = {
+        "scilink_orchestrate_analysis": "analysis_orch",
+        "scilink_orchestrate_planning": "planning_orch",
+        "scilink_orchestrate_simulation": "simulation_orch",
+    }.get(name, "analysis_orch")
     orch = state.get(orch_key)
     if orch is None:
-        mode_label = "analysis" if "analysis" in name else "planning"
+        if "simulation" in name:
+            mode_label, hint = "simulation", "--mode simulate"
+        else:
+            mode_label = "analysis" if "analysis" in name else "planning"
+            hint = f"--mode {mode_label} or --mode both"
         return [types.TextContent(
             type="text",
             text=json.dumps({
                 "status": "error",
                 "message": (
                     f"{mode_label.title()} orchestrator is not available. "
-                    f"Start the server with --mode {mode_label} or --mode both."
+                    f"Start the server with {hint}."
                 ),
             }),
         )]
@@ -1798,6 +1913,15 @@ def _handle_set_autonomy(
                 AutonomyLevel[_level_name])
         except Exception as exc:  # noqa: BLE001
             logging.warning(f"set_autonomy: planning orch not updated: {exc}")
+    if state.get("simulation_orch") is not None:
+        try:
+            from scilink.agents.sim_agents.simulation_orchestrator import (
+                SimulationMode,
+            )
+            state["simulation_orch"].set_simulation_mode(
+                SimulationMode[_level_name])
+        except Exception as exc:  # noqa: BLE001
+            logging.warning(f"set_autonomy: simulation orch not updated: {exc}")
     if state.get("meta_orch") is not None:
         try:
             from scilink.agents.meta_agent.meta_orchestrator import MetaMode

--- a/tests/test_mcp_simulate_mode.py
+++ b/tests/test_mcp_simulate_mode.py
@@ -1,0 +1,130 @@
+"""Simulation orchestrator over MCP — offline tests (handlers with stub orch).
+
+Mirrors tests/test_mcp_meta_mode.py: exercises the `--mode simulate` wiring
+(orchestrate routing, autonomy resolution, background jobs, set_autonomy
+propagation) without a real server or LLM.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from scilink.mcp_server import (  # noqa: E402
+    _execute_run_task_captured,
+    _handle_orchestrate,
+    _handle_set_autonomy,
+)
+from scilink.agents.sim_agents.simulation_orchestrator import (  # noqa: E402
+    SimulationMode,
+)
+
+
+def _state(mode="autonomous"):
+    return {"analysis_orch": None, "planning_orch": None,
+            "simulation_orch": None, "meta_orch": None,
+            "pending": {}, "jobs": {}, "job_counter": 0,
+            "config": {"analysis_mode": mode, "hitl_timeout_s": 5}}
+
+
+class SimStub:
+    """Stands in for SimulationOrchestratorAgent's run_task contract."""
+
+    def __init__(self, resting=SimulationMode.AUTONOMOUS):
+        self.simulation_mode = resting
+        self.seen = []
+
+    def set_simulation_mode(self, mode):
+        self.simulation_mode = mode
+
+    def run_task(self, prompt, autonomy=None, **kw):
+        self.seen.append((prompt, autonomy))
+        return {"status": "success", "summary": "built + ran the calculation",
+                "files_produced": ["POSCAR"], "key_findings": []}
+
+
+# The autonomy branch in _execute_run_task_captured resolves the enum from the
+# orchestrator's module name, so the stub must look like it lives there.
+SimStub.__module__ = "scilink.agents.sim_agents.simulation_orchestrator"
+
+
+class _InlineExecutor:
+    def submit(self, fn, *args):
+        import concurrent.futures
+        f = concurrent.futures.Future()
+        f.set_result(fn(*args))
+        return f
+
+
+def test_run_task_captured_resolves_simulation_mode():
+    stub = SimStub()
+    out = json.loads(_execute_run_task_captured(stub, "build TiO2", "autopilot"))
+    # autopilot serving -> SimulationMode.AUTOPILOT passed to run_task
+    assert stub.seen[0][1] == SimulationMode.AUTOPILOT
+    assert out["status"] == "success"
+    assert out["response"] == "built + ran the calculation"   # summary -> response
+
+
+def test_orchestrate_simulation_requires_simulate_mode():
+    state = _state()
+    (content,) = asyncio.run(_handle_orchestrate(
+        state, "scilink_orchestrate_simulation", {"prompt": "x"}, None))
+    payload = json.loads(content.text)
+    assert payload["status"] == "error"
+    assert "--mode simulate" in payload["message"]      # not "--mode both"
+
+
+def test_orchestrate_simulation_background_job():
+    state = _state()
+    state["simulation_orch"] = SimStub()
+    (content,) = asyncio.run(_handle_orchestrate(
+        state, "scilink_orchestrate_simulation",
+        {"prompt": "relax Cu fcc", "background": True}, _InlineExecutor()))
+    payload = json.loads(content.text)
+    assert payload["status"] == "started"
+    job = state["jobs"][payload["job_id"]]
+    assert job["tool"] == "orchestrate_simulation"
+    assert json.loads(job["future"].result())["status"] == "success"
+
+
+def test_set_autonomy_propagates_to_simulation():
+    state = _state(mode="autonomous")
+    state["simulation_orch"] = SimStub(resting=SimulationMode.AUTONOMOUS)
+    (content,) = _handle_set_autonomy(state, {"mode": "co-pilot"})
+    assert json.loads(content.text)["status"] == "success"
+    assert state["simulation_orch"].simulation_mode == SimulationMode.CO_PILOT
+    _handle_set_autonomy(state, {"mode": "autonomous"})
+    assert state["simulation_orch"].simulation_mode == SimulationMode.AUTONOMOUS
+
+
+def test_simulate_mode_registers_sim_tools_end_to_end(tmp_path):
+    """create_server(mode='simulate') builds the real sim orchestrator and lists
+    its tools with clean scilink_ names — standalone (no analysis/planning leak),
+    orchestrate + control tools present, long tools background-capable."""
+    import mcp.types as types
+    from scilink.mcp_server import create_server
+
+    srv = create_server(api_key="sk-dummy", mode="simulate",
+                        session_dir=str(tmp_path))
+    srv.eager_init()          # constructs the sim orchestrator + tool_map
+    handler = srv.request_handlers[types.ListToolsRequest]
+    res = asyncio.run(handler(types.ListToolsRequest(method="tools/list")))
+    tools = res.root.tools
+    names = {t.name for t in tools}
+
+    # core simulation surface, clean prefix, the orchestrate tool
+    assert {"scilink_run_simulation", "scilink_generate_structure",
+            "scilink_route_simulation", "scilink_orchestrate_simulation",
+            "scilink_analyze_output", "scilink_list_available_software"} <= names
+    assert all(not n.startswith("scilink_sim_") for n in names)   # no collision prefix
+    # generic control/job tools come for free
+    assert {"scilink_job_status", "scilink_job_result",
+            "scilink_respond"} <= names
+    # standalone: analysis/planning tool sets are NOT registered
+    assert "scilink_analyze_file" not in names
+    assert "scilink_run_optimization" not in names
+    # a long sim tool got the optional background param injected
+    rs = next(t for t in tools if t.name == "scilink_run_simulation")
+    assert "background" in (rs.inputSchema.get("properties") or {})


### PR DESCRIPTION
`scilink serve` exposes the **analysis** and **planning** agents over MCP but not **simulation** — so an MCP client (e.g. a LangChain deepagents deep agent) can drive analysis/planning but not DFT/MD/MLIP. This adds a standalone **`--mode simulate`** that serves the `SimulationOrchestratorTools` surface as clean `scilink_*` tools, replicating the exact pattern the analysis/planning modes use.

## Design
- **Standalone mode, not folded into `both`.** Several sim tool names collide with the analysis/planning generic tools (`read_file`, `session_status`, `view_structure`, `save_file`, …); a standalone mode keeps clean names (`scilink_run_simulation`, `scilink_generate_structure`, …) with **no `scilink_sim_` prefix**. Cross-mode workflows already have a home in `--mode meta`, which routes to simulation via `delegate_to_simulation`. `both` stays analyze+plan, unchanged.
- **Mirrors the planning block** everywhere in `mcp_server.py`, including a **guarded construction** — the `[sim]` extra is optional, so a checkout without it just won't offer the mode rather than breaking `scilink serve`.

## Wiring
- `cli/serve.py`: `simulate` added to `--mode` choices (`--print-mcp-json` forwards it unchanged).
- `_init_orchestrators`: guarded `SimulationOrchestratorAgent` construction for `mode == "simulate"`; `state["simulation_orch"]` slot.
- `_ensure_initialized` / `list_tools`: sim `tool_map` + listing loops (plain `scilink_` prefix).
- `scilink_orchestrate_simulation`: background-job tool → `SimulationOrchestratorAgent.run_task`, via `_handle_orchestrate` + a `SimulationMode` branch in `_execute_run_task_captured`; a not-available error points at `--mode simulate`.
- Long tools (`run_simulation`, `run_complete_dft_workflow`, `run_mlip_simulation`, `run_exafs_workflow`, `analyze_output`, `submit_simulation_job`, `generate_final_report`, `orchestrate_simulation`) marked **background-capable**; the run tools gate for approval in co-pilot/autopilot like `run_analysis`/`run_optimization`.
- `set_autonomy` propagates to the sim orchestrator.

## Verification
- New `tests/test_mcp_simulate_mode.py` (5): orchestrate routing + `--mode simulate` error; background job; `SimulationMode` autonomy resolution; `set_autonomy` propagation; **end-to-end** `create_server(mode="simulate")` registering the sim tools with clean names, `orchestrate` + control tools, `background` param injection, and no analysis/planning leakage.
- Existing MCP mode tests (`meta`, `onboarding`) green; `import scilink` clean; `scilink serve --print-mcp-json --mode simulate` emits a valid client config.

Follow-up (separate PR, in the `deepagents-scilink` integration repo): a client example driving a supervised simulation campaign, which unblocks that repo's "Simulation agents — not yet exposed by `scilink serve`" item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)