### PR TITLE
Files-tab markdown listing newest-first; un-hardcode a test's repo path

### DIFF
--- a/scilink/server/artifacts.py
+++ b/scilink/server/artifacts.py
@@ -154,6 +154,15 @@ class ArtifactTracker:
                     continue
             self.known.add(key)
             new.append(s)
+        # Newest first: rglob yields filesystem-walk order, so a turn that
+        # wrote several documents listed them arbitrarily and the one the
+        # user most likely wants (the last written) could land at the bottom.
+        def _mtime(path: str) -> float:
+            try:
+                return Path(path).stat().st_mtime
+            except OSError:
+                return 0.0
+        new.sort(key=_mtime, reverse=True)
         return new
 
     def sweep_turn(self, autonomy: Optional[str] = None) -> Dict[str, Any]:

--- a/tests/test_session_title.py
+++ b/tests/test_session_title.py
@@ -1,7 +1,9 @@
 """generate_session_title must work through whatever transport the agent has."""
 import sys, types
+from pathlib import Path
 from types import SimpleNamespace
-sys.path.insert(0, "/Users/maxim.ziatdinov/Code/SciLink")
+_REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO))
 from scilink.ui.session_meta import generate_session_title
 
 fails = []
@@ -50,7 +52,7 @@ check(generate_session_title(FakeModel(text=""), "x") is None, "empty completion
 check(generate_session_title(FakeModel(text="   ...  "), "x") is None, "punctuation-only -> None")
 
 print("\n=== agent_config no longer carries credentials ===")
-sb = open("/Users/maxim.ziatdinov/Code/SciLink/scilink/ui/components/sidebar.py").read()
+sb = (_REPO / "scilink/ui/components/sidebar.py").read_text()
 import re
 blocks = re.findall(r'st\.session_state\.agent_config = \{[^}]*\}', sb, re.S)
 # the third assignment predates this PR (carries fh_api_key); scope to the two it touched
@@ -58,7 +60,7 @@ blocks = [b for b in blocks if "fh_api_key" not in b]
 check(len(blocks) >= 2, f"found {len(blocks)} agent_config assignments")
 check(all("api_key" not in b and "base_url" not in b for b in blocks),
       "no agent_config assignment carries api_key/base_url")
-app = open("/Users/maxim.ziatdinov/Code/SciLink/scilink/ui/app.py").read()
+app = (_REPO / "scilink/ui/app.py").read_text()
 check("_cfg.get(\"api_key\")" not in app, "call site no longer reads credentials from agent_config")
 check("getattr(st.session_state.agent, \"model\", None)" in app, "call site passes the agent's model")
 
@@ -148,4 +150,14 @@ check('key=f"session_name_input:{_sdir}"' in sb,
 check('key="session_name_input"' not in sb, "no fixed widget key remains")
 
 print("\n" + ("ALL PASSED" if not fails else f"{len(fails)} FAILURE(S): {fails}"))
-sys.exit(1 if fails else 0)
+
+
+def test_session_title_checks():
+    """pytest entry point over the script-style checks above."""
+    assert not fails, fails
+
+
+if __name__ == "__main__":
+    # Script mode keeps the exit code; under pytest a module-level sys.exit
+    # would abort the whole collection run.
+    sys.exit(1 if fails else 0)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -157,6 +157,19 @@ def test_artifact_tracker_md_rules(tmp_path):
     assert [d["name"] for d in out["md_reports"]] == ["brief.md"]
 
 
+def test_artifact_tracker_md_newest_first(tmp_path):
+    import os
+    tracker = ArtifactTracker(str(tmp_path))
+    (tmp_path / "sub").mkdir()
+    t = 1_700_000_000
+    for rel, mt in (("zz_old.md", t), ("sub/mid.md", t + 10), ("aa_new.md", t + 20)):
+        f = tmp_path / rel
+        f.write_text("# d")
+        os.utime(f, (mt, mt))
+    out = tracker.sweep_turn("autonomous")
+    assert [d["name"] for d in out["md_reports"]] == ["aa_new.md", "mid.md", "zz_old.md"]
+
+
 def test_artifact_tracker_debug_subsampling(tmp_path):
     tracker = ArtifactTracker(str(tmp_path))
     for i in range(1, 6):


### PR DESCRIPTION
## Summary

Two small cleanups.

- In the web UI's Files tab and the end-of-turn document cards, markdown documents produced in a turn are now listed newest first. Before, the order was whatever the filesystem walk returned, so the document written last could appear at the bottom.
- `tests/test_session_title.py` no longer hardcodes a path from another machine, so it runs on any checkout instead of failing at collection.

## Technical description

- `scilink/server/artifacts.py`: `find_new_md_documents` sorts its result by file mtime, descending, after the existing filtering (bulk stems, size cap, deliverable marking). No change to which files are included. This is the follow-up the #533 issue text named as a separate, lower-priority surface.
- `tests/test_session_title.py`: derives `_REPO` from `Path(__file__).resolve().parents[1]` for `sys.path` and for the two source files it inspects (`sidebar.py`, `app.py`).
- New test `test_artifact_tracker_md_newest_first` in `tests/test_web_server.py` creates three documents with staged mtimes across a subdirectory and asserts the order.

Not changed: several `*_live.py` tests and `test_read_file_offset_and_index.py` also reference session data from another machine; those depend on data that does not exist elsewhere, not only on a path, and are outside this fix.

Verified: `test_session_title.py`, `test_web_server.py` (40 tests), and `test_artifact_image_rewrite.py` pass.


Also: the script-style test ended with a module-level `sys.exit`, which under pytest aborts the whole collection run once the file imports cleanly. It is now guarded behind `__main__` and exposed through a `test_session_title_checks` function, so it runs as a normal test (43 pass across the three touched files) and still works as a script.
