### PR TITLE
Fix divide-by-None when a plan sets timestep=None (MD minimization)

### DIFF
--- a/scilink/agents/sim_agents/md_simulation_agent.py
+++ b/scilink/agents/sim_agents/md_simulation_agent.py
@@ -576,12 +576,15 @@ class MDSimulationAgent(SimulationAgent):
                 f"{rows}\n"
             )
 
-        ts = plan.get("timestep", 2.0)
+        # `... or <default>`, not `.get(k, <default>)`: a plan may set these keys
+        # explicitly to None — e.g. a minimization has no timestep (GROMACS
+        # `integrator = steep`) — and a None default would divide-by-None below.
+        ts = plan.get("timestep") or 2.0
         equil_steps = int(
-            (plan.get("equilibration_time", 0.5) * 1e6) / ts
+            ((plan.get("equilibration_time") or 0.5) * 1e6) / ts
         )
         prod_steps = int(
-            (plan.get("production_time", 1.5) * 1e6) / ts
+            ((plan.get("production_time") or 1.5) * 1e6) / ts
         )
 
         elements_str = ", ".join(

--- a/tests/test_gromacs_skill.py
+++ b/tests/test_gromacs_skill.py
@@ -180,6 +180,23 @@ def test_sweep_request_degrades_loudly(caplog):
     assert any("no parameter-sweep expander" in r.message for r in caplog.records)
 
 
+def test_minimize_plan_with_none_timestep_does_not_crash(monkeypatch, tmp_path):
+    """A minimization plan sets timestep=None (GROMACS `integrator = steep` has
+    no dt); the step computation must not divide by None (crashed md_minimize in
+    the parity sweep)."""
+    from scilink.agents.sim_agents.md_simulation_agent import MDSimulationAgent
+    a = MDSimulationAgent(working_dir=str(tmp_path),
+                          api_key="dummy", base_url="http://localhost:0")
+    a._load_skill("gromacs")
+    monkeypatch.setattr(a, "_generate_text", lambda prompt: "integrator = steep\n")
+    struct = tmp_path / "s.xyz"
+    struct.write_text("1\n\nAr 0.0 0.0 0.0\n")
+    out = a._generate_md_input(
+        str(struct), "energy-minimize the system", "Ar system",
+        {"element_counts": {"Ar": 1}}, {"timestep": None})   # <- the crash trigger
+    assert isinstance(out, str) and "steep" in out
+
+
 if __name__ == "__main__":
     import sys
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Follow-up from the cross-engine parity sweep, and a **re-land**: this fix was on the #499 branch but landed one commit after #499 merged, so it didn't make it into main.

A minimization plan has no timestep — GROMACS uses `integrator = steep` — so the LLM plan sets `timestep: null`. `plan.get("timestep", 2.0)` returns `None` (the key *exists*, so the default is never used), and the equilibration/production step computation then does `float / None` → `TypeError`, crashing generation. In the parity sweep this hard-failed the GROMACS `md_minimize` case (LAMMPS minimize kept a timestep, so it never hit this).

**Fix:** use `plan.get(k) or <default>` for `timestep` and the equilibration/production times, so an explicit `None` falls back to the default. Regression test: `_generate_md_input` on a minimize plan with `timestep=None` returns a script instead of raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)