### PR TITLE
Shared file I/O engine; analysis mode gets read / append / edit / rename (#481)

### DIFF
--- a/docs/react_ui_roadmap.md
+++ b/docs/react_ui_roadmap.md
@@ -54,7 +54,12 @@ restart, resume).
    route hidden and refused on a remote bind, quit disabled on a shared
    server, reverse-proxy docs. The single-user default is unchanged.
    Remaining, on demand: per-user LLM credentials, sign-in rate limiting.
-4. **Shared file I/O + analysis-mode adoption (#481, on #397).** Extract
+4. ~~**Shared file I/O + analysis-mode adoption (#481)**~~ — DONE
+   2026-09-08: `scilink/utils/file_io.py` is the one reader / writer; the
+   three modes are thin wrappers; analysis mode has the full read / append
+   / edit / rename surface; JSON cap and backup-on-overwrite landed once;
+   the meta's capability cache now keys on the tool modules' source. Was:
+   Extract
    `read_file` / `save_file` / `append_file` / `read_document` into one
    engine in `scilink/utils` (the `file_edit.py` pattern), land the JSON
    cap and backup-on-overwrite once, and give analysis mode the full

--- a/examples/eels_identification_demo/user_edge_fit.py
+++ b/examples/eels_identification_demo/user_edge_fit.py
@@ -1,0 +1,116 @@
+"""User-provided EELS core-loss edge analysis — the kind of script a
+scientist attaches in chat and asks the agent to use (adapting it to the
+session's data as needed).
+
+Pipeline
+--------
+1. Load an (N, 2) array of energy loss (eV) vs intensity.
+2. For each expected edge, fit a power-law background A * E^-r in a
+   pre-edge window and subtract it.
+3. Find the edge onset as the first energy where the background-subtracted
+   signal exceeds 5x the pre-edge residual noise.
+4. Fit Gaussians to the near-edge white lines / peaks within a window
+   after the onset and report their centres, widths and areas.
+5. Write results as JSON and a figure.
+
+Usage:  python user_edge_fit.py spectrum.npy [out_dir]
+"""
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+from scipy.optimize import curve_fit
+
+# Expected core-loss edges in the example (eV): pre-edge fit window, onset
+# search window, and how far past the onset to look for near-edge peaks.
+EDGES = {
+    "Ti_L23": {"pre": (400, 445), "onset": (445, 475), "post_ev": 20, "n_peaks": 2},
+    "O_K":    {"pre": (490, 525), "onset": (525, 545), "post_ev": 25, "n_peaks": 2},
+}
+NOISE_SIGMA_THRESHOLD = 5.0
+
+
+def power_law(E, A, r):
+    return A * np.power(E, -r)
+
+
+def gaussians(E, *p):
+    y = np.zeros_like(E, dtype=float)
+    for i in range(0, len(p), 3):
+        a, mu, sig = p[i:i + 3]
+        y += a * np.exp(-0.5 * ((E - mu) / sig) ** 2)
+    return y
+
+
+def analyze_edge(E, I, name, cfg):
+    lo, hi = cfg["pre"]
+    m = (E >= lo) & (E <= hi)
+    (A, r), _ = curve_fit(power_law, E[m], I[m], p0=(I[m][0] * E[m][0] ** 3, 3.0), maxfev=20000)
+    bg = power_law(E, A, r)
+    sig = I - bg
+    noise = float(np.std(sig[m]))
+
+    olo, ohi = cfg["onset"]
+    w = (E >= olo) & (E <= ohi)
+    above = np.where(w & (sig > NOISE_SIGMA_THRESHOLD * noise))[0]
+    if len(above) == 0:
+        return {"edge": name, "detected": False, "background": {"A": A, "r": r}}
+    onset = float(E[above[0]])
+
+    pw = (E >= onset) & (E <= onset + cfg["post_ev"])
+    Ew, Sw = E[pw], sig[pw]
+    # seed the peaks at the n largest local maxima in the window
+    order = np.argsort(Sw)[::-1]
+    seeds = []
+    for idx in order:
+        if all(abs(Ew[idx] - s) > 2.0 for s in seeds):
+            seeds.append(Ew[idx])
+        if len(seeds) == cfg["n_peaks"]:
+            break
+    p0 = []
+    for mu in sorted(seeds):
+        p0 += [float(Sw.max()), float(mu), 1.5]
+    try:
+        popt, _ = curve_fit(gaussians, Ew, Sw, p0=p0, maxfev=20000)
+        peaks = [{"center_eV": float(popt[i + 1]), "fwhm_eV": float(2.3548 * abs(popt[i + 2])),
+                  "area": float(abs(popt[i]) * abs(popt[i + 2]) * np.sqrt(2 * np.pi))}
+                 for i in range(0, len(popt), 3)]
+        peaks.sort(key=lambda p: p["center_eV"])
+    except RuntimeError:
+        peaks = []
+    return {"edge": name, "detected": True, "onset_eV": onset,
+            "background": {"A": float(A), "r": float(r)}, "peaks": peaks}
+
+
+def main(path, out_dir="."):
+    data = np.load(path)
+    E, I = data[:, 0], data[:, 1]
+    results = {name: analyze_edge(E, I, name, cfg) for name, cfg in EDGES.items()}
+    ti = results["Ti_L23"].get("peaks", [])
+    if len(ti) == 2:
+        results["Ti_L3_L2_separation_eV"] = ti[1]["center_eV"] - ti[0]["center_eV"]
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "edge_fit_results.json").write_text(json.dumps(results, indent=2))
+
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots(figsize=(8, 4))
+    ax.plot(E, I, lw=0.8, label="spectrum")
+    for name, res in results.items():
+        if isinstance(res, dict) and res.get("detected"):
+            ax.axvline(res["onset_eV"], ls="--", lw=0.8, label=f"{name} onset {res['onset_eV']:.1f} eV")
+            for p in res.get("peaks", []):
+                ax.axvline(p["center_eV"], color="gray", lw=0.5)
+    ax.set_xlabel("Energy loss (eV)")
+    ax.set_ylabel("Intensity")
+    ax.legend(fontsize=8)
+    fig.tight_layout()
+    fig.savefig(out / "edge_fit.png", dpi=150)
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2] if len(sys.argv) > 2 else ".")

--- a/examples/file_tools_demo.py
+++ b/examples/file_tools_demo.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Exercise the analysis agent's session-file tools (#481) on the EELS
+identification example — read_document, save_file, edit_file, read_file
+(offset / tail / search), append_file, rename_file, and a real analysis
+whose results JSON is read back with search.
+
+Run from the repo root. Credentials come from the environment, exactly as
+in the UI:
+
+    # Bedrock (default model)
+    export AWS_BEARER_TOKEN_BEDROCK=...   # or AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY
+    export AWS_REGION_NAME=us-east-1
+    python examples/file_tools_demo.py
+
+    # Any other provider: pass the model and set its usual env var
+    export ANTHROPIC_API_KEY=...
+    python examples/file_tools_demo.py --model claude-opus-4-6
+
+Each turn prints the agent's answer; the script ends with an on-disk
+check of what the tools should have produced (backups, renamed file,
+literature file) and a PASS / FAIL line per item. Use --skip-analysis to
+stop before the (slower) run_analysis turn.
+"""
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+DEMO = REPO / "examples" / "eels_identification_demo"
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--model", default="bedrock/us.anthropic.claude-opus-4-8")
+ap.add_argument("--session-dir", default=None,
+                help="Where to put the session (default: ./file_tools_demo_session_<time>)")
+ap.add_argument("--skip-analysis", action="store_true")
+args = ap.parse_args()
+
+session = Path(args.session_dir or f"file_tools_demo_session_{time.strftime('%Y%m%d_%H%M%S')}").resolve()
+session.mkdir(parents=True, exist_ok=True)
+
+# A long, sectioned report the agent must NOT read whole: the point of
+# offset / tail / search.
+long_report = session / "long_report.md"
+long_report.write_text(
+    "# Beamtime report\n\n"
+    + "".join(f"## Section {i}\n\n" + "filler line\n" * 30 for i in range(1, 15))
+    + "\n## Conclusions\n\nThe O K pre-peak splitting is 2.6 eV.\n")
+
+from scilink.agents.exp_agents.analysis_orchestrator import (  # noqa: E402
+    AnalysisMode, AnalysisOrchestratorAgent)
+import scilink.executors as executors  # noqa: E402
+
+executors._GLOBAL_SANDBOX_APPROVED = True   # the demo consents to code execution
+agent = AnalysisOrchestratorAgent(base_dir=str(session), api_key=None,
+                                  model_name=args.model,
+                                  analysis_mode=AnalysisMode.AUTONOMOUS)
+
+turns = [
+    f"Read the example's README at `{DEMO / 'README.md'}` with read_document, then examine the "
+    f"spectrum at `{DEMO / 'spectrum.npy'}` and load its metadata `{DEMO / 'spectrum.json'}`. "
+    "Do NOT run the analysis yet — tell me what the README says the agent should find.",
+
+    "Save a file notes/plan.md (save_file, subfolder 'notes') with exactly three lines describing "
+    "how you would identify the material. Then use edit_file to change the word 'identification' "
+    "in it to 'fingerprinting' (if it is not there, change the first word of line 1 to 'REVISED'). "
+    "Then read the file back with read_file and quote it.",
+
+    f"There is a long report at `{long_report}`. Tell me what its Conclusions section says and "
+    "which line the heading is on. Do not read the whole file — use read_file's search or offset.",
+
+    "Append two more lines to notes/plan.md with append_file, then overwrite the whole file with "
+    "save_file using one new line. Tell me the exact backup filename the overwrite reported, then "
+    "rename the file to final_plan.md with rename_file.",
+]
+if not args.skip_analysis:
+    turns.append(
+        "Now run the analysis in identification mode on the spectrum, grounded on the README you "
+        "read (pass the literature file). When it finishes, open the analysis_results.json it "
+        "produced with read_file — search for the candidate materials rather than reading the "
+        "whole file — and report the top candidate.")
+
+for i, t in enumerate(turns, 1):
+    print(f"\n{'=' * 78}\nTURN {i}: {t}\n{'=' * 78}", flush=True)
+    t0 = time.time()
+    try:
+        ans = agent.chat(t)
+    except Exception as e:  # noqa: BLE001
+        ans = f"<<EXCEPTION: {e!r}>>"
+    print(f"\n--- ANSWER {i} ({time.time() - t0:.0f}s) ---\n{ans}\n", flush=True)
+
+# ── what the tools should have left on disk ─────────────────────
+print("\n" + "=" * 78 + "\nON-DISK CHECKS\n" + "=" * 78)
+checks = {
+    "literature file from read_document": any((session / "literature").glob("provided_documents_*.md")),
+    "edit backup notes/plan.before_edit.md": (session / "notes" / "plan.before_edit.md").is_file(),
+    "overwrite backup notes/plan.before_overwrite.md": (session / "notes" / "plan.before_overwrite.md").is_file(),
+    "renamed file notes/final_plan.md": (session / "notes" / "final_plan.md").is_file(),
+    "original notes/plan.md gone after rename": not (session / "notes" / "plan.md").exists(),
+}
+if not args.skip_analysis:
+    checks["analysis_results.json produced"] = any(session.glob("results/*/analysis_results.json"))
+ok = True
+for label, cond in checks.items():
+    ok &= bool(cond)
+    print(("PASS  " if cond else "FAIL  ") + label)
+print(f"\nSession: {session}")
+print("ALL PASSED" if ok else "SOME CHECKS FAILED — see above")
+sys.exit(0 if ok else 1)

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -258,6 +258,16 @@ If you actually run DFT, prefer `vasp_generator_method="llm"` unless the user as
    - Use when: new knowledge has been synthesized and a linked graduated skill should be updated.
    - Input: skill_name, knowledge_ids (optional — auto-detects if omitted)
 
+**SESSION FILES:**
+19. `read_file` / `save_file` / `append_file` / `edit_file` / `rename_file` / `read_document`:
+   inspect and maintain session artifacts (analysis_results.json, features.csv, generated
+   scripts, metadata.json, logs, reports) without running any analysis. Read with read_file
+   (offset / tail / search navigate a long file — never re-read it hoping to see more);
+   change an existing file with edit_file (exact snippet swap, keeps a backup) rather than
+   rewriting it with save_file; write long content in chunks (save_file then append_file).
+   read_document is for documents the USER provided (papers, protocols): it also saves a
+   literature file for run_analysis. Data files still go to examine_data / run_analysis.
+
 **AGENT SELECTION DECISION TREE:**
 
 ```

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -78,26 +78,11 @@ _READ_DOC_MAX_CHARS = 200_000  # ~50k tokens; longer documents are truncated
 
 
 def _extract_document_text(path: Path, ocr_model: Any = None) -> Dict[str, Any]:
-    """Extract plain text from a PDF / DOCX / Markdown / text file.
-
-    Thin wrapper over the shared ``scilink.parsers.extract_text`` (which adds
-    table-aware PDF extraction); it applies read_document's character cap.
-    When ``ocr_model`` is supplied, scanned/sparse PDF pages are transcribed
-    via the vision-OCR fallback. Returns a dict with ``text`` plus metadata
-    (page/paragraph count, ``n_chars``, ``truncated``, ``n_ocr_pages``).
-    Raises ValueError for an unsupported extension; reader errors propagate
-    to the caller.
-    """
-    from scilink.parsers import extract_text
-
-    info = extract_text(path, ocr_model=ocr_model)
-    text = info.get("text", "")
-    info["truncated"] = len(text) > _READ_DOC_MAX_CHARS
-    if info["truncated"]:
-        text = text[:_READ_DOC_MAX_CHARS]
-        info["text"] = text
-        info["n_chars"] = len(text)
-    return info
+    """Kept as a name for callers; the implementation is the shared engine's
+    (``scilink.utils.file_io.extract_document_text``, #481)."""
+    from ...utils.file_io import extract_document_text
+    return extract_document_text(path, ocr_model=ocr_model,
+                                 max_chars=_READ_DOC_MAX_CHARS)
 
 
 def _build_skill_description(agent_registry: dict = None,
@@ -5974,36 +5959,30 @@ class AnalysisOrchestratorTools:
                     "message": "Invalid filename.",
                 })
 
