### PR TITLE
fix: robust staged MD generation + LAMMPS transport/staging skill guidance

### DIFF
--- a/scilink/agents/sim_agents/md_simulation_agent.py
+++ b/scilink/agents/sim_agents/md_simulation_agent.py
@@ -937,32 +937,55 @@ class MDSimulationAgent(SimulationAgent):
         plan = result["simulation_parameters"]
         impl = self._get_skill_context(section="implementation")
 
-        prompt = (
+        info = result.get("system_info", {})
+        base_prompt = (
             "Split this simulation into 2-4 checkpointed stages.\n\n"
             "SCRIPT:\n"
             f"{full_script}\n\n"
             f"{impl}\n\n"
             "Each stage: complete, standalone, runnable. First reads data file,\n"
             "later stages read restart. All include force field commands.\n"
+            "Each stage uses exactly ONE time integrator (e.g. NPT to equilibrate,\n"
+            "NVT to produce) — never two on a group in the same stage.\n"
             "Use literal values. Write restart at end of each stage.\n\n"
             'Return JSON: {"equilibration": "script...", "production": "script..."}'
         )
-        try:
-            stages = self._generate_json(prompt)
-        except Exception:
-            stages = {"production": full_script}
 
-        stage_scripts = {}
-        steps = []
-        for name, content in stages.items():
-            if not isinstance(content, str):
-                continue
-            content = self._clean_and_fix(content, plan)
-            entry = self._entry_name(name)
-            path = self.working_dir / entry
-            path.write_text(content, encoding="utf-8")
-            stage_scripts[name] = str(path)
-            steps.append({"name": name, "entry_file": entry, "script": content})
+        # Split into per-phase stages, retrying until each stage validates. The
+        # split is what resolves the monolithic deck into single-integrator
+        # phases; the transient monolithic deck is never run, so validity is
+        # based on the STAGES here, not on that deck. Retrying with the concrete
+        # validation errors makes a categorical slip (e.g. a stage that kept two
+        # integrators) self-correct engine-neutrally instead of being papered
+        # over per engine.
+        stage_scripts: Dict[str, str] = {}
+        steps: List[Dict[str, str]] = []
+        stage_errors: List[str] = []
+        prompt = base_prompt
+        for _ in range(3):
+            try:
+                stages = self._generate_json(prompt)
+            except Exception:
+                stages = {"production": full_script}
+            stage_scripts, steps, stage_errors = {}, [], []
+            for name, content in stages.items():
+                if not isinstance(content, str):
+                    continue
+                content = self._clean_and_fix(content, plan)
+                entry = self._entry_name(name)
+                path = self.working_dir / entry
+                path.write_text(content, encoding="utf-8")
+                v = self._validate(str(path), info, plan)
+                if not v.get("valid", True) and v.get("errors"):
+                    stage_errors.extend(f"[{name}] {e}" for e in v["errors"])
+                stage_scripts[name] = str(path)
+                steps.append({"name": name, "entry_file": entry, "script": content})
+            if not stage_errors:
+                break
+            prompt = base_prompt + (
+                "\n\nThe previous split still failed validation — fix these, "
+                "keeping ONE integrator per stage:\n- " + "\n- ".join(stage_errors)
+            )
 
         shared = self._campaign_shared_files(
             structure_file, kw.get("force_field_files"))
@@ -974,7 +997,16 @@ class MDSimulationAgent(SimulationAgent):
             is_staged=True,
             is_campaign=True,
             campaign_kind="staged",
+            # Validity reflects the stages that actually run (each single-
+            # integrator), superseding the transient monolithic deck's checks.
+            validation={
+                "valid": not stage_errors,
+                "errors": stage_errors,
+                "warnings": result.get("validation", {}).get("warnings", []),
+            },
         )
+        if stage_errors:
+            result["status"] = "error"
         # Representative phase for back-compat consumers that read a single
         # input set (the pipeline's input_files normalization, etc.).
         if stage_specs:

