### PR TITLE
Turn off the scalarizer's per-file column-confirmation prompt

### DIFF
--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -3466,13 +3466,19 @@ class OrchestratorTools:
                 }
                 role_hints = {"inputs": inputs, "targets": targets}
 
+            # The scalarizer's per-file "confirm these columns" prompt is off
+            # in every mode: it sat behind four automated checks (runtime,
+            # row-count trap, plot self-check, schema verification), fired
+            # only on the codegen path, and blocked a delegated meta turn on
+            # a terminal keypress. The user's review of inputs/targets
+            # belongs at the campaign schema, not per extraction.
             try:
                 res = self.orch.scalarizer.scalarize(
                     data_path=file_path,
                     objective_query=enhanced_objective,
                     reuse_script_path=script_to_use,
                     experiment_context=exp_context,
-                    enable_human_review=self._get_human_feedback_enabled(),
+                    enable_human_review=False,
                     column_role_hints=role_hints
                 )
 
@@ -3519,7 +3525,7 @@ class OrchestratorTools:
                                     objective_query=enhanced_objective,
                                     reuse_script_path=None,
                                     experiment_context=exp_context,
-                                    enable_human_review=self._get_human_feedback_enabled(),
+                                    enable_human_review=False,
                                     column_role_hints=role_hints
                                 )
                                 if res["status"] != "success":

--- a/scilink/agents/planning_agents/scalarizer_agent.py
+++ b/scilink/agents/planning_agents/scalarizer_agent.py
@@ -415,7 +415,7 @@ class ScalarizerAgent(BaseAgent):
                  reuse_script_path: str = None,
                  experiment_context: Optional[Dict[str, Any]] = None,
                  metadata_path: Optional[str] = None,
-                 enable_human_review: bool = True,
+                 enable_human_review: bool = False,
                  column_role_hints: Optional[Dict] = None) -> Dict[str, Any]:
         """
         Main entry point. Converts raw data -> Scalar Metrics.
@@ -439,7 +439,11 @@ class ScalarizerAgent(BaseAgent):
             objective_query: Natural language instruction (e.g. "Calculate yield").
             experiment_context: Dict of high-level plan info (Hypothesis, etc).
             metadata_path: Path to sidecar JSON describing the data file (Units, Columns).
-            enable_human_review: Pause for human check of the plot/logic.
+            enable_human_review: Pause for a terminal confirmation of the
+                extracted columns after the automated checks pass. Off by
+                default (and off at every orchestrator call site): the
+                automated checks cover it, and the prompt blocks headless
+                and delegated runs.
 
         Returns:
             Dict containing:

--- a/tests/test_scalarizer_review_off.py
+++ b/tests/test_scalarizer_review_off.py
@@ -1,0 +1,59 @@
+"""The scalarizer's per-file "confirm these columns" prompt is off in every
+autonomy mode. It sat behind the automated checks (runtime, row-count trap,
+plot self-check, schema verification), fired only on the codegen path, and
+blocked a delegated meta turn on a terminal keypress. analyze_file and
+analyze_batch must never ask for it; the scalarizer's own default is off."""
+import contextlib
+import inspect
+import io
+import json
+import os
+from pathlib import Path
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-dummy")
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+import pytest
+
+from scilink.agents.planning_agents.planning_orchestrator import (
+    PlanningOrchestratorAgent, AutonomyLevel,
+)
+from scilink.agents.planning_agents.scalarizer_agent import ScalarizerAgent
+
+CSV = "T,t,Y\n30,10,8.5\n90,10,22.4\n50,35,48.8\n"
+
+
+def test_scalarizer_default_is_off():
+    assert inspect.signature(ScalarizerAgent.scalarize).parameters[
+        "enable_human_review"].default is False
+
+
+@pytest.mark.parametrize("level", [AutonomyLevel.CO_PILOT, AutonomyLevel.AUTOPILOT,
+                                   AutonomyLevel.AUTONOMOUS])
+def test_analyze_file_and_batch_never_request_review(tmp_path, level):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "a.csv").write_text(CSV)
+    (data_dir / "b.csv").write_text(CSV)
+    with contextlib.redirect_stdout(io.StringIO()):
+        o = PlanningOrchestratorAgent(
+            base_dir=str(tmp_path / "s"), api_key="sk-dummy",
+            autonomy_level=level, data_dir=str(data_dir))
+    calls = []
+
+    def fake(**kw):
+        calls.append(kw)
+        return {"status": "success", "source_script": None, "passthrough": True,
+                "metrics": {"T": [30.0, 90.0, 50.0], "t": [10.0, 10.0, 35.0],
+                            "Y": [8.5, 22.4, 48.8]},
+                "column_roles": {"inputs": ["T", "t"], "targets": ["Y"]}, "error": None}
+    o.scalarizer.scalarize = fake
+    with contextlib.redirect_stdout(io.StringIO()):
+        out = json.loads(o.tools.execute_tool(
+            "analyze_file", file_path=str(data_dir / "a.csv"),
+            extraction_goal="x", inputs=["T", "t"], targets=["Y"]))
+        assert out["status"] == "success"
+        o.tools.execute_tool("analyze_batch", file_paths=[str(data_dir / "b.csv")],
+                             extraction_goal="x", inputs=["T", "t"], targets=["Y"])
+    assert calls, "scalarize was not called"
+    assert all(kw.get("enable_human_review") is False for kw in calls), calls


### PR DESCRIPTION
## Summary

Ingesting a data file no longer stops to ask you to confirm the extracted columns. That prompt appeared only when the scalarizer had to generate extraction code, after its own automated checks had already passed, and in co-pilot or autopilot it could stall a delegated run waiting for a keypress. Reviewing which columns are the inputs and the target is still worth doing, but at the campaign level, not once per file. Nothing changes for autonomous runs, which never showed the prompt.

## Technical description

- `orchestrator_tools.analyze_file`: both `scalarize` calls (initial and the sidecar-mismatch regeneration) pass `enable_human_review=False`; `analyze_batch` already did. The autonomy-level gate `_get_human_feedback_enabled` is unchanged and still governs plan and code review elsewhere.
- `scalarizer_agent.scalarize`: default `enable_human_review` flips to `False`; docstring says why. The review block itself stays for an explicit opt-in caller.
- `scilink/ui/app.py` and `scilink/server/presenter.py` keep their `review_metrics` handling; it is now dead unless a caller opts in.
- `tests/test_scalarizer_review_off.py`: the scalarizer default is off, and `analyze_file` and `analyze_batch` pass `enable_human_review=False` in all three autonomy levels (captured through a stubbed `scalarize`).
- Live check on Bedrock `us.anthropic.claude-opus-4-8`: an autopilot orchestrator (orchestrator-level human feedback on) ingested a raw two-column spectrum through the codegen path with stdin closed; one attempt, auto-reflection passed, no review prompt, correct peak value stored.
