### PR TITLE
Delegation tree in the sidebar; the detail tab becomes Telemetry

### DIFF
--- a/docs/react_ui_roadmap.md
+++ b/docs/react_ui_roadmap.md
@@ -28,9 +28,9 @@ about *what's next and why*. Updated 2026-09-07.
   recurse; resume card ranks the headline deliverable over a late-refined
   ideation report (#533); activity line narrates plan refinement instead
   of "-"; locked sidebar fields greyed and showing the live session's
-  model/autonomy; Files-tab documents newest-first; **Delegations tab**
-  (live mission-control view of the meta ledger, the last high-value
-  Streamlit panel); bundle no longer committed — built at release by
+  model/autonomy; Files-tab documents newest-first; **mission-control
+  tree** in the sidebar (live, as in Streamlit) with a Telemetry tab for
+  the per-delegation detail (the last high-value Streamlit panel); bundle no longer committed — built at release by
   `release.yml` (see "Standing decisions").
 
 Validation posture: ~60 offline tests across

--- a/docs/react_web_ui.md
+++ b/docs/react_web_ui.md
@@ -84,14 +84,20 @@ authenticating reverse proxy.
   the agent subfolder by subfolder with absolute paths, since the agents'
   own directory listings are one level deep. The meta's `inspect_uploads`
   now reports subfolders and takes `recursive=true`.
-- **Delegations tab** (meta sessions): a live mission-control view of the
-  delegation ledger — grouped by specialist with the worker agents each
-  used, rows colored by status with start time and elapsed/duration,
-  context-flow edges ("← #1"), fan-out / timed-out / resumed tags, and a
-  click that expands the task, the specialist's summary and findings, the
-  produced files (opening in the Files tab), warnings and error. Fed by
-  the session snapshot and `delegations` SSE events as the ledger changes
-  mid-turn; survives refresh and resume.
+- **Mission-control tree** (meta sessions, sidebar — as in Streamlit): a
+  compact live tree of the delegation ledger under the session section —
+  specialist branches, one line per delegation with status glyph, index,
+  short label and context-flow edges ("←#1"), colored by status, pulsing
+  while running, in a bounded scroll box. Always visible while you chat.
+- **Telemetry tab** (meta sessions): the detail behind the tree — grouped
+  by specialist with the worker agents each used, rows with start time and
+  elapsed/duration, fan-out / timed-out / resumed tags, and a click (or a
+  click on a sidebar tree row) that expands the task, the specialist's
+  summary and findings, the produced files (opening in the Files tab),
+  warnings and error. Both surfaces are fed by the session snapshot and
+  `delegations` SSE events as the ledger changes mid-turn, and survive
+  refresh and resume. The per-agent tool sequence and worker action
+  histories (already served by `/telemetry`) are the tab's next content.
 - **Sessions**: the server holds many live sessions; the sidebar lists the
   others with one-click switching, Detach leaves a session running while
   you start or join another, and the welcome screen offers reattach when
@@ -169,7 +175,7 @@ webui/ (Vite + React + TS)  ──REST + SSE──►  scilink/server/ (FastAPI)
 | GET | `/sessions/{id}/thumb?path=&size=&cmap=` | PNG thumbnail; NPY/TIFF rendered as normalized heatmaps |
 | GET | `/sessions/{id}/table?path=&limit=` | CSV/TSV/XLSX head as JSON columns+rows |
 | GET | `/sessions/{id}/zip?path=` | zip a session subdirectory (or the whole session) |
-| GET | `/sessions/{id}/delegations` | meta: the delegation ledger shaped for the Delegations tab (empty for other modes) |
+| GET | `/sessions/{id}/delegations` | meta: the delegation ledger shaped for the sidebar tree and Telemetry tab (empty for other modes) |
 | GET | `/sessions/{id}/telemetry` | meta: full read-only telemetry snapshot (ledger, worker action histories, analysis reasoning, tool sequence) |
 | GET | `/sessions/{id}/provenance` | tool-call timeline from every `events.jsonl` under the session |
 | DELETE | `/sessions/{id}` | reset: stop and drop the live session (dir stays resumable) |

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -166,8 +166,10 @@ export default function App() {
   const [busy, setBusy] = useState<string | null>(null); // init overlay text
   const [startError, setStartError] = useState<string | null>(null);
   const [serverStopped, setServerStopped] = useState(false);
-  const [tab, setTab] = useState<"chat" | "files" | "delegations">("chat");
+  const [tab, setTab] = useState<"chat" | "files" | "telemetry">("chat");
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  // Delegation the sidebar tree asked the Telemetry tab to expand.
+  const [focusDelegation, setFocusDelegation] = useState<number | null>(null);
   const [attachRequest, setAttachRequest] = useState<string | null>(null);
   const [liveSessions, setLiveSessions] = useState<LiveSession[]>([]);
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(() => {
@@ -391,6 +393,11 @@ export default function App() {
         onReset={resetSession}
         onQuit={quitApp}
         liveSessions={liveSessions}
+        delegations={state.delegations}
+        onSelectDelegation={(i) => {
+          setFocusDelegation(i);
+          setTab("telemetry");
+        }}
         onAttachSession={(id) => void attachSession(id)}
         onCloseSession={(id) => {
           void api
@@ -439,15 +446,11 @@ export default function App() {
               </button>
               {mode === "meta" && (
                 <button
-                  className={tab === "delegations" ? "active" : ""}
-                  onClick={() => setTab("delegations")}
+                  className={tab === "telemetry" ? "active" : ""}
+                  onClick={() => setTab("telemetry")}
+                  title="Delegation details (the sidebar tree is the live overview)"
                 >
-                  Delegations
-                  {state.delegations?.delegations.length ? (
-                    <span className="tab-count">
-                      {state.delegations.delegations.length}
-                    </span>
-                  ) : null}
+                  Telemetry
                 </button>
               )}
             </div>
@@ -464,10 +467,11 @@ export default function App() {
               />
             </div>
             {mode === "meta" && (
-              <div className="tab-body" hidden={tab !== "delegations"}>
+              <div className="tab-body" hidden={tab !== "telemetry"}>
                 <DelegationsPanel
                   view={state.delegations}
                   running={state.status === "running"}
+                  focus={focusDelegation}
                 />
               </div>
             )}

--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -708,3 +708,27 @@ details.card iframe { width: 100%; height: 600px; border: none; background: #fff
 }
 .deleg-error { color: #f85149; white-space: pre-wrap; }
 
+/* ── sidebar mission-control tree (meta) ───────────────────── */
+.dtree { font-size: 12.5px; }
+.dtree-root { font-weight: 600; color: var(--text-muted); margin-bottom: 4px; }
+.dtree-empty { margin: 4px 0 0; }
+.dtree-scroll { max-height: 260px; overflow: auto; }
+.dtree-branch { display: flex; align-items: center; gap: 5px; padding: 2px 0; color: var(--text-muted); }
+.dtree-mode { text-transform: capitalize; font-weight: 600; }
+.dtree-line { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre; color: var(--text-dim); }
+.dtree-row {
+  display: flex; align-items: center; gap: 5px; width: 100%; padding: 2px 4px 2px 0;
+  border: none; background: none; border-radius: 4px; text-align: left; cursor: pointer;
+  color: var(--text-muted); font-size: 12.5px;
+}
+.dtree-row:hover { background: var(--bg-panel); border: none; color: var(--text); }
+.dtree-row.status-success { color: #3fb950; }
+.dtree-row.status-error { color: #f85149; }
+.dtree-row.status-running { color: #d29922; }
+.dtree-row.status-running .dtree-glyph { animation: deleg-pulse 1.2s ease-in-out infinite; }
+.dtree-glyph { width: 12px; text-align: center; }
+.dtree-idx { color: var(--text-dim); font-variant-numeric: tabular-nums; }
+.dtree-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.dtree-ctx { color: #58a6ff; font-size: 11px; white-space: nowrap; }
+.dtree-time { white-space: nowrap; }
+

--- a/webui/src/components/DelegationTree.tsx
+++ b/webui/src/components/DelegationTree.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useMemo, useState } from "react";
+import type { DelegationRow, DelegationView } from "../api";
+
+/** Compact mission-control tree for the sidebar — the web twin of the
+ * Streamlit `_meta_delegation_tree`: specialist branches, one line per
+ * delegation (status glyph, index, short label, "←#1" context edges),
+ * colored by status, in a bounded scroll box, live while a turn runs.
+ * A click hands the delegation to the Telemetry tab for its detail. */
+
+const ICON: Record<string, string> = {
+  analysis: "🧪",
+  planning: "📋",
+  simulation: "🧬",
+  fusion: "🔗",
+};
+const ORDER = ["analysis", "planning", "simulation", "fusion"];
+const GLYPH: Record<string, string> = {
+  success: "✓",
+  error: "✗",
+  interrupted: "⏹",
+  cancelled: "⏹",
+  running: "⋯",
+};
+
+function clip(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 1) + "…" : s;
+}
+
+function elapsed(start?: string | null, end?: string | null): string {
+  if (!start) return "";
+  const a = Date.parse(start);
+  const b = end ? Date.parse(end) : Date.now();
+  if (Number.isNaN(a) || Number.isNaN(b) || b < a) return "";
+  const s = Math.round((b - a) / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  return m < 60 ? `${m}m` : `${Math.floor(m / 60)}h${m % 60}m`;
+}
+
+export function DelegationTree({
+  view,
+  running,
+  onSelect,
+}: {
+  view: DelegationView | null;
+  running: boolean;
+  onSelect: (index: number) => void;
+}) {
+  const rows = view?.delegations ?? [];
+  const groups = useMemo(() => {
+    const by = new Map<string, DelegationRow[]>();
+    for (const r of rows) by.set(r.mode, [...(by.get(r.mode) ?? []), r]);
+    return [...by.keys()]
+      .sort(
+        (a, b) =>
+          (ORDER.indexOf(a) + 1 || 99) - (ORDER.indexOf(b) + 1 || 99) ||
+          a.localeCompare(b),
+      )
+      .map((k) => [k, by.get(k)!] as const);
+  }, [rows]);
+  const nRunning = rows.filter((r) => r.status === "running").length;
+
+  // Keep the elapsed time of running rows counting between ledger events.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!nRunning) return;
+    const t = setInterval(() => setTick((n) => n + 1), 1000);
+    return () => clearInterval(t);
+  }, [nRunning]);
+
+  return (
+    <div className="dtree">
+      <div className="dtree-root">
+        🎛️ Mission control
+        <span className="caption">
+          {" "}
+          · {rows.length}
+          {nRunning ? ` · ${nRunning} running` : running ? " · reasoning" : ""}
+        </span>
+      </div>
+      {rows.length === 0 ? (
+        <p className="caption dtree-empty">
+          No delegations yet — the meta routes your goal to a specialist.
+        </p>
+      ) : (
+        <div className="dtree-scroll">
+          {groups.map(([mode, list], gi) => {
+            const lastGroup = gi === groups.length - 1;
+            return (
+              <div key={mode} className="dtree-group">
+                <div className="dtree-branch">
+                  <span className="dtree-line">{lastGroup ? "└─" : "├─"}</span>
+                  <span>{ICON[mode] ?? "•"}</span>
+                  <span className="dtree-mode">{mode}</span>
+                  <span className="caption">({list.length})</span>
+                </div>
+                {list.map((r, ri) => {
+                  const last = ri === list.length - 1;
+                  const ctx = r.context_from.map((i) => `#${i}`).join(",");
+                  return (
+                    <button
+                      type="button"
+                      key={r.index}
+                      className={`dtree-row status-${r.status}`}
+                      title={`${r.label} — ${r.status}${ctx ? ` (context from ${ctx})` : ""}. Click for details.`}
+                      onClick={() => onSelect(r.index)}
+                    >
+                      <span className="dtree-line">
+                        {lastGroup ? "   " : "│  "}
+                        {last ? "└─" : "├─"}
+                      </span>
+                      <span className="dtree-glyph">{GLYPH[r.status] ?? "•"}</span>
+                      <span className="dtree-idx">#{r.index}</span>
+                      <span className="dtree-label">{clip(r.label, 28)}</span>
+                      {ctx && <span className="dtree-ctx">←{ctx}</span>}
+                      {r.status === "running" && (
+                        <span className="dtree-time caption">
+                          {elapsed(r.timestamp, r.completed_at)}
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webui/src/components/DelegationsPanel.tsx
+++ b/webui/src/components/DelegationsPanel.tsx
@@ -46,12 +46,17 @@ function elapsed(start?: string | null, end?: string | null): string {
 export function DelegationsPanel({
   view,
   running,
+  focus = null,
 }: {
   view: DelegationView | null;
   running: boolean;
+  focus?: number | null; // a delegation the sidebar tree asked to expand
 }) {
   const ui = useContext(UIContext);
   const [open, setOpen] = useState<number | null>(null);
+  useEffect(() => {
+    if (focus != null) setOpen(focus);
+  }, [focus]);
   const rows = view?.delegations ?? [];
   const subAgents = view?.sub_agents ?? {};
 

--- a/webui/src/components/Sidebar.tsx
+++ b/webui/src/components/Sidebar.tsx
@@ -5,7 +5,9 @@ import {
   type LiveSession,
   type ResumableSession,
   type SessionSnapshot,
+  type DelegationView,
 } from "../api";
+import { DelegationTree } from "./DelegationTree";
 import logoDark from "../assets/scilink_logo_dark_animated.svg";
 import logoLight from "../assets/scilink_logo_light_animated.svg";
 
@@ -36,6 +38,8 @@ export function Sidebar({
   onReset,
   onQuit,
   liveSessions,
+  delegations = null,
+  onSelectDelegation,
   onAttachSession,
   onCloseSession,
   onDetach,
@@ -55,6 +59,8 @@ export function Sidebar({
   onReset: () => void;
   onQuit: () => void;
   liveSessions: LiveSession[];
+  delegations?: DelegationView | null; // meta: live ledger for the tree
+  onSelectDelegation?: (index: number) => void;
   onAttachSession: (id: string) => void;
   onCloseSession: (id: string) => void;
   onDetach: () => void;
@@ -411,6 +417,16 @@ export function Sidebar({
               Reset Session
             </button>
           </div>
+        </div>
+      )}
+
+      {session && session.mode === "meta" && (
+        <div className="sidebar-section">
+          <DelegationTree
+            view={delegations}
+            running={status === "running"}
+            onSelect={(i) => onSelectDelegation?.(i)}
+          />
         </div>
       )}
 


### PR DESCRIPTION
## Summary

The live delegation overview now sits in the left sidebar, exactly where Streamlit had it: a compact tree under the session section, visible the whole time you chat, with one line per delegation (status glyph, number, short label, context arrows), colored by status and counting elapsed time while a delegation runs. Clicking a row opens that delegation's full detail.

The detail view is kept and its tab is renamed **Telemetry**, which is where the per-agent tool sequence and worker histories will join it later.

## Technical description

- `webui/src/components/DelegationTree.tsx` (new): the sidebar tree, the web twin of Streamlit's `_meta_delegation_tree`. Groups by specialist in a fixed order, box-drawing prefixes for the branch structure, status classes for color, a 1 s ticker while any row is running, a bounded scroll box (260 px). Reads the same `DelegationView` the detail panel uses; no backend change, no new events.
- `Sidebar.tsx`: optional `delegations` and `onSelectDelegation` props; renders the tree in a section after the session block for meta sessions only.
- `App.tsx`: tab renamed `telemetry` (label "Telemetry"); the count badge moves off the tab since the tree carries it; a sidebar click sets a `focusDelegation` and switches to the tab.
- `DelegationsPanel.tsx`: new `focus` prop expands the requested row; docstring reframed as the Telemetry-tab detail.
- Styles for the tree appended to `app.css`.
- Docs: `react_web_ui.md` describes the two surfaces; roadmap wording adjusted.

Verified in Chrome against a resumed meta session with one completed delegation: the tree renders under the session section with the row in green, and clicking it opens Telemetry with the delegation expanded. `tsc -b` clean. The bundle is not committed (built at release).