### PR TITLE
Roadmap: record the 2026-09-07 batch and the standing decisions

### DIFF
--- a/docs/react_ui_roadmap.md
+++ b/docs/react_ui_roadmap.md
@@ -2,7 +2,7 @@
 
 State and forward plan for the `scilink-web` React UI. Companion to
 `react_web_ui.md` (architecture + usage, kept current); this file is
-about *what's next and why*. Updated 2026-09-04.
+about *what's next and why*. Updated 2026-09-07.
 
 ## Where things stand
 
@@ -13,7 +13,7 @@ about *what's next and why*. Updated 2026-09-04.
   gallery, zip), floating figure inset, session lifecycle
   (create/resume/rename/reset/quit), wheel-packaged bundle
   (`scilink[web]` → `scilink-web`).
-- **PR #531 (OPEN)** — daily-driver batch: mid-chat uploads, pasted
+- **PR #531 (MERGED)** — daily-driver batch: mid-chat uploads, pasted
   folder paths (with plan-agent KB-dir reassignment), multi-session UX
   (switcher, detach, per-session close from sidebar and landing page),
   plus the fixes daily use surfaced: SSE heartbeat lock bug (wedged
@@ -21,15 +21,19 @@ about *what's next and why*. Updated 2026-09-04.
   bleed; terminal lines tagged `[HHMMSS]` when several sessions run),
   session-title conversational-output gate, favicon, landing-page mode
   dropdown, collapsible sidebar, inset filmstrip de-dup.
