### PR TITLE
Resolve plan parameter names onto input columns for BO bounds (#67)

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -174,6 +174,76 @@ def resolve_n_candidates(requested, planner_state, new_campaign: bool = False) -
 
 
 
+# Unit / statistic tokens that carry no identity when matching a plan
+# parameter name to a data column ('Temperature' <-> 'temperature_C',
+# 'Time (min)' <-> 'time_min'). Kept to unambiguous unit words; a plan
+# parameter that is ONLY a unit token ('C') reduces to nothing and never
+# matches by tokens (an exact column name still does).
+_PLAN_UNIT_TOKENS = frozenset({
+    "c", "k", "f", "s", "sec", "min", "mins", "h", "hr", "hrs", "ms",
+    "nm", "um", "mm", "cm", "m", "ev", "mev", "kev", "deg", "degc", "degrees",
+    "pct", "percent", "mol", "mmol", "molar", "ul", "ml", "l", "mg", "g", "kg",
+    "w", "mw", "kw", "v", "mv", "kv", "a", "ma", "torr", "bar", "mbar", "pa",
+    "kpa", "psi", "rpm", "wt", "vol", "ratio_pct",
+})
+
+
+def _plan_param_tokens(name) -> set:
+    toks = {t for t in re.split(r"[^a-z0-9]+", str(name).lower()) if t}
+    return toks - _PLAN_UNIT_TOKENS
+
+
+def _resolve_plan_params(plan_names, columns):
+    """Map the plan's ``optimization_params`` names onto the campaign's input
+    columns (issue #67). The plan names knobs in its own words
+    ('Temperature', 'Reaction time (min)'); the data names them as columns
+    ('temperature_C', 'time_min'), and an exact lookup silently fell to
+    data-derived bounds.
+
+    Four rungs, each applied only to names and columns not yet claimed:
+    exact name; exact case-insensitive name; equal token sets with unit
+    words dropped; token subset in either direction. A rung accepts a pair
+    only when it is unambiguous BOTH ways (the name has one candidate column
+    and that column is wanted by one name) — an ambiguous name stays
+    unmatched rather than guessing. Returns ``({plan_name: column},
+    [unmatched plan names], {unmatched name: [candidate columns]})`` — the
+    candidates are the columns an unmatched name could have meant (empty
+    when it resembles none), so the caller can say which ones to choose
+    between instead of just "no match"."""
+    columns = [str(c) for c in columns]
+    resolved: dict = {}
+    pending = [str(n) for n in plan_names]
+    claimed: set = set()
+    col_toks = {c: _plan_param_tokens(c) for c in columns}
+    candidates: dict = {}
+
+    def _rung(candidates_of):
+        nonlocal pending
+        cands = {n: [c for c in candidates_of(n) if c not in claimed]
+                 for n in pending}
+        wanted: dict = {}
+        for n, cs in cands.items():
+            for c in cs:
+                wanted.setdefault(c, []).append(n)
+        for n, cs in cands.items():
+            if len(cs) == 1 and len(wanted[cs[0]]) == 1:
+                resolved[n] = cs[0]
+                claimed.add(cs[0])
+            elif cs:
+                candidates[n] = cs
+        pending = [n for n in pending if n not in resolved]
+
+    _rung(lambda n: [c for c in columns if c == n])
+    _rung(lambda n: [c for c in columns if c.lower() == n.lower()])
+    _rung(lambda n: [c for c in columns
+                     if _plan_param_tokens(n) and col_toks[c] == _plan_param_tokens(n)])
+    _rung(lambda n: [c for c in columns
+                     if _plan_param_tokens(n) and col_toks[c]
+                     and (_plan_param_tokens(n) <= col_toks[c]
+                          or col_toks[c] <= _plan_param_tokens(n))])
+    return resolved, pending, {n: candidates[n] for n in pending if n in candidates}
+
+
 def _norm_level(v) -> str:
     """Canonical label for a categorical level: numeric-looking values compare
     as numbers ('3', '3.0', 3 -> '3'; '2.5' -> '2.5'), everything else as the
@@ -4696,12 +4766,56 @@ class OrchestratorTools:
                             scientific_bounds[name] = (float(min_v), float(max_v))
                             print(f"  🔬 Scientific Constraint Found: {name} must be between {min_v} and {max_v}")
 
+            # #67: re-key the plan's constraints onto the actual input
+            # columns ('Temperature' -> 'temperature_C'). Before this an
+            # exact lookup missed them and the box silently came from the
+            # data. Unresolved plan parameters are reported (with their
+            # ranges) so the caller can pass them as input_bounds.
+            bounds_warnings: List[str] = []
+            plan_param_matches: Dict[str, str] = {}   # column -> plan name
+            _plan_names = list(scientific_bounds) + [
+                n for n in planner_levels if n not in scientific_bounds]
+            if _plan_names:
+                _resolved, _plan_unmatched, _plan_cands = _resolve_plan_params(
+                    _plan_names, list(self.orch.expected_input_columns or []))
+                plan_param_matches = {c: n for n, c in _resolved.items() if c != n}
+                for c, n in plan_param_matches.items():
+                    print(f"  🔗 Plan parameter '{n}' -> input column '{c}'")
+                _inputs_now = list(self.orch.expected_input_columns or [])
+                for n in _plan_unmatched:
+                    _cands = _plan_cands.get(n) or []
+                    if n in scientific_bounds:
+                        _lo, _hi = scientific_bounds[n]
+                        if _cands:
+                            _ex = ", ".join(f"'{c}': [{_lo:g}, {_hi:g}]" for c in _cands)
+                            bounds_warnings.append(
+                                f"Plan parameter '{n}' (range [{_lo:g}, {_hi:g}]) is "
+                                f"ambiguous between input columns {_cands}, so its "
+                                f"range was NOT applied and those columns are bounded "
+                                f"from the data. Pass input_bounds={{{_ex}}} for each "
+                                f"one it applies to.")
+                        else:
+                            bounds_warnings.append(
+                                f"Plan parameter '{n}' (range [{_lo:g}, {_hi:g}]) matched "
+                                f"no input column (inputs: {_inputs_now}); if it is one "
+                                f"of them, pass input_bounds={{'<column>': "
+                                f"[{_lo:g}, {_hi:g}]}}.")
+                    else:
+                        bounds_warnings.append(
+                            f"Plan parameter '{n}' (levels {planner_levels[n]}) matched "
+                            f"no input column (inputs: {_inputs_now}); its level "
+                            f"universe is unused — declare that column categorical "
+                            f"under a matching name to use it.")
+                scientific_bounds = {_resolved[n]: v for n, v in scientific_bounds.items()
+                                     if n in _resolved}
+                planner_levels = {_resolved[n]: v for n, v in planner_levels.items()
+                                  if n in _resolved}
+
             # Caller-stated ranges (instrument limits, safe operating window,
             # allowed concentration range) — the strongest source: whoever
             # runs the instrument knows what it can actually reach. Sticky:
             # remembered on the orchestrator (and checkpointed) so later
             # rounds inherit them until a call overrides them.
-            bounds_warnings: List[str] = []
             if input_bounds:
                 cleaned: Dict[str, tuple] = {}
                 if not isinstance(input_bounds, dict):
@@ -4858,7 +4972,9 @@ class OrchestratorTools:
                     sci_min, sci_max = scientific_bounds[col]
                     input_bounds.append([sci_min, sci_max])
                     bounds_sources[col] = "planner"
-                    print(f"     -> Bound for '{col}': [{sci_min}, {sci_max}] (Source: PLANNER)")
+                    _via = (f", plan parameter '{plan_param_matches[col]}'"
+                            if col in plan_param_matches else "")
+                    print(f"     -> Bound for '{col}': [{sci_min}, {sci_max}] (Source: PLANNER{_via})")
                 else:
                     data_min = float(df[col].min())
                     data_max = float(df[col].max())
@@ -5129,6 +5245,8 @@ class OrchestratorTools:
                     col: [float(lo), float(hi)]
                     for col, (lo, hi) in zip(optimization_inputs, input_bounds)}
                 response["input_bounds_source"] = bounds_sources
+                if plan_param_matches:
+                    response["plan_param_matches"] = plan_param_matches
                 response["input_types"] = {
                     c: ("categorical" if c in level_maps else "continuous")
                     for c in optimization_inputs}

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -93,6 +93,10 @@ Only call `generate_implementation_code` when BOTH conditions are true:
 - When the user specifies a single optimization objective (e.g., "maximize peak area") but
   multiple targets were auto-detected, pass `targets=["Peak_Area"]` directly to
   `run_optimization` instead of re-calling `analyze_file`/`analyze_batch`.
+- If `run_optimization` reports in `input_bounds_warnings` that a plan parameter's range
+  was NOT applied (no matching column, or ambiguous between columns), a constraint the
+  plan set has been dropped: state that plainly to the user, and re-run with
+  `input_bounds` when the plan makes the mapping clear, otherwise ask which column it is.
 
 **RESPONSE STYLE:**
 - After each tool call, summarize the result and wait for user direction.

--- a/tests/test_plan_param_matching.py
+++ b/tests/test_plan_param_matching.py
@@ -1,0 +1,206 @@
+"""#67: the plan's optimization_params name knobs in the planner's words
+('Temperature', 'Reaction time (min)'); the data names them as columns
+('temperature_C', 'time_min'). run_optimization used an exact lookup, so the
+plan's bounds and level universes were silently ignored and the search box
+came from the observed data range. Now the names are resolved onto the input
+columns by normalized tokens, unambiguously both ways, and unresolved plan
+parameters are reported with their ranges.
+
+Offline: scalarizer stubbed to a pass-through, BOAgent's loop stubbed to
+capture its kwargs."""
+import contextlib
+import io
+import json
+import os
+from pathlib import Path
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+import pytest
+
+from scilink.agents.planning_agents.orchestrator_tools import _resolve_plan_params
+from scilink.agents.planning_agents.planning_orchestrator import (
+    PlanningOrchestratorAgent, AutonomyLevel,
+)
+
+
+# ------------------------------------------------------------ resolver --
+
+def _resolve(names, cols):
+    r, un, _ = _resolve_plan_params(names, cols)
+    return r, un
+
+
+def test_exact_and_case_insensitive_win_first():
+    r, un = _resolve(["temperature_C", "Time_Min"], ["temperature_C", "time_min"])
+    assert r == {"temperature_C": "temperature_C", "Time_Min": "time_min"} and un == []
+
+
+def test_ambiguous_candidates_are_reported():
+    r, un, cands = _resolve_plan_params(
+        ["Temperature", "Pressure"], ["temperature_inlet_C", "temperature_outlet_C"])
+    assert r == {} and un == ["Temperature", "Pressure"]
+    assert cands == {"Temperature": ["temperature_inlet_C", "temperature_outlet_C"]}
+
+
+def test_unit_suffix_and_phrasing_variants():
+    r, un = _resolve(
+        ["Temperature", "Reaction time (min)", "Catalyst loading (mol%)", "pH"],
+        ["temperature_C", "time_min", "catalyst_loading", "pH", "yield"])
+    assert r == {"Temperature": "temperature_C", "Reaction time (min)": "time_min",
+                 "Catalyst loading (mol%)": "catalyst_loading", "pH": "pH"}
+    assert un == []
+
+
+def test_equal_tokens_disambiguate_from_a_longer_sibling():
+    r, un = _resolve(["Temperature"], ["temperature_C", "temperature_ramp_C"])
+    assert r == {"Temperature": "temperature_C"} and un == []
+
+
+def test_ambiguous_name_stays_unmatched():
+    r, un = _resolve(["Temperature"], ["temperature_inlet_C", "temperature_outlet_C"])
+    assert r == {} and un == ["Temperature"]
+
+
+def test_two_names_wanting_one_column_both_unmatched():
+    # 'time' and 'Time (min)' are the same name once the unit word drops:
+    # genuinely ambiguous, neither is guessed.
+    r, un = _resolve(["time", "Time (min)"], ["time_min", "T"])
+    assert r == {} and set(un) == {"time", "Time (min)"}
+    r, un = _resolve(["reaction time", "residence time"], ["time_min"])
+    assert r == {} and set(un) == {"reaction time", "residence time"}
+
+
+def test_single_letter_and_unit_only_names_do_not_token_match():
+    r, un = _resolve(["T", "C"], ["temperature_C", "time_min"])
+    assert r == {} and un == ["T", "C"]
+    r, _ = _resolve(["T"], ["T", "t"])
+    assert r == {"T": "T"}                      # case-sensitive exact wins
+    r, un = _resolve(["t"], ["T", "Time"])
+    assert r == {"t": "T"} and un == []         # then case-insensitive
+
+
+def test_unrelated_name_unmatched():
+    r, un = _resolve(["Pressure"], ["temperature_C", "time_min"])
+    assert r == {} and un == ["Pressure"]
+
+
+# ---------------------------------------------------------- integration --
+
+L6 = dict(temperature_C=[30.0, 30.0, 90.0, 90.0, 50.0, 78.0],
+          time_min=[10.0, 50.0, 10.0, 50.0, 35.0, 18.0],
+          solvent=["DMF", "DMSO", "DMF", "DMSO", "DMF", "DMSO"],
+          yield_pct=[8.56, 3.88, 22.47, 10.81, 48.83, 61.1])
+
+
+@pytest.fixture
+def orch(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    with contextlib.redirect_stdout(io.StringIO()):
+        o = PlanningOrchestratorAgent(
+            base_dir=str(tmp_path / "session"), api_key="sk-dummy",
+            autonomy_level=AutonomyLevel.AUTONOMOUS, data_dir=str(data_dir))
+    o.scalarizer.scalarize = lambda **kw: {
+        "status": "success", "metrics": dict(L6), "source_script": None,
+        "column_roles": {"inputs": ["temperature_C", "time_min", "solvent"],
+                         "targets": ["yield_pct"],
+                         "input_types": {"solvent": "categorical"}},
+        "passthrough": True, "error": None}
+    csv = data_dir / "seed.csv"
+    csv.write_text("temperature_C,time_min,solvent,yield_pct\n" + "\n".join(
+        f"{a},{b},{c},{d}" for a, b, c, d in zip(*L6.values())) + "\n")
+    with contextlib.redirect_stdout(io.StringIO()):
+        o.tools.execute_tool("analyze_file", file_path=str(csv), extraction_goal="x",
+                             inputs=["temperature_C", "time_min", "solvent"],
+                             targets=["yield_pct"],
+                             input_types={"solvent": "categorical"})
+    o._captured = {}
+
+    def fake_loop(**kw):
+        o._captured.clear(); o._captured.update(kw)
+        return {"status": "success", "next_parameters": {}, "strategy": {}}
+    o.bo.run_optimization_loop = fake_loop
+    return o
+
+
+def _plan(*params):
+    return {"proposed_experiments": [{"optimization_params": list(params)}]}
+
+
+def _run(o, **kw):
+    with contextlib.redirect_stdout(io.StringIO()) as buf:
+        out = json.loads(o.tools.execute_tool("run_optimization", **kw))
+    return out, buf.getvalue()
+
+
+def test_plan_bounds_apply_through_name_variants(orch):
+    orch.planner.state["current_plan"] = _plan(
+        {"parameter_name": "Temperature", "parameter_type": "continuous",
+         "min_value": 20, "max_value": 120},
+        {"parameter_name": "Reaction time (min)", "min_value": 5, "max_value": 60},
+        {"parameter_name": "Solvent", "parameter_type": "categorical",
+         "levels": ["DMF", "DMSO", "MeCN"]})
+    out, log = _run(orch)
+    assert out["status"] == "success"
+    assert orch._captured["input_bounds"] == [[20.0, 120.0], [5.0, 60.0], [0.0, 2.0]]
+    assert out["input_bounds_source"] == {"temperature_C": "planner", "time_min": "planner",
+                                          "solvent": "categorical"}
+    assert out["plan_param_matches"] == {"temperature_C": "Temperature",
+                                         "time_min": "Reaction time (min)",
+                                         "solvent": "Solvent"}
+    # Planner is authoritative on the level universe, including unobserved MeCN.
+    assert orch.expected_input_levels["solvent"] == ["DMF", "DMSO", "MeCN"]
+    assert "plan parameter 'Temperature'" in log
+    assert "input_bounds_warnings" not in out or not any(
+        "derived from the observed data" in w for w in out["input_bounds_warnings"])
+
+
+def test_unmatched_plan_param_is_reported_with_its_range(orch):
+    orch.planner.state["current_plan"] = _plan(
+        {"parameter_name": "Pressure (bar)", "min_value": 1, "max_value": 10},
+        {"parameter_name": "Temperature", "min_value": 20, "max_value": 120})
+    out, _ = _run(orch)
+    assert orch._captured["input_bounds"][0] == [20.0, 120.0]
+    assert out["input_bounds_source"]["time_min"] == "data"
+    w = " ".join(out["input_bounds_warnings"])
+    assert "Plan parameter 'Pressure (bar)' (range [1, 10]) matched no input column" in w
+    assert "derived from the observed data" in w and "['time_min']" in w
+
+
+def test_caller_bounds_still_beat_matched_plan_bounds(orch):
+    orch.planner.state["current_plan"] = _plan(
+        {"parameter_name": "Temperature", "min_value": 20, "max_value": 120})
+    out, _ = _run(orch, input_bounds={"temperature_C": [40, 80]})
+    assert orch._captured["input_bounds"][0] == [40.0, 80.0]
+    assert out["input_bounds_source"]["temperature_C"] == "caller"
+
+
+def test_exact_names_unchanged_and_no_matches_key(orch):
+    orch.planner.state["current_plan"] = _plan(
+        {"parameter_name": "temperature_C", "min_value": 20, "max_value": 120})
+    out, log = _run(orch)
+    assert orch._captured["input_bounds"][0] == [20.0, 120.0]
+    assert "plan_param_matches" not in out
+    assert "(Source: PLANNER)" in log
+
+
+def test_ambiguous_plan_name_falls_to_data_with_warning(orch):
+    orch.planner.state["current_plan"] = _plan(
+        {"parameter_name": "Temperature", "min_value": 0, "max_value": 100},
+        {"parameter_name": "temp (C)", "min_value": 5, "max_value": 60})
+    out, _ = _run(orch)
+    # Both reduce to 'temp*'-ish names? No: 'Temperature' -> {temperature},
+    # 'temp (C)' -> {temp}; only the first equals temperature_C's tokens.
+    assert orch._captured["input_bounds"][0] == [0.0, 100.0]
+    assert any("Plan parameter 'temp (C)'" in w and "matched no input column" in w
+               for w in out["input_bounds_warnings"])
+    # Two names that are the same after normalization are never guessed.
+    orch.planner.state["current_plan"] = _plan(
+        {"parameter_name": "time", "min_value": 0, "max_value": 100},
+        {"parameter_name": "Time (min)", "min_value": 5, "max_value": 60})
+    out, _ = _run(orch)
+    assert out["input_bounds_source"]["time_min"] == "data"
+    amb = [w for w in out["input_bounds_warnings"] if "ambiguous between" in w]
+    assert len(amb) == 2 and all("'time_min': [" in w for w in amb)


### PR DESCRIPTION
## Summary

When a plan says a knob is called `Temperature` with a range of 20 to 120 °C, and your data file calls that column `temperature_C`, the optimizer now uses the plan's range. Before, it quietly fell back to the range spanned by your existing measurements, so the search never left the region you had already explored, and the assistant then asked you for limits the plan already contained. The same applies to categorical knobs: a plan-declared solvent list (including solvents you have not tried yet) reaches the optimizer under whatever the column is called.

When a plan parameter cannot be mapped safely, for example `Temperature` when the data has both an inlet and an outlet temperature, nothing is guessed. The tool reports the range that was not applied and the columns it could belong to, and the assistant tells you so and asks which one you meant.

Closes #67.

## Technical description

### Change

- `orchestrator_tools._resolve_plan_params(plan_names, columns)` maps each `optimization_params` name to an input column through four rungs, each applied only to names and columns not yet claimed: exact name; case-insensitive name; equal token sets with unit words dropped (`_PLAN_UNIT_TOKENS`); token subset in either direction. A rung accepts a pair only when the name has exactly one candidate and that column is wanted by exactly one name. Returns `(resolved, unmatched, candidates)` where `candidates` lists the columns an unmatched name resembled, for the ambiguity message. Word tokens rather than `difflib` so that `Temperature` finds `temperature_C` and `Reaction time (min)` finds `time_min`, while `T` never token-matches `temperature_C`.
- `run_optimization`: after the plan loop, `scientific_bounds` and `planner_levels` are re-keyed onto the resolved columns. Precedence is unchanged: categorical, then caller `input_bounds`, then planner, then data. The PLANNER log line names the plan parameter it came from; the response adds `plan_param_matches` (column → plan name) when any name differed. Unresolved parameters go into `input_bounds_warnings`: with a range and a ready-to-pass `input_bounds` when ambiguous between named columns, with the range when nothing resembled it, and a note that the level universe is unused for an unmatched categorical.
- `planning_orchestrator` system prompt: one sentence asking the model to state plainly when a plan parameter's range was not applied, re-run with `input_bounds` when the mapping is clear, otherwise ask.

### Tests

`tests/test_plan_param_matching.py` (13 cases): resolver rungs and both-ways ambiguity (equal tokens disambiguate `temperature_C` from `temperature_ramp_C`; `time` vs `Time (min)` are the same name once the unit drops and neither is guessed; single-letter and unit-only names never token-match; case-sensitive exact wins before case-insensitive); integration through the real tool with a stubbed BO loop: planner bounds and a plan-declared unobserved level apply through name variants, unmatched parameter warned with its range, caller bounds still win, exact names unchanged with no `plan_param_matches` key, ambiguous name reports both candidates. Existing input-bounds, input-types, target-directions, candidate-pool, BO seed, prompt snapshot, and MCP suites re-run green.

### Live verification (Bedrock `us.anthropic.claude-opus-4-8`)

- Real `generate_initial_plan` produced parameters named `Temperature` and `Time`; both resolved to `temperature_C` and `time_min`. The model also passed the chat-stated ranges as caller bounds, which correctly took precedence.
- Injected plan with `Temperature`, `Reaction time (min)`, and an unmatched `Pressure (bar)`: both matched columns bounded from the plan, the model flagged the pressure parameter to the user and did not ask for a temperature range.
- Plan-declared categorical `Solvent` with an unobserved `MeCN` level on a column named `solvent`: three levels reached the optimizer.
- Ambiguous `Temperature` against inlet and outlet temperature columns: nothing applied, the model stated the caveat plainly with both column names and asked. Before the prompt sentence it only offered to constrain bounds "if you want".
- Checkpoint restore in a fresh orchestrator keeps the matching.

### Not changed

Caller `input_bounds` validation, the data-derived fallback and its warning, and the MOO narrowing path.
