### PR TITLE
BO: say how a recommendation was selected; tighten physical_constraints

### DIFF
--- a/scilink/agents/planning_agents/bo_agent.py
+++ b/scilink/agents/planning_agents/bo_agent.py
@@ -1016,10 +1016,20 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
                 Note: this counts optimization iterations (calls to this method), 
                 not individual experiments. A batch_size=10 call with 
                 experimental_budget=2 means 2 more calls (up to 20 experiments).
-            physical_constraints: Optional natural language description of physical 
-                experimental constraints. When provided, the agent evaluates the 
-                acquisition landscape and uses LLM reasoning to design a batch that 
-                maximizes information gain while respecting the constraints. Examples:
+            physical_constraints: Optional natural language description of
+                STRUCTURAL FEASIBILITY constraints — which parameter combinations
+                can physically be realized (discrete allowed levels, plate /
+                coupled-equipment layouts, shared-zone couplings). When provided,
+                the agent evaluates the acquisition landscape and uses LLM
+                reasoning to design a batch that maximizes information gain
+                while respecting the constraints — i.e. the recommendation is
+                chosen by the constrained planner and is NOT necessarily the
+                acquisition-function maximum (the result says so in
+                ``selection_method`` and carries the ``acqf_optimum``). Do not
+                pass modeling caveats, interpretation notes or soft preferences
+                here — they belong in ``strategy_hint`` / the objective; passing
+                them diverts the recommendation off the acquisition optimizer for
+                no structural reason. Examples:
                 - "96-well plate: rows share temperature (8 values), columns share pH (12 values)"
                 - "Only 5 catalyst concentrations available: 0.1, 0.5, 1.0, 2.0, 5.0 mM"
                 - "Reactor zones A,B share cooling; C,D share heating. Max 4 temps total."
@@ -1441,16 +1451,21 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
                 print(f"  - ⚠️  Constrained planning failed: {constraint_error}")
                 print(f"  - ↩️  Falling back to unconstrained recommendations")
                 recommendations = c.unconstrained_recommendations
+                c.selection_method = "acqf_optimizer"
             else:
                 recommendations = constrained_recs
                 c.next_x_batch = np.array([
                     [rec[col] for col in input_cols]
                     for rec in recommendations
                 ])
-                print(f"  - ✅ Using constrained batch ({len(recommendations)} experiments)")
+                c.selection_method = "constrained_planner"
+                print(f"  - ✅ Using constrained batch ({len(recommendations)} experiments) — "
+                      "chosen by the constraint-aware planner, not necessarily the "
+                      "acquisition optimum")
             c.constrained_metadata = constrained_metadata
         else:
             recommendations = c.unconstrained_recommendations
+            c.selection_method = "acqf_optimizer"
 
         c.recommendations = recommendations
 
@@ -1541,6 +1556,7 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
                 "plot_path": c.acq_plot_path,
                 "data_path": c.acq_data_path,
             }
+        log_entry["selection_method"] = getattr(c, "selection_method", "acqf_optimizer")
         # Include constrained planning metadata in history
         if c.constrained_metadata:
             log_entry["constrained_planning"] = c.constrained_metadata
@@ -1575,6 +1591,23 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
             result["constrained_planning"] = c.constrained_metadata
         if c.physical_constraints:
             result["constraint_aware"] = True
+        # How the recommendation was selected (#564): every result says
+        # whether it is the acquisition optimum or a deliberate,
+        # constraint-aware deviation chosen by the LLM planner — and in the
+        # latter case carries the optimum it deviated from, so downstream
+        # narration and the UI can label the point faithfully instead of
+        # presenting an LLM-chosen point as the acquisition maximum.
+        result["selection_method"] = getattr(c, "selection_method", "acqf_optimizer")
+        if result["selection_method"] == "constrained_planner":
+            unconstrained = c.unconstrained_recommendations or []
+            result["acqf_optimum"] = (unconstrained[0] if c.batch_size == 1 and unconstrained
+                                      else unconstrained)
+            if c.batch_size == 1 and unconstrained and isinstance(c.recommendations[0], dict):
+                result["deviation_from_acqf_optimum"] = {
+                    k: float(c.recommendations[0][k]) - float(v)
+                    for k, v in unconstrained[0].items()
+                    if k in c.recommendations[0]
+                }
 
         if getattr(c, "candidate_pool_info", None):
             result["candidate_pool"] = c.candidate_pool_info

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -5299,6 +5299,26 @@ class OrchestratorTools:
                 if res.get("inspection"):
                     response["inspection"] = res["inspection"]
 
