### PR TITLE
fix: refine_structure no longer assumes POSCAR output format

### DIFF
--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -501,9 +501,11 @@ class SimulationOrchestratorTools:
             # so crystal is the sensible default *class* (it supplies the
             # class-specific validation rubric). A user-supplied `skill` (rendered
             # into skill_content above) overrides the crystal *generation* skill;
-            # the crystal validation rubric still applies. The orchestrator
-            # appends the POSCAR-format instruction. (When the StructurePlanner
-            # lands it will set structure_class per request.)
+            # the crystal validation rubric still applies. The pipeline appends
+            # the output-format instruction derived from the structure_class
+            # skill's `output_format` frontmatter (extxyz for crystals), NOT a
+            # hardcoded POSCAR. (When the StructurePlanner lands it will set
+            # structure_class per request.)
             result = so.generate_and_validate(
                 description,
                 structure_class=structure_class,
@@ -1292,9 +1294,12 @@ class SimulationOrchestratorTools:
                     "message": f"Failed to construct StructureGenerator: {e}",
                 })
 
-            request = original_request
-            if "poscar" not in request.lower():
-                request = request + ". Save the structure in POSCAR format."
+            # Do NOT assume POSCAR. Honor a user-named format, else round-trip
+            # the format the structure was ORIGINALLY generated in (crystals
+            # default to extxyz). Shared with the regression test via
+            # _refined_request so the real code path is the one under test.
+            request = self._refined_request(
+                original_request, record["structure_path"])
 
             # Re-apply the same skill (if any) the original generation used,
             # so the refinement prompt has the same library guidance available.
@@ -3482,6 +3487,91 @@ class SimulationOrchestratorTools:
             return len(atoms)
         except Exception:
             return None
