### PR TITLE
Anneal the whole skill with temperature at every stage (#498)

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -775,11 +775,62 @@ def _append_fit_domain_guidance(prompt: list, state: dict) -> None:
     )
 
 
+# Domain-skill strictness by annealing temperature (issue #498). ONE
+# temperature governs the whole skill at EVERY stage — planning, plan
+# validation, interpretation and the conformance framing here; codegen /
+# correction via the class-level ``_SKILL_STRICTNESS_SCHEDULE`` — so an
+# escalated (hot) re-run can re-PLAN with the skill already relaxed instead of
+# re-deriving a skill-bound plan it can only patch inside the fit loop:
+# mandatory (T=0) → guidance (T=1) → reference/overridable (T=2). Physics
+# grounding is the baseline's job (best-of-N plausibility rubric + deterministic
+# residual diagnostics), NOT a non-anneable skill rule — hot stays genuinely hot.
+# Each frame is (skill_header_label, intro_text, validation_header_label);
+# frame 0 is the original mandatory wording verbatim, so a first run (T=0) is
+# byte-identical to before.
+_SKILL_STRICTNESS_FRAMES = (
+    ("MANDATORY Domain Skill Rules",
+     "The following rules are MANDATORY. Your analysis plan and implementation "
+     "MUST conform to these domain-specific requirements. These rules encode "
+     "validated domain expertise and take precedence over general-purpose defaults. "
+     "Do NOT substitute your own preferences where these rules specify a method, "
+     "treatment, or constraint.",
+     "MANDATORY Domain Validation Rules"),
+    ("Domain Skill Guidance",
+     "Follow these domain rules unless the data clearly requires a different "
+     "approach. If you deviate from a rule, explain why.",
+     "Domain Validation Guidance"),
+    ("Domain Skill Reference",
+     "Use these domain rules as context. Override any rule where the data "
+     "warrants it, justifying the deviation from what you observe. Physical "
+     "soundness of the result — not rule-adherence — is the standard here.",
+     "Domain Validation Reference"),
+)
+
+
+def _skill_annealing_level(state: dict) -> int:
+    """Effective skill-strictness temperature for skill injection at any stage.
+
+    The QC engine seeds ``_annealing_level`` when the fit loop starts and
+    syncs it on every escalation; planning runs BEFORE that and best-of-N
+    candidates run in state copies, so fall back to the run's requested
+    starting level (``_starting_annealing_level``, set by a hot re-run) when
+    ``_annealing_level`` is unset. A re-run launched hot therefore re-plans
+    with the skill already relaxed; a first run resolves to 0 (unchanged).
+    """
+    level = state.get("_annealing_level")
+    if level is None:
+        level = state.get("_starting_annealing_level") or 0
+    return max(0, min(int(level), len(_SKILL_STRICTNESS_FRAMES) - 1))
+
+
 def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
     """Append domain skill knowledge to an LLM prompt for the given stage.
 
-    With multiple skills loaded, each skill's section is appended in order
-    (most-relevant first) so the LLM can attribute guidance to its source.
+    The skill's binding strength tracks the annealing temperature (see
+    ``_SKILL_STRICTNESS_FRAMES`` / ``_skill_annealing_level``): mandatory
+    when frozen (T=0), overridable when hot (T=2). With multiple skills
+    loaded, each skill's section is appended in order (most-relevant first)
+    so the LLM can attribute guidance to its source.
 
     Args:
         prompt: Mutable list of prompt parts to extend.
@@ -793,6 +844,9 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
     if not skills:
         return
 
+    skill_label, intro_text, validation_label = _SKILL_STRICTNESS_FRAMES[
+        _skill_annealing_level(state)
+    ]
     intro_appended = False
     for sections in skills:
         if not sections:
@@ -802,15 +856,9 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
             continue
         skill_name = sections.get("name", "domain skill")
 
-        prompt.append(f"\n## MANDATORY Domain Skill Rules: {skill_name} ({stage})")
+        prompt.append(f"\n## {skill_label}: {skill_name} ({stage})")
         if not intro_appended:
-            prompt.append(
-                "The following rules are MANDATORY. Your analysis plan and implementation "
-                "MUST conform to these domain-specific requirements. These rules encode "
-                "validated domain expertise and take precedence over general-purpose defaults. "
-                "Do NOT substitute your own preferences where these rules specify a method, "
-                "treatment, or constraint."
-            )
+            prompt.append(intro_text)
             intro_appended = True
         prompt.append(content)
 
@@ -819,7 +867,7 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
         if stage in ("planning", "interpretation"):
             validation = sections.get("validation", "")
             if validation:
-                prompt.append(f"\n## MANDATORY Domain Validation Rules ({skill_name})")
+                prompt.append(f"\n## {validation_label} ({skill_name})")
                 prompt.append(validation)
 
 
@@ -2974,7 +3022,7 @@ Your guidance: '''
         # skill's `implementation` section over its `analysis` synonym.
         recipes = _collect_codegen_recipe(state)
         if recipes:
-            level = state.get("_annealing_level", 0)
+            level = _skill_annealing_level(state)
             preamble = self._SKILL_STRICTNESS_SCHEDULE[
                 min(level, len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
             ].format(name=", ".join(n for n, _ in recipes))
@@ -3198,7 +3246,7 @@ Your guidance: '''
         # Codegen recipe from ALL co-active skills (see _generate_fitting_script).
         recipes = _collect_codegen_recipe(state)
         if recipes:
-            level = state.get("_annealing_level", 0)
+            level = _skill_annealing_level(state)
             preamble = self._SKILL_STRICTNESS_SCHEDULE[
                 min(level, len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
             ].format(name=", ".join(n for n, _ in recipes))
@@ -3229,10 +3277,15 @@ Your guidance: '''
         if not self.conformance_instructions:
             return None
 
-        # Build skill rules text for conformance checking
+        # Build skill rules text for conformance checking. At the hot level
+        # the skill is disregarded (issue #498): the checker's only job is
+        # plan fidelity, and skill rules offered as "reference" were still
+        # read as mandatory criteria (observed live), re-flagging a plan that
+        # deliberately left the skill's model behind.
         skill_rules_text = ""
         skill_sections = state.get("skill_sections")
-        if skill_sections:
+        _hot = len(self._SKILL_STRICTNESS_SCHEDULE) - 1
+        if skill_sections and _skill_annealing_level(state) < _hot:
             skill_name = state.get("skill_name", "domain skill")
             rules_parts = []
             for stage in ("planning", "analysis", "validation"):
@@ -3240,9 +3293,13 @@ Your guidance: '''
                 if content:
                     rules_parts.append(f"### {stage.title()} rules\n{content}")
             if rules_parts:
+                # Conformance checks the script against the (evolving) locked
+                # plan; only the skill FRAMING anneals here — same temperature
+                # as planning/codegen — so a justified hot deviation from the
+                # skill is not re-flagged as mandatory non-conformance.
                 skill_rules_text = (
                     "\n" + self._SKILL_STRICTNESS_SCHEDULE[
-                        min(state.get("_annealing_level", 0),
+                        min(_skill_annealing_level(state),
                             len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
                     ].format(name=skill_name)
                     + "\n".join(rules_parts)
@@ -3860,21 +3917,29 @@ Remember: Rejecting a good fit ({metric_label} {accept_cmp} {accept_threshold:.2
         "of proposing further changes.\n",
     )
 
-    # Same annealing applied to domain skill strictness during fitting.
-    # Planning and interpretation stages always keep skills mandatory.
+    # Domain skill strictness during codegen / correction. Planning, plan
+    # validation, interpretation and conformance anneal at the SAME temperature
+    # via the module-level _SKILL_STRICTNESS_FRAMES / _skill_annealing_level —
+    # the whole skill relaxes uniformly (issue #498); physics grounding is the
+    # baseline's responsibility.
     _SKILL_STRICTNESS_SCHEDULE = (
         # T=0: mandatory
         "## MANDATORY Domain Skill Rules ({name})\n"
         "These rules encode validated domain expertise and take precedence "
         "over defaults.\n\n",
-        # T=1: preferred
+        # T=1: preferred. The locked plan was made at this same temperature
+        # (issue #498), so where a skill recipe conflicts with it the plan
+        # wins — otherwise an imperative recipe ("always follow this exact
+        # sequence") drags a deliberately different plan back to the skill.
         "## Domain Skill Guidance ({name})\n"
         "Follow these rules unless the data clearly requires a different "
-        "approach. If you deviate, explain why.\n\n",
+        "approach. If you deviate, explain why. Where these rules conflict "
+        "with the locked plan, follow the plan.\n\n",
         # T=2: reference
         "## Domain Skill Reference ({name})\n"
         "Use as context. Override any rule if the data warrants it — "
-        "explain the deviation.\n\n",
+        "explain the deviation. Where these rules conflict with the locked "
+        "plan, follow the plan.\n\n",
     )
 
     def _verify_fit_with_llm(self, state: dict, fit_result: dict, history: List[dict] = None, verification_iter: int = 0, annealing_level: int | None = None, best_result: dict | None = None, best_verification: dict | None = None) -> Optional[dict]:
@@ -5553,6 +5618,7 @@ Return JSON with:
         # Winner's (possibly QC-refined) config becomes the regime's config;
         # the caller's existing propagation distributes it.
         state["locked_fitting_config"] = winner["config_after"]
+        self._record_winner_annealing_level(state, winner)
 
         result = winner["result"]
         self._promote_candidate_artifacts(
@@ -5617,6 +5683,24 @@ Return JSON with:
         return max(
             (it.get("annealing_level", 0) for it in iters), default=0
         )
+
+    def _record_winner_annealing_level(self, state: dict, winner: dict) -> None:
+        """Propagate the winning candidate's reached temperature to ``state``.
+
+        Best-of-N candidates run in shallow state COPIES, so the QC engine's
+        ``_annealing_level`` sync never reaches the caller's state. Interpretation
+        must read the level the winning fit actually reached (issue #498) — a
+        fit that went hot reads the skill as reference at interpretation — so
+        stamp it here at winner lock. Monotone: never lowers a level already
+        resolved for this state (the run's starting level included).
+        """
+        result = winner.get("result") or {}
+        reached = max(
+            self._candidate_max_annealing_level(winner),
+            int(result.get("_produced_at_level") or 0),
+            _skill_annealing_level(state),
+        )
+        state["_annealing_level"] = reached
 
     def _candidate_climbed_to_hot(self, c: dict) -> bool:
         """True only if the loop ESCALATED into hot annealing under stall — it

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -41,7 +41,50 @@ from .._qc_engine import CodegenQCEngine, QCEngineSpec, QCItemContext
 from ....utils.codegen_parse import parse_codegen_response
 
 
-def _render_skill_block(state: dict, stage: str) -> str:
+# Domain-skill strictness by annealing temperature (issue #498), same frames
+# as curve fitting: mandatory (T=0) → guidance (T=1) → reference/overridable
+# (T=2). Hyperspectral's temperature is its codegen retry ladder
+# (``_retry_annealing_level``): the ladder's hot rung says "abandon the method
+# family", so the skill block in the regenerated codegen prompt must relax in
+# lockstep instead of staying MANDATORY. Planning / interpretation read the
+# state-level temperature through ``_skill_annealing_level`` (this agent does
+# not seed one today, so they resolve to T=0). Each frame is
+# (skill_header_label, intro_text, validation_header_label); frame 0 is the
+# original mandatory wording verbatim, so a first attempt is byte-identical.
+_SKILL_STRICTNESS_FRAMES = (
+    ("MANDATORY Domain Skill Rules",
+     "The following rules are MANDATORY. Your analysis plan and implementation "
+     "MUST conform to these domain-specific requirements. These rules encode "
+     "validated domain expertise and take precedence over general-purpose defaults. "
+     "Do NOT substitute your own preferences where these rules specify a method, "
+     "treatment, or constraint.",
+     "MANDATORY Domain Validation Rules"),
+    ("Domain Skill Guidance",
+     "Follow these domain rules unless the data clearly requires a different "
+     "approach. If you deviate from a rule, explain why.",
+     "Domain Validation Guidance"),
+    ("Domain Skill Reference",
+     "Use these domain rules as context. Override any rule where the data "
+     "warrants it, justifying the deviation from what you observe. Physical "
+     "soundness of the result — not rule-adherence — is the standard here.",
+     "Domain Validation Reference"),
+)
+
+
+def _skill_annealing_level(state: dict) -> int:
+    """Effective skill-strictness temperature for skill injection.
+
+    Reads ``_annealing_level`` (the live loop temperature), falling back to
+    the run's requested starting level (``_starting_annealing_level``) and
+    then to 0. Same resolver shape as the curve / image controllers.
+    """
+    level = state.get("_annealing_level")
+    if level is None:
+        level = state.get("_starting_annealing_level") or 0
+    return max(0, min(int(level), len(_SKILL_STRICTNESS_FRAMES) - 1))
+
+
+def _render_skill_block(state: dict, stage: str, level: int | None = None) -> str:
     """Render the active domain skill(s) block for ``stage`` as a single string.
 
     With multiple skills loaded, each skill's block is rendered in order
@@ -51,6 +94,10 @@ def _render_skill_block(state: dict, stage: str) -> str:
     exists for the requested stage. Use this from prompt builders that
     assemble a single string (e.g. ``build_code_generation_prompt``); the
     list-mode wrapper ``_append_skill_context`` below uses this internally.
+
+    ``level`` pins the skill-strictness frame (``_SKILL_STRICTNESS_FRAMES``);
+    ``None`` resolves it from ``state`` via ``_skill_annealing_level``. The
+    codegen retry ladder passes its per-attempt rung explicitly.
     """
     skills = state.get("skills_loaded") or (
         [state["skill_sections"]] if state.get("skill_sections") else []
@@ -58,6 +105,11 @@ def _render_skill_block(state: dict, stage: str) -> str:
     if not skills:
         return ""
 
+    if level is None:
+        level = _skill_annealing_level(state)
+    skill_label, intro_text, validation_label = _SKILL_STRICTNESS_FRAMES[
+        max(0, min(int(level), len(_SKILL_STRICTNESS_FRAMES) - 1))
+    ]
     parts: list = []
     intro_appended = False
     for sections in skills:
@@ -68,15 +120,9 @@ def _render_skill_block(state: dict, stage: str) -> str:
             continue
         skill_name = sections.get("name", "domain skill")
 
-        parts.append(f"\n## MANDATORY Domain Skill Rules: {skill_name} ({stage})")
+        parts.append(f"\n## {skill_label}: {skill_name} ({stage})")
         if not intro_appended:
-            parts.append(
-                "The following rules are MANDATORY. Your analysis plan and implementation "
-                "MUST conform to these domain-specific requirements. These rules encode "
-                "validated domain expertise and take precedence over general-purpose defaults. "
-                "Do NOT substitute your own preferences where these rules specify a method, "
-                "treatment, or constraint."
-            )
+            parts.append(intro_text)
             intro_appended = True
         parts.append(content)
 
@@ -87,7 +133,7 @@ def _render_skill_block(state: dict, stage: str) -> str:
         if stage in ("planning", "interpretation", "implementation"):
             validation = sections.get("validation", "")
             if validation:
-                parts.append(f"\n## MANDATORY Domain Validation Rules ({skill_name})")
+                parts.append(f"\n## {validation_label} ({skill_name})")
                 parts.append(validation)
 
     return "\n".join(parts)
@@ -2875,52 +2921,57 @@ class RunDynamicAnalysisController:
                         "    fit_scope=component_mask requested but no usable "
                         "abundance mask — falling back to full_frame.")
 
-            # 1. Define Prompt for this specific task
-            base_prompt = build_code_generation_prompt(
-                target_desc=target_desc,
-                h=h, w=w, e=e,
-                axis_units=axis_units,
-                axis_start=state['energy_axis'][0],
-                axis_end=state['energy_axis'][-1],
-                processing_note=processing_note,
-                hints=state.get("analysis_hints"),
-                objective=state.get("analysis_objective"),
-                required_outputs=required_outputs,
-                # Inject the active skill's `implementation` section so the
-                # code-gen LLM gets domain-specific recipe guidance (lineshape,
-                # baseline, library choice). Empty string when no skill is
-                # active or no implementation section is defined.
-                skill_implementation=_render_skill_block(state, "implementation"),
-                reconstruction_available=reconstruction is not None,
-                auxiliary_operands={k: v.shape for k, v in auxiliary_operands.items()},
-                fit_mask_pixels=((int(fit_mask.sum()), int(fit_mask.size),
-                                  int(target.get("mask_component_index")))
-                                 if fit_mask is not None else None),
-            )
-
-            # Registered tools from the _shared registry (this agent + active
-            # skills). Pre-loaded into the sandbox globals below, so generated
-            # code MAY call them by name (no import) when one fits — the same
-            # optional-tool mechanism the image / curve agents use.
-            _tool_specs = _hyperspectral_tool_specs(state)
-            if _tool_specs:
-                base_prompt += (
-                    "\n\n### REGISTERED TOOLS (pre-loaded — call by name, no import)\n"
-                    "These functions are already in scope. Prefer one when it fits "
-                    "the task (e.g. deriving physical constants) over reimplementing it."
+            # 1. Define Prompt for this specific task. Built by a per-level
+            # function so the retry ladder (qc_refine) can re-render it with
+            # the skill block relaxed to the attempt's rung (issue #498);
+            # level 0 is the unchanged first-attempt prompt.
+            def _render_base_prompt(level: int = 0) -> str:
+                base_prompt = build_code_generation_prompt(
+                    target_desc=target_desc,
+                    h=h, w=w, e=e,
+                    axis_units=axis_units,
+                    axis_start=state['energy_axis'][0],
+                    axis_end=state['energy_axis'][-1],
+                    processing_note=processing_note,
+                    hints=state.get("analysis_hints"),
+                    objective=state.get("analysis_objective"),
+                    required_outputs=required_outputs,
+                    # Inject the active skill's `implementation` section so the
+                    # code-gen LLM gets domain-specific recipe guidance (lineshape,
+                    # baseline, library choice). Empty string when no skill is
+                    # active or no implementation section is defined.
+                    skill_implementation=_render_skill_block(
+                        state, "implementation", level=level),
+                    reconstruction_available=reconstruction is not None,
+                    auxiliary_operands={k: v.shape for k, v in auxiliary_operands.items()},
+                    fit_mask_pixels=((int(fit_mask.sum()), int(fit_mask.size),
+                                      int(target.get("mask_component_index")))
+                                     if fit_mask is not None else None),
                 )
-                for _spec in _tool_specs:
-                    base_prompt += "\n" + _spec.to_prompt()
 
-            # Append a preprocessing-mask hint when one exists and identifies
-            # excluded pixels. The mask is already applied to the data (zero-
-            # filled), so per-pixel fits will produce garbage values on
-            # excluded pixels; the LLM should be told to filter on the mask.
-            mask = state.get("preprocessing_mask")
-            if mask is not None and not bool(mask.all()):
-                n_kept = int(mask.sum())
-                n_total = int(mask.size)
-                base_prompt += f"""
+                # Registered tools from the _shared registry (this agent + active
+                # skills). Pre-loaded into the sandbox globals below, so generated
+                # code MAY call them by name (no import) when one fits — the same
+                # optional-tool mechanism the image / curve agents use.
+                _tool_specs = _hyperspectral_tool_specs(state)
+                if _tool_specs:
+                    base_prompt += (
+                        "\n\n### REGISTERED TOOLS (pre-loaded — call by name, no import)\n"
+                        "These functions are already in scope. Prefer one when it fits "
+                        "the task (e.g. deriving physical constants) over reimplementing it."
+                    )
+                    for _spec in _tool_specs:
+                        base_prompt += "\n" + _spec.to_prompt()
+
+                # Append a preprocessing-mask hint when one exists and identifies
+                # excluded pixels. The mask is already applied to the data (zero-
+                # filled), so per-pixel fits will produce garbage values on
+                # excluded pixels; the LLM should be told to filter on the mask.
+                mask = state.get("preprocessing_mask")
+                if mask is not None and not bool(mask.all()):
+                    n_kept = int(mask.sum())
+                    n_total = int(mask.size)
+                    base_prompt += f"""
 
 ### PREPROCESSING MASK
 A boolean preprocessing mask of shape ({mask.shape[0]}, {mask.shape[1]}) is
@@ -2929,6 +2980,9 @@ available indicating which (axis_0, axis_1) samples carry valid signal:
 into the analysis function — operate on the raw spectra and, if your output
 maps should mark excluded samples, set them to np.nan in your returned maps.
 """
+                return base_prompt
+
+            base_prompt = _render_base_prompt(0)
 
             # --- Run the per-target attempt ladder on the shared engine ---
             # (#327 phase 5). The engine drives the outer loop: initial
@@ -2946,6 +3000,7 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
             ctx.target_index = i
             ctx.required_outputs = required_outputs
             ctx.base_prompt = base_prompt
+            ctx.base_prompt_builder = _render_base_prompt
             ctx.current_prompt = base_prompt
             # Script-bank exemplar (#346): appended to the FIRST attempt's
             # prompt only — retries rebuild from the clean base_prompt, so
@@ -3212,7 +3267,13 @@ maps should mark excluded samples, set them to np.nan in your returned maps.
                    if ctx.annealing_level < 2 else None)
         _history = _render_attempt_history(
             (getattr(ctx, "attempt_entries", None) or [])[:-1])
-        ctx.current_prompt = ctx.base_prompt + _codegen_retry_feedback(
+        # Skill strictness relaxes with the rung (issue #498): a hot retry
+        # that is told to abandon the method family must not also carry a
+        # MANDATORY skill block. Level 0 re-renders the identical base prompt.
+        _builder = getattr(ctx, "base_prompt_builder", None)
+        _base = (_builder(ctx.annealing_level)
+                 if _builder is not None else ctx.base_prompt)
+        ctx.current_prompt = _base + _codegen_retry_feedback(
             ctx.retries, verification.get("error_msg") or "",
             passed_names=getattr(ctx, "last_passed_names", None),
             prior_script=_anchor,

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -319,11 +319,55 @@ def _active_skill_names(state: dict) -> list[str]:
     return [legacy] if legacy else []
 
 
+# Domain-skill strictness by annealing temperature (issue #498). ONE
+# temperature governs the whole skill at EVERY stage — planning, plan
+# validation, interpretation and the conformance framing; codegen / correction
+# via the class-level ``_SKILL_STRICTNESS_SCHEDULE`` — so a hot re-run can
+# re-PLAN with the skill already relaxed. Image skills are advisory by design
+# (composable, not authoritative like curve fitting's), so even T=0 is
+# "expertise to inform", softening to "context" at T=2. Physics grounding is
+# the baseline's job, not a non-anneable skill rule. Each frame is
+# (skill_header_label, intro_text, validation_header_label); frame 0 is the
+# original wording verbatim, so a first run (T=0) is byte-identical to before.
+_SKILL_STRICTNESS_FRAMES = (
+    ("Domain Expertise",
+     "The following guidance is from validated domain expertise. "
+     "Use it to inform your approach.",
+     "Domain Validation Guidance"),
+    ("Domain Expertise (reference)",
+     "Use this validated domain expertise as reference. If the data clearly "
+     "requires a different approach, deviate and explain why.",
+     "Domain Validation Reference"),
+    ("Domain Expertise (context)",
+     "Use this domain expertise as background context. Override any guidance "
+     "where the data warrants it — explain the deviation.",
+     "Domain Validation Context"),
+)
+
+
+def _skill_annealing_level(state: dict) -> int:
+    """Effective skill-strictness temperature for skill injection at any stage.
+
+    The QC engine seeds ``_annealing_level`` when the analysis loop starts and
+    syncs it on every escalation; planning runs BEFORE that and best-of-N
+    candidates run in state copies, so fall back to the run's requested
+    starting level (``_starting_annealing_level``, set by a hot re-run) when
+    ``_annealing_level`` is unset. A re-run launched hot therefore re-plans
+    with the skill already relaxed; a first run resolves to 0 (unchanged).
+    """
+    level = state.get("_annealing_level")
+    if level is None:
+        level = state.get("_starting_annealing_level") or 0
+    return max(0, min(int(level), len(_SKILL_STRICTNESS_FRAMES) - 1))
+
+
 def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
     """Append domain skill knowledge to an LLM prompt for the given stage.
 
-    With multiple skills loaded, sections from each are appended in order
-    so the LLM can attribute guidance to its source.
+    The skill's binding strength tracks the annealing temperature (see
+    ``_SKILL_STRICTNESS_FRAMES`` / ``_skill_annealing_level``). With multiple
+    skills loaded, sections from each are appended in order so the LLM can
+    attribute guidance to its source.
 
     Args:
         prompt: Mutable list of prompt parts to extend.
@@ -339,6 +383,9 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
     if not skills:
         return
 
+    skill_label, intro_text, validation_label = _SKILL_STRICTNESS_FRAMES[
+        _skill_annealing_level(state)
+    ]
     intro_appended = False
     for sections in skills:
         if not sections:
@@ -347,12 +394,9 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
         if not content:
             continue
         skill_name = sections.get("name", "domain skill")
-        prompt.append(f"\n## Domain Expertise: {skill_name} ({stage})")
+        prompt.append(f"\n## {skill_label}: {skill_name} ({stage})")
         if not intro_appended:
-            prompt.append(
-                "The following guidance is from validated domain expertise. "
-                "Use it to inform your approach."
-            )
+            prompt.append(intro_text)
             intro_appended = True
         prompt.append(content)
 
@@ -360,7 +404,7 @@ def _append_skill_context(prompt: list, state: dict, stage: str) -> None:
         if stage in ("planning", "interpretation"):
             validation = sections.get("validation", "")
             if validation:
-                prompt.append(f"\n## Domain Validation Guidance: {skill_name}")
+                prompt.append(f"\n## {validation_label}: {skill_name}")
                 prompt.append(validation)
 
 
@@ -1894,21 +1938,28 @@ class UnifiedImageProcessingController:
         "",
     )
 
-    # Same annealing applied to domain skill strictness during analysis.
-    # Planning and interpretation stages always keep skills at T=0 (guidance).
+    # Domain skill strictness during codegen / correction. Planning, plan
+    # validation, interpretation and conformance anneal at the SAME temperature
+    # via the module-level _SKILL_STRICTNESS_FRAMES / _skill_annealing_level —
+    # the whole skill relaxes uniformly (issue #498); physics grounding is the
+    # baseline's responsibility.
     _SKILL_STRICTNESS_SCHEDULE = (
         # T=0: guidance (default for image analysis — softer than curve fitting's "mandatory")
         "## Domain Expertise Guidance ({name})\n"
         "The following guidance is from validated domain expertise. "
         "Use it to inform your implementation.\n\n",
-        # T=1: light reference
+        # T=1: light reference. The locked plan was made at this same
+        # temperature (issue #498): where a skill recipe conflicts with it the
+        # plan wins.
         "## Domain Expertise Reference ({name})\n"
         "Use as reference. If the data clearly requires a different approach, "
-        "deviate and explain why.\n\n",
+        "deviate and explain why. Where this guidance conflicts with the "
+        "locked plan, follow the plan.\n\n",
         # T=2: context only
         "## Domain Expertise Context ({name})\n"
         "Use as background context only. Override any guidance if the data "
-        "warrants it — explain the deviation.\n\n",
+        "warrants it — explain the deviation. Where this guidance conflicts "
+        "with the locked plan, follow the plan.\n\n",
     )
 
     JUDGE_PROMPT = '''You are a scientific image analysis expert acting as a judge.
@@ -2084,7 +2135,7 @@ Your guidance: '''
         # output is unchanged. Prefers `implementation` over `analysis`.
         recipes = _collect_codegen_recipe(state)
         if recipes:
-            level = state.get("_annealing_level", 0)
+            level = _skill_annealing_level(state)
             preamble = self._SKILL_STRICTNESS_SCHEDULE[
                 min(level, len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
             ].format(name=", ".join(n for n, _ in recipes))
@@ -2348,7 +2399,7 @@ Your guidance: '''
         # Codegen recipe from ALL co-active skills (see the generate-script path).
         recipes = _collect_codegen_recipe(state)
         if recipes:
-            level = state.get("_annealing_level", 0)
+            level = _skill_annealing_level(state)
             preamble = self._SKILL_STRICTNESS_SCHEDULE[
                 min(level, len(self._SKILL_STRICTNESS_SCHEDULE) - 1)
             ].format(name=", ".join(n for n, _ in recipes))
@@ -2379,10 +2430,13 @@ Your guidance: '''
         if not self.conformance_instructions:
             return None
 
-        # Build skill rules text for conformance checking
+        # Build skill rules text for conformance checking. At the hot level
+        # the skill is disregarded (issue #498): the checker's only job is
+        # plan fidelity (mirrors the curve controller).
         skill_rules_text = ""
         skill_sections = state.get("skill_sections")
-        if skill_sections:
+        _hot = len(self._SKILL_STRICTNESS_SCHEDULE) - 1
+        if skill_sections and _skill_annealing_level(state) < _hot:
             skill_name = state.get("skill_name", "domain skill")
             rules_parts = []
             for stage in ("planning", "analysis", "validation"):
@@ -2390,8 +2444,15 @@ Your guidance: '''
                 if content:
                     rules_parts.append(f"### {stage.title()} rules\n{content}")
             if rules_parts:
+                # Conformance checks the script against the (evolving) locked
+                # plan; only the skill FRAMING anneals here — same temperature
+                # as planning/codegen (issue #498) — so a justified hot
+                # deviation is not re-flagged as non-conformance. Frame 0
+                # reproduces the original "Domain Expertise" label verbatim.
+                _skill_label = _SKILL_STRICTNESS_FRAMES[
+                    _skill_annealing_level(state)][0]
                 skill_rules_text = (
-                    f"\n**Domain Expertise ({skill_name}):**\n"
+                    f"\n**{_skill_label} ({skill_name}):**\n"
                     + "\n".join(rules_parts)
                     + "\n"
                 )
@@ -4451,6 +4512,7 @@ Return JSON with:
         # Winner's (possibly QC-refined) config becomes the regime's config;
         # the caller's existing propagation distributes it.
         state["locked_analysis_config"] = winner["config_after"]
+        self._record_winner_annealing_level(state, winner)
 
         result = winner["result"]
         self._promote_candidate_artifacts(result, image_idx, winner["attempt"])
@@ -4507,6 +4569,23 @@ Return JSON with:
         return max(
             (it.get("annealing_level", 0) for it in iters), default=0
         )
+
+    def _record_winner_annealing_level(self, state: dict, winner: dict) -> None:
+        """Propagate the winning candidate's reached temperature to ``state``.
+
+        Best-of-N candidates run in shallow state COPIES, so the QC engine's
+        ``_annealing_level`` sync never reaches the caller's state.
+        Interpretation must read the level the winning analysis actually
+        reached (issue #498), so stamp it here at winner lock. Monotone: never
+        lowers a level already resolved for this state (starting level included).
+        """
+        result = winner.get("result") or {}
+        reached = max(
+            self._candidate_max_annealing_level(winner),
+            int(result.get("_produced_at_level") or 0),
+            _skill_annealing_level(state),
+        )
+        state["_annealing_level"] = reached
 
     def _candidate_climbed_to_hot(self, c: dict) -> bool:
         """True only if the loop ESCALATED into hot annealing under stall —

--- a/tests/test_skill_annealing_all_stages.py
+++ b/tests/test_skill_annealing_all_stages.py
@@ -1,0 +1,421 @@
+"""One temperature governs the whole skill at every stage (issue #498).
+
+Skill strictness used to anneal only inside the codegen/verification loop;
+planning, plan validation, interpretation and (image) conformance injected
+the skill as hard-MANDATORY at every temperature, so a hot re-run re-derived
+the same skill-bound plan and could only deviate while patching the fit.
+
+Now a per-agent ``_SKILL_STRICTNESS_FRAMES`` table, resolved by
+``_skill_annealing_level(state)`` (live ``_annealing_level``, falling back to
+the run's ``_starting_annealing_level``), frames the skill identically at
+all stages: mandatory (T=0) -> guidance (T=1) -> reference/overridable (T=2).
+
+Invariants pinned here:
+  * T=0 framing is BYTE-IDENTICAL to the pre-#498 hardcoded wording (per agent).
+  * planning / interpretation framing relaxes at T=1 / T=2.
+  * a hot RE-RUN (``_starting_annealing_level`` set, loop not started) re-plans
+    with the skill already relaxed.
+  * conformance keeps checking the locked plan; only its skill framing anneals.
+  * best-of-N winner lock propagates the reached level so interpretation reads
+    the FINAL temperature.
+  * hyperspectral's codegen retry ladder re-renders the skill block at the
+    attempt's rung; the first attempt is unchanged.
+"""
+
+import inspect
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from scilink.agents.exp_agents.controllers import curve_fitting_controllers as cc
+from scilink.agents.exp_agents.controllers import image_analysis_controllers as ic
+from scilink.agents.exp_agents.controllers import hyperspectral_controllers as hc
+from scilink.agents.exp_agents._qc_engine import QCItemContext
+
+
+_SKILL = {
+    "name": "xps",
+    "planning": "PLAN-RULES",
+    "analysis": "ANALYSIS-RULES",
+    "implementation": "IMPL-RULES",
+    "interpretation": "INTERP-RULES",
+    "validation": "VALID-RULES",
+}
+
+
+def _state(**extra):
+    st = {"skills_loaded": [dict(_SKILL)],
+          "skill_sections": dict(_SKILL), "skill_name": "xps"}
+    st.update(extra)
+    return st
+
+
+def _render(mod, state, stage):
+    parts = []
+    mod._append_skill_context(parts, state, stage)
+    return parts
+
+
+# ---------------------------------------------------------------------------
+# Level resolver
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mod", [cc, ic, hc], ids=["curve", "image", "hyper"])
+def test_resolver_first_run_is_frozen(mod):
+    assert mod._skill_annealing_level({}) == 0
+    assert mod._skill_annealing_level({"_starting_annealing_level": None}) == 0
+
+
+@pytest.mark.parametrize("mod", [cc, ic, hc], ids=["curve", "image", "hyper"])
+def test_resolver_falls_back_to_starting_level_before_loop_seeds_it(mod):
+    # Planning runs BEFORE the QC engine seeds _annealing_level: a hot re-run
+    # must resolve to its requested starting level.
+    assert mod._skill_annealing_level({"_starting_annealing_level": 2}) == 2
+    assert mod._skill_annealing_level({"_starting_annealing_level": 1}) == 1
+
+
+@pytest.mark.parametrize("mod", [cc, ic, hc], ids=["curve", "image", "hyper"])
+def test_resolver_live_level_wins_and_clamps(mod):
+    assert mod._skill_annealing_level(
+        {"_annealing_level": 1, "_starting_annealing_level": 2}) == 1
+    assert mod._skill_annealing_level(
+        {"_annealing_level": 0, "_starting_annealing_level": 2}) == 0
+    assert mod._skill_annealing_level({"_annealing_level": 99}) == 2
+    assert mod._skill_annealing_level({"_annealing_level": -3}) == 0
+
+
+# ---------------------------------------------------------------------------
+# T=0 byte-identity with the pre-#498 hardcoded wording
+# ---------------------------------------------------------------------------
+
+_CURVE_MANDATORY_INTRO = (
+    "The following rules are MANDATORY. Your analysis plan and implementation "
+    "MUST conform to these domain-specific requirements. These rules encode "
+    "validated domain expertise and take precedence over general-purpose defaults. "
+    "Do NOT substitute your own preferences where these rules specify a method, "
+    "treatment, or constraint."
+)
+
+
+def test_curve_t0_planning_framing_is_byte_identical():
+    assert _render(cc, _state(), "planning") == [
+        "\n## MANDATORY Domain Skill Rules: xps (planning)",
+        _CURVE_MANDATORY_INTRO,
+        "PLAN-RULES",
+        "\n## MANDATORY Domain Validation Rules (xps)",
+        "VALID-RULES",
+    ]
+    # analysis stage: no validation block (unchanged)
+    assert _render(cc, _state(), "analysis") == [
+        "\n## MANDATORY Domain Skill Rules: xps (analysis)",
+        _CURVE_MANDATORY_INTRO,
+        "ANALYSIS-RULES",
+    ]
+
+
+def test_image_t0_planning_framing_is_byte_identical():
+    assert _render(ic, _state(), "planning") == [
+        "\n## Domain Expertise: xps (planning)",
+        "The following guidance is from validated domain expertise. "
+        "Use it to inform your approach.",
+        "PLAN-RULES",
+        "\n## Domain Validation Guidance: xps",
+        "VALID-RULES",
+    ]
+
+
+def test_hyperspectral_t0_framing_is_byte_identical():
+    assert _render(hc, _state(), "planning") == [
+        "\n## MANDATORY Domain Skill Rules: xps (planning)\n"
+        + _CURVE_MANDATORY_INTRO
+        + "\nPLAN-RULES"
+        "\n\n## MANDATORY Domain Validation Rules (xps)"
+        "\nVALID-RULES"
+    ]
+    # implementation (codegen) also carries validation at T=0 — unchanged.
+    block = hc._render_skill_block(_state(), "implementation")
+    assert block.startswith("\n## MANDATORY Domain Skill Rules: xps (implementation)")
+    assert "\n## MANDATORY Domain Validation Rules (xps)\nVALID-RULES" in block
+    assert hc._render_skill_block(_state(), "implementation", level=0) == block
+
+
+@pytest.mark.parametrize("mod", [cc, ic, hc], ids=["curve", "image", "hyper"])
+def test_t0_frame_matches_the_legacy_single_skill_state(mod):
+    # legacy skill_sections-only state renders exactly like skills_loaded
+    legacy = {"skill_sections": dict(_SKILL), "skill_name": "xps"}
+    assert _render(mod, legacy, "planning") == _render(mod, _state(), "planning")
+
+
+# ---------------------------------------------------------------------------
+# Planning / interpretation relax with temperature
+# ---------------------------------------------------------------------------
+
+def test_curve_planning_relaxes_with_live_level():
+    warm = _render(cc, _state(_annealing_level=1), "planning")
+    hot = _render(cc, _state(_annealing_level=2), "planning")
+    assert warm[0] == "\n## Domain Skill Guidance: xps (planning)"
+    assert warm[3] == "\n## Domain Validation Guidance (xps)"
+    assert hot[0] == "\n## Domain Skill Reference: xps (planning)"
+    assert hot[3] == "\n## Domain Validation Reference (xps)"
+    for parts in (warm, hot):
+        assert not any("MANDATORY" in p for p in parts)
+        assert "PLAN-RULES" in parts and "VALID-RULES" in parts  # content intact
+    assert "Override any rule" in hot[1]
+    assert "explain why" in warm[1]
+
+
+def test_image_planning_relaxes_with_live_level():
+    warm = _render(ic, _state(_annealing_level=1), "planning")
+    hot = _render(ic, _state(_annealing_level=2), "planning")
+    assert warm[0] == "\n## Domain Expertise (reference): xps (planning)"
+    assert warm[3] == "\n## Domain Validation Reference: xps"
+    assert hot[0] == "\n## Domain Expertise (context): xps (planning)"
+    assert hot[3] == "\n## Domain Validation Context: xps"
+    assert "Override any guidance" in hot[1]
+
+
+def test_hyperspectral_block_relaxes_with_level():
+    hot = hc._render_skill_block(_state(), "implementation", level=2)
+    assert hot.startswith("\n## Domain Skill Reference: xps (implementation)")
+    assert "MANDATORY" not in hot
+    assert "\n## Domain Validation Reference (xps)\nVALID-RULES" in hot
+    # state-level resolution works too (no level kwarg)
+    assert hc._render_skill_block(_state(_annealing_level=1), "planning").startswith(
+        "\n## Domain Skill Guidance: xps (planning)")
+
+
+@pytest.mark.parametrize("mod", [cc, ic, hc], ids=["curve", "image", "hyper"])
+def test_hot_rerun_replans_with_relaxed_skill(mod):
+    # A re-run launched hot sets ONLY _starting_annealing_level; the loop has
+    # not seeded _annealing_level yet when planning runs.
+    parts = _render(mod, _state(_starting_annealing_level=2), "planning")
+    text = "\n".join(parts)
+    assert "MANDATORY" not in text
+    assert mod._SKILL_STRICTNESS_FRAMES[2][0] in text
+    assert "PLAN-RULES" in text
+
+
+@pytest.mark.parametrize("mod", [cc, ic, hc], ids=["curve", "image", "hyper"])
+def test_interpretation_reads_final_level(mod):
+    # After a fit that went hot, state["_annealing_level"] == 2 (engine sync /
+    # winner lock) -> interpretation reads the skill as reference.
+    hot = "\n".join(_render(mod, _state(_annealing_level=2), "interpretation"))
+    frozen = "\n".join(_render(mod, _state(), "interpretation"))
+    assert mod._SKILL_STRICTNESS_FRAMES[2][0] in hot
+    assert mod._SKILL_STRICTNESS_FRAMES[2][2] in hot
+    assert mod._SKILL_STRICTNESS_FRAMES[0][0] in frozen
+    assert "INTERP-RULES" in hot and "INTERP-RULES" in frozen
+
+
+def test_multi_skill_intro_appears_once_per_frame():
+    st = _state()
+    st["skills_loaded"].append({"name": "raman", "planning": "P2", "validation": "V2"})
+    hot = _render(cc, dict(st, _annealing_level=2), "planning")
+    intro = cc._SKILL_STRICTNESS_FRAMES[2][1]
+    assert hot.count(intro) == 1
+    assert hot[0] == "\n## Domain Skill Reference: xps (planning)"
+    assert "\n## Domain Skill Reference: raman (planning)" in hot
+
+
+# ---------------------------------------------------------------------------
+# Conformance: still checks the locked plan; only the skill framing anneals
+# ---------------------------------------------------------------------------
+
+class _CapturingModel:
+    def __init__(self):
+        self.prompts = []
+
+    def generate_content(self, contents=None, **_):
+        self.prompts.append(contents[0])
+        raise RuntimeError("stop after capture")
+
+
+def _curve_conformance_prompt(state):
+    ctl = object.__new__(cc.UnifiedSeriesProcessingController)
+    ctl.model = _CapturingModel()
+    ctl.logger = logging.getLogger("test")
+    ctl.conformance_instructions = (
+        "PLAN={physical_model}|{analysis_approach}|{parameters_to_extract}|"
+        "{fitting_strategy}\nSKILL={skill_rules}\nSCRIPT={script}")
+    state = dict(state)
+    state["locked_fitting_config"] = {
+        "physical_model": "two Voigts", "analysis_approach": "fit",
+        "parameters_to_extract": ["fwhm"], "fitting_strategy": "lm"}
+    assert ctl._check_plan_conformance(state, "print(1)") is None
+    return ctl.model.prompts[0]
+
+
+def test_curve_conformance_t0_framing_unchanged_and_plan_still_checked():
+    prompt = _curve_conformance_prompt(_state())
+    assert "PLAN=two Voigts|fit|fwhm|lm" in prompt
+    assert "## MANDATORY Domain Skill Rules (xps)" in prompt
+    assert "### Planning rules\nPLAN-RULES" in prompt
+    assert "### Validation rules\nVALID-RULES" in prompt
+
+
+def test_curve_conformance_framing_anneals_with_starting_level():
+    # T=1: rules stay, framed as guidance with plan precedence.
+    prompt = _curve_conformance_prompt(_state(_starting_annealing_level=1))
+    assert "PLAN=two Voigts|fit|fwhm|lm" in prompt  # locked plan still checked
+    assert "MANDATORY" not in prompt
+    assert "## Domain Skill Guidance (xps)" in prompt
+    assert "follow the plan" in prompt
+    assert "PLAN-RULES" in prompt  # content intact, only framing relaxed
+    # T=2 (hot): the skill is disregarded — the checker judges plan fidelity
+    # only. Rules offered as "reference" were still read as mandatory
+    # criteria live, re-flagging a plan that deliberately left the skill.
+    prompt = _curve_conformance_prompt(_state(_starting_annealing_level=2))
+    assert "PLAN=two Voigts|fit|fwhm|lm" in prompt
+    assert "SKILL=\n" in prompt
+    assert "PLAN-RULES" not in prompt and "Domain Skill" not in prompt
+
+
+@pytest.mark.parametrize("mod", [cc, ic], ids=["curve", "image"])
+def test_codegen_schedule_plan_precedence_above_frozen_only(mod):
+    cls = (cc.UnifiedSeriesProcessingController if mod is cc
+           else ic.UnifiedImageProcessingController)
+    sched = cls._SKILL_STRICTNESS_SCHEDULE
+    assert "follow the plan" not in sched[0]  # T=0 text byte-identical
+    assert all("follow the plan" in t for t in sched[1:])
+
+
+def _image_conformance_prompt(state):
+    ctl = object.__new__(ic.UnifiedImageProcessingController)
+    ctl.model = _CapturingModel()
+    ctl.logger = logging.getLogger("test")
+    ctl.conformance_instructions = (
+        "PLAN={processing_pipeline}|{analysis_approach}|{features_to_extract}\n"
+        "SKILL={skill_rules}\nSCRIPT={script}")
+    state = dict(state)
+    state["locked_analysis_config"] = {
+        "processing_pipeline": "flatten->segment", "analysis_approach": "seg",
+        "features_to_extract": ["area"]}
+    assert ctl._check_conformance(state, "print(1)") is None
+    return ctl.model.prompts[0]
+
+
+def test_image_conformance_t0_framing_unchanged_and_anneals():
+    frozen = _image_conformance_prompt(_state())
+    assert "PLAN=flatten->segment|seg|area" in frozen
+    assert "\n**Domain Expertise (xps):**\n" in frozen
+    warm = _image_conformance_prompt(_state(_annealing_level=1))
+    assert "PLAN=flatten->segment|seg|area" in warm
+    assert "\n**Domain Expertise (reference) (xps):**\n" in warm
+    assert "**Domain Expertise (xps):**" not in warm
+    hot = _image_conformance_prompt(_state(_annealing_level=2))
+    assert "PLAN=flatten->segment|seg|area" in hot
+    assert "SKILL=\n" in hot and "PLAN-RULES" not in hot  # skill disregarded
+
+
+# ---------------------------------------------------------------------------
+# Codegen / correction read the same resolver (no divergent level reads)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mod", [cc, ic], ids=["curve", "image"])
+def test_codegen_skill_preamble_reads_the_shared_resolver(mod):
+    src = inspect.getsource(mod)
+    # Every _SKILL_STRICTNESS_SCHEDULE lookup is driven by the resolver;
+    # no stage reads a raw state.get("_annealing_level", 0) for the skill.
+    for m in __import__("re").finditer(r"_SKILL_STRICTNESS_SCHEDULE\[", src):
+        window = src[m.start() - 400: m.end() + 200]
+        assert "_skill_annealing_level(state)" in window, window
+    assert "level = state.get(\"_annealing_level\", 0)\n            preamble" not in src
+
+
+# ---------------------------------------------------------------------------
+# Best-of-N winner lock propagates the reached level (interpretation reads it)
+# ---------------------------------------------------------------------------
+
+def _winner(levels, produced_at=None):
+    result = {"success": True, "quality_history": {"verification_iterations": [
+        {"annealing_level": lv} for lv in levels]}}
+    if produced_at is not None:
+        result["_produced_at_level"] = produced_at
+    return {"result": result, "attempt": 1}
+
+
+@pytest.mark.parametrize("mod,cls", [
+    (cc, "UnifiedSeriesProcessingController"),
+    (ic, "UnifiedImageProcessingController"),
+], ids=["curve", "image"])
+def test_winner_lock_records_reached_level(mod, cls):
+    ctl = object.__new__(getattr(mod, cls))
+    st = _state()
+    ctl._record_winner_annealing_level(st, _winner([0, 1, 2]))
+    assert st["_annealing_level"] == 2
+    st = _state()
+    ctl._record_winner_annealing_level(st, _winner([0, 0]))
+    assert st["_annealing_level"] == 0
+    st = _state()
+    ctl._record_winner_annealing_level(st, _winner([], produced_at=2))
+    assert st["_annealing_level"] == 2
+    # monotone: never lowers a hot re-run's starting level
+    st = _state(_starting_annealing_level=2)
+    ctl._record_winner_annealing_level(st, _winner([]))
+    assert st["_annealing_level"] == 2
+    # interpretation then reads the FINAL level
+    assert mod._SKILL_STRICTNESS_FRAMES[2][0] in "\n".join(
+        _render(mod, st, "interpretation"))
+
+
+@pytest.mark.parametrize("mod", [cc, ic], ids=["curve", "image"])
+def test_winner_lock_calls_recorder(mod):
+    src = inspect.getsource(mod)
+    i = src.index("# --- Lock the winner ---")
+    assert "_record_winner_annealing_level(state, winner)" in src[i:i + 500]
+
+
+# ---------------------------------------------------------------------------
+# Hyperspectral retry ladder re-renders the skill block at the attempt's rung
+# ---------------------------------------------------------------------------
+
+def _hyper_refine(retries, with_builder=True):
+    ctl = object.__new__(hc.RunDynamicAnalysisController)
+    ctl.logger = logging.getLogger("test")
+    ctl._max_verification_override = None
+    st = _state()
+    ctx = QCItemContext(state=st, data=None, data_path="", item_name="t", item_idx=0,
+                        is_regime_anchor=True)
+    ctx.retries = retries
+    ctx.last_code = "print(0)"
+    ctx.attempt_entries = []
+    ctx.last_passed_names = None
+
+    def _builder(level=0):
+        return "HEAD\n" + hc._render_skill_block(st, "implementation", level=level)
+
+    ctx.base_prompt = _builder(0)
+    if with_builder:
+        ctx.base_prompt_builder = _builder
+    out = ctl.qc_refine(ctx, {"error_msg": "bad"})
+    return out["prompt"], ctx
+
+
+def test_hyper_retry_ladder_relaxes_skill_block_with_rung():
+    p0, ctx0 = _hyper_refine(0)
+    assert ctx0.annealing_level == 0
+    assert "## MANDATORY Domain Skill Rules: xps (implementation)" in p0
+    p1, ctx1 = _hyper_refine(1)
+    assert ctx1.annealing_level == 1
+    assert "## Domain Skill Guidance: xps (implementation)" in p1
+    assert "MANDATORY" not in p1.split("HEAD", 1)[1].split("\n\n", 3)[0]
+    p2, ctx2 = _hyper_refine(3)
+    assert ctx2.annealing_level == 2
+    assert "## Domain Skill Reference: xps (implementation)" in p2
+    assert "MANDATORY Domain Skill Rules" not in p2
+    for p in (p0, p1, p2):
+        assert p.startswith("HEAD\n")
+        assert "IMPL-RULES" in p  # recipe content is never dropped
+
+
+def test_hyper_retry_without_builder_keeps_base_prompt():
+    # Defensive: a ctx without the builder (older callers) behaves as before.
+    p, _ = _hyper_refine(3, with_builder=False)
+    assert "## MANDATORY Domain Skill Rules: xps (implementation)" in p
+
+
+def test_hyper_builder_is_wired_on_ctx():
+    src = inspect.getsource(hc.RunDynamicAnalysisController)
+    assert "ctx.base_prompt_builder = _render_base_prompt" in src
+    assert "base_prompt = _render_base_prompt(0)" in src


### PR DESCRIPTION
Closes #498.

## Summary

When an analysis needs a second, "hotter" attempt, the agent is supposed to relax the domain skill it was given — so that if the skill's usual model is wrong for this data, the re-run can leave it behind. Until now that relaxation only happened inside the fitting loop: the **planning** stage still treated the skill as mandatory at every temperature, so a hot re-run re-derived the same skill-bound plan and could only deviate while patching the fit. Interpretation likewise always spoke as if the skill were mandatory, even after the fit had abandoned it.

Now one temperature governs the skill everywhere — planning, plan validation, code generation, conformance checking and interpretation — moving uniformly from *mandatory* (first run) → *guidance* → *reference* (hot re-run). A first run is unchanged: the wording the model sees at the default temperature is byte-identical to before, for all three analysis agents.

**Live check (Opus 4.8):** the `xps` skill applied to a single-line Raman spectrum. Every prompt at every stage carried the expected frame (`MANDATORY Domain Skill Rules` on the first run, `Domain Skill Reference` on the hot re-run); both runs recovered the true line position and width (1332.40 cm⁻¹, FWHM 3.2, R² = 0.999). One live finding shaped the change: with no concrete plan present, the skill's imperative code recipe ("always follow this exact sequence") dragged a hot run back to a Shirley background + spin-orbit doublet on a Raman line even when offered only as "reference" — so relaxed levels now state explicitly that the locked plan wins where a recipe conflicts with it, and the conformance check ignores the skill entirely at the hot level.

---

## Technical details

- **Per-controller `_SKILL_STRICTNESS_FRAMES` + `_skill_annealing_level(state)`** (curve, image, hyperspectral). The resolver reads the live `_annealing_level`, falling back to `_starting_annealing_level` — planning runs before the QC engine seeds the level, so a re-run launched hot re-plans relaxed. Frame 0 is the previous hardcoded wording verbatim (verified byte-identical against `main` for every stage and state shape).
- **`_append_skill_context`** (planning / validation / interpretation) frames by temperature; **conformance** framing anneals (curve already used the schedule; image's hardcoded `**Domain Expertise**` now uses the frame label); codegen/correction preamble reads go through the same resolver (also covers the locked-script reuse path, which ran before the engine seeded the level).
- **Best-of-N winner lock** (`_record_winner_annealing_level`, curve + image): candidates run in shallow state copies, so the engine's level sync never reached the caller's state — interpretation would have read T=0 after a hot fit. The reached level is stamped at winner lock (monotone).
- **Hyperspectral**: no state-level temperature (its `analyze()` has no `starting_annealing_level`), so planning/interpretation resolve to T=0 there; but the codegen retry ladder had the same collision. The base prompt is built by a per-level function (`ctx.base_prompt_builder`) and `qc_refine` re-renders it at the attempt's rung.
- **T≥1 codegen preambles** (curve + image): "Where these rules conflict with the locked plan, follow the plan." **Conformance at hot** drops the skill rules; the checker's only job is plan fidelity. T=0 text untouched. Not ablated live — the clean runs succeeded with this in place; happy to run the ablation if wanted.
- Physics grounding stays the baseline's job (best-of-N plausibility rubric + residual diagnostics); no non-anneable skill carve-out.

**Tests:** `tests/test_skill_annealing_all_stages.py` (39): frozen wording pinned as literals, relaxation at T=1/T=2, hot re-run re-plans, `_annealing_level` precedence + clamping, conformance prompts captured per level, winner propagation, hyperspectral ladder re-render. Related offline subset: 551 passed; the failures in `test_hs_dynamic_records::test_retry_ladder_reaches_hot_and_succeeds` and `test_curve_fitting_orient_and_adapt` are pre-existing on `main`.

**Known nit (pre-existing, not addressed):** `_stamp_hot_deviation` keys on `_produced_at_level`, which only refits carry, so a hot-*start* initial attempt gets no `deviation_note`.
