### PR TITLE
Attach a script in chat: run_analysis(reference_scripts=...) with script-bank semantics

### DIFF
--- a/docs/react_ui_roadmap.md
+++ b/docs/react_ui_roadmap.md
@@ -66,7 +66,11 @@ restart, resume).
    read / edit / write surface it lacks. Prerequisite for anything
    script-shaped in analyze mode (next item) and it folds three
    diverging copies back onto one.
-5. **Attach a script in chat.** Accept `.py` through the paperclip in
+5. ~~**Attach a script in chat**~~ — DONE 2026-09-08: `.py` via the
+   paperclip → `scripts/`; `run_analysis(reference_scripts=[...])`;
+   `_reference_scripts.py` renders the script wherever the agents show the
+   user's guidance (planning, codegen, refinement, correction) with
+   script-bank semantics (adapt, never verbatim). Was: Accept `.py` through the paperclip in
    every mode. Plan mode then already closes the loop (read → edit →
    `generate_implementation_code`). Analyze mode gets a
    `reference_script` argument on `run_analysis` that injects the file's

--- a/docs/react_web_ui.md
+++ b/docs/react_web_ui.md
@@ -130,6 +130,16 @@ rate limiting on sign-in (put the proxy's in front if internet-facing).
   validated server-side and enumerated into the dispatch prompt, with the
   plan agent's resource dirs repointed at the stable folders so KB indexes
   are reused across sessions.
+- **Attach a script** (beyond Streamlit): a `.py` (or `.yaml` / `.md`)
+  dropped on the paperclip in analyze mode lands in the session's
+  `scripts/` folder and the draft says "use it as the reference
+  implementation". The orchestrator passes it to `run_analysis(
+  reference_scripts=[...])`; the analysis agent treats it like a script-bank
+  hit — adapts it to the data (method and parameters kept, I/O conformed
+  to the run's contract), verifies the result in its normal QC loop, and
+  reports what it kept and changed. It is never run verbatim; for verbatim
+  execution use MCP. Plan mode already reads and edits uploaded code
+  (`code/`); meta hands the path through to the analysis child.
 - **Folder uploads** (beyond Streamlit): every dropzone takes a dropped
   directory (walked recursively via the FileSystem entry API), and a click
   on the dropzone or the chat paperclip opens a two-item menu, "Upload
@@ -244,7 +254,7 @@ webui/ (Vite + React + TS)  ──REST + SSE──►  scilink/server/ (FastAPI)
 | GET | `/sessions/{id}/events` | SSE: `log`, `status`, `question`, `question_cleared`, `assistant_message`, `session_named`, `files_changed`, `analysis_image`, `delegations`, `error` |
 | POST | `/sessions/{id}/feedback` | answer the parked HITL question |
 | POST | `/sessions/{id}/stop` | stop the running turn |
-| POST | `/sessions/{id}/uploads` | multipart, `category` = data/metadata/knowledge/code/planning_data/meta; optional `paths` (JSON list of relative paths, one per file) makes it a layout-preserving folder upload |
+| POST | `/sessions/{id}/uploads` | multipart, `category` = data/metadata/knowledge/code/planning_data/meta/scripts; optional `paths` (JSON list of relative paths, one per file) makes it a layout-preserving folder upload |
 | POST | `/sessions/{id}/folders` | validate pasted local folder paths + enumerate tabular contents and immediate subfolders |
 | POST | `/sessions/{id}/plan_dirs` | repoint the plan agent's knowledge/code/data dirs at stable folders |
 | GET | `/sessions/{id}/files?path=` | serve a session file (traversal-fenced) |

--- a/scilink/agents/exp_agents/_reference_scripts.py
+++ b/scilink/agents/exp_agents/_reference_scripts.py
@@ -22,19 +22,24 @@ from typing import Any, Dict, List, Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
-MAX_SCRIPT_BYTES = 64_000
+MAX_SCRIPT_BYTES = 64_000          # per script
+MAX_TOTAL_BYTES = 160_000          # across all attached scripts
 _TEXT_SUFFIXES = {".py", ".txt", ".md", ".r", ".jl", ".m"}
 
 
 def load_reference_scripts(paths: Optional[Sequence[str]], *,
-                           max_bytes: int = MAX_SCRIPT_BYTES) -> List[Dict[str, Any]]:
+                           max_bytes: int = MAX_SCRIPT_BYTES,
+                           max_total_bytes: int = MAX_TOTAL_BYTES) -> List[Dict[str, Any]]:
     """Read the user's scripts into ``[{"label", "path", "text", "truncated"}]``.
 
     A missing, binary, or non-text file is skipped with a warning rather
     than failing the run; a long script is cut at ``max_bytes`` with the
-    cut noted, so the prompt stays bounded.
+    cut noted, and once ``max_total_bytes`` is spent the remaining scripts
+    are listed by name only (``"omitted": True``), so the prompt stays
+    bounded however many files were attached.
     """
     out: List[Dict[str, Any]] = []
+    budget = max_total_bytes
     for raw in paths or []:
         p = Path(str(raw)).expanduser()
         if not p.is_file():
@@ -51,8 +56,15 @@ def load_reference_scripts(paths: Optional[Sequence[str]], *,
         if b"\x00" in data[:4096]:
             logger.warning(f"reference script looks binary, skipped: {p.name}")
             continue
-        truncated = len(data) > max_bytes
-        text = data[:max_bytes].decode("utf-8", errors="replace")
+        if budget <= 0:
+            logger.warning(f"reference script listed by name only (total budget spent): {p.name}")
+            out.append({"label": p.name, "path": str(p), "text": "",
+                        "truncated": False, "omitted": True})
+            continue
+        cap = min(max_bytes, budget)
+        truncated = len(data) > cap
+        text = data[:cap].decode("utf-8", errors="replace")
+        budget -= len(text.encode("utf-8"))
         out.append({"label": p.name, "path": str(p), "text": text,
                     "truncated": truncated})
     return out
@@ -81,7 +93,18 @@ def reference_script_block(state: Dict[str, Any], *, heading: str = "##") -> str
         "in the script's header comment what was kept and what was changed, "
         "and why. Do not run it verbatim: it is a recipe, not the deliverable.",
     ]
+    if len(scripts) > 1:
+        lines.append(
+            "Several scripts were attached. If they cover different stages "
+            "(e.g. preprocessing and fitting), compose them in pipeline "
+            "order. If they are alternatives for the same job, choose the "
+            "one whose method fits this data and goal, use it, and name the "
+            "choice and the reason; do not blend competing methods.")
     for s in scripts:
-        note = " (truncated to the first 64 kB)" if s.get("truncated") else ""
+        if s.get("omitted"):
+            lines.append(f"\n### {s['label']} — attached, but omitted here "
+                         "(size budget spent); read it with read_file if needed.")
+            continue
+        note = " (truncated)" if s.get("truncated") else ""
         lines.append(f"\n### {s['label']}{note}\n```python\n{s['text']}\n```")
     return "\n".join(lines)

--- a/scilink/agents/exp_agents/_reference_scripts.py
+++ b/scilink/agents/exp_agents/_reference_scripts.py
@@ -1,0 +1,87 @@
+"""User-provided reference scripts for the analysis agents.
+
+A scientist attaches a script in chat and says "use it". Semantically that
+is what a script-bank hit or a ``prior_analysis_paths`` run already is —
+a proven implementation to ADAPT rather than reimplement — but it arrives
+as a bare file rather than a prior run's artifact bundle, so it needs its
+own channel: ``run_analysis(reference_scripts=[...])`` → ``analyze(
+reference_scripts=...)`` → ``state["reference_scripts"]`` → a prompt block
+wherever the agents show the user's guidance (planning, code generation,
+refinement and correction prompts). The generated code is then verified by
+the agent's normal sandbox / QC loop, exactly as a bank exemplar is — so a
+mangled adaptation is corrected, not silently wrong.
+
+Package-neutral: stdlib only, no agent imports.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+MAX_SCRIPT_BYTES = 64_000
+_TEXT_SUFFIXES = {".py", ".txt", ".md", ".r", ".jl", ".m"}
+
+
+def load_reference_scripts(paths: Optional[Sequence[str]], *,
+                           max_bytes: int = MAX_SCRIPT_BYTES) -> List[Dict[str, Any]]:
+    """Read the user's scripts into ``[{"label", "path", "text", "truncated"}]``.
+
+    A missing, binary, or non-text file is skipped with a warning rather
+    than failing the run; a long script is cut at ``max_bytes`` with the
+    cut noted, so the prompt stays bounded.
+    """
+    out: List[Dict[str, Any]] = []
+    for raw in paths or []:
+        p = Path(str(raw)).expanduser()
+        if not p.is_file():
+            logger.warning(f"reference script not found, skipped: {raw}")
+            continue
+        if p.suffix.lower() not in _TEXT_SUFFIXES:
+            logger.warning(f"reference script is not a text/script file, skipped: {p.name}")
+            continue
+        try:
+            data = p.read_bytes()
+        except OSError as exc:
+            logger.warning(f"reference script unreadable, skipped: {p.name} ({exc})")
+            continue
+        if b"\x00" in data[:4096]:
+            logger.warning(f"reference script looks binary, skipped: {p.name}")
+            continue
+        truncated = len(data) > max_bytes
+        text = data[:max_bytes].decode("utf-8", errors="replace")
+        out.append({"label": p.name, "path": str(p), "text": text,
+                    "truncated": truncated})
+    return out
+
+
+def reference_script_block(state: Dict[str, Any], *, heading: str = "##") -> str:
+    """The prompt block for ``state['reference_scripts']`` (empty string when
+    none, so callers append unconditionally). ``heading`` is the markdown
+    level the surrounding prompt uses ("##" or "---" style handled by the
+    caller through this prefix)."""
+    scripts = state.get("reference_scripts") or []
+    if not scripts:
+        return ""
+    lines = [
+        f"\n{heading} User-Provided Reference Script"
+        + ("s" if len(scripts) > 1 else ""),
+        "The user attached the script(s) below and asked that they be USED. "
+        "Treat each like a proven script from the script bank: ADAPT it "
+        "rather than reimplementing from scratch — keep its method, model "
+        "choices, parameters and thresholds unless this data demonstrably "
+        "needs a change; conform its input/output to this run's contract "
+        "(read the staged input the instructions name, write the required "
+        "outputs and markers) and drop command-line or plotting glue that "
+        "conflicts with it; keep its variable and function names where "
+        "practical so the user recognizes their code. State in the plan and "
+        "in the script's header comment what was kept and what was changed, "
+        "and why. Do not run it verbatim: it is a recipe, not the deliverable.",
+    ]
+    for s in scripts:
+        note = " (truncated to the first 64 kB)" if s.get("truncated") else ""
+        lines.append(f"\n### {s['label']}{note}\n```python\n{s['text']}\n```")
+    return "\n".join(lines)

--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -267,6 +267,9 @@ If you actually run DFT, prefer `vasp_generator_method="llm"` unless the user as
    rewriting it with save_file; write long content in chunks (save_file then append_file).
    read_document is for documents the USER provided (papers, protocols): it also saves a
    literature file for run_analysis. Data files still go to examine_data / run_analysis.
+   A SCRIPT the user attached and asked you to use is reference material: pass its path in
+   run_analysis(reference_scripts=[...]) — the agent adapts it to the data (never runs it
+   verbatim) — and say in the answer what was kept and what was changed.
 
 **AGENT SELECTION DECISION TREE:**
 

--- a/scilink/agents/exp_agents/analysis_orchestrator_tools.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator_tools.py
@@ -2441,6 +2441,7 @@ class AnalysisOrchestratorTools:
             script_edits: List[dict] = None,
             profile: str = None,
             literature_file: str = None,
+            reference_scripts: List[str] = None,
             r2_threshold: float = None,
             max_verification_iterations: int = None,
             max_series_refits: int = None,
@@ -3068,6 +3069,25 @@ class AnalysisOrchestratorTools:
                     analyze_kwargs["prior_knowledge"] = self.orch.active_knowledge
                 if prior_analysis_paths:
                     analyze_kwargs["prior_analysis_paths"] = prior_analysis_paths
+                if reference_scripts:
+                    # User-attached scripts to ADAPT (the script-bank
+                    # semantics, but for a bare file the user handed over).
+                    # Forwarded by signature introspection like the other
+                    # optional knobs; resolved against the session dir.
+                    import inspect as _inspect
+                    _paths = [reference_scripts] if isinstance(reference_scripts, str) else list(reference_scripts)
+                    _resolved = []
+                    for _rp in _paths:
+                        _pp = Path(str(_rp))
+                        if not _pp.is_absolute():
+                            _pp = Path(self.orch.base_dir) / _pp
+                        _resolved.append(str(_pp))
+                    if "reference_scripts" in _inspect.signature(agent.analyze).parameters:
+                        analyze_kwargs["reference_scripts"] = _resolved
+                    else:
+                        self.logger.info(
+                            f"   reference_scripts ignored: "
+                            f"{self.AGENT_NAMES.get(agent_id, 'agent')} does not take them.")
                 if reuse_locked_script:
                     analyze_kwargs["reuse_locked_script"] = True
                 if script_edits:
@@ -3494,6 +3514,22 @@ class AnalysisOrchestratorTools:
                         "asserting a single answer. Leave unset (defaults to 'fitting') "
                         "for standard analyses where the sample is known."
                     )
+                },
+                "reference_scripts": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Path(s) to script(s) the USER attached and asked to be "
+                        "used (e.g. an uploaded .py under the session's scripts/ "
+                        "folder). Pass them whenever the user says to use, "
+                        "follow, or adapt their script. The agent treats each "
+                        "as a proven implementation to ADAPT — same semantics "
+                        "as a script-bank hit — keeping its method and "
+                        "parameters, conforming its I/O to the run, and "
+                        "verifying the result in its normal QC loop; it is "
+                        "never run verbatim. Absolute, or relative to the "
+                        "session directory."
+                    ),
                 },
                 "prior_analysis_paths": {
                     "type": "array",

--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -49,6 +49,8 @@ from ....hitl import request_human_feedback
 FIT_NAME = "fit.npy"
 
 
+from .._reference_scripts import reference_script_block as _reference_script_block
+
 def _robust_noise_sigma(residual: np.ndarray) -> float:
     """Per-point noise sigma from successive differences — robust to systematic
     structure in the residual (a trend/oscillation barely affects neighbour diffs)."""
@@ -2323,6 +2325,9 @@ class CurveFittingPlanningController:
 
         if state.get("analysis_hints"):
             prompt.append(f"\n## User Guidance\n{state['analysis_hints']}")
+        _ref_block = _reference_script_block(state, heading="##")
+        if _ref_block:
+            prompt.append(_ref_block)
 
         _append_auxiliary_context(prompt, state)
         _append_skill_context(prompt, state, "planning")
@@ -2798,6 +2803,9 @@ class CurveFittingPlanningController:
 
         if state.get("analysis_hints"):
             prompt.append(f"\n## Original Guidance\n{state['analysis_hints']}")
+        _ref_block = _reference_script_block(state, heading="##")
+        if _ref_block:
+            prompt.append(_ref_block)
 
         _append_auxiliary_context(prompt, state)
         _append_skill_context(prompt, state, "planning")
@@ -3298,6 +3306,9 @@ Your guidance: '''
         if state.get("analysis_hints"):
             context_parts.append(
                 "## User Guidance\n" + str(state["analysis_hints"]))
+        _ref_block = _reference_script_block(state, heading="##")
+        if _ref_block:
+            context_parts.append(_ref_block)
         # Identification mode is literature-free in-run (issue #323, D2):
         # literature must not shape the code that writes the fit, matching
         # the planner gates. Covers hand-supplied literature_file too.
@@ -3509,9 +3520,14 @@ Your guidance: '''
         # Keep user guidance (incl. figure-presentation preferences) visible
         # during corrections so a fix doesn't silently undo it. Injected
         # before the response footer — appended after it, guidance loses.
-        if state.get("analysis_hints"):
-            _guidance = ("\n## User Guidance\n"
-                         + str(state["analysis_hints"]) + "\n")
+        if state.get("analysis_hints") or state.get("reference_scripts"):
+            _guidance = ""
+            if state.get("analysis_hints"):
+                _guidance += ("\n## User Guidance\n"
+                              + str(state["analysis_hints"]) + "\n")
+            # The user's reference script stays visible during corrections
+            # too, so a fix does not drift away from the method they asked for.
+            _guidance += _reference_script_block(state, heading="##")
             _marker = "**Response:**"
             if _marker in prompt:
                 prompt = prompt.replace(_marker, _guidance + "\n" + _marker, 1)

--- a/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
+++ b/scilink/agents/exp_agents/controllers/hyperspectral_controllers.py
@@ -72,6 +72,8 @@ _SKILL_STRICTNESS_FRAMES = (
 )
 
 
+from .._reference_scripts import reference_script_block as _reference_script_block
+
 def _skill_annealing_level(state: dict) -> int:
     """Effective skill-strictness temperature for skill injection.
 
@@ -1496,6 +1498,9 @@ class GetInitialComponentParamsController:
                 f"Prioritize these suggestions but also report any other significant features you discover.\n"
                 f"{state['analysis_hints']}"
             )
+        _ref_block = _reference_script_block(state, heading="---")
+        if _ref_block:
+            prompt_parts.append(_ref_block)
 
         _append_skill_context(prompt_parts, state, "planning")
         _append_prior_knowledge_context(prompt_parts, state)
@@ -1754,6 +1759,9 @@ class GetFinalComponentSelectionController:
                 f"Prioritize these suggestions but also report any other significant features you discover.\n"
                 f"{state['analysis_hints']}"
             )
+        _ref_block = _reference_script_block(state, heading="---")
+        if _ref_block:
+            prompt_parts.append(_ref_block)
 
         _append_auxiliary_context(prompt_parts, state)
 
@@ -2340,6 +2348,9 @@ refinement targets are meaningful here — do not request `spatial` or
                 f"Prioritize these suggestions but also report any other significant features you discover.\n"
                 f"{state['analysis_hints']}"
             )
+        _ref_block = _reference_script_block(state, heading="---")
+        if _ref_block:
+            prompt_parts.append(_ref_block)
 
         _append_skill_context(prompt_parts, state, "planning")
         _append_prior_knowledge_context(prompt_parts, state)
@@ -2449,6 +2460,9 @@ class BuildHolisticSynthesisPromptController:
                 f"Prioritize these suggestions but also report any other significant features you discover.\n"
                 f"{state['analysis_hints']}"
             )
+        _ref_block = _reference_script_block(state, heading="---")
+        if _ref_block:
+            prompt_parts.append(_ref_block)
 
         # 2. Build Context for Each Iteration
         all_images = []

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -52,6 +52,8 @@ from ....hitl import request_human_feedback
 _VERIFICATION_IMAGE_CAP_BYTES = int(4.5 * 1024 * 1024)
 
 
+from .._reference_scripts import reference_script_block as _reference_script_block
+
 def _fit_image_under_api_cap(
     image_bytes: bytes, cap: int = _VERIFICATION_IMAGE_CAP_BYTES
 ) -> tuple[bytes, str]:
@@ -1232,6 +1234,9 @@ class ImagePlanningController:
 
         if state.get("analysis_hints"):
             prompt.append(f"\n## User Guidance\n{state['analysis_hints']}")
+        _ref_block = _reference_script_block(state, heading="##")
+        if _ref_block:
+            prompt.append(_ref_block)
 
         _append_auxiliary_context(prompt, state)
         _append_tool_inventory(prompt, agent="image_analysis", active_skills=_active_skill_names(state))
@@ -1616,6 +1621,9 @@ class ImagePlanningController:
 
         if state.get("analysis_hints"):
             prompt.append(f"\n## Original Guidance\n{state['analysis_hints']}")
+        _ref_block = _reference_script_block(state, heading="##")
+        if _ref_block:
+            prompt.append(_ref_block)
 
         _append_auxiliary_context(prompt, state)
         _append_tool_inventory(prompt, agent="image_analysis", active_skills=_active_skill_names(state))
@@ -2088,6 +2096,9 @@ Your guidance: '''
         if state.get("analysis_hints"):
             context_parts.append(
                 "## User Guidance\n" + str(state["analysis_hints"]))
+        _ref_block = _reference_script_block(state, heading="##")
+        if _ref_block:
+            context_parts.append(_ref_block)
         # Authoritative calibration: when the caller supplied spatial metadata it
         # is staged as ``metadata.json`` in the working directory (see
         # stage_and_run). Point the generated script at it so pixel size and the
@@ -2362,9 +2373,14 @@ Your guidance: '''
         # Keep user guidance (incl. figure-presentation preferences) visible
         # during corrections so a fix doesn't silently undo it. Injected
         # before the response footer — appended after it, guidance loses.
-        if state.get("analysis_hints"):
-            _guidance = ("\n## User Guidance\n"
-                         + str(state["analysis_hints"]) + "\n")
+        if state.get("analysis_hints") or state.get("reference_scripts"):
+            _guidance = ""
+            if state.get("analysis_hints"):
+                _guidance += ("\n## User Guidance\n"
+                              + str(state["analysis_hints"]) + "\n")
+            # The user's reference script stays visible during corrections
+            # too, so a fix does not drift away from the method they asked for.
+            _guidance += _reference_script_block(state, heading="##")
             _marker = "**Response:**"
             if _marker in prompt:
                 prompt = prompt.replace(_marker, _guidance + "\n" + _marker, 1)

--- a/scilink/agents/exp_agents/curve_fitting_agent.py
+++ b/scilink/agents/exp_agents/curve_fitting_agent.py
@@ -55,6 +55,8 @@ from .instruct import (
 logger = logging.getLogger(__name__)
 
 
+from ._reference_scripts import load_reference_scripts as _load_reference_scripts
+
 def _empty_auxiliary_state() -> dict:
     """Default auxiliary state — no companion datasets loaded. ``auxiliary_items``
     is the list of per-dataset dicts (label / array / axis / plot_bytes /
@@ -314,6 +316,8 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         max_model_retries: Optional[int] = None,
         outlier_sigma: Optional[float] = None,
         max_verification_iterations: Optional[int] = None,
+        # User-attached scripts to ADAPT (reference, like a script-bank hit).
+        reference_scripts: Optional[List[str]] = None,
         max_series_refits: Optional[int] = None,
         # Annealing schedule start level for THIS run (None/0 = current
         # behavior: start frozen at T=0 and escalate adaptively). A re-run may
@@ -860,6 +864,7 @@ class CurveFittingAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
 
             # Prior curve-fit runs — artifacts surfaced to planner / script-gen
             "prior_analysis_paths": prior_analysis_paths or [],
+            "reference_scripts": _load_reference_scripts(reference_scripts),
             # Opt-in: force verbatim reuse of the prior locked script (#172).
             # Default False — prior runs are agent-judged reference material.
             "reuse_locked_script": bool(reuse_locked_script),

--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -30,6 +30,8 @@ from ...utils.text_io import read_text_utf8
 from ._deprecation import normalize_params
 
 
+from ._reference_scripts import load_reference_scripts as _load_reference_scripts
+
 def _empty_auxiliary_state() -> dict:
     """Default auxiliary state — no companion datasets loaded. ``auxiliary_items``
     is the list of per-dataset dicts (label / array / axis / plot_bytes /
@@ -213,6 +215,8 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # accepted when the task succeeds; higher => more retries. None
         # falls back to the construction default.
         max_verification_iterations: int | None = None,
+        # User-attached scripts to ADAPT (reference, like a script-bank hit).
+        reference_scripts: list | None = None,
         # Locked-script replay (harmonized re-run across sibling datasets):
         # prior_analysis_paths + reuse_locked_script=True replays the prior
         # run's APPROVED dynamic-analysis script(s) verbatim on THIS cube —
@@ -446,6 +450,7 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             structure_image_path=structure_image_path,
             structure_system_info=structure_system_info,
             hints=hints,
+            reference_scripts=reference_scripts,
             objective=objective,
             skill_state=skill_state,
             prior_knowledge=prior_knowledge or [],
@@ -1283,6 +1288,7 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         structure_system_info: Dict[str, Any] | None = None,
         objective: str | None = None,
         hints: str | None = None,
+        reference_scripts: list | None = None,
         skill_state: Dict[str, Any] | None = None,
         prior_knowledge: list | None = None,
         auxiliary_state: Dict[str, Any] | None = None,
@@ -1361,6 +1367,7 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 "structure_image_blob": structure_image_blob,
                 "analysis_hints": hints,
                 "analysis_objective": objective,
+                "reference_scripts": _load_reference_scripts(reference_scripts),
                 "prior_knowledge": prior_knowledge or [],
                 "literature_context": literature_context,
                 # Locked-script replay: SelectRefinementTarget builds the plan
@@ -1402,6 +1409,7 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 "instruction_prompt": instruction_prompt,
                 "analysis_hints": hints,
                 "analysis_objective": objective,
+                "reference_scripts": _load_reference_scripts(reference_scripts),
                 "prior_knowledge": prior_knowledge or [],
                 "literature_context": literature_context,
                 "result_json": None,

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -63,6 +63,8 @@ from .instruct import (
 logger = logging.getLogger(__name__)
 
 
+from ._reference_scripts import load_reference_scripts as _load_reference_scripts
+
 def _empty_auxiliary_state() -> dict:
     """Default auxiliary state — no companion datasets loaded. ``auxiliary_items``
     is the list of per-dataset dicts (label / array / axis / plot_bytes /
@@ -261,6 +263,8 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         # verification loop; higher => more refinement passes. None
         # falls back to the construction default.
         max_verification_iterations: Optional[int] = None,
+        # User-attached scripts to ADAPT (reference, like a script-bank hit).
+        reference_scripts: Optional[List[str]] = None,
         # Number of independent anchor-analysis attempts run in parallel;
         # an LLM judge compares finished attempts (scores + visualizations)
         # and locks the winner. Default 1 = no fan-out.
@@ -532,6 +536,7 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
             "series_metadata": series_metadata or {},
             "analysis_hints": hints,
             "analysis_objective": objective,
+            "reference_scripts": _load_reference_scripts(reference_scripts),
             # Annealing schedule start level (None/0 = start frozen at T=0).
             "_starting_annealing_level": starting_annealing_level,
             # Auxiliary reference data

--- a/scilink/server/files.py
+++ b/scilink/server/files.py
@@ -6,6 +6,7 @@ where they expect them:
   analyze data/metadata, several   -> <session>/uploads/series/<name> (sidebar.py:1333,1365)
   plan knowledge|code|data         -> <session>/<category>/<name>    (chat_uploads.py:388)
   meta (combined dropzone)         -> <session>/uploads/<name>       (chat_uploads.py:411)
+  analyze scripts (.py etc.)       -> <session>/scripts/<name>       (attach-a-script)
 
 Folder uploads (``preserve_paths=True``) keep the client's relative layout
 under the same category root — ``uploads/<folder>/<sub>/<name>`` — so a
@@ -38,6 +39,10 @@ _CATEGORY_EXTENSIONS: Dict[str, tuple] = {
     "code": SUPPORTED_CODE_EXTENSIONS,
     "planning_data": SUPPORTED_PLANNING_DATA_EXTENSIONS,
     "meta": SUPPORTED_META_EXTENSIONS,
+    # A script the user attaches in chat to be ADAPTED by the analysis
+    # agents (run_analysis reference_scripts) — analyze mode's home for
+    # code, which its data / metadata categories rightly reject.
+    "scripts": SUPPORTED_CODE_EXTENSIONS,
 }
 
 
@@ -96,7 +101,7 @@ def _category_root(root: Path, category: str) -> Path:
     if category in ("data", "metadata", "meta"):
         return root / "uploads"
     sub = "data" if category == "planning_data" else category
-    return root / sub
+    return root / sub          # knowledge | code | scripts
 
 
 def save_folder_upload(session_dir: str, category: str,
@@ -195,7 +200,7 @@ def save_uploads(session_dir: str, category: str,
             target = root / "uploads"
     elif category == "meta":
         target = root / "uploads"
-    else:  # knowledge | code | planning_data
+    else:  # knowledge | code | planning_data | scripts
         sub = "data" if category == "planning_data" else category
         target = root / sub
     target.mkdir(parents=True, exist_ok=True)

--- a/tests/test_reference_scripts.py
+++ b/tests/test_reference_scripts.py
@@ -75,3 +75,23 @@ def test_scripts_upload_category(tmp_path):
         files_mod.save_uploads(str(tmp_path), "scripts", [("data.npy", b"")])
     with pytest.raises(files_mod.UploadError):          # still rejected by the data category
         files_mod.save_uploads(str(tmp_path), "data", [("user_edge_fit.py", b"")])
+
+
+def test_multiple_scripts_guidance_and_total_budget(tmp_path):
+    a = tmp_path / "preprocess.py"; a.write_text("def smooth(y): return y\n")
+    b = tmp_path / "fit.py"; b.write_text("def fit(y): return y\n")
+    c = tmp_path / "third.py"; c.write_text("x = 1\n" * 50)
+    state = {"reference_scripts": load_reference_scripts([str(a), str(b)])}
+    block = reference_script_block(state)
+    assert block.startswith("\n## User-Provided Reference Scripts\n")
+    assert "compose them in pipeline order" in block and "do not blend competing methods" in block
+    assert "### preprocess.py" in block and "### fit.py" in block
+    # a single script gets no multi-script paragraph
+    assert "compose them" not in reference_script_block({"reference_scripts": load_reference_scripts([str(a)])})
+    # total budget: later scripts are listed by name only, never dropped silently
+    out = load_reference_scripts([str(a), str(b), str(c)], max_total_bytes=40)
+    assert [s["label"] for s in out] == ["preprocess.py", "fit.py", "third.py"]
+    assert out[0]["truncated"] is False and out[1]["truncated"] is True
+    assert out[2].get("omitted") is True and out[2]["text"] == ""
+    block = reference_script_block({"reference_scripts": out})
+    assert "third.py — attached, but omitted here" in block and "read_file" in block

--- a/tests/test_reference_scripts.py
+++ b/tests/test_reference_scripts.py
@@ -1,0 +1,77 @@
+"""Attach-a-script: a user's script rides into the analysis agents as
+reference material to ADAPT (script-bank semantics for a bare file)."""
+
+import inspect
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scilink.agents.exp_agents._reference_scripts import (
+    load_reference_scripts, reference_script_block)
+
+
+def test_load_skips_bad_inputs_and_truncates(tmp_path):
+    good = tmp_path / "fit.py"; good.write_text("import numpy as np\nprint('hi')\n")
+    binary = tmp_path / "blob.py"; binary.write_bytes(b"\x00\x01\x02" * 100)
+    image = tmp_path / "img.png"; image.write_bytes(b"\x89PNG")
+    big = tmp_path / "big.py"; big.write_text("x = 1\n" * 20000)
+    out = load_reference_scripts([str(good), str(binary), str(image),
+                                  str(tmp_path / "missing.py"), str(big)], max_bytes=1000)
+    assert [s["label"] for s in out] == ["fit.py", "big.py"]
+    assert out[0]["text"].startswith("import numpy") and out[0]["truncated"] is False
+    assert out[1]["truncated"] is True and len(out[1]["text"]) <= 1000
+    assert load_reference_scripts(None) == [] and load_reference_scripts([]) == []
+
+
+def test_block_carries_the_adapt_semantics_and_the_code(tmp_path):
+    p = tmp_path / "user_edge_fit.py"; p.write_text("def power_law(E, A, r):\n    return A * E**-r\n")
+    state = {"reference_scripts": load_reference_scripts([str(p)])}
+    block = reference_script_block(state)
+    assert block.startswith("\n## User-Provided Reference Script\n")
+    for phrase in ("ADAPT", "script bank", "never" if False else "Do not run it verbatim",
+                   "what was kept and what was changed", "### user_edge_fit.py", "def power_law"):
+        assert phrase in block, phrase
+    assert reference_script_block({}) == "" and reference_script_block({"reference_scripts": []}) == ""
+    assert reference_script_block(state, heading="---").startswith("\n--- User-Provided")
+
+
+def test_all_three_agents_accept_reference_scripts():
+    from scilink.agents.exp_agents.curve_fitting_agent import CurveFittingAgent
+    from scilink.agents.exp_agents.image_analysis_agent import ImageAnalysisAgent
+    from scilink.agents.exp_agents.hyperspectral_analysis_agent import HyperspectralAnalysisAgent
+    for cls in (CurveFittingAgent, ImageAnalysisAgent, HyperspectralAnalysisAgent):
+        assert "reference_scripts" in inspect.signature(cls.analyze).parameters, cls.__name__
+
+
+def test_every_guidance_site_also_shows_the_script():
+    """Wherever a controller shows the user's `analysis_hints`, the reference
+    script block must follow — planning, codegen, refinement, correction."""
+    import re
+    base = Path("scilink/agents/exp_agents/controllers")
+    for f in ("curve_fitting_controllers.py", "image_analysis_controllers.py",
+              "hyperspectral_controllers.py"):
+        src = (base / f).read_text()
+        sites = [m.start() for m in re.finditer(r'if state\.get\("analysis_hints"\)', src)]
+        assert sites, f
+        for pos in sites:
+            window = src[pos:pos + 900]
+            assert "_reference_script_block(state" in window, f"{f} @ {src[:pos].count(chr(10)) + 1}"
+
+
+def test_run_analysis_schema_exposes_reference_scripts():
+    src = Path("scilink/agents/exp_agents/analysis_orchestrator_tools.py").read_text()
+    i = src.index('"reference_scripts": {')
+    desc = src[i:i + 900]
+    assert "ADAPT" in desc and "script-bank" in desc and "never" in desc
+
+
+def test_scripts_upload_category(tmp_path):
+    from scilink.server import files as files_mod
+    r = files_mod.save_uploads(str(tmp_path), "scripts", [("user_edge_fit.py", b"print(1)")])
+    assert r["paths"] == [str(tmp_path / "scripts" / "user_edge_fit.py")]
+    with pytest.raises(files_mod.UploadError):
+        files_mod.save_uploads(str(tmp_path), "scripts", [("data.npy", b"")])
+    with pytest.raises(files_mod.UploadError):          # still rejected by the data category
+        files_mod.save_uploads(str(tmp_path), "data", [("user_edge_fit.py", b"")])

--- a/webui/src/components/ChatPanel.tsx
+++ b/webui/src/components/ChatPanel.tsx
@@ -56,7 +56,10 @@ export function ChatPanel({
   const categoryFor = (name: string): string => {
     const e = name.slice(name.lastIndexOf(".") + 1).toLowerCase();
     if (mode === "meta") return "meta";
-    if (mode === "analyze") return e === "json" ? "metadata" : "data";
+    if (mode === "analyze")
+      return e === "json" ? "metadata"
+        : ["py", "yaml", "yml", "md"].includes(e) ? "scripts"
+        : "data";
     // plan mode
     if (["py", "yaml", "yml"].includes(e)) return "code";
     if (["csv", "xlsx", "tsv", "npy", "json", "txt"].includes(e))
@@ -84,11 +87,18 @@ export function ChatPanel({
     }
     setUploadNote(null);
     const quoted = paths.map((p) => `\`${p}\``).join(", ");
