### PR TITLE
Meta: read_file — the plain reader it lacked (#397's last phase)

### DIFF
--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -133,7 +133,9 @@ rather than fabricate a result).
   ONE batched task (pass the file list or their shared directory) so the
   specialist's batch tools engage — never one delegation per file.
 - `inspect_uploads` is for routing only — do not use its output to interpret
-  or analyze the data yourself; hand that to the specialist.
+  or analyze the data yourself; hand that to the specialist. To see what an
+  uploaded SCRIPT or text file actually does before routing it, `read_file`
+  it (view_document is for PDF / Word / tables).
 - A RAW INSTRUMENT container — one whose sidecar / manifest / embedded contract
   says it must be reconstructed or reduced before analysis (e.g. a raw hologram or
   interferogram stack, `generic_image_routing_permitted: false`, a

--- a/scilink/agents/meta_agent/meta_orchestrator_tools.py
+++ b/scilink/agents/meta_agent/meta_orchestrator_tools.py
@@ -1808,7 +1808,9 @@ class MetaOrchestratorTools:
                 if pp.suffix.lower() not in _DOCUMENT_EXTS:
                     errors.append(
                         f"Not a supported document: {p} "
-                        f"(handles {', '.join(sorted(_DOCUMENT_EXTS))})"
+                        f"(handles {', '.join(sorted(_DOCUMENT_EXTS))}) — "
+                        "for a script, log, config or any other text file "
+                        "use read_file."
                     )
                     continue
                 try:
@@ -1943,4 +1945,65 @@ class MetaOrchestratorTools:
                 },
             },
             required=["paths"],
+        )
+
+        # -- read_file ----------------------------------------------------
+        # The plain reader the meta lacked (#397's last phase): a script the
+        # user attached, a session log, a config, a specialist's report.
+        # view_document is the document reader (PDF / DOCX figures, tables);
+        # this is the shared engine every specialist's read_file already
+        # uses (#481), so windowing and truncation notices are identical.
+        _FULL_READ_STEMS = ("report", "summary", "white_paper", "literature")
+        _FULL_READ_MAX_CHARS = 250_000
+
+        def read_file(file_path: str, max_lines: int = 200,
+                      tail: bool = False, search: str = None,
+                      offset: int = None) -> str:
+            print(f"  ⚡ Tool: Reading file '{file_path}'...")
+            path = Path(str(file_path)).expanduser()
+            if not path.is_absolute():
+                path = Path(self.orch.base_dir) / path
+            from ...utils.file_io import read_file_content
+            return json.dumps(read_file_content(
+                path, max_lines=max_lines, tail=tail, search=search,
+                offset=offset, full_read_stems=_FULL_READ_STEMS,
+                full_read_max_chars=_FULL_READ_MAX_CHARS,
+                ocr_model=getattr(self.orch, "model", None),
+                display_path=str(file_path)))
+
+        self._register_tool(
+            func=read_file,
+            name="read_file",
+            description=(
+                "Read a text, code, JSON, CSV or log file — a script the "
+                "user attached (.py etc.), a session or specialist log, a "
+                "config, a report a delegation wrote — without delegating "
+                "anything. Use it to see what an uploaded script does "
+                "before routing it, or to answer a question about a file. "
+                "PDF and Word documents are extracted to text too, but "
+                "view_document is the better reader for those (figures, "
+                "tables). Reads from the TOP by default; reports and "
+                "summaries are returned WHOLE. For a long file do not read "
+                "it repeatedly hoping to see more — a truncated read lists "
+                "the section headings with line numbers: use offset=<line> "
+                "to jump, search='<pattern>' to find where something is, or "
+                "tail=true to read the END. Path is absolute or relative to "
+                "the meta session directory."
+            ),
+            parameters={
+                "file_path": {"type": "string",
+                              "description": "Path to the file to read."},
+                "max_lines": {"type": "integer",
+                              "description": "Maximum lines to return (default: 200)."},
+                "tail": {"type": "boolean", "description": (
+                    "Read the LAST max_lines lines instead of the first.")},
+                "search": {"type": "string", "description": (
+                    "Case-insensitive regex: returns matching lines with line "
+                    "numbers and one line of context, plus the match count, "
+                    "instead of the file body.")},
+                "offset": {"type": "integer", "description": (
+                    "1-based line to start reading from — the way to read the "
+                    "MIDDLE of a file.")},
+            },
+            required=["file_path"],
         )

