### PR TITLE
Worker-agents panel: image and hyperspectral agents persist state from the start

### DIFF
--- a/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
+++ b/scilink/agents/exp_agents/hyperspectral_analysis_agent.py
@@ -393,6 +393,9 @@ class HyperspectralAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
         
         # Initialize and Run Pipeline
         self._init_state(data_path=data_path, metadata=system_info)
+        # State file from the start, for the Worker-agents panel (#566).
+        self._log_action("analysis_started", {"data_path": data_path},
+                         {"status": "running"})
 
         # Load skill(s) if provided. Accepts a single name/path or a list
         # — see PR 3 multi-skill support.

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -448,6 +448,18 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
 
         is_single_image = num_images == 1
 
+        # Persist the worker's state file the moment the run starts (#566):
+        # the web UI's Worker-agents panel reads <agent_type>_state.json and
+        # showed image analysis only after — and only if — the run completed.
+        self._init_state(input_type=input_type, num_images=num_images)
+        self._log_action(
+            action="analysis_started",
+            input_ctx={"num_images": num_images, "input_type": input_type,
+                       "analysis_depth": self.analysis_depth,
+                       "output_directory": str(self.output_dir)},
+            result={"status": "running"},
+        )
+
         self.logger.info("")
         self.logger.info(f"🖼️  IMAGE ANALYSIS - {num_images} image{'s' if num_images > 1 else ''}")
         self.logger.info(f"   Quality: depth={self.analysis_depth}")
@@ -463,6 +475,8 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 first_image = load_image_data(image_paths[0])
                 first_image_name = Path(image_paths[0]).stem
             except Exception as e:
+                self._log_action("image_analysis", {"input_type": input_type},
+                                 {"status": "error", "error": f"Failed to load image: {e}"})
                 return {
                     "status": "error",
                     "error": {"error": "Failed to load image", "details": str(e)},

--- a/scilink/agents/meta_agent/telemetry.py
+++ b/scilink/agents/meta_agent/telemetry.py
@@ -23,6 +23,8 @@ _DETAILED_MAX = 2000  # cap on the analysis detailed_analysis reasoning text
 # a title-cased form of the file stem (so a new agent still shows up sanely).
 _AGENT_LABELS = {
     "curve_fitting": "Curve Fitting",
+    "image_analysis": "Image Analysis",
+    "hyperspectral": "Hyperspectral Analysis",
     "bo": "Bayesian Optimization",
     "scalarizer": "Scalarizer",
 }

--- a/scilink/server/delegations.py
+++ b/scilink/server/delegations.py
@@ -66,7 +66,8 @@ def _sub_agents(session_dir: Optional[str]) -> Dict[str, List[str]]:
     base = Path(session_dir)
     if not base.is_dir():
         return out
-    labels = {"curve_fitting": "Curve Fitting", "bo": "Bayesian Optimization",
+    labels = {"curve_fitting": "Curve Fitting", "image_analysis": "Image Analysis",
+              "hyperspectral": "Hyperspectral Analysis", "bo": "Bayesian Optimization",
               "scalarizer": "Scalarizer"}
     try:
         for sp in sorted(base.rglob("*_state.json")):

--- a/tests/test_meta_telemetry_reader.py
+++ b/tests/test_meta_telemetry_reader.py
@@ -34,3 +34,27 @@ def test_tool_sequence_keeps_error_messages_and_reads_multimodal_results():
     assert seq[1]["status"] == "error" and seq[1]["result"] == {"status": "error", "error": "unreadable image"}
     assert seq[2]["status"] == "error" and seq[2]["result"]["message"] == bad_args["message"]
     assert seq[3]["status"] == "pending" and seq[3]["result"] is None
+
+
+def test_worker_rows_for_image_and_hyperspectral_state_files(tmp_path):
+    """The foundation agents that log their run into <agent_type>_state.json
+    show up as worker rows with friendly names, including a run that is
+    still in progress (only its analysis_started action recorded) — #566."""
+    from scilink.agents.meta_agent.telemetry import _worker_telemetry
+    d = tmp_path / "analysis" / "results" / "img_001"
+    d.mkdir(parents=True)
+    (d / "image_analysis_state.json").write_text(json.dumps({
+        "agent_type": "image_analysis", "status": "active",
+        "action_history": [{"timestamp": "2026-09-08T10:00:00", "action": "analysis_started",
+                            "input": {"num_images": 1}, "result": {"status": "running"}}]}))
+    (d / "hyperspectral_state.json").write_text(json.dumps({
+        "agent_type": "hyperspectral",
+        "action_history": [{"timestamp": "2026-09-08T10:00:00", "action": "analysis_started",
+                            "input": {}, "result": {"status": "running"}},
+                           {"timestamp": "2026-09-08T10:05:00", "action": "analyze",
+                            "input": {}, "result": {"status": "success"}}]}))
+    img = _worker_telemetry(d / "image_analysis_state.json")
+    hs = _worker_telemetry(d / "hyperspectral_state.json")
+    assert (img["specialist"], img["name"], img["action_count"]) == ("analysis", "Image Analysis", 1)
+    assert img["actions"][0]["status"] == "running"
+    assert (hs["name"], hs["action_count"], hs["outcomes"]["success"]) == ("Hyperspectral Analysis", 2, 1)


### PR DESCRIPTION
Closes #566.

## Summary

The Worker-agents panel stayed blank for image-analysis delegations. Both the image and hyperspectral agents now record an `analysis_started` action the moment a run begins, so they appear in the panel while running and after, with friendly names ("Image Analysis", "Hyperspectral Analysis").

## Technical description

The panel reads `<agent_type>_state.json` and lists a worker once `action_history` is non-empty. The image agent only logged one action at the very end of `analyze()` (nothing on the early error path), and never initialized its state with `agent_type`; hyperspectral logged at the end / on error. Now: `ImageAnalysisAgent.analyze` calls `_init_state` + `_log_action("analysis_started", ...)` after input normalization and logs the failed-load path; `HyperspectralAnalysisAgent.analyze` logs `analysis_started` after its `_init_state`. `telemetry._AGENT_LABELS` and `delegations._sub_agents` get the two labels. Test: worker rows for an in-progress image run and a completed hyperspectral run (`tests/test_meta_telemetry_reader.py`).

### Live checks (Bedrock, Opus 4.8, meta sessions)

Image delegation: "Image Analysis" appeared in the Worker-agents data with `analysis_started` while the delegation was still running (about 30 s in), then completed with the `image_analysis` action. Hyperspectral delegation: "Hyperspectral Analysis" appeared with `analysis_started` within two minutes and finished with `analyze`; `hyperspectral_state.json` on disk. Curve fitting still logs only its final action (not in this issue's scope).