+    // A script attached in chat is reference material the agent adapts —
+    // the draft says so, so the user's next words are about what to do
+    // with it rather than about how it was uploaded.
+    const scripts = paths.filter((p) => /\.(py|jl|r|m)$/i.test(p));
     setDraft((d) => {
       const mention =
-        paths.length === 1 && mode === "analyze" && !d
-          ? `I uploaded a data file at ${quoted}. Please examine it.`
-          : `I uploaded ${paths.length} file(s): ${quoted}.`;
+        scripts.length === paths.length && paths.length > 0 && mode !== "meta"
+          ? `I attached my script ${quoted} — use it as the reference implementation ` +
+            `(adapt it to the data as needed) and tell me what you kept and changed.`
+          : paths.length === 1 && mode === "analyze" && !d
+            ? `I uploaded a data file at ${quoted}. Please examine it.`
+            : `I uploaded ${paths.length} file(s): ${quoted}.`;
       return d ? `${d.trimEnd()}\n\n${mention} ` : `${mention} `;
     });
     inputRef.current?.focus();


### PR DESCRIPTION
## Summary

You can attach your own analysis script in chat and tell the agent to use it. Stacked on #555, which it builds on.

- In analyze mode, drop a `.py` on the paperclip. It lands in the session's `scripts/` folder and the draft already says "use it as the reference implementation, adapt it to the data as needed, and tell me what you kept and changed". Send that with your data and the agent takes it from there.
- The agent treats your script the way it treats a proven script from its script bank: it adapts rather than reimplements, keeps your method, model choices, parameters and thresholds unless the data demonstrably needs a change, conforms the input and output to its run, keeps your function names where practical, and states in its answer and in the generated script's header what was kept and what changed. The result goes through the normal sandbox and quality loop, so a mangled adaptation is corrected, not silently wrong.
- It is never run verbatim. That is deliberate: verbatim execution of arbitrary code is what MCP servers are for. No SciLink-specific tool format is involved anywhere.

