### PR TITLE
Sequential uploads stay independent; the orchestrator judges series-ness (#114)

### DIFF
--- a/scilink/ui/components/chat_uploads.py
+++ b/scilink/ui/components/chat_uploads.py
@@ -13,7 +13,58 @@ from ..config import (
     SUPPORTED_PLANNING_DATA_EXTENSIONS,
     extra_data_extensions_for,
 )
-from .sidebar import save_metadata_to_series, save_upload, save_upload_batch
+from .sidebar import (save_metadata_to_series, save_upload,
+                      save_upload_batch, split_upload_arrivals)
+
+
+def build_analyze_prompt(data_path, meta_path=None, has_sidecars=False,
+                         batch=False, first_path=None,
+                         late_paths=None) -> str:
+    """Compose the Analyze dispatch prompt from the upload state.
+
+    The prompt carries the one signal only the UI has — which files
+    arrived together and which were added later — and leaves the
+    series-vs-independent decision to the orchestrator (#114).
+    """
+    if late_paths:
+        lines = [f"- uploaded first: `{first_path or data_path}`"]
+        lines += [f"- added later: `{p}`" for p in late_paths]
+        prompt = (
+            "I uploaded these data files at different times:\n"
+            + "\n".join(lines) + "\n"
+            "Files uploaded at different times are likely independent "
+            "datasets rather than one series. Examine them and decide what "
+            "actually belongs together before analyzing — ask me if it is "
+            "genuinely ambiguous — and analyze independent files "
+            "separately."
+        )
+        if meta_path:
+            prompt += (f"\nA metadata file is at `{meta_path}`; "
+                       "load it and judge which data it describes.")
+        return prompt
+
+    confirm = (
+        " The files were uploaded together as one batch; confirm they "
+        "actually form one series before running a series analysis — if "
+        "they look unrelated, analyze them separately."
+    ) if batch else ""
+
+    if data_path and meta_path:
+        return (
+            f"I uploaded a data file at `{data_path}` "
+            f"and a metadata file at `{meta_path}`. "
+            f"Please examine the data and load the metadata." + confirm
+        )
+    if data_path and has_sidecars:
+        return (
+            f"I uploaded data files at `{data_path}` along with "
+            f"per-file JSON sidecar metadata in the same directory. "
+            f"Please examine the data and load the metadata "
+            f"(pass the directory path `{data_path}` to load_metadata)."
+            + confirm
+        )
+    return (f"I uploaded a data file at `{data_path}`. Please examine it."
+            + confirm)
 
 
 def render_pre_chat_uploads(start_task_fn) -> None:
@@ -56,11 +107,28 @@ def _render_analyze_uploads(start_task_fn) -> None:
         )
         if extra_exts:
             st.caption("Vendor formats enabled via SciFiReaders MCP")
-        if main_data:
-            if len(main_data) == 1:
-                save_upload(main_data[0], "data", auto_dispatch=False)
+        first_data, late_data = split_upload_arrivals(
+            main_data or [], "chat_data")
+        if not main_data:
+            st.session_state.pop("_late_data_paths", None)
+            st.session_state.pop("_first_data_path", None)
+        else:
+            # Late additions (files the accumulating widget gained AFTER
+            # its first batch) are saved as independent uploads, never
+            # merged into a series with the earlier files — the
+            # orchestrator judges what belongs together (#114).
+            if late_data:
+                seen = st.session_state.setdefault("_late_data_paths", [])
+                for f in late_data:
+                    p = save_upload(f, "data", auto_dispatch=False)
+                    if p not in seen:
+                        seen.append(p)
+            elif len(first_data) == 1:
+                st.session_state["_first_data_path"] = save_upload(
+                    first_data[0], "data", auto_dispatch=False)
             else:
