### PR TITLE
Release 0.0.71

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scilink"
-version = "0.0.70"
+version = "0.0.71"
 authors = [
   { name="SciLink Team", email="maxim.ziatdinov@gmail.com" },
 ]


### PR DESCRIPTION
## Summary

Version bump for the 0.0.71 release. Since 0.0.70 the web UI gained two tabs:

- **Skills tab** (#561): upload custom skill markdown for the session and browse the built-in catalog by domain, with a viewer.
- **Telemetry tab** (#562): the tool sequence per agent with arguments, results and inline error messages, worker agent action histories, analysis reports, history download, and the delegation dependency graph as plain SVG (fan-outs collapse into one box, edges routed around boxes, verified by a scenario checker). Also fixes the delegations view never reporting a fan-out's group id.

## Technical description

Only `pyproject.toml` changes (`0.0.70` → `0.0.71`). Tagging the merge commit `v0.0.71` triggers `release.yml`: build the React bundle, build sdist and wheel, attach them to the GitHub release, and publish to PyPI.