### PR TITLE
Resume card surfaces the headline deliverable, not the newest file (#533)

### DIFF
--- a/scilink/agents/planning_agents/user_interface.py
+++ b/scilink/agents/planning_agents/user_interface.py
@@ -62,6 +62,54 @@ def load_deliverables(base_dir: Any) -> List[Dict[str, Any]]:
     return out
 
 
+# Resume-card ranking of marked deliverables. "Most recently modified" is
+# not "the deliverable": a late delegation that refines the ideation report
+# bumps its mtime above the white paper the session actually exists to
+# produce (issue #533). Rank by kind first, mtime only as the tiebreak.
+_HEADLINE_STEMS = ("white_paper",)
+_HEADLINE_TITLES = ("white paper",)
+_SECONDARY_STEMS = ("ideation_report", "portfolio")
+_SECONDARY_TITLES = ("ideation report", "portfolio", "candidate directions")
+_EMBEDDABLE_SUFFIXES = (".md", ".html", ".htm")
+
+
+def deliverable_rank(entry: Dict[str, Any]) -> int:
+    """0 = headline document (white paper), 1 = any other document (technical
+    document, memo, roadmap, plan report, user-named files), 2 = secondary /
+    working artifacts that get refined late (ideation report, portfolio).
+    Classified from the filename stem and the recorded title, since the
+    manifest carries no kind field."""
+    stem = Path(str(entry.get("path", ""))).stem.lower()
+    title = str(entry.get("title", "")).lower()
+    if stem.startswith(_HEADLINE_STEMS) or any(t in title for t in _HEADLINE_TITLES):
+        return 0
+    if stem.startswith(_SECONDARY_STEMS) or any(t in title for t in _SECONDARY_TITLES):
+        return 2
+    return 1
+
+
+def select_headline_deliverable(entries: List[Dict[str, Any]]) -> Optional[Path]:
+    """The one marked deliverable a resumed chat should re-embed: the
+    best-ranked kind (see ``deliverable_rank``), newest by mtime within that
+    rank. Only existing markdown / HTML files qualify (PDF and DOCX twins are
+    recorded but not embeddable). ``None`` when nothing qualifies."""
+    best: Optional[tuple] = None
+    for entry in entries:
+        if not entry.get("deliverable"):
+            continue
+        p = Path(str(entry.get("path", "")))
+        if not p.exists() or p.suffix.lower() not in _EMBEDDABLE_SUFFIXES:
+            continue
+        try:
+            mtime = p.stat().st_mtime
+        except OSError:
+            continue
+        key = (deliverable_rank(entry), -mtime)
+        if best is None or key < best[0]:
+            best = (key, p)
+    return best[1] if best else None
+
+
 def display_files_produced(paths: List[str], base_dir: Any = None) -> None:
     """Print the turn's output files as absolute, pasteable paths.
 

--- a/scilink/server/session_manager.py
+++ b/scilink/server/session_manager.py
@@ -168,18 +168,15 @@ def convert_chat_history_for_display(history: list) -> list:
 
 
 def collect_restored_deliverables(session_path: Path) -> tuple:
-    """(md_paths, html_paths) — only the most recent marked deliverable."""
-    from scilink.agents.planning_agents.user_interface import load_deliverables
-    candidates = []
-    for entry in load_deliverables(session_path):
-        if not entry.get("deliverable"):
-            continue
-        p = Path(entry.get("path", ""))
-        if p.exists() and p.suffix.lower() in (".md", ".html", ".htm"):
-            candidates.append(p)
-    if not candidates:
+    """(md_paths, html_paths) — the session's headline marked deliverable:
+    ranked by kind (white paper > other documents > ideation report /
+    portfolio), newest by mtime within a rank. Shared with the Streamlit
+    sidebar through ``select_headline_deliverable``."""
+    from scilink.agents.planning_agents.user_interface import (
+        load_deliverables, select_headline_deliverable)
+    latest = select_headline_deliverable(load_deliverables(session_path))
+    if latest is None:
         return [], []
-    latest = max(candidates, key=lambda p: p.stat().st_mtime)
     if latest.suffix.lower() == ".md":
         return [str(latest)], []
     return [], [str(latest)]

--- a/scilink/ui/components/sidebar.py
+++ b/scilink/ui/components/sidebar.py
@@ -1061,24 +1061,19 @@ def _collect_restored_deliverables(session_path: Path) -> tuple:
     are the durable record of what the session produced, so a resumed
     chat re-embeds from them.
     """
-    from scilink.agents.planning_agents.user_interface import load_deliverables
+    from scilink.agents.planning_agents.user_interface import (
+        load_deliverables, select_headline_deliverable)
 
-    # Only the most recent deliverable is re-embedded: a session may hold
-    # several revisions under the same title (a revision inherits the
-    # document's name), and embedding all of them repeats near-identical
-    # documents. Manifest entries carry no timestamp, so recency = file
-    # mtime, which also orders correctly across per-child manifests.
+    # Only one deliverable is re-embedded: a session may hold several
+    # revisions under the same title (a revision inherits the document's
+    # name), and embedding all of them repeats near-identical documents.
+    # Which one: ranked by kind (white paper > other documents > ideation
+    # report / portfolio), newest by mtime within a rank — pure recency
+    # surfaced a late-refined ideation report over the white paper (#533).
     # Older versions stay reachable in the Files tab.
-    candidates = []
-    for entry in load_deliverables(session_path):
-        if not entry.get("deliverable"):
-            continue
-        p = Path(entry.get("path", ""))
-        if p.exists() and p.suffix.lower() in (".md", ".html", ".htm"):
-            candidates.append(p)
-    if not candidates:
+    latest = select_headline_deliverable(load_deliverables(session_path))
+    if latest is None:
         return [], []
-    latest = max(candidates, key=lambda p: p.stat().st_mtime)
     if latest.suffix.lower() == ".md":
         return [str(latest)], []
     return [], [str(latest)]

--- a/tests/test_deliverable_card_priority.py
+++ b/tests/test_deliverable_card_priority.py
@@ -1,0 +1,89 @@
+"""Resume 'Latest deliverable' card picks the headline document (#533).
+
+Selection used to be max(mtime) over marked deliverables, so a late
+delegation that refined the ideation report surfaced it over the white
+paper the session exists to produce. Now: rank by kind (white paper > other
+documents > ideation report / portfolio), mtime only as the tiebreak.
+"""
+
+import json
+import os
+from pathlib import Path
+
+from scilink.agents.planning_agents.user_interface import (
+    DELIVERABLES_MANIFEST, deliverable_rank, load_deliverables,
+    select_headline_deliverable)
+from scilink.server.session_manager import collect_restored_deliverables
+
+
+def _write(base: Path, rel: str, title: str, mtime: float,
+           deliverable: bool = True, manifest_dir: str = "") -> Path:
+    p = base / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(f"# {title}\n")
+    os.utime(p, (mtime, mtime))
+    m = base / manifest_dir / DELIVERABLES_MANIFEST
+    m.parent.mkdir(parents=True, exist_ok=True)
+    entries = json.loads(m.read_text()) if m.exists() else []
+    entries.append({"path": str(p.resolve()), "title": title,
+                    "deliverable": deliverable})
+    m.write_text(json.dumps(entries))
+    return p.resolve()
+
+
+T = 1_700_000_000.0
+
+
+def test_white_paper_beats_a_later_refined_ideation_report(tmp_path):
+    wp = _write(tmp_path, "planning/out/white_paper.md", "White paper", T)
+    _write(tmp_path, "planning/out/ideation_report.md",
+           "Ideation report — all candidate directions", T + 900)
+    assert select_headline_deliverable(load_deliverables(tmp_path)) == wp
+    assert collect_restored_deliverables(tmp_path) == ([str(wp)], [])
+
+
+def test_only_secondary_artifacts_still_surface(tmp_path):
+    ir = _write(tmp_path, "ideation_report.md", "Ideation report", T)
+    assert select_headline_deliverable(load_deliverables(tmp_path)) == ir
+
+
+def test_newest_wins_within_a_rank(tmp_path):
+    _write(tmp_path, "a/white_paper.md", "White paper", T)
+    newer = _write(tmp_path, "b/white_paper.md", "White paper", T + 60)
+    assert select_headline_deliverable(load_deliverables(tmp_path)) == newer
+
+
+def test_other_documents_outrank_working_artifacts(tmp_path):
+    memo = _write(tmp_path, "cost_memo.md", "Cost estimate memo", T)
+    _write(tmp_path, "portfolio.md", "Ideation portfolio", T + 60)
+    assert select_headline_deliverable(load_deliverables(tmp_path)) == memo
+    # ...but a white paper outranks the memo regardless of age
+    wp = _write(tmp_path, "white_paper.md", "White paper", T - 3600)
+    assert select_headline_deliverable(load_deliverables(tmp_path)) == wp
+
+
+def test_unmarked_missing_and_non_embeddable_are_skipped(tmp_path):
+    _write(tmp_path, "white_paper.md", "White paper", T, deliverable=False)
+    gone = _write(tmp_path, "gone/white_paper.md", "White paper", T)
+    gone.unlink()
+    _write(tmp_path, "white_paper.pdf", "White paper PDF", T + 10)
+    html = _write(tmp_path, "plan_report.html", "Experimental plan (report)", T)
+    assert select_headline_deliverable(load_deliverables(tmp_path)) == html
+    assert collect_restored_deliverables(tmp_path) == ([], [str(html)])
+    assert collect_restored_deliverables(tmp_path / "empty") == ([], [])
+
+
+def test_rank_uses_title_when_the_filename_is_user_chosen(tmp_path):
+    assert deliverable_rank({"path": "x/top3_brief.md", "title": "White Paper v2"}) == 0
+    assert deliverable_rank({"path": "x/directions.md",
+                             "title": "Ideation report — all candidate directions"}) == 2
+    assert deliverable_rank({"path": "x/roadmap.md", "title": "Roadmap"}) == 1
+    assert deliverable_rank({"path": "x/Portfolio_final.md", "title": ""}) == 2
+
+
+def test_manifests_across_child_orchestrators_are_pooled(tmp_path):
+    wp = _write(tmp_path, "planning/white_paper.md", "White paper", T,
+                manifest_dir="planning")
+    _write(tmp_path, "planning/delegations/02/ideation_report.md",
+           "Ideation report", T + 900, manifest_dir="planning/delegations/02")
+    assert select_headline_deliverable(load_deliverables(tmp_path)) == wp


### PR DESCRIPTION
## Summary

Fixes #533. When you resume a session, the "Latest deliverable" card now shows the session's headline document, not simply whichever file was written last.

Before, a session that produced a white paper and then refined its ideation report or portfolio came back showing the refined ideation report, because that file had the newer timestamp. Now the card prefers the white paper, then any other document (technical document, memo, roadmap, plan report, a file you named yourself), and only then the ideation report or portfolio. Within the same kind, the newest still wins, so a revised white paper replaces the earlier one. Older versions remain in the Files tab as before.

Applies to both the web UI and the Streamlit app.

## Technical description

### Root cause

`collect_restored_deliverables` (web server, feeds the React card) and `_collect_restored_deliverables` (Streamlit sidebar) both selected `max(mtime)` over manifest entries marked `deliverable: true`. A late delegation that rewrites `ideation_report.md` without touching `white_paper.md` wins on mtime.

### Change

- `scilink/agents/planning_agents/user_interface.py` (streamlit-free, already the shared home of `record_deliverable` / `load_deliverables`): new `deliverable_rank(entry)` and `select_headline_deliverable(entries)`.
  - Rank 0: stem starts with `white_paper`, or title contains "white paper".
  - Rank 2: stem starts with `ideation_report` / `portfolio`, or title contains "ideation report", "portfolio", "candidate directions".
  - Rank 1: everything else.
  - Classification uses both the filename stem and the recorded title because the manifest carries no kind field and user-chosen filenames are common (`top3_brief.md` titled "White Paper v2" ranks 0).
  - Selection key is `(rank, -mtime)`; only existing `.md` / `.html` / `.htm` files qualify (PDF and DOCX twins are recorded but not embeddable); unmarked entries and missing files are skipped; stat failures are skipped rather than raised.
- `scilink/server/session_manager.py`: `collect_restored_deliverables` delegates to the ranker; return shape `(md_paths, html_paths)` unchanged, so `SessionManager.resume` and the React card are untouched.
- `scilink/ui/components/sidebar.py`: `_collect_restored_deliverables` delegates to the same ranker; comment updated to record the reason.

Because both selectors call one function, the two UIs cannot drift apart again.

### Tests

`tests/test_deliverable_card_priority.py` (new, 7 tests): white paper beats a later-refined ideation report; a session with only secondary artifacts still surfaces one; newest wins within a rank; other documents outrank working artifacts and a white paper outranks those regardless of age; unmarked, missing, and PDF entries are skipped while an HTML deliverable lands in the HTML slot; title-based ranking for user-chosen filenames; manifests pooled across child orchestrators (`<meta>/planning/...`). Related suites (`test_web_server`, `test_workspace_listing`, `test_ideation_campaign_artifacts`, `test_technical_document_tool`, `test_campaign_scoping`, `test_rename_copy_delegation_integrity`, `test_md_to_pdf`): 144 pass. The Streamlit file is compile-checked; it cannot be imported in the test env (no `streamlit`).

### Not changed

The Files-tab markdown listing order (`scilink/server/artifacts.py`, `find_new_md_documents`) walks the filesystem rather than sorting by recency, as the issue notes. That is a separate surface and is left for a follow-up.