+
+    # Format tokens, mapped to the canonical name the generation script writes.
+    # Split by ambiguity, because a bare substring scan mis-fires on incidental
+    # engine / database / axis mentions ("a VASP calculation", "run a LAMMPS
+    # MD", "the PDB database", "CIF from Materials Project", "the xyz positions
+    # of the adatom") — none of which are format requests. Matching skips such
+    # mentions would suppress the beneficial round-trip AND leave an engine name
+    # in the request that the validator may itself read as "wants POSCAR",
+    # re-inviting the very discrepancy this avoids.
+    #
+    #   UNAMBIGUOUS — a format name with essentially no other meaning; counts
+    #   wherever it appears (word-boundary matched).
+    #   AMBIGUOUS   — doubles as an engine / database / axis name; counts ONLY
+    #   inside an explicit format cue ("in <fmt>", "as <fmt>", "<fmt> format",
+    #   "<fmt> file").
+    # Deliberately assumes NO default — see _existing_structure_format for how
+    # refinement preserves whatever the structure was originally written in.
+    _UNAMBIGUOUS_FORMAT_TOKENS = {
+        "poscar": "POSCAR", "contcar": "POSCAR",
+        "extxyz": "extxyz", "lammps-data": "lammps-data",
+    }
+    _AMBIGUOUS_FORMAT_TOKENS = {
+        "vasp": "POSCAR", "xyz": "xyz", "pdb": "pdb", "cif": "cif",
+        "lammps": "lammps-data",
+    }
+
+    @classmethod
+    def _requested_format(cls, request: str) -> Optional[str]:
+        """Return the file format the user EXPLICITLY named in a request, or
+        None if they named none (the common case). Never guesses a default.
+
+        Unambiguous format names (poscar, contcar, extxyz, lammps-data) count
+        anywhere they appear; ambiguous ones (vasp, xyz, pdb, cif, lammps),
+        which double as engine / database / axis names, count only inside an
+        explicit format cue — 'in <fmt>', 'as <fmt>', '<fmt> format/file'.
+        All matching is word-boundary anchored, so 'xyz' does not fire inside
+        'extxyz' regardless of table order.
+        """
+        import re as _re
+        low = (request or "").lower()
+
+        # Longest-first so 'lammps-data' wins over 'lammps' when both are cued.
+        for tok in sorted(cls._UNAMBIGUOUS_FORMAT_TOKENS, key=len, reverse=True):
+            if _re.search(rf"(?<![\w-]){_re.escape(tok)}(?![\w-])", low):
+                return cls._UNAMBIGUOUS_FORMAT_TOKENS[tok]
+
+        for tok in sorted(cls._AMBIGUOUS_FORMAT_TOKENS, key=len, reverse=True):
+            t = _re.escape(tok)
+            cued = rf"(?:\bin\s+{t}\b|\bas\s+{t}\b|\b{t}\s+(?:format|file)\b)"
+            if _re.search(cued, low):
+                return cls._AMBIGUOUS_FORMAT_TOKENS[tok]
+        return None
+
+    def _refined_request(self, original_request: str,
+                         structure_path: str) -> str:
+        """Build the refinement request WITHOUT assuming any output format.
+
+        If the user explicitly named a format, honor it (return unchanged).
+        Otherwise round-trip whatever format the structure was ORIGINALLY
+        generated in (inferred from its filename), so the refinement request
+        matches the prior script and the validator does not flag a phantom
+        'requested X vs wrote Y' discrepancy that no one actually asked for.
+        Shared by refine_structure and its regression test — one code path,
+        no drift.
+        """
+        if self._requested_format(original_request) is not None:
+            return original_request
+        fmt = self._existing_structure_format(structure_path)
+        if fmt:
+            return f"{original_request}. Save the structure in {fmt} format."
+        return original_request
+
+    @staticmethod
+    def _existing_structure_format(structure_path: str) -> Optional[str]:
+        """Infer the format an already-generated structure was written in,
+        from its filename — so a refinement round-trips the SAME format the
+        generation used instead of assuming one."""
+        p = Path(structure_path)
+        name, suffix = p.name.lower(), p.suffix.lower().lstrip(".")
+        if name in ("poscar", "contcar") or suffix in ("vasp", "poscar"):
+            return "POSCAR"
+        return {
+            "extxyz": "extxyz", "xyz": "xyz", "pdb": "pdb", "cif": "cif",
+            "data": "lammps-data", "lmp": "lammps-data",
+        }.get(suffix)
 
     def _find_script_content(self, structure_path: str) -> Optional[str]:
         """Find the generating script for a POSCAR.

--- a/tests/test_simulation_orchestrator.py
+++ b/tests/test_simulation_orchestrator.py
@@ -374,6 +374,62 @@ def test_2d_list_available_software(model_name: str):
         assert all(v for v in r["installed_by_domain"].values())
 
         print("   ✅ list_available_software: deterministic, no LLM call")
+
+
+def test_2e_refine_preserves_structure_format(model_name: str):
+    """refine_structure must NOT assume POSCAR.
+
+    Regression: refine_structure unconditionally appended 'Save the structure
+    in POSCAR format.' to the request, while generate_structure writes extxyz
+    for crystals — so the validator flagged a phantom 'requested POSCAR vs
+    wrote extxyz' discrepancy even when no one asked for POSCAR. The refined
+    request must round-trip the ORIGINAL format, and honor an explicit
+    user-named format when there is one.
+    """
+    from scilink.agents.sim_agents.simulation_orchestrator_tools import (
+        SimulationOrchestratorTools as S,
+    )
+
+    # _requested_format: fires only on an EXPLICIT format request ...
+    assert S._requested_format("build Si and save as POSCAR") == "POSCAR"
+    assert S._requested_format("a water molecule in xyz") == "xyz"
+    assert S._requested_format("save in lammps-data format") == "lammps-data"
+    assert S._requested_format("please use extxyz") == "extxyz"   # unambiguous
+    # ... and NOT on incidental engine / database / axis mentions, which are
+    # frequent real inputs (this is the case the review flagged).
+    assert S._requested_format("build rutile TiO2 for a VASP calculation") is None
+    assert S._requested_format("relax the Si slab then run a LAMMPS MD") is None
+    assert S._requested_format("a protein from the PDB database") is None
+    assert S._requested_format("the CIF from Materials Project") is None
+    assert S._requested_format("optimize the xyz positions of the adatom") is None
+    assert S._requested_format("rutile TiO2 with an O vacancy") is None
+    # 'xyz' must not fire inside 'extxyz' regardless of table order
+    assert S._requested_format("save in extxyz format") == "extxyz"
+
+    # _existing_structure_format: inferred from the generated file's name
+    assert S._existing_structure_format("/s/structure.extxyz") == "extxyz"
+    assert S._existing_structure_format("/s/POSCAR") == "POSCAR"
+    assert S._existing_structure_format("/s/mol.xyz") == "xyz"
+    assert S._existing_structure_format("/s/unknown.foo") is None
+
+    # Exercise the REAL request-builder refine_structure calls (no copy).
+    refined = S.__new__(S)._refined_request
+
+    # crystal (extxyz) + plain request → round-trips extxyz, NEVER POSCAR
+    out = refined("rutile TiO2 with an O vacancy", "/s/structure.extxyz")
+    assert "extxyz" in out and "POSCAR" not in out
+    # crystal (extxyz) + incidental "VASP" mention → still round-trips extxyz,
+    # not suppressed by the engine name (the regression the review guarded)
+    out = refined("build rutile TiO2 for a VASP calculation", "/s/structure.extxyz")
+    assert "extxyz" in out and "POSCAR" not in out
+    # explicit user request for POSCAR is honored, not overridden
+    assert refined("build Si, save as POSCAR", "/s/POSCAR") == "build Si, save as POSCAR"
+    # molecule (xyz) round-trips xyz
+    assert "xyz" in refined("a benzene molecule", "/s/mol.xyz")
+
+    print("   ✅ refine_structure: preserves original format, no POSCAR default")
+
+
 def test_2d_run_simulation_reuses_prebuilt_structure(model_name: str):
     """run_simulation reuses an in-session structure instead of rebuilding (#4).
 
@@ -1175,6 +1231,7 @@ TARGETED_TESTS = [
     ("edit_file / rename_file",                test_2b_edit_and_rename_file),
     ("Generic file I/O",                       test_2c_generic_file_io),
     ("List available software",                test_2d_list_available_software),
+    ("refine preserves structure format",      test_2e_refine_preserves_structure_format),
     ("run_simulation reuses structure",        test_2d_run_simulation_reuses_prebuilt_structure),
     ("run_simulation executes in-allocation",  test_2e_run_simulation_executes_in_allocation),
     ("Post-run analysis (synthetic)",          test_3_post_run_analysis_synthetic),


### PR DESCRIPTION
# fix: refine_structure no longer assumes POSCAR output format

## Problem

When refining a generated structure, the simulation agent reported that *the user had explicitly requested POSCAR format* and flagged a discrepancy between the generation script writing an **extxyz** file and the "requested" **POSCAR** file — **even when the user never asked for POSCAR**.

## Root cause

`refine_structure` (in `simulation_orchestrator_tools.py`) unconditionally appended `". Save the structure in POSCAR format."` to the refinement request whenever the request didn't already contain the word `"poscar"`:

```python
request = original_request
if "poscar" not in request.lower():
    request = request + ". Save the structure in POSCAR format."
```

This is stale code from when POSCAR was the default output format. Today `generate_structure` writes **engine-neutral extxyz** for crystals (the crystal skill declares `output_format: extxyz`; the engine-native POSCAR is written downstream by the engine step). So on every refinement:

- the request told the validator *"the user wants POSCAR"*, while
- the prior generation script actually wrote **extxyz**,

and the validator dutifully flagged a phantom "requested POSCAR vs wrote extxyz" discrepancy that nobody had asked for.

## Fix

Don't assume any default output format. On refinement:

1. If the user **explicitly named** a format in their request, honor it.
2. Otherwise, **round-trip whatever format the structure was originally generated in** (inferred from its filename), so the refinement request matches the prior script.

New helpers on `SimulationOrchestratorTools`:

- `_requested_format(request)` — the format the user explicitly named (poscar/vasp, xyz, extxyz, pdb, cif, lammps), or `None` (the common case). Never guesses.
- `_existing_structure_format(path)` — the format inferred from the already-generated file's name.

Also corrects a stale comment in `generate_structure` that claimed the orchestrator appends a POSCAR-format instruction — it appends the class-derived format (extxyz for crystals).

## Behavior after fix

| Scenario | Before | After |
|---|---|---|
| Crystal (extxyz) + plain request | forces POSCAR → phantom discrepancy | round-trips **extxyz**, no false flag |
| User explicitly asks for POSCAR | POSCAR | POSCAR (honored) |
| Molecule (`xyz`) / biomolecule (`pdb`) | forces POSCAR | round-trips own format |

## Testing

Added `test_2e_refine_preserves_structure_format` (pure, no LLM) covering both helpers and the exact request-building logic — asserts a crystal refine never injects POSCAR and that an explicit POSCAR request is still honored.

The full targeted suite passes except the pre-existing, environment-specific `Tool error paths` failure (a sandbox `PermissionError` on `/nonexistent`, unrelated to this change — it fails identically on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
