### PR TITLE
Recognise image and curve donors in harmonized fan-out replay

### DIFF
--- a/scilink/agents/meta_agent/fanout.py
+++ b/scilink/agents/meta_agent/fanout.py
@@ -288,6 +288,66 @@ Respond in valid JSON with EXACTLY these keys:
 """
 
 
+# Replayable-donor probe ------------------------------------------------------
+# Each foundation agent persists its approved analysis script differently;
+# the follower side (``prior_analysis_paths`` + ``reuse_locked_script``) is
+# agent-agnostic, so the donor probe must recognise every producer:
+#   hyperspectral — ``dynamic_analysis_records.json`` (per-record
+#                   ``task_success`` gate, script attached);
+#   image         — ``scripts/analysis_script.py`` (or per-image
+#                   ``scripts/<image>.py`` for a series) beside a successful
+#                   ``analysis_results.json``;
+#   curve         — ``scripts/fitting_script.py`` (or per-spectrum
+#                   ``scripts/<spectrum>.py``) beside a successful
+#                   ``analysis_results.json``.
+_SCRIPT_RECORD_NAME = "dynamic_analysis_records.json"
+_REPLAY_SCRIPT_NAMES = ("analysis_script.py", "fitting_script.py")
+
+
+def find_donor_reuse_dir(donor_dir) -> tuple:
+    """Locate the donor run directory a follower can replay verbatim.
+
+    Returns ``(reuse_dir, kind)`` — ``kind`` is ``"records"`` (hyperspectral
+    dynamic-analysis records), ``"script"`` (image/curve locked script) —
+    or ``(None, None)`` when the donor left nothing approved and replayable.
+    Newest candidate wins within each kind; the records kind is preferred
+    because it carries an explicit per-record ``task_success`` gate.
+    """
+    donor_dir = Path(donor_dir)
+    if not donor_dir.is_dir():
+        return None, None
+    cands = sorted(donor_dir.rglob(_SCRIPT_RECORD_NAME),
+                   key=lambda p: p.stat().st_mtime)
+    for c in reversed(cands):
+        try:
+            recs = json.loads(c.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001 - keep looking
+            continue
+        if any(isinstance(r, dict) and r.get("script") and r.get("task_success")
+               for r in recs):
+            return c.parent, "records"
+    results = sorted(donor_dir.rglob("analysis_results.json"),
+                     key=lambda p: p.stat().st_mtime)
+    for res in reversed(results):
+        if "_candidates" in res.parts:      # best-of-N losers, never approved
+            continue
+        if (res.parent / _SCRIPT_RECORD_NAME).exists():
+            continue    # hyperspectral run: its records (judged above) are authoritative
+        try:
+            status = json.loads(res.read_text(encoding="utf-8")).get("status")
+        except Exception:  # noqa: BLE001 - keep looking
+            continue
+        if status not in ("success", "partial"):
+            continue
+        scripts = res.parent / "scripts"
+        if not scripts.is_dir():
+            continue
+        if any((scripts / n).is_file() for n in _REPLAY_SCRIPT_NAMES) \
+                or any(scripts.glob("*.py")):
+            return res.parent, "script"
+    return None, None
+
+
 def _slug(text: str, maxlen: int = 32) -> str:
     """Filesystem-safe short slug from a label."""
     s = re.sub(r"[^a-zA-Z0-9]+", "_", (text or "").strip().lower()).strip("_")
@@ -1342,8 +1402,8 @@ def run_fanout(orch, branches: List[dict],
     # --- harmonized pipeline replay (donor-first) ---
     # The FIRST branch is the pipeline donor: it runs alone under the normal
     # analysis path; its approved dynamic-analysis script(s) are then
-    # replayed VERBATIM by every follower (via the hyperspectral agent's
-    # locked-reuse surface), so cross-branch magnitudes are measured by ONE
+    # replayed VERBATIM by every follower (via each agent's locked-reuse
+    # surface: prior_analysis_paths + reuse_locked_script), so cross-branch magnitudes are measured by ONE
     # frozen pipeline instead of N independently generated ones — the
     # methodological confound fusion otherwise has to discount. A donor that
     # yields no approved replayable script falls back loudly to today's
@@ -1374,20 +1434,9 @@ def run_fanout(orch, branches: List[dict],
         # an approved, replayable script sits on disk; the records are the
         # authority here (each is task_success-gated with the script
         # attached). Only a donor with NO approved record falls back.
-        reuse_dir = None
         _donor_dir = (orch.fanout_dir
                       / f"{entries[0]['index']:02d}_{_slug(donor_label)}")
-        _cands = sorted(_donor_dir.rglob("dynamic_analysis_records.json"),
-                        key=lambda p: p.stat().st_mtime)
-        for _c in reversed(_cands):
-            try:
-                _recs = json.loads(_c.read_text(encoding="utf-8"))
-            except Exception:  # noqa: BLE001 - keep looking
-                continue
-            if any(isinstance(r, dict) and r.get("script")
-                   and r.get("task_success") for r in _recs):
-                reuse_dir = _c.parent
-                break
+        reuse_dir, reuse_kind = find_donor_reuse_dir(_donor_dir)
         if reuse_dir is None:
             msg = (f"harmonize requested but donor '{donor_label}' produced "
                    "no approved replayable script — followers run "
@@ -1403,8 +1452,8 @@ def run_fanout(orch, branches: List[dict],
                       f"(status: {entries[0].get('status')}) but produced an "
                       "approved script — harmonizing on the approved record "
                       "(partial donor, #519).")
-            print(f"  🧬 Donor script approved — followers will replay "
-                  f"{reuse_dir.name} verbatim.")
+            print(f"  🧬 Donor script approved ({reuse_kind}) — followers "
+                  f"will replay {reuse_dir.name} verbatim.")
             harm_block = (
                 "\n\nHARMONIZED PIPELINE REPLAY (mandatory): a sibling "
                 f"dataset (donor '{donor_label}') was already analyzed and "
@@ -1421,7 +1470,7 @@ def run_fanout(orch, branches: List[dict],
                 entries[_i]["harmonized_donor_index"] = entries[0]["index"]
             harmonized_info = {
                 "donor": donor_label, "status": "harmonized",
-                "reuse_dir": str(reuse_dir),
+                "reuse_dir": str(reuse_dir), "reuse_kind": reuse_kind,
                 "followers": [b.get("label") for b in run_branches[1:]],
                 # Surfaced so fusion/readers can weigh a pipeline donated by
                 # a delegation that did not itself finish cleanly (#519).

--- a/tests/test_fanout_donor_probe.py
+++ b/tests/test_fanout_donor_probe.py
@@ -1,0 +1,83 @@
+"""Harmonized fan-out donor probe recognises every foundation agent's
+approved-script layout (hyperspectral records, image/curve locked scripts)."""
+import json
+from pathlib import Path
+
+import pytest
+
+from scilink.agents.meta_agent.fanout import find_donor_reuse_dir
+
+
+def _run_dir(root: Path, name: str, status="success", scripts=(), records=None,
+             candidates=False) -> Path:
+    d = root / "results" / name
+    if candidates:
+        d = d / "_candidates" / "cand_01"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "analysis_results.json").write_text(json.dumps({"status": status}))
+    if scripts:
+        (d / "scripts").mkdir(exist_ok=True)
+        for s in scripts:
+            (d / "scripts" / s).write_text("print('hi')\n")
+    if records is not None:
+        (d / "dynamic_analysis_records.json").write_text(json.dumps(records))
+    return d
+
+
+def test_missing_donor_dir(tmp_path):
+    assert find_donor_reuse_dir(tmp_path / "nope") == (None, None)
+
+
+def test_hyperspectral_records_still_found(tmp_path):
+    d = _run_dir(tmp_path, "hs_run", records=[{"script": "x=1", "task_success": True}])
+    assert find_donor_reuse_dir(tmp_path) == (d, "records")
+
+
+def test_hyperspectral_rejected_records_do_not_fall_back_to_script(tmp_path):
+    # A hyperspectral run whose every record was rejected must NOT be revived
+    # through its scripts/ folder: the records are the authority there.
+    _run_dir(tmp_path, "hs_run", scripts=("analysis_script.py",),
+             records=[{"script": "x=1", "task_success": False}])
+    assert find_donor_reuse_dir(tmp_path) == (None, None)
+
+
+def test_image_locked_script_found(tmp_path):
+    d = _run_dir(tmp_path, "img_run_ImageAnalysis_001", scripts=("analysis_script.py",))
+    assert find_donor_reuse_dir(tmp_path) == (d, "script")
+
+
+def test_curve_locked_script_found(tmp_path):
+    d = _run_dir(tmp_path, "curve_run_CurveFit_001", scripts=("fitting_script.py",))
+    assert find_donor_reuse_dir(tmp_path) == (d, "script")
+
+
+def test_series_per_item_scripts_found(tmp_path):
+    d = _run_dir(tmp_path, "series_run", scripts=("spectrum_a.py", "spectrum_b.py"))
+    assert find_donor_reuse_dir(tmp_path) == (d, "script")
+
+
+def test_failed_run_with_script_is_not_replayable(tmp_path):
+    _run_dir(tmp_path, "img_run", status="error", scripts=("analysis_script.py",))
+    assert find_donor_reuse_dir(tmp_path) == (None, None)
+
+
+def test_success_without_script_is_not_replayable(tmp_path):
+    _run_dir(tmp_path, "img_run")
+    assert find_donor_reuse_dir(tmp_path) == (None, None)
+
+
+def test_best_of_n_candidate_dirs_are_ignored(tmp_path):
+    _run_dir(tmp_path, "img_run", scripts=("analysis_script.py",), candidates=True)
+    assert find_donor_reuse_dir(tmp_path) == (None, None)
+
+
+def test_records_preferred_over_script_and_newest_script_wins(tmp_path):
+    import os, time
+    old = _run_dir(tmp_path, "img_old", scripts=("analysis_script.py",))
+    new = _run_dir(tmp_path, "img_new", scripts=("analysis_script.py",))
+    t = time.time()
+    os.utime(old / "analysis_results.json", (t - 100, t - 100))
+    os.utime(new / "analysis_results.json", (t, t))
+    assert find_donor_reuse_dir(tmp_path) == (new, "script")
+    hs = _run_dir(tmp_path, "hs_run", records=[{"script": "x", "task_success": True}])
+    assert find_donor_reuse_dir(tmp_path) == (hs, "records")


### PR DESCRIPTION
## Summary

When the meta agent runs a **harmonized fan-out** (analyze one dataset first, then re-run its approved script unchanged on the sibling datasets so the numbers are directly comparable), it only knew how to recognize the approved script of the **hyperspectral** agent. If the first dataset was an image or a 1D curve, the fan-out silently gave up on harmonizing: every sibling was analyzed from scratch with its own freshly written script, results were not method-comparable, and slow image analyses could run into the per-branch time limit and be dropped.

This PR teaches the fan-out to recognize the approved scripts of the **image and curve agents** too. Those agents already had the "replay this exact script" ability; the fan-out just never found the script to hand them.

Observed on a real three-map interferometry fan-out: before, the donor finished but both siblings fell back to independent analysis and were cancelled at the 60-minute budget. After, both siblings replayed the donor's script verbatim (reuse verdict "good"), the whole fan-out took 39 minutes, and all three carry the harmonized stamp the fusion step uses.

---

## Technical details

- `scilink/agents/meta_agent/fanout.py`: new `find_donor_reuse_dir(donor_dir) -> (reuse_dir, kind)` replaces the inline `dynamic_analysis_records.json` search.
  - `kind="records"`: hyperspectral records with `script` + `task_success` (unchanged logic, still tried first).
  - `kind="script"`: newest `analysis_results.json` with status `success`/`partial` whose sibling `scripts/` holds `analysis_script.py`, `fitting_script.py`, or per-item series scripts, which is exactly what `_first_prior_image_script` / the curve prior-script lookup resolve on the follower side via `prior_analysis_paths` + `reuse_locked_script`.
  - Guards: a run directory that has a records file is judged by its records only (rejected hyperspectral records are never revived through `scripts/`); `_candidates/` best-of-N folders are skipped.
  - `harmonized_info` gains `reuse_kind`; the log line names the matched kind.
- No changes to the image, curve, or hyperspectral agents.
- Tests: `tests/test_fanout_donor_probe.py` (10 offline cases: records-first, image/curve/series scripts, failed run, no script, candidates ignored, records-authoritative guard, newest wins). Existing suites run green: fan-out robustness, resume, cancellation, partial-donor harmonize, hyperspectral locked replay, image script-edit reuse.
- Pre-existing, unrelated failure on `main`: `tests/test_hs_dynamic_records.py::test_retry_ladder_reaches_hot_and_succeeds` (annealing-ladder expectation), reproduced on an untouched checkout.
