### PR TITLE
Skills tab: persistent memory — bank, review inbox, skills, distillation

### DIFF
--- a/docs/react_ui_roadmap.md
+++ b/docs/react_ui_roadmap.md
@@ -89,8 +89,8 @@ restart, resume).
    sequence, worker agents and analysis reports from `/telemetry` under
    the delegation detail, plus the dependency graph as plain SVG and a
    per-layer history download); Skills (browse/upload DONE 2026-09-08,
-   PR #561; the persistent-memory pipeline UI is a separate, bigger
-   design, next).
+   PR #561; persistent-memory pipeline DONE 2026-09-08 — bank / inbox /
+   skills with the distill jobs, over the same store as `scilink memory`).
 7. **Parity for the switch to default** (see "Standing decisions"):
    simulate mode in the web UI (HPC connection, wizards) is the largest
    gap; after it the web UI covers everything Streamlit does.

--- a/docs/react_web_ui.md
+++ b/docs/react_web_ui.md
@@ -208,8 +208,29 @@ rate limiting on sign-in (put the proxy's in front if internet-facing).
   the session's `custom_skills/`, registered with the agent for this
   session, auto-selectable like built-ins) and browse the catalog — every
   built-in bundle by domain with its one-line description, plus a
-  markdown viewer (frontmatter shown as a caption). Persistent memory
-  (graduated / auto-distilled skills under `~/.scilink`) is not here yet.
+  markdown viewer (frontmatter shown as a caption). Below it, **Persistent
+  memory** — the port of the Streamlit memory panel over one store per
+  server host (`$SCILINK_HOME` or `~/.scilink`, the same store `scilink
+  memory` manages): the on/off switch (persisted to the store's
+  `config.json`; the `SCILINK_MEMORY` env var overrides it and the switch
+  says so), the pipeline strip, and the three stages in the order knowledge
+  flows. **1 · Script bank** — banked scripts by domain with proven (★)
+  badges, cross-session stats and a lazy record inspector (fields + the
+  working script); nominate one for review, or nominate a same-system
+  variant group under one technique label; delete. **2 · Review inbox** —
+  staged records by domain / technique (📜 nominations, 🐛 error lessons,
+  💬 your feedback; same-session records from other labels offered as
+  related), a record inspector with its bank link, discard, and the distill
+  flow: select records, distill into a **new** skill (consolidate; refuses a
+  label that would sweep in unselected records) or into an **existing** one
+  (targets ordered by a technique-match check, built-ins fork on upgrade,
+  mismatches flagged; preview → review the diff and additivity warnings,
+  optionally edit the proposal → apply with a `.md.bak` backup). The two
+  LLM calls (1–3 min) run as background jobs polled every 2 s, using the
+  current session's model. **3 · Skills** — provisional vs approved, with
+  view (frontmatter as caption), validated edit with backup, approve /
+  suspend, delete, and a diff against the shipped built-in for a fork.
+  Destructive actions are two-click confirms (no browser dialogs).
 - **MCP tab** (all modes): connect MCP servers — a `stdio` command, an
   SSE URL, or a streamable-HTTP URL with optional JSON headers — and
   disconnect them; each server card lists the tools it registered. The
