### PR TITLE
Multi-user hardening: token auth, per-user session roots, remote-safe UI

### DIFF
--- a/docs/react_ui_roadmap.md
+++ b/docs/react_ui_roadmap.md
@@ -48,12 +48,12 @@ restart, resume).
    the workflow by hand) and confirm the wheel on the release page carries
    the bundle; decide whether to enable PyPI trusted publishing
    (`PYPI_PUBLISH=true`) or keep uploading with twine.
-3. **Multi-user hardening** — the gate to sharing a lab-server URL:
-   token auth or documented reverse-proxy setup, per-user session
-   roots, and hide the "Use a folder on this machine…" menu item on a
-   non-loopback bind (it cannot work for a remote user). Per-session
-   isolation is already done; only authn/authz is missing. Until then:
-   SSH tunnel.
+3. ~~**Multi-user hardening**~~ — DONE 2026-09-08: `--token` /
+   `--users FILE` bearer + cookie auth, per-user session roots and
+   registries, a refused unauthenticated public bind, the local-folder
+   route hidden and refused on a remote bind, quit disabled on a shared
+   server, reverse-proxy docs. The single-user default is unchanged.
+   Remaining, on demand: per-user LLM credentials, sign-in rate limiting.
 4. **Shared file I/O + analysis-mode adoption (#481, on #397).** Extract
    `read_file` / `save_file` / `append_file` / `read_document` into one
    engine in `scilink/utils` (the `file_edit.py` pattern), land the JSON

--- a/docs/react_web_ui.md
+++ b/docs/react_web_ui.md
@@ -33,11 +33,73 @@ scilink-web --host 127.0.0.1 --port 8422 --session-root .
 ```
 
 `--session-root` is where sessions are created, where the resume list is
-discovered, and the fence for file serving. Binding a non-loopback `--host`
-prints a loud warning: there is **no authentication** in this first cut —
-anyone who can reach the port can execute code through the agents. For
-remote use, tunnel (`ssh -L 8422:127.0.0.1:8422 host`) or front it with an
-authenticating reverse proxy.
+discovered, and the fence for file serving. The default is the local
+single-user tool: loopback bind, no sign-in. To reach it from another
+machine either tunnel (`ssh -L 8422:127.0.0.1:8422 host`) or share it
+properly — see "Sharing on a lab server" below. A non-loopback `--host`
+without authentication is refused.
+
+## Sharing on a lab server
+
+```bash
+# per-user tokens: each user gets <session-root>/users/<name>/
+cat > users.json <<'JSON'
+{"alice": "<token>", "bob": "<token>"}
+JSON
+python -c 'import secrets; print(secrets.token_urlsafe(32))'   # make tokens
+scilink-web --host 0.0.0.0 --port 8422 --session-root /data/scilink --users users.json
+
+# or one shared token (single user, sessions stay in --session-root)
+scilink-web --host 0.0.0.0 --token "$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+# (SCILINK_WEB_TOKEN in the environment works too)
+```
+
+Give each person a sign-in link — `https://host/?token=<their token>` — or
+they paste the token on the sign-in screen. The page exchanges it for an
+HttpOnly cookie and scrubs it from the URL; the sidebar shows who is
+signed in and offers sign-out. Scripts use `Authorization: Bearer <token>`.
+
+What a shared server changes, and only a shared server:
+
+- every `/api/v1` call needs a token (bearer header or the login cookie);
+  `/auth/*` is public so the sign-in screen can load;
+- with `--users`, each user has an isolated session root and live-session
+  registry — another user's session id is a 404, and the resume list only
+  shows their own;
+- "Use a folder on this machine…" disappears from the upload menu and the
+  endpoints behind it (`/folders`, `/plan_dirs`) answer 403: the server is
+  not on the browser's machine, so upload the folder instead;
+- "Quit App" is disabled with `--users` (one person must not stop the
+  server for everyone);
+- cookie sessions live in memory, so a restart signs everyone out.
+
+TLS is the reverse proxy's job. Caddy:
+
+```
+scilink.lab.example.org {
+    reverse_proxy 127.0.0.1:8422
+}
+```
+
+nginx (the `X-Forwarded-Proto` header is what makes the cookie `Secure`;
+`proxy_buffering off` keeps the SSE stream live):
+
+```
+location / {
+    proxy_pass         http://127.0.0.1:8422;
+    proxy_set_header   Host $host;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_http_version 1.1;
+    proxy_buffering    off;
+    proxy_read_timeout 3600s;
+    client_max_body_size 2g;
+}
+```
+
+If the proxy itself authenticates every request (SSO, mTLS), run with
+`--insecure-no-auth` behind it. Not covered yet: per-user LLM credentials
+(entered per session in the sidebar as before; the server stores none),
+rate limiting on sign-in (put the proxy's in front if internet-facing).
 
 ## What's included (first cut)
 
@@ -159,7 +221,10 @@ webui/ (Vite + React + TS)  ──REST + SSE──►  scilink/server/ (FastAPI)
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/config` | modes, models, autonomy options, provider fields, credential availability, consent text |
+| GET | `/auth/me` | public: whether sign-in is required, who is signed in, `local_files` |
+| POST | `/auth/login` | access token → HttpOnly session cookie |
+| POST | `/auth/logout` | drop the cookie session |
+| GET | `/config` | modes, models, autonomy options, provider fields, credential availability, consent text, `auth`, `local_files` |
 | GET | `/sessions?mode=` | live sessions + resumable session dirs |
 | POST | `/sessions` | create, or resume with `resume_dir` |
 | GET/PATCH | `/sessions/{id}` | snapshot / rename |

--- a/scilink/server/app.py
+++ b/scilink/server/app.py
@@ -13,9 +13,9 @@ import mimetypes
 from pathlib import Path
 from typing import Optional
 
-from fastapi import FastAPI, File, Form, Header, HTTPException, UploadFile
+from fastapi import FastAPI, File, Form, Header, HTTPException, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 
 from scilink.providers import provider_for
 from scilink.ui.config import (
@@ -28,10 +28,12 @@ from scilink.ui.session_meta import save_session_name
 
 from . import files as files_mod
 from . import runner
+from .auth import COOKIE_NAME, DEFAULT_USER, AuthConfig, AuthMiddleware, user_root
 from .schemas import (
     CreateSessionRequest,
     FeedbackResponseRequest,
     FolderCheckRequest,
+    LoginRequest,
     PlanDirsRequest,
     RenameSessionRequest,
     SendMessageRequest,
@@ -50,34 +52,119 @@ CONSENT_TEXT = ("I understand that the agent will execute generated "
                 "Python code on my machine")
 
 
-def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
+def create_app(session_root: Path, serve_frontend: bool = True,
+               auth: Optional[AuthConfig] = None,
+               local_files: bool = True) -> FastAPI:
+    """``auth=None`` is the local tool: no authentication, one implicit
+    user whose sessions live in ``session_root``. With an ``AuthConfig``
+    every ``/api/v1`` call must carry a token (bearer header or the login
+    cookie); with per-user tokens each user gets ``<root>/users/<name>/``
+    and an isolated live-session registry. ``local_files=False`` (the CLI
+    sets it for a non-loopback bind) disables the endpoints that read
+    arbitrary paths on the server's machine (pasted folders, plan dirs)
+    — they only make sense when the browser and the server share a host."""
     app = FastAPI(title="SciLink Web", docs_url="/api/docs")
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
-        allow_methods=["*"], allow_headers=["*"],
+        allow_methods=["*"], allow_headers=["*"], allow_credentials=True,
         expose_headers=["X-Preview-Kind"],
     )
-    manager = SessionManager(session_root)
-    app.state.manager = manager
+    app.add_middleware(AuthMiddleware, auth=auth)
+    app.state.auth = auth
+    app.state.local_files = local_files
+    # One SessionManager per user root (a single shared one when auth is
+    # off or a single token is used) — the isolation boundary.
+    managers: dict = {}
+    session_root = session_root.resolve()
 
-    def _session_or_404(session_id: str) -> WebSession:
-        session = manager.get(session_id)
+    def _user(request: Request) -> str:
+        user = getattr(request.state, "user", None)
+        return user or DEFAULT_USER
+
+    def _mgr(request: Request) -> SessionManager:
+        user = _user(request)
+        mgr = managers.get(user)
+        if mgr is None:
+            mgr = SessionManager(user_root(session_root, auth, user))
+            managers[user] = mgr
+        return mgr
+    app.state.manager_for_user = lambda user: managers.get(user)
+    # Single-user deployments (auth off, or one shared token) have exactly
+    # one manager; expose it eagerly under the historical attribute so
+    # tests and tooling that reach for `app.state.manager` keep working.
+    # Multi-user servers have none to single out.
+    if auth is None or not auth.multi_user:
+        managers[DEFAULT_USER] = SessionManager(
+            user_root(session_root, auth, DEFAULT_USER))
+        app.state.manager = managers[DEFAULT_USER]
+    else:
+        app.state.manager = None
+
+    def _session_or_404(request: Request, session_id: str) -> WebSession:
+        session = _mgr(request).get(session_id)
         if session is None:
             raise HTTPException(404, f"No live session {session_id!r} — "
                                      "create or resume it first.")
         return session
 
+    def _require_local_files() -> None:
+        if not local_files:
+            raise HTTPException(
+                403, "Folders on the server's machine are not available on a "
+                     "remote deployment — upload the folder instead.")
+
+    # ── auth ─────────────────────────────────────────────────────
+
+    @app.get("/api/v1/auth/me")
+    def auth_me(request: Request):
+        """Who am I: whether sign-in is required and, if signed in, who."""
+        if auth is None:
+            return {"auth_required": False, "user": DEFAULT_USER,
+                    "multi_user": False, "local_files": local_files}
+        return {"auth_required": True, "user": auth.user_for_request(request),
+                "multi_user": auth.multi_user, "local_files": local_files}
+
+    @app.post("/api/v1/auth/login")
+    def auth_login(request: Request, body: LoginRequest):
+        """Exchange an access token for the HttpOnly session cookie the
+        browser needs (EventSource / <img> / downloads cannot send headers)."""
+        if auth is None:
+            return {"user": DEFAULT_USER}
+        cookie = auth.login(body.token)
+        if cookie is None:
+            raise HTTPException(401, "Invalid access token.")
+        user = auth.user_for_cookie(cookie)
+        resp = JSONResponse({"user": user})
+        secure = (request.headers.get("x-forwarded-proto", request.url.scheme)
+                  == "https")
+        resp.set_cookie(COOKIE_NAME, cookie, httponly=True, samesite="lax",
+                        secure=secure, path="/")
+        return resp
+
+    @app.post("/api/v1/auth/logout")
+    def auth_logout(request: Request):
+        if auth is not None:
+            auth.logout(request.cookies.get(COOKIE_NAME))
+        resp = JSONResponse({"ok": True})
+        resp.delete_cookie(COOKIE_NAME, path="/")
+        return resp
+
     # ── config ───────────────────────────────────────────────────
 
     @app.get("/api/v1/config")
-    def get_config(model: str = "", base_url: str = ""):
+    def get_config(request: Request, model: str = "", base_url: str = ""):
         """Static UI config + credential AVAILABILITY (never values)."""
         modes = [m for m in APP_MODES if m["key"] != "simulate"]
         model_q = model or MODEL_OPTIONS[0]
         prefill = resolve_prefill(model_q, existing_base_url=base_url)
         spec = provider_for(model_q)
         return {
+            "auth": {"required": auth is not None,
+                     "user": _user(request) if auth is None
+                     else auth.user_for_request(request),
+                     "multi_user": bool(auth and auth.multi_user)},
+            "local_files": local_files,
             "modes": modes,
             "models": MODEL_OPTIONS,
             "embedding_models": EMBEDDING_MODEL_OPTIONS,
@@ -106,18 +193,20 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
     # ── sessions ─────────────────────────────────────────────────
 
     @app.get("/api/v1/sessions")
-    def list_sessions(mode: str = "meta"):
-        return {"live": manager.list_live(),
-                "resumable": manager.discover_resumable(mode)}
+    def list_sessions(request: Request, mode: str = "meta"):
+        mgr = _mgr(request)
+        return {"live": mgr.list_live(),
+                "resumable": mgr.discover_resumable(mode)}
 
     @app.post("/api/v1/sessions")
-    def create_session(body: CreateSessionRequest):
+    def create_session(request: Request, body: CreateSessionRequest):
         if not body.consent:
             raise HTTPException(400, "Consent to code execution is required "
                                      "to start a session.")
+        mgr = _mgr(request)
         try:
             if body.resume_dir:
-                session = manager.resume(
+                session = mgr.resume(
                     resume_dir=body.resume_dir, mode=body.mode,
                     model=body.model, autonomy=body.autonomy,
                     api_key=body.api_key, base_url=body.base_url,
@@ -126,7 +215,7 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
                     embedding_model=body.embedding_model,
                     embedding_api_key=body.embedding_api_key)
             else:
-                session = manager.create(
+                session = mgr.create(
                     mode=body.mode, model=body.model, autonomy=body.autonomy,
                     api_key=body.api_key, base_url=body.base_url,
                     provider_fields=body.provider_fields,
@@ -136,23 +225,26 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
                     embedding_api_key=body.embedding_api_key)
         except SessionError as exc:
             raise HTTPException(400, str(exc))
-        return manager.snapshot(session)
+        return mgr.snapshot(session)
 
     @app.get("/api/v1/sessions/{session_id}")
-    def get_session(session_id: str):
-        return manager.snapshot(_session_or_404(session_id))
+    def get_session(request: Request, session_id: str):
+        return _mgr(request).snapshot(_session_or_404(request, session_id))
 
     @app.delete("/api/v1/sessions/{session_id}")
-    def reset_session(session_id: str):
+    def reset_session(request: Request, session_id: str):
         """Reset: stop and drop the live session (its dir stays resumable)."""
-        if not manager.remove(session_id):
+        if not _mgr(request).remove(session_id):
             raise HTTPException(404, f"No live session {session_id!r}.")
         return {"ok": True}
 
     @app.post("/api/v1/quit")
-    def quit_server():
+    def quit_server(request: Request):
         """Port of the Streamlit Quit App button (sidebar.py:550): reply
-        first, then terminate the server process."""
+        first, then terminate the server process. Refused on a shared
+        multi-user server — one user must not shut everyone down."""
+        if auth is not None and auth.multi_user:
+            raise HTTPException(403, "Quit is disabled on a shared server.")
         import os
         import signal
         import threading
@@ -161,8 +253,8 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
         return {"ok": True}
 
     @app.patch("/api/v1/sessions/{session_id}")
-    def rename_session(session_id: str, body: RenameSessionRequest):
-        session = _session_or_404(session_id)
+    def rename_session(request: Request, session_id: str, body: RenameSessionRequest):
+        session = _session_or_404(request, session_id)
         if not save_session_name(session.session_dir, body.name,
                                  named_by="user"):
             raise HTTPException(400, "Could not save the session name.")
@@ -172,8 +264,8 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
     # ── turns ────────────────────────────────────────────────────
 
     @app.post("/api/v1/sessions/{session_id}/messages", status_code=202)
-    def send_message(session_id: str, body: SendMessageRequest):
-        session = _session_or_404(session_id)
+    def send_message(request: Request, session_id: str, body: SendMessageRequest):
+        session = _session_or_404(request, session_id)
         content = body.content.strip()
         if not content:
             raise HTTPException(400, "Empty message.")
@@ -184,14 +276,14 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
         return {"status": "running"}
 
     @app.post("/api/v1/sessions/{session_id}/stop")
-    def stop(session_id: str):
-        session = _session_or_404(session_id)
+    def stop(request: Request, session_id: str):
+        session = _session_or_404(request, session_id)
         stopped = runner.request_stop(session)
         return {"stopped": stopped}
 
     @app.post("/api/v1/sessions/{session_id}/feedback")
-    def feedback(session_id: str, body: FeedbackResponseRequest):
-        session = _session_or_404(session_id)
+    def feedback(request: Request, session_id: str, body: FeedbackResponseRequest):
+        session = _session_or_404(request, session_id)
         turn = session.turn
         pending = turn.pending_question if turn is not None else None
         if pending is None or pending.hreq.id != body.request_id:
@@ -203,11 +295,11 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
     # ── SSE ──────────────────────────────────────────────────────
 
     @app.get("/api/v1/sessions/{session_id}/events")
-    def events(session_id: str, after: Optional[int] = None,
+    def events(request: Request, session_id: str, after: Optional[int] = None,
                last_event_id: Optional[str] = Header(default=None)):
         """SSE stream. ``Last-Event-ID`` (reconnects) wins over ``after``
         (initial attach from a snapshot's ``event_cursor``)."""
-        session = _session_or_404(session_id)
+        session = _session_or_404(request, session_id)
         try:
             cursor = int(last_event_id) if last_event_id else after
         except ValueError:
@@ -221,13 +313,15 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
     # ── pasted local folders (hero forms) ────────────────────────
 
     @app.post("/api/v1/sessions/{session_id}/folders")
-    def check_folders(session_id: str, body: FolderCheckRequest):
+    def check_folders(request: Request, session_id: str, body: FolderCheckRequest):
         """Validate pasted local folder paths and enumerate their tabular
         contents — the web twin of the Streamlit hero folder inputs
         (chat_uploads.py:176-266), which read the local filesystem directly.
         Local-tool posture: these are arbitrary machine paths, exactly as in
-        Streamlit; multi-user deployments gate this at the auth layer."""
-        _session_or_404(session_id)
+        Streamlit — refused (403) when the server is not on the browser's
+        machine (``local_files=False``)."""
+        _require_local_files()
+        _session_or_404(request, session_id)
         _DATA_EXTS = {".csv", ".xlsx", ".tsv", ".txt"}
 
         def _nat(f: Path):
@@ -270,11 +364,12 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
         return {"results": results}
 
     @app.post("/api/v1/sessions/{session_id}/plan_dirs")
-    def set_plan_dirs(session_id: str, body: PlanDirsRequest):
+    def set_plan_dirs(request: Request, session_id: str, body: PlanDirsRequest):
         """Repoint the planning agent's resource dirs at pasted folders (port
         of chat_uploads.py:269-279): stable source paths let the KB reuse its
         FAISS indexes across sessions instead of rebuilding."""
-        session = _session_or_404(session_id)
+        _require_local_files()
+        session = _session_or_404(request, session_id)
         agent = session.agent
         applied = {}
         for attr, raw in (("knowledge_dir", body.knowledge),
@@ -295,7 +390,7 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
     # ── files ────────────────────────────────────────────────────
 
     @app.post("/api/v1/sessions/{session_id}/uploads")
-    def upload(session_id: str, category: str = Form(...),
+    def upload(request: Request, session_id: str, category: str = Form(...),
                files: list[UploadFile] = File(...),
                paths: str = Form("")):
         """Multipart upload. ``paths`` (optional) is a JSON list of relative
@@ -303,7 +398,7 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
         preserved. It travels as its own field rather than in the part
         filenames because browsers are free to strip directory components
         from a Content-Disposition filename."""
-        session = _session_or_404(session_id)
+        session = _session_or_404(request, session_id)
         try:
             if paths:
                 import json as _json
@@ -324,43 +419,43 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
             raise HTTPException(400, str(exc))
 
     @app.get("/api/v1/sessions/{session_id}/tree")
-    def get_tree(session_id: str):
-        session = _session_or_404(session_id)
+    def get_tree(request: Request, session_id: str):
+        session = _session_or_404(request, session_id)
         from .tree import build_tree
         return build_tree(session.session_dir,
                           new_since=session.turn_started_at)
 
     @app.get("/api/v1/sessions/{session_id}/delegations")
-    def get_delegations(session_id: str):
+    def get_delegations(request: Request, session_id: str):
         """The meta session's delegation ledger for the Delegations tab
         (same payload as the `delegations` SSE event). Empty for other
         modes rather than an error, so the client can call it blindly."""
-        session = _session_or_404(session_id)
+        session = _session_or_404(request, session_id)
         from .delegations import delegation_view
         if session.mode != "meta":
             return {"delegations": [], "sub_agents": {}}
         return delegation_view(session.agent, session.session_dir)
 
     @app.get("/api/v1/sessions/{session_id}/telemetry")
-    def get_telemetry(session_id: str):
+    def get_telemetry(request: Request, session_id: str):
         """Full read-only telemetry snapshot (ledger, worker action
         histories, analysis reasoning, per-agent tool sequence) — the
         reader behind the Streamlit Telemetry tab, exposed for the web
         UI's future Telemetry view."""
-        session = _session_or_404(session_id)
+        session = _session_or_404(request, session_id)
         from scilink.agents.meta_agent.telemetry import collect_session_telemetry
         return collect_session_telemetry(session.agent)
 
     @app.get("/api/v1/sessions/{session_id}/provenance")
-    def get_provenance(session_id: str):
-        session = _session_or_404(session_id)
+    def get_provenance(request: Request, session_id: str):
+        session = _session_or_404(request, session_id)
         from .tree import load_provenance
         return {"events": load_provenance(session.session_dir)}
 
     @app.get("/api/v1/sessions/{session_id}/thumb")
-    def get_thumb(session_id: str, path: str, size: int = 256,
+    def get_thumb(request: Request, session_id: str, path: str, size: int = 256,
                   cmap: str = "viridis"):
-        session = _session_or_404(session_id)
+        session = _session_or_404(request, session_id)
         from fastapi.responses import Response
 
         from . import previews
@@ -379,8 +474,8 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
                                  "X-Preview-Kind": kind})
 
     @app.get("/api/v1/sessions/{session_id}/table")
-    def get_table(session_id: str, path: str, limit: int = 500):
-        session = _session_or_404(session_id)
+    def get_table(request: Request, session_id: str, path: str, limit: int = 500):
+        session = _session_or_404(request, session_id)
         from . import previews
         try:
             target = files_mod.resolve_safe(session.session_dir, path)
@@ -394,8 +489,8 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
             raise HTTPException(422, f"Could not read table {path}: {exc}")
 
     @app.get("/api/v1/sessions/{session_id}/zip")
-    def get_zip(session_id: str, path: str = ""):
-        session = _session_or_404(session_id)
+    def get_zip(request: Request, session_id: str, path: str = ""):
+        session = _session_or_404(request, session_id)
         from fastapi.responses import Response
 
         from .tree import zip_directory
@@ -413,8 +508,8 @@ def create_app(session_root: Path, serve_frontend: bool = True) -> FastAPI:
             headers={"Content-Disposition": f'attachment; filename="{name}"'})
 
     @app.get("/api/v1/sessions/{session_id}/files")
-    def get_file(session_id: str, path: str):
-        session = _session_or_404(session_id)
+    def get_file(request: Request, session_id: str, path: str):
+        session = _session_or_404(request, session_id)
         try:
             target = files_mod.resolve_safe(session.session_dir, path)
         except PermissionError as exc:

--- a/scilink/server/auth.py
+++ b/scilink/server/auth.py
@@ -1,0 +1,177 @@
+"""Token authentication and per-user identity for the web backend.
+
+Posture
+-------
+The default is unchanged: no auth, loopback bind, single implicit user —
+the local tool. Auth turns on when the operator configures tokens, and the
+CLI refuses a non-loopback bind without it (anyone who can reach the port
+can run code through the agents).
+
+Two shapes, both bearer tokens:
+
+* ``--token T`` / ``SCILINK_WEB_TOKEN``: one shared token, one user
+  (``default``) whose session root is ``--session-root`` itself — the
+  "share my machine's UI over a tunnel or proxy" case.
+* ``--users FILE``: a JSON object ``{"alice": "<token>", "bob": "<token>"}``.
+  Each user gets an isolated session root ``<session-root>/users/<name>/``,
+  their own live-session registry, and cannot see or attach to anyone
+  else's sessions.
+
+How a request authenticates
+---------------------------
+* ``Authorization: Bearer <token>`` on any request (scripts, curl), or
+* the ``scilink_web`` cookie, minted by ``POST /api/v1/auth/login`` from a
+  token — this is what the browser uses, because ``EventSource``, ``<img>``
+  and download links cannot carry headers. Cookie sessions live in memory
+  (a server restart logs everyone out) and are ``HttpOnly`` + ``SameSite=
+  Lax``; ``Secure`` is set when the request arrived over HTTPS (a reverse
+  proxy terminating TLS forwards ``X-Forwarded-Proto``).
+
+The middleware guards ``/api/v1/*`` only; the SPA shell and its assets are
+public so the login screen can load. ``/api/v1/auth/*`` is public by
+construction.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import secrets
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+COOKIE_NAME = "scilink_web"
+DEFAULT_USER = "default"
+_PUBLIC_PREFIXES = ("/api/v1/auth/",)
+_USERNAME_OK = set("abcdefghijklmnopqrstuvwxyz0123456789_-.")
+
+
+class AuthConfigError(ValueError):
+    """Bad token / users configuration (reported at startup, never at runtime)."""
+
+
+@dataclass
+class AuthConfig:
+    """Token → user table plus the in-memory cookie sessions."""
+
+    users: Dict[str, str]                       # user name -> token
+    multi_user: bool = False                    # per-user session roots
+    _cookies: Dict[str, str] = field(default_factory=dict)  # cookie id -> user
+
+    # -- construction ---------------------------------------------------
+    @classmethod
+    def single(cls, token: str) -> "AuthConfig":
+        token = (token or "").strip()
+        if len(token) < 16:
+            raise AuthConfigError(
+                "The access token must be at least 16 characters; generate "
+                "one with: python -c 'import secrets; print(secrets.token_urlsafe(32))'")
+        return cls(users={DEFAULT_USER: token}, multi_user=False)
+
+    @classmethod
+    def from_users_file(cls, path: Path) -> "AuthConfig":
+        try:
+            data = json.loads(Path(path).read_text())
+        except (OSError, ValueError) as exc:
+            raise AuthConfigError(f"Cannot read users file {path}: {exc}")
+        if not isinstance(data, dict) or not data:
+            raise AuthConfigError(
+                f"{path} must be a non-empty JSON object of {{\"name\": \"token\"}}")
+        users: Dict[str, str] = {}
+        for name, token in data.items():
+            n = str(name).strip()
+            if not n or set(n.lower()) - _USERNAME_OK or n in (".", ".."):
+                raise AuthConfigError(
+                    f"Bad user name {name!r}: letters, digits, '_', '-', '.' only")
+            t = str(token).strip()
+            if len(t) < 16:
+                raise AuthConfigError(f"Token for {n!r} must be at least 16 characters")
+            if t in users.values():
+                raise AuthConfigError(f"Token for {n!r} is not unique")
+            users[n] = t
+        return cls(users=users, multi_user=True)
+
+    # -- checks ---------------------------------------------------------
+    def user_for_token(self, token: str) -> Optional[str]:
+        """Constant-time match of a presented token against every user."""
+        presented = (token or "").encode()
+        match = None
+        for name, t in self.users.items():
+            if hmac.compare_digest(presented, t.encode()):
+                match = name       # keep scanning: no early exit on a hit
+        return match
+
+    def login(self, token: str) -> Optional[str]:
+        """Mint a cookie session for the token's user; returns the cookie
+        value, or None for an unknown token."""
+        user = self.user_for_token(token)
+        if user is None:
+            return None
+        cookie = secrets.token_urlsafe(32)
+        self._cookies[cookie] = user
+        return cookie
+
+    def logout(self, cookie: Optional[str]) -> None:
+        if cookie:
+            self._cookies.pop(cookie, None)
+
+    def user_for_cookie(self, cookie: Optional[str]) -> Optional[str]:
+        return self._cookies.get(cookie or "")
+
+    def user_for_request(self, request: Request) -> Optional[str]:
+        auth = request.headers.get("authorization", "")
+        if auth.lower().startswith("bearer "):
+            return self.user_for_token(auth[7:].strip())
+        return self.user_for_cookie(request.cookies.get(COOKIE_NAME))
+
+
+def user_root(session_root: Path, auth: Optional[AuthConfig], user: str) -> Path:
+    """Where a user's sessions live: the shared root unless per-user roots
+    are on, then ``<root>/users/<name>`` (created on first use)."""
+    if auth is None or not auth.multi_user:
+        return session_root
+    root = (session_root / "users" / user).resolve()
+    if root.parent != (session_root / "users").resolve():
+        raise AuthConfigError(f"User name escapes the users directory: {user!r}")
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+class AuthMiddleware:
+    """Pure-ASGI guard for ``/api/v1/*``: resolves the user onto
+    ``scope["state"]["user"]`` (``default`` when auth is off) and answers
+    401 JSON for unauthenticated API calls. Non-API paths pass through."""
+
+    def __init__(self, app: ASGIApp, auth: Optional[AuthConfig]) -> None:
+        self.app = app
+        self.auth = auth
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        path = scope.get("path", "")
+        state = scope.setdefault("state", {})
+        if self.auth is None:
+            state["user"] = DEFAULT_USER
+            await self.app(scope, receive, send)
+            return
+        if not path.startswith("/api/v1/") or path.startswith(_PUBLIC_PREFIXES):
+            state["user"] = None
+            await self.app(scope, receive, send)
+            return
+        user = self.auth.user_for_request(Request(scope))
+        if user is None:
+            response = JSONResponse(
+                {"detail": "Not authenticated. Sign in with your access token."},
+                status_code=401,
+                headers={"WWW-Authenticate": "Bearer"})
+            await response(scope, receive, send)
+            return
+        state["user"] = user
+        await self.app(scope, receive, send)

--- a/scilink/server/cli.py
+++ b/scilink/server/cli.py
@@ -1,10 +1,15 @@
 """``scilink-web`` — run the web backend (and, when built, the React UI).
 
-Local single-user posture: binds 127.0.0.1 with no auth by default; a
-non-loopback ``--host`` gets a loud warning (anyone who can reach the port
-can run code through the agents). Session directories are created under —
-and file serving is fenced to — ``--session-root`` (default: cwd, matching
-the Streamlit convention of launching from your data directory).
+Local single-user posture by default: binds 127.0.0.1 with no auth.
+Sharing beyond this machine requires authentication — ``--token`` (one
+shared token, one user) or ``--users FILE`` (per-user tokens, isolated
+session roots under ``<session-root>/users/<name>/``) — and a non-loopback
+``--host`` without either is refused (anyone who can reach the port can run
+code through the agents). Put TLS in front with a reverse proxy; see
+docs/react_web_ui.md "Sharing on a lab server". Session directories are
+created under — and file serving is fenced to — ``--session-root``
+(default: cwd, matching the Streamlit convention of launching from your
+data directory).
 """
 
 from __future__ import annotations
@@ -24,6 +29,18 @@ def main(argv=None) -> int:
                         help="Directory holding session dirs (default: cwd).")
     parser.add_argument("--no-open", action="store_true",
                         help="Do not open the browser automatically.")
+    parser.add_argument("--token", default=None,
+                        help="Require this access token (or set "
+                             "SCILINK_WEB_TOKEN). One shared user; sessions "
+                             "stay in --session-root.")
+    parser.add_argument("--users", default=None, metavar="FILE",
+                        help='JSON {"name": "token", ...}: per-user tokens '
+                             "with isolated session roots under "
+                             "<session-root>/users/<name>/.")
+    parser.add_argument("--insecure-no-auth", action="store_true",
+                        help="Allow a non-loopback --host WITHOUT any auth "
+                             "(only behind a reverse proxy that "
+                             "authenticates for you).")
     args = parser.parse_args(argv)
 
     try:
@@ -38,20 +55,53 @@ def main(argv=None) -> int:
         print(f"Session root does not exist: {session_root}", file=sys.stderr)
         return 1
 
-    if args.host not in ("127.0.0.1", "localhost", "::1"):
+    import os
+
+    from .auth import AuthConfig, AuthConfigError
+    loopback = args.host in ("127.0.0.1", "localhost", "::1")
+    auth = None
+    try:
+        if args.users and (args.token or os.environ.get("SCILINK_WEB_TOKEN")):
+            print("Use either --token / SCILINK_WEB_TOKEN or --users, not both.",
+                  file=sys.stderr)
+            return 2
+        if args.users:
+            auth = AuthConfig.from_users_file(Path(args.users).expanduser())
+        elif args.token or os.environ.get("SCILINK_WEB_TOKEN"):
+            auth = AuthConfig.single(args.token or os.environ["SCILINK_WEB_TOKEN"])
+    except AuthConfigError as exc:
+        print(f"scilink-web: {exc}", file=sys.stderr)
+        return 2
+
+    if not loopback and auth is None and not args.insecure_no_auth:
         print("=" * 70, file=sys.stderr)
-        print(f"WARNING: binding to {args.host} exposes the server beyond "
-              "this machine.\nThere is NO authentication: anyone who can "
-              "reach the port can execute\ncode on this machine through the "
-              "agents. Use an SSH tunnel or a reverse\nproxy with auth "
-              "instead of a raw public bind.", file=sys.stderr)
+        print(f"Refusing to bind {args.host} without authentication: anyone "
+              "who can reach the port\ncould execute code on this machine "
+              "through the agents.\n\nPass --token <secret> (or set "
+              "SCILINK_WEB_TOKEN), or --users FILE for per-user tokens.\n"
+              "Generate a token:  python -c 'import secrets; "
+              "print(secrets.token_urlsafe(32))'\nOnly behind a reverse "
+              "proxy that authenticates for you: --insecure-no-auth.",
+              file=sys.stderr)
         print("=" * 70, file=sys.stderr)
+        return 2
+    if not loopback and auth is None:
+        print("WARNING: non-loopback bind with NO authentication "
+              "(--insecure-no-auth). Make sure a reverse proxy in front "
+              "authenticates every request.", file=sys.stderr)
 
     from .app import NO_BUNDLE_MESSAGE, create_app
-    app = create_app(session_root)
+    # Pasted local folder paths only make sense when the browser and the
+    # server share a machine.
+    app = create_app(session_root, auth=auth, local_files=loopback)
     url = f"http://127.0.0.1:{args.port}"
     print(f"SciLink web backend on http://{args.host}:{args.port} "
           f"(sessions in {session_root})")
+    if auth is not None:
+        who = (f"{len(auth.users)} users, per-user session roots"
+               if auth.multi_user else "one shared token")
+        print(f"Authentication ON ({who}). Sign in with the token, or open "
+              f"{url}/?token=<your token> once.")
     if not getattr(app.state, "frontend_dir", None):
         print("=" * 70, file=sys.stderr)
         print(NO_BUNDLE_MESSAGE.rstrip(), file=sys.stderr)

--- a/scilink/server/schemas.py
+++ b/scilink/server/schemas.py
@@ -51,3 +51,9 @@ class PlanDirsRequest(BaseModel):
     knowledge: Optional[str] = None
     code: Optional[str] = None
     data: Optional[str] = None
+
+
+class LoginRequest(BaseModel):
+    """Access token → session cookie (POST /auth/login)."""
+
+    token: str

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -1,0 +1,151 @@
+"""Token auth + per-user isolation for the web backend (multi-user hardening).
+
+Default posture is unchanged (no auth → one implicit user, sessions in the
+root). With tokens: every /api/v1 call needs a bearer header or the login
+cookie; per-user tokens give isolated session roots and registries; the
+local-machine folder endpoints are refused on a remote deployment.
+"""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from scilink.server.app import create_app  # noqa: E402
+from scilink.server.auth import COOKIE_NAME, AuthConfig, AuthConfigError  # noqa: E402
+from scilink.server.session_manager import WebSession  # noqa: E402
+
+TOK_A = "alice-token-0123456789abcdef"
+TOK_B = "bob-token-0123456789abcdefgh"
+
+
+def _users_file(tmp_path):
+    f = tmp_path / "users.json"
+    f.write_text(json.dumps({"alice": TOK_A, "bob": TOK_B}))
+    return f
+
+
+def _fake_session(app, user, sdir_name="analysis_session_20260101_090909"):
+    mgr = app.state.manager_for_user(user)
+    sdir = Path(mgr.session_root) / sdir_name
+    sdir.mkdir(exist_ok=True)
+    session = WebSession(id=sdir.name, session_dir=str(sdir), mode="analyze",
+                         model="gpt-5.4", autonomy="autonomous",
+                         agent=SimpleNamespace())
+    mgr._sessions[sdir.name] = session
+    return session
+
+
+# ── config validation ────────────────────────────────────────────
+
+def test_auth_config_validation(tmp_path):
+    with pytest.raises(AuthConfigError):
+        AuthConfig.single("short")
+    single = AuthConfig.single(TOK_A)
+    assert single.user_for_token(TOK_A) == "default" and not single.multi_user
+    assert single.user_for_token("nope") is None
+    f = tmp_path / "u.json"
+    f.write_text(json.dumps({"alice": TOK_A, "bad/name": TOK_B}))
+    with pytest.raises(AuthConfigError):
+        AuthConfig.from_users_file(f)
+    f.write_text(json.dumps({"alice": TOK_A, "bob": TOK_A}))   # duplicate token
+    with pytest.raises(AuthConfigError):
+        AuthConfig.from_users_file(f)
+    f.write_text("[]")
+    with pytest.raises(AuthConfigError):
+        AuthConfig.from_users_file(f)
+    multi = AuthConfig.from_users_file(_users_file(tmp_path))
+    assert multi.multi_user and multi.user_for_token(TOK_B) == "bob"
+
+
+# ── no auth: unchanged posture ────────────────────────────────────
+
+def test_no_auth_is_open_and_single_root(tmp_path):
+    client = TestClient(create_app(tmp_path, serve_frontend=False))
+    me = client.get("/api/v1/auth/me").json()
+    assert me == {"auth_required": False, "user": "default",
+                  "multi_user": False, "local_files": True}
+    cfg = client.get("/api/v1/config").json()
+    assert cfg["auth"] == {"required": False, "user": "default", "multi_user": False}
+    assert cfg["local_files"] is True
+    assert Path(client.app.state.manager.session_root) == tmp_path.resolve()
+
+
+# ── single shared token ───────────────────────────────────────────
+
+def test_single_token_gate_bearer_and_cookie(tmp_path):
+    app = create_app(tmp_path, serve_frontend=False, auth=AuthConfig.single(TOK_A))
+    client = TestClient(app)
+    # API is closed without a credential; the SPA shell path is not an API path
+    r = client.get("/api/v1/config")
+    assert r.status_code == 401 and r.headers["www-authenticate"] == "Bearer"
+    assert client.get("/api/v1/auth/me").json()["user"] is None
+    # bearer header
+    r = client.get("/api/v1/config", headers={"Authorization": f"Bearer {TOK_A}"})
+    assert r.status_code == 200 and r.json()["auth"]["user"] == "default"
+    # cookie flow
+    assert client.post("/api/v1/auth/login", json={"token": "wrong"}).status_code == 401
+    r = client.post("/api/v1/auth/login", json={"token": TOK_A})
+    assert r.status_code == 200 and r.json()["user"] == "default"
+    assert COOKIE_NAME in r.cookies
+    assert client.get("/api/v1/sessions").status_code == 200   # cookie now set
+    assert client.get("/api/v1/auth/me").json()["user"] == "default"
+    # logout clears it
+    client.post("/api/v1/auth/logout")
+    assert client.get("/api/v1/sessions").status_code == 401
+    # single token: sessions live in the root itself (no users/ subtree)
+    assert Path(app.state.manager.session_root) == tmp_path.resolve()
+    assert not (tmp_path / "users").exists()
+
+
+# ── per-user tokens: isolation ────────────────────────────────────
+
+def test_multi_user_isolation(tmp_path):
+    auth = AuthConfig.from_users_file(_users_file(tmp_path))
+    app = create_app(tmp_path, serve_frontend=False, auth=auth)
+    assert app.state.manager is None            # nothing to single out
+    alice = TestClient(app, headers={"Authorization": f"Bearer {TOK_A}"})
+    bob = TestClient(app, headers={"Authorization": f"Bearer {TOK_B}"})
+    # first touch creates each user's root
+    assert alice.get("/api/v1/sessions").json() == {"live": [], "resumable": []}
+    assert bob.get("/api/v1/sessions").json() == {"live": [], "resumable": []}
+    assert (tmp_path / "users" / "alice").is_dir() and (tmp_path / "users" / "bob").is_dir()
+    # a live session of alice's is invisible and unreachable to bob
+    s = _fake_session(app, "alice")
+    assert [x["id"] for x in alice.get("/api/v1/sessions").json()["live"]] == [s.id]
+    assert bob.get("/api/v1/sessions").json()["live"] == []
+    assert bob.get(f"/api/v1/sessions/{s.id}").status_code == 404
+    assert bob.get(f"/api/v1/sessions/{s.id}/tree").status_code == 404
+    assert bob.delete(f"/api/v1/sessions/{s.id}").status_code == 404
+    assert alice.get(f"/api/v1/sessions/{s.id}").status_code == 200
+    # resumable discovery is per root too
+    (tmp_path / "users" / "bob" / "analysis_session_20260101_010101").mkdir()
+    (tmp_path / "users" / "bob" / "analysis_session_20260101_010101" / "checkpoint.json").write_text("{}")
+    assert [x["id"] for x in bob.get("/api/v1/sessions?mode=analyze").json()["resumable"]] == \
+        ["analysis_session_20260101_010101"]
+    assert alice.get("/api/v1/sessions?mode=analyze").json()["resumable"] == []
+    # shared server: quit is refused; config names the user
+    assert alice.post("/api/v1/quit").status_code == 403
+    assert alice.get("/api/v1/config").json()["auth"] == {
+        "required": True, "user": "alice", "multi_user": True}
+
+
+# ── remote deployment: no server-machine folders ─────────────────
+
+def test_local_files_gate(tmp_path):
+    app = create_app(tmp_path, serve_frontend=False, local_files=False)
+    client = TestClient(app)
+    s = _fake_session(app, "default")
+    assert client.get("/api/v1/config").json()["local_files"] is False
+    r = client.post(f"/api/v1/sessions/{s.id}/folders", json={"paths": ["/etc"]})
+    assert r.status_code == 403
+    r = client.post(f"/api/v1/sessions/{s.id}/plan_dirs", json={"knowledge": "/etc"})
+    assert r.status_code == 403
+    # uploads still work remotely
+    r = client.post(f"/api/v1/sessions/{s.id}/uploads", data={"category": "meta"},
+                    files=[("files", ("a.csv", b"1"))])
+    assert r.status_code == 200

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useReducer, useState } from "react";
 import {
   api,
+  UnauthorizedError,
   type AppConfig,
+  type AuthInfo,
   type ChatMessage,
   type DelegationView,
   type LiveSession,
@@ -17,6 +19,7 @@ import { FilesPanel } from "./components/FilesPanel";
 import { PreChatHero } from "./components/PreChatHero";
 import { AnalysisInset } from "./components/AnalysisInset";
 import { DelegationsPanel } from "./components/DelegationsPanel";
+import { LoginScreen } from "./components/LoginScreen";
 
 interface SessionState {
   snapshot: SessionSnapshot | null;
@@ -161,6 +164,12 @@ function reducer(state: SessionState, action: Action): SessionState {
 
 export default function App() {
   const [config, setConfig] = useState<AppConfig | null>(null);
+  // Auth gate: null = still asking the server; then either signed in (or
+  // auth off) or waiting for a token. A `?token=` link signs in silently.
+  const [auth, setAuth] = useState<AuthInfo | null>(null);
+  const [loginError, setLoginError] = useState<string | null>(null);
+  const [loginBusy, setLoginBusy] = useState(false);
+  const signedIn = auth !== null && (!auth.auth_required || auth.user !== null);
   const [mode, setMode] = useState("meta");
   const [theme, setTheme] = useState<"dark" | "light">("dark");
   const [busy, setBusy] = useState<string | null>(null); // init overlay text
@@ -223,8 +232,68 @@ export default function App() {
     document.documentElement.dataset.theme = theme;
   }, [theme]);
 
+  // Step 1: who am I (public endpoint). A `?token=…` in the URL is a
+  // sign-in link: exchange it for the cookie and scrub it from the URL so
+  // it is not left in history or shared by accident.
   useEffect(() => {
-    api.config().then(setConfig).catch((e) => setStartError(String(e)));
+    const url = new URL(window.location.href);
+    const linkToken = url.searchParams.get("token");
+    const finish = (info: AuthInfo) => setAuth(info);
+    (async () => {
+      try {
+        let info = await api.authMe();
+        if (info.auth_required && !info.user && linkToken) {
+          try {
+            await api.login(linkToken);
+            info = await api.authMe();
+          } catch (e) {
+            setLoginError(e instanceof Error ? e.message : String(e));
+          }
+        }
+        if (linkToken) {
+          url.searchParams.delete("token");
+          window.history.replaceState(null, "", url.pathname + url.search + url.hash);
+        }
+        finish(info);
+      } catch (e) {
+        setStartError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+  }, []);
+
+  const login = async (token: string) => {
+    setLoginBusy(true);
+    setLoginError(null);
+    try {
+      await api.login(token);
+      setAuth(await api.authMe());
+    } catch (e) {
+      setLoginError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoginBusy(false);
+    }
+  };
+
+  const logout = async () => {
+    try {
+      await api.logout();
+    } catch {
+      /* cookie may already be gone */
+    }
+    dispatch({ type: "session_closed" });
+    setConfig(null);
+    setAuth(await api.authMe().catch(() => ({
+      auth_required: true, user: null, multi_user: false, local_files: false,
+    })));
+  };
+
+  // Step 2 (signed in, or auth off): config + live sessions.
+  useEffect(() => {
+    if (!signedIn) return;
+    api.config().then(setConfig).catch((e) => {
+      if (e instanceof UnauthorizedError) setAuth((a) => (a ? { ...a, user: null } : a));
+      else setStartError(String(e));
+    });
     // Reattach on page load: exactly ONE live session (browser refresh,
     // second tab) rejoins it; several live sessions show a picker on the
     // welcome screen instead of guessing.
@@ -244,7 +313,8 @@ export default function App() {
         }
       })
       .catch(() => {});
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [signedIn]);
 
   // Keep the live-session list current: refresh on session/status changes
   // and on a slow poll, so the sidebar's detached-session statuses (running
@@ -366,6 +436,17 @@ export default function App() {
     );
   }
 
+  if (auth === null) {
+    return (
+      <div className="welcome">
+        <p className="tagline">{startError ?? "Connecting…"}</p>
+      </div>
+    );
+  }
+  if (!signedIn) {
+    return <LoginScreen onLogin={(t) => void login(t)} error={loginError} busy={loginBusy} />;
+  }
+
   return (
     <div className="layout">
       {!sidebarOpen && (
@@ -407,6 +488,8 @@ export default function App() {
         }}
         onDetach={detachSession}
         onCollapse={() => toggleSidebar(false)}
+        authUser={auth.auth_required ? auth.user : null}
+        onLogout={auth.auth_required ? () => void logout() : undefined}
         theme={theme}
         onToggleTheme={() => setTheme(theme === "dark" ? "light" : "dark")}
       />
@@ -480,6 +563,7 @@ export default function App() {
                 <PreChatHero
                   mode={mode}
                   sessionId={session.id}
+                  localFiles={auth.local_files}
                   onStart={sendMessage}
                 />
               ) : (

--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -16,7 +16,16 @@ export interface ProviderField {
   help: string;
 }
 
+export interface AuthInfo {
+  auth_required: boolean;
+  user: string | null; // null = not signed in
+  multi_user: boolean;
+  local_files: boolean; // server shares the browser's machine (loopback bind)
+}
+
 export interface AppConfig {
+  auth: { required: boolean; user: string | null; multi_user: boolean };
+  local_files: boolean;
   modes: ModeInfo[];
   models: string[];
   embedding_models: string[];
@@ -217,6 +226,10 @@ export interface CreateSessionBody {
 
 const BASE = "/api/v1";
 
+/** Thrown on a 401 so the app can drop to the sign-in screen (a cookie
+ * session ends when the server restarts). */
+export class UnauthorizedError extends Error {}
+
 async function req<T>(path: string, init?: RequestInit): Promise<T> {
   const r = await fetch(`${BASE}${path}`, init);
   if (!r.ok) {
@@ -226,6 +239,7 @@ async function req<T>(path: string, init?: RequestInit): Promise<T> {
     } catch {
       /* not json */
     }
+    if (r.status === 401) throw new UnauthorizedError(detail);
     throw new Error(detail);
   }
   return r.json() as Promise<T>;
@@ -238,6 +252,10 @@ const json = (body: unknown): RequestInit => ({
 });
 
 export const api = {
+  authMe: () => req<AuthInfo>(`/auth/me`),
+  login: (token: string) => req<{ user: string }>(`/auth/login`, json({ token })),
+  logout: () => req<{ ok: boolean }>(`/auth/logout`, { method: "POST" }),
+
   config: (model?: string, baseUrl?: string) =>
     req<AppConfig>(
       `/config?model=${encodeURIComponent(model ?? "")}&base_url=${encodeURIComponent(baseUrl ?? "")}`,

--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -732,3 +732,8 @@ details.card iframe { width: 100%; height: 600px; border: none; background: #fff
 .dtree-ctx { color: #58a6ff; font-size: 11px; white-space: nowrap; }
 .dtree-time { white-space: nowrap; }
 
+/* ── sign-in ────────────────────────────────────────────────── */
+.login-form { display: flex; gap: 8px; width: min(480px, 90%); margin: 12px auto 0; }
+.login-form input { flex: 1; }
+.signed-in { margin: 0 0 8px; }
+

--- a/webui/src/components/LoginScreen.tsx
+++ b/webui/src/components/LoginScreen.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+
+/** Access-token sign-in for a shared scilink-web server. The token is
+ * exchanged for an HttpOnly cookie by the backend (never stored by the
+ * page); a link of the form `/?token=…` signs in without this screen. */
+export function LoginScreen({
+  onLogin,
+  error,
+  busy,
+}: {
+  onLogin: (token: string) => void;
+  error: string | null;
+  busy: boolean;
+}) {
+  const [token, setToken] = useState("");
+  return (
+    <div className="welcome">
+      <h2>Sign in to SciLink</h2>
+      <p className="tagline">
+        This server requires an access token. Ask the person who runs it, or
+        open the sign-in link they gave you.
+      </p>
+      <form
+        className="login-form"
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (token.trim()) onLogin(token.trim());
+        }}
+      >
+        <input
+          type="password"
+          autoFocus
+          autoComplete="off"
+          placeholder="Access token"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          disabled={busy}
+        />
+        <button className="primary" type="submit" disabled={busy || !token.trim()}>
+          {busy ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+      {error && <p className="caption warn">{error}</p>}
+    </div>
+  );
+}

--- a/webui/src/components/PreChatHero.tsx
+++ b/webui/src/components/PreChatHero.tsx
@@ -21,17 +21,21 @@ const PLANNING_DATA_ACCEPT = ".csv,.xlsx,.tsv,.txt,.npy,.json";
 export function PreChatHero({
   mode,
   sessionId,
+  localFiles = true,
   onStart,
 }: {
   mode: string;
   sessionId: string;
+  /** Server shares the browser's machine: pasted server-side folder paths
+   * are offered. False on a remote deployment (the endpoint refuses too). */
+  localFiles?: boolean;
   onStart: (prompt: string) => void;
 }) {
   if (mode === "analyze")
     return <AnalyzeHero sessionId={sessionId} onStart={onStart} />;
   if (mode === "plan")
-    return <PlanHero sessionId={sessionId} onStart={onStart} />;
-  return <MetaHero sessionId={sessionId} onStart={onStart} />;
+    return <PlanHero sessionId={sessionId} localFiles={localFiles} onStart={onStart} />;
+  return <MetaHero sessionId={sessionId} localFiles={localFiles} onStart={onStart} />;
 }
 
 function AnalyzeHero({
@@ -148,9 +152,11 @@ function AnalyzeHero({
 
 function PlanHero({
   sessionId,
+  localFiles,
   onStart,
 }: {
   sessionId: string;
+  localFiles: boolean;
   onStart: (prompt: string) => void;
 }) {
   const [objective, setObjective] = useState("");
@@ -345,7 +351,7 @@ function PlanHero({
           <Dropzone label="Drop files here or click to browse" accept={KNOWLEDGE_ACCEPT}
             onFiles={uploader("knowledge", setKnowledge)}
             onFolder={folderUploader("knowledge", "knowledge")}
-            onLocalPath={() => setShowPath((p) => ({ ...p, k: true }))} />
+            onLocalPath={localFiles ? () => setShowPath((p) => ({ ...p, k: true })) : undefined} />
           {(showPath.k || kFolder) && (
             <input
               type="text"
@@ -364,7 +370,7 @@ function PlanHero({
           <Dropzone label="Drop files here or click to browse" accept={CODE_ACCEPT}
             onFiles={uploader("code", setCode)}
             onFolder={folderUploader("code", "code")}
-            onLocalPath={() => setShowPath((p) => ({ ...p, c: true }))} />
+            onLocalPath={localFiles ? () => setShowPath((p) => ({ ...p, c: true })) : undefined} />
           {(showPath.c || cFolder) && (
             <input
               type="text"
@@ -383,7 +389,7 @@ function PlanHero({
           <Dropzone label="Drop files here or click to browse" accept={PLANNING_DATA_ACCEPT}
             onFiles={uploader("planning_data", setData)}
             onFolder={folderUploader("planning_data", "data")}
-            onLocalPath={() => setShowPath((p) => ({ ...p, d: true }))} />
+            onLocalPath={localFiles ? () => setShowPath((p) => ({ ...p, d: true })) : undefined} />
           {(showPath.d || dFolder) && (
             <input
               type="text"
@@ -418,9 +424,11 @@ function PlanHero({
 
 function MetaHero({
   sessionId,
+  localFiles,
   onStart,
 }: {
   sessionId: string;
+  localFiles: boolean;
   onStart: (prompt: string) => void;
 }) {
   const [goal, setGoal] = useState("");
@@ -530,7 +538,7 @@ function MetaHero({
               setUploadedFolders((prev) => [...prev, r]);
               return [describeFolder(r.root, r.paths.length, r.dirs.length)];
             }}
-            onLocalPath={() => setShowPath(true)}
+            onLocalPath={localFiles ? () => setShowPath(true) : undefined}
           />
           {(showPath || folders) && (
             <input

--- a/webui/src/components/Sidebar.tsx
+++ b/webui/src/components/Sidebar.tsx
@@ -46,6 +46,8 @@ export function Sidebar({
   onCollapse,
   theme,
   onToggleTheme,
+  authUser = null,
+  onLogout,
 }: {
   config: AppConfig | null;
   mode: string;
@@ -67,6 +69,8 @@ export function Sidebar({
   onCollapse: () => void;
   theme: "dark" | "light";
   onToggleTheme: () => void;
+  authUser?: string | null; // set when the server requires sign-in
+  onLogout?: () => void;
 }) {
   const models = config?.models ?? [];
   const [model, setModel] = useState("");
@@ -177,6 +181,19 @@ export function Sidebar({
           {theme === "dark" ? "☀️" : "🌙"}
         </button>
       </div>
+      {authUser && (
+        <p className="caption signed-in">
+          Signed in as <strong>{authUser}</strong>
+          {onLogout && (
+            <>
+              {" · "}
+              <button type="button" className="link-btn" onClick={onLogout}>
+                Sign out
+              </button>
+            </>
+          )}
+        </p>
+      )}
       {session ? (
         <img
           className="logo"


### PR DESCRIPTION
## Summary

You can now run `scilink-web` on a lab server and share it with a group. Each person signs in with their own access token, gets their own private session space, and cannot see or touch anyone else's sessions.

- **Nothing changes for the usual single-user case.** With no flags, `scilink-web` behaves exactly as before: no sign-in, sessions in the directory you launched from, folder paths on your machine still offered. The existing 42 backend tests pass unchanged, and a no-flag run was checked in the browser: straight to the welcome screen, no sign-in, the upload menu still has all three items.
- **Sharing.** Start with `--users users.json` (a `{"name": "token"}` map) for per-user tokens, or `--token` / `SCILINK_WEB_TOKEN` for one shared token. Binding to a non-loopback address without either is refused with instructions. Hand each person a sign-in link of the form `https://host/?token=…`, or they paste the token on the sign-in screen. The sidebar shows who is signed in and offers sign-out.
- **Remote-safe.** On a shared server the "Use a folder on this machine" option disappears from the upload menu, and the endpoints behind it refuse. "Quit App" is disabled on a multi-user server so one person cannot shut it down for everyone.
- **TLS** is a reverse proxy's job; the docs give a Caddy one-liner and an nginx block.

Verified live with a two-user server bound to all interfaces: sign-in gate, isolation in both directions, cookie flow for the event stream, per-user directories on disk, and the browser sign-in link, hidden folder item, and sign-out.

## Technical description

### Backend

- `scilink/server/auth.py` (new). `AuthConfig.single(token)` and `AuthConfig.from_users_file(path)` (validated names, tokens ≥ 16 chars, unique). Tokens are compared with `hmac.compare_digest` across all users without early exit. Two credential carriers: `Authorization: Bearer <token>` (scripts, curl) and the `scilink_web` cookie minted by `POST /api/v1/auth/login` (HttpOnly, SameSite=Lax, Secure when the request came over HTTPS per `X-Forwarded-Proto`). Cookie sessions are in memory, so a server restart logs everyone out. `AuthMiddleware` is pure ASGI: guards `/api/v1/*` except `/api/v1/auth/*`, sets `scope.state.user` (`default` when auth is off), answers 401 JSON with `WWW-Authenticate: Bearer`. `user_root(session_root, auth, user)` returns the shared root unless per-user roots are on, then `<root>/users/<name>/`, created on first use and fenced against escaping names.
- `scilink/server/app.py`: `create_app(session_root, serve_frontend, auth=None, local_files=True)`. One `SessionManager` per user root, created lazily via `_mgr(request)`; every endpoint takes the request and resolves its manager and session through the requesting user, so another user's session id is simply a 404. For auth-off and single-token deployments the default manager is created eagerly and exposed as `app.state.manager`, the historical attribute tests rely on; multi-user servers expose `app.state.manager_for_user(name)`. New endpoints `GET /auth/me`, `POST /auth/login`, `POST /auth/logout`. `/folders` and `/plan_dirs` return 403 when `local_files` is false. `/quit` returns 403 on a multi-user server. `/config` gains `auth {required, user, multi_user}` and `local_files`. CORS now allows credentials for the Vite dev origin.
- `scilink/server/cli.py`: `--token`, `--users FILE`, `--insecure-no-auth`; a non-loopback `--host` without auth exits 2 with the reason and a token-generation one-liner; `local_files` is set from whether the bind is loopback; startup prints the auth mode and the sign-in link form.
- `scilink/server/schemas.py`: `LoginRequest`.

### Frontend

- `api.ts`: `UnauthorizedError` on 401, `authMe` / `login` / `logout`, `AuthInfo`, `auth` and `local_files` on the config type.
- `App.tsx`: asks `/auth/me` first (public). If sign-in is required and the URL carries `?token=`, exchanges it for the cookie and scrubs the parameter from the URL before anything else loads; otherwise shows `LoginScreen`. Config and sessions load only once signed in. A 401 on config drops back to sign-in. Sign-out clears state and returns to the screen.
- `LoginScreen.tsx` (new): token field and button; the token is only ever sent to `/auth/login`, never stored by the page.
- `Sidebar.tsx`: "Signed in as … · Sign out" when the server requires auth.
- `PreChatHero.tsx`: `localFiles` prop (default true); when false the plan and meta heroes pass no `onLocalPath`, so the menu has no local-folder item and the path inputs never appear.

### Tests

`tests/test_web_auth.py` (new, 5): config validation; no-auth posture unchanged (open API, `default` user, root is the session root); single token via bearer and via cookie including logout and no `users/` subtree; multi-user isolation (per-user roots created on first touch, live sessions and resumable discovery invisible across users, 404 on another user's session for GET/tree/DELETE, quit 403, config names the user); `local_files=False` gating of `/folders` and `/plan_dirs` with uploads still allowed. Existing `tests/test_web_server.py`: 42 pass unchanged. `tsc -b` clean.

### Docs

`docs/react_web_ui.md`: new "Sharing on a lab server" section (flags, users file, sign-in link, reverse proxy examples for Caddy and nginx, what is disabled remotely, what is not yet covered). Roadmap: multi-user hardening marked done.

### Not covered, on purpose

- Per-user LLM credentials are entered per session in the sidebar as before; the server does not store them.
- No rate limiting on `/auth/login`; tokens are long random strings. Put the proxy's rate limit in front if the server is internet-facing.
- Cookie sessions do not survive a server restart.
