### PR TITLE
Bump version to 0.0.69

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scilink"
-version = "0.0.68"
+version = "0.0.69"
 authors = [
   { name="SciLink Team", email="maxim.ziatdinov@gmail.com" },
 ]


### PR DESCRIPTION
## Summary

Version bump for the release carrying the sidebar delegation tree and Telemetry tab, multi-user hardening, and the MCP tab.

## Technical description

`pyproject.toml` version 0.0.68 → 0.0.69. No other change. The `v0.0.69` tag on the merge commit triggers `release.yml`.