--- a/scilink/agents/sim_agents/md_simulation_agent.py
+++ b/scilink/agents/sim_agents/md_simulation_agent.py
@@ -951,18 +951,24 @@ class MDSimulationAgent(SimulationAgent):
             'Return JSON: {"equilibration": "script...", "production": "script..."}'
         )
 
-        # Split into per-phase stages, retrying until each stage validates. The
-        # split is what resolves the monolithic deck into single-integrator
-        # phases; the transient monolithic deck is never run, so validity is
-        # based on the STAGES here, not on that deck. Retrying with the concrete
-        # validation errors makes a categorical slip (e.g. a stage that kept two
-        # integrators) self-correct engine-neutrally instead of being papered
-        # over per engine.
+        # The per-stage decks are what actually run. Nothing downstream reads the
+        # monolithic deck's own validation: `_generate_classical_md_inputs`
+        # setdefaults status="success", and the pre-run InputValidator sees only
+        # stage 0 — so before this change a bad split (a stage that kept both
+        # integrators, or an unresolved template variable) reached the engine,
+        # where the refinement loop could not repair it and the campaign failed
+        # (``refinement_failed``). This method's contribution is to validate each
+        # produced stage HERE and re-split with the concrete errors as feedback,
+        # catching a bad split at generation before it is ever run.
+        written: List[Path] = []
         stage_scripts: Dict[str, str] = {}
         steps: List[Dict[str, str]] = []
         stage_errors: List[str] = []
         prompt = base_prompt
         for _ in range(3):
+            for p in written:                     # a retry may rename stages
+                p.unlink(missing_ok=True)         # (minimize -> equilibration),
+            written = []                          # so drop the prior attempt's files
             try:
                 stages = self._generate_json(prompt)
             except Exception:
@@ -975,6 +981,7 @@ class MDSimulationAgent(SimulationAgent):
                 entry = self._entry_name(name)
                 path = self.working_dir / entry
                 path.write_text(content, encoding="utf-8")
+                written.append(path)
                 v = self._validate(str(path), info, plan)
                 if not v.get("valid", True) and v.get("errors"):
                     stage_errors.extend(f"[{name}] {e}" for e in v["errors"])
@@ -987,6 +994,26 @@ class MDSimulationAgent(SimulationAgent):
                 "keeping ONE integrator per stage:\n- " + "\n- ".join(stage_errors)
             )
 
+        # Last resort before failing generation: run the engine-neutral per-deck
+        # fixer (the same ``_attempt_fix`` used on the monolithic deck) on any
+        # stage still invalid after re-splitting, then re-validate. This keeps a
+        # recoverable stage on the path the refinement loop's dry-run gate would
+        # otherwise have taken, rather than hard-failing outright.
+        if stage_errors:
+            stage_errors = []
+            for step in steps:
+                path = self.working_dir / step["entry_file"]
+                v = self._validate(str(path), info, plan)
+                if not v.get("valid", True) and v.get("errors"):
+                    fixed = self._clean_and_fix(
+                        self._attempt_fix(step["script"], v["errors"], plan), plan)
+                    path.write_text(fixed, encoding="utf-8")
+                    step["script"] = fixed
+                    stage_scripts[step["name"]] = str(path)
+                    v = self._validate(str(path), info, plan)
+                    if not v.get("valid", True) and v.get("errors"):
+                        stage_errors.extend(f"[{step['name']}] {e}" for e in v["errors"])
+
         shared = self._campaign_shared_files(
             structure_file, kw.get("force_field_files"))
         stage_specs = _assemble_sequential_stages(steps, shared)
@@ -997,8 +1024,10 @@ class MDSimulationAgent(SimulationAgent):
             is_staged=True,
             is_campaign=True,
             campaign_kind="staged",
