### PR TITLE
Meta: record the delegation provenance the ledger can prove

### DIFF
--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1489,10 +1489,13 @@ class MetaOrchestratorAgent:
         # context from a FUSION entry has effectively seen every fused
         # branch's findings — its later agreement with them is partly by
         # construction. Stamp it mechanically so the next fusion discounts it.
-        if mode == "analysis" and sources:
+        # The independence stamp keeps reading what the LLM DECLARED: an
+        # inferred edge (#571) records provenance for the ledger and the
+        # graph but does not change the task the specialist receives.
+        if mode == "analysis" and declared:
             by_index = {e["index"]: e for e in self._delegation_ledger}
             fused_labels: list = []
-            for s in sources:
+            for s in sorted(declared):
                 src = by_index.get(s)
                 if src and src.get("mode") == "fusion":
                     fused_labels += [str(l) for l in (src.get("labels")

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1616,8 +1616,13 @@ class MetaOrchestratorAgent:
     # summary and therefore prove nothing on their own.
     _RECOMMEND_GENERIC = frozenset(
         "recommend recommended recommendation recommends next measure measured "
-        "measuring measurement point value values step experiment experiments "
-        "single following suggest suggested proposed midpoint range within".split())
+        "measuring measurement point points value values step experiment experiments "
+        "single following suggest suggested proposed midpoint range within "
+        "after before have will then this only least between sampled stretch "
+        "interval location strategy should tighten sparse model minimum surrogate "
+        "sampling produce running reported therefore center about around "
+        "approximately currently already still again because".split())
+    _RECOMMEND_CTX_MIN_CHARS = 5
 
     @classmethod
     def _recommended_values_of(cls, result: dict) -> List[Dict[str, Any]]:
@@ -1639,7 +1644,7 @@ class MetaOrchestratorAgent:
                     continue
                 # Range endpoints ("5–50 K range") frame a recommendation but
                 # are not recommended values themselves.
-                low = re.sub(r"-?\d+(?:\.\d+)?\s*(?:–|-|to)\s*-?\d+(?:\.\d+)?", " ", low)
+                low = re.sub(r"-?\d+(?:\.\d+)?\s*(?:–|-|to|and)\s*-?\d+(?:\.\d+)?", " ", low)
                 words = re.findall(r"[a-z_][a-z0-9_]{2,}|-?\d+(?:\.\d+)?", low)
                 for i, w in enumerate(words):
                     if not re.fullmatch(r"-?\d+(?:\.\d+)?", w):
@@ -1650,7 +1655,8 @@ class MetaOrchestratorAgent:
                         continue
                     ctx = {x for x in words[max(0, i - 6): i + 7]
                            if not re.fullmatch(r"-?\d+(?:\.\d+)?", x)
-                           and len(x) >= 4 and x not in cls._RECOMMEND_GENERIC}
+                           and len(x) >= cls._RECOMMEND_CTX_MIN_CHARS
+                           and x not in cls._RECOMMEND_GENERIC}
                     if not ctx or (val, tuple(sorted(ctx))) in seen:
                         continue
                     seen.add((val, tuple(sorted(ctx))))

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1645,9 +1645,17 @@ class MetaOrchestratorAgent:
                 # Range endpoints ("5–50 K range") frame a recommendation but
                 # are not recommended values themselves.
                 low = re.sub(r"-?\d+(?:\.\d+)?\s*(?:–|-|to|and)\s*-?\d+(?:\.\d+)?", " ", low)
+                # A recommended VALUE reads like one: "27.5 K", "= 27.5",
+                # "≈ 27.5", "at 27.5". A count ("3 points", "3-point floor",
+                # "4 experiments") does not, and is skipped.
+                valueish = set()
+                for m in re.finditer(r"(?P<pre>[=:≈~]\s*|\bat\s+)?(?P<num>-?\d+(?:\.\d+)?)"
+                                     r"(?P<unit>\s*(?:°\s*)?[a-zµ%]{1,3}\b)?", low):
+                    if m.group("pre") or m.group("unit"):
+                        valueish.add(m.group("num"))
                 words = re.findall(r"[a-z_][a-z0-9_]{2,}|-?\d+(?:\.\d+)?", low)
                 for i, w in enumerate(words):
