### PR TITLE
SAM: prefer Apple MPS when CUDA is absent; fall back to CPU explicitly

### DIFF
--- a/scilink/skills/_shared/particle_analyzer.py
+++ b/scilink/skills/_shared/particle_analyzer.py
@@ -260,6 +260,8 @@ class ParticleAnalyzer:
         sam_params = self._SAM_PRESETS.get(preset_name, {})
         logger.info(f"Running SAM with preset: '{preset_name}' on {self.device}")
         generator = SamAutomaticMaskGenerator(self.sam_model, **sam_params)
+        if str(self.device).startswith("mps"):
+            self._mps_float32_coords(generator)
         try:
             return generator.generate(image_rgb)
         except (RuntimeError, NotImplementedError, TypeError) as exc:
@@ -276,6 +278,24 @@ class ParticleAnalyzer:
             self.sam_model.to(device="cpu")
             generator = SamAutomaticMaskGenerator(self.sam_model, **sam_params)
             return generator.generate(image_rgb)
+
+    @staticmethod
+    def _mps_float32_coords(generator) -> None:
+        """MPS has no float64. The automatic mask generator builds its point
+        grids in float64 (numpy) and hands them to ``torch.as_tensor`` on the
+        model's device, which fails on MPS with "Cannot convert a MPS Tensor
+        to float64". Casting the transformed coordinates to float32 is
+        lossless for pixel coordinates and lets the whole generator run on
+        the GPU."""
+        transform = getattr(getattr(generator, "predictor", None), "transform", None)
+        if transform is None or getattr(transform, "_scilink_float32", False):
+            return
+        original = transform.apply_coords
+
+        def apply_coords(coords, original_size, _f=original):
+            return np.asarray(_f(coords, original_size), dtype=np.float32)
+        transform.apply_coords = apply_coords
+        transform._scilink_float32 = True
 
     # ------------------------------------------------------------------
     # Filtering / pruning

--- a/scilink/skills/_shared/particle_analyzer.py
+++ b/scilink/skills/_shared/particle_analyzer.py
@@ -19,6 +19,15 @@ import torch
 logger = logging.getLogger(__name__)
 
 
+def mps_available() -> bool:
+    """Apple-Silicon GPU present and usable by this torch build."""
+    mps = getattr(torch.backends, "mps", None)
+    try:
+        return bool(mps is not None and mps.is_available())
+    except Exception:  # noqa: BLE001 - a torch build without the backend
+        return False
+
+
 class ParticleAnalyzer:
     """
     End-to-end particle segmentation and analysis using the Segment Anything
@@ -73,8 +82,17 @@ class ParticleAnalyzer:
 
     @staticmethod
     def _resolve_device(device: str) -> str:
+        """``auto`` → the best available accelerator: CUDA, else Apple MPS,
+        else CPU. Forcing CPU when an MPS GPU exists made ViT-H mask
+        generation over a large raster take minutes per call on Apple
+        Silicon — long enough for the SAM fallback to time out and the
+        verifier to re-prescribe it every iteration (#567)."""
         if device == "auto":
-            return "cuda" if torch.cuda.is_available() else "cpu"
+            if torch.cuda.is_available():
+                return "cuda"
+            if mps_available():
+                return "mps"
+            return "cpu"
         return device
 
     @classmethod
@@ -103,7 +121,16 @@ class ParticleAnalyzer:
                 "pip install git+https://github.com/facebookresearch/segment-anything.git"
             )
         sam = sam_model_registry[model_type](checkpoint=checkpoint_path)
-        sam.to(device=self.device)
+        try:
+            sam.to(device=self.device)
+        except Exception as exc:  # noqa: BLE001 - an accelerator that cannot host the model
+            if self.device == "cpu":
+                raise
+            logger.warning(
+                f"SAM could not be placed on '{self.device}' ({exc}); falling back to CPU. "
+                "Expect slow mask generation on large images.")
+            self.device = "cpu"
+            sam.to(device="cpu")
         return sam
 
     # ------------------------------------------------------------------
@@ -231,9 +258,24 @@ class ParticleAnalyzer:
         from segment_anything import SamAutomaticMaskGenerator
 
         sam_params = self._SAM_PRESETS.get(preset_name, {})
-        logger.info(f"Running SAM with preset: '{preset_name}'")
+        logger.info(f"Running SAM with preset: '{preset_name}' on {self.device}")
         generator = SamAutomaticMaskGenerator(self.sam_model, **sam_params)