+                # How the point was selected (#564): pass the stamp through
+                # and, for a planner-chosen point, the acquisition optimum it
+                # deviates from plus a sentence the narration must carry —
+                # so a recommendation sitting away from the plotted
+                # acquisition peak reads as deliberate, not as an optimizer bug.
+                response["selection_method"] = res.get("selection_method", "acqf_optimizer")
+                if response["selection_method"] == "constrained_planner":
+                    optimum = res.get("acqf_optimum")
+                    if level_maps and optimum is not None:
+                        optimum = self._decode_categorical_recs(optimum, level_maps)
+                    response["acqf_optimum"] = optimum
+                    if res.get("deviation_from_acqf_optimum"):
+                        response["deviation_from_acqf_optimum"] = res["deviation_from_acqf_optimum"]
+                    response["selection_note"] = (
+                        "SELECTED BY THE CONSTRAINT-AWARE PLANNER, not the acquisition "
+                        "optimizer: the recommended point was chosen by LLM reasoning over "
+                        "the acquisition landscape under the stated physical constraints "
+                        "and is not necessarily the acquisition-function maximum "
+                        f"(acquisition optimum: {optimum}). State this plainly when "
+                        "reporting the recommendation.")
                 # Include constrained planning metadata
                 if res.get("constrained_planning"):
                     cp = res["constrained_planning"]