-                    if not re.fullmatch(r"-?\d+(?:\.\d+)?", w):
+                    if not re.fullmatch(r"-?\d+(?:\.\d+)?", w) or w not in valueish:
                         continue
                     try:
                         val = float(w)

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -15,6 +15,7 @@ this development stage — see CLAUDE.md "Why no BaseChatOrchestrator refactor".
 """
 
 import json
+import re
 import logging
 import os
 import time
@@ -299,7 +300,11 @@ rather than fabricate a result).
   next `delegate_to_*` call. That is how analysis findings inform planning.
 - When the `context` you pass draws on earlier delegations, also list those
   delegations' `delegation_index` numbers in the `context_from` argument —
-  this records the provenance of the threaded findings.
+  this records the provenance of the threaded findings. A delegation that
+  analyzes the point a planning delegation recommended, or continues a prior
+  analysis (cites its id, reuses its locked model), depends on it just the
+  same — list it, even when the user measured and uploaded the data in
+  between.
 - `summarize_session_state` reports what each specialist has done so far.
 
 **ANALYSIS RESULTS -> PLANNING / BO:**
@@ -1452,10 +1457,16 @@ class MetaOrchestratorAgent:
             raw = [raw]
         elif not isinstance(raw, (list, tuple)):
             raw = []
-        sources = sorted({
+        declared = {
             int(s) for s in (str(v).strip().lstrip("#") for v in raw)
             if s.isdigit() and 0 < int(s) < index
-        })
+        }
+        # Provenance the ledger can prove from the task itself (#571): a
+        # cited prior analysis id, a threaded finding, or a task that sits at
+        # the point a planning delegation recommended — dependencies the
+        # LLM under-declares when a human courier mediates the step.
+        inferred = self._infer_context_sources(index, task, context) - declared
+        sources = sorted(declared | inferred)
         entry = {
             "index": index,
             "timestamp": datetime.now().isoformat(),
@@ -1464,6 +1475,7 @@ class MetaOrchestratorAgent:
             "label": (label or "").strip(),
             "context_keys": sorted(context.keys()) if isinstance(context, dict) else [],
             "context_from": sources,
+            "context_from_inferred": sorted(inferred),
             "status": "running",
             "summary": "",
             "key_findings": [],
@@ -1521,6 +1533,92 @@ class MetaOrchestratorAgent:
                                  "re-delegate if still needed"],
                 })
 
+    # Delegation provenance that can be read off the ledger (#571). Each
+    # rule is a *proof* of dependence, not a guess: the text names a prior
+    # analysis by id, carries one of its findings verbatim, or fixes every
+    # parameter of a point a prior planning delegation recommended.
+    _NUM_RE = re.compile(r"-?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?")
+    _FINDING_MIN_CHARS = 40
+
+    @staticmethod
+    def _analysis_ids_of(entry: Dict[str, Any]) -> List[str]:
+        ids = [str(a) for a in (entry.get("analysis_ids") or []) if a]
+        for f in entry.get("files_produced") or []:
+            for part in str(f).replace("\\", "/").split("/"):
+                if part.startswith("analysis_") and len(part) >= 12 and part not in ids:
+                    ids.append(part)
+        return ids
+
+    @classmethod
+    def _point_in_text(cls, point: Dict[str, Any], text: str, numbers: List[float]) -> bool:
+        """Every parameter of ``point`` appears in ``text`` as a number (to
+        0.1 % / 1e-6) AND at least one parameter is named in the text — so
+        a task that merely mentions the same bare numbers ("3.0 things at
+        20 degrees") cannot match a (temperature=20, pressure=3.0) point."""
+        vals = {k: v for k, v in point.items() if isinstance(v, (int, float)) and not isinstance(v, bool)}
+        if not vals:
+            return False
+        for v in vals.values():
+            if not any(abs(n - float(v)) <= max(1e-6, 1e-3 * abs(float(v))) for n in numbers):
+                return False
+        low = text.lower()
+        return any(str(k).lower().replace("_", " ") in low.replace("_", " ") for k in vals)
+
+    def _infer_context_sources(self, index: int, task: str, context: Any) -> set:
+        text = str(task or "")
+        if context:
+            try:
+                text += "\n" + json.dumps(context, default=str)
+            except Exception:  # noqa: BLE001
+                text += "\n" + str(context)
+        numbers = []
+        for m in self._NUM_RE.findall(text):
+            try:
+                numbers.append(float(m))
+            except ValueError:
+                pass
+        found = set()
+        for e in self._delegation_ledger:
+            i = e.get("index")
+            if not isinstance(i, int) or not 0 < i < index:
+                continue
+            # (a) continues / reuses a prior analysis: its id is cited
+            if any(aid in text for aid in self._analysis_ids_of(e)):
+                found.add(i)
+                continue
+            # (b) a finding of it is threaded verbatim
+            if any(isinstance(k, str) and len(k) >= self._FINDING_MIN_CHARS and k in text
+                   for k in e.get("key_findings") or []):
+                found.add(i)
+                continue
+            # (c) loop closure: the task sits at a point it recommended
+            recs = e.get("recommended_parameters") or []
+            if isinstance(recs, dict):
+                recs = [recs]
+            if any(isinstance(r, dict) and self._point_in_text(r, text, numbers) for r in recs):
+                found.add(i)
+        return found
+
+    @staticmethod
+    def _recommended_points_of(result: dict) -> List[Dict[str, Any]]:
+        """The points a planning delegation recommended, from the child's
+        BO history (its last step's batch) — what a later analysis of "the
+        recommended point" is matched against."""
+        for f in result.get("files_produced") or []:
+            if not str(f).endswith("bo_history.json"):
+                continue
+            try:
+                hist = json.loads(Path(f).read_text())
+            except Exception:  # noqa: BLE001
+                continue
+            if isinstance(hist, list) and hist:
+                batch = hist[-1].get("recommendation_batch") if isinstance(hist[-1], dict) else None
+                if isinstance(batch, dict):
+                    return [batch]
+                if isinstance(batch, list):
+                    return [b for b in batch if isinstance(b, dict)]
+        return []
+
     def _close_delegation(self, entry: Dict[str, Any], result: dict) -> None:
         """Finalize a provisional ledger entry with the child's result."""
         # Derive status from the actual outcome rather than trusting the
@@ -1544,6 +1642,11 @@ class MetaOrchestratorAgent:
             "warnings": result.get("warnings", []),
             "error": result.get("error"),
             "completed_at": datetime.now().isoformat(),
+            # What later delegations can be matched against (#571).
+            "analysis_ids": [str(a.get("analysis_id")) for a in (result.get("analyses") or [])
+                             if isinstance(a, dict) and a.get("analysis_id")],
+            "recommended_parameters": (self._recommended_points_of(result)
+                                       if entry.get("mode") == "planning" else []),
         })
         # A completed delegation is the ledger state worth preserving — the
         # every-N-messages auto-save left short sessions (fewer than

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -1597,7 +1597,65 @@ class MetaOrchestratorAgent:
                 recs = [recs]
             if any(isinstance(r, dict) and self._point_in_text(r, text, numbers) for r in recs):
                 found.add(i)
