### PR TITLE
Telemetry tab: tool sequence, worker agents, analysis reports

### DIFF
--- a/docs/react_ui_roadmap.md
+++ b/docs/react_ui_roadmap.md
@@ -85,11 +85,12 @@ restart, resume).
    connect + the read-only tool inventory, without the Streamlit
    tool-file uploader, whose `tool_schemas` / `create_tool_functions`
    contract is dropped: the attach-a-script path replaces it for
-   adaptation, MCP for verbatim); Telemetry (the tab exists with the
-   per-delegation detail; the `/telemetry` endpoint already serves the
-   full reader, so what is left is the per-agent tool sequence and worker
-   action histories); Skills (browse/upload first; the persistent-memory
-   pipeline UI is a separate, bigger design). Build when actually missed.
+   adaptation, MCP for verbatim); ~~Telemetry~~ DONE 2026-09-08 (tool
+   sequence, worker agents and analysis reports from `/telemetry` under
+   the delegation detail; the graphviz graph is not ported — the sidebar
+   tree carries the same edges); Skills (browse/upload DONE 2026-09-08,
+   PR #561; the persistent-memory pipeline UI is a separate, bigger
+   design, next).
 7. **Parity for the switch to default** (see "Standing decisions"):
    simulate mode in the web UI (HPC connection, wizards) is the largest
    gap; after it the web UI covers everything Streamlit does.

--- a/docs/react_ui_roadmap.md
+++ b/docs/react_ui_roadmap.md
@@ -87,8 +87,8 @@ restart, resume).
    contract is dropped: the attach-a-script path replaces it for
    adaptation, MCP for verbatim); ~~Telemetry~~ DONE 2026-09-08 (tool
    sequence, worker agents and analysis reports from `/telemetry` under
-   the delegation detail; the graphviz graph is not ported — the sidebar
-   tree carries the same edges); Skills (browse/upload DONE 2026-09-08,
+   the delegation detail, plus the dependency graph as plain SVG and a
+   per-layer history download); Skills (browse/upload DONE 2026-09-08,
    PR #561; the persistent-memory pipeline UI is a separate, bigger
    design, next).
 7. **Parity for the switch to default** (see "Standing decisions"):

