### PR TITLE
Derive the history-trim trigger from MAX_HISTORY_MESSAGES, not a 120 literal

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -536,6 +536,12 @@ class AnalysisOrchestratorAgent:
     # Configuration constants
     MAX_TOOL_ITERATIONS = 20
     MAX_HISTORY_MESSAGES = 100
+    # The in-loop trim fires only past cap + hysteresis, so a
+    # session isn't re-trimmed on every turn once it reaches the
+    # cap. cap+20 == the 120 literal this replaces, so default
+    # behavior is unchanged — but a configured cap now actually
+    # moves the trigger.
+    TRIM_HYSTERESIS = 20
     CHECKPOINT_INTERVAL = 10
     
     def __init__(
@@ -1334,7 +1340,10 @@ class AnalysisOrchestratorAgent:
         
         print(f"  ⚠️  Trimming history: {len(history)} → {max_messages} messages")
         
-        context_window = 10
+        # A cap at or below the head window would make recent_window 0 and
+        # history[-0:] the WHOLE list (the trim would grow the history);
+        # shrink the head so a small configured cap still trims.
+        context_window = min(10, max(1, max_messages // 2))
         recent_window = max_messages - context_window
         
         trimmed = history[:context_window] + history[-recent_window:]
@@ -1642,7 +1651,7 @@ class AnalysisOrchestratorAgent:
         self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
         
-        if len(self.messages) > 120:
+        if len(self.messages) > (self.MAX_HISTORY_MESSAGES + self.TRIM_HYSTERESIS):
             print("  ⚠️  Context window getting full - trimming history...")
             system_msg = self.messages[0]
             recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)
@@ -1798,7 +1807,7 @@ class AnalysisOrchestratorAgent:
         self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
         
-        if len(self.messages) > 120:
+        if len(self.messages) > (self.MAX_HISTORY_MESSAGES + self.TRIM_HYSTERESIS):
             print("  ⚠️  Context window getting full - trimming history...")
             system_msg = self.messages[0]
             recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -376,6 +376,12 @@ class MetaOrchestratorAgent:
     # Configuration constants (match the child orchestrators).
     MAX_TOOL_ITERATIONS = 20
     MAX_HISTORY_MESSAGES = 100
+    # The in-loop trim fires only past cap + hysteresis, so a
+    # session isn't re-trimmed on every turn once it reaches the
+    # cap. cap+20 == the 120 literal this replaces, so default
+    # behavior is unchanged — but a configured cap now actually
+    # moves the trigger.
+    TRIM_HYSTERESIS = 20
     CHECKPOINT_INTERVAL = 10
 
     def __init__(
@@ -1637,7 +1643,10 @@ class MetaOrchestratorAgent:
 
         print(f"  ⚠️  Trimming history: {len(history)} → {max_messages} messages")
 
-        context_window = 10
+        # A cap at or below the head window would make recent_window 0 and
+        # history[-0:] the WHOLE list (the trim would grow the history);
+        # shrink the head so a small configured cap still trims.
+        context_window = min(10, max(1, max_messages // 2))
         recent_window = max_messages - context_window
 
         trimmed = history[:context_window] + history[-recent_window:]
@@ -1758,7 +1767,7 @@ class MetaOrchestratorAgent:
         self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
 
-        if len(self.messages) > 120:
+        if len(self.messages) > (self.MAX_HISTORY_MESSAGES + self.TRIM_HYSTERESIS):
             print("  ⚠️  Context window getting full - trimming history...")
             system_msg = self.messages[0]
             recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)
@@ -1919,7 +1928,7 @@ class MetaOrchestratorAgent:
         self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
 
-        if len(self.messages) > 120:
+        if len(self.messages) > (self.MAX_HISTORY_MESSAGES + self.TRIM_HYSTERESIS):
             print("  ⚠️  Context window getting full - trimming history...")
             system_msg = self.messages[0]
             recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -593,6 +593,14 @@ class PlanningOrchestratorAgent:
         google_api_key: DEPRECATED. Use 'api_key' instead.
         local_model: DEPRECATED. Use 'base_url' instead.
     """
+    MAX_HISTORY_MESSAGES = 100
+    # The in-loop trim fires only past cap + hysteresis, so a
+    # session isn't re-trimmed on every turn once it reaches the
+    # cap. cap+20 == the 120 literal this replaces, so default
+    # behavior is unchanged — but a configured cap now actually
+    # moves the trigger.
+    TRIM_HYSTERESIS = 20
+
     def __init__(
         self,
         objective: str = "Undefined Research Goal",
@@ -859,14 +867,14 @@ class PlanningOrchestratorAgent:
         if self.use_openai:
             self.messages = [{"role": "system", "content": system_prompt}]
             if history:
-                recent_history = self._trim_history(history, max_messages=100)
+                recent_history = self._trim_history(history, max_messages=self.MAX_HISTORY_MESSAGES)
                 self.messages.extend(recent_history)
         else:
             # LiteLLM: Initialize messages list similar to OpenAI mode
             # We'll handle tool calls manually instead of using chat_session with AFC
             self.messages = [{"role": "system", "content": system_prompt}]
             if history:
-                recent_history = self._trim_history(history, max_messages=100)
+                recent_history = self._trim_history(history, max_messages=self.MAX_HISTORY_MESSAGES)
                 self.messages.extend(recent_history)
 
     def _convert_tools_to_litellm_format(self) -> List[Dict]:
@@ -1305,14 +1313,18 @@ class PlanningOrchestratorAgent:
         except Exception as e:
             logging.warning(f"Failed to restore checkpoint: {e}")
 
-    def _trim_history(self, history: List[Dict], max_messages: int = 100) -> List[Dict]:
+    def _trim_history(self, history: List[Dict], max_messages: int = None) -> List[Dict]:
         """Keep only recent messages to avoid context window overflow."""
+        max_messages = max_messages or self.MAX_HISTORY_MESSAGES
         if len(history) <= max_messages:
             return history
         
         print(f"  ⚠️  Trimming history: {len(history)} → {max_messages} messages")
         
-        context_window = 10
+        # A cap at or below the head window would make recent_window 0 and
+        # history[-0:] the WHOLE list (the trim would grow the history);
+        # shrink the head so a small configured cap still trims.
+        context_window = min(10, max(1, max_messages // 2))
         recent_window = max_messages - context_window
         
         trimmed = history[:context_window] + history[-recent_window:]
@@ -1674,10 +1686,10 @@ class PlanningOrchestratorAgent:
         self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
         
-        if len(self.messages) > 120:
+        if len(self.messages) > (self.MAX_HISTORY_MESSAGES + self.TRIM_HYSTERESIS):
             print("  ⚠️  Context window getting full - trimming history...")
             system_msg = self.messages[0]
-            recent_msgs = self._trim_history(self.messages[1:], max_messages=100)
+            recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)
             self.messages = [system_msg] + recent_msgs
             # AFTER the trim, not before: the trim is what slices a
             # tool_use away from its tool_result, so repairing first
@@ -1823,10 +1835,10 @@ class PlanningOrchestratorAgent:
         self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
         
-        if len(self.messages) > 120:
+        if len(self.messages) > (self.MAX_HISTORY_MESSAGES + self.TRIM_HYSTERESIS):
             print("  ⚠️  Context window getting full - trimming history...")
             system_msg = self.messages[0]
-            recent_msgs = self._trim_history(self.messages[1:], max_messages=100)
+            recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)
             self.messages = [system_msg] + recent_msgs
             # AFTER the trim, not before: the trim is what slices a
             # tool_use away from its tool_result, so repairing first

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -278,6 +278,12 @@ class SimulationOrchestratorAgent:
     # Configuration constants — mirror AnalysisOrchestratorAgent
     MAX_TOOL_ITERATIONS = 20
     MAX_HISTORY_MESSAGES = 100
+    # The in-loop trim fires only past cap + hysteresis, so a
+    # session isn't re-trimmed on every turn once it reaches the
+    # cap. cap+20 == the 120 literal this replaces, so default
+    # behavior is unchanged — but a configured cap now actually
+    # moves the trigger.
+    TRIM_HYSTERESIS = 20
     CHECKPOINT_INTERVAL = 10
 
     def __init__(
@@ -844,7 +850,7 @@ class SimulationOrchestratorAgent:
         self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
 
-        if len(self.messages) > 120:
+        if len(self.messages) > (self.MAX_HISTORY_MESSAGES + self.TRIM_HYSTERESIS):
             print("  ⚠️  Context window getting full - trimming history...")
             system_msg = self.messages[0]
             recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)
@@ -939,7 +945,7 @@ class SimulationOrchestratorAgent:
         self.messages = close_interrupted_turn(self.messages)
         self.messages.append({"role": "user", "content": user_input})
 
-        if len(self.messages) > 120:
+        if len(self.messages) > (self.MAX_HISTORY_MESSAGES + self.TRIM_HYSTERESIS):
             print("  ⚠️  Context window getting full - trimming history...")
             system_msg = self.messages[0]
             recent_msgs = self._trim_history(self.messages[1:], max_messages=self.MAX_HISTORY_MESSAGES)

--- a/tests/test_trim_gate.py
+++ b/tests/test_trim_gate.py
@@ -1,0 +1,99 @@
+"""The in-loop history-trim trigger must derive from MAX_HISTORY_MESSAGES
+(+ TRIM_HYSTERESIS), not the old hardcoded 120 — so configuring the cap
+actually moves the trigger, while the default (100 + 20) stays byte-
+identical to the literal it replaces.
+
+  python -m pytest tests/test_trim_gate.py -v
+"""
+import inspect
+import os
+import types
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+
+import pytest
+
+
+def _classes():
+    from scilink.agents.exp_agents.analysis_orchestrator import (
+        AnalysisOrchestratorAgent)
+    from scilink.agents.planning_agents.planning_orchestrator import (
+        PlanningOrchestratorAgent)
+    from scilink.agents.sim_agents.simulation_orchestrator import (
+        SimulationOrchestratorAgent)
+    from scilink.agents.meta_agent.meta_orchestrator import (
+        MetaOrchestratorAgent)
+    return {"analysis": AnalysisOrchestratorAgent,
+            "planning": PlanningOrchestratorAgent,
+            "simulate": SimulationOrchestratorAgent,
+            "meta": MetaOrchestratorAgent}
+
+
+def test_default_gate_value_unchanged():
+    for mode, cls in _classes().items():
+        assert cls.MAX_HISTORY_MESSAGES + cls.TRIM_HYSTERESIS == 120, mode
+
+
+def test_no_hardcoded_gate_literal():
+    for mode, cls in _classes().items():
+        for handler in ("_handle_litellm_chat", "_handle_openai_chat"):
+            src = inspect.getsource(getattr(cls, handler))
+            assert "> 120" not in src, f"{mode}.{handler} keeps the literal"
+            assert "MAX_HISTORY_MESSAGES + self.TRIM_HYSTERESIS" in src, \
+                f"{mode}.{handler} gate not derived from the cap"
+
+
+def _fake_completion(**_kw):
+    msg = types.SimpleNamespace(content="ok", tool_calls=None)
+    return types.SimpleNamespace(
+        choices=[types.SimpleNamespace(message=msg, finish_reason="stop")])
+
+
+def _make(mode, cls, tmp_path):
+    kw = dict(api_key="sk-dummy", base_dir=str(tmp_path / mode))
+    if mode == "planning":
+        kw["data_dir"] = str(tmp_path)
+    return cls(**kw)
+
+
+def test_small_cap_does_not_grow_history(tmp_path):
+    """Pre-fix, max_messages <= 10 made recent_window 0 and history[-0:]
+    the WHOLE list — the 'trim' returned first-10 + everything (grew,
+    with duplicates)."""
+    ag = _make("analysis", _classes()["analysis"], tmp_path)
+    history = [{"role": "user", "content": f"m{i}"} for i in range(50)]
+    trimmed = ag._trim_history(history, max_messages=10)
+    assert len(trimmed) <= 11              # 10 + marker
+    contents = [m["content"] for m in trimmed]
+    assert len(contents) == len(set(contents))   # no duplicated messages
+
+
+@pytest.mark.parametrize("mode", ["analysis", "planning", "simulate", "meta"])
+def test_lowered_cap_moves_the_trigger(mode, tmp_path, monkeypatch):
+    import scilink.wrappers.litellm_wrapper as lw
+    monkeypatch.setattr(lw, "litellm_completion", _fake_completion)
+
+    ag = _make(mode, _classes()[mode], tmp_path)
+    ag.MAX_HISTORY_MESSAGES = 10          # gate is now 10 + 20 = 30
+
+    def _seed(n):
+        for i in range(n):
+            role = "user" if i % 2 == 0 else "assistant"
+            ag.messages.append({"role": role, "content": f"filler {i}"})
+
+    # Below the lowered gate: nothing is trimmed.
+    _seed(20)
+    before = len(ag.messages)
+    ag.chat("hello")
+    assert len(ag.messages) >= before + 1   # grew; nothing sliced
+
+    # Past the lowered gate: trimmed down to ~cap (pre-fix: nothing would
+    # happen until 121 messages).
+    _seed(30)
+    assert len(ag.messages) > 30
+    ag.chat("hello again")
+    assert len(ag.messages) <= 10 + 4, (
+        f"{mode}: expected trim to ~cap, got {len(ag.messages)}")
+    if mode != "simulate":               # sim's trim has no marker on main
+        assert any("omitted for context management"
+                   in str(m.get("content", "")) for m in ag.messages), mode


### PR DESCRIPTION
## Summary

Each chat orchestrator trims old conversation turns when a session gets long, and `MAX_HISTORY_MESSAGES` is supposed to control that. In reality it only controlled *how much* survives a trim — *whether* a trim happens was decided by a hardcoded `len(messages) > 120` in every chat handler. So configuring a smaller history cap did nothing at all until message 121, then chopped ~100 messages in one step; this bit us live while testing the session-memory feature (#513). The trigger is now derived from the cap plus a named hysteresis, so a configured cap actually moves the trigger, while default behavior stays exactly as before (100 + 20 equals the old literal).

Along the way the new tests exposed a second, nastier edge: with a cap of 10 or less, the trim's arithmetic produced `history[-0:]` — the whole list — so a "trim" *grew* the history with duplicated messages. Also fixed.

---

**Technical details**

- All 8 gates (both chat handlers × four orchestrators) now read `len(self.messages) > (self.MAX_HISTORY_MESSAGES + self.TRIM_HYSTERESIS)`; `TRIM_HYSTERESIS = 20` is a new class constant next to the cap. The hysteresis preserves the intended sawtooth (a session at the cap isn't re-trimmed on every turn), and the default `100 + 20 == 120` keeps default behavior byte-identical.
- The planning orchestrator had no `MAX_HISTORY_MESSAGES` at all — bare `100`s at four call sites and in `_trim_history`'s signature default; it gains the same constants and the call sites now reference them (same values).
- Small-cap fix: in the marker-style `_trim_history` (analysis / planning / meta), `recent_window = max_messages - context_window` hit 0 when the cap ≤ the 10-message head window, and `history[-0:]` returned everything. The head window now scales as `min(10, cap // 2)`; unchanged for any cap ≥ 20 (so the default path is untouched — sim's slice-trim never had the bug).

**Verification**

- Offline (`tests/test_trim_gate.py`, 7 tests): default gate value is exactly 120 on all four classes; no `> 120` literal remains in any handler (source inspection); a lowered cap actually triggers the trim on all four orchestrators against a stubbed LLM; small caps trim without growing or duplicating.
- Regression: dispatch guards + UI-stop + planning campaigns + sim delegation (28 tests) and fan-out robustness 62/62 green; all 8 LLM-facing surfaces (system prompt + tool schemas × four orchestrators) hash byte-identical to main.
- Live (Bedrock opus-4-8), 9/9: analysis with cap 30 trims at the new gate of 50, recalls a head-window fact exactly, and does not fabricate an evicted value; analysis at default config shows no trim at 118 messages and the same trim-to-~100 past 120 as before the fix; sim with cap 30 trims and replies coherently.

Related: found while building #513 (the session event log), whose trim-marker now points trimmed sessions at `search_session_history` — after both merge, an evicted fact is recovered from the event log instead of being reported as unavailable.