-        return generator.generate(image_rgb)
+        try:
+            return generator.generate(image_rgb)
+        except (RuntimeError, NotImplementedError, TypeError) as exc:
+            # An accelerator backend that cannot run one of SAM's ops (MPS
+            # has had unsupported-op / dtype gaps) fails here, at inference,
+            # not at model placement. Fall back to CPU explicitly — once,
+            # and say so — rather than surfacing a raw backend error.
+            if self.device == "cpu":
+                raise
+            logger.warning(
+                f"SAM inference failed on '{self.device}' ({str(exc)[:200]}); "
+                "retrying on CPU. Expect slow mask generation on large images.")
+            self.device = "cpu"
+            self.sam_model.to(device="cpu")
+            generator = SamAutomaticMaskGenerator(self.sam_model, **sam_params)
+            return generator.generate(image_rgb)
 
     # ------------------------------------------------------------------
     # Filtering / pruning

--- a/tests/test_sam_device.py
+++ b/tests/test_sam_device.py
@@ -104,3 +104,24 @@ def test_inference_failure_on_accelerator_retries_on_cpu(monkeypatch, caplog):
     calls.clear()
     an._run_sam(np.zeros((8, 8, 3), dtype=np.uint8), "default")
     assert calls == ["cpu"]
+
+
+def test_mps_float32_coords_casts_the_generator_points():
+    """MPS has no float64: the generator's point coordinates are cast to
+    float32 on MPS (the live failure was 'Cannot convert a MPS Tensor to
+    float64'), once, and not on other devices."""
+    calls = []
+
+    class _Transform:
+        def apply_coords(self, coords, original_size):
+            calls.append(original_size)
+            return np.asarray(coords, dtype=np.float64) * 2
+
+    gen = SimpleNamespace(predictor=SimpleNamespace(transform=_Transform()))
+    pa.ParticleAnalyzer._mps_float32_coords(gen)
+    out = gen.predictor.transform.apply_coords(np.array([[1.0, 2.0]]), (8, 8))
+    assert out.dtype == np.float32 and out.tolist() == [[2.0, 4.0]] and calls == [(8, 8)]
+    pa.ParticleAnalyzer._mps_float32_coords(gen)  # idempotent: not wrapped twice
+    gen.predictor.transform.apply_coords(np.array([[1.0, 2.0]]), (8, 8))
+    assert len(calls) == 2
+    pa.ParticleAnalyzer._mps_float32_coords(SimpleNamespace())  # no predictor: no-op

