### PR TITLE
Add GROMACS as a molecular_dynamics engine skill

### DIFF
--- a/scilink/agents/sim_agents/md_simulation_agent.py
+++ b/scilink/agents/sim_agents/md_simulation_agent.py
@@ -817,6 +817,16 @@ class MDSimulationAgent(SimulationAgent):
             return None
         if not (self.tools_module
                 and hasattr(self.tools_module, "expand_parameter_sweep")):
+            # A sweep WAS requested (multiple sims + >=2 values) but the active
+            # engine has no expander — degrade to a single run LOUDLY, never
+            # silently. GROMACS is first-class for single + staged generation;
+            # fan-out sweeps are not in the bundle yet.
+            self.logger.warning(
+                "engine %r has no parameter-sweep expander; producing a single "
+                "run instead of the requested %d-point sweep over %r — express "
+                "it as a staged campaign for now",
+                self.skill_name, len(values),
+                plan.get("variable_parameter") or "parameter")
             return None
         return {"var_name": plan.get("variable_parameter") or "parameter",
                 "values": values}

--- a/scilink/agents/sim_agents/md_simulation_agent.py
+++ b/scilink/agents/sim_agents/md_simulation_agent.py
@@ -19,6 +19,11 @@ try:
     _TOOL_REGISTRY["lammps"] = lammps_tools
 except ImportError:
     pass
+try:
+    from ...skills.molecular_dynamics.gromacs import gromacs as gromacs_tools
+    _TOOL_REGISTRY["gromacs"] = gromacs_tools
+except ImportError:
+    pass
 
 
 def _assemble_fanout_stage(
@@ -107,11 +112,30 @@ class MDSimulationAgent(SimulationAgent):
         "openmm":  [".pdb", ".cif"],
     }
     TOOL_REGISTRY = _TOOL_REGISTRY
+    # Each engine names its generated run-control artifact differently: LAMMPS a
+    # single input deck, GROMACS the .mdp, OpenMM a driver script. Keyed by
+    # skill name → (stem, extension); the entry filename is built from these so
+    # nothing downstream hardcodes ``run.lammps``.
+    _ENTRY_FILE = {
+        "lammps": ("run", "lammps"),
+        "gromacs": ("grompp", "mdp"),
+        "openmm": ("run_openmm", "py"),
+    }
+    _DEFAULT_ENTRY = ("run", "lammps")
 
     def __init__(self, working_dir: str, **kwargs):
         super().__init__(working_dir=working_dir, **kwargs)
         self._last_plan: Optional[Dict[str, Any]] = None
         self._last_system_info: Optional[Dict[str, Any]] = None
+
+    def _entry_name(self, stage: Optional[str] = None) -> str:
+        """Entry filename for the active engine, optionally per stage.
+
+        ``lammps`` → ``run.lammps`` / ``run_equilibration.lammps``;
+        ``gromacs`` → ``grompp.mdp`` / ``grompp_equilibration.mdp``.
+        """
+        stem, ext = self._ENTRY_FILE.get(self.skill_name, self._DEFAULT_ENTRY)
+        return f"{stem}_{stage}.{ext}" if stage else f"{stem}.{ext}"
 
     # ================================================================
     # SYSTEM ANALYSIS
@@ -387,7 +411,7 @@ class MDSimulationAgent(SimulationAgent):
                 research_goal, system_description, system_info, plan,
             )
 
-        script_path = self.working_dir / "run.lammps"
+        script_path = self.working_dir / self._entry_name()
         script_path.write_text(script, encoding="utf-8")
 
         validation = self._validate(str(script_path), system_info, plan)