+- **2026-09-07 batch (PRs #536–#539, #544, #545, delegation view)** —
+  folder uploads (recursive drop / directory picker, layout preserved
+  server-side, strays skipped) behind a single upload menu that also holds
+  the pasted-path route; `inspect_uploads` reports subfolders and can
+  recurse; resume card ranks the headline deliverable over a late-refined
+  ideation report (#533); activity line narrates plan refinement instead
+  of "-"; locked sidebar fields greyed and showing the live session's
+  model/autonomy; Files-tab documents newest-first; **Delegations tab**
+  (live mission-control view of the meta ledger, the last high-value
+  Streamlit panel); bundle no longer committed — built at release by
+  `release.yml` (see "Standing decisions").
 
-- **Folder uploads + subfolder-aware meta** (2026-09-07, branch
-  `feature-folder-upload-subfolder-inspect`) — dropzones and the chat
-  input take whole directories (recursive walk, layout preserved
-  server-side, strays skipped), heroes describe nested layouts to the
-  agent, and `inspect_uploads` lists subfolders and can recurse. Closes
-  the gap where a nested drop was invisible to the meta.
-
-Validation posture: ~45 offline tests across
+Validation posture: ~60 offline tests across
 `tests/test_web_server.py`, `test_artifact_image_rewrite.py`,
 `test_capabilities_cache.py`, `test_session_title.py`; live E2E on
 Bedrock (analyze co-pilot end-to-end incl. HITL over the API, stop,
@@ -37,26 +41,30 @@ restart, resume).
 
 ## Next steps, in order
 
-1. **Merge #531**, then a deliberate bake period — real sessions have
-   been the best bug-finder (every architectural defect so far was
-   caught in daily use, fixed same-day).
-2. **Meta delegation view** — the last high-value Streamlit panel.
-   Surface the meta's delegation ledger live (specialist, delegation
-   number, status, context-flow edges) in the sidebar or a third tab.
-   Data already exists on the orchestrator; precedent says
-   live-visibility features (activity line, figure inset) pay for
-   themselves.
+1. **Merge the 2026-09-07 batch, then bake.** Open at time of writing:
+   #544 (listing order + test path), #545 (bundle at release), #546
+   (Delegations tab). Real sessions remain the best bug-finder.
+2. **First tagged release through `release.yml`.** Tag `v0.0.68` (or run
+   the workflow by hand) and confirm the wheel on the release page carries
+   the bundle; decide whether to enable PyPI trusted publishing
+   (`PYPI_PUBLISH=true`) or keep uploading with twine.
 3. **Multi-user hardening** — the gate to sharing a lab-server URL:
    token auth or documented reverse-proxy setup, per-user session
-   roots. Per-session isolation is already done (stdout routing, SSE
-   per session); only authn/authz is missing. Until then: SSH tunnel.
-4. **Remaining panels, on demand** — Skills (browse/upload first; the
-   persistent-memory pipeline UI is a separate, bigger design) and
-   Tools/MCP (connect servers, list registered tools). Build when
-   actually missed.
-5. **Big rocks** (each needs its own design pass; they touch agent
+   roots, and hide the "Use a folder on this machine…" menu item on a
+   non-loopback bind (it cannot work for a remote user). Per-session
+   isolation is already done; only authn/authz is missing. Until then:
+   SSH tunnel.
+4. **Remaining panels, on demand** — Telemetry (the `/telemetry` endpoint
+   already serves the full reader; the Delegations tab covers the ledger,
+   so what is left is the per-agent tool sequence and worker action
+   histories), Skills (browse/upload first; the persistent-memory
+   pipeline UI is a separate, bigger design) and Tools/MCP (connect
+   servers, list registered tools). Build when actually missed.
+5. **Parity for the switch to default** (see "Standing decisions"):
+   simulate mode in the web UI (HPC connection, wizards) is the largest
+   gap; after it the web UI covers everything Streamlit does.
+6. **Big rocks** (each needs its own design pass; they touch agent
    internals, not just the web layer):
-   - Simulate mode UI (HPC connection, wizards).
    - True token streaming (agents expose blocking `chat()` only — the
      live stream is console narration by design until this changes).
    - Real cancellation token (stop is print/log-driven +
@@ -66,11 +74,26 @@ restart, resume).
 
 - Web-UI fixes go straight onto the current feature branch / main —
   no per-fix PRs into an unmerged branch.
-- The Streamlit app (`scilink-ui`) stays untouched and functional; the
-  server reuses its streamlit-free modules (`hitl`, `session_meta`,
-  `ui/config`). Open question, no urgency: a deprecation horizon for
-  Streamlit once the web UI covers everything in daily use —
-  double-maintenance is the cost of keeping both.
+- **The web UI becomes the default.** Decided 2026-09-07: once the web
+  UI reaches daily-use parity (simulate mode being the main gap), the
+  `web` extra's dependencies move into the core install and `scilink-web`
+  supersedes `scilink-ui` as the default; Streamlit is then retired.
+  Until then the Streamlit app stays untouched and functional and the
+  server keeps reusing its streamlit-free modules (`hitl`, `session_meta`,
+  `ui/config`). Consequence: parity gaps are on the critical path, not
+  optional, and nothing new is built Streamlit-only.
+- **The built bundle is not in git.** `scripts/build_webui.sh` produces
+  `scilink/server/static/`; `release.yml` builds it before the wheel and
+  verifies it is inside; CI builds the frontend on every push. A checkout
+  builds once. Rationale: two open frontend PRs always conflicted on the
+  same hashed asset.
+- **One upload control.** Files, folders and "use a folder on this
+  machine" live behind a single menu; the pasted-path route is the local
+  power-user path (no copy, plan-mode KB index reuse), upload is the
+  general mechanism and the only one that works remotely.
+- **Fixes go straight onto `main` via small PRs**, one concern per
+  branch, each verified live where the change is user-visible; commits
+  carry only the generic co-author trailer, no session identifiers.
 - Known accepted limits (also in docs/react_web_ui.md): no token
   streaming; single-process in-memory session registry (restart →
   resume from checkpoint); ~40 concurrently open tabs (Starlette sync

--- a/docs/react_web_ui.md
+++ b/docs/react_web_ui.md
@@ -75,6 +75,14 @@ authenticating reverse proxy.
   the agent subfolder by subfolder with absolute paths, since the agents'
   own directory listings are one level deep. The meta's `inspect_uploads`
   now reports subfolders and takes `recursive=true`.
+- **Delegations tab** (meta sessions): a live mission-control view of the
+  delegation ledger — grouped by specialist with the worker agents each
+  used, rows colored by status with start time and elapsed/duration,
+  context-flow edges ("← #1"), fan-out / timed-out / resumed tags, and a
+  click that expands the task, the specialist's summary and findings, the
+  produced files (opening in the Files tab), warnings and error. Fed by
+  the session snapshot and `delegations` SSE events as the ledger changes
+  mid-turn; survives refresh and resume.
 - **Sessions**: the server holds many live sessions; the sidebar lists the
   others with one-click switching, Detach leaves a session running while
   you start or join another, and the welcome screen offers reattach when
@@ -103,7 +111,8 @@ authenticating reverse proxy.
   - deep links: the tab and selected file live in the URL hash, so a
     refresh (or shared link) lands on the same file.
 
-Not yet ported: simulate mode, the Tools / Skills / Telemetry tabs, vibes.
+Not yet ported: simulate mode, the Tools / Skills tabs, the Telemetry tab's
+per-agent tool sequence (the `/telemetry` endpoint already serves it), vibes.
 
 ## Architecture
 
@@ -140,7 +149,7 @@ webui/ (Vite + React + TS)  ──REST + SSE──►  scilink/server/ (FastAPI)
 | POST | `/sessions` | create, or resume with `resume_dir` |
 | GET/PATCH | `/sessions/{id}` | snapshot / rename |
 | POST | `/sessions/{id}/messages` | start a turn (409 while one runs) |
-| GET | `/sessions/{id}/events` | SSE: `log`, `status`, `question`, `question_cleared`, `assistant_message`, `session_named`, `files_changed`, `analysis_image`, `error` |
+| GET | `/sessions/{id}/events` | SSE: `log`, `status`, `question`, `question_cleared`, `assistant_message`, `session_named`, `files_changed`, `analysis_image`, `delegations`, `error` |
 | POST | `/sessions/{id}/feedback` | answer the parked HITL question |
 | POST | `/sessions/{id}/stop` | stop the running turn |
 | POST | `/sessions/{id}/uploads` | multipart, `category` = data/metadata/knowledge/code/planning_data/meta; optional `paths` (JSON list of relative paths, one per file) makes it a layout-preserving folder upload |
@@ -151,6 +160,8 @@ webui/ (Vite + React + TS)  ──REST + SSE──►  scilink/server/ (FastAPI)
 | GET | `/sessions/{id}/thumb?path=&size=&cmap=` | PNG thumbnail; NPY/TIFF rendered as normalized heatmaps |
 | GET | `/sessions/{id}/table?path=&limit=` | CSV/TSV/XLSX head as JSON columns+rows |
 | GET | `/sessions/{id}/zip?path=` | zip a session subdirectory (or the whole session) |
+| GET | `/sessions/{id}/delegations` | meta: the delegation ledger shaped for the Delegations tab (empty for other modes) |
+| GET | `/sessions/{id}/telemetry` | meta: full read-only telemetry snapshot (ledger, worker action histories, analysis reasoning, tool sequence) |
 | GET | `/sessions/{id}/provenance` | tool-call timeline from every `events.jsonl` under the session |
 | DELETE | `/sessions/{id}` | reset: stop and drop the live session (dir stays resumable) |
 | POST | `/quit` | shut the server down |


### PR DESCRIPTION
## Summary

Documentation only. The React UI roadmap now records what landed today, what comes next in order, and the decisions made: the web UI becomes the default once it reaches parity (retiring Streamlit), the built bundle is no longer committed, one upload control, and the small-PR workflow. The web UI guide gains the Delegations tab, the `delegations` event and the two new endpoints.

## Technical description

- `docs/react_ui_roadmap.md`: state entry for PRs #536–#539, #544, #545, #546; next steps re-ordered (merge + bake, first tagged release via `release.yml`, multi-user hardening incl. hiding the local-folder menu item on non-loopback binds, remaining panels on demand, simulate-mode parity, big rocks); standing decisions rewritten as above; the Streamlit deprecation open question is resolved.
- `docs/react_web_ui.md`: Delegations tab bullet, `delegations` in the SSE event list, `/delegations` and `/telemetry` rows, not-yet-ported list updated.

No code changes.