### PR TITLE
MCP tab: connect servers to the session's agent

### DIFF
--- a/docs/react_ui_roadmap.md
+++ b/docs/react_ui_roadmap.md
@@ -72,13 +72,14 @@ restart, resume).
    script in analyze mode is a separate decision (it would change the
    foundation agents' generate-verify-lock contract); until then the
    verbatim routes are MCP or a package `TOOL_SPEC` contribution.
-6. **Remaining panels, on demand** — Tools = MCP connect + the read-only
-   tool inventory, **without** the Streamlit tool-file uploader (its
-   `tool_schemas` / `create_tool_functions` contract is dropped: the
-   attach-a-script path replaces it for adaptation, MCP for verbatim);
-   Telemetry (the `/telemetry` endpoint already serves the full reader;
-   what is left is the per-agent tool sequence and worker action
-   histories); Skills (browse/upload first; the persistent-memory
+6. **Remaining panels, on demand** — ~~Tools~~ DONE 2026-09-08 (MCP
+   connect + the read-only tool inventory, without the Streamlit
+   tool-file uploader, whose `tool_schemas` / `create_tool_functions`
+   contract is dropped: the attach-a-script path replaces it for
+   adaptation, MCP for verbatim); Telemetry (the tab exists with the
+   per-delegation detail; the `/telemetry` endpoint already serves the
+   full reader, so what is left is the per-agent tool sequence and worker
+   action histories); Skills (browse/upload first; the persistent-memory
    pipeline UI is a separate, bigger design). Build when actually missed.
 7. **Parity for the switch to default** (see "Standing decisions"):
    simulate mode in the web UI (HPC connection, wizards) is the largest

--- a/docs/react_web_ui.md
+++ b/docs/react_web_ui.md
@@ -162,9 +162,9 @@ rate limiting on sign-in (put the proxy's in front if internet-facing).
   histories (already served by `/telemetry`) are the tab's next content.
 - **MCP tab** (all modes): connect MCP servers — a `stdio` command, an
   SSE URL, or a streamable-HTTP URL with optional JSON headers — and
-  disconnect them. Below, collapsed as a reference, what the session's
-  agent can already call: each server's tools, other registered external
-  tools, and the built-in orchestrator tools with a filter. There is deliberately no tool-file
+  disconnect them; each server card lists the tools it registered. The
+  agent's own built-in tools are not listed: in a meta session that would
+  be only the meta's routing tools, not what the specialists can do. There is deliberately no tool-file
   uploader (the Streamlit `tool_schemas` / `create_tool_functions` contract
   is not ported): users hand code to the agents as scripts attached in
   chat, adapted by codegen, or as MCP servers, run verbatim in any
@@ -252,7 +252,7 @@ webui/ (Vite + React + TS)  ──REST + SSE──►  scilink/server/ (FastAPI)
 | GET | `/sessions/{id}/thumb?path=&size=&cmap=` | PNG thumbnail; NPY/TIFF rendered as normalized heatmaps |
 | GET | `/sessions/{id}/table?path=&limit=` | CSV/TSV/XLSX head as JSON columns+rows |
 | GET | `/sessions/{id}/zip?path=` | zip a session subdirectory (or the whole session) |
-| GET | `/sessions/{id}/tools` | built-in tools, external (MCP) tools, connected MCP servers, `mcp_supported` |
+| GET | `/sessions/{id}/tools` | connected MCP servers with their tools, other external tools, `mcp_supported` |
 | POST | `/sessions/{id}/mcp` | connect an MCP server (`name`, `transport` stdio/sse/http, `command` or `url`, `headers`) |
 | DELETE | `/sessions/{id}/mcp/{name}` | disconnect it |
 | GET | `/sessions/{id}/delegations` | meta: the delegation ledger shaped for the sidebar tree and Telemetry tab (empty for other modes) |

--- a/docs/react_web_ui.md
+++ b/docs/react_web_ui.md
@@ -160,6 +160,18 @@ rate limiting on sign-in (put the proxy's in front if internet-facing).
   `delegations` SSE events as the ledger changes mid-turn, and survive
   refresh and resume. The per-agent tool sequence and worker action
   histories (already served by `/telemetry`) are the tab's next content.
+- **Tools tab** (all modes): connect MCP servers — a `stdio` command, an
+  SSE URL, or a streamable-HTTP URL with optional JSON headers — and see
+  what the session's agent can call: each server's tools, other registered
+  external tools, and the built-in orchestrator tools with a filter.
+  Disconnect from the same panel. There is deliberately no tool-file
+  uploader (the Streamlit `tool_schemas` / `create_tool_functions` contract
+  is not ported): users hand code to the agents as scripts attached in
+  chat, adapted by codegen, or as MCP servers, run verbatim in any
+  language. A `stdio` command runs on the server's machine — the same
+  trust as the agents' own code execution, which every session consents
+  to; on a shared server `${VAR}` in header values is not expanded from
+  the server environment.
 - **Sessions**: the server holds many live sessions; the sidebar lists the
   others with one-click switching, Detach leaves a session running while
   you start or join another, and the welcome screen offers reattach when
@@ -188,8 +200,8 @@ rate limiting on sign-in (put the proxy's in front if internet-facing).
   - deep links: the tab and selected file live in the URL hash, so a
     refresh (or shared link) lands on the same file.
 
-Not yet ported: simulate mode, the Tools / Skills tabs, the Telemetry tab's
-per-agent tool sequence (the `/telemetry` endpoint already serves it), vibes.
+Not yet ported: simulate mode, the Skills tab, the Telemetry tab's per-agent
+tool sequence (the `/telemetry` endpoint already serves it), vibes.
 
 ## Architecture
 
@@ -240,6 +252,9 @@ webui/ (Vite + React + TS)  ──REST + SSE──►  scilink/server/ (FastAPI)
 | GET | `/sessions/{id}/thumb?path=&size=&cmap=` | PNG thumbnail; NPY/TIFF rendered as normalized heatmaps |
 | GET | `/sessions/{id}/table?path=&limit=` | CSV/TSV/XLSX head as JSON columns+rows |
 | GET | `/sessions/{id}/zip?path=` | zip a session subdirectory (or the whole session) |
+| GET | `/sessions/{id}/tools` | built-in tools, external (MCP) tools, connected MCP servers, `mcp_supported` |
+| POST | `/sessions/{id}/mcp` | connect an MCP server (`name`, `transport` stdio/sse/http, `command` or `url`, `headers`) |
+| DELETE | `/sessions/{id}/mcp/{name}` | disconnect it |
 | GET | `/sessions/{id}/delegations` | meta: the delegation ledger shaped for the sidebar tree and Telemetry tab (empty for other modes) |
 | GET | `/sessions/{id}/telemetry` | meta: full read-only telemetry snapshot (ledger, worker action histories, analysis reasoning, tool sequence) |
 | GET | `/sessions/{id}/provenance` | tool-call timeline from every `events.jsonl` under the session |

--- a/docs/react_web_ui.md
+++ b/docs/react_web_ui.md
@@ -160,11 +160,11 @@ rate limiting on sign-in (put the proxy's in front if internet-facing).
   `delegations` SSE events as the ledger changes mid-turn, and survive
   refresh and resume. The per-agent tool sequence and worker action
   histories (already served by `/telemetry`) are the tab's next content.
-- **Tools tab** (all modes): connect MCP servers — a `stdio` command, an
-  SSE URL, or a streamable-HTTP URL with optional JSON headers — and see
-  what the session's agent can call: each server's tools, other registered
-  external tools, and the built-in orchestrator tools with a filter.
-  Disconnect from the same panel. There is deliberately no tool-file
+- **MCP tab** (all modes): connect MCP servers — a `stdio` command, an
+  SSE URL, or a streamable-HTTP URL with optional JSON headers — and
+  disconnect them. Below, collapsed as a reference, what the session's
+  agent can already call: each server's tools, other registered external
+  tools, and the built-in orchestrator tools with a filter. There is deliberately no tool-file
   uploader (the Streamlit `tool_schemas` / `create_tool_functions` contract
   is not ported): users hand code to the agents as scripts attached in
   chat, adapted by codegen, or as MCP servers, run verbatim in any

--- a/scilink/server/app.py
+++ b/scilink/server/app.py
@@ -430,8 +430,8 @@ def create_app(session_root: Path, serve_frontend: bool = True,
 
     @app.get("/api/v1/sessions/{session_id}/tools")
     def get_tools(request: Request, session_id: str):
-        """What the session's agent can call: built-in tools, external
-        (MCP) tools, and the connected MCP servers."""
+        """The connected MCP servers and the external tools they (or
+        anything else) registered with the session's agent."""
         from .tools_api import tool_inventory
         return tool_inventory(_session_or_404(request, session_id).agent)
 

--- a/scilink/server/app.py
+++ b/scilink/server/app.py
@@ -34,6 +34,7 @@ from .schemas import (
     FeedbackResponseRequest,
     FolderCheckRequest,
     LoginRequest,
+    MCPConnectRequest,
     PlanDirsRequest,
     RenameSessionRequest,
     SendMessageRequest,
@@ -424,6 +425,44 @@ def create_app(session_root: Path, serve_frontend: bool = True,
         from .tree import build_tree
         return build_tree(session.session_dir,
                           new_since=session.turn_started_at)
+
+    # ── tools / MCP ──────────────────────────────────────────────
+
+    @app.get("/api/v1/sessions/{session_id}/tools")
+    def get_tools(request: Request, session_id: str):
+        """What the session's agent can call: built-in tools, external
+        (MCP) tools, and the connected MCP servers."""
+        from .tools_api import tool_inventory
+        return tool_inventory(_session_or_404(request, session_id).agent)
+
+    @app.post("/api/v1/sessions/{session_id}/mcp")
+    def connect_mcp_server(request: Request, session_id: str,
+                           body: MCPConnectRequest):
+        """Connect an MCP server (stdio command, SSE or streamable-HTTP
+        URL) and register its tools with the agent. A stdio command runs
+        on the server's machine — the same trust as the agents' own code
+        execution, which every session already consents to."""
+        from .tools_api import MCPError, connect_mcp, tool_inventory
+        session = _session_or_404(request, session_id)
+        try:
+            n = connect_mcp(session.agent, name=body.name,
+                            transport=body.transport, command=body.command,
+                            url=body.url, headers=body.headers,
+                            expand_env=local_files)
+        except MCPError as exc:
+            raise HTTPException(exc.status, str(exc))
+        return {"registered": n, "inventory": tool_inventory(session.agent)}
+
+    @app.delete("/api/v1/sessions/{session_id}/mcp/{server_name}")
+    def disconnect_mcp_server(request: Request, session_id: str,
+                              server_name: str):
+        from .tools_api import MCPError, disconnect_mcp, tool_inventory
+        session = _session_or_404(request, session_id)
+        try:
+            disconnect_mcp(session.agent, server_name)
+        except MCPError as exc:
+            raise HTTPException(exc.status, str(exc))
+        return {"ok": True, "inventory": tool_inventory(session.agent)}
 
     @app.get("/api/v1/sessions/{session_id}/delegations")
     def get_delegations(request: Request, session_id: str):

--- a/scilink/server/schemas.py
+++ b/scilink/server/schemas.py
@@ -57,3 +57,14 @@ class LoginRequest(BaseModel):
     """Access token → session cookie (POST /auth/login)."""
 
     token: str
+
+
+
+class MCPConnectRequest(BaseModel):
+    """Connect an MCP server to the session's agent (POST /mcp)."""
+
+    name: str
+    transport: str = "stdio"            # stdio | sse | http
+    command: str = ""                   # stdio: "npx -y @scope/server /path"
+    url: str = ""                       # sse / http
+    headers: Optional[Dict[str, str]] = None

--- a/scilink/server/tools_api.py
+++ b/scilink/server/tools_api.py
@@ -1,0 +1,110 @@
+"""Tool inventory + MCP server management for the web UI's Tools tab.
+
+Read-only over what the orchestrators already expose — ``tools.openai_schemas``
+(the registered tool surface), ``_external_tools`` (tools registered from
+outside, today MCP), ``_mcp_connections`` (name -> MCPConnection) — plus
+thin wrappers over ``connect_mcp_server`` / ``disconnect_mcp_server``.
+Every orchestrator (analysis, planning, meta) has the same three methods;
+a session whose agent lacks them reports ``mcp_supported: False``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+_DESC_MAX = 600
+
+
+def _clip(text: Any) -> str:
+    s = " ".join(str(text or "").split())
+    return s if len(s) <= _DESC_MAX else s[:_DESC_MAX - 1] + "…"
+
+
+def tool_inventory(agent: Any) -> Dict[str, Any]:
+    """``{builtin, external, mcp_servers, mcp_supported}`` for one agent."""
+    external = [{"name": str(t.get("name", "")), "description": _clip(t.get("description"))}
+                for t in (getattr(agent, "_external_tools", None) or [])
+                if isinstance(t, dict) and t.get("name")]
+    external_names = {t["name"] for t in external}
+
+    builtin: List[Dict[str, str]] = []
+    tools = getattr(agent, "tools", None)
+    for td in (getattr(tools, "openai_schemas", None) or []):
+        fn = td.get("function", {}) if isinstance(td, dict) else {}
+        name = fn.get("name")
+        if name and name not in external_names:
+            builtin.append({"name": name, "description": _clip(fn.get("description"))})
+    builtin.sort(key=lambda t: t["name"])
+
+    servers: List[Dict[str, Any]] = []
+    for name, conn in (getattr(agent, "_mcp_connections", None) or {}).items():
+        schemas = getattr(conn, "tool_schemas", None) or []
+        tool_names = []
+        for s in schemas:
+            fn = s.get("function", {}) if isinstance(s, dict) else {}
+            if fn.get("name"):
+                tool_names.append(fn["name"])
+        transport = ("stdio" if getattr(conn, "command", None)
+                     else getattr(conn, "transport", None) or "sse")
+        servers.append({"name": str(name), "transport": transport,
+                        "tools": tool_names})
+    return {
+        "builtin": builtin,
+        "external": external,
+        "mcp_servers": servers,
+        "mcp_supported": callable(getattr(agent, "connect_mcp_server", None)),
+    }
+
+
+class MCPError(Exception):
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+def connect_mcp(agent: Any, *, name: str, transport: str, command: str = "",
+                url: str = "", headers: Optional[Dict[str, str]] = None,
+                expand_env: bool = True) -> int:
+    """Connect an MCP server through the agent's own method. Returns the
+    number of tools registered. ``expand_env`` expands ``${VAR}`` in header
+    values from the server's environment (so tokens stay out of the form);
+    off on a shared server, where a remote user must not read its env."""
+    if not callable(getattr(agent, "connect_mcp_server", None)):
+        raise MCPError(400, "This session's agent does not support MCP servers.")
+    name = (name or "").strip()
+    if not name:
+        raise MCPError(400, "Provide a server name.")
+    if name in (getattr(agent, "_mcp_connections", None) or {}):
+        raise MCPError(409, f"'{name}' is already connected.")
+    if transport not in ("stdio", "sse", "http"):
+        raise MCPError(400, f"Unknown transport {transport!r}.")
+    hdrs = None
+    if headers:
+        hdrs = {str(k): (os.path.expandvars(str(v)) if expand_env else str(v))
+                for k, v in headers.items()}
+    try:
+        if transport == "stdio":
+            parts = (command or "").split()
+            if not parts:
+                raise MCPError(400, "Provide the command to run.")
+            return int(agent.connect_mcp_server(name, command=parts))
+        if not (url or "").strip():
+            raise MCPError(400, "Provide the server URL.")
+        return int(agent.connect_mcp_server(name, url=url.strip(),
+                                            transport=transport, headers=hdrs))
+    except MCPError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - surface the connection failure
+        raise MCPError(400, f"Failed to connect: {exc}")
+
+
+def disconnect_mcp(agent: Any, name: str) -> None:
+    if not callable(getattr(agent, "disconnect_mcp_server", None)):
+        raise MCPError(400, "This session's agent does not support MCP servers.")
+    if name not in (getattr(agent, "_mcp_connections", None) or {}):
+        raise MCPError(404, f"No MCP server named '{name}'.")
+    try:
+        agent.disconnect_mcp_server(name)
+    except Exception as exc:  # noqa: BLE001
+        raise MCPError(400, f"Failed to disconnect: {exc}")

--- a/scilink/server/tools_api.py
+++ b/scilink/server/tools_api.py
@@ -1,11 +1,13 @@
 """Tool inventory + MCP server management for the web UI's Tools tab.
 
-Read-only over what the orchestrators already expose — ``tools.openai_schemas``
-(the registered tool surface), ``_external_tools`` (tools registered from
-outside, today MCP), ``_mcp_connections`` (name -> MCPConnection) — plus
-thin wrappers over ``connect_mcp_server`` / ``disconnect_mcp_server``.
-Every orchestrator (analysis, planning, meta) has the same three methods;
-a session whose agent lacks them reports ``mcp_supported: False``.
+Read-only over what the orchestrators already expose — ``_external_tools``
+(tools registered from outside, today MCP) and ``_mcp_connections`` (name
+-> MCPConnection) — plus thin wrappers over ``connect_mcp_server`` /
+``disconnect_mcp_server``. Every orchestrator (analysis, planning, meta)
+has the same methods; a session whose agent lacks them reports
+``mcp_supported: False``. The agent's own built-in tools are deliberately
+not listed: in a meta session they would be only the meta's routing
+tools, not what the specialists and sub-agents can do, which misleads.
 """
 
 from __future__ import annotations
@@ -22,20 +24,10 @@ def _clip(text: Any) -> str:
 
 
 def tool_inventory(agent: Any) -> Dict[str, Any]:
-    """``{builtin, external, mcp_servers, mcp_supported}`` for one agent."""
+    """``{external, mcp_servers, mcp_supported}`` for one agent."""
     external = [{"name": str(t.get("name", "")), "description": _clip(t.get("description"))}
                 for t in (getattr(agent, "_external_tools", None) or [])
                 if isinstance(t, dict) and t.get("name")]
-    external_names = {t["name"] for t in external}
-
-    builtin: List[Dict[str, str]] = []
-    tools = getattr(agent, "tools", None)
-    for td in (getattr(tools, "openai_schemas", None) or []):
-        fn = td.get("function", {}) if isinstance(td, dict) else {}
-        name = fn.get("name")
-        if name and name not in external_names:
-            builtin.append({"name": name, "description": _clip(fn.get("description"))})
-    builtin.sort(key=lambda t: t["name"])
 
     servers: List[Dict[str, Any]] = []
     for name, conn in (getattr(agent, "_mcp_connections", None) or {}).items():
@@ -50,7 +42,6 @@ def tool_inventory(agent: Any) -> Dict[str, Any]:
         servers.append({"name": str(name), "transport": transport,
                         "tools": tool_names})
     return {
-        "builtin": builtin,
         "external": external,
         "mcp_servers": servers,
         "mcp_supported": callable(getattr(agent, "connect_mcp_server", None)),

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1037,7 +1037,7 @@ def test_tools_inventory_and_mcp_lifecycle(client, tmp_path):
     session.agent = _FakeMcpAgent()
     base = f"/api/v1/sessions/{sdir.name}"
     inv = client.get(f"{base}/tools").json()
-    assert [t["name"] for t in inv["builtin"]] == ["examine_data", "run_analysis"]
+    assert "builtin" not in inv                      # meta-only view would mislead
     assert inv["external"] == [] and inv["mcp_servers"] == [] and inv["mcp_supported"]
     # stdio connect: command split into argv
     r = client.post(f"{base}/mcp", json={"name": "calc", "transport": "stdio",
@@ -1047,7 +1047,6 @@ def test_tools_inventory_and_mcp_lifecycle(client, tmp_path):
     inv = r.json()["inventory"]
     assert inv["mcp_servers"] == [{"name": "calc", "transport": "stdio", "tools": ["calc_add"]}]
     assert inv["external"] == [{"name": "calc_add", "description": "Add."}]
-    assert [t["name"] for t in inv["builtin"]] == ["examine_data", "run_analysis"]
     # duplicate name → 409; http transport with headers; failure → 400
     assert client.post(f"{base}/mcp", json={"name": "calc", "transport": "stdio", "command": "x"}).status_code == 409
     r = client.post(f"{base}/mcp", json={"name": "remote", "transport": "http",
@@ -1065,7 +1064,7 @@ def test_tools_inventory_and_mcp_lifecycle(client, tmp_path):
     # an agent without MCP support
     session.agent = SimpleNamespace()
     inv = client.get(f"{base}/tools").json()
-    assert inv["mcp_supported"] is False and inv["builtin"] == []
+    assert inv["mcp_supported"] is False and inv["mcp_servers"] == []
     assert client.post(f"{base}/mcp", json={"name": "a", "transport": "stdio", "command": "x"}).status_code == 400
 
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -998,3 +998,84 @@ def test_delegation_events_during_turn(client, tmp_path):
             break
         time.sleep(0.05)
     assert "running" in statuses() and statuses()[-1] == "success"
+
+
+# ── Tools tab: inventory + MCP connect / disconnect ───────────────
+
+class _FakeMcpAgent:
+    """Mimics the orchestrators' MCP surface: openai_schemas on .tools,
+    _external_tools, _mcp_connections, connect/disconnect methods."""
+
+    def __init__(self):
+        self.tools = SimpleNamespace(openai_schemas=[
+            {"type": "function", "function": {"name": "run_analysis", "description": "Run it."}},
+            {"type": "function", "function": {"name": "examine_data", "description": "Look."}},
+        ])
+        self._external_tools = []
+        self._mcp_connections = {}
+        self.calls = []
+
+    def connect_mcp_server(self, name, command=None, url=None, env=None,
+                           transport=None, headers=None):
+        self.calls.append((name, command, url, transport, headers))
+        if url == "http://bad":
+            raise RuntimeError("connection refused")
+        schemas = [{"type": "function", "function": {"name": f"{name}_add", "description": "Add."}}]
+        self._mcp_connections[name] = SimpleNamespace(
+            tool_schemas=schemas, command=command, transport=transport or "sse")
+        self._external_tools.append({"name": f"{name}_add", "description": "Add."})
+        return 1
+
+    def disconnect_mcp_server(self, name):
+        conn = self._mcp_connections.pop(name)
+        names = {s["function"]["name"] for s in conn.tool_schemas}
+        self._external_tools = [t for t in self._external_tools if t["name"] not in names]
+
+
+def test_tools_inventory_and_mcp_lifecycle(client, tmp_path):
+    session, sdir = _fake_session(client, tmp_path)
+    session.agent = _FakeMcpAgent()
+    base = f"/api/v1/sessions/{sdir.name}"
+    inv = client.get(f"{base}/tools").json()
+    assert [t["name"] for t in inv["builtin"]] == ["examine_data", "run_analysis"]
+    assert inv["external"] == [] and inv["mcp_servers"] == [] and inv["mcp_supported"]
+    # stdio connect: command split into argv
+    r = client.post(f"{base}/mcp", json={"name": "calc", "transport": "stdio",
+                                          "command": "python -m calc_server --x 1"})
+    assert r.status_code == 200 and r.json()["registered"] == 1
+    assert session.agent.calls[-1][1] == ["python", "-m", "calc_server", "--x", "1"]
+    inv = r.json()["inventory"]
+    assert inv["mcp_servers"] == [{"name": "calc", "transport": "stdio", "tools": ["calc_add"]}]
+    assert inv["external"] == [{"name": "calc_add", "description": "Add."}]
+    assert [t["name"] for t in inv["builtin"]] == ["examine_data", "run_analysis"]
+    # duplicate name → 409; http transport with headers; failure → 400
+    assert client.post(f"{base}/mcp", json={"name": "calc", "transport": "stdio", "command": "x"}).status_code == 409
+    r = client.post(f"{base}/mcp", json={"name": "remote", "transport": "http",
+                                          "url": "https://h/mcp", "headers": {"Authorization": "Bearer t"}})
+    assert r.status_code == 200 and session.agent.calls[-1][3] == "http"
+    assert session.agent.calls[-1][4] == {"Authorization": "Bearer t"}
+    r = client.post(f"{base}/mcp", json={"name": "bad", "transport": "sse", "url": "http://bad"})
+    assert r.status_code == 400 and "connection refused" in r.json()["detail"]
+    assert client.post(f"{base}/mcp", json={"name": "", "transport": "stdio", "command": "x"}).status_code == 400
+    assert client.post(f"{base}/mcp", json={"name": "z", "transport": "carrier-pigeon"}).status_code == 400
+    # disconnect
+    r = client.delete(f"{base}/mcp/calc")
+    assert r.status_code == 200 and [s["name"] for s in r.json()["inventory"]["mcp_servers"]] == ["remote"]
+    assert client.delete(f"{base}/mcp/calc").status_code == 404
+    # an agent without MCP support
+    session.agent = SimpleNamespace()
+    inv = client.get(f"{base}/tools").json()
+    assert inv["mcp_supported"] is False and inv["builtin"] == []
+    assert client.post(f"{base}/mcp", json={"name": "a", "transport": "stdio", "command": "x"}).status_code == 400
+
+
+def test_mcp_header_env_expansion_only_when_local(tmp_path, monkeypatch):
+    from scilink.server.tools_api import connect_mcp
+    monkeypatch.setenv("MY_TOK", "s3cret")
+    agent = _FakeMcpAgent()
+    connect_mcp(agent, name="a", transport="http", url="https://h",
+                headers={"Authorization": "Bearer ${MY_TOK}"}, expand_env=True)
+    assert agent.calls[-1][4]["Authorization"] == "Bearer s3cret"
+    connect_mcp(agent, name="b", transport="http", url="https://h",
+                headers={"Authorization": "Bearer ${MY_TOK}"}, expand_env=False)
+    assert agent.calls[-1][4]["Authorization"] == "Bearer ${MY_TOK}"

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -20,6 +20,7 @@ import { PreChatHero } from "./components/PreChatHero";
 import { AnalysisInset } from "./components/AnalysisInset";
 import { DelegationsPanel } from "./components/DelegationsPanel";
 import { LoginScreen } from "./components/LoginScreen";
+import { ToolsPanel } from "./components/ToolsPanel";
 
 interface SessionState {
   snapshot: SessionSnapshot | null;
@@ -175,7 +176,7 @@ export default function App() {
   const [busy, setBusy] = useState<string | null>(null); // init overlay text
   const [startError, setStartError] = useState<string | null>(null);
   const [serverStopped, setServerStopped] = useState(false);
-  const [tab, setTab] = useState<"chat" | "files" | "telemetry">("chat");
+  const [tab, setTab] = useState<"chat" | "files" | "telemetry" | "tools">("chat");
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   // Delegation the sidebar tree asked the Telemetry tab to expand.
   const [focusDelegation, setFocusDelegation] = useState<number | null>(null);
@@ -527,6 +528,13 @@ export default function App() {
               >
                 Files
               </button>
+              <button
+                className={tab === "tools" ? "active" : ""}
+                onClick={() => setTab("tools")}
+                title="MCP servers and the agent's tool inventory"
+              >
+                Tools
+              </button>
               {mode === "meta" && (
                 <button
                   className={tab === "telemetry" ? "active" : ""}
@@ -547,6 +555,13 @@ export default function App() {
                 active={tab === "files"}
                 selectedPath={selectedFile}
                 onSelect={setSelectedFile}
+              />
+            </div>
+            <div className="tab-body" hidden={tab !== "tools"}>
+              <ToolsPanel
+                sessionId={session.id}
+                active={tab === "tools"}
+                localFiles={auth.local_files}
               />
             </div>
             {mode === "meta" && (

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -531,9 +531,9 @@ export default function App() {
               <button
                 className={tab === "tools" ? "active" : ""}
                 onClick={() => setTab("tools")}
-                title="MCP servers and the agent's tool inventory"
+                title="Connect MCP servers; see what the agent can call"
               >
-                Tools
+                MCP
               </button>
               {mode === "meta" && (
                 <button

--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -208,6 +208,13 @@ export interface FolderCheck {
   subdirs: { path: string; n_files: number }[];
 }
 
+export interface ToolInventory {
+  builtin: { name: string; description: string }[];
+  external: { name: string; description: string }[];
+  mcp_servers: { name: string; transport: string; tools: string[] }[];
+  mcp_supported: boolean;
+}
+
 export interface CreateSessionBody {
   mode: string;
   model: string;
@@ -333,6 +340,17 @@ export const api = {
     req<{ entries: TreeEntry[]; truncated: boolean }>(`/sessions/${id}/tree`),
 
   delegations: (id: string) => req<DelegationView>(`/sessions/${id}/delegations`),
+
+  tools: (id: string) => req<ToolInventory>(`/sessions/${id}/tools`),
+  connectMcp: (
+    id: string,
+    body: { name: string; transport: string; command?: string; url?: string; headers?: Record<string, string> },
+  ) => req<{ registered: number; inventory: ToolInventory }>(`/sessions/${id}/mcp`, json(body)),
+  disconnectMcp: (id: string, server: string) =>
+    req<{ ok: boolean; inventory: ToolInventory }>(
+      `/sessions/${id}/mcp/${encodeURIComponent(server)}`,
+      { method: "DELETE" },
+    ),
 
   provenance: (id: string) =>
     req<{ events: ProvenanceEvent[] }>(`/sessions/${id}/provenance`),

--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -209,7 +209,6 @@ export interface FolderCheck {
 }
 
 export interface ToolInventory {
-  builtin: { name: string; description: string }[];
   external: { name: string; description: string }[];
   mcp_servers: { name: string; transport: string; tools: string[] }[];
   mcp_supported: boolean;

--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -743,7 +743,6 @@ details.card iframe { width: 100%; height: 600px; border: none; background: #fff
 .tools-panel { flex: 1; overflow: auto; padding: 16px 8%; }
 .tools-section { margin-bottom: 22px; }
 .tools-section h3 { font-size: 15px; margin: 0 0 6px; }
-.tools-toggle { font-size: 15px; font-weight: 600; color: var(--text); }
 .mcp-form { display: flex; flex-direction: column; gap: 8px; margin: 8px 0; }
 .mcp-transport { display: flex; gap: 14px; align-items: center; font-size: 13px; }
 .mcp-row { display: flex; gap: 8px; }

--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -737,3 +737,21 @@ details.card iframe { width: 100%; height: 600px; border: none; background: #fff
 .login-form input { flex: 1; }
 .signed-in { margin: 0 0 8px; }
 
+
+
+/* ── Tools tab ───────────────────────────────────────────────── */
+.tools-panel { flex: 1; overflow: auto; padding: 16px 8%; }
+.tools-section { margin-bottom: 22px; }
+.tools-section h3 { font-size: 15px; margin: 0 0 6px; }
+.tools-toggle { font-size: 15px; font-weight: 600; color: var(--text); }
+.mcp-form { display: flex; flex-direction: column; gap: 8px; margin: 8px 0; }
+.mcp-transport { display: flex; gap: 14px; align-items: center; font-size: 13px; }
+.mcp-row { display: flex; gap: 8px; }
+.mcp-row input { flex: 0 0 180px; }
+.mcp-row input.mcp-addr { flex: 1; }
+.mcp-server { border: 1px solid var(--border); border-radius: 8px; padding: 8px 12px; margin-top: 8px; background: var(--bg-card); }
+.mcp-server-head { display: flex; align-items: center; gap: 4px; }
+.mcp-server-head .icon-btn { margin-left: auto; }
+.tool-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+.tool-list { margin: 6px 0 0; padding-left: 18px; font-size: 13px; }
+.tool-list li { margin: 3px 0; }

--- a/webui/src/components/ToolsPanel.tsx
+++ b/webui/src/components/ToolsPanel.tsx
@@ -1,12 +1,13 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { api, type ToolInventory } from "../api";
 
-/** MCP tab — connect MCP servers to the session's agent, and (collapsed,
- * as a reference) see what the agent can already call: the servers'
- * tools, other registered external tools, and the built-in orchestrator
- * tools. Read-only apart from MCP connect / disconnect. There is deliberately no tool-file uploader: users hand
- * code to the agents as scripts attached in chat (adapted by codegen) or
- * as MCP servers (run verbatim, any language). */
+/** MCP tab — connect MCP servers to the session's agent and disconnect
+ * them; each server card lists the tools it registered. Nothing else: the
+ * agent's own built-in tools are not listed (in a meta session that would
+ * be only the meta's routing tools, not what the specialists can do), and
+ * there is deliberately no tool-file uploader — users hand code to the
+ * agents as scripts attached in chat (adapted by codegen) or as MCP
+ * servers (run verbatim, any language). */
 
 type Transport = "stdio" | "sse" | "http";
 
@@ -26,8 +27,6 @@ export function ToolsPanel({
   const [name, setName] = useState("");
   const [addr, setAddr] = useState("");
   const [headers, setHeaders] = useState("");
-  const [filter, setFilter] = useState("");
-  const [showBuiltin, setShowBuiltin] = useState(false);
 
   const refresh = useCallback(() => {
     api.tools(sessionId).then(setInv).catch((e) => setError(String(e)));
@@ -83,14 +82,6 @@ export function ToolsPanel({
     }
   };
 
-  const q = filter.trim().toLowerCase();
-  const builtin = useMemo(
-    () =>
-      (inv?.builtin ?? []).filter(
-        (t) => !q || t.name.toLowerCase().includes(q) || t.description.toLowerCase().includes(q),
-      ),
-    [inv, q],
-  );
   const mcpToolNames = new Set((inv?.mcp_servers ?? []).flatMap((s) => s.tools));
   const otherExternal = (inv?.external ?? []).filter((t) => !mcpToolNames.has(t.name));
 
@@ -224,33 +215,6 @@ export function ToolsPanel({
         </section>
       )}
 
-      <section className="tools-section">
-        <h3>
-          <button type="button" className="link-btn tools-toggle" onClick={() => setShowBuiltin((v) => !v)}>
-            {showBuiltin ? "▾" : "▸"} What the agent can already call
-          </button>
-          <span className="caption"> ({inv?.builtin.length ?? 0})</span>
-        </h3>
-        {showBuiltin && (
-          <>
-            <input
-              type="text"
-              placeholder="Filter tools…"
-              value={filter}
-              onChange={(e) => setFilter(e.target.value)}
-            />
-            <ul className="tool-list">
-              {builtin.map((t) => (
-                <li key={t.name}>
-                  <code>{t.name}</code>
-                  <span className="caption"> — {t.description}</span>
-                </li>
-              ))}
-              {builtin.length === 0 && <li className="caption">No match.</li>}
-            </ul>
-          </>
-        )}
-      </section>
     </div>
   );
 }

--- a/webui/src/components/ToolsPanel.tsx
+++ b/webui/src/components/ToolsPanel.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { api, type ToolInventory } from "../api";
 
-/** Tools tab — connect MCP servers and see what the session's agent can
- * call: the servers' tools, other registered external tools, and the
- * built-in orchestrator tools. Read-only apart from MCP connect /
- * disconnect. There is deliberately no tool-file uploader: users hand
+/** MCP tab — connect MCP servers to the session's agent, and (collapsed,
+ * as a reference) see what the agent can already call: the servers'
+ * tools, other registered external tools, and the built-in orchestrator
+ * tools. Read-only apart from MCP connect / disconnect. There is deliberately no tool-file uploader: users hand
  * code to the agents as scripts attached in chat (adapted by codegen) or
  * as MCP servers (run verbatim, any language). */
 
@@ -227,7 +227,7 @@ export function ToolsPanel({
       <section className="tools-section">
         <h3>
           <button type="button" className="link-btn tools-toggle" onClick={() => setShowBuiltin((v) => !v)}>
-            {showBuiltin ? "▾" : "▸"} Built-in tools
+            {showBuiltin ? "▾" : "▸"} What the agent can already call
           </button>
           <span className="caption"> ({inv?.builtin.length ?? 0})</span>
         </h3>

--- a/webui/src/components/ToolsPanel.tsx
+++ b/webui/src/components/ToolsPanel.tsx
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { api, type ToolInventory } from "../api";
+
+/** Tools tab — connect MCP servers and see what the session's agent can
+ * call: the servers' tools, other registered external tools, and the
+ * built-in orchestrator tools. Read-only apart from MCP connect /
+ * disconnect. There is deliberately no tool-file uploader: users hand
+ * code to the agents as scripts attached in chat (adapted by codegen) or
+ * as MCP servers (run verbatim, any language). */
+
+type Transport = "stdio" | "sse" | "http";
+
+export function ToolsPanel({
+  sessionId,
+  active,
+  localFiles,
+}: {
+  sessionId: string;
+  active: boolean;
+  localFiles: boolean;
+}) {
+  const [inv, setInv] = useState<ToolInventory | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [transport, setTransport] = useState<Transport>("stdio");
+  const [name, setName] = useState("");
+  const [addr, setAddr] = useState("");
+  const [headers, setHeaders] = useState("");
+  const [filter, setFilter] = useState("");
+  const [showBuiltin, setShowBuiltin] = useState(false);
+
+  const refresh = useCallback(() => {
+    api.tools(sessionId).then(setInv).catch((e) => setError(String(e)));
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (active) refresh();
+  }, [active, refresh]);
+
+  const connect = async () => {
+    setError(null);
+    let hdrs: Record<string, string> | undefined;
+    if (transport !== "stdio" && headers.trim()) {
+      try {
+        const parsed = JSON.parse(headers) as unknown;
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+          throw new Error("must be a JSON object");
+        hdrs = parsed as Record<string, string>;
+      } catch (e) {
+        setError(`Headers ${e instanceof Error ? e.message : String(e)}`);
+        return;
+      }
+    }
+    setBusy(`Connecting to ${name}…`);
+    try {
+      const r = await api.connectMcp(sessionId, {
+        name: name.trim(),
+        transport,
+        command: transport === "stdio" ? addr.trim() : undefined,
+        url: transport !== "stdio" ? addr.trim() : undefined,
+        headers: hdrs,
+      });
+      setInv(r.inventory);
+      setName("");
+      setAddr("");
+      setHeaders("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const disconnect = async (server: string) => {
+    setBusy(`Disconnecting ${server}…`);
+    try {
+      const r = await api.disconnectMcp(sessionId, server);
+      setInv(r.inventory);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const q = filter.trim().toLowerCase();
+  const builtin = useMemo(
+    () =>
+      (inv?.builtin ?? []).filter(
+        (t) => !q || t.name.toLowerCase().includes(q) || t.description.toLowerCase().includes(q),
+      ),
+    [inv, q],
+  );
+  const mcpToolNames = new Set((inv?.mcp_servers ?? []).flatMap((s) => s.tools));
+  const otherExternal = (inv?.external ?? []).filter((t) => !mcpToolNames.has(t.name));
+
+  return (
+    <div className="tools-panel">
+      <section className="tools-section">
+        <h3>MCP servers</h3>
+        <p className="caption">
+          Extend the agent with external services — instrument APIs, databases,
+          computational tools, other agents. MCP is the open standard for it;
+          any language, no SciLink-specific format.
+          {!localFiles && (
+            <>
+              {" "}
+              On this shared server a <code>stdio</code> command runs on the server
+              machine.
+            </>
+          )}
+        </p>
+        {inv?.mcp_supported === false ? (
+          <p className="caption warn">This session's agent does not support MCP servers.</p>
+        ) : (
+          <form
+            className="mcp-form"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (name.trim() && addr.trim()) void connect();
+            }}
+          >
+            <div className="mcp-transport">
+              {(["stdio", "sse", "http"] as Transport[]).map((t) => (
+                <label key={t}>
+                  <input
+                    type="radio"
+                    name="mcp-transport"
+                    checked={transport === t}
+                    onChange={() => setTransport(t)}
+                  />{" "}
+                  {t}
+                </label>
+              ))}
+              <span className="caption">
+                {transport === "http"
+                  ? "streamable HTTP — remote / hosted servers"
+                  : transport === "sse"
+                    ? "server-sent events endpoint"
+                    : "a local command (subprocess)"}
+              </span>
+            </div>
+            <div className="mcp-row">
+              <input
+                type="text"
+                placeholder="Server name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                disabled={busy !== null}
+              />
+              <input
+                type="text"
+                className="mcp-addr"
+                placeholder={
+                  transport === "stdio"
+                    ? "npx -y @modelcontextprotocol/server-name /path"
+                    : transport === "sse"
+                      ? "http://localhost:8080/sse"
+                      : "https://host/mcp"
+                }
+                value={addr}
+                onChange={(e) => setAddr(e.target.value)}
+                disabled={busy !== null}
+              />
+              <button className="primary" type="submit" disabled={busy !== null || !name.trim() || !addr.trim()}>
+                {busy && busy.startsWith("Connecting") ? "Connecting…" : "Connect"}
+              </button>
+            </div>
+            {transport !== "stdio" && (
+              <input
+                type="text"
+                placeholder='Headers (JSON, optional) — {"Authorization": "Bearer ${MY_API_KEY}"}'
+                value={headers}
+                onChange={(e) => setHeaders(e.target.value)}
+                disabled={busy !== null}
+              />
+            )}
+          </form>
+        )}
+        {error && <p className="caption warn">{error}</p>}
+        {inv && inv.mcp_servers.length === 0 && (
+          <p className="caption">No MCP servers connected.</p>
+        )}
+        {inv?.mcp_servers.map((s) => (
+          <div key={s.name} className="mcp-server">
+            <div className="mcp-server-head">
+              <strong>{s.name}</strong>
+              <span className="caption">
+                {" "}
+                · {s.transport} · {s.tools.length} tool{s.tools.length === 1 ? "" : "s"}
+              </span>
+              <button
+                type="button"
+                className="icon-btn"
+                title={`Disconnect ${s.name}`}
+                disabled={busy !== null}
+                onClick={() => void disconnect(s.name)}
+              >
+                ✕
+              </button>
+            </div>
+            <div className="tool-chips">
+              {s.tools.map((t) => (
+                <span key={t} className="file-chip" title={inv.external.find((e) => e.name === t)?.description}>
+                  {t}
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </section>
+
+      {otherExternal.length > 0 && (
+        <section className="tools-section">
+          <h3>Registered external tools</h3>
+          <ul className="tool-list">
+            {otherExternal.map((t) => (
+              <li key={t.name}>
+                <code>{t.name}</code>
+                <span className="caption"> — {t.description}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <section className="tools-section">
+        <h3>
+          <button type="button" className="link-btn tools-toggle" onClick={() => setShowBuiltin((v) => !v)}>
+            {showBuiltin ? "▾" : "▸"} Built-in tools
+          </button>
+          <span className="caption"> ({inv?.builtin.length ?? 0})</span>
+        </h3>
+        {showBuiltin && (
+          <>
+            <input
+              type="text"
+              placeholder="Filter tools…"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+            />
+            <ul className="tool-list">
+              {builtin.map((t) => (
+                <li key={t.name}>
+                  <code>{t.name}</code>
+                  <span className="caption"> — {t.description}</span>
+                </li>
+              ))}
+              {builtin.length === 0 && <li className="caption">No match.</li>}
+            </ul>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The web UI has an **MCP** tab in every mode. Connect an MCP server — a local command, an SSE endpoint, or a streamable-HTTP endpoint with optional headers — and the agent can use its tools in chat right away. Each connected server shows as a card listing the tools it registered, with a disconnect button.

Two things are deliberately absent. No tool-file uploader, per the decision recorded in the roadmap: you hand the agents code either as a script attached in chat (which the agent adapts) or as an MCP server (run exactly as written, in any language). And no list of the agent's own built-in tools: in a mission-control session that would be only the meta's routing tools, not what the specialists can do, so it gave a partial picture that read as the whole.

Verified live: a small MCP server exposing a calculator and a fake cryostat readout was connected to a mission-control session; the agent used both in one turn and reported the readings only those tools could produce.

## Technical description

### Backend

- `scilink/server/tools_api.py` (new): `tool_inventory(agent)` reads `_external_tools` and `_mcp_connections` (name, transport inferred from `command` vs `transport`, tool names from each connection's `tool_schemas`), plus `mcp_supported`. `connect_mcp` validates name / transport / command-or-url, returns 409 for a duplicate name, wraps the agent's `connect_mcp_server` (stdio command split into argv; url with transport and headers), and maps failures to 400. `disconnect_mcp` wraps `disconnect_mcp_server` with 404 for an unknown name. `${VAR}` expansion in header values (Streamlit parity, keeps tokens out of the form) is gated on `local_files`, so a remote user cannot read the server's environment through it.
- `scilink/server/app.py`: `GET /sessions/{id}/tools`, `POST /sessions/{id}/mcp`, `DELETE /sessions/{id}/mcp/{name}`; connect and disconnect return the refreshed inventory. `scilink/server/schemas.py`: `MCPConnectRequest`.
- All three orchestrators expose the same MCP methods, so the tab works in analyze, plan, and meta sessions; an agent without them reports `mcp_supported: false` and the form is replaced by a notice.

### Frontend

- `ToolsPanel.tsx` (new): transport radio (stdio / sse / http) with a hint, name + command-or-URL row, headers field for the URL transports, connected-server cards with tool chips and a disconnect button, and a list of any other externally registered tools. Fetches on tab activation and refreshes from the connect / disconnect responses.
- `App.tsx`: `MCP` tab for every mode, mounted alongside the others. `api.ts`: `ToolInventory`, `tools`, `connectMcp`, `disconnectMcp`. Styles appended.

### Tests

Two new tests in `tests/test_web_server.py`: the full lifecycle against a fake agent (inventory shape, stdio argv split, http transport with headers, 409 duplicate, 400 on connection failure / empty name / unknown transport / unsupported agent, disconnect and 404, no `builtin` field) and env-expansion gating. Suite: 44 pass. `tsc -b` clean.

### Live verification

FastMCP stdio server (`add`, `cryostat_temperature`) connected to a Bedrock Opus 4.8 meta session through the endpoint: 2 tools registered. One chat turn asked for both stage temperatures and a sum; the verbose log shows three tool calls and the answer was "The sample stage reads 4.217 K, the shield stage reads 41.9 K, and 19.5 + 22.75 = 42.25", the fake readout values. In Chrome the tab showed the server card with both tools, and disconnect removed the server.

### Docs

`react_web_ui.md`: MCP tab bullet, the three endpoints, not-yet-ported list; roadmap item marked done.