### PR TITLE
Refresh figures rewritten in place (chat figure + inset)

### DIFF
--- a/scilink/server/app.py
+++ b/scilink/server/app.py
@@ -300,7 +300,12 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
         if not target.is_file():
             raise HTTPException(404, f"No such file: {path}")
         media_type = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
-        return FileResponse(target, media_type=media_type)
+        # no-cache = revalidate, not "never store": a figure rewritten in place
+        # (a refined visualization.png at the same path) must not be served
+        # stale from the browser cache. FileResponse still emits ETag/
+        # Last-Modified, so an unchanged file is a cheap 304.
+        return FileResponse(target, media_type=media_type,
+                            headers={"Cache-Control": "no-cache"})
 
     # ── static frontend (production) ─────────────────────────────
 

--- a/scilink/server/artifacts.py
+++ b/scilink/server/artifacts.py
@@ -22,6 +22,17 @@ def _natural_sort_key(s: str):
     return [int(c) if c.isdigit() else c.lower() for c in re.split(r"(\d+)", s)]
 
 
+def _img_key(p: Path) -> str:
+    """Identity for an image artifact: path + mtime, so a figure rewritten
+    in place (a refined ``visualization.png`` at the same path) is seen as
+    new and re-surfaced — matching the report/doc sweeps, which have always
+    keyed on ``path + mtime_ns``. Falls back to bare path when unstattable."""
+    try:
+        return f"{p}:{p.stat().st_mtime_ns}"
+    except OSError:
+        return str(p)
+
+
 def load_deliverable_titles(session_dir: str) -> Dict[str, str]:
     """{resolved md/html path -> title} from the deliverables manifests."""
     try:
@@ -46,7 +57,7 @@ class ArtifactTracker:
         root = Path(self.session_dir)
         for ext in IMAGE_EXTENSIONS:
             for p in root.rglob(f"*{ext}"):
-                self.known.add(str(p))
+                self.known.add(_img_key(p))
         for ext in (".html", ".md"):
             for p in root.rglob(f"*{ext}"):
                 try:
@@ -55,7 +66,7 @@ class ArtifactTracker:
                     self.known.add(str(p))
 
     def mark_known(self, path: str) -> None:
-        self.known.add(path)
+        self.known.add(_img_key(Path(path)))
 
     # -- per-turn sweeps ----------------------------------------------
     def find_new_images(self, autonomy: Optional[str] = None) -> List[str]:
@@ -75,22 +86,24 @@ class ArtifactTracker:
                 if _UPLOAD_DIRS & {part for part in p.relative_to(root).parts[:-1]}:
                     continue
                 s = str(p)
-                if s not in self.known:
+                key = _img_key(p)
+                if key not in self.known:
                     if p.stem.startswith("debug_"):
-                        debug_plots.append(s)
+                        debug_plots.append((key, s))
                     else:
-                        self.known.add(s)
+                        self.known.add(key)
                         new.append(s)
         if debug_plots:
-            for s in debug_plots:
-                self.known.add(s)
+            for key, s in debug_plots:
+                self.known.add(key)
             if autonomy == "co-pilot":
