### PR TITLE
Bump version to 0.0.68

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scilink"
-version = "0.0.67"
+version = "0.0.68"
 authors = [
   { name="SciLink Team", email="maxim.ziatdinov@gmail.com" },
 ]


### PR DESCRIPTION
## Summary

Version bump for the first release built by the new release workflow. The wheel will carry the web UI bundle built in CI.

## Technical description

`pyproject.toml` version 0.0.67 → 0.0.68. No other change. After merge, the `v0.0.68` tag on the merge commit triggers `release.yml`.