-            target_dir = self.orch.base_dir
-            if subfolder:
-                safe_sub = Path(subfolder).name
-                target_dir = target_dir / safe_sub
-            target_dir.mkdir(parents=True, exist_ok=True)
-            dest = target_dir / safe_name
-
-            try:
-                dest.write_text(content, encoding="utf-8")
-                print(f"    💾 Saved: {dest}")
-                return json.dumps({
-                    "status": "success",
-                    "path": str(dest),
-                    "size_bytes": dest.stat().st_size,
-                })
-            except Exception as e:
-                logging.error(f"save_file failed: {e}")
-                return json.dumps({
-                    "status": "error",
-                    "message": str(e),
-                })
+            # Shared engine (#481): traversal-proofing, subfolder, and a
+            # backup before overwriting an existing file.
+            from ...utils.file_io import write_text_file
+            out = write_text_file(Path(self.orch.base_dir), safe_name, content,
+                                  subfolder=subfolder)
+            if out["status"] == "success":
+                print(f"    💾 Saved: {out['path']}"
+                      + (f" (previous version kept: {Path(out['backup']).name})"
+                         if out.get("backup") else ""))
+            return json.dumps(out)
 
         self._register_tool(
             func=save_file,
             name="save_file",
             description=(
                 "Save text content (reports, summaries, tables, scripts, notes) "
-                "to a file in the session directory. Use this to persist "
-                "synthesized knowledge summaries, analysis reports, exported "
-                "results, or any text artifact the user requests."
+                "to a NEW file in the session directory — synthesized knowledge "
+                "summaries, analysis reports, exported results, any text "
+                "artifact the user requests. To change an EXISTING file use "
+                "edit_file (snippet swap, byte-safe) or rename_file; "
+                "overwriting with save_file keeps a .before_overwrite backup. "
+                "Large content may not survive the trip as a single tool-call "
+                "argument — for anything long (roughly >100 lines), save the "
+                "first chunk with save_file and the rest with append_file."
             ),
             parameters={
                 "filename": {
@@ -6029,6 +6008,241 @@ class AnalysisOrchestratorTools:
         )
 
         # =====================================================================
+        # 18b. APPEND / READ / EDIT / RENAME FILE — the generic file surface
+        # planning and simulation already had (#481: adopted as thin
+        # wrappers over the shared engine, not as third copies).
+        # =====================================================================
+        def append_file(filename: str, content: str, subfolder: str = "") -> str:
+            """Append text to a file in the session directory (created if
+            missing). Companion to save_file for chunked writes."""
+            print(f"  ⚡ Tool: Appending to file '{filename}'...")
+            safe_name = Path(filename).name
+            if not safe_name:
+                return json.dumps({"status": "error",
+                                   "message": "Invalid filename."})
+            from ...utils.file_io import write_text_file
+            out = write_text_file(Path(self.orch.base_dir), safe_name, content,
+                                  subfolder=subfolder, append=True)
+            if out["status"] == "success":
+                print(f"    💾 Appended: {out['path']}")
+            return json.dumps(out)
+
+        self._register_tool(
+            func=append_file,
+            name="append_file",
+            description=(
+                "Append text content to a file in the session directory "
+                "(created if it doesn't exist). Use together with save_file "
+                "to write large files in chunks — save_file for the first "
+                "chunk, then append_file for each subsequent chunk — keeping "
+                "every chunk small enough to pass reliably as a tool argument."
+            ),
+            parameters={
+                "filename": {"type": "string",
+                             "description": "Name of the file to append to."},
+                "content": {"type": "string",
+                            "description": "The text content to append."},
+                "subfolder": {"type": "string", "description": (
+                    "Optional subfolder within the session directory, e.g. "
+                    "'reports' or 'exports'. Created if it doesn't exist.")},
+            },
+            required=["filename", "content"],
+        )
+
+        # Files read for their whole content, never their head: an analysis
+        # report's sections sit in sequence, so a head-only read hides all but
+        # the first. Whole up to a cap; past it the read truncates but emits
+        # the section outline so offset= reaches the rest.
+        _FULL_READ_STEMS = ("report", "summary", "literature")
+        _FULL_READ_MAX_CHARS = 250_000
+
+        def read_file(file_path: str, max_lines: int = 200,
+                      tail: bool = False, search: str = None,
+                      offset: int = None) -> str:
+            """Read a text / JSON / CSV / log file — analysis_results.json,
+            features.csv, a generated script, metadata.json, a run log, a
+            report — without triggering any analysis. PDF/DOCX are extracted
+            to text. Reads from the top; offset / tail / search navigate."""
+            print(f"  ⚡ Tool: Reading file '{file_path}'...")
+            path = Path(file_path)
+            if not path.is_absolute():
+                path = Path(self.orch.base_dir) / path
+            from ...utils.file_io import read_file_content
+            return json.dumps(read_file_content(
+                path, max_lines=max_lines, tail=tail, search=search,
+                offset=offset, full_read_stems=_FULL_READ_STEMS,
+                full_read_max_chars=_FULL_READ_MAX_CHARS,
+                ocr_model=getattr(self.orch, "model", None),
+                display_path=file_path))
+
+        self._register_tool(
+            func=read_file,
+            name="read_file",
+            description=(
+                "Read a text, JSON, CSV, or log file from the session — an "
+                "analysis_results.json, a features.csv, a generated analysis "
+                "script, metadata.json, a run log, or a report — without "
+                "triggering any analysis (examine_data / run_analysis are for "
+                "DATA; this is for inspecting artifacts). PDF and Word "
+                "documents are extracted to text automatically (tables "
+                "preserved, scanned pages OCR'd). Reads from the TOP by "
+                "default; reports and summaries are returned WHOLE. For a "
+                "long file do not read it repeatedly hoping to see more — you "
+                "will get the same lines back. A truncated read lists the "
+                "section headings and their line numbers: use offset=<line> "
+                "to jump to one, search='<pattern>' to find where something "
+                "is (and whether it is there at all), or tail=true to read the "
+                "END. Path is absolute or relative to the session directory."
+            ),
+            parameters={
+                "file_path": {"type": "string",
+                              "description": "Path to the file to read."},
+                "max_lines": {"type": "integer",
+                              "description": "Maximum lines to return (default: 200)."},
+                "tail": {"type": "boolean", "description": (
+                    "Read the LAST max_lines lines instead of the first — how "
+                    "a long log or report ENDS.")},
+                "search": {"type": "string", "description": (
+                    "Case-insensitive regex. Returns every matching line with "
+                    "its line number and one line of context either side, "
+                    "plus the total match count — instead of the file body. "
+                    "Far cheaper than reading a long file; answers "
+                    "presence/absence definitively.")},
+                "offset": {"type": "integer", "description": (
+                    "1-based line to start reading from — the way to read the "
+                    "MIDDLE of a file. A truncated read lists section headings "
+                    "with line numbers; pass one here to jump straight there.")},
+            },
+            required=["file_path"],
+        )
+
+        def edit_file(path: str, old_text: str = None, new_text: str = None,
+                      replace_all: bool = False, edits: list = None) -> str:
+            """Surgical in-place edit: replace exact text snippets — one
+            old/new pair, or a batched `edits` list applied atomically."""
+            print(f"  ⚡ Tool: Editing file '{path}'...")
+            try:
+                from ...utils.file_edit import apply_surgical_edits
+                if not edits:
+                    if old_text is None or new_text is None:
+                        return json.dumps({"status": "error", "message": (
+                            "Provide old_text+new_text or a non-empty edits "
+                            "list.")})
+                    edits = [{"old_text": old_text, "new_text": new_text,
+                              "replace_all": replace_all}]
+                root = Path(self.orch.base_dir).resolve()
+                rp = Path(path)
+                if not rp.is_absolute():
+                    rp = root / rp
+                rp = rp.resolve()
+                # Guards + backup live in the shared core; this wrapper owns
+                # path resolution and the analysis-flavored routing text.
+                out = apply_surgical_edits(
+                    rp, edits, root=root, backup_dir=rp.parent,
+                    not_found_message=(
+                        "read_file the file and copy the snippet verbatim, "
+                        "whitespace included."),
+                    too_large_message=(
+                        "Edit too large for edit_file. For a content rewrite "
+                        "use save_file (it keeps a .before_overwrite backup). "
+                        "For a VERBATIM insertion, split the text at unique "
+                        "boundaries into snippets under the cap and pass them "
+                        "TOGETHER as one `edits` list in a single call — not "
+                        "a chain of one-edit calls."),
+                )
+                if out["status"] == "success":
+                    n = out.get("n_edits", 1)
+                    print(f"    ✏️  Edited in place"
+                          f"{f' ({n} edits)' if n > 1 else ''}: {rp.name}")
+                return json.dumps(out)
+            except Exception as e:
+                logging.error(f"edit_file failed: {e}", exc_info=True)
+                return json.dumps({"status": "error", "message": str(e)})
+
+        self._register_tool(
+            func=edit_file,
+            name="edit_file",
+            description=(
+                "Surgically edit an existing session file IN PLACE by "
+                "replacing exact text snippets — a value in a script, a line "
+                "in a report, a key in metadata.json — one old_text/new_text "
+                "pair, or several as an `edits` list applied atomically in one "
+                "call. The old snippet must match byte for byte and be unique "
+                "(or set replace_all). Keeps a .before_edit backup. Do NOT "
+                "rewrite a whole file with save_file when a snippet swap will "
+                "do. Path is absolute or relative to the session directory."
+            ),
+            parameters={
+                "path": {"type": "string",
+                         "description": "Path of the file to edit."},
+                "old_text": {"type": "string", "description": (
+                    "Exact text to replace (verbatim, whitespace included).")},
+                "new_text": {"type": "string",
+                             "description": "Replacement text."},
+                "replace_all": {"type": "boolean", "description": (
+                    "Replace every occurrence (default false: the snippet "
+                    "must be unique).")},
+                "edits": {"type": "array", "items": {"type": "object"},
+                          "description": (
+                    "Batched edits: a list of {old_text, new_text, "
+                    "replace_all?} applied in order, atomically.")},
+            },
+            required=["path"],
+        )
+
+        def rename_file(path: str, new_name: str, copy: bool = False) -> str:
+            """Rename or copy a session file byte-exactly within its own
+            directory — the content never passes through the model."""
+            print(f"  ⚡ Tool: {'Copying' if copy else 'Renaming'} "
+                  f"'{path}' → '{new_name}'...")
+            try:
+                from ...utils.file_edit import rename_or_copy_file
+                root = Path(self.orch.base_dir).resolve()
+                rp = Path(path)
+                if not rp.is_absolute():
+                    rp = root / rp
+                rp = rp.resolve()
+                safe = Path(new_name).name
+                if not safe:
+                    return json.dumps({"status": "error",
+                                       "message": "Invalid new_name."})
+                dest = (rp.parent / safe).resolve()
+                if dest == rp:
+                    return json.dumps({"status": "error", "message": (
+                        f"'{safe}' is already this file's name — nothing to "
+                        f"do.")})
+                out = rename_or_copy_file(rp, dest, root=root, copy=copy)
+                if out["status"] == "success":
+                    print(f"    📛 {'Copied' if copy else 'Renamed'}: "
+                          f"{Path(out['path']).name}")
+                return json.dumps(out)
+            except Exception as e:
+                logging.error(f"rename_file failed: {e}", exc_info=True)
+                return json.dumps({"status": "error", "message": str(e)})
+
+        self._register_tool(
+            func=rename_file,
+            name="rename_file",
+            description=(
+                "Rename or copy a session file BYTE-EXACTLY within its own "
+                "directory — the content never passes through the model. Use "
+                "for a byte-exact rename (copy=false) or an exact duplicate "
+                "(copy=true); never reconstruct a file by regenerating it to "
+                "rename it."
+            ),
+            parameters={
+                "path": {"type": "string", "description": (
+                    "Path of the file — absolute or relative to the session "
+                    "directory.")},
+                "new_name": {"type": "string", "description": (
+                    "The new bare filename (kept in the file's own directory).")},
+                "copy": {"type": "boolean",
+                         "description": "Copy instead of rename (default false)."},
+            },
+            required=["path", "new_name"],
+        )
+
+        # =====================================================================
         # READ DOCUMENT
         # =====================================================================
         def read_document(paths) -> str:
@@ -6036,67 +6250,32 @@ class AnalysisOrchestratorTools:
             text and persist a literature_file for run_analysis."""
             if isinstance(paths, str):
                 paths = [paths]
-            if not paths:
-                return json.dumps({
-                    "status": "error",
-                    "message": "No document path provided.",
-                })
-            print(f"  📄 Tool: Reading {len(paths)} document(s)...")
-            docs, errors = [], []
-            for p in paths:
-                dp = Path(p)
-                if not dp.is_file():
-                    errors.append(f"Not a file: {p}")
-                    continue
-                try:
-                    docs.append((dp, _extract_document_text(
-                        dp, ocr_model=self.orch.model)))
-                except ValueError as e:
-                    errors.append(str(e))
-                except Exception as e:
-                    logging.error(f"read_document failed for {p}: {e}")
-                    errors.append(f"Could not read {dp.name}: {e}")
-            if not docs:
-                return json.dumps({
-                    "status": "error",
-                    "message": "No documents could be read.",
-                    "errors": errors,
-                })
-            combined = "\n\n---\n\n".join(
-                f"## {dp.name}\n\n{info['text']}" for dp, info in docs
-            )
-            combined_truncated = len(combined) > _READ_DOC_MAX_CHARS
-            if combined_truncated:
-                combined = combined[:_READ_DOC_MAX_CHARS]
-            # Persist as a literature_file so run_analysis can ground its plan
-            # in these documents — the same channel search_literature uses.
+            if paths:
+                print(f"  📄 Tool: Reading {len(paths)} document(s)...")
+            # Shared engine (#481) does the extraction, combine and cap;
+            # analysis adds the literature-file persistence so run_analysis
+            # can ground its plan in these documents (the channel
+            # search_literature uses). Relative paths resolve against the
+            # session directory.
+            from ...utils.file_io import read_documents_combined
+            out = read_documents_combined(
+                paths, base_dir=Path(self.orch.base_dir),
+                ocr_model=self.orch.model, max_chars=_READ_DOC_MAX_CHARS)
+            if out["status"] != "success":
+                return json.dumps(out)
             lit_path = None
             try:
                 lit_dir = self.orch.base_dir / "literature"
                 lit_dir.mkdir(parents=True, exist_ok=True)
                 ts = datetime.now().strftime("%Y%m%d_%H%M%S")
                 lit_path = lit_dir / f"provided_documents_{ts}.md"
-                write_text_utf8(lit_path, combined)
+                write_text_utf8(lit_path, out["text"])
             except Exception as e:
                 logging.error(f"read_document: could not save literature file: {e}")
-            n_ocr = sum(info.get("n_ocr_pages", 0) for _, info in docs)
             return json.dumps({
                 "status": "success",
                 "file_path": str(lit_path) if lit_path else None,
-                "n_documents": len(docs),
-                "n_ocr_pages": n_ocr,
-                "ocr_note": (
-                    f"{n_ocr} scanned page(s) had no text layer and were "
-                    "transcribed by vision-OCR — verify any figures/numerics."
-                ) if n_ocr else None,
-                "documents": [
-                    {"name": dp.name,
-                     **{k: v for k, v in info.items() if k != "text"}}
-                    for dp, info in docs
-                ],
-                "errors": errors or None,
-                "combined_truncated": combined_truncated,
-                "text": combined,
+                **{k: v for k, v in out.items() if k != "status"},
                 "hint": (
                     "Pass file_path as `literature_file` to the next "
                     "run_analysis() call so the planner produces a "

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1162,11 +1162,43 @@ class MetaOrchestratorAgent:
     # hits keep child creation truly lazy (first delegation).
     _CAPABILITIES_CACHE = Path.home() / ".scilink" / "capabilities_cache.json"
     _CAPABILITIES_CACHE_MAX = 8
+    # The modules whose registration code defines each specialist's tool
+    # surface. Their CONTENT is part of the cache key: the package version
+    # alone does not move between releases, so a checkout / editable install
+    # served a stale inventory after a tool was added (observed live: the
+    # analysis specialist's new read_file / edit_file were invisible to the
+    # meta until the next version bump).
+    _TOOL_SOURCE_MODULES = (
+        "scilink.agents.exp_agents.analysis_orchestrator_tools",
+        "scilink.agents.planning_agents.orchestrator_tools",
+        "scilink.agents.sim_agents.simulation_orchestrator_tools",
+    )
+
+    @classmethod
+    def _tool_source_fingerprint(cls) -> str:
+        """Short hash of the tool-registration modules' source bytes; found
+        via the import system without importing them (the sim module pulls
+        in ``ase``, which may be absent)."""
+        import hashlib
+        from importlib.util import find_spec
+
+        h = hashlib.sha256()
+        for name in cls._TOOL_SOURCE_MODULES:
+            try:
+                spec = find_spec(name)
+                origin = getattr(spec, "origin", None)
+                if origin and Path(origin).is_file():
+                    h.update(name.encode())
+                    h.update(Path(origin).read_bytes())
+            except Exception:  # noqa: BLE001 - a missing module just adds nothing
+                continue
+        return h.hexdigest()[:16]
 
     def _capabilities_cache_key(self) -> str:
         """Fingerprint of everything the inventory can depend on: package
-        version, third-party agent entry points, sim-extra availability, and
-        the registered extensions (skills / tools / MCP servers)."""
+        version, the tool-registration modules' source, third-party agent
+        entry points, sim-extra availability, and the registered extensions
+        (skills / tools / MCP servers)."""
         import hashlib
 
         try:
@@ -1174,6 +1206,7 @@ class MetaOrchestratorAgent:
             ver = version("scilink")
         except Exception:
             ver = "unknown"
+        src = self._tool_source_fingerprint()
         try:
             from importlib.metadata import entry_points
             eps = sorted(ep.name for ep in entry_points(group="scilink.agents"))
@@ -1191,7 +1224,7 @@ class MetaOrchestratorAgent:
                        for s in (e.get("schemas") or []))))
             for e in self._shared_extensions
         )