@@ -5412,10 +5432,17 @@ class OrchestratorTools:
                 "physical_constraints": {
                     "type": "string",
                     "description": (
-                        "Natural language description of physical experimental constraints that "
-                        "prevent arbitrary parameter combinations. When provided, the optimizer "
-                        "evaluates the full acquisition landscape and uses LLM reasoning to design "
-                        "a realizable batch. Examples:\n"
+                        "Natural language description of STRUCTURAL FEASIBILITY constraints — "
+                        "which parameter combinations can physically be realized (discrete "
+                        "allowed levels, plate / coupled-equipment layouts, shared-zone "
+                        "couplings). When provided, the recommendation is chosen by an "
+                        "LLM constrained-batch planner reasoning over the acquisition "
+                        "landscape, NOT taken from the acquisition-function maximum; the "
+                        "response says so (selection_method) and carries the acqf_optimum. "
+                        "Do NOT pass modeling caveats, interpretation notes or soft "
+                        "preferences here — put those in strategy_hint or the objective; "
+                        "passing them here diverts the recommendation off the acquisition "
+                        "optimizer for no structural reason. Examples:\n"
                         "- '96-well plate: rows share temperature (8 values), columns share pH (12 values)'\n"
                         "- 'Only 5 catalyst concentrations available: 0.1, 0.5, 1.0, 2.0, 5.0 mM'\n"
                         "- 'Reactor has 4 zones with independent temp but shared pressure'\n"

--- a/tests/test_bo_selection_method.py
+++ b/tests/test_bo_selection_method.py
@@ -1,0 +1,83 @@
+"""#564 — every BO result says how its recommendation was selected:
+``acqf_optimizer`` (the acquisition optimum) or ``constrained_planner`` (a
+deliberate, constraint-aware deviation chosen by the LLM planner), and a
+planner-chosen point carries the optimum it deviated from. Exercises the
+two stages directly with a stub agent, no LLM."""
+from types import SimpleNamespace
+
+import numpy as np
+
+from scilink.agents.planning_agents.bo_agent import BOAgent
+
+
+class _Frame:
+    def describe(self):
+        return SimpleNamespace(to_markdown=lambda: "| stats |")
+
+
+def _ctx(batch_size=1, constraints=None):
+    return SimpleNamespace(
+        input_cols=["T", "pH"], target_cols=["yield"], X=np.array([[1.0, 2.0], [3.0, 4.0]]),
+        y=np.array([[0.5], [0.9]]), optimizer=object(), minimize_mask=[], is_moo=False,
+        df=_Frame(), input_bounds=[[0, 10], [0, 14]], objective_text="max yield",
+        budget_ctx={"budget_phase": "n/a"}, batch_size=batch_size,
+        physical_constraints=constraints,
+        unconstrained_recommendations=[{"T": 5.0, "pH": 7.0}] if batch_size == 1
+        else [{"T": 5.0, "pH": 7.0}, {"T": 6.0, "pH": 8.0}],
+        constrained_metadata=None, next_x_batch=None, recommendations=None,
+        # stage 8 fields
+        valid_config={"acquisition_strategy": {"type": "log_ei"}, "model_config": {}},
+        plot_path="p.png", inspection={}, acq_plot_path=None, acq_data_path=None,
+        candidate_pool_info=None, data_path="d.csv", experimental_budget=None,
+        save_acq=False, plot_acq=False, cat_dims=None, output_dir="/tmp/x",
+    )
+
+
+def _agent(planner):
+    a = SimpleNamespace(
+        _summarize_acquisition_landscape=lambda **kw: "landscape",
+        _plan_constrained_batch=planner,
+        _log_action=lambda **kw: None,
+        _run_seed=None,
+    )
+    return a
+
+
+def _run(agent, c):
+    BOAgent._stage_constrained_batch(agent, c)
+    return BOAgent._stage_output(agent, c)
+
+
+def test_unconstrained_is_the_acquisition_optimum():
+    res = _run(_agent(lambda **kw: (None, None, "unused")), _ctx())
+    assert res["selection_method"] == "acqf_optimizer"
+    assert "acqf_optimum" not in res and "constraint_aware" not in res
+    assert res["next_parameters"] == {"T": 5.0, "pH": 7.0}
+
+
+def test_planner_choice_is_marked_and_carries_the_optimum():
+    planner = lambda **kw: ([{"T": 2.0, "pH": 7.0}], {"coverage_summary": "one level"}, None)  # noqa: E731
+    res = _run(_agent(planner), _ctx(constraints="only T in {2, 4, 6}"))
+    assert res["selection_method"] == "constrained_planner"
+    assert res["next_parameters"] == {"T": 2.0, "pH": 7.0}
+    assert res["acqf_optimum"] == {"T": 5.0, "pH": 7.0}
+    assert res["deviation_from_acqf_optimum"] == {"T": -3.0, "pH": 0.0}
+    assert res["constraint_aware"] is True and res["constrained_planning"]["coverage_summary"] == "one level"
+
+
+def test_planner_failure_falls_back_to_the_optimum_and_says_so():
+    res = _run(_agent(lambda **kw: (None, {"validation_errors": ["x"]}, "boom")),
+               _ctx(constraints="plate layout"))
+    assert res["selection_method"] == "acqf_optimizer"
+    assert res["next_parameters"] == {"T": 5.0, "pH": 7.0}
+    assert "acqf_optimum" not in res  # nothing deviated from
+
+
+def test_batch_planner_choice_carries_the_whole_unconstrained_batch(tmp_path):
+    planner = lambda **kw: ([{"T": 2.0, "pH": 7.0}, {"T": 4.0, "pH": 7.0}], {}, None)  # noqa: E731
+    c = _ctx(batch_size=2, constraints="rows share T")
+    c.output_dir = str(tmp_path); c.step_num = 1
+    res = _run(_agent(planner), c)
+    assert res["selection_method"] == "constrained_planner"
+    assert res["acqf_optimum"] == [{"T": 5.0, "pH": 7.0}, {"T": 6.0, "pH": 8.0}]
+    assert "deviation_from_acqf_optimum" not in res  # per-point deltas only for a single point


### PR DESCRIPTION
Closes #564.

## Summary

Every BO result now says whether its recommendation is the acquisition optimum or a deliberate, constraint-aware deviation chosen by the LLM planner, and a planner-chosen point carries the optimum it deviated from. The planning orchestrator passes this through with a sentence the narration must state, so a point away from the plotted acquisition peak reads as intended rather than as an optimizer bug. The `physical_constraints` parameter is now documented as structural feasibility only; modeling caveats belong in `strategy_hint` or the objective.

## Technical description

- `bo_agent.py`: `_stage_constrained_batch` stamps `c.selection_method` (`constrained_planner` on planner success, `acqf_optimizer` otherwise incl. the fallback); `_stage_output` emits `selection_method`, and for a planner choice `acqf_optimum` (the unconstrained recommendation / batch) plus, for a single point, `deviation_from_acqf_optimum` per parameter; `_stage_record` writes the method into `bo_history.json`. Docstring tightened.
- `orchestrator_tools.py`: the tool description tightened the same way; the response carries `selection_method`, `acqf_optimum` (categorical levels decoded), `deviation_from_acqf_optimum` and a `selection_note`.
- The planner is deliberately NOT skipped for `batch_size == 1`: a discrete-levels constraint applies to a single point as much as to a batch, so dropping it there would silently return an infeasible optimum. The invariant the issue asks for — the point is the optimum OR is clearly marked as a deviation — holds through the stamp.
- Tests (`tests/test_bo_selection_method.py`, 4, no LLM): unconstrained → optimizer; planner choice → marked with the optimum and per-parameter deviation; planner failure → optimizer fallback; batch carries the whole unconstrained batch. Existing BO suites: 37 pass.


### Live check (Bedrock, Opus 4.8, plan session)

8-row catalyst/temperature dataset, one BO step with `physical_constraints="only 0.1, 0.5, 1.0, 2.0, 5.0 mM available"`, batch 1. The tool response carried `selection_method: constrained_planner`, `acqf_optimum`, `deviation_from_acqf_optimum` and the `selection_note`; `bo_history.json` records the method; the narration stated plainly that the point was chosen by the constraint-aware planner and not the acquisition maximizer. The same run surfaced a pre-existing bug the new fields made visible — the categorical-encoded catalyst column let the planner mix code-space bounds with mM data and its physical answer was decoded as a level index — filed as #579.

### Live matrix (Bedrock, Opus 4.8, plan sessions, continuous 12-row dataset)

- unconstrained, batch 1 → `selection_method: acqf_optimizer`, no note;
- discrete bath temperatures (45/55/65/75 °C), batch 1 → `constrained_planner`, `acqf_optimum` (82.7 °C) and `deviation_from_acqf_optimum` (−7.7 °C) present, note carried, narration stated the planner selection;
- shared-temperature batch of 4 → `constrained_planner` with the whole unconstrained batch as `acqf_optimum`.