### PR TITLE
Accept common axis-range metadata synonyms in hyperspectral analysis

### DIFF
--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -795,6 +795,28 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                         records.append(rec)
         return records
 
+    def _handle_system_info(self, system_info):
+        """Base handling plus the Tier-1 deterministic alias normalizer.
+
+        Hyperspectral analysis hard-requires a resolvable signal axis, and
+        externally-authored metadata often spells the range as
+        ``spectral_axis: {min, max}`` rather than the canonical
+        ``energy_range: {start, end}``. Folding aliases here — the single
+        entry point for metadata on this agent — means the axis
+        precondition and every downstream reader see the canonical shape.
+        A no-op for already-conformant dicts.
+        """
+        si = super()._handle_system_info(system_info)
+        if si:
+            from .metadata_converter import normalize_metadata_dict
+            si, was_modified = normalize_metadata_dict(si)
+            if was_modified:
+                self.logger.info(
+                    "Metadata aliases folded to the canonical schema "
+                    "(Tier-1 deterministic normalizer)."
+                )
+        return si
+
     def _maybe_bank_scripts(self, records: list, skill_state: dict,
                             data_path: str, system_info) -> list:
         """Bank every approved working script in the script bank (#346).

--- a/scilink/agents/exp_agents/metadata_converter.py
+++ b/scilink/agents/exp_agents/metadata_converter.py
@@ -259,6 +259,13 @@ def _describes_spectral_imaging(metadata: dict) -> bool:
     blob = f"{metadata.get('experiment_type') or ''} {technique}".lower()
     if "hyperspectral" in blob or "datacube" in blob:
         return True
+    # A declared spectral_axis block IS a spectral-axis declaration — the
+    # metadata describes spectral data regardless of what the prose says
+    # (e.g. technique "Raman microscopy" for a mapping datacube). Without
+    # this, such a dict fast-paths through conformance and the axis-range
+    # synonym fold in normalize_metadata_dict never fires.
+    if isinstance(metadata.get("spectral_axis"), dict):
+        return True
     # "spectral/spectroscopy ... imaging/mapping/spectrum-image/cube/grid".
     # "grid" covers grid spectroscopy (STS/CITS-style spectra on an x-y
     # grid), which is a datacube even though nothing in its prose says so.
@@ -409,6 +416,26 @@ def normalize_metadata_dict(metadata: dict) -> tuple[dict, bool]:
         if val is not None:
             er["units"] = val
             er_modified = True
+    # Nested axis-range synonyms: externally-authored metadata often carries
+    # the signal-axis range as a nested dict — ``energy_range`` spelled with
+    # min/max, or a ``spectral_axis: {min, max, units}`` block (instrument
+    # sidecars). Fold the endpoints into canonical start/end. The source key
+    # is left in place (unrecognized keys are preserved, and it may carry
+    # extra context such as the axis name); canonical start/end always wins,
+    # so a dict that already resolves is untouched.
+    if er.get("start") is None or er.get("end") is None:
+        for source in (er, d.get("spectral_axis")):
+            if not isinstance(source, dict):
+                continue
+            lo = source.get("start", source.get("min"))
+            hi = source.get("end", source.get("max"))
+            if lo is None or hi is None:
+                continue
+            er["start"], er["end"] = lo, hi
+            if er.get("units") is None and source.get("units") is not None:
+                er["units"] = source["units"]
+            er_modified = True
+            break
     if er_modified:
         d["energy_range"] = er
         modified = True

--- a/tests/test_metadata_axis_synonyms.py
+++ b/tests/test_metadata_axis_synonyms.py
@@ -1,0 +1,158 @@
+"""Axis-range metadata synonyms fold deterministically into canonical form.
+
+Externally-authored hyperspectral metadata (instrument sidecars) often
+carries the signal-axis range as ``spectral_axis: {min, max, units}`` (or an
+``energy_range`` spelled with min/max) instead of the canonical
+``energy_range: {start, end, units}``. Such dicts used to die at the agent's
+fail-fast axis precondition ("Axis precondition failed") when passed straight
+to ``analyze(system_info=...)``, because the Tier-1 normalizer (a) had no
+nested-range aliases and (b) was never invoked on that path.
+
+These assertions are deterministic (no LLM):
+- the fold is strictly failure->success: canonical metadata passes through
+  byte-identical (the no-op proof), and canonical always wins when both
+  shapes are present;
+- the observed ``spectral_axis`` sidecar shape resolves end to end
+  (``create_axis`` builds the axis after normalization);
+- ``HyperspectralAnalysisAgent._handle_system_info`` applies the fold, so
+  every metadata consumer on that agent sees the canonical shape.
+
+  conda run -n scilink python -m pytest tests/test_metadata_axis_synonyms.py -q
+"""
+import copy
+import logging
+
+import numpy as np
+
+from scilink.agents.exp_agents.metadata_converter import (
+    check_schema_conformance,
+    normalize_metadata_dict,
+)
+from scilink.skills.hyperspectral.eels.eels import create_axis
+
+
+def _sidecar(**overrides):
+    """The literal externally-authored sidecar shape that failed live."""
+    meta = {
+        "experiment_type": "Spectroscopy",
+        "experiment": {"technique": "Raman microscopy",
+                       "details": "532.0 nm laser excitation"},
+        "sample": {"material": "carbon nanowalls on diamond"},
+        "spatial_info": {"field_of_view_x": 6.05, "field_of_view_y": 6.9,
+                         "units": "mm"},
+        "spectral_axis": {"axis_name": "Raman shift", "units": "cm^-1",
+                          "min": 175.02, "max": 3412.72},
+    }
+    meta.update(overrides)
+    return meta
+
+
+# --- the no-op proof: canonical metadata is untouched -----------------------
+
+def test_canonical_metadata_passes_through_identical():
+    meta = {
+        "experiment_type": "Spectroscopy",
+        "experiment": {"technique": "STEM-EELS spectrum image"},
+        "sample": {"material": "TiOx"},
+        "energy_range": {"start": 450.0, "end": 550.0, "units": "eV"},
+    }
+    snapshot = copy.deepcopy(meta)
+    normalized, was_modified = normalize_metadata_dict(meta)
+    assert was_modified is False
+    assert normalized is meta          # fast-path returns the same object
+    assert meta == snapshot            # and it was not mutated
+
+
+def test_canonical_wins_when_both_shapes_present():
+    meta = _sidecar(energy_range={"start": 100.0, "end": 3500.0,
+                                  "units": "cm^-1"})
+    normalized, _ = normalize_metadata_dict(meta)
+    # spectral_axis must NOT override an already-resolvable energy_range.
+    assert normalized["energy_range"]["start"] == 100.0
+    assert normalized["energy_range"]["end"] == 3500.0
+
+
+# --- the folds --------------------------------------------------------------
+
+def test_spectral_axis_min_max_folds_to_energy_range():
+    normalized, was_modified = normalize_metadata_dict(_sidecar())
+    assert was_modified is True
+    er = normalized["energy_range"]
+    assert er["start"] == 175.02 and er["end"] == 3412.72
+    assert er["units"] == "cm^-1"
+    # The source block is preserved (unrecognized keys are kept).
+    assert normalized["spectral_axis"]["axis_name"] == "Raman shift"
+
+
+def test_energy_range_min_max_spelling_folds():
+    meta = _sidecar()
+    meta.pop("spectral_axis")
+    # Prose must describe spectral imaging for conformance to route the dict
+    # into the normalizer at all (scope of the fold: hyperspectral metadata).
+    meta["experiment"] = {"technique": "Raman hyperspectral mapping"}
+    meta["energy_range"] = {"min": 175.02, "max": 3412.72, "units": "cm^-1"}
+    normalized, was_modified = normalize_metadata_dict(meta)
+    assert was_modified is True
+    assert normalized["energy_range"]["start"] == 175.02
+    assert normalized["energy_range"]["end"] == 3412.72
+
+
+def test_half_specified_range_does_not_half_fold():
+    meta = _sidecar()
+    meta["spectral_axis"] = {"units": "cm^-1", "min": 175.02}  # no max
+    normalized, _ = normalize_metadata_dict(meta)
+    er = normalized.get("energy_range") or {}
+    assert er.get("start") is None and er.get("end") is None
+
+
+# --- conformance routing ----------------------------------------------------
+
+def test_spectral_axis_block_marks_dict_spectral():
+    # Technique prose ("Raman microscopy") misses the spectral-imaging word
+    # list, but a declared spectral_axis IS a spectral-axis declaration: the
+    # dict must be flagged non-conformant so the normalizer runs (no
+    # fast-path around the fold), and be conformant once folded.
+    meta = _sidecar()
+    conformant, issues = check_schema_conformance(meta)
+    assert conformant is False
+    assert any("energy axis" in i for i in issues)
+    normalized, _ = normalize_metadata_dict(meta)
+    assert check_schema_conformance(normalized)[0] is True
+
+
+# --- end to end: the axis actually builds -----------------------------------
+
+def test_create_axis_succeeds_after_normalization():
+    normalized, _ = normalize_metadata_dict(_sidecar())
+    axis, xlabel, has_info = create_axis(617, normalized, axis_index=2)
+    assert has_info is True
+    assert axis.shape == (617,)
+    assert np.isclose(axis[0], 175.02) and np.isclose(axis[-1], 3412.72)
+
+
+# --- the agent seam ---------------------------------------------------------
+
+def test_hyperspectral_handle_system_info_applies_fold():
+    from scilink.agents.exp_agents.hyperspectral_analysis_agent import (
+        HyperspectralAnalysisAgent,
+    )
+    # Bare instance without __init__ (no credentials/LLM client needed):
+    # _handle_system_info touches only self.logger and super().
+    agent = HyperspectralAnalysisAgent.__new__(HyperspectralAnalysisAgent)
+    agent.logger = logging.getLogger("test_axis_synonyms")
+    handle = agent._handle_system_info
+    si = handle(_sidecar())
+    assert si["energy_range"]["start"] == 175.02
+    assert si["energy_range"]["end"] == 3412.72
+    # Canonical input still passes through unchanged.
+    canonical = {"experiment_type": "Spectroscopy",
+                 "experiment": {"technique": "EELS spectrum image"},
+                 "sample": {"material": "TiOx"},
+                 "energy_range": {"start": 1.0, "end": 2.0, "units": "eV"}}
+    assert handle(copy.deepcopy(canonical)) == canonical
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

Hyperspectral metadata written outside SciLink — for example an instrument sidecar that records the Raman-shift axis as `spectral_axis: {min, max, units}` — used to make the analysis fail immediately with *"Axis precondition failed: Energy axis information is required"*, even though the axis range was right there under a slightly different name. The scientist's metadata was fine; only the spelling differed from SciLink's canonical `energy_range: {start, end}`.

With this change, the hyperspectral agent recognizes these common spellings and translates them automatically before analysis starts. Metadata that already uses the canonical form behaves exactly as before — this only turns a class of hard failures into working runs. Nothing changes for LLM-based metadata extraction from prose; this is a deterministic translation of unambiguous shapes.

Observed live on collaborator micro-Raman mapping datacubes, where every sidecar uses the `spectral_axis` spelling and every direct `analyze(system_info=...)` call died at the precondition.

---

## Technical details

Three coordinated edits, all in the existing Tier-1 machinery:

1. **`normalize_metadata_dict`** (`metadata_converter.py`): after the flat-key aliases, fold nested axis-range synonyms — `spectral_axis` with `min`/`max` (or `start`/`end`), and `energy_range` spelled with `min`/`max` — into canonical `energy_range.start/end` (+ `units` if absent). Canonical always wins; the source key is preserved (unrecognized keys are kept, and it may carry context such as the axis name).
2. **`_describes_spectral_imaging`**: a declared `spectral_axis` dict now counts as describing spectral data. Without this, a dict whose prose misses the word list (e.g. technique `"Raman microscopy"` for a mapping datacube) fast-paths through `check_schema_conformance` and the fold never fires.
3. **`HyperspectralAnalysisAgent._handle_system_info`**: override applies the Tier-1 normalizer on top of base handling — one seam covering every metadata consumer on the agent (`analyze` pipeline, interpretation prep, precondition). No-op for canonical dicts; scoped to the hyperspectral agent, which is the one with the hard axis requirement.

**Backward compatibility is by construction**: the fold fires only where today's behavior is a hard failure. `tests/test_metadata_axis_synonyms.py` asserts the no-op (canonical dict returns the *same object*, unmutated), canonical-wins when both shapes are present, the literal failing sidecar shape resolving end-to-end through `create_axis`, no half-fold on a half-specified range, and the agent seam. Adjacent suites (`test_metadata_conformance_energy_axis`, `test_system_info_handling`, `test_signal_axis_vector`, offline hyperspectral suites) pass; the one failure in `test_hs_dynamic_records.py::test_retry_ladder_reaches_hot_and_succeeds` reproduces on clean `main` and is unrelated.