### PR TITLE
Drop the "beta" label from the Mission Control mode

### DIFF
--- a/scilink/ui/app.py
+++ b/scilink/ui/app.py
@@ -780,7 +780,7 @@ if not st.session_state.agent_initialized:
                     st.rerun()
         _cur_mode = _mode_map[st.session_state.app_mode]
         _cur_desc = _cur_mode["description"]
-        if _cur_mode.get("beta"):
+        if _cur_mode["key"] == "meta":
             _cur_desc = f"Mission Control · {_cur_desc}"
         st.markdown(
             f'<p style="text-align:center;color:#6B7A8C;font-size:0.85em;'

--- a/scilink/ui/components/chat_uploads.py
+++ b/scilink/ui/components/chat_uploads.py
@@ -347,10 +347,7 @@ def _render_planning_uploads(start_task_fn) -> None:
 def _render_meta_uploads(start_task_fn) -> None:
     st.markdown(
         '<div class="upload-hero-box">'
-        '<p class="upload-hero-title">What would you like to do? '
-        '<span style="font-size:0.45em;vertical-align:middle;'
-        'background:#8893a5;color:#fff;padding:2px 8px;border-radius:9px;'
-        'letter-spacing:1px;font-weight:600;">BETA</span></p>'
+        '<p class="upload-hero-title">What would you like to do?</p>'
         '<p class="upload-hero-subtitle">'
         "Describe your research goal — mission control agent will route "
         "it to the specialist agents</p>"

--- a/scilink/ui/config.py
+++ b/scilink/ui/config.py
@@ -25,7 +25,7 @@ EMBEDDING_MODEL_OPTIONS = [
 
 # ── Mode registry ────────────────────────────────────────────────
 APP_MODES = [
-    {"key": "meta",    "label": "🧪 📋 ⚛️",  "beta": True, "description": "Routes your research goal to the Analyze & Plan specialists"},
+    {"key": "meta",    "label": "🧪 📋 ⚛️",  "description": "Routes your research goal to the Analyze & Plan specialists"},
     {"key": "analyze", "label": "Analyze", "description": "Multi-modal data analysis"},
     {"key": "plan",    "label": "Plan",    "description": "Experimental design & optimization"},
     {"key": "simulate", "label": "Simulate", "description": "Submit and monitor DFT/MD simulations"},

--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -3,7 +3,6 @@
 export interface ModeInfo {
   key: string;
   label: string;
-  beta?: boolean;
   description: string;
 }
 

--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -137,7 +137,6 @@ label.field > span { display: block; margin-bottom: 4px; }
 .mode-trigger[aria-expanded="true"] .mode-caret { transform: rotate(-90deg); }
 .mode-emoji { font-size: 22px; line-height: 1; flex: none; }
 .mode-name { font-weight: 600; white-space: nowrap; }
-.mode-name .beta-pill { margin-left: 8px; }
 
 .mode-menu {
   position: absolute; top: calc(100% + 6px); left: 50%;
@@ -157,11 +156,6 @@ label.field > span { display: block; margin-bottom: 4px; }
 .mode-option.selected { border-color: var(--accent); }
 .welcome .tagline { color: var(--text-muted); font-size: 19px; margin: 0; }
 .welcome .hint { font-size: 14px; color: var(--text-dim); }
-.beta-pill {
-  font-size: 0.55em; vertical-align: middle;
-  background: #8893a5; color: #fff; padding: 2px 8px;
-  border-radius: 9px; letter-spacing: 1px; font-weight: 600;
-}
 
 /* ── chat ───────────────────────────────────────────────────── */
 

--- a/webui/src/components/PreChatHero.tsx
+++ b/webui/src/components/PreChatHero.tsx
@@ -510,7 +510,7 @@ function MetaHero({
   return (
     <div className="hero-wrap">
       <h2 className="hero-title">
-        What would you like to do? <span className="beta-pill">BETA</span>
+        What would you like to do?
       </h2>
       <p className="hero-sub">
         Mission control routes your goal — and any files — to the analysis

--- a/webui/src/components/WelcomeScreen.tsx
+++ b/webui/src/components/WelcomeScreen.tsx
@@ -72,7 +72,6 @@ function ModeSelect({
         <span className="mode-emoji">{cur.emoji}</span>
         <span className="mode-name">
           {cur.name}
-          {current?.beta && <span className="beta-pill">BETA</span>}
         </span>
         <span className="mode-caret">❯</span>
       </button>
@@ -94,7 +93,6 @@ function ModeSelect({
                 <span className="mode-emoji">{mi.emoji}</span>
                 <span className="mode-name">
                   {mi.name}
-                  {m.beta && <span className="beta-pill">BETA</span>}
                 </span>
               </button>
             );


### PR DESCRIPTION
## Summary

Mission Control (the meta mode) no longer carries a BETA badge anywhere: not in the Streamlit mode header or upload hero, not in the React welcome screen, mode picker or pre-chat hero. It is the default entry point and has shipped for several releases.

## Technical description

- `scilink/ui/config.py`: the `beta` flag is removed from the meta mode entry; the web `/config` endpoint passes the mode list through, so the field simply disappears from the API.
- `scilink/ui/app.py`: the "Mission Control · …" description prefix keys on `key == "meta"` instead of the flag. `scilink/ui/components/chat_uploads.py`: BETA span removed from the hero title.
- `webui/src`: `beta?` dropped from the `Mode` type; the pill removed from `WelcomeScreen` (two sites) and `PreChatHero`; `.beta-pill` styles removed. `tsc -b` clean; the config endpoint test passes.