Verified live on the EELS identification example with the included `examples/eels_identification_demo/user_edge_fit.py`: the generated fitting script is headed "Adapted from user_edge_fit.py" with KEPT and CHANGED sections, reuses the script's functions and constants by name, and the answer to the user lists exactly what was kept (power-law background, Gaussian peaks, area formula, output style) and what changed (onset model, peak counts) and why.

## Technical description

### Design

A user script is reference material with script-bank semantics, but it arrives as a bare file rather than a prior run's artifact bundle, so it gets its own channel rather than overloading `prior_analysis_paths` (whose loaders expect `series_fit_results.json` and whose hyperspectral form refuses non-locked use).

- `scilink/agents/exp_agents/_reference_scripts.py` (new, stdlib only): `load_reference_scripts(paths, max_bytes=64_000)` reads text scripts, skipping missing, binary or non-text files with a warning and truncating long ones with a note; `reference_script_block(state, heading)` renders the block with the adapt-not-reimplement guidance and each script in a fenced code block. Empty when there is nothing, so callers append unconditionally.
- `CurveFittingAgent.analyze`, `ImageAnalysisAgent.analyze`, `HyperspectralAnalysisAgent.analyze` take `reference_scripts: list | None` and put the loaded scripts in pipeline state. The hyperspectral agent threads it through `_run_analysis_pipeline` into both of its state dicts.
- Controllers: wherever a controller shows the user's `analysis_hints` the block follows. Planning, code generation, plan refinement and script correction, 12 sites across the three controller modules. The two correction prompts that splice guidance in front of the response marker splice the block the same way, so a fix cannot drift away from the method the user asked for.
- `run_analysis(reference_scripts=[...])`: forwarded by signature introspection like the other optional knobs, relative paths resolved against the session directory, schema text stating when to pass it. The analysis orchestrator prompt gains one sentence. The meta needs nothing: it passes the path in the delegation task and the analysis child does the rest.
- Web: new `scripts` upload category (`SUPPORTED_CODE_EXTENSIONS` → `<session>/scripts/`); the paperclip routes `.py`, `.yaml`, `.yml`, `.md` there in analyze mode, and a script-only attachment produces the reference-implementation draft text. Plan mode keeps routing code to `code/`.
- `examples/eels_identification_demo/user_edge_fit.py`: a realistic user script (power-law background, noise-threshold onset, Gaussian near-edge peaks, JSON and figure) that runs standalone on the example spectrum.