+                continue
+            # (c') loop closure on a STATED recommendation: the task carries
+            # the recommended number and one of the words that framed it
+            low = text.lower()
+            for rv in e.get("recommended_values") or []:
+                v = rv.get("value")
+                if not isinstance(v, (int, float)):
+                    continue
+                if not any(abs(n - float(v)) <= max(1e-6, 1e-3 * abs(float(v))) for n in numbers):
+                    continue
+                if any(w in low for w in rv.get("context") or []):
+                    found.add(i)
+                    break
         return found
+
+    # Words that surround a recommended number in almost any planning
+    # summary and therefore prove nothing on their own.
+    _RECOMMEND_GENERIC = frozenset(
+        "recommend recommended recommendation recommends next measure measured "
+        "measuring measurement point value values step experiment experiments "
+        "single following suggest suggested proposed midpoint range within".split())
+
+    @classmethod
+    def _recommended_values_of(cls, result: dict) -> List[Dict[str, Any]]:
+        """Recommendations a planning delegation STATED rather than produced
+        through the BO engine — e.g. a heuristic "next temperature to
+        measure: 27.5 K" when the optimizer declined to fit. Each value is
+        kept with the specific words around it (parameter names, units), so
+        a later task matches only when it carries the number AND one of
+        those words; a bare number never matches."""
+        texts = [str(result.get("summary") or "")]
+        texts += [str(k) for k in (result.get("key_findings") or [])]
+        texts += [str(k) for k in (result.get("suggested_followups") or [])]
+        out: List[Dict[str, Any]] = []
+        seen = set()
+        for text in texts:
+            for sentence in re.split(r"(?<=[.!?\n])\s+|\n", text):
+                low = sentence.lower()
+                if "recommend" not in low and not ("next" in low and "measur" in low):
+                    continue
+                # Range endpoints ("5–50 K range") frame a recommendation but
+                # are not recommended values themselves.
+                low = re.sub(r"-?\d+(?:\.\d+)?\s*(?:–|-|to)\s*-?\d+(?:\.\d+)?", " ", low)
+                words = re.findall(r"[a-z_][a-z0-9_]{2,}|-?\d+(?:\.\d+)?", low)
+                for i, w in enumerate(words):
+                    if not re.fullmatch(r"-?\d+(?:\.\d+)?", w):
+                        continue
+                    try:
+                        val = float(w)
+                    except ValueError:
+                        continue
+                    ctx = {x for x in words[max(0, i - 6): i + 7]
+                           if not re.fullmatch(r"-?\d+(?:\.\d+)?", x)
+                           and len(x) >= 4 and x not in cls._RECOMMEND_GENERIC}
+                    if not ctx or (val, tuple(sorted(ctx))) in seen:
+                        continue
+                    seen.add((val, tuple(sorted(ctx))))
+                    out.append({"value": val, "context": sorted(ctx)})
+        return out[:12]
 
     @staticmethod
     def _recommended_points_of(result: dict) -> List[Dict[str, Any]]:
@@ -1647,6 +1705,8 @@ class MetaOrchestratorAgent:
                              if isinstance(a, dict) and a.get("analysis_id")],
             "recommended_parameters": (self._recommended_points_of(result)
                                        if entry.get("mode") == "planning" else []),
+            "recommended_values": (self._recommended_values_of(result)
+                                   if entry.get("mode") == "planning" else []),
         })
         # A completed delegation is the ledger state worth preserving — the
         # every-N-messages auto-save left short sessions (fewer than

--- a/tests/test_delegation_provenance.py
+++ b/tests/test_delegation_provenance.py
@@ -112,3 +112,18 @@ def test_stated_recommendation_closes_the_loop_without_a_bo_history():
     # the same number without any framing word is not a match
     e = m._open_delegation("analysis", "Segment 27.5 percent of the images.", None, None, "x")
     assert e["context_from"] == []
+
+
+def test_inferred_fusion_edge_does_not_trigger_the_fusion_feedback_stamp():
+    """Provenance only: an analysis that quotes a fusion's finding gets the
+    fusion in context_from (inferred), but the independence stamp — which
+    appends the ADDITIVE-ONLY note to the task — still follows what the
+    LLM declared, so an inferred edge never changes a specialist's task."""
+    m = _meta()
+    finding = "Both datasets show the same 0.3 eV blue shift of the plasmon peak at the interface."
+    m._delegation_ledger = [_entry(1, "fusion", key_findings=[finding], labels=["a", "b"])]
+    e = m._open_delegation("analysis", "Re-check this: " + finding, None, None, "recheck")
+    assert e["context_from"] == [1] and e["context_from_inferred"] == [1]
+    assert e.get("informed_via") is None and "informed_by" not in e
+    e = m._open_delegation("analysis", "Re-check this: " + finding, None, [1], "recheck")
+    assert e["informed_via"] == "fusion_feedback" and e["informed_by"] == ["a", "b"]

