### PR TITLE
Bump version to 0.0.70

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scilink"
-version = "0.0.69"
+version = "0.0.70"
 authors = [
   { name="SciLink Team", email="maxim.ziatdinov@gmail.com" },
 ]


### PR DESCRIPTION
## Summary

Version bump for the release carrying the shared file I/O engine and analysis-mode file tools, attach-a-script in chat, the meta's plain file reader, and the fan-out decline fix.

## Technical description

`pyproject.toml` version 0.0.69 → 0.0.70. No other change. The `v0.0.70` tag on the merge commit triggers `release.yml`.