-                save_upload_batch(main_data, "data", auto_dispatch=False)
+                st.session_state["_first_data_path"] = save_upload_batch(
+                    first_data, "data", auto_dispatch=False)
     with up_meta:
         main_meta = st.file_uploader(
             "Metadata (optional)",
@@ -77,27 +145,16 @@ def _render_analyze_uploads(start_task_fn) -> None:
     # Show "Analyze" button once data is uploaded
     if st.session_state.uploaded_data_path:
         if st.button("Analyze", type="primary", width="stretch"):
-            data_path = st.session_state.uploaded_data_path
-            meta_path = st.session_state.uploaded_metadata_path
-            has_sidecars = st.session_state.get("uploaded_sidecar_metadata", False)
-            if data_path and meta_path:
-                prompt = (
-                    f"I uploaded a data file at `{data_path}` "
-                    f"and a metadata file at `{meta_path}`. "
-                    f"Please examine the data and load the metadata."
-                )
-            elif data_path and has_sidecars:
-                prompt = (
-                    f"I uploaded data files at `{data_path}` along with "
-                    f"per-file JSON sidecar metadata in the same directory. "
-                    f"Please examine the data and load the metadata "
-                    f"(pass the directory path `{data_path}` to load_metadata)."
-                )
-            else:
-                prompt = (
-                    f"I uploaded a data file at `{data_path}`. "
-                    f"Please examine it."
-                )
+            prompt = build_analyze_prompt(
+                st.session_state.uploaded_data_path,
+                meta_path=st.session_state.uploaded_metadata_path,
+                has_sidecars=st.session_state.get(
+                    "uploaded_sidecar_metadata", False),
+                batch=len(st.session_state.get("_upload_first_batch_chat_data")
+                          or []) > 1,
+                first_path=st.session_state.get("_first_data_path"),
+                late_paths=st.session_state.get("_late_data_paths"),
+            )
             st.session_state.chat_messages.append({"role": "user", "content": prompt})
             start_task_fn(prompt)
 

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -596,11 +596,19 @@ def _render_analyze_sidebar_uploads() -> None:
     )
     if extra_exts:
         st.caption("Vendor formats enabled via SciFiReaders MCP")
+    first_data, late_data = split_upload_arrivals(data_files or [], "sidebar_data")
     if data_files:
-        if len(data_files) == 1:
-            save_upload(data_files[0], "data")
-        else:
-            save_upload_batch(data_files, "data")
+        # Late additions (files the accumulating widget gained AFTER its
+        # first batch) are saved as independent uploads, never merged into
+        # a series with the earlier files — the orchestrator judges what
+        # belongs together (#114).
+        for f in late_data:
+            save_upload(f, "data")
+        if not late_data:
+            if len(first_data) == 1:
+                save_upload(first_data[0], "data")
+            else:
+                save_upload_batch(first_data, "data")
 
     meta_files = st.file_uploader(
         "Metadata file(s)",
@@ -1299,8 +1307,39 @@ def _reset_session() -> None:
     st.rerun()
 
 
-def save_upload(uploaded_file, kind: str, auto_dispatch: bool = True) -> None:
-    """Save an uploaded file and optionally queue an auto-examine/load."""
+def split_upload_arrivals(files, tracker_key: str, state=None):
+    """Partition an accumulating uploader value into (first_batch, late).
+
+    Streamlit's ``file_uploader`` ACCUMULATES files across reruns, so
+    ``len(files)`` alone cannot distinguish "dragged together" (series
+    intent plausible) from "added later, after working with the first"
+    (independent intent likely) — #114. The widget's first non-empty rerun
+    defines the first batch; any file appearing afterwards is a late
+    addition. The partition is stable across reruns, and resets when the
+    user clears the uploader.
+
+    ``state`` is injectable for tests; defaults to ``st.session_state``.
+    """
+    if state is None:
+        state = st.session_state
+    key = f"_upload_first_batch_{tracker_key}"
+    names = [f.name for f in files]
+    if not files:
+        state[key] = None
+        return [], []
+    if state.get(key) is None:
+        state[key] = list(names)
+        return list(files), []
+    first_names = set(state[key])
+    first = [f for f in files if f.name in first_names]
+    late = [f for f in files if f.name not in first_names]
+    return first, late
+
+
+def save_upload(uploaded_file, kind: str, auto_dispatch: bool = True) -> str:
+    """Save an uploaded file and optionally queue an auto-examine/load.
+
+    Returns the saved file's path."""
     session_dir = Path(st.session_state.session_dir)
     upload_dir = session_dir / "uploads"
     upload_dir.mkdir(exist_ok=True)
@@ -1325,6 +1364,7 @@ def save_upload(uploaded_file, kind: str, auto_dispatch: bool = True) -> None:
             else:
                 st.session_state.pending_auto_load_metadata = dest_str
         st.sidebar.success(f"Uploaded {kind} file: {uploaded_file.name}")
+    return dest_str
 
 
 _GLOBAL_META_NAMES = {"metadata.json", "meta.json", "info.json", "experiment.json"}
@@ -1362,8 +1402,9 @@ def save_metadata_to_series(uploaded_files: list, auto_dispatch: bool = True) ->
         )
 
 
-def save_upload_batch(uploaded_files: list, kind: str, auto_dispatch: bool = True) -> None:
-    """Save multiple uploaded files into a subdirectory for series/batch analysis."""
+def save_upload_batch(uploaded_files: list, kind: str, auto_dispatch: bool = True) -> str:
+    """Save multiple uploaded files into a subdirectory for series/batch
+    analysis. Returns the series directory path."""
     session_dir = Path(st.session_state.session_dir)
     upload_dir = session_dir / "uploads"
     upload_dir.mkdir(exist_ok=True)