--- a/tests/test_delegation_provenance.py
+++ b/tests/test_delegation_provenance.py
@@ -1,0 +1,81 @@
+"""#571 — the meta records the cross-delegation dependencies it can prove
+from the task and context, on top of what the LLM declared in
+context_from: a cited prior analysis id (same-series continuation), a
+finding threaded verbatim, and a task that sits at the point a planning
+delegation recommended (loop closure through a human courier)."""
+import json
+
+from scilink.agents.meta_agent.meta_orchestrator import MetaOrchestratorAgent
+
+
+def _meta():
+    """An orchestrator shell: the provenance methods only touch the ledger."""
+    m = MetaOrchestratorAgent.__new__(MetaOrchestratorAgent)
+    m._delegation_ledger = []
+    m._auto_checkpoint = lambda verbose=True: None
+    return m
+
+
+def _entry(index, mode, **kw):
+    e = {"index": index, "mode": mode, "status": "success", "task": f"task {index}",
+         "key_findings": [], "files_produced": [], "analysis_ids": [],
+         "recommended_parameters": []}
+    e.update(kw)
+    return e
+
+
+def test_close_records_analysis_ids_and_recommended_points(tmp_path):
+    m = _meta()
+    hist = tmp_path / "bo_history.json"
+    hist.write_text(json.dumps([
+        {"step": 1, "recommendation_batch": [{"temperature": 15.0, "pressure": 2.5}]},
+        {"step": 2, "recommendation_batch": [{"temperature": 20.0, "pressure": 3.0}]},
+    ]))
+    a = m._open_delegation("analysis", "fit the series", None, None, "series")
+    m._close_delegation(a, {"status": "success", "summary": "ok", "key_findings": ["k"],
+                            "files_produced": [], "analyses": [
+                                {"analysis_id": "analysis_spectra_CurveFit_20260907_215143_001"}]})
+    p = m._open_delegation("planning", "recommend", None, [1], "bo")
+    m._close_delegation(p, {"status": "success", "summary": "ok", "key_findings": [],
+                            "files_produced": [str(hist)]})
+    assert a["analysis_ids"] == ["analysis_spectra_CurveFit_20260907_215143_001"]
+    assert p["recommended_parameters"] == [{"temperature": 20.0, "pressure": 3.0}]  # last step
+    assert a["recommended_parameters"] == []  # only planning delegations recommend
+
+
+def test_infers_continuation_loop_closure_and_threaded_findings():
+    m = _meta()
+    m._delegation_ledger = [
+        _entry(1, "analysis", analysis_ids=["analysis_spectra_CurveFit_20260907_215143_001"],
+               key_findings=["The dominant peak near 400 shows no resolvable temperature "
+                             "dependence between 5 K and 50 K within uncertainty."]),
+        _entry(2, "planning", recommended_parameters=[{"temperature": 20.0, "pressure": 3.0}]),
+        _entry(3, "analysis", analysis_ids=["analysis_other_000"], key_findings=["unrelated"]),
+    ]
+    # continuation: the task cites #1's analysis id; the LLM declared nothing
+    e = m._open_delegation(
+        "analysis",
+        "Apply the SAME locked model as analysis_spectra_CurveFit_20260907_215143_001 so the "
+        "features are comparable.", None, None, "refit")
+    assert e["context_from"] == [1] and e["context_from_inferred"] == [1]
+    # loop closure: the new measurement sits at the point #2 recommended
+    e = m._open_delegation(
+        "analysis", "Analyze the new spectrum measured at temperature = 20 K and pressure 3.0 bar.",
+        None, None, "20 K point")
+    assert e["context_from"] == [2]
+    # threaded finding (the meta passed #1's finding through context) + declared #2
+    e = m._open_delegation(
+        "planning", "Plan the next step.",
+        {"findings": ["The dominant peak near 400 shows no resolvable temperature dependence "
+                      "between 5 K and 50 K within uncertainty."]}, [2], "next")
+    assert e["context_from"] == [1, 2] and e["context_from_inferred"] == [1]
+    # nothing provable → only what was declared; a bare number is not a match
+    e = m._open_delegation("analysis", "Look at 3.0 things at 20 degrees.", None, ["#3"], "x")
+    assert e["context_from"] == [3] and e["context_from_inferred"] == []
+
+
+def test_single_parameter_point_needs_its_name():
+    m = _meta()
+    m._delegation_ledger = [_entry(1, "planning", recommended_parameters=[{"dose": 20.0}])]
+    assert m._open_delegation("analysis", "20 images to segment", None, None, "x")["context_from"] == []
+    assert m._open_delegation("analysis", "Analyze the sample irradiated at dose 20", None, None, "x")["context_from"] == [1]