-                debug_plots.sort(key=_natural_sort_key)
-                selected = [debug_plots[0]]
-                if len(debug_plots) > 2:
-                    selected.append(debug_plots[len(debug_plots) // 2])
-                if len(debug_plots) > 1:
-                    selected.append(debug_plots[-1])
+                paths = [s for _key, s in debug_plots]
+                paths.sort(key=_natural_sort_key)
+                selected = [paths[0]]
+                if len(paths) > 2:
+                    selected.append(paths[len(paths) // 2])
+                if len(paths) > 1:
+                    selected.append(paths[-1])
                 new[0:0] = selected
         return new
 

--- a/scilink/server/runner.py
+++ b/scilink/server/runner.py
@@ -63,9 +63,11 @@ def _image_branch(rel_path: str) -> Optional[str]:
 
 
 def _scan_new_images(session_dir: str, seen: dict) -> list:
-    """Return [(rel_path, label, branch)] for image artifacts new (or freshly
-    rewritten) since the last scan, newest first, capped. Updates ``seen``
-    (abs path -> mtime) in place."""
+    """Return [(rel_path, label, branch, mtime_ns)] for image artifacts new
+    (or freshly rewritten) since the last scan, newest first, capped. Updates
+    ``seen`` (abs path -> mtime_ns) in place. ``mtime_ns`` rides through to the
+    client as a URL version token, so a figure rewritten in place produces a
+    distinct <img> URL and re-fetches instead of showing cached stale bytes."""
     found = []
     skip_dirs = {"__pycache__", ".git", "node_modules"}
     for root, dirs, files in os.walk(session_dir):
@@ -83,7 +85,7 @@ def _scan_new_images(session_dir: str, seen: dict) -> list:
             if any(s in low for s in _IMAGE_SKIP):
                 continue
             try:
-                m = os.stat(ap).st_mtime
+                m = os.stat(ap).st_mtime_ns
             except OSError:
                 continue
             if ap in seen and m <= seen[ap]:
@@ -91,8 +93,8 @@ def _scan_new_images(session_dir: str, seen: dict) -> list:
             seen[ap] = m
             found.append((m, rel))
     found.sort(reverse=True)  # newest first
-    return [(rel, _image_label(rel), _image_branch(rel))
-            for _m, rel in found[:_IMAGE_EMIT_CAP]]
+    return [(rel, _image_label(rel), _image_branch(rel), m)
+            for m, rel in found[:_IMAGE_EMIT_CAP]]
 
 
 @dataclass
@@ -206,10 +208,10 @@ def _watch_log(session, turn, cap) -> None:
                     session.events.emit("files_changed", {})
                     # Push newly-written figures to the live inset (oldest of
                     # this batch first, so the newest ends up "latest").
-                    for rel, label, branch in reversed(
+                    for rel, label, branch, v in reversed(
                             _scan_new_images(session.session_dir, seen_images)):
                         img = {"path": rel, "label": label,
-                               "branch": branch}
+                               "branch": branch, "v": v}
                         turn.live_images.append(img)
                         session.events.emit("analysis_image", img)
                 last_sig = sig
@@ -227,9 +229,9 @@ def _watch_log(session, turn, cap) -> None:
     # (and the first-window case where nothing else changed the signature) —
     # otherwise the LAST figure of a turn is exactly the one the inset misses.
     try:
-        for rel, label, branch in reversed(
+        for rel, label, branch, v in reversed(
                 _scan_new_images(session.session_dir, seen_images)):
-            img = {"path": rel, "label": label, "branch": branch}
+            img = {"path": rel, "label": label, "branch": branch, "v": v}
             turn.live_images.append(img)
             session.events.emit("analysis_image", img)
     except Exception:

--- a/tests/test_artifact_image_rewrite.py
+++ b/tests/test_artifact_image_rewrite.py
@@ -1,0 +1,68 @@
+"""ArtifactTracker re-surfaces a figure rewritten in place.
+
+A curve-fit / hyperspectral refinement loop overwrites its
+``visualization.png`` at the same path across turns. The image sweep used to
+key its known-set on the bare path, so the rewritten figure was judged
+"already seen" and never re-emitted — the web UI kept showing the first
+render. Image identity is now ``path + mtime_ns`` (matching the report/doc
+sweeps), so a rewrite re-surfaces while a byte-for-byte unchanged file does
+not. Deterministic, offline.
+"""
+import os
+
+from scilink.server.artifacts import ArtifactTracker
+
+
+def _write(p, text):
+    p.write_text(text)
+    return p
+
+
+def _bump_mtime(p, delta_ns=5_000_000_000):
+    """Force a strictly newer mtime (avoids coarse-filesystem-resolution
+    flakiness where two quick writes share a timestamp)."""
+    st = p.stat()
+    os.utime(p, ns=(st.st_atime_ns + delta_ns, st.st_mtime_ns + delta_ns))
+
+
+def test_rewritten_image_is_resurfaced(tmp_path):
+    png = _write(tmp_path / "visualization.png", "v1")
+    t = ArtifactTracker(str(tmp_path))
+
+    first = t.find_new_images()
+    assert str(png) in first
+
+    # Same path, unchanged content/mtime -> not re-surfaced.
+    assert t.find_new_images() == []
+
+    # Overwrite in place with a newer mtime -> surfaced again.
+    png.write_text("v2")
+    _bump_mtime(png)
+    again = t.find_new_images()
+    assert str(png) in again, "a rewritten figure must re-surface"
+
+
+def test_resume_marks_current_version_but_not_a_later_rewrite(tmp_path):
+    png = _write(tmp_path / "visualization.png", "v1")
+    t = ArtifactTracker(str(tmp_path))
+    t.mark_all_existing()  # resume: everything on disk is already surfaced
+
+    assert t.find_new_images() == []  # the current version stays suppressed
+
+    png.write_text("v2")
+    _bump_mtime(png)
+    assert str(png) in t.find_new_images()  # but a later rewrite comes through
+
+
+def test_unchanged_file_across_sweeps_never_repeats(tmp_path):
+    _write(tmp_path / "a.png", "x")
+    t = ArtifactTracker(str(tmp_path))
+    assert len(t.find_new_images()) == 1
+    for _ in range(3):
+        assert t.find_new_images() == []
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -7,6 +7,7 @@ are exercised by the live smoke flow, not here.
 """
 
 import json
+import os
 import threading
 import time
 from pathlib import Path
@@ -445,9 +446,22 @@ def test_scan_new_images(tmp_path):
     (root / "previews").mkdir()
     (root / "previews" / "p.png").write_bytes(b"x")    # skip dir, top-level
     out = _scan_new_images(str(root), seen)
-    assert [rel for rel, _label, _branch in out] == ["fit_overlay.png"]
+    assert [rel for rel, _label, _branch, _v in out] == ["fit_overlay.png"]
+    # the version token is the file mtime (nanoseconds), carried to the client
+    assert out[0][3] == (root / "fit_overlay.png").stat().st_mtime_ns
     # already-seen files are not re-emitted
     assert _scan_new_images(str(root), seen) == []
+
+    # An in-place rewrite with a newer mtime IS re-emitted (the inset-refresh
+    # contract): same path, new version token.
+    fit = root / "fit_overlay.png"
+    st = fit.stat()
+    fit.write_bytes(b"y")
+    os.utime(fit, ns=(st.st_atime_ns + 5_000_000_000,
+                      st.st_mtime_ns + 5_000_000_000))
+    rewritten = _scan_new_images(str(root), seen)
+    assert [rel for rel, _l, _b, _v in rewritten] == ["fit_overlay.png"]
+    assert rewritten[0][3] == fit.stat().st_mtime_ns
 
 
 def test_feedback_flow_and_409(client, tmp_path):

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -31,6 +31,7 @@ export interface LiveImage {
   path: string;
   label: string;
   branch: string | null;
+  v?: number; // file mtime — cache-busting version so a rewrite re-fetches
 }
 
 const LIVE_IMAGE_CAP = 30; // keep a bounded filmstrip of recent figures
@@ -109,12 +110,14 @@ function reducer(state: SessionState, action: Action): SessionState {
         case "files_changed":
           return { ...state, filesVersion: state.filesVersion + 1 };
         case "analysis_image": {
-          // De-dup a repeat of the current latest (reconnect replay / rewrite).
+          // De-dup an identical replay (same path AND version) from a
+          // reconnect — but let a genuine in-place rewrite (same path, newer
+          // version) through, so a refined figure updates the inset.
           const prev = state.liveImages[state.liveImages.length - 1];
-          if (prev && prev.path === ev.path) return state;
+          if (prev && prev.path === ev.path && prev.v === ev.v) return state;
           const next = [
             ...state.liveImages,
-            { path: ev.path, label: ev.label, branch: ev.branch },
+            { path: ev.path, label: ev.label, branch: ev.branch, v: ev.v },
           ];
           return {
             ...state,

--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -85,7 +85,12 @@ export interface SessionSnapshot {
   chat_messages: ChatMessage[];
   pending_question: PresentedQuestion | null;
   live_log: string;
-  live_images: { path: string; label: string; branch: string | null }[];
+  live_images: {
+    path: string;
+    label: string;
+    branch: string | null;
+    v?: number;
+  }[];
   event_cursor: number;
 }
 
@@ -230,8 +235,12 @@ export const api = {
     }>;
   },
 
-  fileUrl: (id: string, relPath: string) =>
-    `${BASE}/sessions/${id}/files?path=${encodeURIComponent(relPath)}`,
+  // `v` (a file mtime) is a cache-busting version token: a figure rewritten
+  // in place gets a distinct URL, so the browser re-fetches instead of
+  // serving stale bytes for an unchanged path. The backend ignores it.
+  fileUrl: (id: string, relPath: string, v?: number) =>
+    `${BASE}/sessions/${id}/files?path=${encodeURIComponent(relPath)}` +
+    (v ? `&v=${v}` : ""),
 
   tree: (id: string) =>
     req<{ entries: TreeEntry[]; truncated: boolean }>(`/sessions/${id}/tree`),

--- a/webui/src/components/AnalysisInset.tsx
+++ b/webui/src/components/AnalysisInset.tsx
@@ -107,7 +107,11 @@ export function AnalysisInset({
             onClick={() => openInFiles(img.path)}
             title="Open in Files"
           >
-            <img src={api.fileUrl(sessionId, img.path)} alt={img.label} />
+            <img
+              key={`${img.path}:${img.v ?? ""}`}
+              src={api.fileUrl(sessionId, img.path, img.v)}
+              alt={img.label}
+            />
           </div>
           <div className="inset-foot">
             <button

--- a/webui/src/useSessionEvents.ts
+++ b/webui/src/useSessionEvents.ts
@@ -18,6 +18,7 @@ export type SessionEvent =
       path: string;
       label: string;
       branch: string | null;
+      v?: number;
     }
   | { type: "error"; message: string };
 
@@ -61,6 +62,7 @@ export function useSessionEvents(
         path: d.path,
         label: d.label ?? "",
         branch: d.branch ?? null,
+        v: d.v,
       });
     });
     src.addEventListener("error", (e) => {


### PR DESCRIPTION
## Summary

Reported live: in a running session, a figure the agent rewrites in place — e.g. a refined `visualization.png` at the same path across turns — kept showing the **first** render. Neither the figure attached to the chat nor the floating analysis inset updated. This was two independent bugs stacked on the same path; both are fixed.

**Why it happened**

1. **The completion sweep de-duplicated images by path alone.** `ArtifactTracker` keyed its "already surfaced" set on the bare file path, while the HTML-report and Markdown sweeps have always keyed on `path + mtime`. So a rewritten `visualization.png` at a known path was judged already-seen and never re-attached to a later assistant message.

2. **The image URL had no version token.** Even though the live inset watcher *is* mtime-aware and re-emits on rewrite, the `<img src>` (`…/files?path=visualization.png`) was byte-identical across rewrites, so the browser served cached bytes — and the frontend reducer additionally dropped the re-emit as a same-path duplicate.

Both had to be fixed for the figure and the inset to update.

## What changed

**Backend**
- `artifacts.py`: image identity is now `path + mtime_ns` (new `_img_key`), applied in `find_new_images`, `mark_all_existing`, `mark_known` — a rewritten figure re-surfaces at turn completion; an unchanged one still doesn't.
- `runner.py`: `_scan_new_images` now carries the file `mtime_ns` and threads it into each `analysis_image` event as a version token `v`.
- `app.py`: `get_file` sends `Cache-Control: no-cache` (revalidate — `FileResponse`'s ETag keeps an unchanged file a cheap 304). `get_thumb` already did.

**Frontend**
- `api.fileUrl(id, path, v?)` appends `&v=<mtime>` (backend ignores it); `AnalysisInset` uses it and a version-keyed `<img>`.
- `useSessionEvents` / `App.tsx`: the `analysis_image` event carries `v`; the inset reducer de-dups on `path + v`, so an in-place rewrite (same path, newer version) refreshes while an identical reconnect replay is still suppressed.

## Tests
- New `tests/test_artifact_image_rewrite.py`: a rewrite re-surfaces; resume (`mark_all_existing`) marks only the current version and lets a later rewrite through; an unchanged file never repeats.
- `tests/test_web_server.py`: updated for the `_scan_new_images` 4-tuple/version token, plus a rewrite-re-emits assertion.
- Full `test_web_server.py` + new test green (31 passed); `webui` `tsc -b && vite build` clean.

Branches off `feature-react-webui` (the web server lives only there, not on `main`).