### PR TITLE
Image verification: pivot off a stalled prescription instead of repeating it

### DIFF
--- a/scilink/agents/exp_agents/_qc_engine.py
+++ b/scilink/agents/exp_agents/_qc_engine.py
@@ -277,6 +277,11 @@ class QCItemContext:
         self.stall_count: int = 0
         self.prev_best_score: float = -1.0
         self.iteration: int = 0
+        # A host's reason to stop the loop early with the best result so
+        # far (#568: a prescribed fix that will not take) — checked after
+        # each refinement, logged, then the final-verify path runs as for
+        # the wall-clock budget.
+        self.stop_reason: Optional[str] = None
 
 
 class CodegenQCEngine:
@@ -413,6 +418,11 @@ class CodegenQCEngine:
             refinement_error = refined_config.pop("_refinement_error", None)
             if refinement_error:
                 ctx.verification_history[-1]["refinement_error"] = refinement_error
+
+            if ctx.stop_reason:
+                logger.warning(f"   Stopping verification: {ctx.stop_reason}")
+                host.qc_final_verify(ctx)
+                return
 
             if (spec.config_key is not None
                     and refined_config == ctx.state.get(spec.config_key, {})):

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -5870,6 +5870,9 @@ Return JSON: {{"change_type": "cosmetic" | "analytical" | "rewrite", \
                 "summary": first_result.get("summary"),
                 "saved_arrays": first_result.get("saved_arrays", {}),
                 "quality_history": first_result.get("quality_history"),
+                # A prescription the loop gave up on (#568) is part of the
+                # verdict the caller sees, not only of the persisted item.
+                "stalled_prescriptions": first_result.get("stalled_prescriptions"),
             }
             state["final_script"] = first_result.get("script")
             state["final_viz_bytes"] = first_result.get("visualization_bytes")

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -3497,6 +3497,11 @@ Return JSON with:
         )
         res = engine.run_item(ctx)
         self._bump_bank_adapt_success(res)
+        # Whichever path produced the returned dict (approved, exhausted,
+        # judge / best-available fallback), it carries the stalled
+        # prescriptions so the failure mode is legible (#568).
+        if isinstance(res, dict) and ctx.state.get("_stalled_prescriptions"):
+            res["stalled_prescriptions"] = [dict(s) for s in ctx.state["_stalled_prescriptions"]]
         return res
 
     # --- CodegenQCEngine hooks (bodies moved verbatim from the old driver) ---

--- a/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
+++ b/scilink/agents/exp_agents/controllers/image_analysis_controllers.py
@@ -2952,6 +2952,9 @@ Return JSON:
             tool_constraint=tool_constraint,
         )
 