@@ -1385,6 +1426,7 @@ def save_upload_batch(uploaded_files: list, kind: str, auto_dispatch: bool = Tru
         if auto_dispatch:
             st.session_state.pending_auto_examine = series_dir_str
         st.sidebar.success(f"Uploaded {len(uploaded_files)} files to series/")
+    return series_dir_str
 
 def _start_simulate_session(
     model: str,

--- a/tests/test_upload_arrival_intent.py
+++ b/tests/test_upload_arrival_intent.py
@@ -1,0 +1,135 @@
+"""Offline tests for #114: sequential uploads are no longer silently merged
+into a series — the UI records arrival grouping and the dispatch prompt
+hands the series-vs-independent decision to the orchestrator.
+
+  python -m pytest tests/test_upload_arrival_intent.py -v
+"""
+import types
+from pathlib import Path
+
+from scilink.ui.components.chat_uploads import build_analyze_prompt
+from scilink.ui.components import sidebar as sb
+from scilink.ui.components.sidebar import split_upload_arrivals
+
+
+def _f(name):
+    return types.SimpleNamespace(name=name,
+                                 getvalue=lambda: f"data:{name}".encode())
+
+
+# ------------------------------------------------- split_upload_arrivals
+
+def test_first_batch_defines_membership():
+    state = {}
+    first, late = split_upload_arrivals([_f("a.txt"), _f("b.txt")], "d",
+                                        state)
+    assert [x.name for x in first] == ["a.txt", "b.txt"] and late == []
+    # Same widget value on a later rerun: still all first, stable.
+    first, late = split_upload_arrivals([_f("a.txt"), _f("b.txt")], "d",
+                                        state)
+    assert [x.name for x in first] == ["a.txt", "b.txt"] and late == []
+
+
+def test_late_addition_is_partitioned_out():
+    state = {}
+    split_upload_arrivals([_f("a.txt")], "d", state)
+    first, late = split_upload_arrivals([_f("a.txt"), _f("b.txt")], "d",
+                                        state)
+    assert [x.name for x in first] == ["a.txt"]
+    assert [x.name for x in late] == ["b.txt"]
+    # Stable across further reruns and further additions.
+    first, late = split_upload_arrivals(
+        [_f("a.txt"), _f("b.txt"), _f("c.txt")], "d", state)
+    assert [x.name for x in late] == ["b.txt", "c.txt"]
+
+
+def test_clearing_the_uploader_resets():
+    state = {}
+    split_upload_arrivals([_f("a.txt")], "d", state)
+    split_upload_arrivals([], "d", state)
+    first, late = split_upload_arrivals([_f("b.txt"), _f("c.txt")], "d",
+                                        state)
+    assert [x.name for x in first] == ["b.txt", "c.txt"] and late == []
+
+
+# ------------------------------------------------- build_analyze_prompt
+
+def test_single_file_prompt_unchanged():
+    assert build_analyze_prompt("/u/x.txt") == (
+        "I uploaded a data file at `/u/x.txt`. Please examine it.")
+    assert build_analyze_prompt("/u/x.txt", meta_path="/u/m.json") == (
+        "I uploaded a data file at `/u/x.txt` and a metadata file at "
+        "`/u/m.json`. Please examine the data and load the metadata.")
+
+
+def test_batch_prompt_asks_for_series_confirmation():
+    p = build_analyze_prompt("/u/series", batch=True)
+    assert "uploaded together as one batch" in p
+    assert "confirm they actually form one series" in p
+    # Composes with the metadata variants too.
+    assert "confirm they actually form one series" in build_analyze_prompt(
+        "/u/series", meta_path="/u/m.json", batch=True)
+    assert "confirm they actually form one series" in build_analyze_prompt(
+        "/u/series", has_sidecars=True, batch=True)
+
+
+def test_late_paths_prompt_lists_arrival_groups():
+    p = build_analyze_prompt("/u/b.txt", first_path="/u/a.txt",
+                             late_paths=["/u/b.txt"])
+    assert "- uploaded first: `/u/a.txt`" in p
+    assert "- added later: `/u/b.txt`" in p
+    assert "likely independent datasets" in p
+    assert "ask me if it is genuinely ambiguous" in p
+    p = build_analyze_prompt("/u/b.txt", meta_path="/u/m.json",
+                             first_path="/u/a.txt", late_paths=["/u/b.txt"])
+    assert "judge which data it describes" in p
+
+
+# --------------------------------------- file layout through save helpers
+
+class _State(dict):
+    __getattr__ = dict.__getitem__
+
+    def __setattr__(self, k, v):
+        self[k] = v
+
+
+def _fake_st(tmp_path):
+    return types.SimpleNamespace(
+        session_state=_State(session_dir=str(tmp_path),
+                             _processed_uploads=set()),
+        sidebar=types.SimpleNamespace(success=lambda *a, **k: None),
+    )
+
+
+def test_sequential_uploads_not_merged_into_series(tmp_path, monkeypatch):
+    """The #114 repro, against the real save helpers: file A analyzed, file
+    B added later — B must land flat in uploads/, and no series/ appears."""
+    fake = _fake_st(tmp_path)
+    monkeypatch.setattr(sb, "st", fake)
+    state = {}
+
+    first, late = split_upload_arrivals([_f("A.txt")], "d", state)
+    sb.save_upload(first[0], "data", auto_dispatch=False)
+
+    first, late = split_upload_arrivals([_f("A.txt"), _f("B.txt")], "d",
+                                        state)
+    for f in late:
+        sb.save_upload(f, "data", auto_dispatch=False)
+
+    uploads = tmp_path / "uploads"
+    assert (uploads / "A.txt").exists() and (uploads / "B.txt").exists()
+    assert not (uploads / "series").exists()
+
+
+def test_true_batch_still_becomes_series(tmp_path, monkeypatch):
+    fake = _fake_st(tmp_path)
+    monkeypatch.setattr(sb, "st", fake)
+    state = {}
+    first, late = split_upload_arrivals([_f("A.txt"), _f("B.txt")], "d",
+                                        state)
+    assert not late
+    out = sb.save_upload_batch(first, "data", auto_dispatch=False)
+    series = tmp_path / "uploads" / "series"
+    assert Path(out) == series
+    assert (series / "A.txt").exists() and (series / "B.txt").exists()


### PR DESCRIPTION
## Summary

Uploading a file, analyzing it, then adding a second file later silently turned both into a "series": Streamlit's uploader accumulates files across reruns, and the UI branched on the count alone, merging everything into `uploads/series/`. Per the re-scoping discussion on the issue, the fix moves the decision to where it belongs: the UI now only records the one signal it uniquely has — which files arrived together and which arrived later — and the orchestrator decides what actually belongs together, asking the user only when it's genuinely ambiguous. No new widgets or toggles; files added later are saved as independent uploads, and a genuinely dragged-together batch keeps today's series mechanics with the agent asked to *confirm* series-ness rather than having it asserted.

Closes #114.

---

**Technical details**

- `split_upload_arrivals` (sidebar.py): partitions the accumulating widget value into first-batch vs late additions — first non-empty rerun defines the batch; stable across reruns; resets when the uploader is cleared; state injectable for tests.
- Both upload surfaces rewired (pre-chat zone in `chat_uploads.py`, sidebar uploader): late additions go through `save_upload` individually (never `save_upload_batch`), so no `series/` merge and no re-pointing of `uploaded_data_path` at a directory.
- `build_analyze_prompt` (extracted, pure): late-arrival uploads are listed with their arrival groups and flagged "likely independent — decide what belongs together, ask if genuinely ambiguous, analyze independent files separately"; together-batches get "confirm they actually form one series" (composing with the metadata/sidecar variants). Single-file prompts are byte-identical to before.
- `save_upload` / `save_upload_batch` now return the saved path (previously returned None).

**Verification**

- Offline (`tests/test_upload_arrival_intent.py`, 8): partition semantics (stability, late detection, clear-reset), prompt shapes, and the #114 repro against the real save helpers — a late file lands flat with no `series/` created; a true batch still becomes `series/`. UI regression suites pass (56 total).
- Live (Bedrock opus-4-8), three scenarios asserted from the session's `events.jsonl` (#513): a late-arrival unrelated pair → "two independent datasets, analyzed separately", one successful per-file `run_analysis` each, no directory run; an unrelated pair sitting in `series/` under the batch prompt → "two files that do not form a series", analyzed per-file; and the control — a genuine 3-file temperature series under the same prompt → confirmed and run as ONE series analysis on the directory with proper `series_metadata` (no over-correction). In two runs the #411 metadata-ownership guard fired mid-scenario and the agent recovered with a clean retry — correct composition of both features.
- Known limitation: the literal Streamlit widget wiring is covered by simulated-rerun tests calling the real save helpers; a browser-driven test wasn't possible in this session (extension unavailable). The accumulate-across-reruns widget behavior is the documented Streamlit semantics the issue itself describes.