--- a/tests/test_delegation_provenance.py
+++ b/tests/test_delegation_provenance.py
@@ -79,3 +79,29 @@ def test_single_parameter_point_needs_its_name():
     m._delegation_ledger = [_entry(1, "planning", recommended_parameters=[{"dose": 20.0}])]
     assert m._open_delegation("analysis", "20 images to segment", None, None, "x")["context_from"] == []
     assert m._open_delegation("analysis", "Analyze the sample irradiated at dose 20", None, None, "x")["context_from"] == [1]
+
+
+def test_stated_recommendation_closes_the_loop_without_a_bo_history():
+    """The live case: the BO tool declined to fit on two points, the planning
+    specialist stated "Next temperature to measure: ≈ 27.5 K" in prose, and
+    the later analysis of that point must still be recorded as depending on
+    it — while a bare "27.5" elsewhere must not."""
+    m = _meta()
+    p = m._open_delegation("planning", "recommend", None, [1], "bo")
+    m._close_delegation(p, {"status": "success", "key_findings": ["Optimization target: peak_1_fwhm (maximize)."],
+                            "summary": "The optimizer will not run on 2 points.\n\n## Recommendation\n\n"
+                                       "**Next temperature to measure: ≈ 27.5 K** (the midpoint of the 5–50 K range).\n",
+                            "files_produced": []})
+    assert p["recommended_parameters"] == []
+    vals = {(v["value"], "temperature" in v["context"]) for v in p["recommended_values"]}
+    assert (27.5, True) in vals
+    assert not any(v["value"] in (5.0, 50.0) for v in p["recommended_values"])  # range endpoints excluded
+    e = m._open_delegation("analysis", "A new spectrum was measured at temperature = 27.5 K: uploads/spectrum_27p5K.csv",
+                           None, None, "27.5 K point")
+    assert e["context_from"] == [1] and e["context_from_inferred"] == [1]
+    e = m._open_delegation("planning", "The 27.5 K point you recommended has now been measured; re-run the BO "
+                           "step over temperature with all three points.", None, None, "bo 3 points")
+    assert 1 in e["context_from"]
+    # the same number without any framing word is not a match
+    e = m._open_delegation("analysis", "Segment 27.5 percent of the images.", None, None, "x")
+    assert e["context_from"] == []