### Tests

`tests/test_reference_scripts.py` (6): loader edge cases (binary, non-text, missing, truncation); block content and both heading styles; all three `analyze` signatures; every `analysis_hints` site in the three controller modules carries the block (a source-level invariant, so a future guidance site cannot forget it); the schema text; the `scripts` upload category and that the data category still rejects `.py`. Agent suites (`test_curve_fitting_*`, `test_hyperspectral_*`, `test_hs_locked_replay`, `test_spectral_unmixer_mask`, `test_web_server`): pass. Full suite versus `main`: identical failure set (the one order-dependent `test_trim_gate` case excepted), 24 more passing tests.

A first full-suite run caught a real defect: the hyperspectral state dict I had patched lives in a helper that did not receive the new parameter, so two hyperspectral tests failed with a `NameError`. Threaded properly and re-run clean.

### Live verification (Bedrock Opus 4.8, autonomous analyze session)

Prompt: the example spectrum and metadata plus "I attached my script `user_edge_fit.py` — use it as the reference implementation (adapt it to the data as needed) to fit the Ti L2,3 and O K edges, and tell me what you kept and what you changed."

- The plan named the script's method before any code was written ("power-law background A·E^-r over the pre-edge window").
- The generated `fitting_script.py` opens with "Adapted from user_edge_fit.py", a KEPT list and a CHANGED list, and reuses `power_law`, `gaussians`, `analyze_edge`, `EDGES`, `NOISE_SIGMA_THRESHOLD`, the `Ti_L23` / `O_K` keys and the FWHM constant by name.
- The run passed the quality loop at R² 0.999 and the answer reconciled the result with the script: kept the per-edge power-law background, Gaussian peak parameterization and area formula, the two-edge structure and the JSON-plus-figure output; changed the onset detection to a fitted edge step and the peak counts from two per edge to four and three, with the reason for each.
- Cost note: this was a thorough best-of-N run with annealing and took about 25 minutes; the file-tool turns in #555 take seconds.

### Not in scope

Verbatim execution of a user script in analyze mode (a foundation-agent contract change; MCP is the verbatim route today), and per-user script libraries.