--- a/docs/react_web_ui.md
+++ b/docs/react_web_ui.md
@@ -177,9 +177,14 @@ rate limiting on sign-in (put the proxy's in front if internet-facing).
   an action to its input, result and rationale) and the **analysis
   reports** (each analysis's claims and reasoning). Polled every 3 s while
   a turn runs, since the tool sequence reads the agents' live message
-  lists, and refreshed on every ledger change otherwise. The Streamlit
-  tab's graphviz dependency graph is not ported: the sidebar tree and the
-  ledger rows already show the same dispatch and context-flow edges.
+  lists, and refreshed on every ledger change otherwise. Each layer's
+  full chat history can be opened in Files or downloaded as JSON. Above
+  the ledger sits the **dependency graph** from the Streamlit tab, drawn
+  as plain SVG (no graphviz): the meta-agent root, one box per delegation
+  colored by status and annotated with its sub-agents, grey dispatch
+  edges, blue context edges; boxes are layered by context depth, edges
+  that skip a layer bow around the boxes between, and clicking a box
+  expands its ledger row.
 - **MCP tab** (all modes): connect MCP servers — a `stdio` command, an
   SSE URL, or a streamable-HTTP URL with optional JSON headers — and
   disconnect them; each server card lists the tools it registered. The

--- a/docs/react_web_ui.md
+++ b/docs/react_web_ui.md
@@ -187,11 +187,23 @@ rate limiting on sign-in (put the proxy's in front if internet-facing).
   wider than six wraps into rows, the parallel branches of one fan-out
   collapse into a single stacked box with their outcome counts (30
   branches are one node, not 30 boxes and 60 edges), every edge is routed
-  around the boxes it does not connect (the smallest sideways bow that
-  clears them; sources in a wrapped layer sit in its last row so their
-  edges never cross a sibling row), and clicking a box expands its
-  ledger row (a fan-out box opens its first failed branch). Checked at 45
-  delegations.
+  around the boxes it does not connect (straight when nothing is in the
+  way, else a sweep inside the free band between rows into the nearest
+  vertical lane that clears every box — a column gap, the strip beside a
+  row, or the canvas edge; sources in a wrapped layer sit in its last row
+  so their edges never cross a sibling row), and clicking a box expands
+  its ledger row (a fan-out box opens its first failed branch). Layout
+  and routing are a pure module (`webui/src/delegationGraph.ts`) checked
+  by `npm run check:graph` (`webui/scripts/graph_check.ts`): sixteen
+  ledger scenarios — chains, diamonds, skip edges, fan-outs with fusion
+  and a non-member consumer, two fan-outs, wide layers, a 40-deep chain,
+  20 sources into one fusion, out-of-order indices, unknown / self /
+  duplicate sources, a cycle, 45 delegations — each asserting the drawn
+  context edges equal the ledger's `context_from` relations, one
+  dispatch edge per node, endpoints on the right boxes, no edge through
+  a third box, downward flow, no overlapping boxes. Edge paths carry
+  `data-from` / `data-to` and node groups `data-node`, so the same audit
+  can be run against the rendered SVG in a browser.
 - **MCP tab** (all modes): connect MCP servers — a `stdio` command, an
   SSE URL, or a streamable-HTTP URL with optional JSON headers — and
   disconnect them; each server card lists the tools it registered. The

--- a/docs/react_web_ui.md
+++ b/docs/react_web_ui.md
@@ -171,8 +171,9 @@ rate limiting on sign-in (put the proxy's in front if internet-facing).
   refresh and resume. Below the ledger, from the `/telemetry` snapshot:
   the **tool sequence** (every tool call each layer's LLM made — meta,
   analysis specialist, planning specialist — with the input/output shape
-  in the table and the actual arguments and result on click, plus a link
-  to the full chat history in Files), the **worker agents** (each
+  in the table and the actual arguments and result on click — a failed
+  call shows its error message inline in red instead of the shape — plus
+  a link to the full chat history in Files), the **worker agents** (each
   sub-agent's action history with outcomes; a row expands to its actions,
   an action to its input, result and rationale) and the **analysis
   reports** (each analysis's claims and reasoning). Polled every 3 s while

--- a/docs/react_web_ui.md
+++ b/docs/react_web_ui.md
@@ -186,8 +186,10 @@ rate limiting on sign-in (put the proxy's in front if internet-facing).
   edges, blue context edges; boxes are layered by context depth, a layer
   wider than six wraps into rows, the parallel branches of one fan-out
   collapse into a single stacked box with their outcome counts (30
-  branches are one node, not 30 boxes and 60 edges), edges that skip a
-  layer bow around the boxes between, and clicking a box expands its
+  branches are one node, not 30 boxes and 60 edges), every edge is routed
+  around the boxes it does not connect (the smallest sideways bow that
+  clears them; sources in a wrapped layer sit in its last row so their
+  edges never cross a sibling row), and clicking a box expands its
   ledger row (a fan-out box opens its first failed branch). Checked at 45
   delegations.
 - **MCP tab** (all modes): connect MCP servers — a `stdio` command, an

--- a/docs/react_web_ui.md
+++ b/docs/react_web_ui.md
@@ -168,8 +168,18 @@ rate limiting on sign-in (put the proxy's in front if internet-facing).
   summary and findings, the produced files (opening in the Files tab),
   warnings and error. Both surfaces are fed by the session snapshot and
   `delegations` SSE events as the ledger changes mid-turn, and survive
-  refresh and resume. The per-agent tool sequence and worker action
-  histories (already served by `/telemetry`) are the tab's next content.
+  refresh and resume. Below the ledger, from the `/telemetry` snapshot:
+  the **tool sequence** (every tool call each layer's LLM made — meta,
+  analysis specialist, planning specialist — with the input/output shape
+  in the table and the actual arguments and result on click, plus a link
+  to the full chat history in Files), the **worker agents** (each
+  sub-agent's action history with outcomes; a row expands to its actions,
+  an action to its input, result and rationale) and the **analysis
+  reports** (each analysis's claims and reasoning). Polled every 3 s while
+  a turn runs, since the tool sequence reads the agents' live message
+  lists, and refreshed on every ledger change otherwise. The Streamlit
+  tab's graphviz dependency graph is not ported: the sidebar tree and the
+  ledger rows already show the same dispatch and context-flow edges.
 - **MCP tab** (all modes): connect MCP servers — a `stdio` command, an
   SSE URL, or a streamable-HTTP URL with optional JSON headers — and
   disconnect them; each server card lists the tools it registered. The
@@ -210,8 +220,7 @@ rate limiting on sign-in (put the proxy's in front if internet-facing).
   - deep links: the tab and selected file live in the URL hash, so a
     refresh (or shared link) lands on the same file.
 
-Not yet ported: simulate mode, the Skills tab, the Telemetry tab's per-agent
-tool sequence (the `/telemetry` endpoint already serves it), vibes.
+Not yet ported: simulate mode, the Skills tab, vibes.
 
 ## Architecture
 

--- a/docs/react_web_ui.md
+++ b/docs/react_web_ui.md
@@ -182,9 +182,13 @@ rate limiting on sign-in (put the proxy's in front if internet-facing).
   the ledger sits the **dependency graph** from the Streamlit tab, drawn
   as plain SVG (no graphviz): the meta-agent root, one box per delegation
   colored by status and annotated with its sub-agents, grey dispatch
-  edges, blue context edges; boxes are layered by context depth, edges
-  that skip a layer bow around the boxes between, and clicking a box
-  expands its ledger row.
+  edges, blue context edges; boxes are layered by context depth, a layer
+  wider than six wraps into rows, the parallel branches of one fan-out
+  collapse into a single stacked box with their outcome counts (30
+  branches are one node, not 30 boxes and 60 edges), edges that skip a
+  layer bow around the boxes between, and clicking a box expands its
+  ledger row (a fan-out box opens its first failed branch). Checked at 45
+  delegations.
 - **MCP tab** (all modes): connect MCP servers — a `stdio` command, an
   SSE URL, or a streamable-HTTP URL with optional JSON headers — and
   disconnect them; each server card lists the tools it registered. The

--- a/scilink/agents/meta_agent/telemetry.py
+++ b/scilink/agents/meta_agent/telemetry.py
@@ -156,7 +156,16 @@ def _analysis_reports(base_dir: Path) -> List[Dict[str, Any]]:
 
 
 def _maybe_json(value: Any) -> Any:
-    """Parse a JSON string into a dict/list; leave anything else as-is."""
+    """Parse a JSON string into a dict/list; leave anything else as-is.
+
+    A multimodal tool message (an image-bearing result on Claude / Gemini)
+    carries ``content`` as a list of parts; its text part is the tool's
+    JSON, so that is what gets parsed — the image bytes are dropped.
+    """
+    if isinstance(value, list) and value and all(isinstance(v, dict) for v in value):
+        texts = [v.get("text") for v in value if v.get("type") == "text"]
+        if texts:
+            return _maybe_json("\n".join(str(t) for t in texts))
     if isinstance(value, str):
         try:
             return json.loads(value)

--- a/scilink/server/delegations.py
+++ b/scilink/server/delegations.py
@@ -113,8 +113,11 @@ def delegation_view(agent: Any, session_dir: Optional[str] = None
                                  if str(x).isdigit()],
                 "informed_by": list(e.get("informed_by") or []),
                 "fanout": bool(fan),
-                "fanout_group": (fan.get("id") or fan.get("group")
-                                 if isinstance(fan, dict) else None),
+                # run_fanout stamps ``fanout=True`` + ``parallel_group``
+                # ("fanout_<n>"); a dict-shaped marker is accepted too.
+                "fanout_group": e.get("parallel_group")
+                or (fan.get("id") or fan.get("group")
+                    if isinstance(fan, dict) else None),
                 "labels": list(e.get("labels") or []),   # fusion inputs
                 "timestamp": e.get("timestamp"),
                 "completed_at": e.get("completed_at"),

--- a/tests/test_meta_telemetry_reader.py
+++ b/tests/test_meta_telemetry_reader.py
@@ -1,0 +1,36 @@
+"""The telemetry reader's tool-sequence extraction: a failed tool call keeps
+its error message, and an image-bearing (multimodal) tool message is
+classified by its text part rather than reported as ok."""
+import json
+
+from scilink.agents.meta_agent.telemetry import _extract_tool_calls
+
+
+def _call(i, name, args):
+    return {"role": "assistant", "content": "", "tool_calls": [
+        {"id": f"c{i}", "type": "function",
+         "function": {"name": name, "arguments": json.dumps(args)}}]}
+
+
+def test_tool_sequence_keeps_error_messages_and_reads_multimodal_results():
+    err = {"status": "error", "error": "FileNotFoundError: no such file 'x.npy'"}
+    bad_args = {"status": "error", "message": "Invalid JSON in tool arguments"}
+    messages = [
+        _call(1, "read_file", {"path": "x.npy"}),
+        {"role": "tool", "tool_call_id": "c1", "content": json.dumps(err)},
+        _call(2, "view_image", {"path": "a.png"}),
+        # multimodal result: text part carries the tool JSON, image part follows
+        {"role": "tool", "tool_call_id": "c2", "content": [
+            {"type": "text", "text": json.dumps({"status": "error", "error": "unreadable image"})},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}]},
+        _call(3, "inspect_uploads", {"path": "."}),
+        {"role": "tool", "tool_call_id": "c3", "content": json.dumps(bad_args)},
+        _call(4, "delegate_to_analysis", {"task": "t"}),   # still running: no result
+    ]
+    seq = _extract_tool_calls(messages)
+    assert [c["tool"] for c in seq] == ["read_file", "view_image", "inspect_uploads",
+                                        "delegate_to_analysis"]
+    assert seq[0]["status"] == "error" and seq[0]["result"]["error"].startswith("FileNotFoundError")
+    assert seq[1]["status"] == "error" and seq[1]["result"] == {"status": "error", "error": "unreadable image"}
+    assert seq[2]["status"] == "error" and seq[2]["result"]["message"] == bad_args["message"]
+    assert seq[3]["status"] == "pending" and seq[3]["result"] is None

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -923,10 +923,15 @@ def test_delegation_view_shapes_the_ledger(tmp_path):
                       completed_at="2026-09-07T10:03:30", feature_tables=["ft"]),
         _ledger_entry(2, "planning", "running", context_from=[1, "x"]),
         _ledger_entry(3, "fusion", "success", labels=["a", "b"], context_from=[1]),
+        # a run_fanout branch is stamped fanout=True + parallel_group
+        dict(_ledger_entry(4, "analysis", "success", context_from=[1]),
+             fanout=True, parallel_group="fanout_4"),
     ])
     view = delegation_view(agent, str(tmp_path))
     rows = view["delegations"]
-    assert [r["index"] for r in rows] == [1, 2, 3]
+    assert [r["index"] for r in rows] == [1, 2, 3, 4]
+    assert rows[3]["fanout"] is True and rows[3]["fanout_group"] == "fanout_4"
+    assert rows[0]["fanout"] is False and rows[0]["fanout_group"] is None
     assert rows[0]["files_produced"] == ["analysis/results/fit.png", "/elsewhere/x.csv"]
     assert rows[0]["n_feature_tables"] == 1
     assert len(rows[0]["summary"]) <= 1200 and rows[0]["summary"].endswith("…")

--- a/webui/package.json
+++ b/webui/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "build:package": "npm run build && rsync -a --delete dist/ ../scilink/server/static/",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "check:graph": "node --experimental-strip-types scripts/graph_check.ts"
   },
   "dependencies": {
     "katex": "^0.16.11",

--- a/webui/scripts/graph_check.ts
+++ b/webui/scripts/graph_check.ts
@@ -1,0 +1,208 @@
+/** Headless check of the delegation graph's layout and routing.
+ *
+ *   npm run check:graph        (node --experimental-strip-types)
+ *
+ * Runs ledger scenarios through `computeGraph` and asserts, independently
+ * of the module's own routing helpers (the path string is re-parsed and
+ * re-sampled here):
+ *   1. the context edges are exactly the ledger's `context_from`
+ *      relations mapped to nodes (fan-out branches → their group node),
+ *      deduplicated, self-edges dropped, unknown sources dropped;
+ *   2. exactly one dispatch edge per node;
+ *   3. every edge starts at the bottom centre of its `from` box (or the
+ *      root) and ends at the top centre of its `to` box;
+ *   4. no edge passes through a box it does not connect;
+ *   5. a consumer sits below every source (except inside a cycle);
+ *   6. boxes never overlap and stay inside the canvas.
+ */
+import { computeGraph, NODE_H, NODE_W, type Graph } from "../src/delegationGraph.ts";
+import type { DelegationRow } from "../src/api.ts";
+
+function row(index: number, mode: string, context_from: number[] = [], extra: Partial<DelegationRow> = {}): DelegationRow {
+  return {
+    index, mode, label: `d${index}`, task: `task ${index}`, status: "success",
+    context_from, informed_by: [], fanout: false, fanout_group: null, labels: [],
+    timestamp: null, completed_at: null, summary: "", key_findings: [],
+    files_produced: [], n_feature_tables: 0, warnings: [], error: null,
+    timed_out: false, resumed: false, ...extra,
+  };
+}
+const fan = (index: number, group: string, cf: number[]) =>
+  row(index, "analysis", cf, { fanout: true, fanout_group: group });
+
+// ── scenarios ────────────────────────────────────────────────────────
+const scenarios: Record<string, DelegationRow[]> = {
+  single: [row(1, "analysis")],
+  chain: [row(1, "analysis"), row(2, "analysis", [1]), row(3, "simulation", [2]),
+          row(4, "planning", [3]), row(5, "analysis", [4])],
+  diamond: [row(1, "analysis"), row(2, "analysis", [1]), row(3, "planning", [1]),
+            row(4, "fusion", [2, 3])],
+  skip_edges: [row(1, "analysis"), row(2, "analysis", [1]), row(3, "analysis", [2]),
+               row(4, "planning", [1]), row(5, "analysis", [1, 3]), row(6, "analysis", [1, 2, 3, 4, 5])],
+  fanout_fusion: [row(1, "analysis"), ...[2, 3, 4, 5, 6, 7, 8, 9].map((i) => fan(i, "fanout_2", [1])),
+                  row(10, "fusion", [2, 3, 4, 5, 6, 7, 8, 9]), row(11, "planning", [10]),
+                  row(12, "analysis", [5]),           // one branch feeds a non-member
+                  row(13, "analysis", [5, 10])],       // a branch AND the fusion
+  two_fanouts: [row(1, "analysis"), ...[2, 3, 4].map((i) => fan(i, "fanout_2", [1])),
+                row(5, "fusion", [2, 3, 4]), ...[6, 7, 8].map((i) => fan(i, "fanout_6", [5])),
+                row(9, "fusion", [6, 7, 8]), row(10, "planning", [5, 9])],
+  fanout_mixed_sources: [row(1, "analysis"), row(2, "analysis"),
+                         fan(3, "fanout_3", [1]), fan(4, "fanout_3", [2]), fan(5, "fanout_3", []),
+                         row(6, "fusion", [3, 4, 5])],
+  wide_standalone: Array.from({ length: 14 }, (_, i) => row(i + 1, "analysis")),
+  wide_with_sources: [...Array.from({ length: 13 }, (_, i) => row(i + 1, "analysis")),
+                      row(14, "planning", [1]), row(15, "analysis", [7, 13]), row(16, "fusion", [14, 15])],
+  out_of_order_ledger: [row(3, "analysis", [1]), row(1, "analysis"), row(2, "planning", [3, 1])],
+  bad_sources: [row(1, "analysis", [99]),         // unknown source
+                row(2, "analysis", [2]),          // self
+                row(3, "analysis", [1, 1, 2]),    // duplicate
+                row(4, "analysis", [3, 99, 4])],
+  cycle: [row(1, "analysis"), row(2, "analysis", [1, 3]), row(3, "analysis", [2])],
+  statuses: [row(1, "analysis", [], { status: "error" }), row(2, "analysis", [1], { status: "running" }),
+             row(3, "planning", [1], { status: "interrupted" }), row(4, "analysis", [2, 3], { status: "cancelled" })],
+  big45: (() => {
+    const rs = [row(1, "analysis")];
+    for (let i = 2; i <= 31; i++) rs.push(fan(i, "fanout_2", [1]));
+    rs.push(row(32, "fusion", Array.from({ length: 30 }, (_, k) => k + 2)));
+    rs.push(row(33, "planning", [32]));
+    for (let i = 34; i <= 40; i++) rs.push(row(i, "analysis"));
+    rs.push(row(41, "analysis"), row(42, "analysis", [41]), row(43, "simulation", [42]),
+            row(44, "planning", [43]), row(45, "analysis", [44, 32], { status: "running" }));
+    return rs;
+  })(),
+  deep_chain_40: Array.from({ length: 40 }, (_, i) => row(i + 1, "analysis", i ? [i] : [])),
+  everyone_feeds_last: [...Array.from({ length: 20 }, (_, i) => row(i + 1, "analysis")),
+                        row(21, "fusion", Array.from({ length: 20 }, (_, i) => i + 1))],
+};
+
+// ── independent geometry helpers ─────────────────────────────────────
+type Pt = { x: number; y: number };
+/** Re-parse an SVG path of M / L / C commands into a sampler — independent
+ * of the module's own curve code. */
+function parsePath(d: string): { start: Pt; end: Pt; at: (t: number) => Pt } {
+  const tokens = d.match(/[MLC]|-?\d+(\.\d+)?/g)!;
+  const segs: ((t: number) => Pt)[] = [];
+  let cur: Pt = { x: 0, y: 0 };
+  let start: Pt | null = null;
+  for (let i = 0; i < tokens.length;) {
+    const cmd = tokens[i++];
+    const n = (): number => Number(tokens[i++]);
+    if (cmd === "M") { cur = { x: n(), y: n() }; start ??= cur; }
+    else if (cmd === "L") {
+      const a = cur, b = { x: n(), y: n() };
+      segs.push((t) => ({ x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t }));
+      cur = b;
+    } else if (cmd === "C") {
+      const a = cur, c1 = { x: n(), y: n() }, c2 = { x: n(), y: n() }, b = { x: n(), y: n() };
+      segs.push((t) => {
+        const u = 1 - t;
+        return { x: u ** 3 * a.x + 3 * u * u * t * c1.x + 3 * u * t * t * c2.x + t ** 3 * b.x,
+                 y: u ** 3 * a.y + 3 * u * u * t * c1.y + 3 * u * t * t * c2.y + t ** 3 * b.y };
+      });
+      cur = b;
+    } else throw new Error(`unexpected path token ${cmd} in ${d}`);
+  }
+  return {
+    start: start!, end: cur,
+    at: (t) => {
+      const k = Math.min(segs.length - 1, Math.floor(t * segs.length));
+      return segs[k](t * segs.length - k);
+    },
+  };
+}
+const inRect = (p: Pt, r: { x: number; y: number }, m = 0) =>
+  p.x >= r.x - m && p.x <= r.x + NODE_W + m && p.y >= r.y - m && p.y <= r.y + NODE_H + m;
+const near = (a: Pt, b: Pt) => Math.abs(a.x - b.x) < 1e-6 && Math.abs(a.y - b.y) < 1e-6;
+
+// ── checks ───────────────────────────────────────────────────────────
+let failures = 0;
+function check(scn: string, cond: boolean, msg: string) {
+  if (!cond) { failures++; console.log(`  FAIL [${scn}] ${msg}`); }
+}
+
+function expectedContextEdges(rows: DelegationRow[], g: Graph): Set<string> {
+  const out = new Set<string>();
+  for (const r of rows) {
+    const to = g.nodeOfIndex.get(r.index)!;
+    for (const src of r.context_from) {
+      const from = g.nodeOfIndex.get(src);
+      if (from && from !== to) out.add(`${from}->${to}`);
+    }
+  }
+  return out;
+}
+
+function inCycle(g: Graph, a: string, b: string): boolean {
+  // b reachable from a AND a reachable from b through `sources`
+  const reach = (from: string, to: string) => {
+    const seen = new Set<string>(); const stack = [from];
+    while (stack.length) {
+      const id = stack.pop()!;
+      if (id === to) return true;
+      if (seen.has(id)) continue; seen.add(id);
+      const n = g.nodes.find((x) => x.id === id);
+      for (const s of n?.sources ?? []) stack.push(s);
+    }
+    return false;
+  };
+  return reach(a, b) && reach(b, a);
+}
+
+for (const [name, rows] of Object.entries(scenarios)) {
+  const g = computeGraph(rows);
+  const boxOf = new Map(g.placed.map((p) => [p.node.id, p]));
+  const rootBox = { x: g.root.x, y: g.root.y };
+
+  // 1. context edges == ledger relations
+  const drawn = new Set(g.edges.filter((e) => e.kind === "context").map((e) => `${e.from}->${e.to}`));
+  const expected = expectedContextEdges(rows, g);
+  for (const e of expected) check(name, drawn.has(e), `missing context edge ${e}`);
+  for (const e of drawn) check(name, expected.has(e), `spurious context edge ${e}`);
+  check(name, g.edges.filter((e) => e.kind === "context").length === drawn.size, "duplicate context edge");
+
+  // 2. one dispatch edge per node
+  const disp = g.edges.filter((e) => e.kind === "dispatch");
+  check(name, disp.length === g.placed.length, `dispatch edges ${disp.length} != nodes ${g.placed.length}`);
+  check(name, new Set(disp.map((e) => e.to)).size === disp.length, "duplicate dispatch edge");
+
+  // every ledger row is in exactly one node
+  for (const r of rows) check(name, boxOf.has(g.nodeOfIndex.get(r.index)!), `row #${r.index} not placed`);
+
+  for (const e of g.edges) {
+    const path = parsePath(e.d);
+    const fromBox = e.from === "root" ? rootBox : boxOf.get(e.from)!;
+    const toBox = boxOf.get(e.to)!;
+    // 3. endpoints on the right boxes
+    check(name, near(path.start, { x: fromBox.x + NODE_W / 2, y: fromBox.y + NODE_H }),
+          `edge ${e.from}->${e.to} does not start at the bottom of ${e.from}`);
+    check(name, near(path.end, { x: toBox.x + NODE_W / 2, y: toBox.y }),
+          `edge ${e.from}->${e.to} does not end at the top of ${e.to}`);
+    // 4. no crossing of a third box (100 samples, 2 px margin)
+    const others = [...g.placed.filter((p) => p.node.id !== e.from && p.node.id !== e.to),
+                    ...(e.from === "root" ? [] : [{ x: g.root.x, y: g.root.y }])];
+    let crossed: string | null = null;
+    for (let i = 1; i < 300 && !crossed; i++) {
+      const pt = path.at(i / 300);
+      for (const o of others) if (inRect(pt, o, 2)) { crossed = "node" in o ? (o as any).node.id : "root"; break; }
+    }
+    check(name, crossed === null, `edge ${e.from}->${e.to} crosses ${crossed}`);
+    // 5. top-to-bottom flow
+    if (e.kind === "context" && !inCycle(g, e.from, e.to))
+      check(name, toBox.y > fromBox.y + NODE_H, `edge ${e.from}->${e.to} does not flow downward`);
+  }
+
+  // 6. no overlapping boxes; inside the canvas
+  const all = [...g.placed.map((p) => ({ id: p.node.id, x: p.x, y: p.y })), { id: "root", ...rootBox }];
+  for (let i = 0; i < all.length; i++) {
+    check(name, all[i].x >= 0 && all[i].y >= 0 && all[i].x + NODE_W <= g.width && all[i].y + NODE_H <= g.height,
+          `box ${all[i].id} outside canvas`);
+    for (let j = i + 1; j < all.length; j++) {
+      const a = all[i], b = all[j];
+      const overlap = a.x < b.x + NODE_W && b.x < a.x + NODE_W && a.y < b.y + NODE_H && b.y < a.y + NODE_H;
+      check(name, !overlap, `boxes ${a.id} and ${b.id} overlap`);
+    }
+  }
+  console.log(`${failures ? "  " : "ok  "}${name}: ${g.placed.length} nodes, ${drawn.size} context edges, ${disp.length} dispatch edges, ${g.width}×${g.height}`);
+}
+console.log(failures ? `\n${failures} FAILURE(S)` : "\nall scenarios pass");
+process.exit(failures ? 1 : 0);

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -19,6 +19,7 @@ import { FilesPanel } from "./components/FilesPanel";
 import { PreChatHero } from "./components/PreChatHero";
 import { AnalysisInset } from "./components/AnalysisInset";
 import { DelegationsPanel } from "./components/DelegationsPanel";
+import { TelemetryDetails } from "./components/TelemetryDetails";
 import { LoginScreen } from "./components/LoginScreen";
 import { ToolsPanel } from "./components/ToolsPanel";
 
@@ -539,7 +540,7 @@ export default function App() {
                 <button
                   className={tab === "telemetry" ? "active" : ""}
                   onClick={() => setTab("telemetry")}
-                  title="Delegation details (the sidebar tree is the live overview)"
+                  title="Delegation details, tool sequence, worker agents (the sidebar tree is the live overview)"
                 >
                   Telemetry
                 </button>
@@ -566,11 +567,19 @@ export default function App() {
             </div>
             {mode === "meta" && (
               <div className="tab-body" hidden={tab !== "telemetry"}>
-                <DelegationsPanel
-                  view={state.delegations}
-                  running={state.status === "running"}
-                  focus={focusDelegation}
-                />
+                <div className="telemetry-scroll">
+                  <DelegationsPanel
+                    view={state.delegations}
+                    running={state.status === "running"}
+                    focus={focusDelegation}
+                  />
+                  <TelemetryDetails
+                    sessionId={session.id}
+                    active={tab === "telemetry"}
+                    running={state.status === "running"}
+                    ledgerVersion={state.delegations}
+                  />
+                </div>
               </div>
             )}
             <div className="tab-body" hidden={tab !== "chat"}>

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -572,6 +572,7 @@ export default function App() {
                     view={state.delegations}
                     running={state.status === "running"}
                     focus={focusDelegation}
+                    metaMode={session.autonomy}
                   />
                   <TelemetryDetails
                     sessionId={session.id}

--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -111,6 +111,61 @@ export interface DelegationView {
   sub_agents: Record<string, string[]>; // specialist -> worker agents used
 }
 
+/** GET /sessions/{id}/telemetry — the meta session's read-only snapshot
+ * (scilink.agents.meta_agent.telemetry.collect_session_telemetry). */
+export interface ToolCall {
+  tool: string;
+  args: Record<string, unknown>;
+  result: unknown;
+  status: string; // success | ok | error | pending | …
+}
+
+export interface WorkerAction {
+  timestamp: string | null;
+  action: string;
+  status: string;
+  rationale: string | null;
+  input: unknown;
+  result: unknown;
+  feedback: unknown;
+}
+
+export interface WorkerAgent {
+  specialist: string; // analysis | planning | other
+  name: string;
+  status: string | null;
+  action_count: number;
+  actions_by_type: Record<string, number>;
+  outcomes: { success: number; error: number; other: number };
+  first_timestamp: string | null;
+  last_timestamp: string | null;
+  actions: WorkerAction[];
+  source_file: string;
+}
+
+export interface AnalysisReport {
+  analysis_id: string;
+  status: string | null;
+  detailed_analysis: string;
+  claims: { claim: string | null; impact: string | null }[];
+  output_dir: string;
+  report_file: string;
+}
+
+export interface TelemetrySnapshot {
+  meta: {
+    meta_mode: string;
+    session_dir: string;
+    delegations_total: number;
+    delegations: unknown[];
+  };
+  specialists: Record<string, Record<string, unknown>>;
+  agents: WorkerAgent[];
+  sub_agents: Record<string, string[]>;
+  analysis_reports: AnalysisReport[];
+  tool_sequence: Record<string, { calls: ToolCall[]; source: string }>;
+}
+
 export interface SessionSnapshot {
   id: string;
   mode: string;
@@ -339,6 +394,7 @@ export const api = {
     req<{ entries: TreeEntry[]; truncated: boolean }>(`/sessions/${id}/tree`),
 
   delegations: (id: string) => req<DelegationView>(`/sessions/${id}/delegations`),
+  telemetry: (id: string) => req<TelemetrySnapshot>(`/sessions/${id}/telemetry`),
 
   tools: (id: string) => req<ToolInventory>(`/sessions/${id}/tools`),
   connectMcp: (

--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -785,4 +785,4 @@ details.card iframe { width: 100%; height: 600px; border: none; background: #fff
 .deleg-graph { display: block; max-width: 100%; height: auto; }
 .deleg-graph-node:hover rect { filter: brightness(1.12); }
 .link-btn[download] { text-decoration: none; }
-
+.tel-err { color: #f85149; font-family: inherit; font-size: 13px; white-space: pre-wrap; }

--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -780,3 +780,9 @@ details.card iframe { width: 100%; height: 600px; border: none; background: #fff
 .tel-report .tel-json { margin: 8px 0; }
 .tel-report .file-chip-btn { margin-top: 4px; }
 
+/* Delegation dependency graph (SVG twin of the Streamlit graphviz chart) */
+.deleg-graph-wrap { margin: 4px 0 18px; overflow-x: auto; }
+.deleg-graph { display: block; max-width: 100%; height: auto; }
+.deleg-graph-node:hover rect { filter: brightness(1.12); }
+.link-btn[download] { text-decoration: none; }
+

--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -656,7 +656,9 @@ details.card iframe { width: 100%; height: 600px; border: none; background: #fff
   margin-left: 6px; padding: 0 6px; border-radius: 9px; font-size: 11px;
   background: var(--bg-card); border: 1px solid var(--border); color: var(--text-muted);
 }
-.deleg-panel { flex: 1; overflow: auto; padding: 16px 8%; }
+.telemetry-scroll { flex: 1; overflow: auto; }
+.deleg-panel { padding: 16px 8%; }
+.tel-details { padding: 0 8% 24px; }
 .deleg-head { display: flex; align-items: baseline; gap: 12px; margin-bottom: 12px; }
 .deleg-title { font-weight: 600; font-size: 15px; }
 .deleg-empty { margin-top: 24px; text-align: center; }
@@ -754,3 +756,27 @@ details.card iframe { width: 100%; height: 600px; border: none; background: #fff
 .tool-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
 .tool-list { margin: 6px 0 0; padding-left: 18px; font-size: 13px; }
 .tool-list li { margin: 3px 0; }
+
+/* Telemetry details — tool sequence, worker agents, analysis reports */
+.tel-layer { margin: 10px 0 16px; }
+.tel-layer-head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 4px; }
+.tel-table { width: 100%; border-collapse: collapse; font-size: 13px; table-layout: auto; }
+.tel-table th { text-align: left; font-weight: 500; color: var(--text-dim); padding: 4px 8px; border-bottom: 1px solid var(--border); white-space: nowrap; }
+.tel-table td { padding: 5px 8px; border-bottom: 1px solid var(--border); vertical-align: top; }
+.tel-row { cursor: pointer; }
+.tel-row:hover td { background: var(--bg-panel); }
+.tel-row.open td { background: var(--bg-panel); border-bottom: none; }
+.tel-row-detail td { padding: 4px 8px 12px 24px; }
+.tel-shape { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; color: var(--text-dim); word-break: break-word; }
+.tel-json { margin: 0; padding: 8px 10px; max-height: 320px; overflow: auto; font-size: 12px; white-space: pre-wrap; word-break: break-word; background: var(--code-bg); border: 1px solid var(--code-border); border-radius: 4px; }
+.tel-status { font-size: 12px; padding: 1px 7px; border-radius: 10px; border: 1px solid var(--border); color: var(--text-dim); white-space: nowrap; }
+.tel-status.status-success, .tel-status.status-ok, .tel-status.status-completed { color: #3fb950; border-color: #3fb95055; }
+.tel-status.status-error, .tel-status.status-failed { color: #f85149; border-color: #f8514955; }
+.tel-status.status-running, .tel-status.status-pending { color: #d29922; border-color: #d2992255; }
+.tel-by-type { display: flex; flex-wrap: wrap; gap: 6px; margin: 4px 0 8px; }
+.tel-actions { margin-top: 4px; }
+.tel-report { margin: 8px 0; padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; }
+.tel-report summary { cursor: pointer; display: flex; align-items: baseline; gap: 10px; }
+.tel-report .tel-json { margin: 8px 0; }
+.tel-report .file-chip-btn { margin-top: 4px; }
+

--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -784,5 +784,6 @@ details.card iframe { width: 100%; height: 600px; border: none; background: #fff
 .deleg-graph-wrap { margin: 4px 0 18px; overflow-x: auto; }
 .deleg-graph { display: block; max-width: 100%; height: auto; }
 .deleg-graph-node:hover rect { filter: brightness(1.12); }
+.deleg-graph-halo { fill: var(--bg-app); opacity: 0.85; }
 .link-btn[download] { text-decoration: none; }
 .tel-err { color: #f85149; font-family: inherit; font-size: 13px; white-space: pre-wrap; }

--- a/webui/src/components/DelegationGraph.tsx
+++ b/webui/src/components/DelegationGraph.tsx
@@ -29,11 +29,62 @@ function trunc(s: string, n: number): string {
   return s.length <= n ? s : s.slice(0, n - 1) + "…";
 }
 
+/** A graph node: one delegation, or a whole fan-out group (the N parallel
+ * branches of one run_fanout call) collapsed into a single stacked box —
+ * 30 branches as 30 boxes with 30 context edges in and 30 out is noise,
+ * and the branches are siblings of one meta call anyway. */
+interface GNode {
+  id: string;
+  rows: DelegationRow[];
+  group: string | null; // fanout_group when collapsed
+  sources: string[]; // node-level context_from
+}
+
 interface Placed {
-  row: DelegationRow;
+  node: GNode;
   x: number;
   y: number;
-  layer: number; // 0 = directly under the root
+  layer: number; // visual row; 0 = directly under the root
+}
+
+function buildNodes(rows: DelegationRow[]): GNode[] {
+  const nodeOf = new Map<number, string>();
+  const nodes: GNode[] = [];
+  const groups = new Map<string, GNode>();
+  for (const r of [...rows].sort((a, b) => a.index - b.index)) {
+    if (r.fanout && r.fanout_group) {
+      let g = groups.get(r.fanout_group);
+      if (!g) {
+        g = { id: `g:${r.fanout_group}`, rows: [], group: r.fanout_group, sources: [] };
+        groups.set(r.fanout_group, g);
+        nodes.push(g);
+      }
+      g.rows.push(r);
+      nodeOf.set(r.index, g.id);
+    } else {
+      const n = { id: `d:${r.index}`, rows: [r], group: null, sources: [] };
+      nodes.push(n);
+      nodeOf.set(r.index, n.id);
+    }
+  }
+  for (const n of nodes) {
+    const seen = new Set<string>();
+    for (const r of n.rows)
+      for (const src of r.context_from) {
+        const id = nodeOf.get(src);
+        if (id && id !== n.id && !seen.has(id)) {
+          seen.add(id);
+          n.sources.push(id);
+        }
+      }
+  }
+  return nodes;
+}
+
+function groupStatus(rows: DelegationRow[]): string {
+  if (rows.some((r) => r.status === "running")) return "running";
+  if (rows.every((r) => r.status === "error")) return "error";
+  return "success";
 }
 
 /** An edge that skips layers would run straight through the boxes in
@@ -47,6 +98,8 @@ function bowedPath(x1: number, y1: number, x2: number, y2: number, bow: number):
   return `M ${x1} ${y1} C ${x1 + bow} ${my}, ${x2 + bow} ${my}, ${x2} ${y2}`;
 }
 const BOW = 70;
+const MAX_PER_ROW = 6;   // a wider layer wraps into several rows
+const LABEL_MAX_SOURCES = 3; // "ctx" labels only where they stay legible
 
 export function DelegationGraph({
   rows,
@@ -62,51 +115,65 @@ export function DelegationGraph({
   onSelect: (index: number) => void;
 }) {
   const { placed, width, height, root } = useMemo(() => {
-    const byIndex = new Map(rows.map((r) => [r.index, r]));
-    const depth = new Map<number, number>();
-    const depthOf = (r: DelegationRow, seen = new Set<number>()): number => {
-      const cached = depth.get(r.index);
+    const nodes = buildNodes(rows);
+    const byId = new Map(nodes.map((n) => [n.id, n]));
+    const depth = new Map<string, number>();
+    const depthOf = (n: GNode, seen = new Set<string>()): number => {
+      const cached = depth.get(n.id);
       if (cached !== undefined) return cached;
-      if (seen.has(r.index)) return 0; // defensive: a cycle in context_from
-      seen.add(r.index);
+      if (seen.has(n.id)) return 0; // defensive: a cycle in context_from
+      seen.add(n.id);
       let d = 0;
-      for (const src of r.context_from) {
-        const s = byIndex.get(src);
+      for (const src of n.sources) {
+        const s = byId.get(src);
         if (s) d = Math.max(d, depthOf(s, seen) + 1);
       }
-      depth.set(r.index, d);
+      depth.set(n.id, d);
       return d;
     };
-    const layers: DelegationRow[][] = [];
-    for (const r of [...rows].sort((a, b) => a.index - b.index)) {
-      const d = depthOf(r);
-      (layers[d] ??= []).push(r);
+    const layers: GNode[][] = [];
+    for (const n of nodes) {
+      const d = depthOf(n);
+      (layers[d] ??= []).push(n);
     }
-    const widest = Math.max(1, ...layers.map((l) => l.length));
+    // A layer wider than MAX_PER_ROW wraps into several visual rows (a
+    // 40-branch fan-out would otherwise be one 7000 px line). `layer` on
+    // a placed node is its visual row, which is what edge bowing needs.
+    const visualRows: GNode[][] = [];
+    for (const layer of layers) {
+      for (let i = 0; i < layer.length; i += MAX_PER_ROW) {
+        visualRows.push(layer.slice(i, i + MAX_PER_ROW));
+      }
+    }
+    const widest = Math.max(1, ...visualRows.map((l) => l.length));
     const width = PAD * 2 + widest * NODE_W + (widest - 1) * GAP_X;
     const root = { x: width / 2 - NODE_W / 2, y: PAD };
     const placed: Placed[] = [];
-    layers.forEach((layer, li) => {
-      const rowW = layer.length * NODE_W + (layer.length - 1) * GAP_X;
+    visualRows.forEach((vr, li) => {
+      const rowW = vr.length * NODE_W + (vr.length - 1) * GAP_X;
       const x0 = (width - rowW) / 2;
-      layer.forEach((row, i) => {
+      vr.forEach((node, i) => {
         placed.push({
-          row,
+          node,
           x: x0 + i * (NODE_W + GAP_X),
           y: PAD + (li + 1) * (NODE_H + GAP_Y),
           layer: li,
         });
       });
     });
-    const height = PAD * 2 + (layers.length + 1) * NODE_H + layers.length * GAP_Y;
-    const margin = Math.max(0, layers.length - 1) * BOW * 0.75;
+    const height = PAD * 2 + (visualRows.length + 1) * NODE_H + visualRows.length * GAP_Y;
+    // Bows are capped (see below), so the side margin is bounded too.
+    const margin = Math.min(2, Math.max(0, visualRows.length - 1)) * BOW;
     for (const p of placed) p.x += margin;
     root.x += margin;
     return { placed, width: width + 2 * margin, height, root };
   }, [rows]);
 
   if (rows.length === 0) return null;
-  const at = new Map(placed.map((p) => [p.row.index, p]));
+  const at = new Map(placed.map((p) => [p.node.id, p]));
+  const nodeOfIndex = new Map<number, string>();
+  for (const p of placed) for (const r of p.node.rows) nodeOfIndex.set(r.index, p.node.id);
+  const selectedId = selected == null ? null : nodeOfIndex.get(selected) ?? null;
   const modeLabel = metaMode
     ? metaMode.charAt(0).toUpperCase() + metaMode.slice(1).toLowerCase()
     : "";
@@ -135,18 +202,19 @@ export function DelegationGraph({
         {/* dispatch edges: root -> every delegation */}
         {placed.map((p) => (
           <path
-            key={`d${p.row.index}`}
+            key={`d${p.node.id}`}
             d={bowedPath(root.x + NODE_W / 2, root.y + NODE_H,
-                         p.x + NODE_W / 2, p.y, -BOW * p.layer)}
+                         p.x + NODE_W / 2, p.y, -Math.min(2, p.layer) * BOW)}
             fill="none"
             stroke="#8893a5"
-            strokeWidth={1.2}
+            strokeWidth={p.layer === 0 ? 1.2 : 0.8}
+            opacity={p.layer === 0 ? 1 : 0.45}
             markerEnd="url(#dg-arrow-grey)"
           />
         ))}
         {/* context edges: source -> consumer */}
         {placed.flatMap((p) =>
-          p.row.context_from.map((src) => {
+          p.node.sources.map((src) => {
             const s = at.get(src);
             if (!s) return null;
             const x1 = s.x + NODE_W / 2;
@@ -154,19 +222,25 @@ export function DelegationGraph({
             const x2 = p.x + NODE_W / 2;
             const y2 = p.y;
             const my = (y1 + y2) / 2;
-            const bow = BOW * (p.layer - s.layer - 1);
+            // Collinear nodes need the bow; a source off to the side does not.
+            const skipped = p.layer - s.layer - 1;
+            const bow = Math.abs(x1 - x2) < NODE_W / 2 ? BOW * Math.min(2, skipped) : 0;
+            const many = p.node.sources.length > LABEL_MAX_SOURCES;
             return (
-              <g key={`c${src}-${p.row.index}`}>
+              <g key={`c${src}-${p.node.id}`}>
                 <path
                   d={bowedPath(x1, y1, x2, y2, bow)}
                   fill="none"
                   stroke="#58a6ff"
-                  strokeWidth={2}
+                  strokeWidth={many ? 1.2 : 2}
+                  opacity={many ? 0.7 : 1}
                   markerEnd="url(#dg-arrow-blue)"
                 />
-                <text x={(x1 + x2) / 2 + bow * 0.75 + 4} y={my - 2} fontSize={10} fill="#58a6ff">
-                  ctx
-                </text>
+                {!many && (
+                  <text x={(x1 + x2) / 2 + bow * 0.75 + 4} y={my - 2} fontSize={10} fill="#58a6ff">
+                    ctx
+                  </text>
+                )}
               </g>
             );
           }),
@@ -182,14 +256,58 @@ export function DelegationGraph({
           </text>
         </g>
 
-        {/* delegations */}
+        {/* delegations — a fan-out group is one stacked box */}
         {placed.map((p) => {
-          const r = p.row;
+          const n = p.node;
+          const isSel = selectedId === n.id;
+          if (n.group) {
+            const rs = n.rows;
+            const nOk = rs.filter((r) => r.status === "success").length;
+            const nErr = rs.filter((r) => r.status === "error").length;
+            const nRun = rs.filter((r) => r.status === "running").length;
+            const first = rs.find((r) => r.status === "error") ?? rs[0];
+            const lo = Math.min(...rs.map((r) => r.index));
+            const hi = Math.max(...rs.map((r) => r.index));
+            const subs = subAgents[rs[0].mode] ?? [];
+            const counts = [`${nOk} ✓`, nErr ? `${nErr} ✗` : "", nRun ? `${nRun} ⋯` : ""]
+              .filter(Boolean).join(" · ");
+            return (
+              <g
+                key={n.id}
+                className="deleg-graph-node"
+                onClick={() => onSelect(first.index)}
+                style={{ cursor: "pointer" }}
+              >
+                <title>{`fan-out #${lo}–#${hi} (${rs.length} branches) · ${counts}\n${rs.map((r) => r.label).join("\n")}`}</title>
+                <rect x={p.x + 6} y={p.y - 6} width={NODE_W} height={NODE_H} rx={8}
+                      fill={FILL[groupStatus(rs)] ?? DEFAULT_FILL} opacity={0.45} stroke="#30363d" />
+                <rect x={p.x + 3} y={p.y - 3} width={NODE_W} height={NODE_H} rx={8}
+                      fill={FILL[groupStatus(rs)] ?? DEFAULT_FILL} opacity={0.7} stroke="#30363d" />
+                <rect x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx={8}
+                      fill={FILL[groupStatus(rs)] ?? DEFAULT_FILL}
+                      stroke={isSel ? "#fff" : "#30363d"} strokeWidth={isSel ? 2 : 1} />
+                <text x={p.x + NODE_W / 2} y={p.y + 17} textAnchor="middle"
+                      fontSize={11} fill="#fff" fontWeight={600}>
+                  #{lo}–#{hi} · fan-out ×{rs.length}
+                </text>
+                <text x={p.x + NODE_W / 2} y={p.y + 32} textAnchor="middle"
+                      fontSize={11} fill="#fff">
+                  {counts}
+                </text>
+                {subs.length > 0 && (
+                  <text x={p.x + NODE_W / 2} y={p.y + 46} textAnchor="middle"
+                        fontSize={10} fill="#fff" opacity={0.85}>
+                    ↳ {trunc(subs.join(", "), 26)}
+                  </text>
+                )}
+              </g>
+            );
+          }
+          const r = n.rows[0];
           const subs = subAgents[r.mode] ?? [];
-          const isSel = selected === r.index;
           return (
             <g
-              key={r.index}
+              key={n.id}
               className="deleg-graph-node"
               onClick={() => onSelect(r.index)}
               style={{ cursor: "pointer" }}
@@ -218,7 +336,8 @@ export function DelegationGraph({
       </svg>
       <p className="caption">
         Grey edge = the meta dispatched the delegation. Blue edge = a
-        delegation's result fed the next as context. Click a box to expand it below.
+        delegation's result fed the next as context. A stacked box is one
+        fan-out (its parallel branches). Click a box to expand it below.
       </p>
     </div>
   );

--- a/webui/src/components/DelegationGraph.tsx
+++ b/webui/src/components/DelegationGraph.tsx
@@ -1,13 +1,17 @@
 import { useMemo } from "react";
 import type { DelegationRow } from "../api";
+import { computeGraph, groupStatus, NODE_H, NODE_W } from "../delegationGraph";
 
 /** Dependency graph of the delegation ledger — the web twin of the
  * Streamlit telemetry tab's graphviz chart, drawn as plain SVG so it needs
  * no renderer: a meta-agent root, one box per delegation colored by status
  * and annotated with the sub-agents its specialist used, grey dispatch
  * edges from the root, and blue "ctx" edges where one delegation's result
- * fed another as context. Nodes are layered by context depth (a delegation
- * sits below everything it read from), so the flow reads top to bottom. */
+ * fed another as context. Layout and routing live in
+ * `../delegationGraph.ts` (pure, checked by `scripts/graph_check.ts`);
+ * this file only draws. Edge paths carry `data-from` / `data-to` and node
+ * groups `data-node`, so the rendered geometry can be audited against the
+ * ledger in a browser. */
 
 const FILL: Record<string, string> = {
   success: "#3fb950",
@@ -18,131 +22,11 @@ const FILL: Record<string, string> = {
 };
 const DEFAULT_FILL = "#8893a5";
 const ROOT_FILL = "#30363d";
-
-const NODE_W = 168;
-const NODE_H = 54;
-const GAP_X = 22;
-const GAP_Y = 46;
-const PAD = 12;
+const LABEL_MAX_SOURCES = 3; // "ctx" labels only where they stay legible
 
 function trunc(s: string, n: number): string {
   return s.length <= n ? s : s.slice(0, n - 1) + "…";
 }
-
-/** A graph node: one delegation, or a whole fan-out group (the N parallel
- * branches of one run_fanout call) collapsed into a single stacked box —
- * 30 branches as 30 boxes with 30 context edges in and 30 out is noise,
- * and the branches are siblings of one meta call anyway. */
-interface GNode {
-  id: string;
-  rows: DelegationRow[];
-  group: string | null; // fanout_group when collapsed
-  sources: string[]; // node-level context_from
-}
-
-interface Placed {
-  node: GNode;
-  x: number;
-  y: number;
-  layer: number; // visual row; 0 = directly under the root
-}
-
-function buildNodes(rows: DelegationRow[]): GNode[] {
-  const nodeOf = new Map<number, string>();
-  const nodes: GNode[] = [];
-  const groups = new Map<string, GNode>();
-  for (const r of [...rows].sort((a, b) => a.index - b.index)) {
-    if (r.fanout && r.fanout_group) {
-      let g = groups.get(r.fanout_group);
-      if (!g) {
-        g = { id: `g:${r.fanout_group}`, rows: [], group: r.fanout_group, sources: [] };
-        groups.set(r.fanout_group, g);
-        nodes.push(g);
-      }
-      g.rows.push(r);
-      nodeOf.set(r.index, g.id);
-    } else {
-      const n = { id: `d:${r.index}`, rows: [r], group: null, sources: [] };
-      nodes.push(n);
-      nodeOf.set(r.index, n.id);
-    }
-  }
-  for (const n of nodes) {
-    const seen = new Set<string>();
-    for (const r of n.rows)
-      for (const src of r.context_from) {
-        const id = nodeOf.get(src);
-        if (id && id !== n.id && !seen.has(id)) {
-          seen.add(id);
-          n.sources.push(id);
-        }
-      }
-  }
-  return nodes;
-}
-
-function groupStatus(rows: DelegationRow[]): string {
-  if (rows.some((r) => r.status === "running")) return "running";
-  if (rows.every((r) => r.status === "error")) return "error";
-  return "success";
-}
-
-/** Edge routing. A straight edge between rows would run through any box
- * that lies between its ends (a wrapped row of the same layer, a node
- * alone on the centre line), so every edge is tested against the boxes it
- * does not connect and, if it hits one, bowed sideways — the smallest bow
- * that clears everything wins, nearer side first. Cheap: a few dozen
- * nodes, a handful of candidate bows, twenty samples per candidate. */
-const BOW = 70;
-const BOWS = [0, -1, 1, -2, 2, -3, 3];
-const HIT_MARGIN = 6;
-
-interface Rect { x: number; y: number; w: number; h: number }
-
-function cubic(x1: number, y1: number, x2: number, y2: number, bow: number) {
-  const my = (y1 + y2) / 2;
-  const cx1 = x1 + bow, cx2 = x2 + bow;
-  return {
-    d: bow
-      ? `M ${x1} ${y1} C ${cx1} ${my}, ${cx2} ${my}, ${x2} ${y2}`
-      : `M ${x1} ${y1} L ${x2} ${y2}`,
-    at: (t: number) => {
-      const u = 1 - t;
-      return {
-        x: u * u * u * x1 + 3 * u * u * t * cx1 + 3 * u * t * t * cx2 + t * t * t * x2,
-        y: u * u * u * y1 + 3 * u * u * t * my + 3 * u * t * t * my + t * t * t * y2,
-      };
-    },
-  };
-}
-
-function hits(curve: { at: (t: number) => { x: number; y: number } }, rects: Rect[]): boolean {
-  for (let i = 1; i < 20; i++) {
-    const { x, y } = curve.at(i / 20);
-    for (const r of rects) {
-      if (x >= r.x - HIT_MARGIN && x <= r.x + r.w + HIT_MARGIN &&
-          y >= r.y - HIT_MARGIN && y <= r.y + r.h + HIT_MARGIN) return true;
-    }
-  }
-  return false;
-}
-
-/** Path for an edge from (x1,y1) down to (x2,y2) avoiding `obstacles`
- * (every box except the two it connects), plus the point to label. Prefers
- * a straight line, then the side with more room. */
-function route(x1: number, y1: number, x2: number, y2: number, obstacles: Rect[],
-               preferLeft: boolean) {
-  const order = preferLeft ? BOWS : BOWS.map((b) => -b);
-  let fallback = cubic(x1, y1, x2, y2, 0);
-  for (const k of order) {
-    const c = cubic(x1, y1, x2, y2, k * BOW);
-    if (!hits(c, obstacles)) return { d: c.d, mid: c.at(0.5) };
-    if (k === 0) fallback = c;
-  }
-  return { d: fallback.d, mid: fallback.at(0.5) };
-}
-const MAX_PER_ROW = 6;   // a wider layer wraps into several rows
-const LABEL_MAX_SOURCES = 3; // "ctx" labels only where they stay legible
 
 export function DelegationGraph({
   rows,
@@ -157,79 +41,14 @@ export function DelegationGraph({
   selected: number | null;
   onSelect: (index: number) => void;
 }) {
-  const { placed, width, height, root } = useMemo(() => {
-    const nodes = buildNodes(rows);
-    const byId = new Map(nodes.map((n) => [n.id, n]));
-    const depth = new Map<string, number>();
-    const depthOf = (n: GNode, seen = new Set<string>()): number => {
-      const cached = depth.get(n.id);
-      if (cached !== undefined) return cached;
-      if (seen.has(n.id)) return 0; // defensive: a cycle in context_from
-      seen.add(n.id);
-      let d = 0;
-      for (const src of n.sources) {
-        const s = byId.get(src);
-        if (s) d = Math.max(d, depthOf(s, seen) + 1);
-      }
-      depth.set(n.id, d);
-      return d;
-    };
-    const layers: GNode[][] = [];
-    for (const n of nodes) {
-      const d = depthOf(n);
-      (layers[d] ??= []).push(n);
-    }
-    // A layer wider than MAX_PER_ROW wraps into several visual rows (a
-    // 40-branch fan-out would otherwise be one 7000 px line). `layer` on
-    // a placed node is its visual row, which is what edge bowing needs.
-    const isSource = new Set(nodes.flatMap((n) => n.sources));
-    const visualRows: GNode[][] = [];
-    for (const layer of layers) {
-      // In a wrapped layer, nodes that feed later layers go to its last
-      // row so their outgoing edges never cross a sibling row.
-      const ordered = layer.length > MAX_PER_ROW
-        ? [...layer.filter((n) => !isSource.has(n.id)), ...layer.filter((n) => isSource.has(n.id))]
-        : layer;
-      for (let i = 0; i < ordered.length; i += MAX_PER_ROW) {
-        visualRows.push(ordered.slice(i, i + MAX_PER_ROW));
-      }
-    }
-    const widest = Math.max(1, ...visualRows.map((l) => l.length));
-    const width = PAD * 2 + widest * NODE_W + (widest - 1) * GAP_X;
-    const root = { x: width / 2 - NODE_W / 2, y: PAD };
-    const placed: Placed[] = [];
-    visualRows.forEach((vr, li) => {
-      const rowW = vr.length * NODE_W + (vr.length - 1) * GAP_X;
-      const x0 = (width - rowW) / 2;
-      vr.forEach((node, i) => {
-        placed.push({
-          node,
-          x: x0 + i * (NODE_W + GAP_X),
-          y: PAD + (li + 1) * (NODE_H + GAP_Y),
-          layer: li,
-        });
-      });
-    });
-    const height = PAD * 2 + (visualRows.length + 1) * NODE_H + visualRows.length * GAP_Y;
-    // Room for the widest bow an edge may take (see route()).
-    const margin = visualRows.length > 1 ? 3 * BOW * 0.75 : 0;
-    for (const p of placed) p.x += margin;
-    root.x += margin;
-    return { placed, width: width + 2 * margin, height, root };
-  }, [rows]);
-
+  const g = useMemo(() => computeGraph(rows), [rows]);
   if (rows.length === 0) return null;
-  const at = new Map(placed.map((p) => [p.node.id, p]));
-  const nodeOfIndex = new Map<number, string>();
-  for (const p of placed) for (const r of p.node.rows) nodeOfIndex.set(r.index, p.node.id);
+  const { placed, root, width, height, edges, nodeOfIndex } = g;
   const selectedId = selected == null ? null : nodeOfIndex.get(selected) ?? null;
-  const rectOf = (p: Placed): Rect => ({ x: p.x, y: p.y, w: NODE_W, h: NODE_H });
-  const rootRect: Rect = { x: root.x, y: root.y, w: NODE_W, h: NODE_H };
-  const obstaclesExcept = (...ids: string[]) =>
-    placed.filter((q) => !ids.includes(q.node.id)).map(rectOf);
   const modeLabel = metaMode
     ? metaMode.charAt(0).toUpperCase() + metaMode.slice(1).toLowerCase()
     : "";
+  const sourcesOf = new Map(placed.map((p) => [p.node.id, p.node.sources.length]));
 
   return (
     <div className="deleg-graph-wrap">
@@ -252,58 +71,55 @@ export function DelegationGraph({
           </marker>
         </defs>
 
-        {/* dispatch edges: root -> every delegation */}
-        {placed.map((p) => (
-          <path
-            key={`d${p.node.id}`}
-            d={route(root.x + NODE_W / 2, root.y + NODE_H, p.x + NODE_W / 2, p.y,
-                     obstaclesExcept(p.node.id), p.x + NODE_W / 2 <= width / 2).d}
-            fill="none"
-            stroke="#8893a5"
-            strokeWidth={p.layer === 0 ? 1.2 : 0.8}
-            opacity={p.layer === 0 ? 1 : 0.45}
-            markerEnd="url(#dg-arrow-grey)"
-          />
-        ))}
+        {/* dispatch edges: root -> every node (faint below the first row) */}
+        {edges.filter((e) => e.kind === "dispatch").map((e) => {
+          const p = placed.find((q) => q.node.id === e.to)!;
+          return (
+            <path
+              key={`d${e.to}`}
+              data-kind="dispatch"
+              data-from="root"
+              data-to={e.to}
+              d={e.d}
+              fill="none"
+              stroke="#8893a5"
+              strokeWidth={p.layer === 0 ? 1.2 : 0.8}
+              opacity={p.layer === 0 ? 1 : 0.45}
+              markerEnd="url(#dg-arrow-grey)"
+            />
+          );
+        })}
         {/* context edges: source -> consumer */}
-        {placed.flatMap((p) =>
-          p.node.sources.map((src) => {
-            const s = at.get(src);
-            if (!s) return null;
-            const x1 = s.x + NODE_W / 2;
-            const y1 = s.y + NODE_H;
-            const x2 = p.x + NODE_W / 2;
-            const y2 = p.y;
-            const r = route(x1, y1, x2, y2,
-                            [rootRect, ...obstaclesExcept(s.node.id, p.node.id)],
-                            (x1 + x2) / 2 <= width / 2);
-            const many = p.node.sources.length > LABEL_MAX_SOURCES;
-            return (
-              <g key={`c${src}-${p.node.id}`}>
-                <path
-                  d={r.d}
-                  fill="none"
-                  stroke="#58a6ff"
-                  strokeWidth={many ? 1.2 : 2}
-                  opacity={many ? 0.7 : 1}
-                  markerEnd="url(#dg-arrow-blue)"
-                />
-                {!many && (
-                  <g>
-                    <rect x={r.mid.x + 3} y={r.mid.y - 12} width={22} height={13} rx={3}
-                          className="deleg-graph-halo" />
-                    <text x={r.mid.x + 5} y={r.mid.y - 2} fontSize={10} fill="#58a6ff">
-                      ctx
-                    </text>
-                  </g>
-                )}
-              </g>
-            );
-          }),
-        )}
+        {edges.filter((e) => e.kind === "context").map((e) => {
+          const many = (sourcesOf.get(e.to) ?? 0) > LABEL_MAX_SOURCES;
+          return (
+            <g key={`c${e.from}-${e.to}`}>
+              <path
+                data-kind="context"
+                data-from={e.from}
+                data-to={e.to}
+                d={e.d}
+                fill="none"
+                stroke="#58a6ff"
+                strokeWidth={many ? 1.2 : 2}
+                opacity={many ? 0.7 : 1}
+                markerEnd="url(#dg-arrow-blue)"
+              />
+              {!many && (
+                <g>
+                  <rect x={e.mid.x + 3} y={e.mid.y - 12} width={22} height={13} rx={3}
+                        className="deleg-graph-halo" />
+                  <text x={e.mid.x + 5} y={e.mid.y - 2} fontSize={10} fill="#58a6ff">
+                    ctx
+                  </text>
+                </g>
+              )}
+            </g>
+          );
+        })}
 
         {/* root */}
-        <g>
+        <g data-node="root">
           <rect x={root.x} y={root.y} width={NODE_W} height={NODE_H} rx={8}
                 fill={ROOT_FILL} stroke="#30363d" />
           <text x={root.x + NODE_W / 2} y={root.y + NODE_H / 2 + 4}
@@ -312,7 +128,7 @@ export function DelegationGraph({
           </text>
         </g>
 
-        {/* delegations — a fan-out group is one stacked box */}
+        {/* nodes — a fan-out group is one stacked box */}
         {placed.map((p) => {
           const n = p.node;
           const isSel = selectedId === n.id;
@@ -327,20 +143,22 @@ export function DelegationGraph({
             const subs = subAgents[rs[0].mode] ?? [];
             const counts = [`${nOk} ✓`, nErr ? `${nErr} ✗` : "", nRun ? `${nRun} ⋯` : ""]
               .filter(Boolean).join(" · ");
+            const fill = FILL[groupStatus(rs)] ?? DEFAULT_FILL;
             return (
               <g
                 key={n.id}
+                data-node={n.id}
                 className="deleg-graph-node"
                 onClick={() => onSelect(first.index)}
                 style={{ cursor: "pointer" }}
               >
                 <title>{`fan-out #${lo}–#${hi} (${rs.length} branches) · ${counts}\n${rs.map((r) => r.label).join("\n")}`}</title>
                 <rect x={p.x + 6} y={p.y - 6} width={NODE_W} height={NODE_H} rx={8}
-                      fill={FILL[groupStatus(rs)] ?? DEFAULT_FILL} opacity={0.45} stroke="#30363d" />
+                      fill={fill} opacity={0.45} stroke="#30363d" />
                 <rect x={p.x + 3} y={p.y - 3} width={NODE_W} height={NODE_H} rx={8}
-                      fill={FILL[groupStatus(rs)] ?? DEFAULT_FILL} opacity={0.7} stroke="#30363d" />
-                <rect x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx={8}
-                      fill={FILL[groupStatus(rs)] ?? DEFAULT_FILL}
+                      fill={fill} opacity={0.7} stroke="#30363d" />
+                <rect data-box="1" x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx={8}
+                      fill={fill}
                       stroke={isSel ? "#fff" : "#30363d"} strokeWidth={isSel ? 2 : 1} />
                 <text x={p.x + NODE_W / 2} y={p.y + 17} textAnchor="middle"
                       fontSize={11} fill="#fff" fontWeight={600}>
@@ -364,12 +182,13 @@ export function DelegationGraph({
           return (
             <g
               key={n.id}
+              data-node={n.id}
               className="deleg-graph-node"
               onClick={() => onSelect(r.index)}
               style={{ cursor: "pointer" }}
             >
               <title>{`#${r.index} · ${r.mode} · ${r.status}\n${r.label}${subs.length ? `\n↳ ${subs.join(", ")}` : ""}`}</title>
-              <rect x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx={8}
+              <rect data-box="1" x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx={8}
                     fill={FILL[r.status] ?? DEFAULT_FILL}
                     stroke={isSel ? "#fff" : "#30363d"} strokeWidth={isSel ? 2 : 1} />
               <text x={p.x + NODE_W / 2} y={p.y + 17} textAnchor="middle"

--- a/webui/src/components/DelegationGraph.tsx
+++ b/webui/src/components/DelegationGraph.tsx
@@ -87,17 +87,60 @@ function groupStatus(rows: DelegationRow[]): string {
   return "success";
 }
 
-/** An edge that skips layers would run straight through the boxes in
- * between (nodes alone in a layer sit on the same centre line), so it is
- * bowed sideways by one step per skipped layer — right for context
- * edges, left for dispatch edges — the way a layout engine routes
- * around obstacles. */
-function bowedPath(x1: number, y1: number, x2: number, y2: number, bow: number): string {
-  if (!bow) return `M ${x1} ${y1} L ${x2} ${y2}`;
-  const my = (y1 + y2) / 2;
-  return `M ${x1} ${y1} C ${x1 + bow} ${my}, ${x2 + bow} ${my}, ${x2} ${y2}`;
-}
+/** Edge routing. A straight edge between rows would run through any box
+ * that lies between its ends (a wrapped row of the same layer, a node
+ * alone on the centre line), so every edge is tested against the boxes it
+ * does not connect and, if it hits one, bowed sideways — the smallest bow
+ * that clears everything wins, nearer side first. Cheap: a few dozen
+ * nodes, a handful of candidate bows, twenty samples per candidate. */
 const BOW = 70;
+const BOWS = [0, -1, 1, -2, 2, -3, 3];
+const HIT_MARGIN = 6;
+
+interface Rect { x: number; y: number; w: number; h: number }
+
+function cubic(x1: number, y1: number, x2: number, y2: number, bow: number) {
+  const my = (y1 + y2) / 2;
+  const cx1 = x1 + bow, cx2 = x2 + bow;
+  return {
+    d: bow
+      ? `M ${x1} ${y1} C ${cx1} ${my}, ${cx2} ${my}, ${x2} ${y2}`
+      : `M ${x1} ${y1} L ${x2} ${y2}`,
+    at: (t: number) => {
+      const u = 1 - t;
+      return {
+        x: u * u * u * x1 + 3 * u * u * t * cx1 + 3 * u * t * t * cx2 + t * t * t * x2,
+        y: u * u * u * y1 + 3 * u * u * t * my + 3 * u * t * t * my + t * t * t * y2,
+      };
+    },
+  };
+}
+
+function hits(curve: { at: (t: number) => { x: number; y: number } }, rects: Rect[]): boolean {
+  for (let i = 1; i < 20; i++) {
+    const { x, y } = curve.at(i / 20);
+    for (const r of rects) {
+      if (x >= r.x - HIT_MARGIN && x <= r.x + r.w + HIT_MARGIN &&
+          y >= r.y - HIT_MARGIN && y <= r.y + r.h + HIT_MARGIN) return true;
+    }
+  }
+  return false;
+}
+
+/** Path for an edge from (x1,y1) down to (x2,y2) avoiding `obstacles`
+ * (every box except the two it connects), plus the point to label. Prefers
+ * a straight line, then the side with more room. */
+function route(x1: number, y1: number, x2: number, y2: number, obstacles: Rect[],
+               preferLeft: boolean) {
+  const order = preferLeft ? BOWS : BOWS.map((b) => -b);
+  let fallback = cubic(x1, y1, x2, y2, 0);
+  for (const k of order) {
+    const c = cubic(x1, y1, x2, y2, k * BOW);
+    if (!hits(c, obstacles)) return { d: c.d, mid: c.at(0.5) };
+    if (k === 0) fallback = c;
+  }
+  return { d: fallback.d, mid: fallback.at(0.5) };
+}
 const MAX_PER_ROW = 6;   // a wider layer wraps into several rows
 const LABEL_MAX_SOURCES = 3; // "ctx" labels only where they stay legible
 
@@ -139,10 +182,16 @@ export function DelegationGraph({
     // A layer wider than MAX_PER_ROW wraps into several visual rows (a
     // 40-branch fan-out would otherwise be one 7000 px line). `layer` on
     // a placed node is its visual row, which is what edge bowing needs.
+    const isSource = new Set(nodes.flatMap((n) => n.sources));
     const visualRows: GNode[][] = [];
     for (const layer of layers) {
-      for (let i = 0; i < layer.length; i += MAX_PER_ROW) {
-        visualRows.push(layer.slice(i, i + MAX_PER_ROW));
+      // In a wrapped layer, nodes that feed later layers go to its last
+      // row so their outgoing edges never cross a sibling row.
+      const ordered = layer.length > MAX_PER_ROW
+        ? [...layer.filter((n) => !isSource.has(n.id)), ...layer.filter((n) => isSource.has(n.id))]
+        : layer;
+      for (let i = 0; i < ordered.length; i += MAX_PER_ROW) {
+        visualRows.push(ordered.slice(i, i + MAX_PER_ROW));
       }
     }
     const widest = Math.max(1, ...visualRows.map((l) => l.length));
@@ -162,8 +211,8 @@ export function DelegationGraph({
       });
     });
     const height = PAD * 2 + (visualRows.length + 1) * NODE_H + visualRows.length * GAP_Y;
-    // Bows are capped (see below), so the side margin is bounded too.
-    const margin = Math.min(2, Math.max(0, visualRows.length - 1)) * BOW;
+    // Room for the widest bow an edge may take (see route()).
+    const margin = visualRows.length > 1 ? 3 * BOW * 0.75 : 0;
     for (const p of placed) p.x += margin;
     root.x += margin;
     return { placed, width: width + 2 * margin, height, root };
@@ -174,6 +223,10 @@ export function DelegationGraph({
   const nodeOfIndex = new Map<number, string>();
   for (const p of placed) for (const r of p.node.rows) nodeOfIndex.set(r.index, p.node.id);
   const selectedId = selected == null ? null : nodeOfIndex.get(selected) ?? null;
+  const rectOf = (p: Placed): Rect => ({ x: p.x, y: p.y, w: NODE_W, h: NODE_H });
+  const rootRect: Rect = { x: root.x, y: root.y, w: NODE_W, h: NODE_H };
+  const obstaclesExcept = (...ids: string[]) =>
+    placed.filter((q) => !ids.includes(q.node.id)).map(rectOf);
   const modeLabel = metaMode
     ? metaMode.charAt(0).toUpperCase() + metaMode.slice(1).toLowerCase()
     : "";
@@ -203,8 +256,8 @@ export function DelegationGraph({
         {placed.map((p) => (
           <path
             key={`d${p.node.id}`}
-            d={bowedPath(root.x + NODE_W / 2, root.y + NODE_H,
-                         p.x + NODE_W / 2, p.y, -Math.min(2, p.layer) * BOW)}
+            d={route(root.x + NODE_W / 2, root.y + NODE_H, p.x + NODE_W / 2, p.y,
+                     obstaclesExcept(p.node.id), p.x + NODE_W / 2 <= width / 2).d}
             fill="none"
             stroke="#8893a5"
             strokeWidth={p.layer === 0 ? 1.2 : 0.8}
@@ -221,15 +274,14 @@ export function DelegationGraph({
             const y1 = s.y + NODE_H;
             const x2 = p.x + NODE_W / 2;
             const y2 = p.y;
-            const my = (y1 + y2) / 2;
-            // Collinear nodes need the bow; a source off to the side does not.
-            const skipped = p.layer - s.layer - 1;
-            const bow = Math.abs(x1 - x2) < NODE_W / 2 ? BOW * Math.min(2, skipped) : 0;
+            const r = route(x1, y1, x2, y2,
+                            [rootRect, ...obstaclesExcept(s.node.id, p.node.id)],
+                            (x1 + x2) / 2 <= width / 2);
             const many = p.node.sources.length > LABEL_MAX_SOURCES;
             return (
               <g key={`c${src}-${p.node.id}`}>
                 <path
-                  d={bowedPath(x1, y1, x2, y2, bow)}
+                  d={r.d}
                   fill="none"
                   stroke="#58a6ff"
                   strokeWidth={many ? 1.2 : 2}
@@ -237,9 +289,13 @@ export function DelegationGraph({
                   markerEnd="url(#dg-arrow-blue)"
                 />
                 {!many && (
-                  <text x={(x1 + x2) / 2 + bow * 0.75 + 4} y={my - 2} fontSize={10} fill="#58a6ff">
-                    ctx
-                  </text>
+                  <g>
+                    <rect x={r.mid.x + 3} y={r.mid.y - 12} width={22} height={13} rx={3}
+                          className="deleg-graph-halo" />
+                    <text x={r.mid.x + 5} y={r.mid.y - 2} fontSize={10} fill="#58a6ff">
+                      ctx
+                    </text>
+                  </g>
                 )}
               </g>
             );

--- a/webui/src/components/DelegationGraph.tsx
+++ b/webui/src/components/DelegationGraph.tsx
@@ -1,0 +1,225 @@
+import { useMemo } from "react";
+import type { DelegationRow } from "../api";
+
+/** Dependency graph of the delegation ledger — the web twin of the
+ * Streamlit telemetry tab's graphviz chart, drawn as plain SVG so it needs
+ * no renderer: a meta-agent root, one box per delegation colored by status
+ * and annotated with the sub-agents its specialist used, grey dispatch
+ * edges from the root, and blue "ctx" edges where one delegation's result
+ * fed another as context. Nodes are layered by context depth (a delegation
+ * sits below everything it read from), so the flow reads top to bottom. */
+
+const FILL: Record<string, string> = {
+  success: "#3fb950",
+  error: "#f85149",
+  running: "#d29922",
+  interrupted: "#8893a5",
+  cancelled: "#8893a5",
+};
+const DEFAULT_FILL = "#8893a5";
+const ROOT_FILL = "#30363d";
+
+const NODE_W = 168;
+const NODE_H = 54;
+const GAP_X = 22;
+const GAP_Y = 46;
+const PAD = 12;
+
+function trunc(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + "…";
+}
+
+interface Placed {
+  row: DelegationRow;
+  x: number;
+  y: number;
+  layer: number; // 0 = directly under the root
+}
+
+/** An edge that skips layers would run straight through the boxes in
+ * between (nodes alone in a layer sit on the same centre line), so it is
+ * bowed sideways by one step per skipped layer — right for context
+ * edges, left for dispatch edges — the way a layout engine routes
+ * around obstacles. */
+function bowedPath(x1: number, y1: number, x2: number, y2: number, bow: number): string {
+  if (!bow) return `M ${x1} ${y1} L ${x2} ${y2}`;
+  const my = (y1 + y2) / 2;
+  return `M ${x1} ${y1} C ${x1 + bow} ${my}, ${x2 + bow} ${my}, ${x2} ${y2}`;
+}
+const BOW = 70;
+
+export function DelegationGraph({
+  rows,
+  subAgents,
+  metaMode,
+  selected,
+  onSelect,
+}: {
+  rows: DelegationRow[];
+  subAgents: Record<string, string[]>;
+  metaMode?: string | null;
+  selected: number | null;
+  onSelect: (index: number) => void;
+}) {
+  const { placed, width, height, root } = useMemo(() => {
+    const byIndex = new Map(rows.map((r) => [r.index, r]));
+    const depth = new Map<number, number>();
+    const depthOf = (r: DelegationRow, seen = new Set<number>()): number => {
+      const cached = depth.get(r.index);
+      if (cached !== undefined) return cached;
+      if (seen.has(r.index)) return 0; // defensive: a cycle in context_from
+      seen.add(r.index);
+      let d = 0;
+      for (const src of r.context_from) {
+        const s = byIndex.get(src);
+        if (s) d = Math.max(d, depthOf(s, seen) + 1);
+      }
+      depth.set(r.index, d);
+      return d;
+    };
+    const layers: DelegationRow[][] = [];
+    for (const r of [...rows].sort((a, b) => a.index - b.index)) {
+      const d = depthOf(r);
+      (layers[d] ??= []).push(r);
+    }
+    const widest = Math.max(1, ...layers.map((l) => l.length));
+    const width = PAD * 2 + widest * NODE_W + (widest - 1) * GAP_X;
+    const root = { x: width / 2 - NODE_W / 2, y: PAD };
+    const placed: Placed[] = [];
+    layers.forEach((layer, li) => {
+      const rowW = layer.length * NODE_W + (layer.length - 1) * GAP_X;
+      const x0 = (width - rowW) / 2;
+      layer.forEach((row, i) => {
+        placed.push({
+          row,
+          x: x0 + i * (NODE_W + GAP_X),
+          y: PAD + (li + 1) * (NODE_H + GAP_Y),
+          layer: li,
+        });
+      });
+    });
+    const height = PAD * 2 + (layers.length + 1) * NODE_H + layers.length * GAP_Y;
+    const margin = Math.max(0, layers.length - 1) * BOW * 0.75;
+    for (const p of placed) p.x += margin;
+    root.x += margin;
+    return { placed, width: width + 2 * margin, height, root };
+  }, [rows]);
+
+  if (rows.length === 0) return null;
+  const at = new Map(placed.map((p) => [p.row.index, p]));
+  const modeLabel = metaMode
+    ? metaMode.charAt(0).toUpperCase() + metaMode.slice(1).toLowerCase()
+    : "";
+
+  return (
+    <div className="deleg-graph-wrap">
+      <svg
+        className="deleg-graph"
+        viewBox={`0 0 ${width} ${height}`}
+        width={width}
+        height={height}
+        role="img"
+        aria-label="Delegation dependency graph"
+      >
+        <defs>
+          <marker id="dg-arrow-grey" viewBox="0 0 10 10" refX="9" refY="5"
+                  markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#8893a5" />
+          </marker>
+          <marker id="dg-arrow-blue" viewBox="0 0 10 10" refX="9" refY="5"
+                  markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#58a6ff" />
+          </marker>
+        </defs>
+
+        {/* dispatch edges: root -> every delegation */}
+        {placed.map((p) => (
+          <path
+            key={`d${p.row.index}`}
+            d={bowedPath(root.x + NODE_W / 2, root.y + NODE_H,
+                         p.x + NODE_W / 2, p.y, -BOW * p.layer)}
+            fill="none"
+            stroke="#8893a5"
+            strokeWidth={1.2}
+            markerEnd="url(#dg-arrow-grey)"
+          />
+        ))}
+        {/* context edges: source -> consumer */}
+        {placed.flatMap((p) =>
+          p.row.context_from.map((src) => {
+            const s = at.get(src);
+            if (!s) return null;
+            const x1 = s.x + NODE_W / 2;
+            const y1 = s.y + NODE_H;
+            const x2 = p.x + NODE_W / 2;
+            const y2 = p.y;
+            const my = (y1 + y2) / 2;
+            const bow = BOW * (p.layer - s.layer - 1);
+            return (
+              <g key={`c${src}-${p.row.index}`}>
+                <path
+                  d={bowedPath(x1, y1, x2, y2, bow)}
+                  fill="none"
+                  stroke="#58a6ff"
+                  strokeWidth={2}
+                  markerEnd="url(#dg-arrow-blue)"
+                />
+                <text x={(x1 + x2) / 2 + bow * 0.75 + 4} y={my - 2} fontSize={10} fill="#58a6ff">
+                  ctx
+                </text>
+              </g>
+            );
+          }),
+        )}
+
+        {/* root */}
+        <g>
+          <rect x={root.x} y={root.y} width={NODE_W} height={NODE_H} rx={8}
+                fill={ROOT_FILL} stroke="#30363d" />
+          <text x={root.x + NODE_W / 2} y={root.y + NODE_H / 2 + 4}
+                textAnchor="middle" fontSize={12} fill="#fff" fontWeight={600}>
+            Meta-agent{modeLabel ? ` (${modeLabel})` : ""}
+          </text>
+        </g>
+
+        {/* delegations */}
+        {placed.map((p) => {
+          const r = p.row;
+          const subs = subAgents[r.mode] ?? [];
+          const isSel = selected === r.index;
+          return (
+            <g
+              key={r.index}
+              className="deleg-graph-node"
+              onClick={() => onSelect(r.index)}
+              style={{ cursor: "pointer" }}
+            >
+              <title>{`#${r.index} · ${r.mode} · ${r.status}\n${r.label}${subs.length ? `\n↳ ${subs.join(", ")}` : ""}`}</title>
+              <rect x={p.x} y={p.y} width={NODE_W} height={NODE_H} rx={8}
+                    fill={FILL[r.status] ?? DEFAULT_FILL}
+                    stroke={isSel ? "#fff" : "#30363d"} strokeWidth={isSel ? 2 : 1} />
+              <text x={p.x + NODE_W / 2} y={p.y + 17} textAnchor="middle"
+                    fontSize={11} fill="#fff" fontWeight={600}>
+                #{r.index} · {r.mode}
+              </text>
+              <text x={p.x + NODE_W / 2} y={p.y + 32} textAnchor="middle"
+                    fontSize={11} fill="#fff">
+                {trunc(r.label, 24)}
+              </text>
+              {subs.length > 0 && (
+                <text x={p.x + NODE_W / 2} y={p.y + 46} textAnchor="middle"
+                      fontSize={10} fill="#fff" opacity={0.85}>
+                  ↳ {trunc(subs.join(", "), 26)}
+                </text>
+              )}
+            </g>
+          );
+        })}
+      </svg>
+      <p className="caption">
+        Grey edge = the meta dispatched the delegation. Blue edge = a
+        delegation's result fed the next as context. Click a box to expand it below.
+      </p>
+    </div>
+  );
+}

--- a/webui/src/components/DelegationsPanel.tsx
+++ b/webui/src/components/DelegationsPanel.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useMemo, useState } from "react";
 import type { DelegationRow, DelegationView } from "../api";
 import { UIContext } from "../UIContext";
+import { DelegationGraph } from "./DelegationGraph";
 
 /** Mission-control view of the meta session's delegation ledger — the web
  * twin of the Streamlit sidebar tree + telemetry graph. Grouped by
@@ -47,10 +48,12 @@ export function DelegationsPanel({
   view,
   running,
   focus = null,
+  metaMode = null,
 }: {
   view: DelegationView | null;
   running: boolean;
   focus?: number | null; // a delegation the sidebar tree asked to expand
+  metaMode?: string | null; // autopilot | autonomous, for the graph's root label
 }) {
   const ui = useContext(UIContext);
   const [open, setOpen] = useState<number | null>(null);
@@ -100,6 +103,14 @@ export function DelegationsPanel({
           specialist. Delegations appear here as they start.
         </p>
       ) : (
+        <>
+        <DelegationGraph
+          rows={rows}
+          subAgents={subAgents}
+          metaMode={metaMode}
+          selected={open}
+          onSelect={(i) => setOpen(open === i ? null : i)}
+        />
         <div className="deleg-tree">
           {groups.map(([mode, list]) => (
             <div key={mode} className="deleg-group">
@@ -239,6 +250,7 @@ export function DelegationsPanel({
             </div>
           ))}
         </div>
+        </>
       )}
     </div>
   );

--- a/webui/src/components/TelemetryDetails.tsx
+++ b/webui/src/components/TelemetryDetails.tsx
@@ -123,6 +123,8 @@ export function TelemetryDetails({
           layers.map(([key, label]) => (
             <ToolSequence
               key={key}
+              sessionId={sessionId}
+              layerKey={key}
               label={label}
               calls={seq[key].calls}
               source={seq[key].source ? relativeTo(root, seq[key].source) : null}
@@ -198,11 +200,15 @@ export function TelemetryDetails({
 }
 
 function ToolSequence({
+  sessionId,
+  layerKey,
   label,
   calls,
   source,
   onOpenSource,
 }: {
+  sessionId: string;
+  layerKey: string;
   label: string;
   calls: ToolCall[];
   source: string | null;
@@ -217,14 +223,24 @@ function ToolSequence({
           {calls.length} tool call{calls.length === 1 ? "" : "s"}
         </span>
         {source && (
-          <button
-            type="button"
-            className="link-btn"
-            title="The full chat history this sequence was read from"
-            onClick={() => onOpenSource(source)}
-          >
-            full history
-          </button>
+          <>
+            <button
+              type="button"
+              className="link-btn"
+              title="Open the chat history this sequence was read from in Files"
+              onClick={() => onOpenSource(source)}
+            >
+              full history
+            </button>
+            <a
+              className="link-btn"
+              href={api.fileUrl(sessionId, source)}
+              download={`${layerKey}_chat_history.json`}
+              title="Download the full chat history (JSON)"
+            >
+              ⬇ download
+            </a>
+          </>
         )}
       </div>
       <table className="tel-table">

--- a/webui/src/components/TelemetryDetails.tsx
+++ b/webui/src/components/TelemetryDetails.tsx
@@ -49,6 +49,20 @@ function typeSummary(obj: unknown, limit = 160): string {
   return s.length <= limit ? s : s.slice(0, limit - 1) + "…";
 }
 
+/** The error message a failed tool result carries, if any: tools return
+ * `{status: "error", error | message | detail: "..."}`; the executor wraps
+ * an exception and a bad-argument call the same way. */
+function errorText(result: unknown): string | null {
+  if (!result || typeof result !== "object" || Array.isArray(result)) return null;
+  const r = result as Record<string, unknown>;
+  for (const k of ["error", "message", "detail", "reason"]) {
+    const v = r[k];
+    if (typeof v === "string" && v.trim()) return v;
+    if (v && typeof v === "object") return asJson(v);
+  }
+  return null;
+}
+
 function asJson(v: unknown): string {
   let s: string;
   try {
@@ -259,7 +273,11 @@ function ToolSequence({
                 <td className="caption">{i + 1}</td>
                 <td><code>{c.tool}</code></td>
                 <td className="tel-shape">{typeSummary(c.args)}</td>
-                <td className="tel-shape">{typeSummary(c.result)}</td>
+                <td className={`tel-shape${c.status === "error" ? " tel-err" : ""}`}>
+                  {c.status === "error"
+                    ? (errorText(c.result) ?? typeSummary(c.result))
+                    : typeSummary(c.result)}
+                </td>
                 <td><span className={`tel-status status-${c.status}`}>{c.status}</span></td>
               </tr>,
               isOpen && (
@@ -328,7 +346,9 @@ function WorkerRow({ agent }: { agent: WorkerAgent }) {
                       <td className="caption">{shortTime(a.timestamp)}</td>
                       <td><code>{a.action}</code></td>
                       <td><span className={`tel-status status-${a.status}`}>{a.status}</span></td>
-                      <td className="tel-shape">{a.rationale ?? ""}</td>
+                      <td className={`tel-shape${a.status === "error" ? " tel-err" : ""}`}>
+                        {a.status === "error" ? (errorText(a.result) ?? a.rationale ?? "") : (a.rationale ?? "")}
+                      </td>
                     </tr>,
                     isOpen && (
                       <tr key={`${i}-d`} className="tel-row-detail">

--- a/webui/src/components/TelemetryDetails.tsx
+++ b/webui/src/components/TelemetryDetails.tsx
@@ -1,0 +1,346 @@
+import { useCallback, useContext, useEffect, useState } from "react";
+import { api, type TelemetrySnapshot, type ToolCall, type WorkerAgent } from "../api";
+import { UIContext } from "../UIContext";
+
+/** The Telemetry tab's lower half — what the meta session's agents actually
+ * did, from the read-only `/telemetry` snapshot (the port of Streamlit's
+ * telemetry tab minus the graphviz graph, which the sidebar tree already
+ * shows as context-flow edges):
+ *
+ *  - Tool sequence: every tool call each layer's LLM made, in order, with
+ *    the input / output *shape* in the table and the actual JSON on click.
+ *  - Worker agents: each sub-agent's action_history (curve fitting, BO,
+ *    scalarizer, …) with outcomes; a row expands to its actions, an action
+ *    to its input / result / rationale.
+ *  - Analysis reports: each analysis's scientific claims and reasoning.
+ *
+ * Polled every 3 s while a turn runs — the tool sequence reads the agents'
+ * live message lists, so it moves mid-turn — and refreshed on every ledger
+ * change otherwise. */
+
+const LAYER_LABELS: [string, string][] = [
+  ["meta", "Meta-agent"],
+  ["analysis", "Analysis specialist"],
+  ["planning", "Planning specialist"],
+];
+
+const JSON_CAP = 4000;
+
+function typeName(v: unknown): string {
+  if (v === null || v === undefined) return "null";
+  if (typeof v === "boolean") return "bool";
+  if (typeof v === "number") return Number.isInteger(v) ? "int" : "float";
+  if (typeof v === "string") return "str";
+  if (Array.isArray(v)) return `list[${v.length}]`;
+  if (typeof v === "object") return `dict[${Object.keys(v as object).length}]`;
+  return typeof v;
+}
+
+/** Type signature of a value: for a dict its keys mapped to value types,
+ * otherwise the bare type. Shape without content, so the table stays narrow. */
+function typeSummary(obj: unknown, limit = 160): string {
+  if (obj === null || obj === undefined) return "—";
+  let s: string;
+  if (Array.isArray(obj)) s = `list[${obj.length}]`;
+  else if (typeof obj === "object") {
+    const entries = Object.entries(obj as Record<string, unknown>);
+    s = entries.length ? `{${entries.map(([k, v]) => `${k}: ${typeName(v)}`).join(", ")}}` : "{}";
+  } else s = typeName(obj);
+  return s.length <= limit ? s : s.slice(0, limit - 1) + "…";
+}
+
+function asJson(v: unknown): string {
+  let s: string;
+  try {
+    s = typeof v === "string" ? v : JSON.stringify(v, null, 2) ?? "null";
+  } catch {
+    s = String(v);
+  }
+  return s.length <= JSON_CAP ? s : s.slice(0, JSON_CAP) + `\n… (${s.length - JSON_CAP} more characters)`;
+}
+
+function shortTime(ts: string | null | undefined): string {
+  if (!ts) return "";
+  const t = ts.includes("T") ? ts.split("T", 2)[1] : ts;
+  return t.slice(0, 8);
+}
+
+function relativeTo(root: string, path: string): string {
+  const r = root.endsWith("/") ? root : root + "/";
+  return path.startsWith(r) ? path.slice(r.length) : path;
+}
+
+export function TelemetryDetails({
+  sessionId,
+  active,
+  running,
+  ledgerVersion,
+}: {
+  sessionId: string;
+  active: boolean;
+  running: boolean;
+  ledgerVersion: unknown; // any change (a delegations event) triggers a refresh
+}) {
+  const ui = useContext(UIContext);
+  const [tel, setTel] = useState<TelemetrySnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    api.telemetry(sessionId).then((t) => { setTel(t); setError(null); })
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)));
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (active) refresh();
+  }, [active, refresh, ledgerVersion]);
+
+  useEffect(() => {
+    if (!active || !running) return;
+    const t = setInterval(refresh, 3000);
+    return () => clearInterval(t);
+  }, [active, running, refresh]);
+
+  if (error) return <p className="caption warn">Telemetry unavailable: {error}</p>;
+  if (!tel) return null;
+
+  const seq = tel.tool_sequence ?? {};
+  const layers = LAYER_LABELS.filter(([k]) => (seq[k]?.calls?.length ?? 0) > 0);
+  const agents = tel.agents ?? [];
+  const reports = tel.analysis_reports ?? [];
+  const root = tel.meta?.session_dir ?? "";
+
+  return (
+    <div className="tel-details">
+      <section className="tools-section">
+        <h3>Tool sequence</h3>
+        <p className="caption">
+          Every tool call each agent's LLM made, in order. The table shows the shape of
+          each input and output; click a row for the actual arguments and result.
+        </p>
+        {layers.length === 0 ? (
+          <p className="caption">No tool calls recorded yet.</p>
+        ) : (
+          layers.map(([key, label]) => (
+            <ToolSequence
+              key={key}
+              label={label}
+              calls={seq[key].calls}
+              source={seq[key].source ? relativeTo(root, seq[key].source) : null}
+              onOpenSource={ui.openInFiles}
+            />
+          ))
+        )}
+      </section>
+
+      <section className="tools-section">
+        <h3>
+          Worker agents <span className="caption">({agents.length})</span>
+        </h3>
+        <p className="caption">
+          The sub-agents the specialists ran and each one's action history.
+        </p>
+        {agents.length === 0 ? (
+          <p className="caption">No worker agent has recorded actions yet.</p>
+        ) : (
+          <table className="tel-table">
+            <thead>
+              <tr>
+                <th>specialist</th><th>agent</th><th>status</th><th>actions</th>
+                <th>outcomes</th><th>first</th><th>last</th>
+              </tr>
+            </thead>
+            <tbody>
+              {agents.map((a, i) => <WorkerRow key={a.source_file ?? i} agent={a} />)}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      {reports.length > 0 && (
+        <section className="tools-section">
+          <h3>
+            Analysis reports <span className="caption">({reports.length})</span>
+          </h3>
+          {reports.map((r) => (
+            <details key={r.report_file} className="tel-report">
+              <summary>
+                <code>{r.analysis_id}</code>
+                <span className={`tel-status status-${r.status ?? ""}`}>{r.status ?? "—"}</span>
+                <span className="caption">
+                  {r.claims.length} claim{r.claims.length === 1 ? "" : "s"}
+                </span>
+              </summary>
+              {r.claims.length > 0 && (
+                <ul className="deleg-list">
+                  {r.claims.map((c, i) => (
+                    <li key={i}>
+                      {c.claim}
+                      {c.impact && <span className="caption"> — {c.impact}</span>}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {r.detailed_analysis && <pre className="tel-json">{r.detailed_analysis}</pre>}
+              <button
+                type="button"
+                className="file-chip-btn"
+                title="Open in Files"
+                onClick={() => ui.openInFiles(relativeTo(root, r.report_file))}
+              >
+                analysis_results.json
+              </button>
+            </details>
+          ))}
+        </section>
+      )}
+    </div>
+  );
+}
+
+function ToolSequence({
+  label,
+  calls,
+  source,
+  onOpenSource,
+}: {
+  label: string;
+  calls: ToolCall[];
+  source: string | null;
+  onOpenSource: (path: string) => void;
+}) {
+  const [open, setOpen] = useState<number | null>(null);
+  return (
+    <div className="tel-layer">
+      <div className="tel-layer-head">
+        <strong>{label}</strong>
+        <span className="caption">
+          {calls.length} tool call{calls.length === 1 ? "" : "s"}
+        </span>
+        {source && (
+          <button
+            type="button"
+            className="link-btn"
+            title="The full chat history this sequence was read from"
+            onClick={() => onOpenSource(source)}
+          >
+            full history
+          </button>
+        )}
+      </div>
+      <table className="tel-table">
+        <thead>
+          <tr><th>#</th><th>tool</th><th>input</th><th>output</th><th>status</th></tr>
+        </thead>
+        <tbody>
+          {calls.map((c, i) => {
+            const isOpen = open === i;
+            return [
+              <tr
+                key={i}
+                className={`tel-row${isOpen ? " open" : ""}`}
+                onClick={() => setOpen(isOpen ? null : i)}
+              >
+                <td className="caption">{i + 1}</td>
+                <td><code>{c.tool}</code></td>
+                <td className="tel-shape">{typeSummary(c.args)}</td>
+                <td className="tel-shape">{typeSummary(c.result)}</td>
+                <td><span className={`tel-status status-${c.status}`}>{c.status}</span></td>
+              </tr>,
+              isOpen && (
+                <tr key={`${i}-d`} className="tel-row-detail">
+                  <td colSpan={5}>
+                    <div className="deleg-field">
+                      <span className="deleg-k">Arguments</span>
+                      <pre className="tel-json">{asJson(c.args)}</pre>
+                    </div>
+                    <div className="deleg-field">
+                      <span className="deleg-k">Result</span>
+                      <pre className="tel-json">
+                        {c.status === "pending" ? "(no result yet)" : asJson(c.result)}
+                      </pre>
+                    </div>
+                  </td>
+                </tr>
+              ),
+            ];
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function WorkerRow({ agent }: { agent: WorkerAgent }) {
+  const [open, setOpen] = useState(false);
+  const [openAction, setOpenAction] = useState<number | null>(null);
+  const o = agent.outcomes;
+  return (
+    <>
+      <tr className={`tel-row${open ? " open" : ""}`} onClick={() => setOpen(!open)}>
+        <td>{agent.specialist}</td>
+        <td><strong>{agent.name}</strong></td>
+        <td><span className={`tel-status status-${agent.status ?? ""}`}>{agent.status ?? "—"}</span></td>
+        <td>{agent.action_count}</td>
+        <td className="tel-shape">
+          {o.success} ✓{o.error ? ` · ${o.error} ✗` : ""}{o.other ? ` · ${o.other} other` : ""}
+        </td>
+        <td className="caption">{shortTime(agent.first_timestamp)}</td>
+        <td className="caption">{shortTime(agent.last_timestamp)}</td>
+      </tr>
+      {open && (
+        <tr className="tel-row-detail">
+          <td colSpan={7}>
+            <div className="caption tel-by-type">
+              {Object.entries(agent.actions_by_type).map(([k, n]) => (
+                <span key={k} className="deleg-chip">{k} ×{n}</span>
+              ))}
+            </div>
+            <table className="tel-table tel-actions">
+              <thead>
+                <tr><th>#</th><th>time</th><th>action</th><th>status</th><th>rationale</th></tr>
+              </thead>
+              <tbody>
+                {agent.actions.map((a, i) => {
+                  const isOpen = openAction === i;
+                  return [
+                    <tr
+                      key={i}
+                      className={`tel-row${isOpen ? " open" : ""}`}
+                      onClick={(e) => { e.stopPropagation(); setOpenAction(isOpen ? null : i); }}
+                    >
+                      <td className="caption">{i + 1}</td>
+                      <td className="caption">{shortTime(a.timestamp)}</td>
+                      <td><code>{a.action}</code></td>
+                      <td><span className={`tel-status status-${a.status}`}>{a.status}</span></td>
+                      <td className="tel-shape">{a.rationale ?? ""}</td>
+                    </tr>,
+                    isOpen && (
+                      <tr key={`${i}-d`} className="tel-row-detail">
+                        <td colSpan={5}>
+                          <div className="deleg-field">
+                            <span className="deleg-k">Input</span>
+                            <pre className="tel-json">{asJson(a.input)}</pre>
+                          </div>
+                          <div className="deleg-field">
+                            <span className="deleg-k">Result</span>
+                            <pre className="tel-json">{asJson(a.result)}</pre>
+                          </div>
+                          {a.feedback != null && a.feedback !== "" && (
+                            <div className="deleg-field">
+                              <span className="deleg-k">Feedback</span>
+                              <pre className="tel-json">{asJson(a.feedback)}</pre>
+                            </div>
+                          )}
+                        </td>
+                      </tr>
+                    ),
+                  ];
+                })}
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}

--- a/webui/src/delegationGraph.ts
+++ b/webui/src/delegationGraph.ts
@@ -1,0 +1,267 @@
+import type { DelegationRow } from "./api";
+
+/** Pure layout + routing for the delegation dependency graph (no React, no
+ * DOM), so it can be checked headlessly: `scripts/graph_check.ts` runs a
+ * set of ledger scenarios through `computeGraph` and asserts that the
+ * drawn edges are exactly the ledger's `context_from` relations, that
+ * every edge starts and ends on the boxes it names, that no edge crosses
+ * any other box, and that the flow runs top to bottom.
+ *
+ * Nodes: one per delegation, except the parallel branches of one
+ * run_fanout call (same `fanout_group`), which collapse into a single
+ * stacked node. Edges: one grey dispatch edge root → node, and one blue
+ * context edge per (source node → consumer node) relation. */
+
+export const NODE_W = 168;
+export const NODE_H = 54;
+const GAP_X = 22;
+const GAP_Y = 46;
+const PAD = 12;
+export const MAX_PER_ROW = 6; // a wider layer wraps into several rows
+const HIT_MARGIN = 6;
+
+export interface GraphNode {
+  id: string; // "d:<index>" or "g:<fanout_group>"
+  rows: DelegationRow[];
+  group: string | null; // fanout_group when collapsed
+  sources: string[]; // node-level context_from, deduplicated, self excluded
+}
+
+export interface PlacedNode {
+  node: GraphNode;
+  x: number;
+  y: number;
+  layer: number; // visual row; 0 = directly under the root
+}
+
+export interface GraphEdge {
+  kind: "dispatch" | "context";
+  from: string; // "root" or a node id
+  to: string; // a node id
+  d: string; // SVG path
+  mid: { x: number; y: number }; // where a label goes
+  bow: number; // 0 = straight; else the channel's offset from the straight midline
+}
+
+export interface Graph {
+  nodes: GraphNode[];
+  placed: PlacedNode[];
+  root: { x: number; y: number };
+  width: number;
+  height: number;
+  edges: GraphEdge[];
+  nodeOfIndex: Map<number, string>;
+}
+
+export interface Rect { x: number; y: number; w: number; h: number }
+
+export function buildNodes(rows: DelegationRow[]): GraphNode[] {
+  const nodeOf = new Map<number, string>();
+  const nodes: GraphNode[] = [];
+  const groups = new Map<string, GraphNode>();
+  for (const r of [...rows].sort((a, b) => a.index - b.index)) {
+    if (r.fanout && r.fanout_group) {
+      let g = groups.get(r.fanout_group);
+      if (!g) {
+        g = { id: `g:${r.fanout_group}`, rows: [], group: r.fanout_group, sources: [] };
+        groups.set(r.fanout_group, g);
+        nodes.push(g);
+      }
+      g.rows.push(r);
+      nodeOf.set(r.index, g.id);
+    } else {
+      const n = { id: `d:${r.index}`, rows: [r], group: null, sources: [] };
+      nodes.push(n);
+      nodeOf.set(r.index, n.id);
+    }
+  }
+  for (const n of nodes) {
+    const seen = new Set<string>();
+    for (const r of n.rows)
+      for (const src of r.context_from) {
+        const id = nodeOf.get(src);
+        if (id && id !== n.id && !seen.has(id)) {
+          seen.add(id);
+          n.sources.push(id);
+        }
+      }
+  }
+  return nodes;
+}
+
+/* ── routing ──────────────────────────────────────────────────────── */
+
+/** Rows are separated by a band of GAP_Y that holds no box, and columns
+ * by a gap of GAP_X. An edge is therefore routed as: a sweep from the
+ * source's bottom centre into a vertical channel, made entirely inside
+ * the free band below the source row; the channel straight down; a sweep
+ * from the channel to the target's top centre, entirely inside the free
+ * band above the target row. Only the channel can meet a box, so the
+ * candidates are vertical lanes (see `lanes` in computeGraph): the column
+ * gaps of every row, the strip beside each row, the canvas edges. A straight line is
+ * tried first — between adjacent rows it can never cross a box, and a
+ * straight diagonal that misses everything reads best. */
+const EDGE_CHANNEL = 20; // lane just inside the canvas edge
+const LANE_CLEAR = HIT_MARGIN + 8; // a lane just outside a row's first / last box
+const SWEEP = GAP_Y - HIT_MARGIN - 4; // vertical room for a sweep (stays off the next row)
+const SAMPLES = 40;
+
+interface Curve { d: string; at: (t: number) => { x: number; y: number }; bow: number }
+
+function bez(p0: number, p1: number, p2: number, p3: number, t: number): number {
+  const u = 1 - t;
+  return u * u * u * p0 + 3 * u * u * t * p1 + 3 * u * t * t * p2 + t * t * t * p3;
+}
+
+export function straight(x1: number, y1: number, x2: number, y2: number): Curve {
+  return { d: `M ${x1} ${y1} L ${x2} ${y2}`, bow: 0,
+           at: (t) => ({ x: x1 + (x2 - x1) * t, y: y1 + (y2 - y1) * t }) };
+}
+
+/** Sweep → channel at `xc` → sweep. */
+export function channel(x1: number, y1: number, x2: number, y2: number, xc: number): Curve {
+  const g = Math.min(SWEEP, (y2 - y1) / 2);
+  const ya = y1 + g, yb = y2 - g; // channel from ya down to yb
+  const d = `M ${x1} ${y1} C ${x1} ${ya}, ${xc} ${y1}, ${xc} ${ya}`
+          + ` L ${xc} ${yb} C ${xc} ${y2}, ${x2} ${yb}, ${x2} ${y2}`;
+  const at = (t: number) => {
+    if (t < 1 / 3) {
+      const u = t * 3;
+      return { x: bez(x1, x1, xc, xc, u), y: bez(y1, ya, y1, ya, u) };
+    }
+    if (t < 2 / 3) {
+      const u = (t - 1 / 3) * 3;
+      return { x: xc, y: ya + (yb - ya) * u };
+    }
+    const u = (t - 2 / 3) * 3;
+    return { x: bez(xc, xc, x2, x2, u), y: bez(yb, y2, yb, y2, u) };
+  };
+  return { d, at, bow: xc - (x1 + x2) / 2 };
+}
+
+function hits(curve: Curve, rects: Rect[]): boolean {
+  for (let i = 1; i < SAMPLES; i++) {
+    const { x, y } = curve.at(i / SAMPLES);
+    for (const r of rects) {
+      if (x >= r.x - HIT_MARGIN && x <= r.x + r.w + HIT_MARGIN &&
+          y >= r.y - HIT_MARGIN && y <= r.y + r.h + HIT_MARGIN) return true;
+    }
+  }
+  return false;
+}
+
+/** The first candidate that keeps the edge off every obstacle: straight,
+ * then channels in the column gaps nearest the endpoints, then the canvas
+ * edges. Falls back to straight (never happens with the edge channels
+ * available, which are box-free by construction). */
+function route(x1: number, y1: number, x2: number, y2: number, obstacles: Rect[],
+               lanes: number[]) {
+  const line = straight(x1, y1, x2, y2);
+  if (!hits(line, obstacles)) return { d: line.d, mid: line.at(0.5), bow: 0 };
+  const midX = (x1 + x2) / 2;
+  const ordered = [...lanes].sort((a, b) => Math.abs(a - midX) - Math.abs(b - midX));
+  for (const xc of ordered) {
+    const c = channel(x1, y1, x2, y2, xc);
+    if (!hits(c, obstacles)) return { d: c.d, mid: c.at(0.5), bow: c.bow };
+  }
+  return { d: line.d, mid: line.at(0.5), bow: 0 };
+}
+
+/* ── layout ───────────────────────────────────────────────────────── */
+
+export function computeGraph(rows: DelegationRow[]): Graph {
+  const nodes = buildNodes(rows);
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const nodeOfIndex = new Map<number, string>();
+  for (const n of nodes) for (const r of n.rows) nodeOfIndex.set(r.index, n.id);
+
+  // Layer = context depth: a node sits below everything it read from. A
+  // cycle (defensive; the ledger cannot produce one) breaks at the node
+  // that closes it.
+  const depth = new Map<string, number>();
+  const depthOf = (n: GraphNode, seen = new Set<string>()): number => {
+    const cached = depth.get(n.id);
+    if (cached !== undefined) return cached;
+    if (seen.has(n.id)) return 0;
+    seen.add(n.id);
+    let d = 0;
+    for (const src of n.sources) {
+      const s = byId.get(src);
+      if (s) d = Math.max(d, depthOf(s, seen) + 1);
+    }
+    depth.set(n.id, d);
+    return d;
+  };
+  const layers: GraphNode[][] = [];
+  for (const n of nodes) (layers[depthOf(n)] ??= []).push(n);
+
+  // A layer wider than MAX_PER_ROW wraps into rows; within a wrapped
+  // layer the nodes that feed later layers go to its last row, so their
+  // outgoing edges never cross a sibling row.
+  const isSource = new Set(nodes.flatMap((n) => n.sources));
+  const visualRows: GraphNode[][] = [];
+  for (const layer of layers) {
+    const ordered = layer.length > MAX_PER_ROW
+      ? [...layer.filter((n) => !isSource.has(n.id)), ...layer.filter((n) => isSource.has(n.id))]
+      : layer;
+    for (let i = 0; i < ordered.length; i += MAX_PER_ROW)
+      visualRows.push(ordered.slice(i, i + MAX_PER_ROW));
+  }
+
+  const widest = Math.max(1, ...visualRows.map((l) => l.length));
+  const margin = visualRows.length > 1 ? 2 * EDGE_CHANNEL + 4 : 0; // room for edge channels
+  const width = PAD * 2 + widest * NODE_W + (widest - 1) * GAP_X + 2 * margin;
+  const root = { x: width / 2 - NODE_W / 2, y: PAD };
+  const placed: PlacedNode[] = [];
+  visualRows.forEach((vr, li) => {
+    const rowW = vr.length * NODE_W + (vr.length - 1) * GAP_X;
+    const x0 = (width - rowW) / 2;
+    vr.forEach((node, i) => {
+      placed.push({ node, x: x0 + i * (NODE_W + GAP_X),
+                    y: PAD + (li + 1) * (NODE_H + GAP_Y), layer: li });
+    });
+  });
+  const height = PAD * 2 + (visualRows.length + 1) * NODE_H + visualRows.length * GAP_Y;
+
+  // Edges: dispatch root → every node; context source → consumer.
+  const at = new Map(placed.map((p) => [p.node.id, p]));
+  const rectOf = (p: PlacedNode): Rect => ({ x: p.x, y: p.y, w: NODE_W, h: NODE_H });
+  const rootRect: Rect = { x: root.x, y: root.y, w: NODE_W, h: NODE_H };
+  const obstaclesExcept = (...ids: string[]) =>
+    placed.filter((q) => !ids.includes(q.node.id)).map(rectOf);
+  // Candidate vertical lanes: the column gaps of every row, the strip just
+  // outside each row's first and last box, and the canvas edges. An edge
+  // that cannot go straight takes the nearest lane that clears every box.
+  const lanes = new Set<number>([EDGE_CHANNEL, width - EDGE_CHANNEL]);
+  for (const vr of visualRows) {
+    const xs = placed.filter((p) => vr.includes(p.node)).map((p) => p.x).sort((a, b) => a - b);
+    lanes.add(xs[0] - LANE_CLEAR);
+    lanes.add(xs[xs.length - 1] + NODE_W + LANE_CLEAR);
+    for (let i = 0; i + 1 < xs.length; i++) lanes.add((xs[i] + NODE_W + xs[i + 1]) / 2);
+  }
+  const laneList = [...lanes].filter((x) => x >= EDGE_CHANNEL - 1 && x <= width - EDGE_CHANNEL + 1);
+  const edges: GraphEdge[] = [];
+  for (const p of placed) {
+    const r = route(root.x + NODE_W / 2, root.y + NODE_H, p.x + NODE_W / 2, p.y,
+                    obstaclesExcept(p.node.id), laneList);
+    edges.push({ kind: "dispatch", from: "root", to: p.node.id, ...r });
+  }
+  for (const p of placed) {
+    for (const src of p.node.sources) {
+      const s = at.get(src);
+      if (!s) continue;
+      const x1 = s.x + NODE_W / 2, y1 = s.y + NODE_H;
+      const x2 = p.x + NODE_W / 2, y2 = p.y;
+      const r = route(x1, y1, x2, y2, [rootRect, ...obstaclesExcept(s.node.id, p.node.id)],
+                      laneList);
+      edges.push({ kind: "context", from: s.node.id, to: p.node.id, ...r });
+    }
+  }
+  return { nodes, placed, root, width, height, edges, nodeOfIndex };
+}
+
+export function groupStatus(rows: DelegationRow[]): string {
+  if (rows.some((r) => r.status === "running")) return "running";
+  if (rows.every((r) => r.status === "error")) return "error";
+  return "success";
+}


### PR DESCRIPTION
## Summary

The **Telemetry** tab in a meta session now shows what the agents actually did, not only which delegations ran. Under the delegation detail you get every tool call each layer made in order (the meta, the analysis specialist, the planning specialist) with a click to see the exact arguments and result, each worker agent's action history (curve fitting, Bayesian optimization, scalarizer, and so on) down to the input, result and rationale of a single action, and every analysis's scientific claims and reasoning. It updates while a turn runs, so you can watch a delegation unfold.

This is the web port of the Streamlit telemetry tab, including its dependency graph (drawn as plain SVG, no graphviz needed: root, status-colored delegation boxes with their sub-agents, grey dispatch edges, blue context edges; click a box to expand its row) and the per-layer download of the full chat history.

## Technical description

The `GET /sessions/{id}/telemetry` endpoint (`collect_session_telemetry`) was already wired. One server fix: `delegation_view` read the fan-out marker as a dict, but `run_fanout` stamps `fanout=True` + `parallel_group="fanout_<n>"`, so `fanout_group` was always null; it now reads `parallel_group` (test added), which the graph keys on. Reader fix in `telemetry.py`: an image-bearing tool result is a multimodal message whose content is a list of parts, which `_maybe_json` left as a list, so `_action_status` called every such result ok; the text part is now parsed (new `tests/test_meta_telemetry_reader.py` covers an exception-wrapped error, a bad-argument error, a multimodal error and a pending call). Everything else is frontend.

- `webui/src/components/TelemetryDetails.tsx` (new), rendered below `DelegationsPanel` in the Telemetry tab body (both inside a new `.telemetry-scroll` container so the tab scrolls as one page).
  - **Tool sequence**: per layer in `tool_sequence` (meta / analysis / planning, in that order, empty layers hidden). Table columns `# | tool | input | output | status`; input/output are the type signature (`{task: str, label: str}`, `list[21]`), a TypeScript port of the Streamlit `_type_summary`. Clicking a row expands the actual `args` and `result` as JSON, capped at 4000 characters; a `pending` call shows "(no result yet)". A failed call (`status: error`) shows its error message inline in red in the output cell (`error` / `message` / `detail` / `reason` keys, the shapes tools and the executor produce), in the worker action list too. The "full history" link opens the layer's `chat_history.json` in the Files tab (the absolute `source` path is made session-relative from `meta.session_dir`).
  - **Worker agents**: one row per `agents` entry (specialist, name, status, action count, outcomes, first/last timestamp); expands to `actions_by_type` chips and the action table (time, action, status, rationale); an action expands to input / result / feedback JSON.
  - **Analysis reports**: a `<details>` per `analysis_reports` entry with the claims (claim + impact), the capped `detailed_analysis`, and a chip that opens the `analysis_results.json` in Files.
  - Refresh policy: fetched when the tab is active, re-fetched whenever the `delegations` view object changes (a ledger SSE event), and polled every 3 s while `status === "running"` because `_tool_sequence` reads the agents' live `messages` and therefore moves mid-turn. Nothing is fetched while the tab is hidden.
- `DelegationGraph.tsx` (new), rendered above the ledger in `DelegationsPanel`: nodes layered by context depth (a delegation sits below everything in its `context_from`), centered per layer; edges that skip a layer are bowed sideways by one step per skipped layer (right for context, left for dispatch) so they do not cross the boxes between; the canvas widens by the deepest bow. A layer wider than six wraps into rows; the branches of one fan-out (same `fanout_group`) collapse into one stacked node with outcome counts and a single context edge in/out; every edge is routed around the boxes it does not connect: straight when clear, else a sweep inside the box-free band between rows into the nearest vertical lane (a column gap of any row, the strip beside a row, or the canvas edge) that clears every box; sources in a wrapped layer go to its last row so their edges never cross a sibling row. Layout and routing are a pure module, `webui/src/delegationGraph.ts`, and `npm run check:graph` (`webui/scripts/graph_check.ts`, Node type-stripping, no test framework added) runs sixteen ledger scenarios through it asserting: drawn context edges == the ledger's `context_from` relations (branches → group node), one dispatch edge per node, endpoints on the right boxes, no edge through a third box, downward flow, no overlapping boxes. Edge paths carry `data-from`/`data-to` and node groups `data-node`; the same audit was run in Chrome against the rendered SVG (browser geometry, ledger from `/delegations`) on four resumed sessions, all clean; dispatch edges below the first row are faint; `ctx` labels sit on the routed curve over a halo and are dropped past three sources. Clicking a node sets the panel's open row (a fan-out node opens its first failed branch). Root label carries the meta autonomy (`session.autonomy`).
- Each tool-sequence layer has a `⬇ download` link (`api.fileUrl` with the `download` attribute, cookie-authenticated like the zip links) next to "full history".
- `api.ts`: `TelemetrySnapshot`, `ToolCall`, `WorkerAgent`, `WorkerAction`, `AnalysisReport` types and `api.telemetry`.
- `app.css`: `.tel-*` table, status pill and JSON block styles using the existing theme tokens (`--code-bg`, `--code-border`, `--text-dim`); the delegation panel loses its own scroll to the shared container.

### Verification

`tsc -b` and `npm run build` clean. Checked in Chrome on a resumed meta session (one delegation, Curve Fitting worker): meta layer with 2 calls and analysis layer with 3, row expansion showing the `select_agent` arguments and result, the worker row expanding to its `curve_fit` action and that action's input/result, the report expanding to its claim and reasoning. No console errors. The graph was checked on the same session with three synthetic ledger entries added to the checkpoint (planning ← #1, running analysis ← #1,#2, failed simulation) to exercise layering, bowed edges and every status color; the download URL returns the JSON. Scaling checked on a 45-entry synthetic ledger (a 30-branch fan-out feeding a fusion and a plan, a four-step chain across three specialists, seven standalone analyses): the fan-out is one node and the whole graph fits the panel. The existing server test already covers the endpoint on a bare agent.

### Docs

`react_web_ui.md`: Telemetry tab bullet rewritten, not-yet-ported list updated. `react_ui_roadmap.md`: item 6 marks Telemetry and Skills browse/upload done; persistent-memory UI is next.