-            # Validity reflects the stages that actually run (each single-
-            # integrator), superseding the transient monolithic deck's checks.
+            # Report validity of the STAGES that actually run. The monolithic
+            # deck's own validation (from generate_simulation) is computed but
+            # discarded by the pipeline, so it is not a gate — do not treat it
+            # as one.
             validation={
                 "valid": not stage_errors,
                 "errors": stage_errors,

--- a/scilink/skills/molecular_dynamics/lammps/lammps.md
+++ b/scilink/skills/molecular_dynamics/lammps/lammps.md
@@ -84,7 +84,41 @@ Liquids and solutions:
 2. NPT at target T,P for 0.5-2 ns → density convergence
 3. Production: NPT or NVT
 
+### Staging integrators (multi-phase runs)
+
+Each stage uses exactly ONE time integrator on a group. To move between phases —
+e.g. NPT density equilibration → NVT production — `unfix` the previous integrator
+BEFORE defining the next, and give them distinct fix IDs:
+
+```
+fix   eq all npt temp {temperature} {temperature} {Tdamp} iso {pressure} {pressure} {Pdamp}
+run   {equil_steps}
+unfix eq
+fix   prod all nvt temp {temperature} {temperature} {Tdamp}
+# … production output (e.g. the stress log a viscosity goal needs) …
+run   {prod_steps}
+```
+
+A single script legitimately contains both an npt and an nvt fix, but only ONE
+may be active on a group at a time — leaving both active is the fix nvt/npt
+conflict in Forbidden patterns.
+
 ### Technique-specific requirements
+
+Transport coefficients (viscosity, self-diffusion) — equilibrium Green-Kubo/Einstein:
+- The deck's job is to EMIT the raw time series; the coefficient is computed AFTER
+  the run by the matching `simulation_analysis` skill (e.g. `viscosity_greenkubo`).
+  Do NOT compute the transport coefficient in the input — no in-deck stress-
+  autocorrelation integral, no `variable visc`/`${visc}`, no `fix ave/correlate`
+  for the coefficient itself.
+- **Shear viscosity:** on the production run, log the full pressure tensor densely
+  — add `pxy pxz pyz vol` to `thermo_style custom` with a tight `thermo` interval
+  (every few fs), or write them via `fix ave/time {N} 1 {N} v_pxy v_pxz v_pyz file
+  stress.dat`. The `viscosity_greenkubo` skill reads that log (it also needs T and
+  vol) and does the Green-Kubo integral. It converges slowly for viscous liquids →
+  the production run must be long (tens of ns) with stress sampled every few fs.
+- **Self-diffusion:** dump the unwrapped coordinate trajectory at a regular
+  interval; the diffusion analysis skill computes the MSD/Einstein slope.
 
 Tensile deformation:
 - `fix deform x erate R` + thermostat on transverse dims

--- a/scilink/skills/molecular_dynamics/lammps/lammps.md
+++ b/scilink/skills/molecular_dynamics/lammps/lammps.md
@@ -113,8 +113,11 @@ Transport coefficients (viscosity, self-diffusion) — equilibrium Green-Kubo/Ei
   for the coefficient itself.
 - **Shear viscosity:** on the production run, log the full pressure tensor densely
   — add `pxy pxz pyz vol` to `thermo_style custom` with a tight `thermo` interval
-  (every few fs), or write them via `fix ave/time {N} 1 {N} v_pxy v_pxz v_pyz file
-  stress.dat`. The `viscosity_greenkubo` skill reads that log (it also needs T and
+  (every few fs), or define `variable pxy equal pxy` (and `pxz`, `pyz`) and write
+  them with `fix ave/time {N} 1 {N} v_pxy v_pxz v_pyz file stress.dat` (`fix
+  ave/time` averages variables/computes, not bare thermo keywords, so the
+  `variable` lines are required). The `viscosity_greenkubo` skill reads that log
+  (it also needs T and
   vol) and does the Green-Kubo integral. It converges slowly for viscous liquids →
   the production run must be long (tens of ns) with stress sampled every few fs.
 - **Self-diffusion:** dump the unwrapped coordinate trajectory at a regular

--- a/tests/test_md_staged_split.py
+++ b/tests/test_md_staged_split.py
@@ -1,0 +1,95 @@
+"""Unit tests for ``MDSimulationAgent.generate_staged_simulation``'s per-stage
+validate-and-retry (no LLM, no engine).
+
+Covers the branches added by the staged-split fix:
+  1. a clean split validates in one attempt;
+  2. a split that keeps two integrators self-corrects on re-split;
+  3. a persistently bad split is repaired by the per-deck ``_attempt_fix``
+     fallback (no hard fail);
+  4. a persistently bad split that ``_attempt_fix`` cannot repair fails
+     generation (``status == "error"``).
+
+Validation uses the REAL ``lammps.validate_script``; only the LLM-facing methods
+and the monolithic ``generate_simulation`` are stubbed, so the test exercises the
+actual splitting / validation / retry control flow.
+"""
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import scilink.agents.sim_agents.md_simulation_agent as M
+from scilink.agents.sim_agents.base_agent import SimulationAgent
+import scilink.skills.molecular_dynamics.lammps.lammps as lammps_tools
+
+# A clean single-integrator equilibration stage (NPT, unfixed) ...
+_EQ = ("units real\natom_style full\nread_data system.data\n"
+       "minimize 1.0e-4 1.0e-6 5000 50000\n"
+       "fix eq all npt temp 298 298 100 iso 1 1 1000\nrun 1000\nunfix eq\n"
+       "write_restart eq.restart\n")
+# ... a clean single-integrator production stage (NVT) ...
+_PROD = ("units real\natom_style full\nread_restart eq.restart\n"
+         "fix prod all nvt temp 298 298 100\nrun 1000\nwrite_restart prod.restart\n")
+# ... and a BAD stage that kept both integrators on the same group (no unfix).
+_PROD_BAD = ("units real\natom_style full\nread_data system.data\n"
+             "fix eq all npt temp 298 298 100 iso 1 1 1000\nrun 1000\n"
+             "fix prod all nvt temp 298 298 100\nrun 1000\n")
+
+
+def _agent(tmp, split_seq, attempt_fix=lambda s, e, p: s):
+    """A minimally-wired MDSimulationAgent: real _validate/_entry_name against
+    the lammps tools, stubbed LLM-facing methods and monolithic generation."""
+    a = object.__new__(M.MDSimulationAgent)
+    a.working_dir = Path(tmp)
+    a.skill_name = "lammps"
+    a.tools_module = lammps_tools
+    a.logger = MagicMock()
+    a._validate = SimulationAgent._validate.__get__(a)
+    a._entry_name = M.MDSimulationAgent._entry_name.__get__(a)
+    a._get_skill_context = lambda section=None: ""
+    a._campaign_shared_files = lambda *x, **k: {}
+    a._clean_and_fix = lambda s, plan: s
+    a._attempt_fix = attempt_fix
+    a._generate_json = MagicMock(side_effect=list(split_seq))
+    a.generate_simulation = lambda **k: {
+        "script_path": str(Path(tmp) / "run.lammps"),
+        "simulation_parameters": {}, "system_info": {},
+        "validation": {"valid": False, "errors": ["monolithic conflict"],
+                       "warnings": []},
+    }
+    Path(tmp, "run.lammps").write_text(_PROD_BAD)   # the transient monolithic deck
+    return a
+
+
+def test_clean_split_validates_in_one_attempt():
+    a = _agent(tempfile.mkdtemp(), [{"equilibration": _EQ, "production": _PROD}])
+    r = a.generate_staged_simulation("system.data", "goal")
+    assert r["validation"]["valid"] is True
+    assert r.get("status") != "error"
+    assert a._generate_json.call_count == 1
+    assert "input_files" in r
+
+
+def test_conflicted_split_self_corrects_on_resplit():
+    a = _agent(tempfile.mkdtemp(),
+               [{"production": _PROD_BAD}, {"equilibration": _EQ, "production": _PROD}])
+    r = a.generate_staged_simulation("system.data", "goal")
+    assert r["validation"]["valid"] is True
+    assert r.get("status") != "error"
+    assert a._generate_json.call_count == 2
+
+
+def test_persistent_bad_split_repaired_by_attempt_fix():
+    a = _agent(tempfile.mkdtemp(), [{"production": _PROD_BAD}] * 3,
+               attempt_fix=lambda s, e, p: _PROD)     # fixer returns a clean deck
+    r = a.generate_staged_simulation("system.data", "goal")
+    assert r["validation"]["valid"] is True
+    assert r.get("status") != "error"
+
+
+def test_persistent_bad_split_unrepairable_fails_generation():
+    a = _agent(tempfile.mkdtemp(), [{"production": _PROD_BAD}] * 3,
+               attempt_fix=lambda s, e, p: _PROD_BAD)  # fixer cannot repair it
+    r = a.generate_staged_simulation("system.data", "goal")
+    assert r["validation"]["valid"] is False
+    assert r["status"] == "error"
+    assert any("both" in e.lower() for e in r["validation"]["errors"])


### PR DESCRIPTION
# fix: staged MD generation validates the split stages (catch a bad split before it runs)

## Problem

Staged MD campaigns (`staged=True`: minimize → NPT-equilibrate → NVT-produce) intermittently failed generation with `[…] full -> refinement_failed`, on two recurring LAMMPS deck errors the refinement loop could not repair at run time:

1. `Unresolved template variables: ['${visc}']` — the model computed shear viscosity *in* the LAMMPS input (an undefined `variable visc`).
2. `fix nvt and fix npt both on group(s): {'all'}` — a produce/equilibrate stage kept both integrators.

Surfaced running an experiment-validated electrolyte use case end to end.

## Root cause (corrected per review — thanks @ziatdinovmax)

`generate_staged_simulation` generates a monolithic deck *only as the source for the model to split*, then splits it into per-phase stages and returns those. Before this PR **the split stages were not validated** — a bad split (a stage that kept both integrators, or an unresolved `${visc}`) went straight to the engine, where the refinement loop's dry-run gate + fixer could not repair the categorical conflict → `refinement_failed`.

The monolithic deck's own validation does **not** gate anything: `_generate_classical_md_inputs` setdefaults `status="success"` and the pre-run `InputValidator` sees only stage 0. (An earlier version of this description wrongly said it did — corrected.)

## Fix

**Engine-neutral, in the MD agent.** `generate_staged_simulation` now:
1. **Validates each produced stage** via the engine-neutral `_validate` and, on any error, **re-splits with the concrete errors as feedback** (one integrator per stage) — up to three attempts. This per-stage structural check + retry is what the PR adds; it did not exist before.
2. **Last-resort per-stage repair:** if a stage is still invalid, runs the same engine-neutral `_attempt_fix` used on the monolithic deck and re-validates, before failing — preserving the recovery path the refinement loop's dry-run gate would otherwise have taken.
3. Only if a stage is *still* invalid does generation hard-fail (`status="error"`), rather than shipping a broken stage to the engine.
4. Unlinks the prior attempt's stage files on each retry (a retry may rename stages, e.g. `minimize` → `equilibration`).

**Skill (`lammps.md`):** a "Transport coefficients" entry stating the deck emits the raw stress log for the `viscosity_greenkubo` analysis skill (never an in-deck `${visc}`), and a positive `unfix`-between-stages template. The `fix ave/time` snippet now defines `variable pxy equal pxy` (etc.), since `fix ave/time` averages variables/computes, not bare thermo keywords.

## Behavior after fix

| Scenario | Before | After |
|---|---|---|
| Clean split | shipped unvalidated | validated, runs |
| Split keeps two integrators / `${visc}` | reached engine → `refinement_failed` | re-split with feedback, then `_attempt_fix`; runs if recoverable |
| Unrecoverable after retries + fix | reached engine → `refinement_failed` | `status="error"` at generation |

## Testing

`tests/test_md_staged_split.py` (no LLM/engine; real `lammps.validate_script`): clean split; conflicted → self-corrects on re-split; persistent-bad → repaired by `_attempt_fix`; unrepairable → `status="error"`.

**End-to-end:** the electrolyte use case now runs — all four members clear deck validation into the staged run, where before every member hit `full -> refinement_failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