@@ -807,7 +831,7 @@ class MDSimulationAgent(SimulationAgent):
         engine skill's (``expand_parameter_sweep``); this method only assembles
         the engine-neutral ``stages`` structure the refinement loop consumes.
         """
-        entry = "run.lammps"
+        entry = self._entry_name()
         shared = self._campaign_shared_files(structure_file, force_field_files)
         members = self.tools_module.expand_parameter_sweep(
             base_script, sweep["var_name"], sweep["values"])
@@ -921,7 +945,7 @@ class MDSimulationAgent(SimulationAgent):
             if not isinstance(content, str):
                 continue
             content = self._clean_and_fix(content, plan)
-            entry = f"run_{name}.lammps"
+            entry = self._entry_name(name)
             path = self.working_dir / entry
             path.write_text(content, encoding="utf-8")
             stage_scripts[name] = str(path)

--- a/scilink/skills/molecular_dynamics/gromacs/__init__.py
+++ b/scilink/skills/molecular_dynamics/gromacs/__init__.py
@@ -1,0 +1,1 @@
+"""GROMACS skill bundle for the molecular_dynamics scale."""

--- a/scilink/skills/molecular_dynamics/gromacs/gromacs.md
+++ b/scilink/skills/molecular_dynamics/gromacs/gromacs.md
@@ -33,6 +33,13 @@ inputs GROMACS consumes alongside it; `gmx grompp` assembles all three into a
 force field is a biomolecular/soft-matter one (OPLS-AA, AMBER, CHARMM, GROMOS)
 and PME electrostatics with explicit solvent are expected.
 
+**Scope:** this bundle covers **single-shot** and **staged** (min → NVT → NPT →
+production) generation. **Fan-out parameter sweeps** (one independent run per
+value of a swept variable) are **not yet supported** — the bundle ships no
+`expand_parameter_sweep`, so a sweep request degrades to a single run (the agent
+logs a warning). Express a multi-value study as an explicit staged campaign for
+now; a sweep expander is the follow-up.
+
 ## Planning
 
 **Ensemble & phases:** a production run is staged — energy minimization

--- a/scilink/skills/molecular_dynamics/gromacs/gromacs.md
+++ b/scilink/skills/molecular_dynamics/gromacs/gromacs.md
@@ -1,0 +1,154 @@
+---
+description: GROMACS classical molecular dynamics — .mdp run-control files for biomolecular and soft-matter systems (proteins, membranes, solvated small molecules) and condensed phases, with the OPLS-AA / AMBER / CHARMM / GROMOS force fields, PME electrostatics, and thermostats/barostats for NVT/NPT ensembles.
+outputs:
+  trajectory: [xtc, trr]
+  thermo_log: [md.log, ener.edr]
+detect:
+  binaries: [gmx, gmx_mpi, gmx_d, mdrun, mdrun_mpi]
+  env_vars: [GMXBIN, GMXDATA, GMXLIB]
+  python_modules: []
+  guidance: |
+    GROMACS ships one driver binary, `gmx` (double-precision `gmx_d`,
+    MPI build `gmx_mpi`), with sub-commands: `gmx grompp` preprocesses
+    an .mdp + topology (.top) + coordinates (.gro/.pdb) into a run
+    input (.tpr), and `gmx mdrun -deffnm md` runs it. Older/threaded
+    builds expose a standalone `mdrun`. On HPC the binary appears after
+    `module load gromacs/<version>`, which also sets $GMXBIN/$GMXDATA.
+    Detection should treat `gmx`/`gmx_mpi`/`mdrun` on $PATH, or any of
+    these env vars, as a positive hit. GROMACS has no importable Python
+    runtime surface, so python_modules is empty.
+---
+# GROMACS Classical Molecular Dynamics Skill
+
+## Overview
+
+Classical atomistic dynamics with GROMACS, the de-facto engine for biomolecular
+and soft-matter MD: solvated proteins, nucleic acids, lipid membranes, and
+solvated small molecules, as well as bulk liquids. The primary artifact this
+skill generates is the **`.mdp` run-control file** — the run parameters
+(integrator, ensemble, thermostat/barostat, cutoffs, electrostatics, output
+cadence). The topology (`.top`/`.itp`) and coordinates (`.gro`/`.pdb`) are the
+inputs GROMACS consumes alongside it; `gmx grompp` assembles all three into a
+`.tpr`, and `gmx mdrun` executes it. GROMACS is the natural MD engine where the
+force field is a biomolecular/soft-matter one (OPLS-AA, AMBER, CHARMM, GROMOS)
+and PME electrostatics with explicit solvent are expected.
+
+## Planning
+
+**Ensemble & phases:** a production run is staged — energy minimization
+(`integrator = steep`), then NVT equilibration (temperature coupling on, position
+restraints optional), then NPT equilibration (add pressure coupling), then the
+NPT/NVT production run. Each phase is its own `.mdp`; later phases continue from
+the previous checkpoint (`gmx mdrun -cpi`).
+
+**Thermostat:** `tcoupl = v-rescale` (velocity-rescaling; the robust,
+canonical-sampling default) for equilibration and production. `nose-hoover` for
+a rigorously correct production ensemble once equilibrated. Set `tc-grps` to
+couple solute and solvent separately (e.g. `Protein Non-Protein` or `System`),
+`ref-t` to the target temperature per group, and `tau-t` (0.1 ps typical).
+
+**Barostat (NPT only):** `pcoupl = c-rescale` (or `parrinello-rahman` for
+production), `ref-p = 1.0` bar, `tau-p = 2.0`, and a `compressibility` (4.5e-5
+bar⁻¹ for water). Do NOT set pressure coupling for an NVT run.
+
+**Timestep:** `dt = 0.002` ps (2 fs) with `constraints = h-bonds` (LINCS);
+`dt = 0.001` (1 fs) if bonds are unconstrained. `nsteps` sets the run length
+(25 ns = 12,500,000 steps at 2 fs).
+
+**Electrostatics & cutoffs:** `coulombtype = PME` for explicit-solvent systems,
+`rcoulomb = 1.0`, `rvdw = 1.0` nm, `cutoff-scheme = Verlet`. PME is expected for
+biomolecular/solvated work; reaction-field only for special cases.
+
+**Force field:** the topology is written for a specific force field (OPLS-AA,
+AMBER, CHARMM36, GROMOS). The `.mdp` must be consistent with it — CHARMM needs
+`vdw-modifier = force-switch` with `rvdw-switch = 1.0`, `rvdw = 1.2`; OPLS/AMBER
+use plain cutoffs at 1.0 nm.
+
+## Implementation
+
+The generated artifact is a complete `.mdp`. Skeleton for an NPT production run:
+
+    ; run control
+    integrator      = md
+    dt              = 0.002
+    nsteps          = 12500000        ; 25 ns
+    ; output control
+    nstxout-compressed = 5000         ; trajectory every 10 ps
+    nstenergy       = 5000
+    nstlog          = 5000
+    ; neighbor searching / cutoffs
+    cutoff-scheme   = Verlet
+    rlist           = 1.0
+    rvdw            = 1.0
+    rcoulomb        = 1.0
+    ; electrostatics
+    coulombtype     = PME
+    fourierspacing  = 0.12
+    ; temperature coupling
+    tcoupl          = v-rescale
+    tc-grps         = System
+    tau-t           = 0.1
+    ref-t           = 300
+    ; pressure coupling (NPT)
+    pcoupl          = c-rescale
+    pcoupltype      = isotropic
+    tau-p           = 2.0
+    ref-p           = 1.0
+    compressibility = 4.5e-5
+    ; bonds
+    constraints     = h-bonds
+    constraint-algorithm = lincs
+
+**Energy minimization** deck (a distinct phase):
+
+    integrator      = steep
+    emtol           = 1000.0
+    emstep          = 0.01
+    nsteps          = 50000
+    cutoff-scheme   = Verlet
+    coulombtype     = PME
+    rvdw            = 1.0
+    rcoulomb        = 1.0
+
+**Per-phase decks:** emit one `.mdp` per phase (min → NVT → NPT → production).
+NVT drops the `pcoupl` block; the production deck uses `parrinello-rahman` /
+`nose-hoover` once the system is equilibrated. `gen-vel = yes` with `gen-temp`
+seeds velocities on the first NVT phase only.
+
+**Execution:** `gmx grompp -f md.mdp -c conf.gro -p topol.top -o md.tpr` then
+`gmx mdrun -deffnm md`.
+
+## Interpretation
+
+Read a finished run against the request, not just whether `mdrun` exited.
+
+- **Energy/temperature/pressure** (`.edr`, via `gmx energy`): temperature must
+  sit at `ref-t` and pressure average near `ref-p` for an NPT run; a large drift
+  means the system never equilibrated.
+- **Density** (NPT): should plateau at the physical value for the fluid; a
+  falling or unphysical density signals a barostat or topology problem.
+- **Constraint/energy warnings** (`md.log`): "LINCS warnings", "1-4 interaction
+  not within cutoff", or blowing-up energies indicate a bad start structure or
+  too-large a timestep — minimize/equilibrate more, not a longer production run.
+- **Trajectory** (`.xtc`/`.trr`): confirm the cadence recorded the observable
+  the goal needs (e.g. frequent stress/velocity output for transport
+  properties).
+
+## Validation
+
+**Pre-run checks (before `grompp`):**
+
+- `integrator` is set (`md`, `md-vv`, or `steep`/`cg` for minimization), and
+  `dt` and `nsteps` are present and physical (`dt` ≤ 0.002 with `constraints =
+  h-bonds`, ≤ 0.001 without).
+- Temperature coupling is well-formed: `tcoupl` names a real thermostat, and the
+  number of `ref-t` and `tau-t` values matches the number of `tc-grps`.
+- Pressure coupling is present for an NPT request and ABSENT for NVT; when
+  present, `ref-p`, `tau-p`, and `compressibility` are set.
+- `cutoff-scheme = Verlet`, and `rvdw`/`rcoulomb` are set; `coulombtype = PME`
+  for an explicit-solvent/biomolecular system.
+- The cutoffs are consistent with the force field (CHARMM force-switch at
+  1.2 nm; OPLS/AMBER plain at 1.0 nm).
+- `constraints` and `constraint-algorithm` are consistent with `dt`.
+- For thermochemistry/transport, the output cadence (`nstxout-compressed`,
+  `nstenergy`) records the quantity the goal requires.

--- a/scilink/skills/molecular_dynamics/gromacs/gromacs.py
+++ b/scilink/skills/molecular_dynamics/gromacs/gromacs.py
@@ -1,0 +1,153 @@
+"""GROMACS tools module — deterministic `.mdp` parsing and validation.
+
+Registered in ``MDSimulationAgent.TOOL_REGISTRY`` under ``"gromacs"`` (the LAMMPS
+twin: ``molecular_dynamics/lammps/lammps.py``). The MD agent calls
+``validate_script(script_path, system_info)`` after generating the run-control
+file and hands the result to the refinement loop, exactly as for LAMMPS.
+
+GROMACS's primary generated artifact is the ``.mdp`` run-control file; the
+topology (.top) and coordinates (.gro) are supplied alongside it. So the checks
+here are ``.mdp``-shaped: a well-formed integrator/timestep, a thermostat, a
+consistent NVT-vs-NPT pressure-coupling block, and sane cutoffs/electrostatics.
+No GROMACS binary is needed — the deck is checked, not run.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+# GROMACS treats '-' and '_' in .mdp option names as equivalent; we normalize
+# both to '-' so `nstxout_compressed` and `nstxout-compressed` are one key.
+_THERMOSTATS = {"berendsen", "nose-hoover", "v-rescale", "andersen",
+                "andersen-massive"}
+_BAROSTATS = {"berendsen", "parrinello-rahman", "c-rescale", "mttk"}
+_OFF = {"no", "none", ""}
+
+
+def parse_mdp(text: str) -> Dict[str, str]:
+    """Parse a `.mdp` into a normalized ``{option: value}`` dict.
+
+    Keys are lowercased with '_' → '-'; comments (``;`` to end of line) are
+    stripped; the last assignment of a repeated key wins (GROMACS semantics).
+    """
+    out: Dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.split(";", 1)[0].strip()
+        if not line or "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        out[key.strip().lower().replace("_", "-")] = val.strip()
+    return out
+
+
+def _num(val: Optional[str]) -> Optional[float]:
+    if val is None:
+        return None
+    try:
+        return float(val.split()[0])
+    except (ValueError, IndexError):
+        return None
+
+
+def _n_fields(val: Optional[str]) -> int:
+    return len(val.split()) if val else 0
+
+
+def validate_script(script_path: str,
+                    system_info: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Validate a GROMACS `.mdp` run-control file structurally.
+
+    Checks: integrator present; timestep present, numeric, and consistent with
+    the constraint setting; a thermostat for a dynamics run; a well-formed
+    NVT-vs-NPT pressure-coupling block; ref-t / tc-grps field-count agreement;
+    and cutoff/electrostatics presence. Returns the same shape as the LAMMPS
+    validator so the refinement loop consumes it identically.
+    """
+    result: Dict[str, Any] = {
+        "valid": True,
+        "errors": [],
+        "warnings": [],
+        "integrator": None,
+        "dt": None,
+        "nsteps": None,
+        "ensemble": None,
+        "thermostat": None,
+        "barostat": None,
+    }
+    try:
+        content = Path(script_path).read_text()
+    except Exception as e:
+        return {**result, "valid": False, "errors": [f"Cannot read: {e}"]}
+
+    mdp = parse_mdp(content)
+    errors = result["errors"]
+    warnings = result["warnings"]
+
+    integrator = mdp.get("integrator")
+    result["integrator"] = integrator
+    if not integrator:
+        errors.append("no `integrator` set (expected md / md-vv / steep / cg)")
+    is_minimizer = (integrator or "").lower() in ("steep", "cg", "l-bfgs")
+
+    dt = _num(mdp.get("dt"))
+    result["dt"] = dt
+    if not is_minimizer:
+        if "dt" not in mdp:
+            errors.append("no `dt` (timestep) set for a dynamics run")
+        elif dt is None:
+            errors.append(f"`dt` is not numeric: {mdp.get('dt')!r}")
+        elif dt > 0.005:
+            errors.append(f"`dt` = {dt} ps is unphysically large for atomistic MD")
+        else:
+            constraints = mdp.get("constraints", "none").lower()
+            if dt > 0.002 and constraints in _OFF:
+                warnings.append(
+                    f"`dt` = {dt} ps without bond constraints — use "
+                    "`constraints = h-bonds` for 2 fs, or reduce dt to 0.001")
+
+    if "nsteps" not in mdp:
+        warnings.append("no `nsteps` set (run length)")
+    else:
+        result["nsteps"] = mdp.get("nsteps")
+
+    if not is_minimizer:
+        tcoupl = mdp.get("tcoupl", "no").lower()
+        result["thermostat"] = tcoupl if tcoupl not in _OFF else None
+        if tcoupl in _OFF:
+            warnings.append("no thermostat (`tcoupl`) on a dynamics run — the "
+                            "ensemble is unthermostatted (NVE)")
+        elif tcoupl not in _THERMOSTATS:
+            warnings.append(f"`tcoupl = {tcoupl}` is not a recognized thermostat")
+        # ref-t / tau-t must have one value per tc-grps group.
+        n_grps = _n_fields(mdp.get("tc-grps"))
+        n_reft = _n_fields(mdp.get("ref-t"))
+        if n_grps and n_reft and n_grps != n_reft:
+            errors.append(
+                f"`ref-t` has {n_reft} value(s) but `tc-grps` has {n_grps} "
+                "group(s) — they must match")
+        elif tcoupl not in _OFF and n_reft == 0:
+            warnings.append("thermostat on but no `ref-t` (target temperature)")
+
+    pcoupl = mdp.get("pcoupl", "no").lower()
+    result["barostat"] = pcoupl if pcoupl not in _OFF else None
+    if pcoupl not in _OFF:
+        result["ensemble"] = "NPT"
+        if pcoupl not in _BAROSTATS:
+            warnings.append(f"`pcoupl = {pcoupl}` is not a recognized barostat")
+        for req in ("ref-p", "tau-p", "compressibility"):
+            if req not in mdp:
+                errors.append(f"pressure coupling on but `{req}` is missing")
+    elif not is_minimizer:
+        result["ensemble"] = "NVT" if result["thermostat"] else "NVE"
+
+    if not is_minimizer:
+        if mdp.get("cutoff-scheme", "").lower() != "verlet":
+            warnings.append("`cutoff-scheme` should be `Verlet` on modern GROMACS")
+        if "coulombtype" not in mdp:
+            warnings.append("no `coulombtype` set (expected PME for "
+                            "explicit-solvent systems)")
+        if "rvdw" not in mdp or "rcoulomb" not in mdp:
+            warnings.append("missing `rvdw` / `rcoulomb` cutoff(s)")
+
+    result["valid"] = len(errors) == 0
+    return result

--- a/tests/test_gromacs_skill.py
+++ b/tests/test_gromacs_skill.py
@@ -155,6 +155,31 @@ def test_entry_filename_is_engine_parameterized():
     assert a._entry_name("production") == "run_production.lammps"
 
 
+def test_gromacs_bundle_has_no_sweep_expander():
+    """Documents the scoped limitation: no fan-out parameter sweeps yet."""
+    from scilink.skills.molecular_dynamics.gromacs import gromacs as g
+    assert not hasattr(g, "expand_parameter_sweep")
+
+
+def test_sweep_request_degrades_loudly(caplog):
+    """A sweep requested on GROMACS (no expander) must warn, not silently
+    produce a single run (PR #499 review)."""
+    import logging
+    from scilink.agents.sim_agents.md_simulation_agent import (
+        MDSimulationAgent, _TOOL_REGISTRY,
+    )
+    a = MDSimulationAgent(working_dir=tempfile.mkdtemp(),
+                          api_key="dummy", base_url="http://localhost:0")
+    a.skill_name = "gromacs"
+    a.tools_module = _TOOL_REGISTRY["gromacs"]        # real module, no expander
+    plan = {"requires_multiple_simulations": True, "number_of_simulations": 3,
+            "variable_values": [300, 350, 400], "variable_parameter": "temperature"}
+    with caplog.at_level(logging.WARNING):
+        spec = a._sweep_spec(plan)
+    assert spec is None                                # degraded to a single run
+    assert any("no parameter-sweep expander" in r.message for r in caplog.records)
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_gromacs_skill.py
+++ b/tests/test_gromacs_skill.py
@@ -1,0 +1,160 @@
+"""Tests for the GROMACS molecular_dynamics engine skill.
+
+Covers the deterministic `.mdp` validator, the parser's normalization, and the
+agent integration (discovery, tool-registry registration, engine-parameterized
+entry filename) that makes GROMACS a first-class MD engine alongside LAMMPS.
+"""
+import tempfile
+
+import pytest
+
+from scilink.skills.molecular_dynamics.gromacs import gromacs as g
+
+
+def _mdp(tmp_path, text):
+    p = tmp_path / "grompp.mdp"
+    p.write_text(text)
+    return str(p)
+
+
+_GOOD_NPT = """\
+integrator = md
+dt = 0.002
+nsteps = 500000
+constraints = h-bonds
+cutoff-scheme = Verlet
+coulombtype = PME
+rvdw = 1.0
+rcoulomb = 1.0
+tcoupl = v-rescale
+tc-grps = Protein Water
+ref-t = 300 300
+tau-t = 0.1 0.1
+pcoupl = c-rescale
+ref-p = 1.0
+tau-p = 2.0
+compressibility = 4.5e-5
+"""
+
+_GOOD_NVT = """\
+integrator = md
+dt = 0.001
+cutoff-scheme = Verlet
+coulombtype = PME
+rvdw = 1.0
+rcoulomb = 1.0
+tcoupl = nose-hoover
+tc-grps = System
+ref-t = 310
+tau-t = 0.5
+nsteps = 100000
+"""
+
+_MINIMIZE = """\
+integrator = steep
+emtol = 1000.0
+nsteps = 50000
+cutoff-scheme = Verlet
+coulombtype = PME
+rvdw = 1.0
+rcoulomb = 1.0
+"""
+
+
+# ── parser ─────────────────────────────────────────────────────────
+
+def test_parse_mdp_normalizes_dashes_and_comments():
+    txt = "nstxout_compressed = 5000  ; trajectory\nDT = 0.002\n"
+    mdp = g.parse_mdp(txt)
+    assert mdp["nstxout-compressed"] == "5000"   # '_' -> '-'
+    assert mdp["dt"] == "0.002"                   # lowercased key
+    assert ";" not in "".join(mdp.values())       # comment stripped
+
+
+def test_parse_mdp_last_assignment_wins():
+    mdp = g.parse_mdp("ref-t = 300\nref-t = 310\n")
+    assert mdp["ref-t"] == "310"
+
+
+# ── validator ──────────────────────────────────────────────────────
+
+def test_good_npt_is_valid(tmp_path):
+    r = g.validate_script(_mdp(tmp_path, _GOOD_NPT))
+    assert r["valid"] is True
+    assert r["errors"] == []
+    assert r["ensemble"] == "NPT"
+    assert r["thermostat"] == "v-rescale"
+    assert r["barostat"] == "c-rescale"
+
+
+def test_good_nvt_has_no_barostat(tmp_path):
+    r = g.validate_script(_mdp(tmp_path, _GOOD_NVT))
+    assert r["valid"] is True
+    assert r["ensemble"] == "NVT"
+    assert r["barostat"] is None
+
+
+def test_minimizer_valid_without_thermostat(tmp_path):
+    """A steepest-descent minimization needs no thermostat/timestep-constraint."""
+    r = g.validate_script(_mdp(tmp_path, _MINIMIZE))
+    assert r["valid"] is True
+    assert r["integrator"] == "steep"
+
+
+def test_ref_t_group_mismatch_is_an_error(tmp_path):
+    txt = _GOOD_NVT.replace("tc-grps = System", "tc-grps = Protein Water")
+    r = g.validate_script(_mdp(tmp_path, txt))
+    assert r["valid"] is False
+    assert any("tc-grps" in e for e in r["errors"])
+
+
+def test_npt_missing_barostat_params_is_an_error(tmp_path):
+    txt = ("integrator = md\ndt = 0.002\nconstraints = h-bonds\n"
+           "tcoupl = v-rescale\ntc-grps = System\nref-t = 300\n"
+           "pcoupl = parrinello-rahman\n")   # no ref-p / tau-p / compressibility
+    r = g.validate_script(_mdp(tmp_path, txt))
+    assert r["valid"] is False
+    assert sum("missing" in e for e in r["errors"]) >= 3
+
+
+def test_large_timestep_without_constraints_warns(tmp_path):
+    txt = ("integrator = md\ndt = 0.004\ntcoupl = v-rescale\n"
+           "tc-grps = System\nref-t = 300\ncutoff-scheme = Verlet\n")
+    r = g.validate_script(_mdp(tmp_path, txt))
+    assert any("dt" in w and "constraint" in w for w in r["warnings"])
+
+
+def test_unreadable_file_is_invalid():
+    r = g.validate_script("/no/such/file.mdp")
+    assert r["valid"] is False
+    assert r["errors"]
+
+
+# ── agent integration ──────────────────────────────────────────────
+
+def test_gromacs_is_a_discovered_md_skill():
+    from scilink.skills.loader import list_skills
+    assert "gromacs" in list_skills(domain="molecular_dynamics")
+
+
+def test_gromacs_is_registered_in_the_tool_registry():
+    from scilink.agents.sim_agents.md_simulation_agent import _TOOL_REGISTRY
+    assert "gromacs" in _TOOL_REGISTRY
+    assert hasattr(_TOOL_REGISTRY["gromacs"], "validate_script")
+
+
+def test_entry_filename_is_engine_parameterized():
+    from scilink.agents.sim_agents.md_simulation_agent import MDSimulationAgent
+    a = MDSimulationAgent(working_dir=tempfile.mkdtemp(),
+                          api_key="dummy", base_url="http://localhost:0")
+    a.skill_name = "gromacs"
+    assert a._entry_name() == "grompp.mdp"
+    assert a._entry_name("equilibration") == "grompp_equilibration.mdp"
+    a.skill_name = "lammps"                      # unchanged for LAMMPS
+    assert a._entry_name() == "run.lammps"
+    assert a._entry_name("production") == "run_production.lammps"
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Makes **GROMACS** a first-class MD engine alongside LAMMPS. The `MDSimulationAgent` was already engine-neutral except in one spot — it wrote the generated run-control file under a hardcoded `run.lammps` entry name. This parameterizes that by engine and registers a GROMACS tools module; skill discovery (`list_skills`), the extension map, and the `validate_script` hook were already generic.

### What's in the bundle
- **`gromacs.md`** — engine knowledge with a `detect:` block on `gmx`/`gmx_mpi`/`mdrun`. The primary generated artifact is the **`.mdp`** run-control file; the skill covers integrator/`dt`/`nsteps`, v-rescale / nose-hoover thermostats, c-rescale / parrinello-rahman barostats for NVT vs NPT, PME + Verlet cutoffs, constraints, and the staged min→NVT→NPT→production workflow (`gmx grompp` → `gmx mdrun`).
- **`gromacs.py`** — deterministic `parse_mdp` (dash/underscore-normalized, comment-stripped) and `validate_script(script_path, system_info)` matching the LAMMPS validator contract (`{valid, errors, warnings, ...}`): integrator/timestep sanity, a thermostat on dynamics runs, a well-formed NVT-vs-NPT pressure-coupling block, `ref-t`/`tc-grps` field-count agreement, and cutoff/electrostatics presence.

### Agent integration
- Register the `gromacs` tools module in `_TOOL_REGISTRY`.
- Add an `_ENTRY_FILE` map + `_entry_name()` helper (`lammps`→`run.lammps`, `gromacs`→`grompp.mdp`, `openmm`→`run_openmm.py`) and use it at the three entry-file sites (single, fan-out campaign, staged). **LAMMPS behavior is unchanged** — still `run.lammps` / `run_<stage>.lammps`.

### Tests
`tests/test_gromacs_skill.py` (12): parser normalization + last-assignment-wins; validator on good NPT/NVT, a minimizer, a `ref-t`/`tc-grps` mismatch, missing barostat params, a large-timestep warning, and an unreadable file; plus agent integration (discovery, registry membership, engine-parameterized entry name, LAMMPS unchanged). The LAMMPS-skill suite (130) and MD-agent smoke/FF tests stay green.

### Why
This makes the "one agent per method, engines as skills" MD side extensible in practice, not just in principle — and backs the architecture figure's GROMACS chip with real code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Scope
GROMACS is first-class for **single-shot** and **staged** (min→NVT→NPT→production) generation. **Fan-out parameter sweeps are not yet supported** — the bundle ships no `expand_parameter_sweep`, so a sweep request degrades to a single run with a loud warning (`_sweep_spec`). A sweep expander is the follow-up.