### PR TITLE
Add ORCA as a molecular_qc engine skill

### DIFF
--- a/scilink/skills/molecular_qc/orca/__init__.py
+++ b/scilink/skills/molecular_qc/orca/__init__.py
@@ -1,0 +1,1 @@
+"""ORCA skill bundle for the molecular_qc scale."""

--- a/scilink/skills/molecular_qc/orca/orca.md
+++ b/scilink/skills/molecular_qc/orca/orca.md
@@ -1,0 +1,181 @@
+---
+description: ORCA molecular quantum chemistry — Gaussian-basis DFT, HF, and post-HF (MP2, DLPNO-CCSD(T)) on finite molecules and ions; geometry optimization, analytic frequencies/thermochemistry, and CPCM/SMD implicit solvation. Charge/multiplicity-aware; RI/RIJCOSX-accelerated; handles charged ion pairs that periodic codes cannot.
+detect:
+  binaries: [orca]
+  env_vars: []
+  python_modules: []
+  guidance: |
+    ORCA runs as the `orca` binary, invoked `orca orca.inp > orca.out`. It
+    MUST be called by its FULL PATH (e.g. `/opt/orca/orca orca.inp`) so ORCA
+    can locate its own sub-executables (orca_scf, orca_gtoint, ...) in the
+    same directory; a bare `orca` on $PATH works only if the whole install
+    dir is on $PATH. Parallelism is internal — set `%pal nprocs N end` in the
+    deck and still launch the single `orca` command (do NOT wrap it in
+    `mpirun`; ORCA spawns MPI itself and needs its bundled OpenMPI on
+    $LD_LIBRARY_PATH). On HPC it is usually available after
+    `module load orca/<version>`. Detection should treat the `orca` binary
+    (on $PATH or a known install dir) as a positive hit. ORCA has no standard
+    environment variables and is an external executable, so env_vars and
+    python_modules are empty.
+---
+# ORCA Molecular Quantum Chemistry Skill
+
+## overview
+
+Gaussian-basis-set molecular electronic structure with ORCA, for finite
+molecules, ions, and small clusters — NOT periodic solids. This skill covers
+deck generation for DFT, Hartree–Fock, and post-HF correlated methods
+(MP2, and DLPNO-CCSD(T) — ORCA's near-linear-scaling coupled cluster) together
+with geometry optimization, analytic vibrational frequencies and
+thermochemistry, and implicit solvation (CPCM / SMD). The target is decks that
+are physically correct, charge/multiplicity-consistent, and aligned with
+standard computational-chemistry practice. ORCA is the right tool where periodic
+planewave codes are not: charged species (e.g. carbamate / ammonium ion pairs),
+solution-phase free energies, and analytic-Hessian thermochemistry — and its
+DLPNO-CCSD(T) makes gold-standard energetics affordable on sizeable molecules.
+
+## planning
+
+**Method selection (the method is a keyword-line choice, not a separate code):**
+- DFT for geometries, conformers, and routine thermochemistry. Hybrid
+  functionals (B3LYP, PBE0) or range-separated/dispersion-corrected
+  (ωB97X-D3, M06-2X) for main-group thermochemistry of amines/carbamates.
+  Add an empirical dispersion correction (`D3BJ` or `D4`) with functionals that
+  lack it — put it directly on the `!` line (`! B3LYP D3BJ ...`).
+- HF only as a reference or a starting point for post-HF.
+- Post-HF: MP2, then `DLPNO-CCSD(T)` for benchmark reaction energies on a few
+  key species once DFT geometries are in hand. DLPNO-CCSD(T)/CBS on the
+  optimized geometry is the gold-standard ΔH check and is far cheaper than
+  canonical CCSD(T); reserve it for the rate-determining comparison and pair it
+  with a correlation-fitting aux basis (see basis).
+
+**Basis set:** the def2 family is a sound default — def2-SVP for optimization
+and frequencies, def2-TZVP (or def2-TZVPD for anions) for final single-point
+energies. Diffuse functions matter for anions (carbamate) and for solvation;
+prefer the "D"/ma- variants there. ORCA leans on the resolution of the identity:
+add `def2/J` as the Coulomb-fitting auxiliary basis for RI-J / RIJCOSX (standard
+with hybrids: `! RIJCOSX def2/J`), and a `/C` correlation-fitting basis
+(e.g. `def2-TZVP/C`) for MP2 / DLPNO. Confirm the basis covers every element.
+
+**Charge & multiplicity:** set both explicitly on the coordinate line
+(`* xyz <charge> <mult>`), from the chemistry. Neutral closed-shell amine →
+`* xyz 0 1`. Carbamate anion → charge -1; ammonium cation → charge +1; the
+neutral ion pair as a whole → charge 0. An odd electron count requires an
+open-shell treatment (`! UKS`/`! UHF`, multiplicity 2).
+
+**Solvation:** for the liquid-phase energetics that actually matter here, add
+CPCM or SMD. Gas-phase numbers will misrank ion-pair stability. Use the solvent
+of the working fluid (or water as a reference): `! CPCM(water)`, or SMD via a
+`%cpcm smd true SMDsolvent "water" end` block.
+
+**Workflow staging:** optimize → frequencies → high-level single point. ORCA can
+combine `! Opt Freq` in one run; when staging as separate phases, each reads the
+previous phase's geometry (e.g. `* xyzfile <charge> <mult> prev.xyz`).
+Frequencies must be computed at the same level/basis as the optimization, and a
+true minimum (no imaginary modes) confirmed before trusting thermochemistry.
+
+## implementation
+
+An ORCA deck is a single text file (conventionally `orca.inp`): one or more
+`!` "simple-keyword" lines, optional `%block ... end` sections for detailed
+settings, and a coordinate block.
+
+**Deck skeleton:**
+
+    ! B3LYP D3BJ def2-SVP RIJCOSX def2/J TightSCF Opt Freq
+    %maxcore 3000
+    %pal nprocs 8 end
+    * xyz 0 1
+      <element>  x  y  z
+      ...
+    *
+
+- The `!` line carries method, dispersion, basis, RI/aux basis, SCF/opt
+  tightness, and run types (`Opt`, `Freq`/`NumFreq`; a bare deck with none is a
+  single-point energy).
+- `%maxcore` is memory **per core** in MB; `%pal nprocs N end` sets core count.
+
+**Implicit solvation** — add to the `!` line for CPCM, or a block for SMD:
+
+    ! CPCM(water)
+    # ...or SMD:
+    %cpcm
+      smd true
+      SMDsolvent "water"
+    end
+
+Solvation must be active for the energy/thermo phases whose solution-phase
+values you report.
+
+**Charged ion pair example** (carbamate anion, solution-phase optimization):
+
+    ! M06-2X D3ZERO def2-TZVPD RIJCOSX def2/J CPCM(water) TightSCF Opt Freq
+    %pal nprocs 8 end
+    * xyz -1 1
+      ...
+    *
+
+**Post-HF single point** (DLPNO-CCSD(T) on a DFT geometry):
+
+    ! DLPNO-CCSD(T) def2-TZVP def2-TZVP/C RIJCOSX def2/J TightSCF
+    %pal nprocs 8 end
+    * xyzfile 0 1 opt.xyz
+
+**Reading a previous phase's geometry:** `* xyzfile <charge> <mult> prev.xyz`
+points at the `.xyz` ORCA writes after an optimization, so per-phase decks chain
+cleanly and the refinement loop can run, assess, and fix each phase
+independently.
+
+## interpretation
+
+Read a finished run against the calculation's intent, not just exit status.
+The deterministic snapshot (`orca_output.snapshot_run`, via cclib) surfaces the
+fields below; judge them against the request. ORCA prints
+`****ORCA TERMINATED NORMALLY****` on a clean finish — its absence means the run
+crashed even if partial output parses.
+
+- **SCF convergence** (cclib `scfenergies`): the SCF energy must be present and
+  converged for any result to be meaningful. `SCF NOT CONVERGED AFTER ...` in
+  the log means it did not finish.
+- **Geometry convergence** (cclib `optdone`): for an optimization this must be
+  True; if False the geometry is still moving and the energy is not a minimum.
+- **Imaginary frequencies** (cclib `vibfreqs`, negative values): a genuine
+  minimum has zero; one imaginary mode is a transition state; several usually
+  mean a bad geometry or too-loose optimization. Thermochemistry is only valid
+  at a true minimum.
+- **Thermochemistry** (cclib `enthalpy`, `freeenergy`, in Hartree): use these
+  for ΔH / ΔG of reaction. Reaction ΔH = Σ products − Σ reactants; for the
+  carbamate equilibrium include amine, CO2, carbamate, ammonium, and ion pair.
+- **Basis/method warnings:** watch for a missing basis or auxiliary basis
+  (`could not find the basis`), an inconsistent charge/multiplicity
+  (`... multiplicity ... is odd`), or an unknown keyword
+  (`UNRECOGNIZED OR DUPLICATED KEYWORD`).
+
+When a result contradicts the chemistry (a "minimum" with imaginary modes, or a
+gas-phase ranking that flips a known liquid/solid trend), distrust the inputs —
+charge/multiplicity, missing solvation, basis/aux basis — before the number.
+
+## validation
+
+**Pre-run checks (before submitting a deck):**
+
+- The `!` line names a method **and** a basis, and the basis set exists for
+  every element in the geometry (def2 families cover H–Rn; verify for any
+  heavy/unusual atoms and add ECPs / a covering basis where required).
+- When RI/RIJCOSX or a correlated method is requested, the matching auxiliary
+  basis is present: `def2/J` for RI-J / RIJCOSX Coulomb fitting, a `/C` basis
+  (e.g. `def2-TZVP/C`) for MP2 / DLPNO correlation fitting.
+- The coordinate line sets `<charge>` and `<mult>` consistently with the
+  species: even electron count → singlet unless deliberately open-shell; odd
+  electrons → multiplicity 2 with an unrestricted method (`UKS`/`UHF`).
+- The requested run type matches the intent: `Opt` for a geometry, a `Freq`
+  after the optimization (same level/basis) for thermochemistry, neither for a
+  single point.
+- For solution-phase requests, a CPCM keyword or SMD block is present and the
+  solvent is named; the thermo/energy phases run with it active.
+- The coordinate block is well-formed: `* xyz <charge> <mult>` ... closed with a
+  lone `*` (or `* xyzfile <charge> <mult> file.xyz`), and coordinates are sane
+  (no overlapping atoms, reasonable bond lengths) — ORCA will run a garbage
+  geometry to a garbage number.
+- Resource blocks are reasonable: `%maxcore` is per-core memory in MB (not
+  total), and `%pal nprocs N end` matches the cores the job will actually get.

--- a/scilink/skills/molecular_qc/orca/orca_geometry.py
+++ b/scilink/skills/molecular_qc/orca/orca_geometry.py
@@ -1,0 +1,198 @@
+"""Deterministic geometry-consistency check for ORCA decks (issue #400).
+
+The deck's inline coordinate block (``* xyz <charge> <mult> ... *``) is
+transcribed from the source structure by the LLM; a dropped atom or a wrong
+element yields a deck that runs to completion on the *wrong* system — the run
+succeeds, the output parses, and the answer is simply for a different molecule.
+This module parses that block and compares it against the source structure file
+on atom count and per-element composition, so a silent transcription error fails
+generation loudly.
+
+No LLM, cheap, engine-specific: it lives in the ORCA skill bundle and the agent
+resolves it through the registry (the agent names no parser). It is the ORCA
+twin of ``molecular_qc/nwchem/nwchem_geometry.py``.
+"""
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Any, Dict, List, Optional
+
+from ..._shared._spec import ToolSpec
+
+# Coordinate-block styles ORCA accepts after the leading ``*``. Only ``xyz`` is
+# a plain Cartesian list we can count atom-for-atom; the rest read coordinates
+# out-of-band or in internal coordinates, so we skip rather than risk a false
+# fail (mirrors the NWChem check's Z-matrix / external-coordinate handling).
+_CARTESIAN_MARK = "xyz"
+_NONCARTESIAN_MARKS = {"xyzfile", "int", "internal", "gzmt"}
+# ORCA placeholders that are not physical atoms: ``DA`` dummy centres and ``Q``
+# point charges. Ghost atoms (basis without a nucleus) are written with a
+# trailing colon on the element tag (``O:``) and are excluded the same way.
+_GHOST_DUMMY = {"da", "q"}
+# Leading 1-2 letters of an atom-line token. Case-insensitive (ORCA element
+# tags are case-insensitive), normalized with ``.capitalize()`` and checked
+# against the real element symbols below.
+_ELEMENT_RE = re.compile(r"^([A-Za-z]{1,2})")
+
+_SYMBOLS_CACHE = None
+
+
+def _is_element(symbol: str) -> bool:
+    """Whether ``symbol`` (already capitalized) is a real chemical element."""
+    global _SYMBOLS_CACHE
+    if _SYMBOLS_CACHE is None:
+        try:
+            from ase.data import chemical_symbols
+            _SYMBOLS_CACHE = frozenset(chemical_symbols)
+        except Exception:
+            _SYMBOLS_CACHE = frozenset()
+    return symbol in _SYMBOLS_CACHE
+
+
+def _parse_geometry_block(deck: str) -> Optional[Dict[str, Any]]:
+    """Parse the first ORCA ``* xyz <charge> <mult> ... *`` coordinate block.
+
+    Returns ``None`` when there is no coordinate block, otherwise
+    ``{"elements": [...], "reliable": bool, "note": str}``. ``reliable`` is
+    ``False`` when the block reads coordinates out-of-band (``xyzfile``) or in
+    internal coordinates (``int``/``gzmt``) — the caller then skips instead of
+    failing.
+    """
+    in_block = False
+    elements: List[str] = []
+    for raw in deck.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("*"):
+            rest = line[1:].strip()
+            if not in_block:
+                # Opening delimiter: `* <mark> <charge> <mult> [file]`.
+                mark = rest.split()[0].lower() if rest else ""
+                if mark == _CARTESIAN_MARK:
+                    in_block = True
+                    continue
+                if mark in _NONCARTESIAN_MARKS:
+                    return {"elements": [], "reliable": False,
+                            "note": f"coordinate block uses `{mark}` (external / "
+                                    "internal coordinates); atom-count check skipped"}
+                # Unknown coordinate style — be conservative.
+                return {"elements": [], "reliable": False,
+                        "note": f"unrecognized coordinate style `* {rest[:40]}`; "
+                                "check skipped"}
+            # A bare `*` (or `* ...`) while in the block closes it.
+            return {"elements": elements, "reliable": True, "note": ""}
+        if not in_block:
+            continue
+        # An atom line inside the Cartesian block: element symbol + x y z. A
+        # ghost (trailing colon) or dummy/point-charge centre is not a physical
+        # atom; a >=4-token line whose leading token is NOT a real element
+        # cannot be counted — skip the whole check rather than silently drop the
+        # line (a dropped line would fail a correct deck loudly, the very
+        # failure this module promises to avoid).
+        toks = line.split()
+        if len(toks) < 4:                 # an atom line needs an element + x y z
+            continue
+        tag = toks[0]
+        if tag.endswith(":"):             # ORCA ghost atom (basis, no nucleus)
+            continue
+        m = _ELEMENT_RE.match(tag)        # tag/fragment-tolerant: "O1"/"C(1)" -> "O"/"C"
+        sym = m.group(1).capitalize() if m else None
+        if sym is not None and sym.lower() in _GHOST_DUMMY:
+            continue                      # dummy / point charge: not a physical atom
+        if sym is None or not _is_element(sym):
+            return {"elements": [], "reliable": False,
+                    "note": f"unrecognized atom line in coordinate block: "
+                            f"{line[:60]!r}"}
+        elements.append(sym)
+    # Block opened but no explicit closing `*` — use what we parsed.
+    return ({"elements": elements, "reliable": True, "note": ""}
+            if in_block else None)
+
+
+def _source_elements(structure_file: str) -> Optional[List[str]]:
+    try:
+        from ase.io import read as ase_read
+        atoms = ase_read(structure_file)
+        return list(atoms.get_chemical_symbols())
+    except Exception:
+        return None
+
+
+def check_geometry_consistency(*, input_files: Dict[str, str],
+                               structure_file: str,
+                               **_ignored: Any) -> Dict[str, Any]:
+    """Compare a generated ORCA deck's geometry to the source structure.
+
+    Returns a status dict:
+      * ``ok``       — atom count and per-element composition match;
+      * ``mismatch`` — they differ (fail loud; a wrong-system deck is
+                       unrecoverable downstream);
+      * ``skipped``  — no parseable coordinate block, or the structure file
+                       can't be read (never block on an inapplicable case).
+    """
+    parsed: Optional[Dict[str, Any]] = None
+    for content in (input_files or {}).values():
+        if isinstance(content, str):
+            block = _parse_geometry_block(content)
+            if block is not None:
+                parsed = block
+                break
+    if parsed is None:
+        return {"status": "skipped",
+                "reason": "no parseable `* xyz ... *` coordinate block in the deck"}
+    if not parsed["reliable"]:
+        return {"status": "skipped", "reason": parsed["note"]}
+    deck_elems = parsed["elements"]
+
+    src_elems = _source_elements(structure_file)
+    if src_elems is None:
+        return {"status": "skipped",
+                "reason": f"could not read source structure {structure_file!r}"}
+
+    deck_comp, src_comp = Counter(deck_elems), Counter(src_elems)
+    if deck_comp == src_comp:
+        return {"status": "ok", "n_atoms": len(deck_elems),
+                "composition": dict(sorted(deck_comp.items()))}
+
+    reasons: List[str] = []
+    if len(deck_elems) != len(src_elems):
+        reasons.append(f"atom count {len(deck_elems)} (deck) vs "
+                       f"{len(src_elems)} (source)")
+    per_el = [f"{el}: {deck_comp.get(el, 0)} vs {src_comp.get(el, 0)}"
+              for el in sorted(set(deck_comp) | set(src_comp))
+              if deck_comp.get(el, 0) != src_comp.get(el, 0)]
+    if per_el:
+        reasons.append("per-element counts (deck vs source) — " + ", ".join(per_el))
+    return {
+        "status": "mismatch",
+        "reason": "; ".join(reasons),
+        "deck_composition": dict(sorted(deck_comp.items())),
+        "source_composition": dict(sorted(src_comp.items())),
+    }
+
+
+TOOL_SPEC = ToolSpec(
+    name="check_geometry_consistency",
+    description=(
+        "Deterministically verify that a generated ORCA deck's inline "
+        "coordinate block (`* xyz <charge> <mult> ... *`) matches the source "
+        "structure file on atom count and per-element composition, catching a "
+        "silent LLM transcription error (a dropped atom or wrong element) that "
+        "would otherwise run to completion on the wrong system."
+    ),
+    parameters={
+        "input_files": {"type": "object",
+                        "description": "{filename: contents} of the generated deck"},
+        "structure_file": {"type": "string",
+                           "description": "the source structure the deck was generated from"},
+    },
+    required=["input_files", "structure_file"],
+    signature=("check_geometry_consistency(*, input_files, structure_file) -> "
+               "dict(status='ok'|'mismatch'|'skipped', ...)"),
+    import_line=("from scilink.skills.molecular_qc.orca.orca_geometry "
+                 "import check_geometry_consistency"),
+    agents=["simulation"],
+    returns="status dict; a 'mismatch' fails generation loudly",
+)

--- a/scilink/skills/molecular_qc/orca/orca_output.py
+++ b/scilink/skills/molecular_qc/orca/orca_output.py
@@ -1,0 +1,272 @@
+"""ORCA output snapshot parser.
+
+Reads a completed (or failed) ORCA molecular-QC run and produces a structured
+summary that simulate-mode critics hand to the LLM when assessing the run.
+Discovered via the skill registry when the ``orca`` skill is active and called
+through :func:`scilink.skills._shared._registry.get_tool_function`.
+
+The parse goes through **cclib**, which reads ORCA / NWChem / Gaussian / PySCF
+output uniformly — so this ``snapshot_run`` shares the exact contract of the
+NWChem twin (``molecular_qc/nwchem/nwchem_output.py``); only the engine-specific
+error signatures and output-filename conventions differ. cclib is imported
+lazily inside the function so this module (and its ``TOOL_SPEC``) import cleanly
+even where cclib is not installed.
+
+All code paths return a dict with a ``status`` key; failures are reported in the
+returned structure rather than raised, so callers can hand the result to the LLM
+uniformly.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ..._shared._spec import ToolSpec
+
+logger = logging.getLogger(__name__)
+
+
+# Known ORCA failure signatures surfaced via the output log so the summary can
+# flag common failure modes even when cclib cannot parse a value.
+_ORCA_ERROR_HINTS = [
+    ("SCF NOT CONVERGED AFTER",
+     "SCF did not converge — raise `%scf maxiter`, try `SlowConv`/`VerySlowConv`, "
+     "a different guess (`%scf guess ...`), or add diffuse functions for anions"),
+    ("The optimization did not converge",
+     "geometry optimization did not converge — loosen nothing; check the geometry, "
+     "raise `%geom maxiter`, or revisit the method/basis"),
+    ("ORCA finished by error termination",
+     "ORCA aborted — see the lines above the termination banner for the cause"),
+    ("UNRECOGNIZED OR DUPLICATED KEYWORD",
+     "deck syntax error — an unknown/duplicated keyword on the `!` line or in a "
+     "`%...end` block"),
+    ("is odd. Please specify the correct multiplicity",
+     "charge/multiplicity inconsistent with the electron count — fix the "
+     "`* xyz <charge> <mult>` line"),
+    ("Error (ORCA_MAIN): Multiplicity",
+     "multiplicity inconsistent with the electron count — fix charge/mult on the "
+     "coordinate line"),
+    ("could not find the basis",
+     "basis set missing for an element — pick a covering basis or add it"),
+    ("Error : Basis set", "basis set problem — check the basis keyword covers every element"),
+    ("There are no atoms",
+     "empty/unreadable coordinate block — check the `* xyz ... *` geometry"),
+    ("aborting the run", "ORCA aborted the run — inspect the log for the cause"),
+]
+
+# ORCA prints this banner on a clean finish.
+_ORCA_SUCCESS_MARK = "ORCA TERMINATED NORMALLY"
+
+
+def _classify_log_errors(log_text: str) -> List[str]:
+    """Return human-readable hints matching known ORCA error patterns."""
+    hits: List[str] = []
+    low = log_text.lower()
+    for pattern, hint in _ORCA_ERROR_HINTS:
+        if pattern.lower() in low:
+            hits.append(f"{pattern}: {hint}")
+    return hits
+
+
+def _read_tail(path: Path, max_chars: int = 80_000) -> Optional[str]:
+    """Read a file, returning at most ``max_chars`` of its tail."""
+    try:
+        text = path.read_text(errors="replace")
+    except Exception as e:  # pragma: no cover - unreadable file
+        logger.warning("Could not read %s: %s", path, e)
+        return None
+    return text[-max_chars:] if len(text) > max_chars else text
+
+
+def _summarize_with_cclib(log_path: Path) -> Dict[str, Any]:
+    """Parse an ORCA output via cclib and extract convergence + energetics.
+
+    Returns a dict with some subset of ``converged``, ``scf_energy_eV``,
+    ``n_imaginary_freqs``, ``enthalpy_hartree``, ``free_energy_hartree``.
+    On parse failure returns ``{"error": "..."}``. cclib is imported here so
+    the module stays importable without it.
+    """
+    try:
+        import cclib
+    except ImportError as e:
+        return {"error": f"cclib not available: {e}"}
+
+    try:
+        data = cclib.io.ccread(str(log_path))
+    except Exception as e:  # pragma: no cover - cclib parse failure
+        return {"error": f"cclib parse failed: {e}"}
+    if data is None:
+        return {"error": "cclib could not parse the output"}
+
+    out: Dict[str, Any] = {}
+
+    # optdone: True when a geometry optimization converged. For a single-point
+    # there is no optimization, so absence is not a failure.
+    optdone = getattr(data, "optdone", None)
+    out["converged"] = bool(optdone) if optdone is not None else None
+
+    scf = getattr(data, "scfenergies", None)
+    if scf is not None and len(scf):
+        out["scf_energy_eV"] = float(scf[-1])
+
+    vibfreqs = getattr(data, "vibfreqs", None)
+    if vibfreqs is not None:
+        out["n_imaginary_freqs"] = int(sum(1 for f in vibfreqs if f < 0))
+
+    enthalpy = getattr(data, "enthalpy", None)
+    if enthalpy is not None:
+        out["enthalpy_hartree"] = float(enthalpy)
+
+    freeenergy = getattr(data, "freeenergy", None)
+    if freeenergy is not None:
+        out["free_energy_hartree"] = float(freeenergy)
+
+    return out
+
+
+def snapshot_run(output_dir: str) -> Dict[str, Any]:
+    """Summarize an ORCA run directory into a structured snapshot.
+
+    Inspects the directory for an ORCA output log (``*.out`` / ``*.log`` /
+    ``stdout``), parses it with cclib for convergence and energetics, and
+    tail-matches the log for known ORCA failure patterns and the normal
+    termination banner.
+
+    Args:
+        output_dir: Path to the directory containing the run's output files.
+
+    Returns:
+        A dict with fields:
+
+            status              ``"ok"`` or ``"error"``
+            output_directory    The directory inspected
+            files_found         List of recognized output files present
+            parse               Dict from :func:`_summarize_with_cclib`
+                                (convergence + energetics), or ``None`` when
+                                no log was found
+            scf_energy          Convenience alias for the SCF energy (eV)
+            free_energy         Convenience alias for the free energy (Hartree)
+            imaginary_freqs     Convenience alias for the imaginary-mode count
+            converged           Convenience alias for optimization convergence
+            terminated_normally Whether the ORCA success banner was found
+            log_error_hints     List of ``"<pattern>: <hint>"`` strings
+            convergence_status  ``"converged"`` / ``"not_converged"`` /
+                                ``"failed"`` / ``"unknown"``
+            headline            One-sentence top-line assessment
+    """
+    out_dir = Path(output_dir)
+    if not out_dir.exists():
+        return {"status": "error", "message": f"Directory not found: {output_dir}"}
+    if not out_dir.is_dir():
+        return {"status": "error", "message": f"Not a directory: {output_dir}"}
+
+    summary: Dict[str, Any] = {
+        "status": "ok",
+        "output_directory": str(out_dir),
+        "files_found": [],
+        "parse": None,
+        "scf_energy": None,
+        "free_energy": None,
+        "imaginary_freqs": None,
+        "converged": None,
+        "terminated_normally": None,
+        "log_error_hints": [],
+        "convergence_status": "unknown",
+    }
+
+    # ORCA output filenames are not fixed (usually the input stem + ``.out``);
+    # gather the usual candidates.
+    logs = sorted(out_dir.glob("*.out")) + sorted(out_dir.glob("*.log"))
+    for extra in ("stdout", "stdout.log", "orca.out"):
+        p = out_dir / extra
+        if p.exists() and p not in logs:
+            logs.append(p)
+    summary["files_found"] = [p.name for p in logs]
+
+    if not logs:
+        summary["headline"] = (
+            "No ORCA output found in the directory. The run may not have "
+            "started, or output files use an unexpected name."
+        )
+        return summary
+
+    log_path = logs[-1]
+    parsed = _summarize_with_cclib(log_path)
+    summary["parse"] = parsed
+    if "error" not in parsed:
+        summary["scf_energy"] = parsed.get("scf_energy_eV")
+        summary["free_energy"] = parsed.get("free_energy_hartree")
+        summary["imaginary_freqs"] = parsed.get("n_imaginary_freqs")
+        summary["converged"] = parsed.get("converged")
+        if parsed.get("converged") is True:
+            summary["convergence_status"] = "converged"
+        elif parsed.get("converged") is False:
+            summary["convergence_status"] = "not_converged"
+        elif parsed.get("scf_energy_eV") is not None:
+            # Single-point with an energy but no optimization to converge.
+            summary["convergence_status"] = "converged"
+
+    log_text = _read_tail(log_path)
+    if log_text:
+        summary["terminated_normally"] = _ORCA_SUCCESS_MARK.lower() in log_text.lower()
+        summary["log_error_hints"] = _classify_log_errors(log_text)
+        if summary["convergence_status"] == "unknown" and summary["log_error_hints"]:
+            summary["convergence_status"] = "failed"
+        # A run that never printed the normal-termination banner and has no
+        # parsed energy has almost certainly crashed.
+        if (summary["terminated_normally"] is False
+                and summary["convergence_status"] == "unknown"):
+            summary["convergence_status"] = "failed"
+
+    status = summary["convergence_status"]
+    if status == "converged":
+        summary["headline"] = "Run completed; SCF/geometry converged."
+    elif status == "not_converged":
+        summary["headline"] = (
+            "Optimization did NOT converge — check the geometry, increase "
+            "iterations, or revisit the method/basis."
+        )
+    elif status == "failed":
+        summary["headline"] = (
+            "Run appears to have failed (errors found, or ORCA did not "
+            "terminate normally). See log_error_hints for known patterns."
+        )
+    else:
+        summary["headline"] = (
+            "Convergence status could not be determined (cclib unavailable or "
+            "output incomplete). Install cclib and confirm the output log."
+        )
+    return summary
+
+
+TOOL_SPEC = ToolSpec(
+    name="snapshot_run",
+    description=(
+        "Read an ORCA run directory and return a structured snapshot of "
+        "convergence status, energetics (SCF energy, enthalpy, free energy), "
+        "imaginary-frequency count, whether ORCA terminated normally, and any "
+        "matched error patterns. Parsed via cclib. Discovered and dispatched "
+        "when the ``orca`` skill is active."
+    ),
+    parameters={
+        "output_dir": {
+            "type": "string",
+            "description": (
+                "Absolute path to the directory containing the ORCA run's "
+                "output files (*.out / *.log / stdout)."
+            ),
+        },
+    },
+    required=["output_dir"],
+    signature="snapshot_run(output_dir: str) -> dict",
+    import_line="from scilink.skills.molecular_qc.orca.orca_output import snapshot_run",
+    agents=["simulation"],
+    returns=(
+        "dict with status, files_found, parse (convergence + energetics), "
+        "convenience aliases (scf_energy, free_energy, imaginary_freqs, "
+        "converged), terminated_normally, log_error_hints, convergence_status, "
+        "and a one-line headline."
+    ),
+)

--- a/tests/test_orca_geometry_check.py
+++ b/tests/test_orca_geometry_check.py
@@ -1,0 +1,250 @@
+"""Tests for the deterministic ORCA geometry-consistency check (issue #400).
+
+The ORCA twin of ``test_molecular_qc_geometry_check.py``: it parses ORCA's
+``* xyz <charge> <mult> ... *`` coordinate block and compares composition
+against the source structure, failing generation loudly on a silent
+transcription error.
+"""
+import textwrap
+
+import pytest
+
+from scilink.skills.molecular_qc.orca.orca_geometry import (
+    check_geometry_consistency,
+)
+
+_CO2_XYZ = textwrap.dedent("""\
+    3
+    CO2
+    O 0.0 0.0 0.0
+    C 0.0 0.0 1.16
+    O 0.0 0.0 2.32
+""")
+
+_DECK_OK = textwrap.dedent("""\
+    # CO2 single point
+    ! B3LYP def2-SVP RIJCOSX def2/J TightSCF
+    %pal nprocs 4 end
+    * xyz 0 1
+      O 0.0 0.0 0.0
+      C 0.0 0.0 1.16
+      O 0.0 0.0 2.32
+    *
+""")
+
+# One oxygen dropped from the deck.
+_DECK_DROPPED = textwrap.dedent("""\
+    ! B3LYP def2-SVP
+    * xyz 0 1
+      O 0.0 0.0 0.0
+      C 0.0 0.0 1.16
+    *
+""")
+
+# Carbon transcribed as nitrogen.
+_DECK_WRONG_EL = textwrap.dedent("""\
+    ! B3LYP def2-SVP
+    * xyz 0 1
+      O 0.0 0.0 0.0
+      N 0.0 0.0 1.16
+      O 0.0 0.0 2.32
+    *
+""")
+
+_DECK_NO_GEOM = "! B3LYP def2-SVP\n%pal nprocs 4 end\n"
+
+
+@pytest.fixture
+def co2_xyz(tmp_path):
+    p = tmp_path / "co2.xyz"
+    p.write_text(_CO2_XYZ)
+    return str(p)
+
+
+def test_matching_deck_ok(co2_xyz):
+    r = check_geometry_consistency(input_files={"orca.inp": _DECK_OK},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "ok"
+    assert r["n_atoms"] == 3
+    assert r["composition"] == {"C": 1, "O": 2}
+
+
+def test_dropped_atom_mismatch(co2_xyz):
+    r = check_geometry_consistency(input_files={"orca.inp": _DECK_DROPPED},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "mismatch"
+    assert "atom count 2" in r["reason"]
+    assert r["deck_composition"] == {"C": 1, "O": 1}
+    assert r["source_composition"] == {"C": 1, "O": 2}
+
+
+def test_wrong_element_mismatch(co2_xyz):
+    r = check_geometry_consistency(input_files={"orca.inp": _DECK_WRONG_EL},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "mismatch"
+    assert "N:" in r["reason"] and "C:" in r["reason"]
+
+
+def test_no_coordinate_block_skipped(co2_xyz):
+    r = check_geometry_consistency(input_files={"orca.inp": _DECK_NO_GEOM},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "skipped"
+
+
+def test_unreadable_structure_skipped():
+    r = check_geometry_consistency(input_files={"orca.inp": _DECK_OK},
+                                   structure_file="/no/such/file.xyz")
+    assert r["status"] == "skipped"
+
+
+def test_composition_is_order_independent(co2_xyz):
+    reordered = textwrap.dedent("""\
+        ! HF def2-SVP
+        * xyz 0 1
+          C 0.0 0.0 1.16
+          O 0.0 0.0 2.32
+          O 0.0 0.0 0.0
+        *
+    """)
+    r = check_geometry_consistency(input_files={"orca.inp": reordered},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "ok"
+
+
+def test_star_no_space_ok(co2_xyz):
+    """`*xyz 0 1` (no space after the star) is valid ORCA syntax."""
+    deck = textwrap.dedent("""\
+        ! B3LYP def2-SVP
+        *xyz 0 1
+          O 0.0 0.0 0.0
+          C 0.0 0.0 1.16
+          O 0.0 0.0 2.32
+        *
+    """)
+    r = check_geometry_consistency(input_files={"orca.inp": deck},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "ok" and r["composition"] == {"C": 1, "O": 2}
+
+
+def test_xyzfile_skipped(co2_xyz):
+    """External-coordinate `* xyzfile ...` can't be counted -> skip, not fail."""
+    deck = "! B3LYP def2-SVP Opt\n* xyzfile 0 1 prev.xyz\n"
+    r = check_geometry_consistency(input_files={"orca.inp": deck},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "skipped"
+    assert "xyzfile" in r["reason"]
+
+
+def test_internal_coordinates_skipped(co2_xyz):
+    """A Z-matrix / internal-coordinate block -> skip, not false-fail."""
+    deck = textwrap.dedent("""\
+        ! B3LYP def2-SVP Opt
+        * int 0 1
+          O 0 0 0  0.0 0.0 0.0
+          C 1 0 0  1.16 0.0 0.0
+          O 1 2 0  1.16 180.0 0.0
+        *
+    """)
+    r = check_geometry_consistency(input_files={"orca.inp": deck},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "skipped"
+    assert "int" in r["reason"]
+
+
+def test_ghost_atoms_excluded(co2_xyz):
+    """ORCA ghost atoms (`O:` trailing colon) are basis-only, not physical."""
+    deck = textwrap.dedent("""\
+        ! B3LYP def2-SVP
+        * xyz 0 1
+          O  0.0 0.0 0.0
+          C  0.0 0.0 1.16
+          O  0.0 0.0 2.32
+          H: 5.0 5.0 5.0
+        *
+    """)
+    r = check_geometry_consistency(input_files={"orca.inp": deck},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "ok"
+    assert r["composition"] == {"C": 1, "O": 2}
+
+
+def test_dummy_atom_excluded(co2_xyz):
+    """ORCA dummy centres (`DA`) are not physical atoms -> excluded, still ok."""
+    deck = textwrap.dedent("""\
+        ! B3LYP def2-SVP
+        * xyz 0 1
+          O  0.0 0.0 0.0
+          C  0.0 0.0 1.16
+          O  0.0 0.0 2.32
+          DA 5.0 5.0 5.0
+        *
+    """)
+    r = check_geometry_consistency(input_files={"orca.inp": deck},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "ok"
+    assert r["composition"] == {"C": 1, "O": 2}
+
+
+def test_lowercase_deck_ok(co2_xyz):
+    """ORCA element tags are case-insensitive — a lowercase deck is valid."""
+    deck = textwrap.dedent("""\
+        ! b3lyp def2-svp
+        * xyz 0 1
+          o 0.0 0.0 0.0
+          c 0.0 0.0 1.16
+          o 0.0 0.0 2.32
+        *
+    """)
+    r = check_geometry_consistency(input_files={"orca.inp": deck},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "ok"
+    assert r["composition"] == {"C": 1, "O": 2}
+
+
+def test_unrecognized_atom_line_skipped(co2_xyz):
+    """A >=4-token coordinate line that isn't a real element -> skip, not fail."""
+    deck = textwrap.dedent("""\
+        ! B3LYP def2-SVP
+        * xyz 0 1
+          O  0.0 0.0 0.0
+          Zz 0.0 0.0 1.16
+          O  0.0 0.0 2.32
+        *
+    """)
+    r = check_geometry_consistency(input_files={"orca.inp": deck},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "skipped"
+    assert "unrecognized" in r["reason"]
+
+
+def test_registry_resolves_the_tool():
+    from scilink.skills._shared._registry import get_tool_function
+    fn = get_tool_function("check_geometry_consistency", active_skills=["orca"])
+    assert callable(fn)
+
+
+def test_orca_is_a_supported_engine():
+    from scilink.agents.sim_agents.molecular_qc_agent import MolecularQCAgent
+    assert "orca" in MolecularQCAgent.supported_software()
+
+
+def test_agent_fails_loud_on_mismatch(co2_xyz, monkeypatch):
+    """generate_inputs(software='orca') returns status='error' on a dropped atom."""
+    from scilink.agents.sim_agents.molecular_qc_agent import MolecularQCAgent
+
+    # base_url set -> no vendor-credential check at construction; no network.
+    agent = MolecularQCAgent(api_key="dummy", base_url="http://localhost:0")
+
+    class _Resp:
+        text = "ignored"
+
+    monkeypatch.setattr(agent.model, "generate_content",
+                        lambda *a, **k: _Resp())
+    monkeypatch.setattr(agent, "_parse_response",
+                        lambda text: {"input_files": {"orca.inp": _DECK_DROPPED}})
+
+    result = agent.generate_inputs(structure_file=co2_xyz, request="single point",
+                                   software="orca")
+    assert result["status"] == "error"
+    assert "inconsistent" in result["message"]
+    assert result["geometry_check"]["status"] == "mismatch"

--- a/tests/test_orca_output.py
+++ b/tests/test_orca_output.py
@@ -1,0 +1,97 @@
+"""Tests for the ORCA deterministic critic hook (``snapshot_run`` via cclib).
+
+Layers, by dependency:
+  1. TOOL_SPEC shape + module import — no cclib, no fixture.
+  2. Graceful behavior on missing / empty run dirs — no cclib, no fixture.
+  3. Log classification (error hints, normal-termination banner) from a
+     synthetic ``.out`` — no cclib (the tail-text pass runs regardless).
+  4. Real-output parse — needs cclib AND a captured ORCA ``.out`` fixture;
+     auto-skips until one is dropped into ``tests/fixtures/orca/``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from scilink.skills.molecular_qc.orca.orca_output import snapshot_run, TOOL_SPEC
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "orca"
+
+
+# ── Layer 1: spec + import (no cclib, no fixture) ──────────────────
+
+def test_tool_spec_shape():
+    assert TOOL_SPEC.name == "snapshot_run"
+    assert "simulation" in TOOL_SPEC.agents
+    assert "output_dir" in TOOL_SPEC.parameters
+    assert TOOL_SPEC.required == ["output_dir"]
+    assert TOOL_SPEC.import_line.endswith(
+        "molecular_qc.orca.orca_output import snapshot_run"
+    )
+
+
+# ── Layer 2: graceful no-output handling (no cclib, no fixture) ─────
+
+def test_snapshot_missing_dir():
+    out = snapshot_run("/no/such/run/dir")
+    assert out["status"] == "error"
+
+
+def test_snapshot_empty_dir(tmp_path):
+    out = snapshot_run(str(tmp_path))
+    assert out["status"] == "ok"
+    assert out["files_found"] == []
+    assert out["convergence_status"] == "unknown"
+    assert out["scf_energy"] is None
+    assert out["terminated_normally"] is None
+
+
+# ── Layer 3: log classification from a synthetic .out (no cclib) ────
+
+def test_scf_not_converged_flagged(tmp_path):
+    (tmp_path / "orca.out").write_text(
+        "some header\nSCF NOT CONVERGED AFTER  125 CYCLES\nmore text\n"
+    )
+    out = snapshot_run(str(tmp_path))
+    assert out["convergence_status"] == "failed"
+    assert any("SCF NOT CONVERGED" in h for h in out["log_error_hints"])
+
+
+def test_normal_termination_detected(tmp_path):
+    (tmp_path / "orca.out").write_text(
+        "run output ...\n****ORCA TERMINATED NORMALLY****\nTOTAL RUN TIME: ...\n"
+    )
+    out = snapshot_run(str(tmp_path))
+    assert out["terminated_normally"] is True
+    assert out["log_error_hints"] == []
+
+
+def test_no_banner_no_energy_reads_as_failed(tmp_path):
+    """A log that never reached the normal-termination banner (and cclib finds
+    no energy) is treated as a crash, not an unknown."""
+    (tmp_path / "orca.out").write_text("partial output, process killed\n")
+    out = snapshot_run(str(tmp_path))
+    assert out["terminated_normally"] is False
+    # With no parseable energy and no banner, status resolves to failed.
+    assert out["convergence_status"] == "failed"
+
+
+# ── Layer 4: real parse (needs cclib + a captured fixture) ─────────
+
+@pytest.mark.skipif(
+    not FIXTURE_DIR.is_dir() or not any(FIXTURE_DIR.glob("*.out")),
+    reason=("no real ORCA .out fixture captured yet — drop one into "
+            "tests/fixtures/orca/ to enable"),
+)
+def test_snapshot_real_output():
+    pytest.importorskip("cclib")
+    out = snapshot_run(str(FIXTURE_DIR))
+    assert out["status"] == "ok"
+    assert out["files_found"], "expected the .out file to be discovered"
+    assert out["scf_energy"] is not None
+    assert out["convergence_status"] in {"converged", "not_converged", "failed"}
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Adds **ORCA** as a first-class `molecular_qc` engine, mirroring the NWChem bundle. No agent changes were needed — `MolecularQCAgent.supported_software()` auto-discovers the new `molecular_qc/orca/` bundle, and the registry resolves its tools scoped to the active skill.

### What's in the bundle
- **`orca.md`** — engine knowledge with a `detect:` block on the `orca` binary. Covers method selection (DFT, HF, MP2, `DLPNO-CCSD(T)`), the def2 basis + RI/RIJCOSX auxiliary-basis discipline, charge/multiplicity on the `* xyz <charge> <mult>` line, CPCM/SMD solvation, opt→freq→single-point staging, and the `!` / `%block ... end` / `* xyz ... *` deck form — plus interpretation and pre-run validation sections.
- **`orca_geometry.py`** — deterministic `check_geometry_consistency` (the ORCA twin of the NWChem #400 check). Parses the `* xyz ... *` block and compares atom count + per-element composition to the source structure, failing generation loudly on a silent transcription error. Conservatively **skips** (never false-fails) external (`xyzfile`) / internal (`int`/`gzmt`) coordinates and excludes ghost (`O:`) and dummy (`DA`) centres.
- **`orca_output.py`** — `snapshot_run` via cclib (which parses ORCA natively), with ORCA-specific error signatures (SCF-not-converged, bad charge/mult, missing basis, unknown keyword) and the `****ORCA TERMINATED NORMALLY****` banner check.

### Tests
`tests/test_orca_geometry_check.py` (16 cases): match / dropped atom / wrong element / composition order-independence / `*xyz` no-space / xyzfile+internal skips / ghost+dummy exclusion / lowercase / unrecognized-line skip / registry resolves / `orca` in `supported_software()` / agent fails loud on mismatch.
`tests/test_orca_output.py`: TOOL_SPEC shape, missing/empty-dir handling, and deterministic log classification (SCF-not-converged → failed, normal-termination banner, crash-without-banner → failed) with a fixture-gated real-parse layer.

Full molecular-QC + skill-loading + router suites stay green (49 passed); the NWChem bundle's tools still resolve to their own bundle (no cross-contamination).

### Why
Beyond adding a useful QC engine, this makes the "one agent per method, engines as skills" architecture figure honest about listing ORCA alongside NWChem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)