--- a/tests/test_meta_inspect_subfolders.py
+++ b/tests/test_meta_inspect_subfolders.py
@@ -114,3 +114,26 @@ def test_walk_file_cap(tmp_path, monkeypatch):
         (d / "s" / f"f{i}.txt").write_text("x")
     walked = _walk_files(d, max_depth=3)
     assert len(walked["files"]) == 3 and walked["depth_truncated"] is True
+
+
+def test_meta_read_file_is_the_shared_reader(tmp_path):
+    """The meta's plain reader (#397's last phase) — a wrapper over the
+    shared engine, so an attached script reads like it does in any mode."""
+    cap = _tools(tmp_path)
+    assert "read_file" in cap
+    read, params = cap["read_file"]
+    assert {"file_path", "max_lines", "tail", "search", "offset"} <= set(params)
+    (tmp_path / "uploads").mkdir(exist_ok=True)
+    script = tmp_path / "uploads" / "user_edge_fit.py"
+    script.write_text("".join(f"def f{i}(): pass\n" for i in range(300)) + "MARKER_END = 1\n")
+    out = json.loads(read(file_path="uploads/user_edge_fit.py"))      # relative to the session
+    assert out["status"] == "success" and out["truncated"] is True and "def f0" in out["content"]
+    assert json.loads(read(file_path=str(script), search="MARKER_END"))["match_lines"] == [301]
+    assert "MARKER_END" in json.loads(read(file_path=str(script), tail=True, max_lines=2))["content"]
+    rep = tmp_path / "analysis_report.md"; rep.write_text("x\n" * 400)
+    assert json.loads(read(file_path=str(rep)))["truncated"] is False   # whole-read stem
+    assert json.loads(read(file_path="nope.py"))["status"] == "error"
+    # view_document still refuses code, but now says where to go
+    view, _ = cap["view_document"]
+    out = json.loads(view(paths=[str(script)]))
+    assert any("use read_file" in e for e in (out.get("errors") or [str(out)]))


### PR DESCRIPTION
## Summary

The mission-control agent can now read an uploaded script or any plain text file itself. Stacked on #556.

Observed in your live session today: handed an attached `.py`, the meta probed the first lines, tried `view_document` (which refuses code), tried a session-history search, and routed from the probe alone. It routed correctly, but it could not read what you gave it. Now it reads the file with `read_file`, the same reader every specialist has, with the same navigation for long files.

## Technical description

- `scilink/agents/meta_agent/meta_orchestrator_tools.py`: `read_file(file_path, max_lines, tail, search, offset)` registered after `view_document`, a thin wrapper over `scilink.utils.file_io.read_file_content` (the #481 engine) with whole-read stems `report`, `summary`, `white_paper`, `literature`; relative paths resolve against the meta session directory. `view_document`'s refusal for a non-document extension now ends with "for a script, log, config or any other text file use read_file".
- `scilink/agents/meta_agent/meta_orchestrator.py`: one sentence in the inspecting-uploads block saying which reader is for what.
- Test (`tests/test_meta_inspect_subfolders.py`): the tool registers with its parameters, reads a 301-line script relative to the session with truncation, finds a symbol with `search` at the right line, reads the tail, returns a report whole, errors on a missing file, and `view_document` now points at `read_file`.

Live (Bedrock Opus 4.8): a meta session read the attached `user_edge_fit.py` with `read_file` twice — once for the summary, once with `search` — and answered the line-number question correctly (line 31).