### PR TITLE
orca geometry check: skip counterpoise/ghost decks instead of false-failing

### DIFF
--- a/scilink/skills/molecular_qc/orca/orca_geometry.py
+++ b/scilink/skills/molecular_qc/orca/orca_geometry.py
@@ -61,6 +61,13 @@ def _parse_geometry_block(deck: str) -> Optional[Dict[str, Any]]:
     """
     in_block = False
     elements: List[str] = []
+    # A block carrying ghost/dummy centres is a counterpoise/BSSE fragment (one
+    # monomer in the dimer basis, the rest as ghosts): its physical-atom count is
+    # a SUBSET of the source complex by design, so an atom-count comparison would
+    # false-fail. Track it and skip the check rather than reject a correct deck.
+    _GHOST_NOTE = ("coordinate block carries ghost/dummy centres "
+                   "(counterpoise/BSSE fragment); atom-count check skipped")
+    ghost_seen = False
     for raw in deck.splitlines():
         line = raw.split("#", 1)[0].strip()
         if not line:
@@ -82,6 +89,8 @@ def _parse_geometry_block(deck: str) -> Optional[Dict[str, Any]]:
                         "note": f"unrecognized coordinate style `* {rest[:40]}`; "
                                 "check skipped"}
             # A bare `*` (or `* ...`) while in the block closes it.
+            if ghost_seen:
+                return {"elements": [], "reliable": False, "note": _GHOST_NOTE}
             return {"elements": elements, "reliable": True, "note": ""}
         if not in_block:
             continue
@@ -96,10 +105,12 @@ def _parse_geometry_block(deck: str) -> Optional[Dict[str, Any]]:
             continue
         tag = toks[0]
         if tag.endswith(":"):             # ORCA ghost atom (basis, no nucleus)
+            ghost_seen = True
             continue
         m = _ELEMENT_RE.match(tag)        # tag/fragment-tolerant: "O1"/"C(1)" -> "O"/"C"
         sym = m.group(1).capitalize() if m else None
         if sym is not None and sym.lower() in _GHOST_DUMMY:
+            ghost_seen = True
             continue                      # dummy / point charge: not a physical atom
         if sym is None or not _is_element(sym):
             return {"elements": [], "reliable": False,
@@ -107,8 +118,11 @@ def _parse_geometry_block(deck: str) -> Optional[Dict[str, Any]]:
                             f"{line[:60]!r}"}
         elements.append(sym)
     # Block opened but no explicit closing `*` — use what we parsed.
-    return ({"elements": elements, "reliable": True, "note": ""}
-            if in_block else None)
+    if not in_block:
+        return None
+    if ghost_seen:
+        return {"elements": [], "reliable": False, "note": _GHOST_NOTE}
+    return {"elements": elements, "reliable": True, "note": ""}
 
 
 def _source_elements(structure_file: str) -> Optional[List[str]]:

--- a/tests/test_orca_geometry_check.py
+++ b/tests/test_orca_geometry_check.py
@@ -151,8 +151,9 @@ def test_internal_coordinates_skipped(co2_xyz):
     assert "int" in r["reason"]
 
 
-def test_ghost_atoms_excluded(co2_xyz):
-    """ORCA ghost atoms (`O:` trailing colon) are basis-only, not physical."""
+def test_ghost_atoms_skip_the_check(co2_xyz):
+    """A block with ghost atoms (`O:` trailing colon) is a counterpoise/BSSE
+    fragment — skip, don't atom-count against the full source."""
     deck = textwrap.dedent("""\
         ! B3LYP def2-SVP
         * xyz 0 1
@@ -164,12 +165,12 @@ def test_ghost_atoms_excluded(co2_xyz):
     """)
     r = check_geometry_consistency(input_files={"orca.inp": deck},
                                    structure_file=co2_xyz)
-    assert r["status"] == "ok"
-    assert r["composition"] == {"C": 1, "O": 2}
+    assert r["status"] == "skipped"
+    assert "ghost" in r["reason"] or "counterpoise" in r["reason"]
 
 
-def test_dummy_atom_excluded(co2_xyz):
-    """ORCA dummy centres (`DA`) are not physical atoms -> excluded, still ok."""
+def test_dummy_atom_skips_the_check(co2_xyz):
+    """ORCA dummy centres (`DA`) also make the atom count a non-comparison."""
     deck = textwrap.dedent("""\
         ! B3LYP def2-SVP
         * xyz 0 1
@@ -181,8 +182,26 @@ def test_dummy_atom_excluded(co2_xyz):
     """)
     r = check_geometry_consistency(input_files={"orca.inp": deck},
                                    structure_file=co2_xyz)
-    assert r["status"] == "ok"
-    assert r["composition"] == {"C": 1, "O": 2}
+    assert r["status"] == "skipped"
+
+
+def test_counterpoise_fragment_skips_not_mismatch(co2_xyz):
+    """The parity-sweep failure: a BSSE fragment deck (one monomer real, the
+    other as ghosts) has fewer physical atoms than the full source by design —
+    it must SKIP, not report a mismatch and fail generation."""
+    # Source is CO2 (C + 2 O). A counterpoise fragment: one O real, C + one O
+    # ghost — 1 physical atom vs 3 in the source.
+    deck = textwrap.dedent("""\
+        ! DLPNO-CCSD(T) def2-TZVP def2-TZVP/C
+        * xyz 0 1
+          O  0.0 0.0 0.0
+          C: 0.0 0.0 1.16
+          O: 0.0 0.0 2.32
+        *
+    """)
+    r = check_geometry_consistency(input_files={"orca.inp": deck},
+                                   structure_file=co2_xyz)
+    assert r["status"] == "skipped"          # NOT "mismatch"
 
 
 def test_lowercase_deck_ok(co2_xyz):


### PR DESCRIPTION
Follow-up from the cross-engine parity sweep. `check_geometry_consistency` (the ORCA #400 twin) **false-failed a valid counterpoise/BSSE deck**, aborting generation.

A BSSE fragment block is one monomer in the dimer basis with the other monomer as **ghost atoms** (trailing-colon element tags). The check correctly excludes ghosts as non-physical, but then compared the remaining physical-atom count (e.g. 1 C + 1 O) against the full-complex source (2 C + 2 O) and reported a `mismatch` → `status="error"`. In the parity sweep this hard-failed the `DLPNO-CCSD(T)` CO-dimer case.

**Fix:** track whether a coordinate block carried ghost/dummy centres and **skip** the check (`reliable=False`) when it did — matching the conservatism the module already applies to external (`xyzfile`) / internal (`int`/`gzmt`) coordinates. Ordinary ghost-free decks are still atom-counted, so a genuine dropped-atom/wrong-element transcription error is still caught loudly.

**Tests:** ghost- and dummy-bearing decks now `skipped` (were `ok`); a counterpoise fragment deck (fewer physical atoms than the source) `skipped` (was `mismatch`); all the real-mismatch/skip cases unchanged (17 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)