+        prompt_text += self._stalled_prescriptions_block(
+            state.get("_stalled_prescriptions"))
+
         # Add history context
         history_context = build_verification_prompt_with_history(
             current_result={
@@ -3159,6 +3162,7 @@ Return JSON:
         state: dict,
         verification: dict,
         history: list | None = None,
+        stalled: list | None = None,
     ) -> dict:
         """Apply LLM verification feedback to refine the analysis configuration.
 
@@ -3219,7 +3223,7 @@ Return JSON:
 **FALSE POSITIVES:** {', '.join(false_positives) if false_positives else 'None identified'}
 
 **RECOMMENDED ACTION:** {recommended_action}
-
+{self._stalled_prescriptions_block(stalled)}
 Return JSON with the refined analysis approach:
 {{
     "processing_pipeline": "updated pipeline description",
@@ -3876,14 +3880,113 @@ Return JSON with:
                 verification.get("recommended_action", "")
             )
 
+        # A prescription the codegen cannot make "take" would otherwise be
+        # re-issued to the last iteration (#568). Detect it and pivot.
+        stalled = self._detect_stalled_prescription(ctx, verification)
+        if stalled:
+            self._note_stalled_prescription(ctx, stalled)
+
         # Apply LLM's recommended fixes. Pass the
         # accumulated verification_history so the refiner
         # can see prior scores/pipelines and recognize
         # regressions instead of iterating blindly on the
         # previous (possibly degraded) config.
         return self._apply_verification_feedback(
-            ctx.state, verification, history=ctx.verification_history
+            ctx.state, verification, history=ctx.verification_history,
+            stalled=ctx.state.get("_stalled_prescriptions"),
         )
+
+    # ── stalled prescriptions (#568) ────────────────────────────────
+    # The verifier gates acceptance on a specific fix; when the codegen
+    # cannot satisfy it (an unavailable capability, an environment limit,
+    # a fix the model keeps mis-implementing) the same mandate came back
+    # every iteration and the run burned its budget repeating it. A
+    # prescription is *stalled* once it has been issued STALL_TIMES times
+    # in a row with no improvement of the best score since it first
+    # appeared. Then: it is named as stalled to the refiner AND the
+    # verifier (do not re-issue; pivot to a different path or accept the
+    # best result), and if it comes back once more anyway the loop stops
+    # with the best result so far and a legible reason.
+    STALL_TIMES = 3
+    _PRESCRIPTION_STOPWORDS = frozenset(
+        "the a an and or of to in on for with use using apply via by from "
+        "into that this then than is are be it its as at should must none".split())
+
+    @classmethod
+    def _prescription_tokens(cls, action) -> frozenset:
+        words = re.findall(r"[a-z0-9_]{3,}", str(action or "").lower())
+        return frozenset(w for w in words if w not in cls._PRESCRIPTION_STOPWORDS)
+
+    @classmethod
+    def _same_prescription(cls, a, b) -> bool:
+        ta, tb = cls._prescription_tokens(a), cls._prescription_tokens(b)
+        if not ta or not tb:
+            return False
+        return len(ta & tb) / len(ta | tb) >= 0.5
+
+    def _detect_stalled_prescription(self, ctx: QCItemContext,
+                                     verification: dict) -> Optional[dict]:
+        action = str(verification.get("recommended_action") or "").strip()
+        if not action or action.lower() in ("none", "n/a"):
+            return None
+        history = ctx.verification_history or []
+        # Consecutive tail of the history carrying this prescription (the
+        # current verification is already appended by qc_assess).
+        run = []
+        for entry in reversed(history):
+            if self._same_prescription(entry.get("recommended_action"), action):
+                run.append(entry)
+            else:
+                break
+        if len(run) < self.STALL_TIMES:
+            return None
+        run.reverse()
+        first_score = run[0].get("quality_score") or 0.0
+        best_since = max((e.get("quality_score") or 0.0) for e in run)
+        if best_since > first_score + 0.02:
+            return None  # the fix is landing, however slowly
+        return {"prescription": action, "times": len(run),
+                "score_at_first": first_score, "best_since": best_since}
+
+    def _note_stalled_prescription(self, ctx: QCItemContext, stalled: dict) -> None:
+        known = ctx.state.setdefault("_stalled_prescriptions", [])
+        prior = next((k for k in known
+                      if self._same_prescription(k["prescription"], stalled["prescription"])),
+                     None)
+        if prior is None:
+            known.append(dict(stalled))
+            self.logger.warning(
+                f"   Prescribed fix did not take after {stalled['times']} tries "
+                f"(score {stalled['score_at_first']:.2f} → {stalled['best_since']:.2f}): "
+                f"\"{stalled['prescription'][:120]}\" — pivoting: it will not be "
+                "re-issued; a different path or the best result so far is next.")
+            return
+        prior["times"] = stalled["times"]
+        # Re-issued even after being named stalled: stop repeating.
+        ctx.stop_reason = (
+            f"prescribed fix \"{stalled['prescription'][:120]}\" did not take after "
+            f"{stalled['times']} tries; keeping the best result so far "
+            f"(score {ctx.best_score:.2f})")
+
+    @staticmethod
+    def _stalled_prescriptions_block(stalled) -> str:
+        if not stalled:
+            return ""
+        lines = ["\n**STALLED PRESCRIPTIONS — DO NOT RE-ISSUE:**"]
+        for st in stalled:
+            lines.append(
+                f"- \"{st['prescription'][:200]}\" was prescribed {st['times']} times and did "
+                f"not take (score {st.get('score_at_first', 0):.2f} → "
+                f"{st.get('best_since', 0):.2f}). The environment or the code generator "
+                "cannot satisfy it. Do not prescribe or mandate it again: either name a "
+                "materially different method path, or, if the best result is "
+                "scientifically adequate, accept it.")
+        return "\n".join(lines) + "\n"
+
+    def _stamp_stalled(self, ctx: QCItemContext) -> None:
+        stalled = ctx.state.get("_stalled_prescriptions")
+        if stalled and isinstance(ctx.best_result, dict):
+            ctx.best_result["stalled_prescriptions"] = [dict(s) for s in stalled]
 
     def qc_refit(self, ctx: QCItemContext, verification: dict,
                  refine_from: Optional[str], just_escalated_to_hot: bool) -> dict:
@@ -3980,6 +4083,7 @@ Return JSON with:
         # Judge is only called after all alternatives are exhausted.
 
     def qc_post_verification(self, ctx: QCItemContext) -> Optional[dict]:
+        self._stamp_stalled(ctx)
         # --- Explicit fast-path bypass (#271) ---
         # The initial score is provisional (0.0) when no verification ran,
         # so the accept gate below cannot pass it; return the accepted

--- a/scilink/agents/exp_agents/image_analysis_agent.py
+++ b/scilink/agents/exp_agents/image_analysis_agent.py
@@ -1590,6 +1590,10 @@ class ImageAnalysisAgent(SimpleFeedbackMixin, BaseAnalysisAgent):
                 results["quality_warning"] = series_results[0]["quality_warning"]
             if series_results and series_results[0].get("quality_history"):
                 results["quality_history"] = series_results[0]["quality_history"]
+            # A prescription the verification loop gave up on (#568) is part
+            # of the verdict the caller sees.
+            if series_results and series_results[0].get("stalled_prescriptions"):
+                results["stalled_prescriptions"] = series_results[0]["stalled_prescriptions"]
 
             # #172: surface the locked-script reuse verdict for the orchestrator
             if series_results and series_results[0].get("reuse_validity"):

--- a/tests/test_stalled_prescription.py
+++ b/tests/test_stalled_prescription.py
@@ -1,0 +1,153 @@
+"""#568 — the image verification loop pivots off a stalled prescription: a
+fix the verifier keeps re-issuing that never moves the score is named to
+the refiner and the verifier as stalled (do not re-issue), stamped on the
+result, and if it comes back once more the loop stops with the best
+result so far and a legible reason — instead of burning the whole budget
+repeating it."""
+import logging
+from types import SimpleNamespace
+
+from scilink.agents.exp_agents._qc_engine import CodegenQCEngine, QCEngineSpec, QCItemContext
+from scilink.agents.exp_agents.controllers.image_analysis_controllers import (
+    UnifiedImageProcessingController as Host,
+)
+
+
+def _host():
+    h = Host.__new__(Host)
+    h.logger = logging.getLogger("test.stalled")
+    return h
+
+
+def _ctx(actions_scores, state=None):
+    """A QC context whose verification history carries the given
+    (recommended_action, quality_score) pairs, oldest first."""
+    c = SimpleNamespace(state=state if state is not None else {},
+                        verification_history=[{"recommended_action": a, "quality_score": s}
+                                              for a, s in actions_scores],
+                        best_score=max((s for _, s in actions_scores), default=0.0),
+                        best_result={"success": True}, stop_reason=None)
+    return c
+
+
+SAM = "Invoke the SAM fallback (run_sam_analysis) and substitute its masks for the watershed output."
+SAM2 = "Substitute SAM masks: call run_sam_analysis as the fallback and replace the watershed segmentation."
+OTHER = "Increase the Gaussian blur sigma before thresholding to merge fragmented particles."
+
+
+def test_same_prescription_is_token_overlap_not_exact_text():
+    assert Host._same_prescription(SAM, SAM2)
+    assert not Host._same_prescription(SAM, OTHER)
+    assert not Host._same_prescription("", SAM) and not Host._same_prescription("none", "none")
+
+
+def test_detects_three_repeats_without_improvement_only():
+    h = _host()
+    # two repeats: not yet
+    assert h._detect_stalled_prescription(_ctx([(SAM, 0.5), (SAM2, 0.5)]), {"recommended_action": SAM}) is None
+    # three repeats, flat score: stalled
+    st = h._detect_stalled_prescription(_ctx([(OTHER, 0.4), (SAM, 0.5), (SAM2, 0.51), (SAM, 0.5)]),
+                                        {"recommended_action": SAM})
+    assert st and st["times"] == 3 and st["score_at_first"] == 0.5 and st["best_since"] == 0.51
+    # three repeats but the score climbed: the fix is landing, not stalled
+    assert h._detect_stalled_prescription(_ctx([(SAM, 0.4), (SAM2, 0.5), (SAM, 0.6)]),
+                                          {"recommended_action": SAM}) is None
+    # a different prescription in between breaks the run
+    assert h._detect_stalled_prescription(_ctx([(SAM, 0.5), (OTHER, 0.5), (SAM, 0.5)]),
+                                          {"recommended_action": SAM}) is None
+    # "none" is never a prescription
+    assert h._detect_stalled_prescription(_ctx([("none", 0.5)] * 4), {"recommended_action": "none"}) is None
+
+
+def test_first_stall_pivots_then_a_repeat_stops_the_loop(caplog):
+    h = _host()
+    ctx = _ctx([(SAM, 0.5), (SAM2, 0.5), (SAM, 0.5)])
+    st = h._detect_stalled_prescription(ctx, {"recommended_action": SAM})
+    with caplog.at_level(logging.WARNING, logger="test.stalled"):
+        h._note_stalled_prescription(ctx, st)
+    assert ctx.stop_reason is None
+    assert ctx.state["_stalled_prescriptions"][0]["prescription"] == SAM
+    assert "did not take after 3 tries" in caplog.text and "pivoting" in caplog.text
+    # the prompts now carry the block
+    block = Host._stalled_prescriptions_block(ctx.state["_stalled_prescriptions"])
+    assert "STALLED PRESCRIPTIONS" in block and "prescribed 3 times" in block
+    # re-issued once more after the pivot → stop with a reason, no new entry
+    ctx.verification_history.append({"recommended_action": SAM2, "quality_score": 0.5})
+    st = h._detect_stalled_prescription(ctx, {"recommended_action": SAM2})
+    h._note_stalled_prescription(ctx, st)
+    assert len(ctx.state["_stalled_prescriptions"]) == 1
+    assert ctx.state["_stalled_prescriptions"][0]["times"] == 4
+    assert "did not take after 4 tries" in ctx.stop_reason
+    # and the result is stamped for legibility
+    h._stamp_stalled(ctx)
+    assert ctx.best_result["stalled_prescriptions"][0]["times"] == 4
+
+
+def test_refinement_prompt_names_the_stalled_fix():
+    h = _host()
+    prompts = []
+    h.model = SimpleNamespace(generate_content=lambda **kw: prompts.append(kw["contents"][0]) or SimpleNamespace(text="{}"))
+    h.generation_config = None
+    h.safety_settings = None
+    h._parse = lambda r: ({}, "no json")
+    state = {"locked_analysis_config": {"processing_pipeline": "watershed", "analysis_approach": "x"},
+             "_annealing_level": 0}
+    stalled = [{"prescription": SAM, "times": 3, "score_at_first": 0.5, "best_since": 0.5}]
+    h._apply_verification_feedback(state, {"recommended_action": SAM, "issues_found": []},
+                                   history=[], stalled=stalled)
+    assert prompts and "STALLED PRESCRIPTIONS — DO NOT RE-ISSUE" in prompts[0]
+    assert "materially different method path" in prompts[0]
+
+
+class _LoopHost:
+    """Minimal engine host: every verification prescribes the same fix; the
+    refine hook stops the loop on its second call the way the image host
+    does after a pivot is ignored."""
+    _CONSTRAINT_ANNEALING_SCHEDULE = ("T0", "T1", "T2")
+    max_verification_iterations = 7
+
+    def __init__(self):
+        self.logger = logging.getLogger("test.loophost")
+        self.calls = []
+
+    def qc_loop_setup(self, ctx):
+        pass
+
+    def qc_verify(self, ctx):
+        self.calls.append("verify")
+        return {"quality_score": 0.5, "recommended_action": SAM}
+
+    def qc_assess(self, ctx, v):
+        ctx.verification_history.append({"quality_score": 0.5, "recommended_action": SAM})
+
+    def qc_check_accept(self, ctx, v):
+        return False
+
+    def qc_refine(self, ctx, v):
+        self.calls.append("refine")
+        if self.calls.count("refine") == 2:
+            ctx.stop_reason = "prescribed fix did not take"
+        return {"pipeline": f"p{len(self.calls)}"}
+
+    def qc_refit(self, ctx, v, refine_from, hot):
+        self.calls.append("refit")
+        return {"success": True}
+
+    def qc_after_refit(self, ctx, r, v):
+        self.calls.append("after_refit")
+
+    def qc_final_verify(self, ctx):
+        self.calls.append("final_verify")
+
+
+def test_engine_stops_on_the_host_stop_reason():
+    host = _LoopHost()
+    engine = CodegenQCEngine(host, QCEngineSpec(config_key=None, refine_anchor="none", refit_fail_msg="refit failed"))
+    ctx = QCItemContext(state={}, data=None, data_path="x", item_name="i", item_idx=0,
+                        is_regime_anchor=True)
+    ctx.n_levels = 3
+    ctx.best_result = {"success": True}
+    ctx.best_score = 0.5
+    engine._verification_loop(ctx)
+    # verify/refine twice; the second refine set stop_reason → final verify, no more refits
+    assert host.calls == ["verify", "refine", "refit", "after_refit", "verify", "refine", "final_verify"]


### PR DESCRIPTION
Closes #568.

## Summary

When the verifier kept prescribing a fix the code generator could not make take, the run repeated it until the verification budget was gone. The image verification loop now recognizes a stalled prescription — the same fix issued three iterations in a row with no score improvement — names it to both the refiner and the verifier as "do not re-issue: choose a materially different path or accept the best result", and if it comes back once more anyway, stops with the best result so far and a legible reason recorded on the result.

## Technical description

- `image_analysis_controllers.py`: `_same_prescription` (token Jaccard ≥ 0.5, so rewordings count; "none" never matches), `_detect_stalled_prescription` (consecutive tail of `verification_history` with the same action, `STALL_TIMES = 3`, best score since first appearance within 0.02), `_note_stalled_prescription` (records in `state["_stalled_prescriptions"]`, warns; a repeat after the pivot sets `ctx.stop_reason`), `_stalled_prescriptions_block` (added to the refinement prompt via a new `stalled=` parameter of `_apply_verification_feedback` and to the verifier prompt in `_verify_quality`), `_stamp_stalled` (result field `stalled_prescriptions`, applied in `qc_post_verification`).
- `_qc_engine.py`: `QCItemContext.stop_reason`; after each refinement the loop logs it and takes the final-verify path exactly as for the wall-clock budget.
- Tests (`tests/test_stalled_prescription.py`, 5): rewording tolerance; the detection rule; pivot then stop with the result stamp; the prompt block; the engine stopping on a host's reason (minimal fake host). The two `qc_golden` image failures are pre-existing on main.

### Live check (Bedrock, Opus 4.8 — induced stall)

Real image agent end to end (planning, code generation, sandbox, refinement) with the verifier replaced by a stub that always scores 0.5 and prescribes "invoke run_sam_analysis and substitute its masks" while `segment_anything` is absent from the execution interpreter. Budget 7 iterations. Observed: verifications 1–3 repeat the fix; after the third the host logs "Prescribed fix did not take after 3 tries (score 0.50 → 0.50) … pivoting"; the refiner prompt carries the stalled block from call 3 and the verifier from call 4; verification 4 re-issues it and the loop stops ("Stopping verification: prescribed fix … did not take after 4 tries; keeping the best result so far") — 4 of 7 iterations used. The returned result carries `stalled_prescriptions` (times 4, score 0.50 → 0.50); the first two passes exposed that the stamp reached the persisted item but not the returned dict, fixed in two follow-up commits. Run time about nine minutes per pass.