### PR TITLE
Lock the run_task cap-exhaustion status flip; document the meta cap split (#211)

### DIFF
--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -363,6 +363,13 @@ class MetaOrchestratorAgent:
         restore_checkpoint: Whether to restore from a previous checkpoint.
         meta_mode: Autonomy level (AUTOPILOT or AUTONOMOUS). The meta has
             only these two — see MetaMode.
+        max_iterations: Per-turn tool-iteration cap for the META's OWN chat
+            loop only (default 20). It is NOT forwarded to delegations: a
+            child orchestrator runs each delegated task under its own cap
+            (default 20), so raising this does not give a specialist more
+            steps. Delegation depth and per-delegation tool budget are
+            separate dimensions; a child that exhausts its cap reports the
+            delegation as status="error" with the cap warning.
         knowledge_dir: Optional stable knowledge/KB directory for the
             planning child (documents plus its persisted embedding index,
             e.g. the ``./kb_storage`` a standalone plan session built).

--- a/tests/test_run_task_cap_exhaustion.py
+++ b/tests/test_run_task_cap_exhaustion.py
@@ -1,0 +1,73 @@
+"""Regression tests for #211 item 1: the #208 status flip.
+
+``chat()`` handles an exhausted iteration cap by returning the warning
+string (preserving CLI/UI behavior) and setting ``_last_chat_hit_iter_cap``;
+``run_task`` must surface that as ``status="error"`` to programmatic
+callers instead of silently reporting success. This contract crosses the
+chat loop / run_task seam via a flag, so a chat-loop refactor can break it
+without any type error — these tests are the tripwire.
+
+  python -m pytest tests/test_run_task_cap_exhaustion.py -v
+"""
+import os
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+
+import pytest
+
+CAP_WARNING = ("⚠️ Reached maximum tool iterations (3). The task may be "
+               "incomplete.")
+
+
+def _make(mode, tmp_path):
+    if mode == "analysis":
+        from scilink.agents.exp_agents.analysis_orchestrator import (
+            AnalysisOrchestratorAgent)
+        return AnalysisOrchestratorAgent(api_key="sk-dummy",
+                                         base_dir=str(tmp_path / "an"))
+    if mode == "planning":
+        from scilink.agents.planning_agents.planning_orchestrator import (
+            PlanningOrchestratorAgent)
+        return PlanningOrchestratorAgent(api_key="sk-dummy",
+                                         data_dir=str(tmp_path),
+                                         base_dir=str(tmp_path / "pl"))
+    from scilink.agents.sim_agents.simulation_orchestrator import (
+        SimulationOrchestratorAgent)
+    return SimulationOrchestratorAgent(api_key="sk-dummy",
+                                       base_dir=str(tmp_path / "si"))
+
+
+@pytest.mark.parametrize("mode", ["analysis", "planning", "simulate"])
+def test_cap_exhaustion_flips_status_to_error(mode, tmp_path):
+    orch = _make(mode, tmp_path)
+    original_cap = orch.max_iterations
+
+    def fake_chat(_prompt):
+        # What a real chat() turn looks like after burning its whole
+        # iteration budget: warning string returned, flag set.
+        orch._last_chat_hit_iter_cap = True
+        return CAP_WARNING
+
+    orch.chat = fake_chat
+    result = orch.run_task("some task", max_iterations=3)
+
+    assert result["status"] == "error", (
+        f"{mode}: cap exhaustion reported as {result['status']!r} — "
+        "the #208 silent-success bug is back")
+    assert CAP_WARNING in (result.get("error") or "")
+    # The per-call max_iterations override must not leak past the call.
+    assert orch.max_iterations == original_cap
+
+
+@pytest.mark.parametrize("mode", ["analysis", "planning", "simulate"])
+def test_clean_completion_still_reports_success(mode, tmp_path):
+    orch = _make(mode, tmp_path)
+
+    def fake_chat(_prompt):
+        orch._last_chat_hit_iter_cap = False
+        return "All done."
+
+    orch.chat = fake_chat
+    result = orch.run_task("some task")
+    assert result["status"] == "success"
+    assert not result.get("error")


### PR DESCRIPTION
## Summary

Two small follow-ups left over from the #208 fix (which stopped `run_task` from reporting a gave-up-mid-task turn as success). First, that fix now has a tripwire: regression tests on all three orchestrators assert that a chat turn exhausting its iteration cap surfaces from `run_task` as `status="error"` — the signal crosses the chat-loop/`run_task` seam via a flag, so a future refactor could silently reintroduce the old bug and nothing would have caught it. Second, the meta agent's `max_iterations` is now documented honestly: it caps the meta's own chat loop only and is not passed down to specialist children, who keep their own default of 20 — previously the parameter was undocumented and it was natural to assume it applied everywhere.

Closes #211.

Per the issue's own recommendation, the alternative "plumb the meta's cap into delegations" option is deliberately not taken here — that's an API-shape change worth its own discussion, and the live test confirms the current split works as now documented.

---

**Technical details**

- `tests/test_run_task_cap_exhaustion.py` (6 tests): for analysis / planning / simulation, a stubbed `chat()` that sets `_last_chat_hit_iter_cap` and returns the warning string must yield `run_task` → `status="error"` with the warning in `error`, and the per-call `max_iterations` override must be restored on the instance; clean-completion controls pin the success path. Mirrors the `test_5_run_task_without_llm` stub shape.
- `MetaOrchestratorAgent` class docstring gains the `max_iterations` entry naming the split (meta's own loop only; delegation depth vs per-delegation tool budget are separate dimensions; an exhausted child reports the delegation as an error).
- Live (Bedrock opus-4-8), 9/9: a REAL cap exhaustion (`run_task(max_iterations=2)` on a genuine fitting task) returns `status="error"` with the cap warning and restores the cap; the same task under the default cap succeeds with one analysis; a meta built with `max_iterations=50` delegates while its analysis child verifiably runs under its own cap of 20, and the delegation succeeds (fitted peak center 5.100 ± 0.003 vs planted 5.1).