-        payload = json.dumps([ver, eps, has_sim, ext])
+        payload = json.dumps([ver, src, eps, has_sim, ext])
         return hashlib.sha256(payload.encode()).hexdigest()[:16]
 
     def _build_capabilities_block(self) -> str:

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -5539,32 +5539,36 @@ class OrchestratorTools:
             # scattered LLM-saved files OUTSIDE the delegation directory —
             # live, a white paper landed in planning/<slug>/ as a sibling of
             # delegations/, duplicating the copy already written inside it.
-            target_dir = self._output_dir()
-            if subfolder:
-                safe_sub = Path(subfolder).name
-                target_dir = target_dir / safe_sub
-            target_dir.mkdir(parents=True, exist_ok=True)
-            dest = target_dir / safe_name
-
             try:
-                dest.write_text(content, encoding="utf-8")
+                # Shared engine (#481): traversal-proofing, subfolder,
+                # backup-on-overwrite. Planning layers deliverable recording
+                # and the PDF-twin invariant on top.
+                from ...utils.file_io import write_text_file
+                out = write_text_file(self._output_dir(), safe_name, content,
+                                      subfolder=subfolder)
+                if out["status"] != "success":
+                    return json.dumps(out)
+                dest = Path(out["path"])
                 from .user_interface import format_path, record_deliverable
                 record_deliverable(self.orch.base_dir, dest, title,
                                    deliverable)
+                # The overwrite backup is a produced file like edit_file's
+                # pre-edit copy: recorded (not as a deliverable) so the UI
+                # lists it and a forgotten flag can never hide it.
+                if out.get("backup"):
+                    record_deliverable(self.orch.base_dir, Path(out["backup"]),
+                                       f"Pre-overwrite copy of {dest.name}")
                 print(f"    💾 Saved{' (deliverable)' if deliverable else ''}: "
-                      f"{format_path(dest)}")
+                      f"{format_path(dest)}"
+                      + (f" (previous version kept: {Path(out['backup']).name})"
+                         if out.get("backup") else ""))
                 # Same invariant as edit_file and the revision branch: a
                 # markdown write never leaves a stale PDF twin beside it
                 # (live, an agent rewrote a document via save_file and its
                 # forwarded PDF kept serving the old content).