@@ -250,7 +271,7 @@ rate limiting on sign-in (put the proxy's in front if internet-facing).
   - deep links: the tab and selected file live in the URL hash, so a
     refresh (or shared link) lands on the same file.
 
-Not yet ported: simulate mode, the Skills tab's persistent-memory section, vibes.
+Not yet ported: simulate mode, vibes.
 
 ## Architecture
 
@@ -304,6 +325,17 @@ webui/ (Vite + React + TS)  ──REST + SSE──►  scilink/server/ (FastAPI)
 | GET | `/sessions/{id}/skills` | catalog: built-in bundles by domain with descriptions, the session's custom skills |
 | GET | `/sessions/{id}/skills/{domain}/{name}` | a skill's markdown (`domain` = catalog domain or `custom`) |
 | POST | `/sessions/{id}/skills` | multipart `.md` uploads → `custom_skills/`, registered with the agent |
+| GET | `/memory` | the store: switch, pipeline counts, bank by domain (+ variant groups), inbox by domain/technique, skills |
+| POST | `/memory/enabled` | `{enabled}` → persisted to the store's `config.json` |
+| GET/PUT | `/memory/skills/{domain}/{name}` | a persistent skill's markdown / validated edit with `.md.bak` backup |
+| POST | `/memory/skills/{domain}/{name}/{action}` | `promote` · `demote` · `prune` · `diff` (fork vs built-in) · `fork` (copy a built-in into the store) |
+| GET/DELETE | `/memory/bank/{domain}/{id}` | a bank record (fields + script) / delete it |
+| POST | `/memory/bank/{domain}/{id}/nominate`, `/memory/bank/{domain}/nominate-group` | send a record, or a variant group under one label, to the review inbox |
+| GET/DELETE | `/memory/inbox/{domain}/{id}` | a staged record (fields, script, bank link) / discard it |
+| POST | `/memory/inbox/{domain}/targets` | upgrade targets for a selection, with the technique-match verdict |
+| POST | `/memory/inbox/{domain}/consolidate`, `/propose-upgrade` | start an LLM job (`{session_id}` names the model) → `{job_id}` |
+| GET | `/memory/jobs/{id}` | job status → `result` (consolidate: the new skill; upgrade: the proposal with diff + warnings) |
+| POST | `/memory/inbox/{domain}/apply-upgrade`, `/memory/check-upgrade` | write a reviewed proposal (forking a built-in first) / re-check an edited one |
 | GET | `/sessions/{id}/tools` | connected MCP servers with their tools, other external tools, `mcp_supported` |
 | POST | `/sessions/{id}/mcp` | connect an MCP server (`name`, `transport` stdio/sse/http, `command` or `url`, `headers`) |
 | DELETE | `/sessions/{id}/mcp/{name}` | disconnect it |

--- a/scilink/server/app.py
+++ b/scilink/server/app.py
@@ -15,7 +15,7 @@ from typing import Optional
 
 from fastapi import FastAPI, File, Form, Header, HTTPException, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, StreamingResponse
 
 from scilink.providers import provider_for
 from scilink.ui.config import (
@@ -35,6 +35,13 @@ from .schemas import (
     FolderCheckRequest,
     LoginRequest,
     MCPConnectRequest,
+    MemoryApplyRequest,
+    MemoryCheckRequest,
+    MemoryConsolidateRequest,
+    MemoryEditRequest,
+    MemoryEnabledRequest,
+    MemoryIdsRequest,
+    MemoryUpgradeRequest,
     PlanDirsRequest,
     RenameSessionRequest,
     SendMessageRequest,
@@ -439,7 +446,6 @@ def create_app(session_root: Path, serve_frontend: bool = True,
     @app.get("/api/v1/sessions/{session_id}/skills/{domain}/{name}")
     def get_skill_markdown(request: Request, session_id: str, domain: str, name: str):
         """A skill's markdown — `domain` is a catalog domain, or `custom`."""
-        from fastapi.responses import PlainTextResponse
 
         from .skills_api import SkillError, skill_markdown
         session = _session_or_404(request, session_id)
@@ -462,6 +468,117 @@ def create_app(session_root: Path, serve_frontend: bool = True,
             return register_uploaded_skills(session.agent, session.session_dir, payload)
         except SkillError as exc:
             raise HTTPException(exc.status, str(exc))
+
+    # ── persistent memory ────────────────────────────────────────
+    # One store per server host ($SCILINK_HOME or ~/.scilink), shared by
+    # every session and — on a multi-user server — every user: it is the
+    # host's curated knowledge, the same thing `scilink memory` manages.
+
+    from .memory_api import MemoryError
+
+    def _mem(fn, *args, **kw):
+        try:
+            return fn(*args, **kw)
+        except MemoryError as exc:
+            raise HTTPException(exc.status, exc.message) from exc
+
+    @app.get("/api/v1/memory")
+    def memory_overview():
+        """The switch, the pipeline strip, the bank, the inbox, the skills."""
+        from .memory_api import memory_overview as _overview
+        return _overview()
+
+    @app.post("/api/v1/memory/enabled")
+    def memory_set_enabled(body: MemoryEnabledRequest):
+        from .memory_api import set_enabled
+        return set_enabled(body.enabled)
+
+    @app.get("/api/v1/memory/skills/{domain}/{name}")
+    def memory_skill_text(domain: str, name: str):
+        from .memory_api import skill_text
+        return PlainTextResponse(_mem(skill_text, domain, name), media_type="text/markdown; charset=utf-8")
+
+    @app.put("/api/v1/memory/skills/{domain}/{name}")
+    def memory_skill_edit(domain: str, name: str, body: MemoryEditRequest):
+        from .memory_api import skill_edit
+        return _mem(skill_edit, domain, name, body.content)
+
+    @app.post("/api/v1/memory/skills/{domain}/{name}/{action}")
+    def memory_skill_action(domain: str, name: str, action: str):
+        """promote · demote · prune · diff (a fork against its built-in) ·
+        fork (copy a built-in into the store, shadowing it)."""
+        from .memory_api import fork_builtin, skill_action
+        if action == "fork":
+            return _mem(fork_builtin, domain, name)
+        return _mem(skill_action, domain, name, action)
+
+    @app.get("/api/v1/memory/bank/{domain}/{rid}")
+    def memory_bank_record(domain: str, rid: str):
+        from .memory_api import bank_record
+        return _mem(bank_record, domain, rid)
+
+    @app.delete("/api/v1/memory/bank/{domain}/{rid}")
+    def memory_bank_delete(domain: str, rid: str):
+        from .memory_api import bank_delete
+        return _mem(bank_delete, domain, rid)
+
+    @app.post("/api/v1/memory/bank/{domain}/{rid}/nominate")
+    def memory_bank_nominate(domain: str, rid: str):
+        from .memory_api import bank_nominate
+        return _mem(bank_nominate, domain, rid)
+
+    @app.post("/api/v1/memory/bank/{domain}/nominate-group")
+    def memory_bank_nominate_group(domain: str, body: MemoryIdsRequest):
+        from .memory_api import bank_nominate_group
+        return _mem(bank_nominate_group, domain, body.ids, body.technique)
+
+    @app.get("/api/v1/memory/inbox/{domain}/{sid}")
+    def memory_inbox_record(domain: str, sid: str):
+        from .memory_api import inbox_record
+        return _mem(inbox_record, domain, sid)
+
+    @app.delete("/api/v1/memory/inbox/{domain}/{sid}")
+    def memory_inbox_discard(domain: str, sid: str):
+        from .memory_api import inbox_discard
+        return _mem(inbox_discard, domain, sid)
+
+    @app.post("/api/v1/memory/inbox/{domain}/targets")
+    def memory_upgrade_targets(domain: str, body: MemoryIdsRequest):
+        from .memory_api import upgrade_targets
+        return {"targets": _mem(upgrade_targets, domain, body.ids)}
+
+    @app.post("/api/v1/memory/inbox/{domain}/consolidate")
+    def memory_consolidate(request: Request, domain: str, body: MemoryConsolidateRequest):
+        """Start the distillation job (1-3 min); poll /memory/jobs/{id}."""
+        from .memory_api import llm_call_for, start_consolidate
+        session = _session_or_404(request, body.session_id)
+        return _mem(start_consolidate, domain, body.ids, body.label,
+                    _mem(llm_call_for, session.agent))
+
+    @app.post("/api/v1/memory/inbox/{domain}/propose-upgrade")
+    def memory_propose_upgrade(request: Request, domain: str, body: MemoryUpgradeRequest):
+        """Start the upgrade-preview job (writes nothing); poll /memory/jobs/{id}."""
+        from .memory_api import llm_call_for, start_propose_upgrade
+        session = _session_or_404(request, body.session_id)
+        return _mem(start_propose_upgrade, domain, body.ids, body.target_domain,
+                    body.target_name, _mem(llm_call_for, session.agent))
+
+    @app.post("/api/v1/memory/inbox/{domain}/apply-upgrade")
+    def memory_apply_upgrade(domain: str, body: MemoryApplyRequest):
+        from .memory_api import apply_upgrade
+        return _mem(apply_upgrade, domain, body.ids, body.target_domain,
+                    body.target_name, body.content, body.fork_builtin)
+
+    @app.post("/api/v1/memory/check-upgrade")
+    def memory_check_upgrade(body: MemoryCheckRequest):
+        """Additivity warnings + diff for an edited proposal."""
+        from .memory_api import upgrade_check
+        return upgrade_check(body.existing, body.proposed)
+
+    @app.get("/api/v1/memory/jobs/{job_id}")
+    def memory_job(job_id: str):
+        from .memory_api import job_status
+        return _mem(job_status, job_id)
 
     # ── tools / MCP ──────────────────────────────────────────────
 
@@ -617,7 +734,6 @@ def create_app(session_root: Path, serve_frontend: bool = True,
             # The bundle is built at release time (release wheels carry it)
             # and is not in git — a checkout must build it once. Say so at
             # "/" instead of serving a bare 404 next to a working API.
-            from fastapi.responses import PlainTextResponse
 
             @app.get("/", include_in_schema=False)
             def _no_frontend():

--- a/scilink/server/memory_api.py
+++ b/scilink/server/memory_api.py
@@ -1,0 +1,559 @@
+"""Persistent-memory surface for the web UI — the port of the Streamlit
+memory panel (``scilink/ui/components/skills.py``) over the same backend
+(``scilink.skills._shared._memory`` / ``_staging`` / ``_script_bank``,
+also the backend of ``scilink memory``).
+
+One store per server host (``$SCILINK_HOME`` or ``~/.scilink``): it is not
+per session and not per user. The pipeline reads top to bottom in the
+order knowledge flows — every success lands in the **script bank**
+automatically; nominations, error lessons and user feedback wait in the
+**review inbox**; reviewed knowledge is distilled (one large LLM call)
+into **skills** that guide planning, provisional until approved.
+
+Everything here is a plain function returning JSON-able dicts so the
+endpoints stay thin; the two LLM-backed operations (consolidate into a new
+skill, propose an upgrade to an existing one) take one to three minutes,
+so they run as background **jobs** polled by id — a web request cannot
+block that long the way the Streamlit spinner did.
+"""
+
+from __future__ import annotations
+
+import difflib
+import logging
+import os
+import re
+import shutil
+import tempfile
+import threading
+import uuid
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_CONSOLIDATED_LABEL_RE = re.compile(r"[^a-z0-9]+")
+
+
+class MemoryError(Exception):
+    """A user-facing failure with an HTTP status."""
+
+    def __init__(self, status: int, message: str):
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
+def _mods():
+    from scilink.skills import loader
+    from scilink.skills._shared import _memory, _script_bank, _staging
+    return loader, _memory, _script_bank, _staging
+
+
+def normalize_label(label: str) -> str:
+    return _CONSOLIDATED_LABEL_RE.sub("_", (label or "").lower()).strip("_")[:48]
+
+
+# ── overview ─────────────────────────────────────────────────────────
+
+def _safe(fn: Callable[[], Any], default: Any) -> Any:
+    try:
+        return fn()
+    except Exception as exc:  # noqa: BLE001 - one bad store must not break the panel
+        logger.warning(f"memory panel: {fn.__name__ if hasattr(fn, '__name__') else fn} failed: {exc}")
+        return default
+
+
+def _inbox_row(rec: Dict[str, Any], _staging) -> Dict[str, Any]:
+    prov = str(rec.get("provenance") or "")
+    return {
+        "id": rec.get("id"),
+        "domain": rec.get("domain"),
+        "technique": rec.get("technique") or "unlabeled",
+        "provenance": prov,
+        "provenance_label": _staging.PROVENANCE_LABELS.get(prov, prov or "?"),
+        "metric": _safe(lambda: _staging.metric_label(rec), ""),
+        "session": rec.get("session"),
+        "bank_id": rec.get("bank_id"),
+        "model": rec.get("model") or rec.get("planned_model"),
+        "has_script": bool((rec.get("working_script") or rec.get("script") or "").strip()),
+    }
+
+
+def memory_overview() -> Dict[str, Any]:
+    """Everything the panel shows at once: the switch, the pipeline strip,
+    the bank by domain (with variant-group suggestions), the inbox by
+    domain / technique, the skills. Never raises for a bad record."""
+    loader, _memory, _script_bank, _staging = _mods()
+    enabled = loader.memory_enabled()
+    env = os.environ.get("SCILINK_MEMORY", "").strip()
+
+    skills = _safe(_memory.list_memory, [])
+    bank_rows = _safe(_script_bank.bank_summary, [])
+    staged = _safe(_staging.list_staged, [])
+    need = _safe(_staging.consolidate_min_n, 2)
+    proven_n = _safe(_script_bank.proven_n, 2)
+
+    bank: List[Dict[str, Any]] = []
+    by_domain: Dict[str, List[Dict[str, Any]]] = {}
+    for r in bank_rows:
+        by_domain.setdefault(r.get("domain") or "?", []).append(r)
+    for domain, recs in sorted(by_domain.items()):
+        groups = _safe(lambda d=domain: [g for g in _script_bank.find_variant_groups(d)
+                                          if g.get("n_unpromoted", 0) > 0], [])
+        bank.append({
+            "domain": domain,
+            "n_proven": sum(1 for r in recs if r.get("proven")),
+            "records": [{
+                "id": r.get("id"), "label": r.get("label"),
+                "n_successes": r.get("n_successes"), "n_retrievals": r.get("n_retrievals"),
+                "sessions": r.get("sessions") or [], "metric": r.get("metric"),
+                "created_at": r.get("created_at"), "proven": bool(r.get("proven")),
+                "promoted_to_staging": r.get("promoted_to_staging"),
+            } for r in recs],
+            "variant_groups": [{
+                "ids": g.get("ids") or [], "min_similarity": g.get("min_similarity"),
+                "suggested_technique": g.get("suggested_technique"),
+                "n_unpromoted": g.get("n_unpromoted"),
+            } for g in groups],
+        })
+
+    inbox_groups: Dict[tuple, List[Dict[str, Any]]] = {}
+    for rec in staged:
+        if not isinstance(rec, dict):
+            continue
+        key = (rec.get("domain") or "?", rec.get("technique") or "unlabeled")
+        inbox_groups.setdefault(key, []).append(rec)
+    inbox: List[Dict[str, Any]] = []
+    for (domain, technique), recs in sorted(inbox_groups.items()):
+        # Same-session records filed under other labels (the lessons these
+        # very analyses produced) are offered alongside the group.
+        sessions = {r.get("session") for r in recs if r.get("session")}
+        related = [o for o in staged if isinstance(o, dict)
+                   and o.get("domain") == domain
+                   and (o.get("technique") or "unlabeled") != technique
+                   and o.get("session") in sessions]
+        inbox.append({
+            "domain": domain, "technique": technique,
+            "ready": len(recs) >= need,
+            "records": [_inbox_row(r, _staging) for r in recs],
+            "related": [_inbox_row(r, _staging) for r in related],
+        })
+
+    n_ready = sum(1 for g in inbox if g["ready"])
+    return {
+        "enabled": enabled,
+        "env_override": env or None,
+        "home": str(loader.scilink_home()),
+        "consolidate_min_n": need,
+        "proven_n": proven_n,
+        "pipeline": {
+            "bank_total": len(bank_rows),
+            "bank_proven": sum(1 for r in bank_rows if r.get("proven")),
+            "inbox_total": len(staged),
+            "inbox_ready": n_ready,
+            "skills_total": len(skills),
+            "skills_provisional": sum(1 for s in skills if s.get("provisional")),
+        },
+        "bank": bank,
+        "inbox": inbox,
+        "skills": [{
+            "name": s.get("name"), "domain": s.get("domain"), "path": s.get("path"),
+            "provisional": bool(s.get("provisional")), "provenance": s.get("provenance"),
+            "session": s.get("session"), "description": s.get("description") or "",
+            "metric": _safe(lambda s=s: _staging.metric_label(s), ""),
+            "shadows_builtin": _shadows_builtin(s.get("domain"), s.get("name")),
+        } for s in skills],
+    }
+
+
+def _shadows_builtin(domain: Optional[str], name: Optional[str]) -> bool:
+    try:
+        from scilink.skills.loader import _SKILLS_DIR
+        return bool(domain and name and (_SKILLS_DIR / domain / name / f"{name}.md").is_file())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def set_enabled(enabled: bool) -> Dict[str, Any]:
+    loader, *_ = _mods()
+    loader.set_memory_enabled(bool(enabled))
+    return {"enabled": loader.memory_enabled(),
+            "env_override": os.environ.get("SCILINK_MEMORY", "").strip() or None}
+
+
+# ── skills (stage 3) ─────────────────────────────────────────────────
+
+def skill_text(domain: str, name: str) -> str:
+    _, _memory, *_ = _mods()
+    try:
+        return _memory.show_memory(domain, name)
+    except FileNotFoundError as exc:
+        raise MemoryError(404, str(exc)) from exc
+
+
+def skill_edit(domain: str, name: str, content: str) -> Dict[str, Any]:
+    _, _memory, *_ = _mods()
+    try:
+        out = _memory.edit_memory(domain, name, content)
+    except FileNotFoundError as exc:
+        raise MemoryError(404, str(exc)) from exc
+    if out.get("status") != "success":
+        raise MemoryError(400, out.get("message") or "Save failed.")
+    return out
+
+
+def skill_action(domain: str, name: str, action: str) -> Dict[str, Any]:
+    """promote (approve for routing) · demote (suspend) · prune (delete) ·
+    diff (against the shipped built-in, for a fork)."""
+    _, _memory, *_ = _mods()
+    fn = {"promote": _memory.promote_memory, "demote": _memory.demote_memory,
+          "prune": _memory.prune_memory, "diff": _memory.diff_builtin}.get(action)
+    if fn is None:
+        raise MemoryError(400, f"Unknown skill action {action!r}.")
+    try:
+        out = fn(domain, name)
+    except FileNotFoundError as exc:
+        raise MemoryError(404, str(exc)) from exc
+    if isinstance(out, dict) and out.get("status") == "error":
+        raise MemoryError(400, out.get("message") or f"{action} failed.")
+    return out
+
+
+def fork_builtin(domain: str, name: str) -> Dict[str, Any]:
+    _, _memory, *_ = _mods()
+    try:
+        out = _memory.fork_builtin(domain, name)
+    except FileNotFoundError as exc:
+        raise MemoryError(404, str(exc)) from exc
+    if out.get("status") != "success":
+        raise MemoryError(409, out.get("message") or "Fork failed.")
+    return out
+
+
+# ── script bank (stage 1) ────────────────────────────────────────────
+
+_BANK_HIDDEN = {"id", "domain", "script_hash", "working_script"}
+
+
+def bank_record(domain: str, rid: str) -> Dict[str, Any]:
+    _, _, _script_bank, _ = _mods()
+    rec = _script_bank.get_record(domain, rid)
+    if rec is None:
+        raise MemoryError(404, f"No bank record {domain}/{rid}.")
+    fields = {k: v for k, v in rec.items()
+              if k not in _BANK_HIDDEN and v not in (None, "", [], {})}
+    return {"id": rid, "domain": domain, "fields": fields,
+            "script": rec.get("working_script") or ""}
+
+
+def bank_nominate(domain: str, rid: str) -> Dict[str, Any]:
+    _, _, _script_bank, _ = _mods()
+    out = _script_bank.promote_to_staging(domain, rid)
+    if out.get("status") != "success":
+        raise MemoryError(409, out.get("message") or "Nomination failed.")
+    return out
+
+
+def bank_nominate_group(domain: str, ids: List[str], technique: Optional[str]) -> Dict[str, Any]:
+    _, _, _script_bank, _ = _mods()
+    out = _script_bank.promote_group_to_staging(domain, list(ids), technique=technique or None)
+    if out.get("status") != "success":
+        raise MemoryError(409, out.get("message") or "Group nomination failed.")
+    return out
+
+
+def bank_delete(domain: str, rid: str) -> Dict[str, Any]:
+    _, _, _script_bank, _ = _mods()
+    n = _script_bank.remove_records(domain, [rid])
+    if not n:
+        raise MemoryError(404, f"No bank record {domain}/{rid}.")
+    return {"status": "success", "removed": n}
+
+
+# ── review inbox (stage 2) ───────────────────────────────────────────
+
+_STAGED_HIDDEN = {"id", "domain", "technique", "session", "working_script", "script"}
+
+
+def inbox_record(domain: str, sid: str) -> Dict[str, Any]:
+    _, _, _script_bank, _staging = _mods()
+    rec = _staging.get_staged(domain, sid)
+    if rec is None:
+        raise MemoryError(404, f"No staged record {domain}/{sid}.")
+    fields = {k: v for k, v in rec.items()
+              if k not in _STAGED_HIDDEN and v not in (None, "", [], {})}
+    bank_link = None
+    if rec.get("bank_id"):
+        brec = _safe(lambda: _script_bank.get_record(domain, rec["bank_id"]), None)
+        n_succ = ((brec or {}).get("stats") or {}).get("n_successes")
+        bank_link = {"bank_id": rec["bank_id"], "n_successes": n_succ}
+    return {**_inbox_row(rec, _staging), "fields": fields,
+            "script": rec.get("working_script") or rec.get("script") or "",
+            "bank": bank_link}
+
+
+def inbox_discard(domain: str, sid: str) -> Dict[str, Any]:
+    _, _, _, _staging = _mods()
+    n = _staging.remove_staged(domain, [sid])
+    if not n:
+        raise MemoryError(404, f"No staged record {domain}/{sid}.")
+    return {"status": "success", "removed": n}
+
+
+# Technique-match heuristic (ported from the Streamlit panel): does a
+# record's context plausibly belong to a skill, judged on the skill's
+# `technique:` routing tokens? Flags a mismatched upgrade BEFORE the
+# expensive preview call.
+_GENERIC_TECH_TOKENS = {"spectroscopy", "spectrometry", "spectrum", "spectra",
+                        "microscopy", "micro", "imaging", "absorption",
+                        "emission", "analysis", "scattering"}
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _skill_tokens(domain: str, name: str):
+    tech_tokens, all_tokens = set(), set()
+    try:
+        loader, *_ = _mods()
+        meta = (loader.load_skill(name, domain=domain) or {}).get("meta") or {}
+        tech = meta.get("technique") or []
+        if isinstance(tech, str):
+            tech = [tech]
+        for t in tech:
+            tech_tokens |= {w for w in _TOKEN_RE.findall(str(t).lower())
+                            if len(w) >= 3 and w not in _GENERIC_TECH_TOKENS}
+        for s in [name, meta.get("description") or ""]:
+            all_tokens |= {w for w in _TOKEN_RE.findall(str(s).lower()) if len(w) >= 3}
+    except Exception:  # noqa: BLE001
+        pass
+    return tech_tokens, all_tokens | tech_tokens
+
+
+def _record_tokens(rec: Dict[str, Any]) -> set:
+    ctx = rec.get("measurement_context") or {}
+    fields = (list(ctx.values()) if isinstance(ctx, dict) else []) + [
+        rec.get("model"), rec.get("technique"), rec.get("planned_model"),
+        rec.get("final_model_type"), rec.get("analysis_target")]
+    toks: set = set()
+    for v in fields:
+        toks |= {w for w in _TOKEN_RE.findall(str(v or "").lower()) if len(w) >= 3}
+    return toks
+
+
+def _target_matches(recs: List[Dict[str, Any]], domain: str, name: str) -> Optional[bool]:
+    tech_tokens, all_tokens = _skill_tokens(domain, name)
+    votes = []
+    for rec in recs:
+        rt = _record_tokens(rec)
+        if not rt:
+            votes.append(None)
+        elif tech_tokens:
+            votes.append(bool(rt & tech_tokens))
+        elif all_tokens:
+            votes.append(bool(rt & all_tokens) or None)
+        else:
+            votes.append(None)
+    if any(v is True for v in votes):
+        return True
+    if votes and all(v is False for v in votes):
+        return False
+    return None
+
+
+def upgrade_targets(domain: str, ids: List[str]) -> List[Dict[str, Any]]:
+    """Skills the selected records could upgrade — persistent ones in this
+    domain, then built-ins (which fork on upgrade) — each with a
+    true / false / null technique-match verdict, matches first."""
+    loader, _memory, _, _staging = _mods()
+    recs = [r for r in (_staging.get_staged(domain, i) for i in ids) if r]
+    persistent = {s["name"] for s in _safe(lambda: _memory.list_memory(domain=domain), [])}
+    builtin = [n for n in _safe(lambda: loader.list_skills(domain), []) if n not in persistent]
+    out = []
+    for n in sorted(persistent):
+        out.append({"domain": domain, "name": n, "builtin": False,
+                    "match": _target_matches(recs, domain, n)})
+    for n in sorted(builtin):
+        out.append({"domain": domain, "name": n, "builtin": True,
+                    "match": _target_matches(recs, domain, n)})
+    out.sort(key=lambda t: {True: 0, None: 1, False: 2}[t["match"]])
+    return out
+
+
+def upgrade_check(existing: str, proposed: str) -> Dict[str, Any]:
+    """Additivity warnings + unified diff for a (possibly edited) proposal."""
+    from scilink.skills._shared._staging import _regression_warnings
+    diff = "\n".join(difflib.unified_diff(
+        (existing or "").splitlines(), (proposed or "").splitlines(),
+        fromfile="current", tofile="after upgrade", lineterm=""))
+    return {"warnings": list(_regression_warnings(existing or "", proposed or "")),
+            "diff": diff}
+
+
+# ── LLM-backed jobs ──────────────────────────────────────────────────
+
+_jobs: Dict[str, Dict[str, Any]] = {}
+_jobs_lock = threading.Lock()
+
+
+def llm_call_for(agent: Any) -> Callable[[str], str]:
+    """The session's own model as a plain prompt → text callable (the same
+    thing the Streamlit panel and `scilink memory` build)."""
+    model = getattr(agent, "model", None)
+    if model is None or not hasattr(model, "generate_content"):
+        raise MemoryError(400, "This session's agent has no model to distill with.")
+
+    def _call(prompt: str) -> str:
+        r = model.generate_content(contents=[prompt])
+        return r.text if hasattr(r, "text") else str(r)
+    return _call
+
+
+def _start_job(kind: str, fn: Callable[[], Dict[str, Any]], label: str) -> Dict[str, Any]:
+    job_id = uuid.uuid4().hex[:12]
+    job = {"id": job_id, "kind": kind, "label": label, "status": "running",
+           "result": None, "error": None}
+    with _jobs_lock:
+        _jobs[job_id] = job
+
+    def _run():
+        try:
+            res = fn()
+            if isinstance(res, dict) and res.get("status") == "error":
+                job["status"] = "error"
+                job["error"] = res.get("message") or f"{kind} failed."
+                job["result"] = res
+            else:
+                job["status"] = "done"
+                job["result"] = res
+        except Exception as exc:  # noqa: BLE001 - LLM output is untrusted
+            logger.exception(f"memory job {kind} failed")
+            job["status"] = "error"
+            job["error"] = str(exc)
+    threading.Thread(target=_run, name=f"memory-{kind}-{job_id}", daemon=True).start()
+    return {"job_id": job_id, "status": "running", "label": label}
+
+
+def job_status(job_id: str) -> Dict[str, Any]:
+    with _jobs_lock:
+        job = _jobs.get(job_id)
+    if job is None:
+        raise MemoryError(404, f"No memory job {job_id}.")
+    return dict(job)
+
+
+def start_consolidate(domain: str, ids: List[str], label: str,
+                      llm_call: Callable[[str], str]) -> Dict[str, Any]:
+    """Distill the selected records into a NEW provisional skill
+    ``auto_<label>``. The records are relabeled under ``label`` first (the
+    consolidation reads a whole technique group), so other records already
+    carrying that label would be swept in — refused unless selected."""
+    loader, _, _, _staging = _mods()
+    if not loader.memory_enabled():
+        raise MemoryError(400, "Persistent memory is off — turn it on to distill.")
+    norm = normalize_label(label)
+    if not norm:
+        raise MemoryError(400, "Empty skill name.")
+    need = _staging.consolidate_min_n()
+    if len(ids) < need:
+        raise MemoryError(400, f"Needs at least {need} selected records (one example "
+                               "is too idiosyncratic to generalize).")
+    swept = [r["id"] for r in _staging.list_staged(domain)
+             if (r.get("technique") or "") == norm and r.get("id") not in ids]
+    if swept:
+        raise MemoryError(409, f"'{norm}' is also the label of {len(swept)} unselected "
+                               f"record(s) ({', '.join(swept)}) — they would be included. "
+                               "Select them or rename.")
+    for rid in ids:
+        if _staging.get_staged(domain, rid) is None:
+            raise MemoryError(404, f"No staged record {domain}/{rid}.")
+    from scilink.agents.exp_agents.instruct import (
+        SKILL_UPDATE_INSTRUCTIONS, T2_CONSOLIDATION_INSTRUCTIONS)
+
+    def _work():
+        for rid in ids:
+            _staging.relabel_staged(domain, rid, norm)
+        res = _staging.consolidate_technique(
+            domain, norm, llm_call=llm_call,
+            consolidation_template=T2_CONSOLIDATION_INSTRUCTIONS,
+            update_template=SKILL_UPDATE_INSTRUCTIONS)
+        if res.get("status") == "success":
+            res = {**res, "skill_name": f"auto_{norm}", "domain": domain}
+        return res
+    return _start_job("consolidate", _work, f"{len(ids)} → auto_{norm}")
+
+
+def start_propose_upgrade(domain: str, ids: List[str], target_domain: str,
+                          target_name: str, llm_call: Callable[[str], str]) -> Dict[str, Any]:
+    """Build the merged skill for review WITHOUT writing it. A built-in
+    target is previewed against a temporary copy; applying forks it."""
+    loader, _memory, _, _staging = _mods()
+    if not loader.memory_enabled():
+        raise MemoryError(400, "Persistent memory is off — turn it on to distill.")
+    if not ids:
+        raise MemoryError(400, "Select at least one record.")
+    recs = [r for r in (_staging.get_staged(domain, i) for i in ids) if r]
+    if len(recs) != len(ids):
+        raise MemoryError(404, "One or more selected records no longer exist.")
+    persistent = {s["name"] for s in _safe(lambda: _memory.list_memory(domain=target_domain), [])}
+    builtin_target = target_name not in persistent
+    from scilink.agents.exp_agents.instruct import (
+        KNOWLEDGE_TO_SKILL_INSTRUCTIONS, SKILL_UPDATE_INSTRUCTIONS)
+    from scilink.skills.loader import _SKILLS_DIR
+    match = _target_matches(recs, target_domain, target_name)
+
+    def _work():
+        skills_root = None
+        tmp_root = None
+        if builtin_target:
+            src = _SKILLS_DIR / target_domain / target_name / f"{target_name}.md"
+            if not src.is_file():
+                return {"status": "error",
+                        "message": f"No skill {target_domain}/{target_name} (persistent or built-in)."}
+            tmp_root = Path(tempfile.mkdtemp(prefix="scilink_preview_"))
+            (tmp_root / target_domain / target_name).mkdir(parents=True)
+            shutil.copy(src, tmp_root / target_domain / target_name / f"{target_name}.md")
+            skills_root = tmp_root
+        try:
+            prop = _staging.propose_skill_upgrade(
+                domain, list(ids), target_domain=target_domain, target_name=target_name,
+                llm_call=llm_call, fresh_template=KNOWLEDGE_TO_SKILL_INSTRUCTIONS,
+                update_template=SKILL_UPDATE_INSTRUCTIONS, skills_root=skills_root)
+        finally:
+            if tmp_root is not None:
+                shutil.rmtree(tmp_root, ignore_errors=True)
+        if prop.get("status") != "success":
+            return prop
+        check = upgrade_check(prop["existing_content"], prop["proposed_content"])
+        warnings = check["warnings"] + list(prop.get("regression_warnings") or [])
+        if match is False:
+            warnings.append("technique mismatch: the selection's context does not match "
+                            "this skill's routing — confirm this upgrade belongs here")
+        return {
+            "status": "success", "domain": domain, "staged_ids": list(ids),
+            "target_domain": target_domain, "target_name": target_name,
+            "builtin_target": builtin_target,
+            "existing_content": prop["existing_content"],
+            "proposed_content": prop["proposed_content"],
+            "warnings": warnings, "diff": check["diff"],
+        }
+    return _start_job("upgrade", _work, f"{len(ids)} → {target_domain}/{target_name}")
+
+
+def apply_upgrade(domain: str, ids: List[str], target_domain: str, target_name: str,
+                  content: str, fork_first: bool) -> Dict[str, Any]:
+    """Write a reviewed (possibly edited) proposal: fork the built-in first
+    when the target was one, back up the current file, write, consume the
+    records."""
+    _, _memory, _, _staging = _mods()
+    if not (content or "").strip():
+        raise MemoryError(400, "Empty skill content.")
+    if fork_first:
+        out = _memory.fork_builtin(target_domain, target_name)
+        if out.get("status") != "success" and "already forked" not in str(out.get("message")):
+            raise MemoryError(409, out.get("message") or "Fork failed.")
+    res = _staging.apply_skill_upgrade(
+        domain, list(ids), target_domain=target_domain, target_name=target_name,
+        proposed_content=content if content.endswith("\n") else content + "\n")
+    if res.get("status") != "success":
+        raise MemoryError(400, res.get("message") or "Apply failed.")
+    return res

--- a/scilink/server/schemas.py
+++ b/scilink/server/schemas.py
@@ -3,7 +3,7 @@ their endpoints); requests get pydantic validation."""
 
 from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 
@@ -68,3 +68,44 @@ class MCPConnectRequest(BaseModel):
     command: str = ""                   # stdio: "npx -y @scope/server /path"
     url: str = ""                       # sse / http
     headers: Optional[Dict[str, str]] = None
+
+
+# ── persistent memory ────────────────────────────────────────────────
+
+class MemoryEnabledRequest(BaseModel):
+    enabled: bool
+
+
+class MemoryEditRequest(BaseModel):
+    content: str
+
+
+class MemoryIdsRequest(BaseModel):
+    ids: List[str]
+    technique: Optional[str] = None
+
+
+class MemoryConsolidateRequest(BaseModel):
+    ids: List[str]
+    label: str
+    session_id: str                 # the live session whose model distills
+
+
+class MemoryUpgradeRequest(BaseModel):
+    ids: List[str]
+    target_domain: str
+    target_name: str
+    session_id: str
+
+
+class MemoryApplyRequest(BaseModel):
+    ids: List[str]
+    target_domain: str
+    target_name: str
+    content: str
+    fork_builtin: bool = False
+
+
+class MemoryCheckRequest(BaseModel):
+    existing: str
+    proposed: str

--- a/tests/test_web_memory.py
+++ b/tests/test_web_memory.py
@@ -1,0 +1,289 @@
+"""The web UI's persistent-memory endpoints (scilink/server/memory_api.py)
+over a seeded store: the switch, the pipeline overview, bank / inbox /
+skill records and actions, the technique-match target ordering, the
+LLM-backed consolidate and upgrade jobs (fake model), the apply path
+that forks a built-in, and the additivity check."""
+import json
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from scilink.server.app import create_app  # noqa: E402
+
+
+SKILL_JSON = {
+    "description": "Distilled Raman D/G fitting rules",
+    "overview": "Two-Voigt D/G model on a linear baseline.",
+    "planning": "Seed peaks from the local maxima near 1350 and 1580.",
+    "implementation": "Fit with lmfit VoigtModel x2 + LinearModel.",
+    "interpretation": "Report the D/G area ratio.",
+    "validation": "R² above 0.98 and residual without structure.",
+}
+
+
+class _FakeModel:
+    """Returns the canned skill JSON for any prompt (the graduation flow
+    parses a JSON object with description + canonical sections)."""
+    def __init__(self):
+        self.prompts = []
+
+    def generate_content(self, contents):
+        self.prompts.append(contents[0])
+        return SimpleNamespace(text=json.dumps(SKILL_JSON))
+
+
+@pytest.fixture
+def mem_client(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("SCILINK_HOME", str(home))
+    monkeypatch.delenv("SCILINK_MEMORY", raising=False)
+    monkeypatch.setenv("SCILINK_CONSOLIDATE_N", "2")  # two records suffice in tests
+    client = TestClient(create_app(tmp_path / "sessions", serve_frontend=False))
+    return client
+
+
+def _seed(tmp_path):
+    """The Streamlit panel test's full-pipeline seed: one banked script
+    proven across three sessions and nominated, an error lesson and a
+    feedback record in the same technique group, a provisional skill."""
+    from scilink.skills._shared import _script_bank as sb, _staging
+    from scilink.skills.loader import graduated_skills_dir
+
+    rid = sb.add_record("curve_fitting", {
+        "working_script": "# hot win\nimport numpy as np\n",
+        "data_fingerprint": {"kind": "curve"},
+        "measurement_context": {"technique": "Raman"},
+        "technique_signals": {"model_type": "two voigt"},
+        "outcome": {"metric": {"name": "r_squared", "value": 0.99}},
+        "provenance": {"session": "s1"}})["id"]
+    for s in ("s2", "s3"):
+        sb.record_success("curve_fitting", rid, session=s)
+    out = sb.promote_to_staging("curve_fitting", rid, technique="raman_dg",
+                                provenance="t2_hot_win",
+                                extra={"deviation_from_plan": "switched model"})
+    e = _staging.stage_solution("curve_fitting", "raman_dg", {
+        "provenance": "error_fix", "model": "m",
+        "error_lessons": [{"error": "SNIP no converge", "fix": "fixed iter"}],
+        "session": "s1"})
+    f = _staging.stage_solution("curve_fitting", "raman_dg", {
+        "provenance": "user_correction", "model": "m",
+        "user_feedback": "always report baseline fraction", "session": "s1"})
+    # a second, unnominated bank record so the bank has a plain row too
+    rid2 = sb.add_record("curve_fitting", {
+        "working_script": "# plain\nprint(1)\n",
+        "data_fingerprint": {"kind": "curve"},
+        "technique_signals": {"model_type": "gaussian"},
+        "outcome": {"metric": {"name": "r_squared", "value": 0.9}},
+        "provenance": {"session": "s9"}})["id"]
+    d = graduated_skills_dir() / "curve_fitting" / "myskill"
+    d.mkdir(parents=True)
+    (d / "myskill.md").write_text(
+        "---\ndescription: My provisional skill\nprovisional: true\n---\n"
+        "## overview\n\nskill body\n")
+    return {"bank": rid, "bank2": rid2, "staged": out["staged_id"], "err": e, "fb": f}
+
+
+def _session(client, tmp_path):
+    from scilink.server.session_manager import WebSession
+    sdir = tmp_path / "sessions" / "meta_session_20260101_090909"
+    sdir.mkdir(parents=True, exist_ok=True)
+    agent = SimpleNamespace(model=_FakeModel())
+    session = WebSession(id=sdir.name, session_dir=str(sdir), mode="meta",
+                         model="fake", autonomy="autopilot", agent=agent)
+    client.app.state.manager._sessions[sdir.name] = session
+    return session
+
+
+def _wait_job(client, job_id, timeout=20):
+    for _ in range(int(timeout * 20)):
+        j = client.get(f"/api/v1/memory/jobs/{job_id}").json()
+        if j["status"] != "running":
+            return j
+        time.sleep(0.05)
+    raise AssertionError("job did not finish")
+
+
+def test_memory_overview_switch_and_records(mem_client, tmp_path):
+    ids = _seed(tmp_path)
+    c = mem_client
+    ov = c.get("/api/v1/memory").json()
+    assert ov["enabled"] is False and ov["env_override"] is None
+    assert ov["pipeline"] == {"bank_total": 2, "bank_proven": 1, "inbox_total": 3,
+                              "inbox_ready": 1, "skills_total": 1, "skills_provisional": 1}
+    bank = {d["domain"]: d for d in ov["bank"]}["curve_fitting"]
+    rows = {r["id"]: r for r in bank["records"]}
+    assert rows[ids["bank"]]["proven"] and rows[ids["bank"]]["n_successes"] == 3
+    assert rows[ids["bank"]]["promoted_to_staging"] == ids["staged"]
+    assert rows[ids["bank2"]]["proven"] is False and rows[ids["bank2"]]["promoted_to_staging"] is None
+    (group,) = ov["inbox"]
+    assert (group["domain"], group["technique"], group["ready"]) == ("curve_fitting", "raman_dg", True)
+    provs = {r["id"]: r["provenance_label"] for r in group["records"]}
+    assert provs == {ids["staged"]: "solved from scratch (banked)",
+                     ids["err"]: "error fix", ids["fb"]: "your feedback"}
+    (skill,) = ov["skills"]
+    assert skill["name"] == "myskill" and skill["provisional"] is True
+    assert skill["description"] == "My provisional skill" and skill["shadows_builtin"] is False
+
+    # the switch persists to config.json; the env var overrides it
+    assert c.post("/api/v1/memory/enabled", json={"enabled": True}).json()["enabled"] is True
+    assert c.get("/api/v1/memory").json()["enabled"] is True
+    cfg = json.loads((tmp_path / "home" / "config.json").read_text())
+    assert cfg["memory_enabled"] is True
+
+    # bank record + inbox record inspectors
+    b = c.get(f"/api/v1/memory/bank/curve_fitting/{ids['bank']}").json()
+    assert b["script"].startswith("# hot win") and "working_script" not in b["fields"]
+    assert b["fields"]["stats"]["n_successes"] == 3
+    r = c.get(f"/api/v1/memory/inbox/curve_fitting/{ids['staged']}").json()
+    assert r["bank"] == {"bank_id": ids["bank"], "n_successes": 3}
+    assert r["fields"]["deviation_from_plan"] == "switched model"
+    assert c.get("/api/v1/memory/inbox/curve_fitting/nope").status_code == 404
+    assert c.get("/api/v1/memory/bank/curve_fitting/nope").status_code == 404
+
+    # nominate the plain record; a second nomination is refused while staged
+    out = c.post(f"/api/v1/memory/bank/curve_fitting/{ids['bank2']}/nominate").json()
+    assert out["status"] == "success" and out["staged_id"]
+    assert c.post(f"/api/v1/memory/bank/curve_fitting/{ids['bank2']}/nominate").status_code == 409
+    # discard that staged copy → the bank row is nominatable again
+    assert c.delete(f"/api/v1/memory/inbox/curve_fitting/{out['staged_id']}").json()["removed"] == 1
+    ov = c.get("/api/v1/memory").json()
+    row = [r for r in ov["bank"][0]["records"] if r["id"] == ids["bank2"]][0]
+    assert row["promoted_to_staging"] is None
+    # delete the bank record
+    assert c.delete(f"/api/v1/memory/bank/curve_fitting/{ids['bank2']}").json()["removed"] == 1
+    assert c.delete(f"/api/v1/memory/bank/curve_fitting/{ids['bank2']}").status_code == 404
+
+
+def test_memory_skill_lifecycle(mem_client, tmp_path):
+    _seed(tmp_path)
+    c = mem_client
+    base = "/api/v1/memory/skills/curve_fitting/myskill"
+    r = c.get(base)
+    assert r.status_code == 200 and r.headers["content-type"].startswith("text/markdown")
+    assert "provisional: true" in r.text
+    # edit: validated, backed up
+    bad = c.put(base, json={"content": "no headings at all\n"})
+    assert bad.status_code == 400 and "section" in bad.json()["detail"]
+    ok = c.put(base, json={"content": "---\ndescription: edited\nprovisional: true\n---\n## overview\n\nnew body\n"})
+    assert ok.status_code == 200 and Path(ok.json()["backup_path"]).is_file()
+    assert "new body" in c.get(base).text
+    # promote → approved (auto-routable); demote → provisional again
+    assert c.post(f"{base}/promote").json()["promoted"] is True
+    assert c.get("/api/v1/memory").json()["skills"][0]["provisional"] is False
+    assert c.post(f"{base}/demote").json()["provisional"] is True
+    assert c.get("/api/v1/memory").json()["skills"][0]["provisional"] is True
+    assert c.post(f"{base}/bogus").status_code == 400
+    # fork a built-in: shadows it; diff starts identical; prune removes it
+    f = c.post("/api/v1/memory/skills/curve_fitting/raman/fork").json()
+    assert f["status"] == "success" and Path(f["path"]).is_file()
+    assert c.post("/api/v1/memory/skills/curve_fitting/raman/fork").status_code == 409
+    d = c.post("/api/v1/memory/skills/curve_fitting/raman/diff").json()
+    assert d["identical"] is True
+    skills = {s["name"]: s for s in c.get("/api/v1/memory").json()["skills"]}
+    assert skills["raman"]["shadows_builtin"] is True and skills["myskill"]["shadows_builtin"] is False
+    assert c.post("/api/v1/memory/skills/curve_fitting/raman/prune").json()["pruned"] is True
+    assert c.post(f"{base}/prune").json()["pruned"] is True
+    assert c.get(base).status_code == 404
+    assert c.post("/api/v1/memory/skills/curve_fitting/nope/fork").status_code == 404
+
+
+def test_memory_targets_consolidate_and_upgrade_jobs(mem_client, tmp_path):
+    ids = _seed(tmp_path)
+    c = mem_client
+    session = _session(c, tmp_path)
+    c.post("/api/v1/memory/enabled", json={"enabled": True})
+
+    # targets: the persistent skill first (unknown match), built-ins after;
+    # the Raman-context records match the raman skill, not epr
+    t = c.post("/api/v1/memory/inbox/curve_fitting/targets",
+               json={"ids": [ids["staged"]]}).json()["targets"]
+    by = {x["name"]: x for x in t}
+    assert by["myskill"]["builtin"] is False
+    assert by["raman"]["builtin"] is True and by["raman"]["match"] is True
+    assert by["epr"]["match"] is False
+    assert t.index(by["raman"]) < t.index(by["epr"])
+
+    # consolidate guards: memory off, too few records, swept label
+    c.post("/api/v1/memory/enabled", json={"enabled": False})
+    r = c.post("/api/v1/memory/inbox/curve_fitting/consolidate",
+               json={"ids": [ids["staged"], ids["err"]], "label": "raman dg", "session_id": session.id})
+    assert r.status_code == 400 and "off" in r.json()["detail"]
+    c.post("/api/v1/memory/enabled", json={"enabled": True})
+    r = c.post("/api/v1/memory/inbox/curve_fitting/consolidate",
+               json={"ids": [ids["staged"]], "label": "raman dg", "session_id": session.id})
+    assert r.status_code == 400 and "at least" in r.json()["detail"]
+    r = c.post("/api/v1/memory/inbox/curve_fitting/consolidate",
+               json={"ids": [ids["staged"], ids["err"]], "label": "raman dg", "session_id": session.id})
+    assert r.status_code == 409 and ids["fb"] in r.json()["detail"]
+    assert c.post("/api/v1/memory/inbox/curve_fitting/consolidate",
+                  json={"ids": [ids["staged"]], "label": "x", "session_id": "nope"}).status_code == 404
+
+    # upgrade preview against the built-in raman skill (previewed on a temp
+    # copy — nothing written), then apply → forks it and consumes the record
+    r = c.post("/api/v1/memory/inbox/curve_fitting/propose-upgrade",
+               json={"ids": [ids["fb"]], "target_domain": "curve_fitting",
+                     "target_name": "raman", "session_id": session.id})
+    assert r.status_code == 200, r.text
+    job = _wait_job(c, r.json()["job_id"])
+    assert job["status"] == "done", job
+    prop = job["result"]
+    assert prop["builtin_target"] is True and prop["proposed_content"] and prop["diff"]
+    assert "Distilled Raman" in prop["proposed_content"]
+    assert session.agent.model.prompts  # the session's model was used
+    from scilink.skills.loader import graduated_skills_dir
+    assert not (graduated_skills_dir() / "curve_fitting" / "raman").exists()
+    chk = c.post("/api/v1/memory/check-upgrade",
+                 json={"existing": prop["existing_content"], "proposed": prop["proposed_content"]}).json()
+    assert chk["diff"] == prop["diff"] and isinstance(chk["warnings"], list)
+    ap = c.post("/api/v1/memory/inbox/curve_fitting/apply-upgrade",
+                json={"ids": [ids["fb"]], "target_domain": "curve_fitting", "target_name": "raman",
+                      "content": prop["proposed_content"], "fork_builtin": True}).json()
+    assert ap["status"] == "success" and ap["n_consumed"] == 1
+    fork = graduated_skills_dir() / "curve_fitting" / "raman" / "raman.md"
+    assert fork.is_file() and "Distilled Raman" in fork.read_text()
+    assert (fork.parent / "raman.md.bak").is_file()
+
+    # consolidate the two remaining records into a NEW provisional skill
+    r = c.post("/api/v1/memory/inbox/curve_fitting/consolidate",
+               json={"ids": [ids["staged"], ids["err"]], "label": "Raman D/G", "session_id": session.id})
+    assert r.status_code == 200, r.text
+    job = _wait_job(c, r.json()["job_id"])
+    assert job["status"] == "done", job
+    assert job["result"]["skill_name"] == "auto_raman_d_g"
+    ov = c.get("/api/v1/memory").json()
+    assert ov["pipeline"]["inbox_total"] == 0
+    names = {s["name"]: s for s in ov["skills"]}
+    assert names["auto_raman_d_g"]["provisional"] is True
+    assert names["auto_raman_d_g"]["provenance"] == "t2_consolidated"
+    assert c.get("/api/v1/memory/jobs/nope").status_code == 404
+
+
+def test_memory_overview_survives_hostile_records(mem_client, tmp_path):
+    """Markdown/HTML in labels, missing tiers, plain-float metrics, a corrupt
+    bank file, a corrupt and a degenerate staged file must not break the
+    overview (the Streamlit panel's hostile-store test, over the API)."""
+    from scilink.skills._shared import _script_bank as sb, _staging
+    sb.add_record("curve_fitting", {
+        "working_script": "# s", "data_fingerprint": {"kind": "curve"},
+        "measurement_context": {},
+        "technique_signals": {"model_type": "**bold** <script>x</script> `tick`"},
+        "outcome": {"metric": 0.97}, "provenance": {"session": "s"}})
+    sb.add_record("curve_fitting", {
+        "working_script": "# s2", "data_fingerprint": None,
+        "measurement_context": None, "technique_signals": None,
+        "outcome": None, "provenance": {"session": "s"}})
+    (sb._domain_dir("curve_fitting") / "corrupt.json").write_text("{broken")
+    d = _staging.staging_dir() / "curve_fitting"
+    d.mkdir(parents=True)
+    (d / "broken.json").write_text("{not json")
+    (d / "weird.json").write_text(json.dumps({"id": "weird", "domain": "curve_fitting",
+                                              "technique": None, "provenance": 42}))
+    ov = mem_client.get("/api/v1/memory").json()
+    assert ov["pipeline"]["bank_total"] == 2
+    assert [g["technique"] for g in ov["inbox"]] == ["unlabeled"]
+    assert ov["inbox"][0]["records"][0]["provenance_label"] == "42"

--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -166,6 +166,48 @@ export interface TelemetrySnapshot {
   tool_sequence: Record<string, { calls: ToolCall[]; source: string }>;
 }
 
+
+/** Persistent memory (GET /memory and friends — scilink/server/memory_api.py). */
+export interface MemoryBankRow {
+  id: string; label: string; n_successes: number; n_retrievals: number;
+  sessions: string[]; metric: unknown; created_at: string | null;
+  proven: boolean; promoted_to_staging: string | null;
+}
+export interface MemoryVariantGroup {
+  ids: string[]; min_similarity: number | null; suggested_technique: string | null; n_unpromoted: number;
+}
+export interface MemoryInboxRow {
+  id: string; domain: string; technique: string; provenance: string; provenance_label: string;
+  metric: string; session: string | null; bank_id: string | null; model: string | null; has_script: boolean;
+}
+export interface MemoryInboxGroup {
+  domain: string; technique: string; ready: boolean;
+  records: MemoryInboxRow[]; related: MemoryInboxRow[];
+}
+export interface MemorySkill {
+  name: string; domain: string; path: string; provisional: boolean; provenance: string | null;
+  session: string | null; description: string; metric: string; shadows_builtin: boolean;
+}
+export interface MemoryOverview {
+  enabled: boolean; env_override: string | null; home: string;
+  consolidate_min_n: number; proven_n: number;
+  pipeline: { bank_total: number; bank_proven: number; inbox_total: number; inbox_ready: number;
+              skills_total: number; skills_provisional: number };
+  bank: { domain: string; n_proven: number; records: MemoryBankRow[]; variant_groups: MemoryVariantGroup[] }[];
+  inbox: MemoryInboxGroup[];
+  skills: MemorySkill[];
+}
+export interface MemoryBankRecord { id: string; domain: string; fields: Record<string, unknown>; script: string }
+export interface MemoryInboxRecord extends MemoryInboxRow {
+  fields: Record<string, unknown>; script: string; bank: { bank_id: string; n_successes: number | null } | null;
+}
+export interface MemoryTarget { domain: string; name: string; builtin: boolean; match: boolean | null }
+export interface MemoryJob { id: string; kind: string; label: string; status: "running" | "done" | "error"; result: unknown; error: string | null }
+export interface MemoryProposal {
+  status: string; domain: string; staged_ids: string[]; target_domain: string; target_name: string;
+  builtin_target: boolean; existing_content: string; proposed_content: string; warnings: string[]; diff: string;
+}
+
 export interface SessionSnapshot {
   id: string;
   mode: string;
@@ -421,6 +463,57 @@ export const api = {
       catalog: SkillCatalog;
     }>;
   },
+
+  // persistent memory (one store per server host, not per session)
+  memory: () => req<MemoryOverview>("/memory"),
+  setMemoryEnabled: (enabled: boolean) =>
+    req<{ enabled: boolean }>("/memory/enabled", {
+      method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ enabled }) }),
+  memorySkillText: async (domain: string, name: string) => {
+    const r = await fetch(`${BASE}/memory/skills/${encodeURIComponent(domain)}/${encodeURIComponent(name)}`);
+    if (!r.ok) throw new Error((await r.json()).detail ?? r.statusText);
+    return r.text();
+  },
+  memorySkillEdit: (domain: string, name: string, content: string) =>
+    req<{ status: string; backup_path: string }>(
+      `/memory/skills/${encodeURIComponent(domain)}/${encodeURIComponent(name)}`,
+      { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ content }) }),
+  memorySkillAction: (domain: string, name: string, action: "promote" | "demote" | "prune" | "diff" | "fork") =>
+    req<Record<string, unknown>>(
+      `/memory/skills/${encodeURIComponent(domain)}/${encodeURIComponent(name)}/${action}`, { method: "POST" }),
+  memoryBankRecord: (domain: string, id: string) =>
+    req<MemoryBankRecord>(`/memory/bank/${encodeURIComponent(domain)}/${encodeURIComponent(id)}`),
+  memoryBankDelete: (domain: string, id: string) =>
+    req<{ removed: number }>(`/memory/bank/${encodeURIComponent(domain)}/${encodeURIComponent(id)}`, { method: "DELETE" }),
+  memoryBankNominate: (domain: string, id: string) =>
+    req<{ status: string; staged_id: string; technique: string }>(
+      `/memory/bank/${encodeURIComponent(domain)}/${encodeURIComponent(id)}/nominate`, { method: "POST" }),
+  memoryBankNominateGroup: (domain: string, ids: string[], technique: string | null) =>
+    req<{ status: string; staged_ids: string[]; technique: string; ready_to_consolidate?: boolean; n_staged_total?: number }>(
+      `/memory/bank/${encodeURIComponent(domain)}/nominate-group`,
+      { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ ids, technique }) }),
+  memoryInboxRecord: (domain: string, id: string) =>
+    req<MemoryInboxRecord>(`/memory/inbox/${encodeURIComponent(domain)}/${encodeURIComponent(id)}`),
+  memoryInboxDiscard: (domain: string, id: string) =>
+    req<{ removed: number }>(`/memory/inbox/${encodeURIComponent(domain)}/${encodeURIComponent(id)}`, { method: "DELETE" }),
+  memoryTargets: async (domain: string, ids: string[]) =>
+    (await req<{ targets: MemoryTarget[] }>(`/memory/inbox/${encodeURIComponent(domain)}/targets`,
+      { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ ids }) })).targets,
+  memoryConsolidate: (domain: string, ids: string[], label: string, session_id: string) =>
+    req<{ job_id: string; label: string }>(`/memory/inbox/${encodeURIComponent(domain)}/consolidate`,
+      { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ ids, label, session_id }) }),
+  memoryProposeUpgrade: (domain: string, ids: string[], target_domain: string, target_name: string, session_id: string) =>
+    req<{ job_id: string; label: string }>(`/memory/inbox/${encodeURIComponent(domain)}/propose-upgrade`,
+      { method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids, target_domain, target_name, session_id }) }),
+  memoryApplyUpgrade: (domain: string, ids: string[], target_domain: string, target_name: string, content: string, fork_builtin: boolean) =>
+    req<{ status: string; backup_path: string; n_consumed: number }>(`/memory/inbox/${encodeURIComponent(domain)}/apply-upgrade`,
+      { method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids, target_domain, target_name, content, fork_builtin }) }),
+  memoryCheckUpgrade: (existing: string, proposed: string) =>
+    req<{ warnings: string[]; diff: string }>("/memory/check-upgrade",
+      { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ existing, proposed }) }),
+  memoryJob: (id: string) => req<MemoryJob>(`/memory/jobs/${id}`),
 
   tools: (id: string) => req<ToolInventory>(`/sessions/${id}/tools`),
   connectMcp: (

--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -804,3 +804,48 @@ details.card iframe { width: 100%; height: 600px; border: none; background: #fff
 .skill-viewer-body { overflow: auto; padding: 12px 16px; font-size: 13px; }
 .skill-front { white-space: pre-wrap; margin: 0 0 12px; padding: 8px 10px; border-left: 3px solid var(--border-strong); background: var(--bg-panel); border-radius: 4px; font-family: inherit; }
 
+/* ── Persistent memory (Skills tab) ─────────────────────────────── */
+.mem-panel h4 { font-size: 14px; margin: 18px 0 4px; }
+.mem-switch { display: flex; align-items: center; gap: 8px; margin: 8px 0; font-size: 13px; flex-wrap: wrap; }
+.mem-info { padding: 8px 10px; border-left: 3px solid var(--border-strong); background: var(--bg-panel); border-radius: 4px; }
+.mem-pipeline { font-size: 13px; margin: 8px 0 4px; color: var(--text); }
+.mem-notice { display: flex; align-items: center; gap: 8px; font-size: 13px; padding: 6px 10px; border-radius: 6px; border: 1px solid var(--border); margin: 8px 0; }
+.mem-notice.ok { border-color: #3fb95055; color: #3fb950; }
+.mem-notice.warn { border-color: #d2992255; color: #d29922; }
+.mem-stage { margin-top: 6px; padding-top: 6px; border-top: 1px solid var(--border); }
+.mem-subhead { font-size: 13px; font-weight: 600; margin: 10px 0 4px; }
+.mem-group { margin: 6px 0; padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px; }
+.mem-group > summary { cursor: pointer; display: flex; align-items: baseline; gap: 8px; font-size: 13px; flex-wrap: wrap; }
+.mem-card { margin: 8px 0; padding: 8px 10px; border: 1px dashed var(--border-strong); border-radius: 6px; font-size: 13px; }
+.mem-row { padding: 6px 0 6px 6px; border-top: 1px solid var(--border); font-size: 13px; }
+.mem-row.related { opacity: 0.85; padding-left: 14px; }
+.mem-row-main { display: flex; flex-direction: column; gap: 2px; }
+.mem-label { word-break: break-word; }
+.mem-row-actions { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-top: 4px; }
+.mem-row-actions input[type="text"] { max-width: 260px; }
+.mem-check { display: inline-flex; align-items: baseline; gap: 6px; cursor: pointer; }
+.mem-check input { margin: 0; position: relative; top: 1px; }
+.mem-detail { margin: 6px 0 4px; padding: 8px 10px; border: 1px solid var(--border); border-radius: 6px; }
+.mem-fields { margin: 0 0 6px; font-size: 12px; }
+.mem-fields > div { display: grid; grid-template-columns: 140px 1fr; gap: 8px; padding: 2px 0; }
+.mem-fields dt { color: var(--text-dim); }
+.mem-fields dd { margin: 0; word-break: break-word; white-space: pre-wrap; }
+.mem-script { max-height: 400px; }
+.mem-distill { margin-top: 8px; padding: 8px 10px; background: var(--bg-panel); border-radius: 6px; font-size: 13px; }
+.mem-dest { display: flex; gap: 16px; margin: 6px 0; }
+.mem-dest label { display: inline-flex; align-items: center; gap: 6px; cursor: pointer; }
+.mem-job { display: flex; align-items: center; gap: 8px; margin: 8px 0 0; color: #d29922; font-size: 13px; }
+.mem-job .spinner { width: 12px; height: 12px; border: 2px solid #d2992255; border-top-color: #d29922; border-radius: 50%; animation: mem-spin 0.9s linear infinite; }
+@keyframes mem-spin { to { transform: rotate(360deg); } }
+.mem-review { margin-top: 10px; padding: 8px 10px; border: 1px solid var(--border-strong); border-radius: 6px; font-size: 13px; }
+.mem-editor { width: 100%; box-sizing: border-box; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; margin: 6px 0; }
+.mem-diff { margin: 6px 0; padding: 8px 10px; max-height: 360px; overflow: auto; font-size: 12px; background: var(--code-bg); border: 1px solid var(--code-border); border-radius: 4px; white-space: pre; }
+.mem-diff .add { color: #3fb950; }
+.mem-diff .del { color: #f85149; }
+.mem-diff .hunk { color: #58a6ff; }
+.mem-desc { margin: 4px 0; font-size: 13px; }
+.mem-skill .md-body { font-size: 13px; }
+.link-btn.danger { color: var(--danger); }
+.link-btn.armed { font-weight: 600; text-decoration: underline; }
+button.primary.small { padding: 4px 10px; font-size: 13px; width: auto; }
+

--- a/webui/src/components/MemoryPanel.tsx
+++ b/webui/src/components/MemoryPanel.tsx
@@ -1,0 +1,934 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  api,
+  type MemoryBankRecord,
+  type MemoryInboxGroup,
+  type MemoryInboxRecord,
+  type MemoryInboxRow,
+  type MemoryOverview,
+  type MemoryProposal,
+  type MemorySkill,
+  type MemoryTarget,
+} from "../api";
+import { MarkdownBody } from "./MarkdownBody";
+
+/** Persistent memory — the port of the Streamlit memory panel over the
+ * `/api/v1/memory` endpoints. One store per server host (`~/.scilink`),
+ * shared by every session. The pipeline reads top to bottom in the order
+ * knowledge flows:
+ *
+ *   1 · Script bank   every approved analysis banks its working script;
+ *                     proven records (★) can be nominated for review
+ *   2 · Review inbox  nominations, error lessons and your feedback wait
+ *                     here; distill a selection into a NEW skill or into
+ *                     an EXISTING one (one large LLM call, run as a
+ *                     background job and polled)
+ *   3 · Skills        the curated end: provisional skills wait for your
+ *                     approval; approved ones auto-route; a fork of a
+ *                     built-in shadows the shipped copy
+ *
+ * Every destructive action is a two-click confirm (no browser dialogs). */
+
+const PROV_ICON: Record<string, string> = {
+  error_fix: "🐛",
+  user_correction: "💬",
+};
+
+function normalizeLabel(label: string): string {
+  return label.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "").slice(0, 48);
+}
+
+function errText(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/** A button whose first click arms it ("confirm?") and second click acts;
+ * it disarms after three seconds. */
+function ConfirmButton({
+  label,
+  confirmLabel = "confirm?",
+  onConfirm,
+  className = "link-btn danger",
+  disabled,
+  title,
+}: {
+  label: string;
+  confirmLabel?: string;
+  onConfirm: () => void;
+  className?: string;
+  disabled?: boolean;
+  title?: string;
+}) {
+  const [armed, setArmed] = useState(false);
+  useEffect(() => {
+    if (!armed) return;
+    const t = setTimeout(() => setArmed(false), 3000);
+    return () => clearTimeout(t);
+  }, [armed]);
+  return (
+    <button
+      type="button"
+      className={className + (armed ? " armed" : "")}
+      disabled={disabled}
+      title={title}
+      onClick={() => {
+        if (armed) {
+          setArmed(false);
+          onConfirm();
+        } else setArmed(true);
+      }}
+    >
+      {armed ? confirmLabel : label}
+    </button>
+  );
+}
+
+function DiffView({ diff }: { diff: string }) {
+  if (!diff) return <pre className="mem-diff">(no textual change)</pre>;
+  return (
+    <pre className="mem-diff">
+      {diff.split("\n").map((l, i) => (
+        <span
+          key={i}
+          className={
+            l.startsWith("+") && !l.startsWith("+++") ? "add"
+              : l.startsWith("-") && !l.startsWith("---") ? "del"
+              : l.startsWith("@@") ? "hunk" : ""
+          }
+        >
+          {l}
+          {"\n"}
+        </span>
+      ))}
+    </pre>
+  );
+}
+
+function Fields({ fields }: { fields: Record<string, unknown> }) {
+  return (
+    <dl className="mem-fields">
+      {Object.entries(fields).map(([k, v]) => (
+        <div key={k}>
+          <dt>{k.replace(/_/g, " ")}</dt>
+          <dd>{typeof v === "string" ? v : JSON.stringify(v)}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export function MemoryPanel({ sessionId, active }: { sessionId: string; active: boolean }) {
+  const [ov, setOv] = useState<MemoryOverview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<{ kind: "ok" | "warn"; text: string } | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setOv(await api.memory());
+      setError(null);
+    } catch (e) {
+      setError(errText(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (active) void refresh();
+  }, [active, refresh]);
+
+  const notify = useCallback((kind: "ok" | "warn", text: string) => {
+    setNotice({ kind, text });
+  }, []);
+
+  if (error) {
+    return (
+      <section className="tools-section">
+        <h3>Persistent memory</h3>
+        <p className="caption warn">Could not read persistent memory: {error}</p>
+      </section>
+    );
+  }
+  if (!ov) return null;
+  const p = ov.pipeline;
+  const memOn = ov.enabled;
+
+  return (
+    <section className="tools-section mem-panel">
+      <h3>Persistent memory</h3>
+      <p className="caption">
+        Graduated and auto-distilled skills stored under <code>{ov.home}</code> — they
+        survive sessions and upgrades. Provisional skills (auto-distilled from hard problems
+        the agent had to solve from scratch) are held out of auto-routing until you approve them.
+      </p>
+
+      <label className="mem-switch">
+        <input
+          type="checkbox"
+          checked={memOn}
+          disabled={Boolean(ov.env_override)}
+          onChange={async (e) => {
+            try {
+              await api.setMemoryEnabled(e.target.checked);
+              await refresh();
+            } catch (err) {
+              notify("warn", errText(err));
+            }
+          }}
+        />
+        <span>Enable persistent memory</span>
+        <span className="caption">
+          {memOn
+            ? "on: auto-staging + reuse of approved skills"
+            : "off (default): inert — nothing is staged and approved skills are not loaded"}
+        </span>
+      </label>
+      {ov.env_override && (
+        <p className="caption warn">
+          ⚠️ <code>SCILINK_MEMORY={ov.env_override}</code> is set in the server's environment and
+          overrides this switch.
+        </p>
+      )}
+      {!memOn && (
+        <p className="caption mem-info">
+          Persistent memory is <strong>OFF</strong>. Turn it on to capture hard-won solutions, your
+          feedback and error fixes, and to load approved skills into runs. Existing items below are
+          kept and can still be reviewed.
+        </p>
+      )}
+
+      <p className="mem-pipeline">
+        Script bank ({p.bank_total}{p.bank_proven ? `, ★${p.bank_proven} proven` : ""}) →
+        Review inbox ({p.inbox_total}{p.inbox_ready ? `, ${p.inbox_ready} ready to distill` : ""}) →
+        Skills ({p.skills_total}{p.skills_provisional ? `, ${p.skills_provisional} provisional` : ""})
+      </p>
+
+      {notice && (
+        <p className={`mem-notice ${notice.kind}`}>
+          {notice.text}
+          <button type="button" className="icon-btn" title="Dismiss" onClick={() => setNotice(null)}>
+            ✕
+          </button>
+        </p>
+      )}
+
+      <BankSection ov={ov} onChange={refresh} notify={notify} />
+      <InboxSection ov={ov} sessionId={sessionId} onChange={refresh} notify={notify} />
+      <SkillsSection ov={ov} onChange={refresh} notify={notify} />
+    </section>
+  );
+}
+
+/* ── 1 · script bank ─────────────────────────────────────────────── */
+
+function BankSection({
+  ov,
+  onChange,
+  notify,
+}: {
+  ov: MemoryOverview;
+  onChange: () => Promise<void>;
+  notify: (k: "ok" | "warn", t: string) => void;
+}) {
+  const [viewing, setViewing] = useState<Record<string, MemoryBankRecord | "loading">>({});
+  const [groupLabels, setGroupLabels] = useState<Record<string, string>>({});
+
+  const toggleView = async (domain: string, id: string) => {
+    const key = `${domain}/${id}`;
+    if (viewing[key]) {
+      setViewing((v) => { const n = { ...v }; delete n[key]; return n; });
+      return;
+    }
+    setViewing((v) => ({ ...v, [key]: "loading" }));
+    try {
+      const rec = await api.memoryBankRecord(domain, id);
+      setViewing((v) => ({ ...v, [key]: rec }));
+    } catch (e) {
+      notify("warn", errText(e));
+      setViewing((v) => { const n = { ...v }; delete n[key]; return n; });
+    }
+  };
+
+  return (
+    <div className="mem-stage">
+      <h4>1 · Script bank <span className="caption">— every success, recorded automatically</span></h4>
+      <p className="caption">
+        Each approved analysis banks its working script with a fingerprint of the data it solved;
+        later runs retrieve the closest match as a starting point. Records that keep succeeding
+        across sessions (★, {ov.proven_n} or more) are evidence-backed skill candidates — nominate one
+        to send it into the review inbox below.
+      </p>
+      {ov.bank.length === 0 && (
+        <p className="caption">No banked scripts yet — they accumulate as analyses succeed.</p>
+      )}
+      {ov.bank.map((d) => (
+        <details key={d.domain} className="mem-group">
+          <summary>
+            <code>{d.domain}</code> — {d.records.length} banked
+            {d.n_proven ? `, ★ ${d.n_proven} proven` : ""}
+          </summary>
+          {d.variant_groups.map((g) => {
+            const gkey = `${d.domain}::${g.ids.join(",")}`;
+            const label = groupLabels[gkey] ?? g.suggested_technique ?? "";
+            return (
+              <div key={gkey} className="mem-card">
+                <div>
+                  💡 <strong>{g.ids.length} records look like the same system</strong>
+                  <span className="caption"> (min pairwise similarity {g.min_similarity}): </span>
+                  {g.ids.map((i) => <code key={i}>{i} </code>)}
+                </div>
+                <p className="caption">
+                  Nominate them together under one technique label so consolidation can distill a
+                  general skill from all variants at once.
+                </p>
+                <div className="mem-row-actions">
+                  <input
+                    type="text"
+                    value={label}
+                    placeholder="technique label"
+                    onChange={(e) => setGroupLabels((m) => ({ ...m, [gkey]: e.target.value }))}
+                  />
+                  <button
+                    type="button"
+                    className="link-btn"
+                    onClick={async () => {
+                      try {
+                        const out = await api.memoryBankNominateGroup(d.domain, g.ids, label || null);
+                        notify("ok", `Staged ${out.staged_ids.length} under [${out.technique}]` +
+                          (out.ready_to_consolidate ? " — ready to consolidate in the review inbox." : "."));
+                        await onChange();
+                      } catch (e) {
+                        notify("warn", errText(e));
+                      }
+                    }}
+                  >
+                    Nominate {g.ids.length} as one technique
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+          {d.records.map((r) => {
+            const key = `${d.domain}/${r.id}`;
+            const v = viewing[key];
+            const metric = r.metric && typeof r.metric === "object" && (r.metric as { value?: unknown }).value != null
+              ? ` · ${(r.metric as { name?: string }).name ?? "metric"}=${String((r.metric as { value?: unknown }).value)}`
+              : typeof r.metric === "number" ? ` · metric=${r.metric}` : "";
+            return (
+              <div key={r.id} className="mem-row">
+                <div className="mem-row-main">
+                  <span className="caption">
+                    id={r.id} · {r.proven ? "★ proven" : `${r.n_successes}/${ov.proven_n} sessions`}
+                    {r.promoted_to_staging ? ` · ✓ in review inbox (${r.promoted_to_staging})` : ""}
+                    {" · "}retrieved {r.n_retrievals}×{metric}
+                  </span>
+                  <div className="mem-label">{r.label}</div>
+                </div>
+                <div className="mem-row-actions">
+                  <button type="button" className="link-btn" onClick={() => void toggleView(d.domain, r.id)}>
+                    {v ? "hide" : "view"}
+                  </button>
+                  <button
+                    type="button"
+                    className="link-btn"
+                    disabled={Boolean(r.promoted_to_staging)}
+                    title={r.promoted_to_staging ? "Already in the review inbox." :
+                      "Sends this script to the review inbox, where it can be distilled into a skill. The bank record is kept."}
+                    onClick={async () => {
+                      try {
+                        const out = await api.memoryBankNominate(d.domain, r.id);
+                        notify("ok", `Staged as ${out.staged_id} [${out.technique}] — review it in the inbox below.`);
+                        await onChange();
+                      } catch (e) {
+                        notify("warn", errText(e));
+                      }
+                    }}
+                  >
+                    nominate for review
+                  </button>
+                  <ConfirmButton
+                    label="delete"
+                    onConfirm={async () => {
+                      try {
+                        await api.memoryBankDelete(d.domain, r.id);
+                        await onChange();
+                      } catch (e) {
+                        notify("warn", errText(e));
+                      }
+                    }}
+                  />
+                </div>
+                {v === "loading" && <p className="caption">loading…</p>}
+                {v && v !== "loading" && (
+                  <div className="mem-detail">
+                    <Fields fields={v.fields} />
+                    {v.script && (
+                      <>
+                        <div className="caption">working script:</div>
+                        <pre className="tel-json mem-script">{v.script}</pre>
+                      </>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </details>
+      ))}
+    </div>
+  );
+}
+
+/* ── 2 · review inbox ────────────────────────────────────────────── */
+
+function recordLabel(r: MemoryInboxRow, groupTechnique: string): string {
+  let s = `${PROV_ICON[r.provenance] ?? "📜"} ${r.id} · ${r.provenance_label}`;
+  if (r.metric) s += ` · ${r.metric}`;
+  if (r.technique !== groupTechnique) s += ` (from ${r.technique})`;
+  if (r.session) s += ` · ${r.session}`;
+  return s;
+}
+
+function InboxSection({
+  ov,
+  sessionId,
+  onChange,
+  notify,
+}: {
+  ov: MemoryOverview;
+  sessionId: string;
+  onChange: () => Promise<void>;
+  notify: (k: "ok" | "warn", t: string) => void;
+}) {
+  return (
+    <div className="mem-stage">
+      <h4>2 · Review inbox <span className="caption">— lessons awaiting your call</span></h4>
+      <p className="caption">
+        Three knowledge streams converge here: 📜 script nominations, 🐛 error lessons, 💬 your
+        feedback. Select records and distill them into a <strong>new</strong> skill or into an{" "}
+        <strong>existing</strong> one — either way they merge in one pass: method + pitfalls + your
+        constraints.
+      </p>
+      {ov.inbox.length === 0 && <p className="caption">No staged records.</p>}
+      {ov.inbox.map((g) => (
+        <InboxGroup
+          key={`${g.domain}/${g.technique}`}
+          group={g}
+          ov={ov}
+          sessionId={sessionId}
+          onChange={onChange}
+          notify={notify}
+        />
+      ))}
+    </div>
+  );
+}
+
+function InboxGroup({
+  group: g,
+  ov,
+  sessionId,
+  onChange,
+  notify,
+}: {
+  group: MemoryInboxGroup;
+  ov: MemoryOverview;
+  sessionId: string;
+  onChange: () => Promise<void>;
+  notify: (k: "ok" | "warn", t: string) => void;
+}) {
+  const pool = useMemo(() => [...g.records, ...g.related], [g]);
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(g.records.map((r) => r.id)));
+  const [inspect, setInspect] = useState<Record<string, MemoryInboxRecord | "loading">>({});
+  const [dest, setDest] = useState<"new" | "existing">("new");
+  const [label, setLabel] = useState(g.technique);
+  const [targets, setTargets] = useState<MemoryTarget[] | null>(null);
+  const [target, setTarget] = useState<string>("");
+  const [job, setJob] = useState<{ id: string; label: string; started: number; kind: "consolidate" | "upgrade" } | null>(null);
+  const [proposal, setProposal] = useState<MemoryProposal | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [edited, setEdited] = useState("");
+  const [check, setCheck] = useState<{ warnings: string[]; diff: string } | null>(null);
+  const checkTimer = useRef<number | null>(null);
+  const [, setTick] = useState(0);
+
+  // Records may change under us (a nomination, a discard): keep the
+  // selection to what still exists, default-select the group's own rows.
+  useEffect(() => {
+    setSelected((s) => {
+      const ids = new Set(pool.map((r) => r.id));
+      const next = new Set([...s].filter((i) => ids.has(i)));
+      for (const r of g.records) if (!s.size || !next.size) next.add(r.id);
+      return next;
+    });
+  }, [pool, g.records]);
+
+  const selectedIds = useMemo(() => pool.filter((r) => selected.has(r.id)).map((r) => r.id), [pool, selected]);
+  const need = ov.consolidate_min_n;
+  const memOn = ov.enabled;
+
+  // targets for "an existing skill": fetched when that destination is
+  // chosen and re-fetched when the selection changes (the match verdict
+  // depends on which records are selected)
+  useEffect(() => {
+    if (dest !== "existing") return;
+    let cancelled = false;
+    api.memoryTargets(g.domain, selectedIds).then((t) => {
+      if (cancelled) return;
+      setTargets(t);
+      setTarget((cur) => (t.some((x) => x.name === cur) ? cur : (t[0]?.name ?? "")));
+    }).catch((e) => notify("warn", errText(e)));
+    return () => { cancelled = true; };
+  }, [dest, g.domain, selectedIds, notify]);
+
+  // poll a running job
+  useEffect(() => {
+    if (!job) return;
+    const t = setInterval(async () => {
+      setTick((n) => n + 1);
+      try {
+        const j = await api.memoryJob(job.id);
+        if (j.status === "running") return;
+        setJob(null);
+        if (j.status === "error") {
+          notify("warn", job.kind === "consolidate"
+            ? `Consolidation failed — no skill was written; the records are unchanged. Try again. (${j.error})`
+            : `Could not build the upgrade — nothing was written. Try again. (${j.error})`);
+          return;
+        }
+        if (job.kind === "consolidate") {
+          const r = j.result as { n_examples?: number; skill_name?: string };
+          notify("ok", `Consolidated ${r.n_examples ?? ""} → ${r.skill_name} (provisional — approve it in Skills below).`);
+          await onChange();
+        } else {
+          const prop = j.result as MemoryProposal;
+          setProposal(prop);
+          setEdited(prop.proposed_content);
+          setCheck({ warnings: prop.warnings, diff: prop.diff });
+          setEditing(false);
+        }
+      } catch (e) {
+        setJob(null);
+        notify("warn", errText(e));
+      }
+    }, 2000);
+    return () => clearInterval(t);
+  }, [job, notify, onChange]);
+
+  // re-check an edited proposal (debounced)
+  useEffect(() => {
+    if (!proposal || !editing) return;
+    if (checkTimer.current) window.clearTimeout(checkTimer.current);
+    checkTimer.current = window.setTimeout(async () => {
+      try {
+        setCheck(await api.memoryCheckUpgrade(proposal.existing_content, edited));
+      } catch { /* keep the last check */ }
+    }, 600);
+    return () => { if (checkTimer.current) window.clearTimeout(checkTimer.current); };
+  }, [edited, editing, proposal]);
+
+  const toggleInspect = async (id: string) => {
+    if (inspect[id]) {
+      setInspect((m) => { const n = { ...m }; delete n[id]; return n; });
+      return;
+    }
+    setInspect((m) => ({ ...m, [id]: "loading" }));
+    try {
+      const rec = await api.memoryInboxRecord(g.domain, id);
+      setInspect((m) => ({ ...m, [id]: rec }));
+    } catch (e) {
+      notify("warn", errText(e));
+      setInspect((m) => { const n = { ...m }; delete n[id]; return n; });
+    }
+  };
+
+  const norm = normalizeLabel(label);
+  const swept = ov.inbox
+    .filter((x) => x.domain === g.domain && x.technique === norm)
+    .flatMap((x) => x.records.map((r) => r.id))
+    .filter((id) => !selected.has(id));
+  const canConsolidate = memOn && selectedIds.length >= need && Boolean(norm) && swept.length === 0 && !job;
+  const tgt = targets?.find((t) => t.name === target) ?? null;
+  const elapsed = job ? Math.round((Date.now() - job.started) / 1000) : 0;
+
+  return (
+    <details className="mem-group">
+      <summary>
+        <code>{g.domain}/{g.technique}</code> — {g.records.length} staged
+        {g.ready && <span className="tel-status status-success">ready to distill</span>}
+      </summary>
+
+      {pool.map((r) => {
+        const ins = inspect[r.id];
+        return (
+          <div key={r.id} className={`mem-row${r.technique !== g.technique ? " related" : ""}`}>
+            <div className="mem-row-main">
+              <label className="mem-check">
+                <input
+                  type="checkbox"
+                  checked={selected.has(r.id)}
+                  onChange={(e) => setSelected((s) => {
+                    const n = new Set(s);
+                    if (e.target.checked) n.add(r.id); else n.delete(r.id);
+                    return n;
+                  })}
+                />
+                <span>{recordLabel(r, g.technique)}</span>
+              </label>
+            </div>
+            <div className="mem-row-actions">
+              <button type="button" className="link-btn" onClick={() => void toggleInspect(r.id)}>
+                {ins ? "hide" : "inspect"}
+              </button>
+              <ConfirmButton
+                label="discard"
+                title="Remove from the review inbox without distilling it. A nominated bank record becomes nominatable again."
+                onConfirm={async () => {
+                  try {
+                    await api.memoryInboxDiscard(g.domain, r.id);
+                    notify("warn", `De-staged ${r.id}.`);
+                    await onChange();
+                  } catch (e) {
+                    notify("warn", errText(e));
+                  }
+                }}
+              />
+            </div>
+            {ins === "loading" && <p className="caption">loading…</p>}
+            {ins && ins !== "loading" && (
+              <div className="mem-detail">
+                {ins.bank && (
+                  <p className="caption">
+                    from bank <code>{ins.bank.bank_id}</code>
+                    {ins.bank.n_successes && ins.bank.n_successes > 1
+                      ? ` (succeeded in ${ins.bank.n_successes} sessions)` : ""}
+                  </p>
+                )}
+                <Fields fields={ins.fields} />
+                {ins.script && (
+                  <>
+                    <div className="caption">working script:</div>
+                    <pre className="tel-json mem-script">{ins.script}</pre>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      <div className="mem-distill">
+        <strong>Distill</strong>
+        <span className="caption"> {selectedIds.length} selected</span>
+        <div className="mem-dest">
+          <label><input type="radio" checked={dest === "new"} onChange={() => setDest("new")} /> a new skill</label>
+          <label><input type="radio" checked={dest === "existing"} onChange={() => setDest("existing")} /> an existing skill</label>
+        </div>
+        {!memOn && <p className="caption warn">Persistent memory is off — turn it on to distill.</p>}
+
+        {dest === "new" ? (
+          <div className="mem-row-actions">
+            <input type="text" value={label} placeholder="new skill name" onChange={(e) => setLabel(e.target.value)} />
+            <button
+              type="button"
+              className="primary small"
+              disabled={!canConsolidate}
+              title={canConsolidate ? "One large model call — typically 1–3 minutes."
+                : selectedIds.length < need ? `Needs at least ${need} selected records (one example is too idiosyncratic to generalize).`
+                : undefined}
+              onClick={async () => {
+                try {
+                  const j = await api.memoryConsolidate(g.domain, selectedIds, label, sessionId);
+                  setJob({ id: j.job_id, label: j.label, started: Date.now(), kind: "consolidate" });
+                } catch (e) {
+                  notify("warn", errText(e));
+                }
+              }}
+            >
+              Consolidate {selectedIds.length} → auto_{norm || "…"}
+            </button>
+          </div>
+        ) : (
+          <div className="mem-row-actions">
+            {targets === null ? (
+              <span className="caption">loading targets…</span>
+            ) : targets.length === 0 ? (
+              <span className="caption">No skills in this domain to upgrade.</span>
+            ) : (
+              <select value={target} onChange={(e) => setTarget(e.target.value)}>
+                {targets.map((t) => (
+                  <option key={t.name} value={t.name}>
+                    {t.match === true ? "✓ " : t.match === false ? "⚠ " : "· "}
+                    {t.domain}/{t.name}{t.builtin ? " (built-in — forks on upgrade)" : ""}
+                  </option>
+                ))}
+              </select>
+            )}
+            <button
+              type="button"
+              className="primary small"
+              disabled={!memOn || !selectedIds.length || !tgt || Boolean(job)}
+              title={memOn ? "Builds the merged skill for review — one large model call, typically 1–3 min. Writes nothing."
+                : "Persistent memory is off."}
+              onClick={async () => {
+                if (!tgt) return;
+                try {
+                  const j = await api.memoryProposeUpgrade(g.domain, selectedIds, tgt.domain, tgt.name, sessionId);
+                  setJob({ id: j.job_id, label: j.label, started: Date.now(), kind: "upgrade" });
+                } catch (e) {
+                  notify("warn", errText(e));
+                }
+              }}
+            >
+              Preview upgrade ({selectedIds.length} → {tgt?.name ?? "…"})
+            </button>
+          </div>
+        )}
+        {dest === "new" && swept.length > 0 && (
+          <p className="caption warn">
+            <code>{norm}</code> is also the label of {swept.length} unselected record(s) — they would be
+            included. Select them or rename.
+          </p>
+        )}
+        {dest === "existing" && tgt?.match === false && (
+          <p className="caption warn">
+            ⚠️ Technique mismatch: the selection doesn't match <code>{tgt.name}</code>'s technique
+            routing — upgrading would pollute an unrelated skill.
+          </p>
+        )}
+        {job && (
+          <p className="mem-job">
+            <span className="spinner" /> {job.kind === "consolidate" ? "Distilling" : "Building the merged skill for review"}{" "}
+            {job.label} — typically 1–3 min, {elapsed}s so far. You can keep working; this box updates on its own.
+          </p>
+        )}
+      </div>
+
+      {proposal && (
+        <div className="mem-review">
+          <strong>
+            Review upgrade → <code>{proposal.target_domain}/{proposal.target_name}</code>
+          </strong>
+          <span className="caption">
+            {" "}— applies in place; the current version is backed up to <code>.md.bak</code>
+            {proposal.builtin_target ? "; the built-in is forked into the store first" : ""}.
+          </span>
+          <label className="mem-check">
+            <input type="checkbox" checked={editing} onChange={(e) => setEditing(e.target.checked)} />
+            <span>Edit proposal before applying</span>
+          </label>
+          {editing && (
+            <textarea className="mem-editor" value={edited} onChange={(e) => setEdited(e.target.value)} rows={18} />
+          )}
+          {(check?.warnings ?? []).map((w, i) => (
+            <p key={i} className="caption warn">Additivity check: {w}</p>
+          ))}
+          <DiffView diff={check?.diff ?? proposal.diff} />
+          <div className="mem-row-actions">
+            <button
+              type="button"
+              className="primary small"
+              onClick={async () => {
+                try {
+                  await api.memoryApplyUpgrade(g.domain, proposal.staged_ids, proposal.target_domain,
+                    proposal.target_name, editing ? edited : proposal.proposed_content, proposal.builtin_target);
+                  notify("ok", `Upgraded ${proposal.target_domain}/${proposal.target_name} (backup saved).`);
+                  setProposal(null);
+                  await onChange();
+                } catch (e) {
+                  notify("warn", errText(e));
+                }
+              }}
+            >
+              Apply upgrade
+            </button>
+            <button type="button" className="link-btn" onClick={() => setProposal(null)}>Cancel</button>
+          </div>
+        </div>
+      )}
+    </details>
+  );
+}
+
+/* ── 3 · skills ──────────────────────────────────────────────────── */
+
+function SkillsSection({
+  ov,
+  onChange,
+  notify,
+}: {
+  ov: MemoryOverview;
+  onChange: () => Promise<void>;
+  notify: (k: "ok" | "warn", t: string) => void;
+}) {
+  const provisional = ov.skills.filter((s) => s.provisional);
+  const approved = ov.skills.filter((s) => !s.provisional);
+  return (
+    <div className="mem-stage">
+      <h4>3 · Skills <span className="caption">— curated knowledge that guides planning</span></h4>
+      <p className="caption">
+        The end of the pipeline: reviewed knowledge with planning-layer authority. Approved skills
+        auto-route; provisional ones wait for your call; a fork of a built-in shadows the shipped copy.
+      </p>
+      {provisional.length > 0 && <div className="mem-subhead">Provisional — awaiting review ({provisional.length})</div>}
+      {provisional.map((s) => (
+        <SkillRow key={`${s.domain}/${s.name}`} skill={s} memOn={ov.enabled} onChange={onChange} notify={notify} />
+      ))}
+      {approved.length > 0 && <div className="mem-subhead">Approved for routing ({approved.length})</div>}
+      {approved.map((s) => (
+        <SkillRow key={`${s.domain}/${s.name}`} skill={s} memOn={ov.enabled} onChange={onChange} notify={notify} />
+      ))}
+      {ov.skills.length === 0 && (
+        <p className="caption">No skills yet — they are distilled from the review inbox above.</p>
+      )}
+    </div>
+  );
+}
+
+function SkillRow({
+  skill: s,
+  memOn,
+  onChange,
+  notify,
+}: {
+  skill: MemorySkill;
+  memOn: boolean;
+  onChange: () => Promise<void>;
+  notify: (k: "ok" | "warn", t: string) => void;
+}) {
+  const ref = `${s.domain}/${s.name}`;
+  const [text, setText] = useState<string | null>(null);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [diff, setDiff] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const load = async () => api.memorySkillText(s.domain, s.name);
+  const front = text ? /^---\n([\s\S]*?)\n---\n?/.exec(text) : null;
+
+  return (
+    <details className="mem-group mem-skill">
+      <summary>
+        <span className={`tel-status ${s.provisional ? "status-pending" : "status-success"}`}>
+          {s.provisional ? "provisional" : "approved"}
+        </span>
+        <code>{ref}</code>
+        {s.metric && <span className="caption">{s.metric}</span>}
+        {s.shadows_builtin && <span className="deleg-tag" title="A fork: shadows the shipped built-in of the same name">fork of built-in</span>}
+      </summary>
+      {s.description && <p className="mem-desc"><em>{s.description}</em></p>}
+      {s.provenance && (
+        <p className="caption">provenance: {s.provenance}{s.session ? ` · session: ${s.session}` : ""}</p>
+      )}
+      <div className="mem-row-actions">
+        <button
+          type="button"
+          className="link-btn"
+          onClick={async () => {
+            if (text) { setText(null); return; }
+            try { setText(await load()); } catch (e) { notify("warn", errText(e)); }
+          }}
+        >
+          {text ? "hide" : "view"}
+        </button>
+        <button
+          type="button"
+          className="link-btn"
+          onClick={async () => {
+            if (editing !== null) { setEditing(null); setSaveError(null); return; }
+            try { setEditing(await load()); } catch (e) { notify("warn", errText(e)); }
+          }}
+        >
+          {editing !== null ? "close editor" : "edit"}
+        </button>
+        {s.provisional ? (
+          <button
+            type="button"
+            className="primary small"
+            disabled={!memOn}
+            title={memOn ? "Clears the provisional flag — the skill enters the auto-routing menu."
+              : "Persistent memory is off — approved skills won't load until you turn it on."}
+            onClick={async () => {
+              try {
+                await api.memorySkillAction(s.domain, s.name, "promote");
+                notify("ok", `Approved ${ref} — now auto-routable.`);
+                await onChange();
+              } catch (e) { notify("warn", errText(e)); }
+            }}
+          >
+            Approve for routing
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="link-btn"
+            title="Set back to provisional — taken out of the auto-routing menu (still explicitly loadable) until you approve it again."
+            onClick={async () => {
+              try {
+                await api.memorySkillAction(s.domain, s.name, "demote");
+                notify("warn", `Suspended ${ref} — provisional again.`);
+                await onChange();
+              } catch (e) { notify("warn", errText(e)); }
+            }}
+          >
+            Suspend (provisional)
+          </button>
+        )}
+        {s.shadows_builtin && (
+          <button
+            type="button"
+            className="link-btn"
+            onClick={async () => {
+              if (diff !== null) { setDiff(null); return; }
+              try {
+                const d = await api.memorySkillAction(s.domain, s.name, "diff") as { diff: string; identical: boolean };
+                setDiff(d.identical ? "" : d.diff);
+              } catch (e) { notify("warn", errText(e)); }
+            }}
+          >
+            {diff !== null ? "hide diff" : "diff vs built-in"}
+          </button>
+        )}
+        <ConfirmButton
+          label="delete"
+          onConfirm={async () => {
+            try {
+              await api.memorySkillAction(s.domain, s.name, "prune");
+              notify("warn", `Pruned ${ref}.`);
+              await onChange();
+            } catch (e) { notify("warn", errText(e)); }
+          }}
+        />
+      </div>
+      {diff !== null && (diff ? <DiffView diff={diff} /> : <p className="caption">Identical to the shipped built-in.</p>)}
+      {text && (
+        <div className="mem-detail md-body">
+          {front && <pre className="skill-front caption">{front[1].trim()}</pre>}
+          <MarkdownBody text={front ? text.slice(front[0].length) : text} />
+        </div>
+      )}
+      {editing !== null && (
+        <div className="mem-detail">
+          <textarea className="mem-editor" value={editing} onChange={(e) => setEditing(e.target.value)} rows={18} />
+          {saveError && <p className="caption warn">{saveError}</p>}
+          <div className="mem-row-actions">
+            <button
+              type="button"
+              className="primary small"
+              title="Validates frontmatter/sections; the previous version is backed up to .md.bak."
+              onClick={async () => {
+                try {
+                  await api.memorySkillEdit(s.domain, s.name, editing);
+                  notify("ok", `Saved ${ref} (backup: .md.bak).`);
+                  setEditing(null);
+                  setSaveError(null);
+                  setText(null);
+                  await onChange();
+                } catch (e) { setSaveError(errText(e)); }
+              }}
+            >
+              Save changes
+            </button>
+          </div>
+        </div>
+      )}
+    </details>
+  );
+}

--- a/webui/src/components/SkillsPanel.tsx
+++ b/webui/src/components/SkillsPanel.tsx
@@ -2,11 +2,11 @@ import { useCallback, useEffect, useState } from "react";
 import { api, type SkillCatalog } from "../api";
 import { Dropzone } from "./Dropzone";
 import { MarkdownBody } from "./MarkdownBody";
+import { MemoryPanel } from "./MemoryPanel";
 
 /** Skills tab — upload custom skills for this session and browse the
  * catalog (built-in bundles by domain, plus what you uploaded), with a
- * markdown viewer. Persistent memory (graduated / auto-distilled skills
- * under ~/.scilink) is a separate surface, not this panel. */
+ * markdown viewer, then the persistent-memory pipeline (MemoryPanel). */
 
 export function SkillsPanel({
   sessionId,
@@ -145,6 +145,8 @@ export function SkillsPanel({
           );
         })}
       </section>
+
+      <MemoryPanel sessionId={sessionId} active={active} />
 
       {viewing && (
         <div className="skill-viewer" role="dialog" aria-label={viewing.title}>


### PR DESCRIPTION
## Summary

The web UI's Skills tab now carries the **persistent memory** panel that the Streamlit app had: the knowledge SciLink accumulates across sessions under `~/.scilink`, in the order it flows.

1. **Script bank** — every approved analysis banks its working script. Records that keep succeeding across sessions are marked proven; you can inspect any record (its fields and the script), nominate one for review, nominate a group of same-system variants under one technique label, or delete it.
2. **Review inbox** — nominated scripts, error lessons and your own feedback wait here, grouped by technique. Inspect a record, discard it, or select records and distill them: into a **new** skill, or into an **existing** one where you review the proposed merge as a diff, optionally edit it, and apply with a backup. Distillation is one large model call (1–3 min) and runs in the background while you keep working.
3. **Skills** — provisional skills wait for your approval; approved ones auto-route. View, edit (validated, backed up), approve or suspend, delete, and for a fork of a built-in skill, diff it against the shipped version.

The on/off switch is here too, persisted to the store; the panel says so when the `SCILINK_MEMORY` environment variable overrides it.

## Technical description

- `scilink/server/memory_api.py` (new): plain functions over the existing backend (`scilink.skills._shared._memory` / `_staging` / `_script_bank`, the same one `scilink memory` and the Streamlit panel use). `memory_overview()` returns everything the panel shows in one call (switch + env override, pipeline counts, bank by domain with `find_variant_groups` suggestions, inbox by domain/technique with same-session *related* records from other labels, skills with a `shadows_builtin` flag) and never raises for a hostile or corrupt record. The technique-match heuristic (`_skill_tokens` / `_record_tokens`) is ported from the Streamlit panel to order upgrade targets and flag mismatches before the expensive call. The two LLM operations run as background jobs (`_start_job`, polled via `/memory/jobs/{id}`) using the named session's model (`session.agent.model.generate_content`), because a web request cannot block for minutes the way the Streamlit spinner did; a built-in target is previewed on a temporary copy and forked only on apply. Guards: memory off, fewer than `consolidate_min_n` records, a label that would sweep in unselected records (409 naming them), unknown records / session.
- `app.py`: endpoints under `/api/v1/memory` (see the table in `docs/react_web_ui.md`); `MemoryError(status, message)` → `HTTPException`. One store per server host, shared by every session and every user of a multi-user server.
- `webui/src/components/MemoryPanel.tsx` (new), mounted under the catalog in `SkillsPanel`: the switch, pipeline strip, three stages with lazy record inspectors, the distill flow (selection incl. related records, new/existing destination, swept-label guard computed client-side, target select with ✓/⚠ badges, job progress, diff review with optional editing and a debounced re-check of additivity warnings, apply/cancel), and skill rows. Destructive actions are two-click confirms — no browser dialogs. `api.ts`: types + calls.

### Tests

`tests/test_web_memory.py` (new, 4 tests) over the Streamlit panel's full-pipeline seed with a fake model: overview counts and rows, the switch (persisted; env override reported), inspectors, nominate → 409 on repeat → discard → nominatable again → delete, the skill lifecycle (invalid edit 400, valid edit + backup, promote, demote, fork a built-in → diff identical → prune), target ordering and match verdicts, consolidate guards, the upgrade job against a built-in with apply → fork + backup + consumed record, the consolidate job → `auto_<label>` provisional with `t2_consolidated` provenance, and a hostile/corrupt store. Web + memory suites: 119 pass. Full suite compared against main: no new failures (the 22 that differ are order-dependent live-test skips that pass in isolation on both branches).

### Live check (Bedrock, Opus 4.8)

On a seeded scratch store (two domains, a proven record, a 4-record variant group, three inbox streams plus a related same-session lesson, a hostile label, a corrupt file, a modified fork of the built-in `raman` skill), through the browser: switch persisted to `config.json`; bank inspector; group nomination staged 3 variants under one label; inbox inspector with its bank link; swept-label warning disabling consolidation until renamed; two-click discard; fork diff; invalid edit rejected, valid edit saved with backup; approve; suspend. Then with the real model: **consolidate** 4 records (a banked hot win, an error lesson, the user's feedback, and the related SNIP lesson pulled in from another label) → `auto_raman_dg` rewritten with `n_examples: 4`, every lesson present in the right section (clip window before fitting, area not height ratio, FWHM flag, SNIP iterations), backup kept, inbox group consumed; **upgrade** 3 variant records into the approved `voigt_baseline_rules` → preview in seconds, diff reviewed, proposal edited in the panel and the additivity check re-run (a destructive edit is flagged as "24% shorter", an additive one is clean), applied with backup, records consumed, bank rows nominatable again. The CLI (`scilink memory list/staged/status`) reads the same store identically.

### Docs

`react_web_ui.md`: Skills-tab bullet extended with the memory panel, the endpoint table, not-yet-ported list; `react_ui_roadmap.md`: item 6 marks the memory pipeline done.