### PR TITLE
Web live inset: stream best-of-N candidate figures as they appear

### DIFF
--- a/scilink/server/runner.py
+++ b/scilink/server/runner.py
@@ -39,12 +39,24 @@ _LOG_POLL_S = 0.5
 _IMAGE_EXTS = {".png", ".jpg", ".jpeg"}
 _IMAGE_SKIP = ("testloop", "elbow_plot", "summary_grid", "_candidates",
                "/previews/", "/.")
+# The one exception to the `_candidates` skip (#565): best-of-N attempts run
+# in `<item>/_candidates/cand_NN/` and only the winner is promoted up — at
+# the END of the item. A single-item run with best-of-N therefore showed
+# nothing in the inset during the whole escalation. The canonical
+# `visualization.png` each candidate writes streams as it appears, labeled
+# by candidate; the losers' other artifacts stay skipped.
+_CANDIDATE_VIZ = re.compile(r"/_candidates/cand_(\d+)/visualization\.png$")
 _TS_SUFFIX = re.compile(r"_\d{8}_\d{6}$")
 _IMAGE_EMIT_CAP = 4          # newest N per fs tick — avoid a flood on a dir dump
 
 
 def _image_label(rel_path: str) -> str:
-    """A short human label from an artifact filename."""
+    """A short human label from an artifact filename; a best-of-N candidate
+    figure is labeled by its candidate number (the promoted winner, written
+    at the item's top level, supersedes it under the plain label)."""
+    m = _CANDIDATE_VIZ.search("/" + rel_path.replace(os.sep, "/").lower())
+    if m:
+        return f"candidate {int(m.group(1))}"
     stem = os.path.splitext(os.path.basename(rel_path))[0]
     stem = _TS_SUFFIX.sub("", stem)
     stem = re.sub(r"^Global_Analysis_", "", stem)
@@ -83,7 +95,7 @@ def _scan_new_images(session_dir: str, seen: dict) -> list:
             # whose absolute path contains a skip token must not silently
             # filter every figure.
             low = "/" + rel.replace(os.sep, "/").lower()
-            if any(s in low for s in _IMAGE_SKIP):
+            if any(s in low for s in _IMAGE_SKIP) and not _CANDIDATE_VIZ.search(low):
                 continue
             try:
                 m = os.stat(ap).st_mtime_ns

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -487,8 +487,18 @@ def test_scan_new_images(tmp_path):
     (root / "elbow_plot_k.png").write_bytes(b"x")      # skip token in name
     (root / "previews").mkdir()
     (root / "previews" / "p.png").write_bytes(b"x")    # skip dir, top-level
+    # best-of-N: a candidate's canonical figure streams (labeled by
+    # candidate), its other artifacts do not (#565)
+    cand = root / "results" / "img" / "_candidates" / "cand_02"
+    cand.mkdir(parents=True)
+    (cand / "visualization.png").write_bytes(b"x")
+    (cand / "debug_masks.png").write_bytes(b"x")
     out = _scan_new_images(str(root), seen)
-    assert [rel for rel, _label, _branch, _v in out] == ["fit_overlay.png"]
+    rels = {rel: label for rel, label, _branch, _v in out}
+    assert set(rels) == {"fit_overlay.png", "results/img/_candidates/cand_02/visualization.png"}
+    assert rels["results/img/_candidates/cand_02/visualization.png"] == "candidate 2"
+    assert rels["fit_overlay.png"] == "fit overlay"
+    out = [o for o in out if o[0] == "fit_overlay.png"]
     # the version token is the file mtime (nanoseconds), carried to the client
     assert out[0][3] == (root / "fit_overlay.png").stat().st_mtime_ns
     # already-seen files are not re-emitted


### PR DESCRIPTION
Closes #565.

## Summary

The "watch the analysis" inset only lit up when a promoted winner appeared, which for a single image or spectrum with best-of-N is the very end of the run. Candidate figures now stream as each candidate writes its canonical figure, labeled "candidate N", and the promoted winner supersedes them when the item completes. The rest of the candidates' internals stays hidden.

## Technical description

`scilink/server/runner.py`: `_IMAGE_SKIP` still lists `_candidates`; a narrow exception (`_CANDIDATE_VIZ`, `/_candidates/cand_NN/visualization.png`) lets the canonical figure through and `_image_label` names it `candidate N`. The scanner is shared by both foundation agents that use the `_candidates` + promotion layout (`_locked_exec.py`), and the per-tick emit cap still applies. Test extended in `tests/test_web_server.py::test_scan_new_images`: the candidate's `visualization.png` is emitted with the candidate label, its `debug_masks.png` is not.

### Live checks (Bedrock, Opus 4.8, meta sessions)

Single image, best-of-3: the inset received candidate 0, candidate 2 and candidate 1 during the escalation, then the promoted `visualization`. Single spectrum, best-of-3 (curve fitting): candidates 0/1/2 streamed through the escalation and each refit, then the promoted figure. Hyperspectral: the dashboards streamed as before.