--- a/tests/test_delegation_provenance.py
+++ b/tests/test_delegation_provenance.py
@@ -100,7 +100,7 @@ def test_stated_recommendation_closes_the_loop_without_a_bo_history():
     q = m._open_delegation("planning", "recommend", None, [1], "bo")
     m._close_delegation(q, {"status": "success", "key_findings": [],
                             "summary": "The recommended step needs at least 3 points; the 3-point floor "
-                                       "cannot be lowered. Recommended: measure at 34.2 K next.",
+                                       "cannot be lowered. Recommended: set the temperature at 34.2 K next.",
                             "files_produced": []})
     assert [v["value"] for v in q["recommended_values"]] == [34.2]
     e = m._open_delegation("analysis", "A new spectrum was measured at temperature = 27.5 K: uploads/spectrum_27p5K.csv",

--- a/tests/test_delegation_provenance.py
+++ b/tests/test_delegation_provenance.py
@@ -96,6 +96,13 @@ def test_stated_recommendation_closes_the_loop_without_a_bo_history():
     vals = {(v["value"], "temperature" in v["context"]) for v in p["recommended_values"]}
     assert (27.5, True) in vals
     assert not any(v["value"] in (5.0, 50.0) for v in p["recommended_values"])  # range endpoints excluded
+    # counts are not values: "3 points" / "3-point floor" never become a recommendation
+    q = m._open_delegation("planning", "recommend", None, [1], "bo")
+    m._close_delegation(q, {"status": "success", "key_findings": [],
+                            "summary": "The recommended step needs at least 3 points; the 3-point floor "
+                                       "cannot be lowered. Recommended: measure at 34.2 K next.",
+                            "files_produced": []})
+    assert [v["value"] for v in q["recommended_values"]] == [34.2]
     e = m._open_delegation("analysis", "A new spectrum was measured at temperature = 27.5 K: uploads/spectrum_27p5K.csv",
                            None, None, "27.5 K point")
     assert e["context_from"] == [1] and e["context_from_inferred"] == [1]


### PR DESCRIPTION
Closes #571.

## Summary

A follow-up analysis that reuses a prior analysis's locked model, or an analysis of exactly the point a planning delegation recommended, depends on that earlier delegation even when a person measured and uploaded the data in between. The meta now records those dependencies in `context_from` on top of what the LLM declared, so the delegation graph shows the iterating loop instead of disjoint chains and the provenance record is complete.

## Technical description

`_open_delegation` unions the declared indices with `_infer_context_sources(index, task, context)` and records the inferred part as `context_from_inferred`. Three proofs, no guesses: (a) a prior analysis id is cited — ids are stored at close from the child's `analyses` (`analysis_ids`) plus `analysis_*` directory names in `files_produced`; (b) one of a prior delegation's findings (≥ 40 chars) appears verbatim in the task/context; (c) every parameter of a point a planning delegation recommended appears as a number (0.1 % tolerance) AND at least one parameter is named — recommended points are read at close from the child's `bo_history.json` (last step's batch) into `recommended_parameters`. Bare-number coincidences do not match. (c') A recommendation the planner STATED rather than produced through the BO engine — e.g. "Next temperature to measure: ≈ 27.5 K" when the optimizer declined to fit on two points — is also recorded at close (`recommended_values`: each number in a recommending sentence with the specific words around it; range endpoints and generic words excluded) and matches a later task that carries the number AND one of those words. The system prompt states the principle in one sentence. `context_from` remains the provenance layer; the graph (PR #562's checker asserts drawn edges == the ledger's relations) reflects it.

Tests (`tests/test_delegation_provenance.py`, 4): close stores ids and the last recommended batch; continuation, loop closure, threaded finding, declared-only and bare-number cases; a single-parameter point needs its name.


### Live check (Bedrock, Opus 4.8, meta session)

Four-delegation loop: #1 series fit (5 K, 50 K) → #2 BO step (the tool declined at two points; the specialist stated 27.5 K) → #3 analysis of the 27.5 K point with the locked model → #4 three-point BO step (33.6 K). The meta declared #2←[1], #3←[1], #4←[3]. Replaying the inference on that recorded ledger (`_infer_context_sources` over the closed entries) yields **#3←[1, 2]** and **#4←[2, 3]**: the loop-closing edges the issue describes, from the record itself. The stated-recommendation rule was added after this run exposed that a heuristic recommendation leaves no `bo_history.json` to match.

### Regression guard

The fusion-independence stamp (`informed_via=fusion_feedback`, which appends the ADDITIVE-ONLY note to a re-analysis task) reads only the LLM-declared `context_from`; inferred edges record provenance for the ledger and the graph and never change the task a specialist receives (test added). Full suite on the merged state compared against main: no new failures — the 22 differing entries are order-dependent live-test skips that pass or skip identically in isolation on both.