-                pdf_refreshed = self._refresh_pdf_twin(dest)
-                return json.dumps({
-                    "status": "success",
-                    "path": str(dest),
-                    "size_bytes": dest.stat().st_size,
-                    "deliverable": bool(deliverable),
-                    "pdf_refreshed": pdf_refreshed,
-                })
+                out["deliverable"] = bool(deliverable)
+                out["pdf_refreshed"] = self._refresh_pdf_twin(dest)
+                return json.dumps(out)
             except Exception as e:
                 logging.error(f"save_file failed: {e}")
                 return json.dumps({
@@ -5655,28 +5659,12 @@ class OrchestratorTools:
             # scattered LLM-saved files OUTSIDE the delegation directory —
             # live, a white paper landed in planning/<slug>/ as a sibling of
             # delegations/, duplicating the copy already written inside it.
-            target_dir = self._output_dir()
-            if subfolder:
-                safe_sub = Path(subfolder).name
-                target_dir = target_dir / safe_sub
-            target_dir.mkdir(parents=True, exist_ok=True)
-            dest = target_dir / safe_name
-
-            try:
-                with open(dest, "a", encoding="utf-8") as f:
-                    f.write(content)
-                print(f"    💾 Appended: {dest}")
-                return json.dumps({
-                    "status": "success",
-                    "path": str(dest),
-                    "size_bytes": dest.stat().st_size,
-                })
-            except Exception as e:
-                logging.error(f"append_file failed: {e}")
-                return json.dumps({
-                    "status": "error",
-                    "message": str(e),
-                })
+            from ...utils.file_io import write_text_file
+            out = write_text_file(self._output_dir(), safe_name, content,
+                                  subfolder=subfolder, append=True)
+            if out["status"] == "success":
+                print(f"    💾 Appended: {out['path']}")
+            return json.dumps(out)
 
         self._register_tool(
             func=append_file,
@@ -6280,203 +6268,17 @@ class OrchestratorTools:
             if error:
                 return error
 
-            path = Path(resolved)
-            if not path.is_file():
-                return json.dumps({
-                    "status": "error",
-                    "message": f"Not a file: {file_path}"
-                })
-
-            try:
-                ext = path.suffix.lower()
-
-                # Size guard — skip for Excel/CSV since we cap at 50 rows × 40 cols.
-                # Documents get more headroom: extraction is page-based and a
-                # figure-heavy PDF is megabytes of images, not of text.
-                if ext not in ('.xlsx', '.xls', '.csv'):
-                    size_mb = path.stat().st_size / (1024 * 1024)
-                    cap_mb = 25 if ext in ('.pdf', '.docx') else 5
-                    if size_mb > cap_mb:
-                        return json.dumps({
-                            "status": "error",
-                            "message": f"File too large ({size_mb:.1f} MB)."
-                        })
-
-                if ext == ".json":
-                    with open(path, 'r', encoding='utf-8') as f:
-                        data = json.load(f)
-                    content = json.dumps(data, indent=2)
-                elif ext in ('.xlsx', '.xls', '.csv'):
-                    MAX_PREVIEW_ROWS = 100
-                    MAX_PREVIEW_COLS = 40
-                    MAX_PREVIEW_CHARS = 30000
-                    if ext == '.csv':
-                        df_preview = pd.read_csv(path, nrows=MAX_PREVIEW_ROWS)
-                        with open(path) as _f:
-                            total_rows = sum(1 for _ in _f) - 1
-                    else:
-                        df_preview = pd.read_excel(path, nrows=MAX_PREVIEW_ROWS)
-                        try:
-                            import openpyxl
-                            _wb = openpyxl.load_workbook(path, read_only=True)
-                            total_rows = _wb.active.max_row - 1
-                            _wb.close()
-                        except Exception:
-                            total_rows = len(df_preview)
-                    total_cols = len(df_preview.columns)
-                    display_df = df_preview.iloc[:, :MAX_PREVIEW_COLS]
-                    preview_text = display_df.to_string()
-                    # Adaptive row reduction if output exceeds char budget
-                    if len(preview_text) > MAX_PREVIEW_CHARS and len(display_df) > 5:
-                        ratio = MAX_PREVIEW_CHARS / len(preview_text)
-                        fewer_rows = max(5, int(len(display_df) * ratio))
-                        display_df = display_df.iloc[:fewer_rows]
-                        preview_text = display_df.to_string()
-                        if len(preview_text) > MAX_PREVIEW_CHARS:
-                            preview_text = preview_text[:MAX_PREVIEW_CHARS] + "\n... (truncated)"
-                    shown_rows = len(display_df)
-                    shown_cols = len(display_df.columns)
-                    trunc_parts = []
-                    if shown_rows < total_rows:
-                        trunc_parts.append(f"first {shown_rows} rows")
-                    if shown_cols < total_cols:
-                        trunc_parts.append(f"first {shown_cols} columns")
-                    trunc = f" (showing {', '.join(trunc_parts)})" if trunc_parts else ""
-                    content = f"Shape: {total_rows} rows × {total_cols} columns{trunc}\n\n{preview_text}"
-                else:
-                    doc_meta = {}
-                    if ext in ('.pdf', '.docx'):
-                        # #397 phase 0: opened as text, a PDF returns its
-                        # compressed byte streams — live, a delegation handed
-                        # a proposal PDF could not ground on it (one run
-                        # proceeded from the caller's paraphrase; another
-                        # refused an adversarial review outright). Extraction
-                        # is ALREADY shared infrastructure; route through it.
-                        from ...parsers.extract import extract_text
-                        info = extract_text(
-                            str(path),
-                            ocr_model=getattr(self.orch.planner, "model",
-                                              None))
-                        raw = info.get("text") or ""
-                        if not raw.strip():
-                            return json.dumps({
-                                "status": "error",
-                                "message": (
-                                    f"No extractable text in {path.name} "
-                                    "(empty or image-only document).")})
-                        lines = raw.splitlines(keepends=True)
-                        doc_meta = {k: info[k] for k in
-                                    ("n_pages", "n_ocr_pages", "n_paragraphs")
-                                    if info.get(k) is not None}
-                        doc_meta["extracted"] = ext.lstrip(".")
-                    else:
-                        with open(path, 'r', encoding='utf-8',
-                                  errors='replace') as f:
-                            lines = f.readlines()
-                    total = len(lines)
-
-                    if search:
-                        # The real question behind most repeat reads is "is X
-                        # in here, and where" — a search, not a read. Answering
-                        # it directly costs one call and stays cheap however
-                        # long the file is.
-                        try:
-                            rx = re.compile(search, re.I)
-                        except re.error as e:
-                            return json.dumps({
-                                "status": "error",
-                                "message": f"Invalid search pattern: {e}"})
-                        hits = [i for i, ln in enumerate(lines) if rx.search(ln)]
-                        CAP = 40
-                        shown, out = hits[:CAP], []
-                        for i in shown:
-                            lo, hi = max(0, i - 1), min(total, i + 2)
-                            out.append(f"@@ line {i + 1}\n"
-                                       + "".join(lines[lo:hi]).rstrip("\n"))
-                        body = "\n\n".join(out) if out else "(no matches)"
-                        note = (f"{len(hits)} matching line(s) in {total} total"
-                                + (f"; showing the first {CAP}" if len(hits) > CAP
-                                   else ""))
-                        return json.dumps({
-                            "status": "success",
-                            "file_path": str(path),
-                            "mode": "search",
-                            "pattern": search,
-                            "matches": len(hits),
-                            "match_lines": [i + 1 for i in shown],
-                            "total_lines": total,
-                            "content": f"{note}\n\n{body}",
-                            **doc_meta,
-                        })
-
-                    # A truncated read must say what it is missing and where,
-                    # or the agent cannot tell a short file from a short read.
-                    def _outline():
-                        heads = [(i + 1, ln.strip()) for i, ln in
-                                 enumerate(lines) if ln.startswith('#')]
-                        if len(heads) < 2:
-                            return ""
-                        return "\nSections: " + " · ".join(
-                            f"{h.lstrip('# ')[:44]} @ line {n}"
-                            for n, h in heads[:12]) + (
-                            " …" if len(heads) > 12 else "")
-
-                    # Files read for their whole content, not their head.
-                    whole = (any(s in path.name.lower()
-                                 for s in _FULL_READ_STEMS)
-                             and offset is None and not tail
-                             and len("".join(lines)) <= _FULL_READ_MAX_CHARS)
-
-                    truncated = True
-                    if whole or total <= max_lines:
-                        first, last, content = 1, total, "".join(lines)
-                        truncated = False
-                    elif offset is not None:
-                        start = max(0, offset - 1)
-                        shown = lines[start:start + max_lines]
-                        first, last = start + 1, min(total, start + max_lines)
-                        content = "".join(shown) + (
-                            f"\n... (showing lines {first}-{last} of {total}."
-                            f"{_outline()})")
-                    elif tail:
-                        shown = lines[-max_lines:]
-                        first, last = total - max_lines + 1, total
-                        more = (f"... ({first - 1} earlier lines not shown; "
-                                f"omit tail to read from the top)")
-                        content = more + "\n" + "".join(shown)
-                    else:
-                        shown = lines[:max_lines]
-                        first, last = 1, max_lines
-                        content = "".join(shown) + (
-                            f"\n... ({total - max_lines} more lines not "
-                            f"shown — this is a TRUNCATED READ, not the whole "
-                            f"file. Jump to any part with offset=<line>; read "
-                            f"the END with tail=true; find something with "
-                            f"search='<pattern>'; or raise max_lines."
-                            f"{_outline()})")
-
-                    return json.dumps({
-                        "status": "success",
-                        "file_path": str(path),
-                        "mode": "tail" if tail else "head",
-                        "total_lines": total,
-                        "shown_lines": f"{first}-{last}",
-                        "truncated": truncated,
-                        "content": content,
-                        **doc_meta,
-                    })
-
-                return json.dumps({
-                    "status": "success",
-                    "file_path": str(path),
-                    "content": content
-                })
-
-            except Exception as e:
-                return json.dumps({
-                    "status": "error",
-                    "message": f"Failed to read file: {e}"
-                })
+            # Shared engine (#481): windowing (head / offset / tail /
+            # search), tabular preview, PDF / DOCX extraction, JSON cap.
+            # Planning keeps its path resolution and its whole-read stems.
+            from ...utils.file_io import read_file_content
+            return json.dumps(read_file_content(
+                Path(resolved), max_lines=max_lines, tail=tail,
+                search=search, offset=offset,
+                full_read_stems=_FULL_READ_STEMS,
+                full_read_max_chars=_FULL_READ_MAX_CHARS,
+                ocr_model=getattr(self.orch.planner, "model", None),
+                display_path=file_path))
 
         self._register_tool(
             func=read_file,

--- a/scilink/agents/sim_agents/simulation_orchestrator_tools.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator_tools.py
@@ -30,26 +30,10 @@ _READ_DOC_MAX_CHARS = 200_000
 
 
 def _extract_document_text(path: Path, ocr_model: Any = None) -> Dict[str, Any]:
-    """Extract plain text from a PDF / DOCX / Markdown / text file.
-
-    Thin wrapper over the shared ``scilink.parsers.extract_text`` (which adds
-    table-aware PDF extraction); it applies read_document's character cap.
-    When ``ocr_model`` is supplied, scanned/sparse PDF pages are transcribed
-    via the vision-OCR fallback. Returns a dict with ``text`` plus metadata
-    (page/paragraph count, ``n_chars``, ``truncated``, ``n_ocr_pages``).
-    Raises ValueError for an unsupported extension; reader errors propagate
-    to the caller.
-    """
-    from ...parsers import extract_text
-
-    info = extract_text(path, ocr_model=ocr_model)
-    text = info.get("text", "")
-    info["truncated"] = len(text) > _READ_DOC_MAX_CHARS
-    if info["truncated"]:
-        text = text[:_READ_DOC_MAX_CHARS]
-        info["text"] = text
-        info["n_chars"] = len(text)
-    return info
+    """Kept as a name for callers; the implementation is the shared engine's."""
+    from ...utils.file_io import extract_document_text
+    return extract_document_text(path, ocr_model=ocr_model,
+                                 max_chars=_READ_DOC_MAX_CHARS)
 
 
 class SimulationOrchestratorTools:
@@ -1848,27 +1832,17 @@ class SimulationOrchestratorTools:
                     "message": "Invalid filename.",
                 })
 
-            target_dir = Path(self.orch.base_dir)
-            if subfolder:
-                safe_sub = Path(subfolder).name
-                target_dir = target_dir / safe_sub
-            target_dir.mkdir(parents=True, exist_ok=True)
-            dest = target_dir / safe_name
-
-            try:
-                dest.write_text(content, encoding="utf-8")
-                print(f"    💾 Saved: {dest}")
-                return json.dumps({
-                    "status": "success",
-                    "path": str(dest),
-                    "size_bytes": dest.stat().st_size,
-                })
-            except Exception as e:
-                logging.error(f"save_file failed: {e}")
-                return json.dumps({
-                    "status": "error",
-                    "message": str(e),
-                })
+            # Shared engine (#481): traversal-proofing, subfolder, and the
+            # backup-on-overwrite #480 asked for (a generated INCAR can no
+            # longer be silently clobbered).
+            from ...utils.file_io import write_text_file
+            out = write_text_file(Path(self.orch.base_dir), safe_name, content,
+                                  subfolder=subfolder)
+            if out["status"] == "success":
+                print(f"    💾 Saved: {out['path']}"
+                      + (f" (previous version kept: {Path(out['backup']).name})"
+                         if out.get("backup") else ""))
+            return json.dumps(out)
 
         self._register_tool(
             func=save_file,
@@ -1922,28 +1896,12 @@ class SimulationOrchestratorTools:
                     "message": "Invalid filename.",
                 })
 
-            target_dir = Path(self.orch.base_dir)
-            if subfolder:
-                safe_sub = Path(subfolder).name
-                target_dir = target_dir / safe_sub
-            target_dir.mkdir(parents=True, exist_ok=True)
-            dest = target_dir / safe_name
-
-            try:
-                with open(dest, "a", encoding="utf-8") as f:
-                    f.write(content)
-                print(f"    💾 Appended: {dest}")
-                return json.dumps({
-                    "status": "success",
-                    "path": str(dest),
-                    "size_bytes": dest.stat().st_size,
-                })
-            except Exception as e:
-                logging.error(f"append_file failed: {e}")
-                return json.dumps({
-                    "status": "error",
-                    "message": str(e),
-                })
+            from ...utils.file_io import write_text_file
+            out = write_text_file(Path(self.orch.base_dir), safe_name, content,
+                                  subfolder=subfolder, append=True)
+            if out["status"] == "success":
+                print(f"    💾 Appended: {out['path']}")
+            return json.dumps(out)
 
         self._register_tool(
             func=append_file,
@@ -1998,201 +1956,15 @@ class SimulationOrchestratorTools:
             path = Path(file_path)
             if not path.is_absolute():
                 path = Path(self.orch.base_dir) / path
-            if not path.is_file():
-                return json.dumps({
-                    "status": "error",
-                    "message": f"Not a file: {file_path}",
-                })
-
-            try:
-                ext = path.suffix.lower()
-
-                # Size guard — skip for Excel/CSV since we cap at 100 rows × 40
-                # cols. Documents get more headroom: extraction is page-based
-                # and a figure-heavy PDF is megabytes of images, not of text.
-                if ext not in ('.xlsx', '.xls', '.csv'):
-                    size_mb = path.stat().st_size / (1024 * 1024)
-                    cap_mb = 25 if ext in ('.pdf', '.docx') else 5
-                    if size_mb > cap_mb:
-                        return json.dumps({
-                            "status": "error",
-                            "message": f"File too large ({size_mb:.1f} MB).",
-                        })
-
-                if ext == ".json":
-                    with open(path, 'r', encoding='utf-8') as f:
-                        data = json.load(f)
-                    content = json.dumps(data, indent=2)
-                    return json.dumps({
-                        "status": "success",
-                        "file_path": str(path),
-                        "content": content,
-                    })
-
-                if ext in ('.xlsx', '.xls', '.csv'):
-                    MAX_PREVIEW_ROWS = 100
-                    MAX_PREVIEW_COLS = 40
-                    MAX_PREVIEW_CHARS = 30000
-                    if ext == '.csv':
-                        df_preview = pd.read_csv(path, nrows=MAX_PREVIEW_ROWS)
-                        with open(path) as _f:
-                            total_rows = sum(1 for _ in _f) - 1
-                    else:
-                        df_preview = pd.read_excel(path, nrows=MAX_PREVIEW_ROWS)
-                        try:
-                            import openpyxl
-                            _wb = openpyxl.load_workbook(path, read_only=True)
-                            total_rows = _wb.active.max_row - 1
-                            _wb.close()
-                        except Exception:
-                            total_rows = len(df_preview)
-                    total_cols = len(df_preview.columns)
-                    display_df = df_preview.iloc[:, :MAX_PREVIEW_COLS]
-                    preview_text = display_df.to_string()
-                    if len(preview_text) > MAX_PREVIEW_CHARS and len(display_df) > 5:
-                        ratio = MAX_PREVIEW_CHARS / len(preview_text)
-                        fewer_rows = max(5, int(len(display_df) * ratio))
-                        display_df = display_df.iloc[:fewer_rows]
-                        preview_text = display_df.to_string()
-                        if len(preview_text) > MAX_PREVIEW_CHARS:
-                            preview_text = preview_text[:MAX_PREVIEW_CHARS] + "\n... (truncated)"
-                    shown_rows = len(display_df)
-                    shown_cols = len(display_df.columns)
-                    trunc_parts = []
-                    if shown_rows < total_rows:
-                        trunc_parts.append(f"first {shown_rows} rows")
-                    if shown_cols < total_cols:
-                        trunc_parts.append(f"first {shown_cols} columns")
-                    trunc = f" (showing {', '.join(trunc_parts)})" if trunc_parts else ""
-                    content = f"Shape: {total_rows} rows × {total_cols} columns{trunc}\n\n{preview_text}"
-                    return json.dumps({
-                        "status": "success",
-                        "file_path": str(path),
-                        "content": content,
-                    })
-
-                doc_meta = {}
-                if ext in ('.pdf', '.docx'):
-                    # Opened as text a PDF returns its compressed byte streams;
-                    # route through the shared extractor instead (table-aware,
-                    # OCR fallback via the session model).
-                    from ...parsers.extract import extract_text
-                    info = extract_text(
-                        str(path), ocr_model=getattr(self.orch, "model", None))
-                    raw = info.get("text") or ""
-                    if not raw.strip():
-                        return json.dumps({
-                            "status": "error",
-                            "message": (
-                                f"No extractable text in {path.name} "
-                                "(empty or image-only document)."),
-                        })
-                    lines = raw.splitlines(keepends=True)
-                    doc_meta = {k: info[k] for k in
-                                ("n_pages", "n_ocr_pages", "n_paragraphs")
-                                if info.get(k) is not None}
-                    doc_meta["extracted"] = ext.lstrip(".")
-                else:
-                    with open(path, 'r', encoding='utf-8',
-                              errors='replace') as f:
-                        lines = f.readlines()
-                total = len(lines)
-
-                if search:
-                    # The real question behind most repeat reads is "is X in
-                    # here, and where" — a search, not a read. Answer it
-                    # directly, cheaply, however long the file is.
-                    try:
-                        rx = re.compile(search, re.I)
-                    except re.error as e:
-                        return json.dumps({
-                            "status": "error",
-                            "message": f"Invalid search pattern: {e}"})
-                    hits = [i for i, ln in enumerate(lines) if rx.search(ln)]
-                    CAP = 40
-                    shown, out = hits[:CAP], []
-                    for i in shown:
-                        lo, hi = max(0, i - 1), min(total, i + 2)
-                        out.append(f"@@ line {i + 1}\n"
-                                   + "".join(lines[lo:hi]).rstrip("\n"))
-                    body = "\n\n".join(out) if out else "(no matches)"
-                    note = (f"{len(hits)} matching line(s) in {total} total"
-                            + (f"; showing the first {CAP}" if len(hits) > CAP
-                               else ""))
-                    return json.dumps({
-                        "status": "success",
-                        "file_path": str(path),
-                        "mode": "search",
-                        "pattern": search,
-                        "matches": len(hits),
-                        "match_lines": [i + 1 for i in shown],
-                        "total_lines": total,
-                        "content": f"{note}\n\n{body}",
-                        **doc_meta,
-                    })
-
-                # A truncated read must say what it is missing and where, or the
-                # agent cannot tell a short file from a short read.
-                def _outline():
-                    heads = [(i + 1, ln.strip()) for i, ln in
-                             enumerate(lines) if ln.startswith('#')]
-                    if len(heads) < 2:
-                        return ""
-                    return "\nSections: " + " · ".join(
-                        f"{h.lstrip('# ')[:44]} @ line {n}"
-                        for n, h in heads[:12]) + (
-                        " …" if len(heads) > 12 else "")
-
-                # Files read for their whole content, not their head.
-                whole = (any(s in path.name.lower()
-                             for s in _FULL_READ_STEMS)
-                         and offset is None and not tail
-                         and len("".join(lines)) <= _FULL_READ_MAX_CHARS)
-
-                truncated = True
-                if whole or total <= max_lines:
-                    first, last, content = 1, total, "".join(lines)
-                    truncated = False
-                elif offset is not None:
-                    start = max(0, offset - 1)
-                    shown = lines[start:start + max_lines]
-                    first, last = start + 1, min(total, start + max_lines)
-                    content = "".join(shown) + (
-                        f"\n... (showing lines {first}-{last} of {total}."
-                        f"{_outline()})")
-                elif tail:
-                    shown = lines[-max_lines:]
-                    first, last = total - max_lines + 1, total
-                    more = (f"... ({first - 1} earlier lines not shown; "
-                            f"omit tail to read from the top)")
-                    content = more + "\n" + "".join(shown)
-                else:
-                    shown = lines[:max_lines]
-                    first, last = 1, max_lines
-                    content = "".join(shown) + (
-                        f"\n... ({total - max_lines} more lines not "
-                        f"shown — this is a TRUNCATED READ, not the whole "
-                        f"file. Jump to any part with offset=<line>; read "
-                        f"the END with tail=true; find something with "
-                        f"search='<pattern>'; or raise max_lines."
-                        f"{_outline()})")
-
-                return json.dumps({
-                    "status": "success",
-                    "file_path": str(path),
-                    "mode": "tail" if tail else "head",
-                    "total_lines": total,
-                    "shown_lines": f"{first}-{last}",
-                    "truncated": truncated,
-                    "content": content,
-                    **doc_meta,
-                })
-
-            except Exception as e:
-                return json.dumps({
-                    "status": "error",
-                    "message": f"Failed to read file: {e}",
-                })
+            # Shared engine (#481); simulation keeps its whole-read stems
+            # (reports and summaries) and session-relative resolution.
+            from ...utils.file_io import read_file_content
+            return json.dumps(read_file_content(
+                path, max_lines=max_lines, tail=tail, search=search,
+                offset=offset, full_read_stems=_FULL_READ_STEMS,
+                full_read_max_chars=_FULL_READ_MAX_CHARS,
+                ocr_model=getattr(self.orch, "model", None),
+                display_path=file_path))
 
         self._register_tool(
             func=read_file,
@@ -2262,58 +2034,13 @@ class SimulationOrchestratorTools:
             the user provided."""
             if isinstance(paths, str):
                 paths = [paths]
-            if not paths:
-                return json.dumps({
-                    "status": "error",
-                    "message": "No document path provided.",
-                })
-            print(f"  📄 Tool: Reading {len(paths)} document(s)...")
-            docs, errors = [], []
-            for p in paths:
-                dp = Path(p)
-                if not dp.is_absolute():
-                    dp = Path(self.orch.base_dir) / dp
-                if not dp.is_file():
-                    errors.append(f"Not a file: {p}")
-                    continue
-                try:
-                    docs.append((dp, _extract_document_text(
-                        dp, ocr_model=getattr(self.orch, "model", None))))
-                except ValueError as e:
-                    errors.append(str(e))
-                except Exception as e:
-                    logging.error(f"read_document failed for {p}: {e}")
-                    errors.append(f"Could not read {dp.name}: {e}")
-            if not docs:
-                return json.dumps({
-                    "status": "error",
-                    "message": "No documents could be read.",
-                    "errors": errors,
-                })
-            combined = "\n\n---\n\n".join(
-                f"## {dp.name}\n\n{info['text']}" for dp, info in docs
-            )
-            combined_truncated = len(combined) > _READ_DOC_MAX_CHARS
-            if combined_truncated:
-                combined = combined[:_READ_DOC_MAX_CHARS]
-            n_ocr = sum(info.get("n_ocr_pages", 0) for _, info in docs)
-            return json.dumps({
-                "status": "success",
-                "n_documents": len(docs),
-                "n_ocr_pages": n_ocr,
-                "ocr_note": (
-                    f"{n_ocr} scanned page(s) had no text layer and were "
-                    "transcribed by vision-OCR — verify any figures/numerics."
-                ) if n_ocr else None,
-                "documents": [
-                    {"name": dp.name,
-                     **{k: v for k, v in info.items() if k != "text"}}
-                    for dp, info in docs
-                ],
-                "errors": errors or None,
-                "combined_truncated": combined_truncated,
-                "text": combined,
-            })
+            if paths:
+                print(f"  📄 Tool: Reading {len(paths)} document(s)...")
+            from ...utils.file_io import read_documents_combined
+            return json.dumps(read_documents_combined(
+                paths, base_dir=Path(self.orch.base_dir),
+                ocr_model=getattr(self.orch, "model", None),
+                max_chars=_READ_DOC_MAX_CHARS))
 
         self._register_tool(
             func=read_document,

--- a/scilink/utils/file_io.py
+++ b/scilink/utils/file_io.py
@@ -1,0 +1,393 @@
+"""Generic file I/O engine shared by the orchestrators' file tools (#481).
+
+One implementation per operation; everything mode-specific arrives as a
+parameter. The orchestrators keep thin wrappers that own tool registration,
+transcript prints, relative-path resolution, the mode-flavored routing text,
+and (planning) deliverable recording + the PDF-twin invariant. This is the
+same split ``file_edit.py`` already uses for ``edit_file`` / ``rename_file``.
+
+Why one engine: the planning, analysis and simulation copies had started to
+need the *same* fixes — the JSON pretty-print with no cap, and
+backup-on-overwrite for ``save_file`` — and each mode's copy had drifted in
+small accidental ways. Both fixes land here, once:
+
+* ``read_file_content`` windows a pretty-printed JSON exactly like text
+  (``max_lines`` / ``offset`` / ``tail`` / ``search``), so a large JSON no
+  longer lands whole in context; a small one is returned whole as before.
+* ``write_text_file`` backs up an existing file before overwriting it
+  (``<stem>.before_overwrite<suffix>``, counter-suffixed, never clobbering),
+  the way ``edit_file`` always backed up before an edit.
+
+Every function returns a plain dict the wrapper serializes; nothing here
+prints or raises for the ordinary failure modes (a missing file, a bad
+pattern) — those come back as ``{"status": "error", "message": ...}``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import shutil
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ── read_file ────────────────────────────────────────────────────────
+
+# Size guards: documents get more headroom because extraction is
+# page-based and a figure-heavy PDF is megabytes of images, not text.
+# Tabular files are previewed (rows × cols), so they carry no byte cap.
+DEFAULT_TEXT_CAP_MB = 5
+DEFAULT_DOC_CAP_MB = 25
+_TABULAR = (".xlsx", ".xls", ".csv")
+_DOCUMENT = (".pdf", ".docx")
+MAX_PREVIEW_ROWS = 100
+MAX_PREVIEW_COLS = 40
+MAX_PREVIEW_CHARS = 30_000
+SEARCH_HIT_CAP = 40
+DEFAULT_FULL_READ_MAX_CHARS = 250_000
+
+
+def _size_error(path: Path, cap_mb: float) -> Optional[Dict[str, Any]]:
+    size_mb = path.stat().st_size / (1024 * 1024)
+    if size_mb > cap_mb:
+        return {"status": "error",
+                "message": f"File too large ({size_mb:.1f} MB)."}
+    return None
+
+
+def _tabular_preview(path: Path, ext: str) -> str:
+    import pandas as pd
+
+    if ext == ".csv":
+        df_preview = pd.read_csv(path, nrows=MAX_PREVIEW_ROWS)
+        with open(path) as _f:
+            total_rows = sum(1 for _ in _f) - 1
+    else:
+        df_preview = pd.read_excel(path, nrows=MAX_PREVIEW_ROWS)
+        try:
+            import openpyxl
+            _wb = openpyxl.load_workbook(path, read_only=True)
+            total_rows = _wb.active.max_row - 1
+            _wb.close()
+        except Exception:  # noqa: BLE001 - fall back to what pandas read
+            total_rows = len(df_preview)
+    total_cols = len(df_preview.columns)
+    display_df = df_preview.iloc[:, :MAX_PREVIEW_COLS]
+    preview_text = display_df.to_string()
+    # Adaptive row reduction if the rendering exceeds the char budget.
+    if len(preview_text) > MAX_PREVIEW_CHARS and len(display_df) > 5:
+        ratio = MAX_PREVIEW_CHARS / len(preview_text)
+        fewer_rows = max(5, int(len(display_df) * ratio))
+        display_df = display_df.iloc[:fewer_rows]
+        preview_text = display_df.to_string()
+        if len(preview_text) > MAX_PREVIEW_CHARS:
+            preview_text = preview_text[:MAX_PREVIEW_CHARS] + "\n... (truncated)"
+    shown_rows, shown_cols = len(display_df), len(display_df.columns)
+    trunc_parts = []
+    if shown_rows < total_rows:
+        trunc_parts.append(f"first {shown_rows} rows")
+    if shown_cols < total_cols:
+        trunc_parts.append(f"first {shown_cols} columns")
+    trunc = f" (showing {', '.join(trunc_parts)})" if trunc_parts else ""
+    return f"Shape: {total_rows} rows × {total_cols} columns{trunc}\n\n{preview_text}"
+
+
+def _outline(lines: Sequence[str]) -> str:
+    """Section headings with line numbers, so a truncated read says where
+    the rest is instead of only that it is missing."""
+    heads = [(i + 1, ln.strip()) for i, ln in enumerate(lines)
+             if ln.startswith("#")]
+    if len(heads) < 2:
+        return ""
+    return "\nSections: " + " · ".join(
+        f"{h.lstrip('# ')[:44]} @ line {n}" for n, h in heads[:12]) + (
+        " …" if len(heads) > 12 else "")
+
+
+def window_lines(lines: List[str], *, max_lines: int = 200,
+                 tail: bool = False, search: Optional[str] = None,
+                 offset: Optional[int] = None,
+                 whole: bool = False) -> Dict[str, Any]:
+    """The windowing half of ``read_file`` over an already-loaded list of
+    lines (``keepends`` style): search / offset / tail / head, with the
+    truncation notices that name the way to the rest. Returns the result
+    fields (``mode``, ``content``, ...) without ``status`` / ``file_path``.
+    """
+    total = len(lines)
+    if search:
+        # The real question behind most repeat reads is "is X in here, and
+        # where" — a search, not a read. Answer it in one cheap call.
+        try:
+            rx = re.compile(search, re.I)
+        except re.error as e:
+            return {"status": "error",
+                    "message": f"Invalid search pattern: {e}"}
+        hits = [i for i, ln in enumerate(lines) if rx.search(ln)]
+        shown, out = hits[:SEARCH_HIT_CAP], []
+        for i in shown:
+            lo, hi = max(0, i - 1), min(total, i + 2)
+            out.append(f"@@ line {i + 1}\n" + "".join(lines[lo:hi]).rstrip("\n"))
+        body = "\n\n".join(out) if out else "(no matches)"
+        note = (f"{len(hits)} matching line(s) in {total} total"
+                + (f"; showing the first {SEARCH_HIT_CAP}"
+                   if len(hits) > SEARCH_HIT_CAP else ""))
+        return {"mode": "search", "pattern": search, "matches": len(hits),
+                "match_lines": [i + 1 for i in shown], "total_lines": total,
+                "content": f"{note}\n\n{body}"}
+
+    truncated = True
+    if whole or total <= max_lines:
+        first, last, content = 1, total, "".join(lines)
+        truncated = False
+    elif offset is not None:
+        start = max(0, offset - 1)
+        shown = lines[start:start + max_lines]
+        first, last = start + 1, min(total, start + max_lines)
+        content = "".join(shown) + (
+            f"\n... (showing lines {first}-{last} of {total}."
+            f"{_outline(lines)})")
+    elif tail:
+        shown = lines[-max_lines:]
+        first, last = total - max_lines + 1, total
+        more = (f"... ({first - 1} earlier lines not shown; "
+                f"omit tail to read from the top)")
+        content = more + "\n" + "".join(shown)
+    else:
+        shown = lines[:max_lines]
+        first, last = 1, max_lines
+        content = "".join(shown) + (
+            f"\n... ({total - max_lines} more lines not shown — this is a "
+            f"TRUNCATED READ, not the whole file. Jump to any part with "
+            f"offset=<line>; read the END with tail=true; find something "
+            f"with search='<pattern>'; or raise max_lines."
+            f"{_outline(lines)})")
+    return {"mode": "tail" if tail else "head", "total_lines": total,
+            "shown_lines": f"{first}-{last}", "truncated": truncated,
+            "content": content}
+
+
+def read_file_content(path: Path, *, max_lines: int = 200,
+                      tail: bool = False, search: Optional[str] = None,
+                      offset: Optional[int] = None,
+                      full_read_stems: Iterable[str] = (),
+                      full_read_max_chars: int = DEFAULT_FULL_READ_MAX_CHARS,
+                      ocr_model: Any = None,
+                      text_cap_mb: float = DEFAULT_TEXT_CAP_MB,
+                      doc_cap_mb: float = DEFAULT_DOC_CAP_MB,
+                      display_path: Optional[str] = None) -> Dict[str, Any]:
+    """The whole ``read_file`` reader over a resolved, existing file.
+
+    JSON is pretty-printed then windowed like text (the cap #481 asked for:
+    a small JSON is returned whole, a large one truncates with the same
+    offset / tail / search escape hatches); CSV / Excel are previewed as a
+    rows × cols table; PDF / DOCX are extracted through the shared parser
+    (OCR fallback via ``ocr_model``) and windowed like text; everything else
+    is read as UTF-8 text. ``full_read_stems`` names files (by substring of
+    the name) that are returned whole up to ``full_read_max_chars``.
+    """
+    path = Path(path)
+    if not path.is_file():
+        return {"status": "error",
+                "message": f"Not a file: {display_path or path}"}
+    shown_path = str(path)
+    try:
+        ext = path.suffix.lower()
+        if ext not in _TABULAR:
+            err = _size_error(path, doc_cap_mb if ext in _DOCUMENT else text_cap_mb)
+            if err:
+                return err
+
+        if ext in _TABULAR:
+            return {"status": "success", "file_path": shown_path,
+                    "content": _tabular_preview(path, ext)}
+
+        doc_meta: Dict[str, Any] = {}
+        if ext == ".json":
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            lines = json.dumps(data, indent=2).splitlines(keepends=True)
+        elif ext in _DOCUMENT:
+            # Opened as text a PDF returns its compressed byte streams (#397);
+            # extraction is shared infrastructure — route through it.
+            from scilink.parsers.extract import extract_text
+            info = extract_text(str(path), ocr_model=ocr_model)
+            raw = info.get("text") or ""
+            if not raw.strip():
+                return {"status": "error",
+                        "message": (f"No extractable text in {path.name} "
+                                    "(empty or image-only document).")}
+            lines = raw.splitlines(keepends=True)
+            doc_meta = {k: info[k] for k in ("n_pages", "n_ocr_pages", "n_paragraphs")
+                        if info.get(k) is not None}
+            doc_meta["extracted"] = ext.lstrip(".")
+        else:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                lines = f.readlines()
+
+        name = path.name.lower()
+        whole = (any(s in name for s in full_read_stems)
+                 and offset is None and not tail
+                 and len("".join(lines)) <= full_read_max_chars)
+        win = window_lines(lines, max_lines=max_lines, tail=tail,
+                           search=search, offset=offset, whole=whole)
+        if win.get("status") == "error":
+            return win
+        return {"status": "success", "file_path": shown_path, **win, **doc_meta}
+    except Exception as e:  # noqa: BLE001 - the tool reports, never raises
+        return {"status": "error", "message": f"Failed to read file: {e}"}
+
+
+# ── save_file / append_file ─────────────────────────────────────────
+
+def _next_backup_path(dest: Path) -> Path:
+    """``<stem>.before_overwrite<suffix>``, then ``.before_overwrite.2``,
+    ``.3``, … — never clobbering an earlier backup."""
+    base = dest.with_name(f"{dest.stem}.before_overwrite{dest.suffix}")
+    if not base.exists():
+        return base
+    n = 2
+    while True:
+        cand = dest.with_name(f"{dest.stem}.before_overwrite.{n}{dest.suffix}")
+        if not cand.exists():
+            return cand
+        n += 1
+
+
+def write_text_file(base_dir: Path, filename: str, content: str, *,
+                    subfolder: str = "", append: bool = False,
+                    backup_on_overwrite: bool = True) -> Dict[str, Any]:
+    """Write (or append) UTF-8 text under ``base_dir``.
+
+    Traversal-proof: only the last path component of ``filename`` and of
+    ``subfolder`` is used, so ``../../x`` lands inside the session. On an
+    overwrite (``append=False``, file exists, ``backup_on_overwrite``) the
+    previous content is copied to a counter-suffixed ``.before_overwrite``
+    sibling first — a generated INCAR or a report can no longer be silently
+    clobbered while ``edit_file`` on the same file would have backed up.
+    """
+    safe_name = Path(filename).name
+    if not safe_name or safe_name in (".", ".."):
+        return {"status": "error", "message": "Invalid filename."}
+    target_dir = Path(base_dir)
+    if subfolder:
+        safe_sub = Path(subfolder).name
+        if safe_sub and safe_sub not in (".", ".."):
+            target_dir = target_dir / safe_sub
+    dest = target_dir / safe_name
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        existed = dest.exists()
+        backup: Optional[str] = None
+        if append:
+            with open(dest, "a", encoding="utf-8") as f:
+                f.write(content)
+        else:
+            if existed and backup_on_overwrite and dest.is_file():
+                bak = _next_backup_path(dest)
+                try:
+                    shutil.copyfile(dest, bak)
+                    backup = str(bak)
+                except OSError as exc:  # keep writing: a lost backup beats a lost write
+                    logger.warning(f"backup before overwrite failed for {dest}: {exc}")
+            dest.write_text(content, encoding="utf-8")
+        out: Dict[str, Any] = {"status": "success", "path": str(dest),
+                               "size_bytes": dest.stat().st_size,
+                               "created": not existed}
+        if not append:
+            out["overwritten"] = existed
+            if backup:
+                out["backup"] = backup
+        return out
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"{'append_file' if append else 'save_file'} failed: {e}")
+        return {"status": "error", "message": str(e)}
+
+
+# ── read_document ───────────────────────────────────────────────────
+
+DEFAULT_READ_DOC_MAX_CHARS = 200_000  # ~50k tokens; longer is truncated
+
+
+def extract_document_text(path: Path, ocr_model: Any = None,
+                          max_chars: int = DEFAULT_READ_DOC_MAX_CHARS
+                          ) -> Dict[str, Any]:
+    """Extract plain text from a PDF / DOCX / Markdown / text file.
+
+    Thin wrapper over the shared ``scilink.parsers.extract_text`` (table-
+    aware PDF extraction, vision-OCR fallback for scanned pages when
+    ``ocr_model`` is given) that applies the per-document character cap.
+    Returns ``text`` plus metadata (page / paragraph counts, ``n_chars``,
+    ``truncated``, ``n_ocr_pages``). Raises ValueError for an unsupported
+    extension; reader errors propagate to the caller.
+    """
+    from scilink.parsers import extract_text
+
+    info = extract_text(path, ocr_model=ocr_model)
+    text = info.get("text", "")
+    info["truncated"] = len(text) > max_chars
+    if info["truncated"]:
+        text = text[:max_chars]
+        info["text"] = text
+        info["n_chars"] = len(text)
+    return info
+
+
+def read_documents_combined(paths: Sequence[str], *, base_dir: Optional[Path] = None,
+                            ocr_model: Any = None,
+                            max_chars: int = DEFAULT_READ_DOC_MAX_CHARS
+                            ) -> Dict[str, Any]:
+    """Extract several documents and combine them into one text block.
+
+    Relative paths resolve against ``base_dir`` when given. Returns
+    ``{"status": "error", ...}`` when nothing could be read, otherwise the
+    combined text with per-document metadata, the errors for the ones that
+    failed, and the OCR page count — the wrapper adds its mode's extras
+    (analysis persists a literature file; sim / planning do not).
+    """
+    if isinstance(paths, str):
+        paths = [paths]
+    if not paths:
+        return {"status": "error", "message": "No document path provided."}
+    docs: List[Tuple[Path, Dict[str, Any]]] = []
+    errors: List[str] = []
+    for p in paths:
+        dp = Path(p)
+        if base_dir is not None and not dp.is_absolute():
+            dp = Path(base_dir) / dp
+        if not dp.is_file():
+            errors.append(f"Not a file: {p}")
+            continue
+        try:
+            docs.append((dp, extract_document_text(dp, ocr_model=ocr_model,
+                                                   max_chars=max_chars)))
+        except ValueError as e:
+            errors.append(str(e))
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"read_document failed for {p}: {e}")
+            errors.append(f"Could not read {dp.name}: {e}")
+    if not docs:
+        return {"status": "error", "message": "No documents could be read.",
+                "errors": errors}
+    combined = "\n\n---\n\n".join(f"## {dp.name}\n\n{info['text']}"
+                                   for dp, info in docs)
+    combined_truncated = len(combined) > max_chars
+    if combined_truncated:
+        combined = combined[:max_chars]
+    n_ocr = sum(info.get("n_ocr_pages", 0) for _, info in docs)
+    return {
+        "status": "success",
+        "n_documents": len(docs),
+        "n_ocr_pages": n_ocr,
+        "ocr_note": (f"{n_ocr} scanned page(s) had no text layer and were "
+                     "transcribed by vision-OCR — verify any figures/numerics."
+                     ) if n_ocr else None,
+        "documents": [{"name": dp.name,
+                       **{k: v for k, v in info.items() if k != "text"}}
+                      for dp, info in docs],
+        "errors": errors or None,
+        "combined_truncated": combined_truncated,
+        "text": combined,
+    }

--- a/tests/test_capabilities_cache.py
+++ b/tests/test_capabilities_cache.py
@@ -76,3 +76,25 @@ def test_cache_bounded(tmp_path):
     cached = json.loads(meta._CAPABILITIES_CACHE.read_text())
     assert len(cached) <= MetaOrchestratorAgent._CAPABILITIES_CACHE_MAX
     assert "block" in cached.values()
+
+
+def test_key_moves_when_a_tool_module_changes(tmp_path, monkeypatch):
+    """A new tool in any specialist must miss the cache without a version
+    bump: the registration modules' source is part of the key."""
+    import sys
+    pkg = tmp_path / "fake_tools_mod.py"
+    pkg.write_text("TOOLS = ['save_file']\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(MetaOrchestratorAgent, "_TOOL_SOURCE_MODULES",
+                        ("fake_tools_mod",))
+    sys.modules.pop("fake_tools_mod", None)
+    meta = _bare_meta(tmp_path, [])
+    k1 = meta._capabilities_cache_key()
+    pkg.write_text("TOOLS = ['save_file', 'read_file']\n")
+    k2 = meta._capabilities_cache_key()
+    assert k1 != k2
+    assert meta._capabilities_cache_key() == k2       # deterministic
+    # a module that cannot be found contributes nothing, never raises
+    monkeypatch.setattr(MetaOrchestratorAgent, "_TOOL_SOURCE_MODULES",
+                        ("no_such_module_xyz",))
+    assert isinstance(meta._capabilities_cache_key(), str)

--- a/tests/test_file_io_engine.py
+++ b/tests/test_file_io_engine.py
@@ -1,0 +1,175 @@
+"""The shared file I/O engine (#481): one reader / writer for every mode.
+
+Behavior-preserving extraction of the planning / analysis / simulation
+copies, plus the two guards the issue asked for: a cap on pretty-printed
+JSON (windowed like text) and backup-on-overwrite for save_file.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scilink.utils.file_io import (
+    read_documents_combined, read_file_content, window_lines, write_text_file)
+
+BODY = ([f"line {i}\n" for i in range(1, 501)]
+        + ["\n", "## References\n", "[1] Boettiger et al. 2013\n",
+           "[2] Dakos et al. 2024\n"])
+
+
+@pytest.fixture
+def doc(tmp_path):
+    p = tmp_path / "paper.md"
+    p.write_text("".join(BODY))
+    return p
+
+
+# ── windowing ────────────────────────────────────────────────────
+
+def test_head_default_and_truncation_notice(doc):
+    out = read_file_content(doc)
+    assert out["status"] == "success" and out["mode"] == "head"
+    assert out["shown_lines"] == "1-200" and out["truncated"] is True
+    assert out["total_lines"] == 504
+    assert "tail=true" in out["content"] and "search=" in out["content"]
+    assert "## References" not in out["content"]
+
+
+def test_tail_offset_search(doc):
+    t = read_file_content(doc, tail=True, max_lines=10)
+    assert t["mode"] == "tail" and t["shown_lines"] == "495-504"
+    assert "[2] Dakos et al. 2024" in t["content"] and "earlier lines not shown" in t["content"]
+    o = read_file_content(doc, offset=498, max_lines=3)
+    assert o["shown_lines"] == "498-500" and "line 498" in o["content"]
+    assert "Sections:" not in o["content"]       # one heading: no outline (needs 2+)
+    s = read_file_content(doc, search=r"^##\s*References")
+    assert s["mode"] == "search" and s["matches"] == 1 and s["match_lines"] == [502]
+    assert "@@ line 502" in s["content"]
+    none = read_file_content(doc, search="Acknowledgements")
+    assert none["matches"] == 0 and "(no matches)" in none["content"]
+    broad = read_file_content(doc, search="line")
+    assert broad["matches"] == 500 and len(broad["match_lines"]) == 40
+    assert "showing the first 40" in broad["content"]
+    bad = read_file_content(doc, search="[unclosed")
+    assert bad["status"] == "error" and "Invalid search pattern" in bad["message"]
+
+
+def test_short_file_whole_and_full_read_stems(tmp_path):
+    small = tmp_path / "small.md"
+    small.write_text("one\ntwo\n")
+    out = read_file_content(small)
+    assert out["truncated"] is False and out["content"] == "one\ntwo\n"
+    assert out["shown_lines"] == "1-2"
+    lit = tmp_path / "literature_search_1.md"
+    lit.write_text("".join(f"row {i}\n" for i in range(1000)))
+    whole = read_file_content(lit, full_read_stems=("literature_search",))
+    assert whole["truncated"] is False and whole["total_lines"] == 1000
+    # ...but offset / tail still window it, and the char cap still applies
+    assert read_file_content(lit, full_read_stems=("literature_search",), tail=True)["truncated"] is True
+    assert read_file_content(lit, full_read_stems=("literature_search",),
+                             full_read_max_chars=100)["truncated"] is True
+
+
+def test_missing_and_oversized(tmp_path):
+    assert read_file_content(tmp_path / "nope.txt")["status"] == "error"
+    big = tmp_path / "big.log"
+    big.write_bytes(b"x" * (6 * 1024 * 1024))
+    assert "too large" in read_file_content(big)["message"]
+    assert read_file_content(big, text_cap_mb=10)["status"] == "success"
+
+
+# ── JSON: the cap #481 asked for ─────────────────────────────────
+
+def test_small_json_is_returned_whole_pretty_printed(tmp_path):
+    p = tmp_path / "plan.json"
+    p.write_text(json.dumps({"a": 1, "b": [1, 2]}))
+    out = read_file_content(p)
+    assert out["status"] == "success" and out["truncated"] is False
+    assert '"a": 1' in out["content"] and out["content"].startswith("{\n")
+
+
+def test_large_json_is_windowed_not_dumped(tmp_path):
+    p = tmp_path / "big.json"
+    p.write_text(json.dumps({f"key_{i}": list(range(20)) for i in range(400)}))
+    out = read_file_content(p)
+    assert out["truncated"] is True and out["shown_lines"] == "1-200"
+    assert out["total_lines"] > 8000
+    assert "TRUNCATED READ" in out["content"]
+    found = read_file_content(p, search="key_399")
+    assert found["matches"] == 1
+    assert len(read_file_content(p, max_lines=50)["content"]) < 5000
+
+
+# ── tabular + documents ──────────────────────────────────────────
+
+def test_csv_preview(tmp_path):
+    p = tmp_path / "t.csv"
+    p.write_text("a,b\n" + "".join(f"{i},{i*2}\n" for i in range(300)))
+    out = read_file_content(p)
+    assert out["status"] == "success" and out["content"].startswith("Shape: 300 rows × 2 columns")
+    assert "showing first 100 rows" in out["content"]
+
+
+def test_pdf_is_extracted_and_windowed(tmp_path):
+    pytest.importorskip("fitz")
+    pytest.importorskip("markdown_it")
+    from scilink.utils.md_to_pdf import markdown_to_pdf
+    md = tmp_path / "prop.md"
+    md.write_text("# Proposal\n\n" + "".join(f"Aim {i}: MARKER-{i}. " for i in range(1, 30))
+                  + "\n\n## References\n\n[1] MARKER-REF Boettiger 2013\n")
+    pdf = markdown_to_pdf(md, tmp_path / "prop.pdf")
+    out = read_file_content(pdf)
+    assert "%PDF" not in out["content"] and "MARKER-1" in out["content"]
+    assert out["extracted"] == "pdf" and out["n_pages"] >= 1
+    assert read_file_content(pdf, search="MARKER-REF")["matches"] == 1
+    docs = read_documents_combined([str(pdf), str(md), str(tmp_path / "gone.pdf")])
+    assert docs["status"] == "success" and docs["n_documents"] == 2
+    assert docs["errors"] == ["Not a file: " + str(tmp_path / "gone.pdf")]
+    assert "## prop.pdf" in docs["text"] and "## prop.md" in docs["text"]
+
+
+def test_read_documents_relative_and_empty(tmp_path):
+    (tmp_path / "notes.md").write_text("hello")
+    out = read_documents_combined(["notes.md"], base_dir=tmp_path)
+    assert out["n_documents"] == 1 and "hello" in out["text"]
+    assert read_documents_combined([])["status"] == "error"
+    assert read_documents_combined(["nope.md"], base_dir=tmp_path)["status"] == "error"
+    cap = read_documents_combined(["notes.md"], base_dir=tmp_path, max_chars=3)
+    assert cap["combined_truncated"] is True and len(cap["text"]) == 3
+
+
+# ── write: traversal-proof, append, backup-on-overwrite ──────────
+
+def test_write_append_and_backup(tmp_path):
+    r = write_text_file(tmp_path, "../../escape.txt", "x", subfolder="../protocols")
+    assert r["status"] == "success" and r["created"] is True and r["overwritten"] is False
+    assert (tmp_path / "protocols" / "escape.txt").read_text() == "x"
+    assert not (tmp_path.parent.parent / "escape.txt").exists()
+    r = write_text_file(tmp_path, "escape.txt", "more", subfolder="protocols", append=True)
+    assert r["status"] == "success" and r["created"] is False
+    assert (tmp_path / "protocols" / "escape.txt").read_text() == "xmore"
+    # overwrite: previous content is preserved in a counter-suffixed sibling
+    r = write_text_file(tmp_path, "escape.txt", "v2", subfolder="protocols")
+    assert r["overwritten"] is True
+    assert Path(r["backup"]).name == "escape.before_overwrite.txt"
+    assert Path(r["backup"]).read_text() == "xmore"
+    r = write_text_file(tmp_path, "escape.txt", "v3", subfolder="protocols")
+    assert Path(r["backup"]).name == "escape.before_overwrite.2.txt"
+    assert Path(r["backup"]).read_text() == "v2"
+    assert (tmp_path / "protocols" / "escape.txt").read_text() == "v3"
+    # opt out
+    r = write_text_file(tmp_path, "escape.txt", "v4", subfolder="protocols",
+                        backup_on_overwrite=False)
+    assert "backup" not in r and r["overwritten"] is True
+    assert write_text_file(tmp_path, "/", "x")["status"] == "error"
+    assert write_text_file(tmp_path, "", "x")["status"] == "error"
+
+
+def test_window_lines_direct_and_outline():
+    out = window_lines(["a\n", "b\n", "c\n"], max_lines=2)
+    assert out["truncated"] and out["shown_lines"] == "1-2"
+    assert window_lines(["a\n"], max_lines=2)["truncated"] is False
+    lines = ["# One\n"] + ["x\n"] * 300 + ["## Two\n", "y\n"]
+    out = window_lines(lines, max_lines=10)
+    assert "Sections: One @ line 1 · Two @ line 302" in out["content"]

--- a/tests/test_file_tools_per_mode.py
+++ b/tests/test_file_tools_per_mode.py
@@ -1,0 +1,161 @@
+"""The three orchestrators' file tools as thin wrappers over the shared
+engine (#481): identical windowing / writing behavior per mode, plus each
+mode's own extras (planning: deliverable recording + delegation scoping;
+analysis: literature-file persistence; sim: whole-read report stems).
+Analysis mode gains append / read / edit / rename here.
+"""
+
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+# ── fixtures: bare orchestrators, real tool registration ─────────
+
+def _analysis_tools(base):
+    from scilink.agents.exp_agents.analysis_orchestrator_tools import AnalysisOrchestratorTools
+    t = AnalysisOrchestratorTools.__new__(AnalysisOrchestratorTools)
+    t.orch = SimpleNamespace(base_dir=Path(base), model=None, analysis_results=[],
+                             futurehouse_api_key=None, current_metadata=None)
+    t.functions_map, t.openai_schemas = {}, []
+    t._register_all_tools()
+    return t
+
+
+def _sim_tools(base):
+    from scilink.agents.sim_agents.simulation_orchestrator_tools import SimulationOrchestratorTools
+    t = SimulationOrchestratorTools.__new__(SimulationOrchestratorTools)
+    t.orch = SimpleNamespace(base_dir=str(base), model=None, generated_structures=[])
+    t.functions_map, t.openai_schemas = {}, []
+    t.logger = logging.getLogger("sim-test")
+    t._register_all_tools()
+    return t
+
+
+def _planning_tools(base):
+    from scilink.agents.planning_agents.orchestrator_tools import OrchestratorTools
+    return OrchestratorTools(SimpleNamespace(base_dir=Path(base), planner=SimpleNamespace()))
+
+
+def _call(t, name, **kw):
+    return json.loads(t.functions_map[name](**kw))
+
+
+# ── analysis: the new surface ────────────────────────────────────
+
+def test_analysis_registers_the_full_surface(tmp_path):
+    t = _analysis_tools(tmp_path)
+    names = {s["function"]["name"] for s in t.openai_schemas}
+    assert {"save_file", "append_file", "read_file", "edit_file", "rename_file",
+            "read_document"} <= names
+    desc = next(s["function"]["description"] for s in t.openai_schemas
+                if s["function"]["name"] == "read_file")
+    assert "do not read it repeatedly" in desc and "tail=true" in desc
+
+
+def test_analysis_write_read_edit_rename_roundtrip(tmp_path):
+    t = _analysis_tools(tmp_path)
+    r = _call(t, "save_file", filename="notes.md", content="# Notes\n\nalpha = 1\n",
+              subfolder="reports")
+    assert r["status"] == "success" and r["created"] is True
+    p = tmp_path / "reports" / "notes.md"
+    r = _call(t, "append_file", filename="notes.md", content="beta = 2\n", subfolder="reports")
+    assert r["status"] == "success" and p.read_text().endswith("beta = 2\n")
+    # read: relative to the session dir, whole (short file)
+    r = _call(t, "read_file", file_path="reports/notes.md")
+    assert r["status"] == "success" and r["truncated"] is False and "alpha = 1" in r["content"]
+    # edit: surgical, backed up; a miss names read_file
+    r = _call(t, "edit_file", path="reports/notes.md", old_text="alpha = 1", new_text="alpha = 10")
+    assert r["status"] == "success" and "alpha = 10" in p.read_text()
+    assert (tmp_path / "reports" / "notes.before_edit.md").read_text().startswith("# Notes")
+    r = _call(t, "edit_file", path="reports/notes.md", old_text="gamma", new_text="x")
+    assert r["status"] == "error" and "read_file" in r["message"]
+    # overwrite through save_file keeps a backup
+    r = _call(t, "save_file", filename="notes.md", content="rewritten\n", subfolder="reports")
+    assert r["overwritten"] is True and Path(r["backup"]).name == "notes.before_overwrite.md"
+    assert "alpha = 10" in Path(r["backup"]).read_text()
+    # rename: byte-exact, within the directory, path-escapes stripped
+    r = _call(t, "rename_file", path="reports/notes.md", new_name="../../final.md")
+    assert r["status"] == "success" and (tmp_path / "reports" / "final.md").read_text() == "rewritten\n"
+    assert not (tmp_path / "reports" / "notes.md").exists()
+    assert _call(t, "rename_file", path="reports/final.md", new_name="final.md")["status"] == "error"
+
+
+def test_analysis_read_file_windows_and_json(tmp_path):
+    t = _analysis_tools(tmp_path)
+    log = tmp_path / "run.log"
+    log.write_text("".join(f"step {i}\n" for i in range(1, 1001)) + "DONE ok\n")
+    head = _call(t, "read_file", file_path=str(log))
+    assert head["truncated"] is True and head["shown_lines"] == "1-200"
+    tail = _call(t, "read_file", file_path=str(log), tail=True, max_lines=3)
+    assert "DONE ok" in tail["content"]
+    found = _call(t, "read_file", file_path="run.log", search=r"^DONE")
+    assert found["matches"] == 1 and found["match_lines"] == [1001]
+    res = tmp_path / "analysis_results.json"
+    res.write_text(json.dumps({"peaks": [{"pos": i} for i in range(500)]}))
+    j = _call(t, "read_file", file_path="analysis_results.json")
+    assert j["status"] == "success" and j["truncated"] is True     # the JSON cap
+    assert _call(t, "read_file", file_path="analysis_results.json", search='"pos": 499')["matches"] == 1
+    # whole-read stems: a report is returned whole
+    rep = tmp_path / "analysis_report.md"
+    rep.write_text("".join(f"# S{i}\nbody\n" for i in range(300)))
+    assert _call(t, "read_file", file_path="analysis_report.md")["truncated"] is False
+    assert _call(t, "read_file", file_path="missing.txt")["status"] == "error"
+
+
+def test_analysis_read_document_persists_literature_file(tmp_path):
+    t = _analysis_tools(tmp_path)
+    (tmp_path / "methods.md").write_text("# Methods\n\nUse pseudo-Voigt.\n")
+    r = _call(t, "read_document", paths=["methods.md", "nope.pdf"])   # relative resolves
+    assert r["status"] == "success" and r["n_documents"] == 1
+    assert r["errors"] == ["Not a file: nope.pdf"]
+    assert "pseudo-Voigt" in r["text"] and "literature_file" in r["hint"]
+    lit = Path(r["file_path"])
+    assert lit.parent == tmp_path / "literature" and "pseudo-Voigt" in lit.read_text()
+    assert _call(t, "read_document", paths=[])["status"] == "error"
+    assert _call(t, "read_document", paths="nope.md")["status"] == "error"
+
+
+# ── simulation: behavior preserved + backup ───────────────────────
+
+def test_sim_file_tools_on_the_engine(tmp_path):
+    t = _sim_tools(tmp_path)
+    r = _call(t, "save_file", filename="INCAR_notes.md", content="ENCUT = 400\n", subfolder="reports")
+    assert r["status"] == "success"
+    r = _call(t, "save_file", filename="INCAR_notes.md", content="ENCUT = 520\n", subfolder="reports")
+    assert r["overwritten"] is True and Path(r["backup"]).read_text() == "ENCUT = 400\n"
+    r = _call(t, "append_file", filename="INCAR_notes.md", content="ISMEAR = 0\n", subfolder="reports")
+    assert (tmp_path / "reports" / "INCAR_notes.md").read_text() == "ENCUT = 520\nISMEAR = 0\n"
+    # whole-read stems: report / summary
+    rep = tmp_path / "run_summary.md"
+    rep.write_text("".join(f"line {i}\n" for i in range(600)))
+    assert _call(t, "read_file", file_path="run_summary.md")["truncated"] is False
+    other = tmp_path / "OUTCAR"
+    other.write_text("".join(f"line {i}\n" for i in range(600)))
+    assert _call(t, "read_file", file_path="OUTCAR")["truncated"] is True
+    assert _call(t, "read_file", file_path="OUTCAR", search="line 599")["matches"] == 1
+    r = _call(t, "read_document", paths=["run_summary.md"])
+    assert r["status"] == "success" and "file_path" not in r      # sim persists nothing
+
+
+# ── planning: extras preserved on top of the engine ──────────────
+
+def test_planning_save_keeps_deliverable_and_gets_backup(tmp_path):
+    t = _planning_tools(tmp_path)
+    r = json.loads(t.execute_tool("save_file", filename="brief.md", content="# v1\n",
+                                  deliverable=True, title="Brief"))
+    assert r["status"] == "success" and r["deliverable"] is True and "pdf_refreshed" in r
+    from scilink.agents.planning_agents.user_interface import load_deliverables
+    assert any(e["path"].endswith("brief.md") and e["deliverable"] for e in load_deliverables(tmp_path))
+    r = json.loads(t.execute_tool("save_file", filename="brief.md", content="# v2\n",
+                                  deliverable=True, title="Brief"))
+    assert r["overwritten"] is True and Path(r["backup"]).read_text() == "# v1\n"
+    # the overwrite backup is recorded as a produced (non-deliverable) file
+    entries = {Path(e["path"]).name: e for e in load_deliverables(tmp_path)}
+    assert entries["brief.before_overwrite.md"]["deliverable"] is False
+    assert entries["brief.md"]["deliverable"] is True
+    r = json.loads(t.execute_tool("read_file", file_path=str(tmp_path / "brief.md")))
+    assert r["content"] == "# v2\n"


### PR DESCRIPTION
## Summary

Closes #481. All three modes now share one implementation of the everyday file tools, and analysis mode gets the full set it was missing.

- **Analysis mode can now read, append, edit, and rename session files.** Before it could only save a file and read a document. Now, like planning and simulation, it has `read_file` (with offset, tail, and search for long files), `append_file` for chunked writes, `edit_file` for exact snippet swaps with a backup, and `rename_file` for byte-exact renames. `save_file` and `read_document` keep working as before.
- **Two safety guards, everywhere at once.** Overwriting an existing file with `save_file` now keeps a `.before_overwrite` copy (counter-suffixed, never clobbered), the way `edit_file` always kept a `.before_edit` copy. And reading a large JSON file no longer dumps the whole thing into the agent's context: it is paged like any other text, with search to jump to a key.
- **Nothing else changes for the agents.** Planning still records deliverables and refreshes PDF twins on save; simulation still returns reports and summaries whole; the transcripts read the same. The three modes cannot drift apart again, because there is one reader and one writer.

Verified live on Bedrock Opus 4.8 in all four agents (analysis, planning, simulation, and a meta delegation), plus an adversarial sweep of every tool in every mode. Details below.

## Technical description

### Engine: `scilink/utils/file_io.py` (new)

The `file_edit.py` pattern: one implementation per operation, everything mode-specific as a parameter.

- `read_file_content(path, *, max_lines, tail, search, offset, full_read_stems, full_read_max_chars, ocr_model, text_cap_mb, doc_cap_mb, display_path)`: size guards (5 MB text, 25 MB documents, none for tabular), CSV/Excel preview (rows × cols, adaptive char budget), PDF/DOCX through `parsers.extract_text` with OCR fallback, JSON pretty-printed and windowed, everything else UTF-8 text. `window_lines(...)` is the windowing half on its own: search (case-insensitive regex, 40-hit cap, one line of context), offset, tail, head, the truncation notice that names the way out, and the section outline (two or more headings).
- `write_text_file(base_dir, filename, content, *, subfolder, append, backup_on_overwrite)`: traversal-proof (last component of filename and subfolder only), mkdir, append or overwrite; on overwrite copies the previous content to `<stem>.before_overwrite<suffix>` then `.before_overwrite.2`, `.3`, …; a backup failure is logged and the write proceeds (a lost backup beats a lost write). Returns `path`, `size_bytes`, `created`, `overwritten`, `backup`.
- `extract_document_text(path, ocr_model, max_chars)` and `read_documents_combined(paths, *, base_dir, ocr_model, max_chars)`: the extraction, combine, cap, per-document metadata and OCR note that analysis and simulation each carried.

### Wrappers

- **Planning** (`orchestrator_tools.py`): `save_file` and `append_file` call the engine rooted at `_output_dir()` (delegation scoping preserved), then layer deliverable recording and the PDF-twin refresh; the overwrite backup is recorded as a produced non-deliverable file, matching how `edit_file` records its pre-edit copy. `read_file` keeps `_resolve_data_path` and its `("literature_search",)` whole-read stems and calls the engine. About 270 lines of duplicated body removed.
- **Simulation** (`simulation_orchestrator_tools.py`): `save_file`, `append_file`, `read_file` (stems `report`, `summary`, `literature_search`) and `read_document` on the engine; the module-level `_extract_document_text` is kept as a name and delegates. About 350 lines removed.
- **Analysis** (`analysis_orchestrator_tools.py`): `save_file` on the engine (gains the backup); `read_document` on the engine with the literature-file persistence and `run_analysis` hint kept, and relative paths now resolve against the session dir; **new** `append_file`, `read_file` (stems `report`, `summary`, `literature`), `edit_file` and `rename_file` as thin wrappers over the engine and `utils/file_edit`, with analysis-flavored routing text (a snippet miss points at `read_file`; an oversized edit points at `save_file`, which now backs up). The analysis orchestrator prompt gains a "SESSION FILES" item stating the routing principle in one paragraph.

Per-mode routing text and tool descriptions are otherwise preserved verbatim.

### One more fix the live test forced

The meta's specialist-capability inventory is cached on disk keyed by package version and extensions. In a checkout or editable install the version does not move between releases, so after this change the meta still told the user the analysis specialist had only `save_file` and `read_document` (observed live; delegation itself worked). The key now also includes a content hash of the three tool-registration modules (`_TOOL_SOURCE_MODULES`, located via `find_spec` without importing, so a missing `ase` never matters). Re-running the same question live after the fix listed all six tools.

### Tests

- `tests/test_file_io_engine.py` (new, 11): windowing modes and notices, whole-read stems and their cap, missing and oversized files, small JSON returned whole and large JSON windowed and searchable, CSV preview, PDF extraction and windowing, combined documents with relative paths and errors, append and counter-suffixed backups with opt-out, the outline.
- `tests/test_file_tools_per_mode.py` (new, 6): the registered tools of each mode against a bare orchestrator: analysis' full surface and its roundtrip (save, append, read, edit with backup and the `read_file` hint on a miss, overwrite backup, rename with escapes stripped), its windowing and JSON cap on `analysis_results.json`, `read_document` persisting the literature file; simulation's backup, whole-read stems and no literature persistence; planning's deliverable recording, backup, and the backup's manifest entry.
- `tests/test_capabilities_cache.py`: +1, the key moves when a tool module's source changes and tolerates a missing module.
- Pre-existing `test_read_file_modes.py`, `test_save_file_chunking.py`, `test_edit_file_tool.py` pass unchanged (one test in `test_save_file_chunking.py` fails on `main` too, for an unrelated dispatch-guard message).
- Full suite on the branch versus a clean `main` worktree: identical failure sets except `test_trim_gate.py::test_no_hardcoded_gate_literal`, which passes on its own and as a file on the branch (order-dependent, untouched by this change); the branch passes 16 more tests than `main`.

### Live verification (Bedrock Opus 4.8, autonomous)

- **Analysis**, 6 turns: `read_document` persisted the literature file and `examine_data` ran; `save_file` then `edit_file` then `read_file` roundtrip with the `.before_edit` copy on disk; `read_file` search found the Conclusions section of a 454-line report at line 452 without a full read; `read_file` search found `entry_599` in a 600-entry JSON at line 4794; overwrite reported `session_notes.before_overwrite.md` and `rename_file` did a true rename; `run_analysis` on the synthetic spectrum then `read_file` on the produced `analysis_results.json` reported centers 420.03 and 609.94 against ground truth 420 and 610.
- **Planning**, 4 turns: PDF read through the extractor answered the mode at 610; a 114-line deliverable written as `save_file` plus five `append_file` chunks; `edit_file` replaced three occurrences with a backup and `read_file` tail showed the end; overwrite kept `protocol.before_overwrite.md` and reported the PDF-twin status.
- **Simulation**, 4 turns: save, append, and read back; search to the Conclusions line; overwrite backup then `edit_file` confirmed by `read_file`; `read_document`.
- **Meta**: the inventory question exposed the cache issue above and, after the fix, listed all six analysis tools; a delegation to analysis used `read_document`, `examine_data`, `save_file` and `read_file` and returned the file's content.
- **Adversarial sweep** of every tool in every mode (26 cases each; plan has no `read_document` by design): traversal on save, append, edit and rename; empty content and files; a directory as a file; `max_lines=0`; unicode and CRLF; binary through read and edit; malformed JSON; bad regex; offset beyond EOF and negative; tail larger than the file; ambiguous snippet, `replace_all`, batched atomicity on a miss; four-deep overwrite chain with distinct backups; rename onto an existing file and copy; mixed `read_document` with unsupported and missing entries; a 20 000-key JSON windowed and searchable; a CSV with quoted commas and empty cells. All pass.

### Not in scope

The meta's `view_document` (#397's remaining phase) and the meta inventory's description truncation, which hides `read_file`'s parameter list from the meta's routing text (the specialist itself sees the full schema).
