### PR TITLE
Publish every ~/.scilink store write atomically (part 1 of #398)

### DIFF
--- a/scilink/knowledge/kb_store.py
+++ b/scilink/knowledge/kb_store.py
@@ -38,6 +38,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from ..skills.loader import scilink_home
+from ..utils.text_io import atomic_write_text
 
 _logger = logging.getLogger(__name__)
 
@@ -221,7 +222,7 @@ def _write_manifest(kb_dir: Path, **fields) -> Dict[str, Any]:
     manifest = read_manifest(kb_dir) or {}
     manifest.update(fields)
     manifest["updated_at"] = datetime.now().isoformat(timespec="seconds")
-    (kb_dir / MANIFEST_NAME).write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    atomic_write_text(kb_dir / MANIFEST_NAME, json.dumps(manifest, indent=2))
     return manifest
 
 

--- a/scilink/skills/_shared/_graduation.py
+++ b/scilink/skills/_shared/_graduation.py
@@ -35,6 +35,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
+from ...utils.text_io import atomic_write_text
 from ..loader import graduated_skills_dir
 
 
@@ -386,7 +387,7 @@ def graduate_to_skill_file(
     # Loader-style bundles include __init__.py; harmless for path-loaded
     # skills, but keeps the layout consistent with built-ins.
     (skill_dir / "__init__.py").touch()
-    skill_path.write_text(skill_content, encoding="utf-8")
+    atomic_write_text(skill_path, skill_content)
 
     word_count = len(skill_content.split())
     warning = None

--- a/scilink/skills/_shared/_memory.py
+++ b/scilink/skills/_shared/_memory.py
@@ -19,6 +19,7 @@ import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ...utils.text_io import atomic_write_text
 from ..loader import graduated_skills_dir, load_skill
 from ._graduation import safe_path_component
 
@@ -158,7 +159,7 @@ def promote_memory(
         # No frontmatter left; drop the fence entirely.
         new_text = body.lstrip("\n")
 
-    md.write_text(new_text, encoding="utf-8")
+    atomic_write_text(md, new_text)
 
     moved_to = None
     if to_domain and to_domain != domain:
@@ -211,7 +212,7 @@ def demote_memory(domain: str, name: str, *, root: Optional[Path] = None) -> Dic
         allow_unicode=True,
         width=10_000,
     ).strip()
-    md.write_text(f"---\n{frontmatter}\n---\n{body}", encoding="utf-8")
+    atomic_write_text(md, f"---\n{frontmatter}\n---\n{body}")
     return {
         "status": "success",
         "name": name,
@@ -257,8 +258,8 @@ def edit_memory(domain: str, name: str, content: str, *,
                 "message": "The skill needs at least one '## section' heading."}
 
     backup = md.with_name(md.name + ".bak")
-    backup.write_text(md.read_text(), encoding="utf-8")
-    md.write_text(content, encoding="utf-8")
+    atomic_write_text(backup, md.read_text())
+    atomic_write_text(md, content)
     return {"status": "success", "path": str(md), "backup_path": str(backup)}
 
 
@@ -291,7 +292,7 @@ def fork_builtin(domain: str, name: str, *, root: Optional[Path] = None) -> Dict
                             f"({dest_md}); upgrade or prune that copy.")}
     dest_dir.mkdir(parents=True, exist_ok=True)
     (dest_dir / "__init__.py").touch()
-    dest_md.write_text(src_md.read_text(), encoding="utf-8")
+    atomic_write_text(dest_md, src_md.read_text())
     sibling_tools = sorted(
         f.name for f in src_md.parent.glob("*.py") if f.name != "__init__.py")
     return {

--- a/scilink/skills/_shared/_script_bank.py
+++ b/scilink/skills/_shared/_script_bank.py
@@ -43,6 +43,7 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
+from ...utils.text_io import atomic_write_text
 from ..loader import scilink_home, memory_enabled, _TRUTHY, _FALSY
 from ._graduation import safe_path_component, warn_if_ephemeral_store
 
@@ -127,7 +128,7 @@ def add_record(domain: str, record: Dict[str, Any], *, root: Optional[Path] = No
             ):
                 rec["outcome"]["best_metric"] = metric
         rec["updated_at"] = now
-        path.write_text(json.dumps(rec, indent=2, default=str), encoding="utf-8")
+        atomic_write_text(path, json.dumps(rec, indent=2, default=str))
         return {"id": rec["id"], "action": "updated"}
 
     warn_if_ephemeral_store()
@@ -143,7 +144,7 @@ def add_record(domain: str, record: Dict[str, Any], *, root: Optional[Path] = No
         "stats": {"n_successes": 1, "n_retrievals": 0},
         **record,
     }
-    (d / f"{rid}.json").write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+    atomic_write_text(d / f"{rid}.json", json.dumps(payload, indent=2, default=str))
     return {"id": rid, "action": "created"}
 
 
@@ -636,7 +637,7 @@ def mark_retrieved(domain: str, rid: str, *, root: Optional[Path] = None) -> Non
         rec = json.loads(f.read_text())
         stats = rec.setdefault("stats", {})
         stats["n_retrievals"] = int(stats.get("n_retrievals", 0)) + 1
-        f.write_text(json.dumps(rec, indent=2, default=str), encoding="utf-8")
+        atomic_write_text(f, json.dumps(rec, indent=2, default=str))
     except Exception:
         pass
 
@@ -662,7 +663,7 @@ def record_success(domain: str, rid: str, session: Optional[str] = None,
                 sessions.append(session)
                 del sessions[:-_MAX_SESSIONS]
         rec["updated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
-        f.write_text(json.dumps(rec, indent=2, default=str), encoding="utf-8")
+        atomic_write_text(f, json.dumps(rec, indent=2, default=str))
     except Exception:
         pass
 
@@ -830,8 +831,8 @@ def promote_to_staging(domain: str, rid: str, technique: Optional[str] = None,
     rec["promoted_to_staging"] = sid
     rec["promoted_reason"] = provenance
     rec["updated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
-    (_domain_dir(domain, root=root) / f"{rid}.json").write_text(
-        json.dumps(rec, indent=2, default=str), encoding="utf-8")
+    atomic_write_text(_domain_dir(domain, root=root) / f"{rid}.json",
+                      json.dumps(rec, indent=2, default=str))
     return {"status": "success", "staged_id": sid, "technique": label,
             "domain": domain, "bank_id": rid}
 

--- a/scilink/skills/_shared/_staging.py
+++ b/scilink/skills/_shared/_staging.py
@@ -22,6 +22,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
+from ...utils.text_io import atomic_write_text
 from ..loader import scilink_home, load_skill, list_skills, graduated_skills_dir
 from ._graduation import graduate_to_skill_file, safe_path_component, warn_if_ephemeral_store
 
@@ -99,7 +100,7 @@ def stage_solution(
     d.mkdir(parents=True, exist_ok=True)
     sid = uuid.uuid4().hex[:8]
     payload = {"id": sid, "domain": domain, "technique": technique, **record}
-    (d / f"{sid}.json").write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+    atomic_write_text(d / f"{sid}.json", json.dumps(payload, indent=2, default=str))
     return sid
 
 
@@ -161,8 +162,8 @@ def relabel_staged(domain: str, sid: str, technique: str, *,
     if not label:
         return {"status": "error", "message": "Empty technique label."}
     rec["technique"] = label
-    (_domain_dir(domain, root=root) / f"{sid}.json").write_text(
-        json.dumps(rec, indent=2, default=str), encoding="utf-8")
+    atomic_write_text(_domain_dir(domain, root=root) / f"{sid}.json",
+                      json.dumps(rec, indent=2, default=str))
     return {"status": "success", "technique": label, "id": sid}
 
 
@@ -541,9 +542,9 @@ def apply_skill_upgrade(
     # Back up the current version (single last-version undo; .bak is ignored by
     # the loader, which only discovers <name>.md).
     backup = target_md.with_name(target_md.name + ".bak")
-    backup.write_text(target_md.read_text(), encoding="utf-8")
+    atomic_write_text(backup, target_md.read_text())
     (target_md.parent / "__init__.py").touch()
-    target_md.write_text(proposed_content, encoding="utf-8")
+    atomic_write_text(target_md, proposed_content)
     removed = remove_staged(domain, staged_ids, root=root)
     return {
         "status": "success",

--- a/scilink/skills/loader.py
+++ b/scilink/skills/loader.py
@@ -138,7 +138,8 @@ def set_memory_enabled(enabled: bool) -> Path:
     cfg = _read_config()
     cfg["memory_enabled"] = bool(enabled)
     p = _config_path()
-    p.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    from ..utils.text_io import atomic_write_text
+    atomic_write_text(p, json.dumps(cfg, indent=2))
     return p
 
 

--- a/scilink/ui/components/wizard_state.py
+++ b/scilink/ui/components/wizard_state.py
@@ -75,7 +75,8 @@ def _load() -> Dict[str, Dict[str, Any]]:
 def _save(data: Dict[str, Dict[str, Any]]) -> None:
     try:
         _STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
-        _STATE_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        from ...utils.text_io import atomic_write_text
+        atomic_write_text(_STATE_PATH, json.dumps(data, indent=2))
     except Exception as exc:
         logging.warning("Could not write %s: %s", _STATE_PATH, exc)
 

--- a/scilink/utils/available_software.py
+++ b/scilink/utils/available_software.py
@@ -370,8 +370,8 @@ class AvailableSoftware:
         """Write the state to YAML, returning the path written."""
         p = Path(path) if path else _yaml_path()
         p.parent.mkdir(parents=True, exist_ok=True)
-        with open(p, "w", encoding="utf-8") as f:
-            yaml.safe_dump(
-                self._data, f, sort_keys=True, default_flow_style=False
-            )
+        from .text_io import atomic_write_text
+        atomic_write_text(p, yaml.safe_dump(
+            self._data, sort_keys=True, default_flow_style=False
+        ))
         return p

--- a/scilink/utils/text_io.py
+++ b/scilink/utils/text_io.py
@@ -28,9 +28,50 @@ persists or reloads model-generated prose should move here too.
 """
 from __future__ import annotations
 
+import contextlib
 import logging
+import os
+import tempfile
 from pathlib import Path
 from typing import Any
+
+
+def atomic_write_text(path: Any, text: str) -> Path:
+    """Write ``text`` to ``path`` as UTF-8 via a same-directory temp file
+    published with ``os.replace``.
+
+    A reader can never observe a torn/half-written file: it sees either the
+    old content or the new content, whole. Concurrent writers are
+    last-writer-wins. This is NOT a lock — read-modify-write races between
+    sessions remain (#398 part 2); it only removes the silent-corruption
+    window that a plain ``write_text`` leaves open for every reader of the
+    shared ``~/.scilink`` store.
+
+    The temp file lives in the destination directory so the ``os.replace``
+    is a same-filesystem rename (atomic on POSIX and Windows).
+    """
+    p = Path(path)
+    fd, tmp = tempfile.mkstemp(dir=str(p.parent), prefix=f".{p.name}.",
+                               suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        # mkstemp creates 0600 and os.replace carries that mode onto the
+        # destination; match what a plain write_text would have produced —
+        # keep an existing file's mode, honor the umask for a new one.
+        try:
+            mode = os.stat(p).st_mode & 0o777
+        except OSError:
+            umask = os.umask(0)
+            os.umask(umask)
+            mode = 0o666 & ~umask
+        os.chmod(tmp, mode)
+        os.replace(tmp, p)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+    return p
 
 
 def write_text_utf8(path: Any, text: str, *, append: bool = False) -> Path:

--- a/tests/test_store_atomic_writes.py
+++ b/tests/test_store_atomic_writes.py
@@ -1,0 +1,132 @@
+"""Tests for #398 part 1: atomic publishes for the ~/.scilink store.
+
+Engine-level tests for atomic_write_text plus a multi-process hammer
+asserting a reader can never observe a torn file, and a store-level check
+that script-bank record writes stay valid JSON under concurrency.
+"""
+import json
+import multiprocessing as mp
+import os
+import time
+from pathlib import Path
+
+from scilink.utils.text_io import atomic_write_text
+
+
+def test_basic_write_and_overwrite(tmp_path):
+    p = tmp_path / "rec.json"
+    atomic_write_text(p, '{"v": 1}')
+    assert json.loads(p.read_text()) == {"v": 1}
+    atomic_write_text(p, '{"v": 2}')
+    assert json.loads(p.read_text()) == {"v": 2}
+    # No temp-file droppings left behind.
+    assert [f.name for f in tmp_path.iterdir()] == ["rec.json"]
+
+
+def test_permissions_preserved_and_umask_honored(tmp_path):
+    import stat
+
+    p = tmp_path / "existing.json"
+    p.write_text("{}")
+    os.chmod(p, 0o644)
+    atomic_write_text(p, '{"v": 1}')
+    assert stat.S_IMODE(os.stat(p).st_mode) == 0o644
+
+    umask = os.umask(0)
+    os.umask(umask)
+    q = tmp_path / "fresh.json"
+    atomic_write_text(q, '{"v": 1}')
+    assert stat.S_IMODE(os.stat(q).st_mode) == 0o666 & ~umask
+
+
+def test_unicode_roundtrip(tmp_path):
+    p = tmp_path / "note.md"
+    text = "α → β, Δ = −0.5 µm"
+    atomic_write_text(p, text)
+    assert p.read_text(encoding="utf-8") == text
+
+
+def test_failed_write_leaves_no_tmp(tmp_path):
+    p = tmp_path / "x.json"
+
+    class Boom:
+        def __str__(self):
+            raise RuntimeError("boom")
+
+    try:
+        atomic_write_text(p, Boom())  # type: ignore[arg-type]
+    except Exception:
+        pass
+    assert list(tmp_path.iterdir()) == []
+
+
+def _writer(path_str, wid, n_writes):
+    # ~100 KB payloads widen the window a torn write would occupy.
+    filler = "x" * 100_000
+    for i in range(n_writes):
+        atomic_write_text(path_str,
+                          json.dumps({"writer": wid, "i": i, "fill": filler}))
+
+
+def test_concurrent_writers_never_torn(tmp_path):
+    """N processes hammer one file; every read must parse as a whole payload."""
+    p = tmp_path / "shared.json"
+    atomic_write_text(p, json.dumps({"writer": -1, "i": -1, "fill": ""}))
+
+    n_writers, n_writes = 4, 150
+    procs = [mp.Process(target=_writer, args=(str(p), w, n_writes))
+             for w in range(n_writers)]
+    for pr in procs:
+        pr.start()
+
+    reads = 0
+    deadline = time.time() + 60
+    while any(pr.is_alive() for pr in procs) and time.time() < deadline:
+        rec = json.loads(p.read_text(encoding="utf-8"))  # must never raise
+        assert set(rec) == {"writer", "i", "fill"}
+        reads += 1
+    for pr in procs:
+        pr.join(timeout=30)
+        assert pr.exitcode == 0
+
+    final = json.loads(p.read_text(encoding="utf-8"))
+    assert final["i"] == n_writes - 1  # some writer's last payload, whole
+    assert reads > 0
+    # Publishing left no temp files behind.
+    assert [f.name for f in tmp_path.iterdir()] == ["shared.json"]
+
+
+def _banker(root_str, session_id, script, n):
+    from scilink.skills._shared import _script_bank as sb
+    for _ in range(n):
+        sb.add_record("curve_fitting", {
+            "working_script": script,
+            "provenance": {"session": session_id},
+            "outcome": {"metric": "r2=0.99"},
+        }, root=Path(root_str))
+
+
+def test_script_bank_records_stay_parseable_under_concurrency(tmp_path, monkeypatch):
+    """Concurrent add_record calls must never leave an unparseable record —
+    the masked-data-loss mode where _find_by_hash skips a torn file forever.
+    (Lost increments / duplicate records are the RMW race — #398 part 2.)"""
+    monkeypatch.setenv("SCILINK_MEMORY", "1")
+    root = tmp_path / "bank"
+    script = "import numpy as np\nprint('fit')\n"
+    procs = [mp.Process(target=_banker, args=(str(root), f"s{w}", script, 25))
+             for w in range(3)]
+    for pr in procs:
+        pr.start()
+    for pr in procs:
+        pr.join(timeout=120)
+        assert pr.exitcode == 0
+
+    records = list((root / "curve_fitting").glob("*.json"))
+    assert records, "no records were banked"
+    for f in records:
+        rec = json.loads(f.read_text(encoding="utf-8"))  # all parseable
+        assert rec.get("script_hash")
+    # No temp droppings in the domain dir.
+    leftovers = [f.name for f in (root / "curve_fitting").iterdir()
+                 if f.suffix == ".tmp"]
+    assert leftovers == []


### PR DESCRIPTION
## Summary

The `~/.scilink` store (graduated skills, script bank, knowledge-base manifests, config files) is shared by every SciLink session on a machine, but its files were written in place — a session reading a file while another session was mid-write could see a half-written file. Worst case, a half-written script-bank record is skipped by readers forever, so a proven script silently disappears from retrieval with no error anywhere. Every store write now goes through a temp file published by an atomic rename: a reader always sees either the old file or the new file, whole — never a torn one.

This is part 1 of #398 (torn-read elimination). Part 2 — locks around the read-modify-write hot spots (lost stat increments, duplicate records, concurrent skill-graduation merges) — remains on the issue and involves a dependency decision (`filelock`).

---

**Technical details**

- New `atomic_write_text(path, text)` in `scilink/utils/text_io.py`: same-directory `mkstemp` + `os.replace` (the pattern `_tool_cache.py` already used), UTF-8 pinned like the module's other helpers, temp file unlinked on failure. It preserves an existing destination's permissions and honors the umask for new files, so rewritten store files keep their readability (plain `mkstemp` would have silently tightened `0644` → `0600`); confirmed byte-identical content vs the old writes.
- All 21 store write sites routed through it: script-bank records (5 sites — including the three added by the edit-adapt work after #398 was filed), staging (4), skill graduation, `scilink memory` markdown writes (5), the KB manifest, `config.json`, `wizard_state.json`, `available_software.yaml`. A sweep confirms no plain `write_text` remains in any store module. `_reconcile.py`'s HTML write targets a session artifact, not the store, and is untouched; the tool cache's existing atomic publish is untouched.
- Existing stored files are unaffected until their next update, which produces byte-identical content under a new inode; no migration, no read-path change.
- Tests (`tests/test_store_atomic_writes.py`, 6): overwrite + no temp droppings, permission preservation + umask, unicode round-trip, failure cleanup, a 4-process hammer where a continuously-reading parent must never observe a torn file, and concurrent script-bank `add_record` leaving every record parseable (the masked-data-loss mode). Existing suites for all touched modules pass: 213 tests across script bank, bank edit-adapt, KB store, persistent memory, graduation, loader, and memory panel.