--- a/tests/test_sam_device.py
+++ b/tests/test_sam_device.py
@@ -1,0 +1,106 @@
+"""SAM device resolution (#567): ``auto`` prefers CUDA, then Apple MPS, then
+CPU; an accelerator that cannot host or run the model falls back to CPU
+explicitly (with a warning) instead of failing or, worse, silently forcing
+CPU when a GPU exists."""
+import logging
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from scilink.skills._shared import particle_analyzer as pa  # noqa: E402
+
+
+def _fake_backends(monkeypatch, *, cuda: bool, mps):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: cuda)
+    if mps is None:
+        monkeypatch.setattr(torch.backends, "mps", None, raising=False)
+    else:
+        monkeypatch.setattr(torch.backends, "mps",
+                            SimpleNamespace(is_available=lambda: mps), raising=False)
+
+
+@pytest.mark.parametrize("cuda,mps,expected", [
+    (True, True, "cuda"),
+    (False, True, "mps"),
+    (False, False, "cpu"),
+    (False, None, "cpu"),   # a torch build without the MPS backend at all
+])
+def test_auto_prefers_cuda_then_mps_then_cpu(monkeypatch, cuda, mps, expected):
+    _fake_backends(monkeypatch, cuda=cuda, mps=mps)
+    assert pa.ParticleAnalyzer._resolve_device("auto") == expected
+
+
+def test_explicit_device_is_honored(monkeypatch):
+    _fake_backends(monkeypatch, cuda=False, mps=True)
+    assert pa.ParticleAnalyzer._resolve_device("cpu") == "cpu"
+    assert pa.ParticleAnalyzer._resolve_device("cuda:1") == "cuda:1"
+
+
+class _Model:
+    def __init__(self, fail_on=()):
+        self.fail_on = set(fail_on)
+        self.device = None
+
+    def to(self, device):
+        if device in self.fail_on:
+            raise RuntimeError(f"cannot place on {device}")
+        self.device = device
+        return self
+
+
+def _analyzer(monkeypatch, model, device):
+    """A ParticleAnalyzer with the model registry and checkpoint download
+    stubbed out, on the given resolved device."""
+    import sys
+    registry = {"vit_h": lambda checkpoint: model}
+    monkeypatch.setitem(sys.modules, "segment_anything",
+                        SimpleNamespace(sam_model_registry=registry,
+                                        SamAutomaticMaskGenerator=None))
+    monkeypatch.setattr(pa.ParticleAnalyzer, "_ensure_checkpoint",
+                        classmethod(lambda cls, p, m: "ckpt.pth"))
+    return pa.ParticleAnalyzer(checkpoint_path="ckpt.pth", model_type="vit_h", device=device)
+
+
+def test_placement_failure_falls_back_to_cpu_with_warning(monkeypatch, caplog):
+    model = _Model(fail_on={"mps"})
+    with caplog.at_level(logging.WARNING, logger=pa.logger.name):
+        an = _analyzer(monkeypatch, model, "mps")
+    assert an.device == "cpu" and model.device == "cpu"
+    assert "falling back to CPU" in caplog.text
+
+
+def test_placement_failure_on_cpu_is_not_swallowed(monkeypatch):
+    with pytest.raises(RuntimeError):
+        _analyzer(monkeypatch, _Model(fail_on={"cpu"}), "cpu")
+
+
+def test_inference_failure_on_accelerator_retries_on_cpu(monkeypatch, caplog):
+    """MPS gaps show up at inference, not placement: the first generate()
+    raises, the retry runs on CPU, and the analyzer remembers the switch."""
+    import sys
+    model = _Model()
+    calls = []
+
+    class _Gen:
+        def __init__(self, sam, **params):
+            self.sam = sam
+
+        def generate(self, img):
+            calls.append(self.sam.device)
+            if self.sam.device == "mps":
+                raise NotImplementedError("aten::upsample_bicubic2d not implemented for MPS")
+            return [{"area": 10}]
+
+    an = _analyzer(monkeypatch, model, "mps")
+    sys.modules["segment_anything"].SamAutomaticMaskGenerator = _Gen
+    with caplog.at_level(logging.WARNING, logger=pa.logger.name):
+        masks = an._run_sam(np.zeros((8, 8, 3), dtype=np.uint8), "default")
+    assert masks == [{"area": 10}] and calls == ["mps", "cpu"]
+    assert an.device == "cpu" and "retrying on CPU" in caplog.text
+    # a later call goes straight to CPU
+    calls.clear()
+    an._run_sam(np.zeros((8, 8, 3), dtype=np.uint8), "default")
+    assert calls == ["cpu"]


### PR DESCRIPTION
Closes #567.

## Summary

On Apple Silicon, SAM was forced onto the CPU even though the MPS GPU was available, because the device resolver only knew about CUDA. ViT-H mask generation over a large image then took minutes per call, the SAM fallback timed out, and the verifier kept re-prescribing it. With this change `auto` picks CUDA, then MPS, then CPU. If MPS cannot host or run the model, SAM falls back to the CPU explicitly, with a warning, instead of failing or silently defaulting to CPU.

## Technical description

- `particle_analyzer._resolve_device`: CUDA → MPS (`mps_available()`, a module-level helper tolerant of torch builds without the backend) → CPU.
- `_load_model`: placement failure on an accelerator falls back to CPU with a warning; a CPU failure still raises.
- `_run_sam`: MPS gaps surface at inference (unsupported op / dtype), not at placement — a `RuntimeError` / `NotImplementedError` / `TypeError` on an accelerator retries once on CPU, and the analyzer remembers the switch so later calls go straight to CPU.
- Tests (`tests/test_sam_device.py`, 8): every backend combination for `auto`, explicit devices honored, placement fallback + warning, CPU failure not swallowed, inference retry on CPU and the remembered switch.

Live check pending: running ViT-H on MPS on this machine needs the 2.5 GB checkpoint download.

### Live check (Apple Silicon, ViT-B checkpoint)

`auto` resolved to MPS. The first MPS inference failed with the exact caveat the issue anticipated — `Cannot convert a MPS Tensor to float64` from the automatic mask generator's float64 point grids — and the new fallback caught it and produced the same 34 raw masks on CPU. A follow-up commit casts the generator's point coordinates to float32 on MPS, after which the whole generator runs on the GPU with identical masks. A 2048² raster exceeded the MPS memory ceiling (9 GB on this machine) and fell back to CPU as designed. Timing runs were cut short to protect the machine's RAM, so no MPS-vs-CPU speed figure is claimed here.