### PR TITLE
Route image trend-codegen through the compile-checked parser

### DIFF
--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -6749,7 +6749,9 @@ Return JSON with:
                 generation_config=self.generation_config,
                 safety_settings=self.safety_settings,
             )
-            result_json, error_dict = self._parse(response)
+            result_json, error_dict = parse_codegen_response(
+                response, field="script", logger=self.logger
+            )
             if error_dict and not (result_json and 'script' in result_json):
                 return None
             return result_json
@@ -6816,7 +6818,9 @@ Return JSON with: {{"diagnosis": "...", "script": "corrected script"}}
                 generation_config=self.generation_config,
                 safety_settings=self.safety_settings,
             )
-            result_json, _ = self._parse(response)
+            result_json, _ = parse_codegen_response(
+                response, field="script", logger=self.logger
+            )
             if result_json:
                 self.logger.info(
                     f"   Diagnosis: {result_json.get('diagnosis', 'N/A')}"

--- a/tests/test_image_trend_codegen_parse.py
+++ b/tests/test_image_trend_codegen_parse.py
@@ -1,0 +1,83 @@
+"""Regression test for #244: the image trend-codegen path must use the
+compile-checked parse_codegen_response (like the curve trend controller has
+since #240), so a non-compilable or truncated script is rejected+retried
+rather than executed.
+
+Offline — the LLM is stubbed.
+
+  python -m pytest tests/test_image_trend_codegen_parse.py -v
+"""
+import json
+import logging
+import types
+
+from scilink.agents.exp_agents.controllers.image_analysis_controllers import (
+    ConditionalImageTrendController,
+)
+
+GOOD_SCRIPT = "import json\nprint('trend ok')\n"
+BROKEN_SCRIPT = "def f(:\n    pass"  # does not compile
+
+
+def _controller(fake_text, finish_reason=None):
+    obj = ConditionalImageTrendController.__new__(ConditionalImageTrendController)
+    obj.logger = logging.getLogger("test_image_trend_parse")
+
+    class _Model:
+        def generate_content(self, contents, generation_config=None,
+                             safety_settings=None):
+            resp = types.SimpleNamespace(text=fake_text, raw_text=fake_text)
+            if finish_reason is not None:
+                resp.candidates = [
+                    types.SimpleNamespace(finish_reason=finish_reason)
+                ]
+            return resp
+
+    obj.model = _Model()
+    obj.generation_config = None
+    obj.safety_settings = None
+    return obj
+
+
+def _state():
+    return {"series_results": [
+        {"success": True, "index": 0, "name": "a.npy"},
+        {"success": True, "index": 1, "name": "b.npy"},
+    ], "series_metadata": {"variable": "T"}, "flagged_images": []}
+
+
+def test_json_response_parses_with_side_fields():
+    tc = _controller(json.dumps({
+        "analysis_approach": "trend dashboard",
+        "script": GOOD_SCRIPT,
+    }))
+    out = tc._generate_trend_script(_state())
+    assert out and out["script"].strip() == GOOD_SCRIPT.strip()
+    assert out.get("analysis_approach") == "trend dashboard"
+
+
+def test_fenced_response_parses():
+    tc = _controller(f"Here is the script:\n```python\n{GOOD_SCRIPT}```\n")
+    out = tc._generate_trend_script(_state())
+    assert out and "print('trend ok')" in out["script"]
+
+
+def test_noncompilable_script_rejected():
+    tc = _controller(json.dumps({"script": BROKEN_SCRIPT}))
+    assert tc._generate_trend_script(_state()) is None
+
+
+def test_truncated_response_rejected():
+    # finish_reason == 0 is the wrapper's finish_reason=length marker.
+    tc = _controller('{"script": "print(', finish_reason=0)
+    assert tc._generate_trend_script(_state()) is None
+
+
+def test_correct_script_returns_fix_and_rejects_garbage():
+    tc = _controller(json.dumps({"diagnosis": "bad import",
+                                 "script": GOOD_SCRIPT}))
+    assert tc._correct_script(BROKEN_SCRIPT, "SyntaxError", 1).strip() == \
+        GOOD_SCRIPT.strip()
+
+    tc = _controller(json.dumps({"diagnosis": "x", "script": BROKEN_SCRIPT}))
+    assert tc._correct_script(BROKEN_SCRIPT, "SyntaxError", 1) is None


### PR DESCRIPTION
## Summary

When analyzing an image series, the final trend stage asks the LLM to write a small Python script that plots how the extracted features evolve. That stage was still reading the LLM's reply with an old, fragile parser — the one code-generation site missed when the rest were hardened in #240. On weaker models this is exactly where a garbled reply could slip through and be executed, or fail confusingly. The trend stage now uses the same robust parser as everything else: replies are checked for valid Python before running, recoverable formatting mistakes are salvaged, and cut-off replies are recognized and retried.

Closes #244.

---

**Technical details**

- `ConditionalImageTrendController._generate_trend_script` and its `_correct_script` now call `parse_codegen_response(response, field="script", logger=self.logger)`, mirroring the curve trend controller converted in #240 byte-for-byte. The constructor keeps its (now unused) `parse_fn` arg, as the curve twin does.
- This adds the `ast.parse` compile-check, JSON-escaping salvage, and distinct truncation detection (`finish_reason=length`), and removes the legacy balanced-brace fallback that could return a wrong embedded dict.
- Offline regression (`tests/test_image_trend_codegen_parse.py`, 5 tests): JSON and fenced responses parse with side fields preserved; a non-compilable script and a truncated response are rejected rather than executed; the correction path returns fixes and rejects garbage.
- Live-validated on Bedrock (`bedrock/us.anthropic.claude-opus-4-8`): a 3-image synthetic particle-coarsening series ran the full pipeline; the trend stage generated and executed `trend_analysis.py` through the new path and produced a correct dashboard — mean diameter 15→35 px over 0→20 min matching the planted ground truth (radii 5/9/14 px), linear coarsening fit 0.99 px/min (R²=1.000) plus an LSW cube-law panel.