### PR TITLE
BO: the constrained planner works in one space for categorical inputs

### DIFF
--- a/scilink/agents/planning_agents/bo_agent.py
+++ b/scilink/agents/planning_agents/bo_agent.py
@@ -303,6 +303,79 @@ class OptimizationAgent(BaseAgent):
     # Acquisition Landscape Summarization (for constrained batch planning)
     # =====================================================================
 
+    # ── categorical inputs in the constrained planner (#579) ─────────
+    # An index-encoded categorical column reaches the optimizer as codes
+    # 0..n-1, but the constrained planner is an LLM reasoning over physical
+    # constraints and a physical-unit data summary. Mixing the two spaces
+    # let it "exclude the 5.0 mM stock because the bound is 4.0" and return
+    # a physical value that was then decoded as a level index. Everything
+    # the planner reads is therefore rendered in level names, and every
+    # value it returns is mapped back to a code here.
+
+    @staticmethod
+    def _norm_level_label(v) -> str:
+        sv = str(v).strip()
+        try:
+            f = float(sv)
+            return str(int(f)) if f == int(f) else repr(f)
+        except (TypeError, ValueError):
+            return sv
+
+    @classmethod
+    def _level_of(cls, levels: List[str], code) -> str:
+        """Level name for a (possibly fractional) code — nearest index."""
+        try:
+            i = int(round(float(code)))
+        except (TypeError, ValueError):
+            return str(code)
+        return str(levels[max(0, min(len(levels) - 1, i))])
+
+    @classmethod
+    def _code_of(cls, levels: List[str], value) -> Optional[int]:
+        """Code for a planner-returned value: an exact level name (numeric-
+        looking values compare as numbers), else the nearest numeric level
+        within 1 % of the level spacing, else None (a validation error)."""
+        norm = cls._norm_level_label(value)
+        labels = [cls._norm_level_label(l) for l in levels]
+        if norm in labels:
+            return labels.index(norm)
+        try:
+            fv = float(str(value).strip())
+            nums = [float(l) for l in labels]
+        except (TypeError, ValueError):
+            return None
+        i = int(np.argmin([abs(n - fv) for n in nums]))
+        spacing = (max(nums) - min(nums)) / max(1, len(nums) - 1)
+        return i if abs(nums[i] - fv) <= max(1e-9, 0.01 * spacing) else None
+
+    def _decode_point(self, point: Dict[str, Any], input_levels) -> Dict[str, Any]:
+        """A code-space point rendered in level names (numeric levels as numbers)."""
+        if not input_levels or not point:
+            return point
+        out = dict(point)
+        for col, levels in input_levels.items():
+            if col in out:
+                lv = self._level_of(levels, out[col])
+                try:
+                    out[col] = float(lv)
+                except (TypeError, ValueError):
+                    out[col] = lv
+        return out
+
+    def _physical_frame(self, df, input_levels):
+        """The data frame with categorical codes replaced by level names."""
+        if not input_levels:
+            return df
+        out = df.copy()
+        for col, levels in input_levels.items():
+            if col in out.columns:
+                mapped = out[col].map(lambda v, L=levels: self._level_of(L, v))
+                try:
+                    out[col] = mapped.astype(float)
+                except (TypeError, ValueError):
+                    out[col] = mapped
+        return out
+
     def _summarize_acquisition_landscape(
         self,
         optimizer,
@@ -310,7 +383,8 @@ class OptimizationAgent(BaseAgent):
         input_bounds: List[List[float]],
         is_moo: bool = False,
         n_regions: int = 15,
-        grid_resolution: int = 40
+        grid_resolution: int = 40,
+        input_levels: Optional[Dict[str, List[str]]] = None,
     ) -> str:
         """
         Evaluate the acquisition function on a dense grid, cluster high-value 
@@ -379,7 +453,10 @@ class OptimizationAgent(BaseAgent):
         rows = []
         for i, region in enumerate(regions):
             param_strs = " | ".join(
-                f"{region['center'][j]:.4f}" for j in range(len(input_cols))
+                (self._level_of(input_levels[col], region['center'][j])
+                 if input_levels and col in input_levels
+                 else f"{region['center'][j]:.4f}")
+                for j, col in enumerate(input_cols)
             )
             spread_str = ", ".join(
                 f"{s:.3f}" for s in region.get('spread', [0.0] * len(input_cols))
@@ -523,7 +600,8 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
         current_best_value: Dict[str, float],
         budget_ctx: Dict[str, Any],
         is_moo: bool = False,
-        pareto_front: Optional[List[Dict]] = None
+        pareto_front: Optional[List[Dict]] = None,
+        input_levels: Optional[Dict[str, List[str]]] = None,
     ) -> Tuple[Optional[List[Dict[str, float]]], Optional[Dict[str, Any]], Optional[str]]:
         """
         Use LLM to design a physically constrained experiment batch informed by 
@@ -558,7 +636,10 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
             f"Every experiment in the batch must have ALL of these keys in its \"params\" dict. "
             f"Use these exact strings — do not rename, abbreviate, or expand them.",
             f"\n## Parameter Bounds\n" + "\n".join(
-                f"- {col}: [{bounds[0]}, {bounds[1]}]" 
+                (f"- {col}: CATEGORICAL — one of {json.dumps([str(l) for l in input_levels[col]])} "
+                 f"(use one of these exact values)")
+                if input_levels and col in input_levels
+                else f"- {col}: [{bounds[0]}, {bounds[1]}]"
                 for col, bounds in zip(input_cols, input_bounds)
             ),
             f"\n## Acquisition Landscape\n{acq_summary}",
@@ -687,10 +768,30 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
                         )
                         continue
                     
-                    # Check values within bounds (with tolerance for constraint snapping)
+                    # Check values within bounds (with tolerance for constraint snapping);
+                    # a categorical value must be one of its levels and is
+                    # stored as its code so downstream stays in the
+                    # optimizer's space (the orchestrator decodes it once).
                     tolerance = 0.01
+                    rec: Dict[str, float] = {}
+                    bad = False
                     for col, bounds in zip(input_cols, input_bounds):
-                        val = float(params[col])
+                        if input_levels and col in input_levels:
+                            code = self._code_of(input_levels[col], params[col])
+                            if code is None:
+                                validation_errors.append(
+                                    f"Experiment {i+1}: {col}={params[col]!r} is not one of "
+                                    f"the levels {[str(l) for l in input_levels[col]]}")
+                                bad = True
+                                continue
+                            rec[col] = float(code)
+                            continue
+                        try:
+                            val = float(params[col])
+                        except (TypeError, ValueError):
+                            validation_errors.append(f"Experiment {i+1}: {col}={params[col]!r} is not numeric")
+                            bad = True
+                            continue
                         param_range = bounds[1] - bounds[0]
                         tol = param_range * tolerance if param_range > 0 else 0.01
                         if val < bounds[0] - tol or val > bounds[1] + tol:
@@ -698,8 +799,9 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
                                 f"Experiment {i+1}: {col}={val} outside bounds "
                                 f"[{bounds[0]}, {bounds[1]}]"
                             )
-                    
-                    rec = {col: float(params[col]) for col in input_cols}
+                        rec[col] = val
+                    if bad:
+                        continue
                     recommendations.append(rec)
                 
                 if validation_errors:
@@ -989,7 +1091,8 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
                              fidelity_config: Optional[Dict[str, Any]] = None,
                              skill: Union[str, List[str], None] = None,
                              candidate_pool: Union[str, List[List[float]], np.ndarray, None] = None,
-                             seed: Optional[int] = None) -> Dict[str, Any]:
+                             seed: Optional[int] = None,
+                             input_levels: Optional[Dict[str, List[str]]] = None) -> Dict[str, Any]:
         """
         Run one iteration of the Bayesian Optimization loop.
         
@@ -1106,6 +1209,10 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
             save_acq=save_acq, plot_acq=plot_acq, fixed_noise_std=fixed_noise_std,
             cat_dims=cat_dims, dkl_config=dkl_config, fidelity_config=fidelity_config,
             candidate_pool=candidate_pool,
+            # Level names of index-encoded categorical inputs (#579): the
+            # constrained planner reasons in physical terms, so it sees these
+            # instead of code-space bounds and its answers are mapped back.
+            input_levels=dict(input_levels) if input_levels else None,
             minimize_mask=[], constrained_metadata=None,
             acq_plot_path=None, acq_data_path=None,
         )
@@ -1392,11 +1499,13 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
         if c.physical_constraints:
             print(f"  - 📐 Physical constraints detected. Generating acquisition landscape...")
 
+            levels = getattr(c, "input_levels", None) or None
             acq_summary = self._summarize_acquisition_landscape(
                 optimizer=optimizer,
                 input_cols=input_cols,
                 input_bounds=c.input_bounds,
-                is_moo=c.is_moo
+                is_moo=c.is_moo,
+                input_levels=levels,
             )
 
             # Get current best for context (un-negate for display)
@@ -1427,9 +1536,18 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
                 }
                 pareto_front = None
 
-            # df still has original values (only y array was negated),
-            # so df.describe() shows natural units for LLM display
-            data_summary_str = c.df.describe().to_markdown()
+            # The planner reads physical units: categorical codes are
+            # rendered as their level names in the data summary, the
+            # current best / Pareto points and the unconstrained picks.
+            _phys = self._physical_frame(c.df, levels)
+            try:
+                data_summary_str = _phys.describe(include="all").to_markdown()
+            except Exception:  # noqa: BLE001 - tabulate / mixed dtypes
+                data_summary_str = _phys.describe().to_string()
+            if levels:
+                current_best = self._decode_point(current_best, levels) if current_best else current_best
+                if pareto_front:
+                    pareto_front = [self._decode_point(p, levels) for p in pareto_front]
 
             constrained_recs, constrained_metadata, constraint_error = self._plan_constrained_batch(
                 objective_text=c.objective_text,
@@ -1438,7 +1556,9 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
                 batch_size=c.batch_size,
                 acq_summary=acq_summary,
                 physical_constraints=c.physical_constraints,
-                unconstrained_recommendations=c.unconstrained_recommendations,
+                unconstrained_recommendations=[self._decode_point(r, levels)
+                                               for r in c.unconstrained_recommendations],
+                input_levels=levels,
                 data_summary_str=data_summary_str,
                 current_best=current_best,
                 current_best_value=current_best_value,

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -5253,6 +5253,9 @@ class OrchestratorTools:
                     plot_acq=True,
                     save_acq=True,
                     cat_dims=cat_dims if cat_dims else None,
+                    # Level names for the constrained planner (#579): it
+                    # reasons in physical terms; codes stay the optimizer's.
+                    input_levels=level_maps if level_maps else None,
                     skill=skill,
                     fidelity_config=fidelity_config,
                     candidate_pool=resolved_pool,

--- a/scilink/server/app.py
+++ b/scilink/server/app.py
@@ -71,6 +71,8 @@ def create_app(session_root: Path, serve_frontend: bool = True,
     sets it for a non-loopback bind) disables the endpoints that read
     arbitrary paths on the server's machine (pasted folders, plan dirs)
     — they only make sense when the browser and the server share a host."""
+    from .cli import _headless_matplotlib
+    _headless_matplotlib()
     app = FastAPI(title="SciLink Web", docs_url="/api/docs")
     app.add_middleware(
         CORSMiddleware,

--- a/scilink/server/cli.py
+++ b/scilink/server/cli.py
@@ -19,7 +19,25 @@ import sys
 from pathlib import Path
 
 
+def _headless_matplotlib() -> None:
+    """Force a non-interactive backend before any agent imports pyplot.
+
+    The agents draw diagnostics on the server's worker threads; on macOS
+    matplotlib's default GUI backend refuses that ("Cannot create a GUI
+    FigureManager outside the main thread"), so a plan session's BO step
+    failed at its plot unless something else had switched to Agg first.
+    """
+    import os
+    os.environ.setdefault("MPLBACKEND", "Agg")
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+    except Exception:  # noqa: BLE001 - matplotlib absent or already locked
+        pass
+
+
 def main(argv=None) -> int:
+    _headless_matplotlib()
     parser = argparse.ArgumentParser(
         prog="scilink-web",
         description="SciLink web backend (REST + SSE) for the React UI.")

--- a/tests/test_bo_categorical_planner_space.py
+++ b/tests/test_bo_categorical_planner_space.py
@@ -1,0 +1,136 @@
+"""#579 — the constrained planner works in ONE space. An index-encoded
+categorical input reaches the optimizer as codes, but the planner (an LLM
+reasoning over physical constraints) is shown the level names — in the
+bounds, the acquisition landscape, the data summary, the current best and
+the unconstrained picks — and every value it returns is mapped back to a
+code before it flows downstream (where the orchestrator decodes once)."""
+import json
+import types
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+
+from scilink.agents.planning_agents.bo_agent import BOAgent
+
+LEVELS = {"catalyst_conc_mM": ["0.1", "0.5", "1", "2", "5"]}
+
+
+def test_code_and_level_mapping():
+    lv = LEVELS["catalyst_conc_mM"]
+    assert BOAgent._level_of(lv, 3) == "2" and BOAgent._level_of(lv, 2.6) == "2"
+    assert BOAgent._level_of(lv, -1) == "0.1" and BOAgent._level_of(lv, 9) == "5"
+    # exact level names (numeric-looking values compare as numbers)
+    assert BOAgent._code_of(lv, "2") == 3 and BOAgent._code_of(lv, 2.0) == 3 and BOAgent._code_of(lv, "2.0") == 3
+    assert BOAgent._code_of(lv, 0.1) == 0 and BOAgent._code_of(lv, "5") == 4
+    # a nearby value snaps only within 1 % of the level spacing
+    assert BOAgent._code_of(lv, 2.005) == 3
+    assert BOAgent._code_of(lv, 1.95) is None and BOAgent._code_of(lv, 3.0) is None
+    # string levels: exact only
+    assert BOAgent._code_of(["A", "B"], "B") == 1 and BOAgent._code_of(["A", "B"], "b") is None
+
+
+def _agent(planner_json):
+    """A BOAgent shell whose model returns the planner's JSON verbatim."""
+    a = BOAgent.__new__(BOAgent)
+    a.model = SimpleNamespace(generate_content=lambda *args, **kw: SimpleNamespace(text=json.dumps(planner_json)))
+    a.generation_config = None
+    a.prompts = []
+    real = a.model.generate_content
+
+    def capture(*args, **kw):
+        a.prompts.append(args[0] if args else kw.get("contents"))
+        return real(*args, **kw)
+    a.model.generate_content = capture
+    return a
+
+
+def test_planner_sees_levels_and_its_physical_answer_becomes_a_code():
+    planner = {"batch": [{"experiment_id": 1, "params": {"catalyst_conc_mM": 2.0, "temperature_C": 80.0}}],
+               "allocation_strategy": "s", "coverage_summary": "c", "trade_offs": "t"}
+    a = _agent(planner)
+    recs, meta, err = a._plan_constrained_batch(
+        objective_text="max yield", input_cols=["catalyst_conc_mM", "temperature_C"],
+        input_bounds=[[0.0, 4.0], [40.0, 80.0]], batch_size=1, acq_summary="landscape",
+        physical_constraints="only 0.1, 0.5, 1.0, 2.0, 5.0 mM stocks",
+        unconstrained_recommendations=[{"catalyst_conc_mM": 1.0, "temperature_C": 80.0}],
+        data_summary_str="| stats |", current_best={"catalyst_conc_mM": 2.0, "temperature_C": 73.0},
+        current_best_value={"yield": 52.0}, budget_ctx={"budget_phase": "unlimited"},
+        is_moo=False, pareto_front=None, input_levels=LEVELS)
+    assert err is None and meta["valid_count"] == 1
+    # the planner said 2.0 mM (physical) → code 3 downstream
+    assert recs == [{"catalyst_conc_mM": 3.0, "temperature_C": 80.0}]
+    prompt = "\n".join(p if isinstance(p, str) else str(p) for p in a.prompts[0])
+    assert 'catalyst_conc_mM: CATEGORICAL — one of ["0.1", "0.5", "1", "2", "5"]' in prompt
+    assert "[0.0, 4.0]" not in prompt          # no code-space bound for the categorical input
+    assert "temperature_C: [40.0, 80.0]" in prompt
+
+
+def test_planner_value_off_the_levels_is_a_validation_error():
+    planner = {"batch": [{"experiment_id": 1, "params": {"catalyst_conc_mM": 3.0, "temperature_C": 80.0}},
+                         {"experiment_id": 2, "params": {"catalyst_conc_mM": "5", "temperature_C": 60.0}}]}
+    a = _agent(planner)
+    recs, meta, err = a._plan_constrained_batch(
+        objective_text="o", input_cols=["catalyst_conc_mM", "temperature_C"],
+        input_bounds=[[0.0, 4.0], [40.0, 80.0]], batch_size=2, acq_summary="l",
+        physical_constraints="stocks", unconstrained_recommendations=[], data_summary_str="s",
+        current_best={}, current_best_value={}, budget_ctx={"budget_phase": "unlimited"},
+        input_levels=LEVELS)
+    assert err is None
+    assert recs == [{"catalyst_conc_mM": 4.0, "temperature_C": 60.0}]   # only the valid one, as a code
+    assert any("not one of the levels" in e for e in meta["validation_errors"])
+
+
+def test_landscape_and_summary_render_level_names():
+    a = BOAgent.__new__(BOAgent)
+    a._cluster_acquisition_regions = lambda grid, acq, cols, bounds, n: [
+        {"center": np.array([3.0, 80.0]), "acq_value": 0.9, "spread": [0.2, 1.0], "notes": ""},
+        {"center": np.array([0.7, 60.0]), "acq_value": 0.4, "spread": [0.2, 1.0], "notes": ""}]
+    optimizer = SimpleNamespace(evaluate_acquisition=lambda pts: np.ones(len(pts)))
+    table = a._summarize_acquisition_landscape(optimizer, ["catalyst_conc_mM", "temperature_C"],
+                                               [[0.0, 4.0], [40.0, 80.0]], input_levels=LEVELS)
+    assert "| 1 | 2 | 80.0000 |" in table and "| 2 | 0.5 | 60.0000 |" in table   # codes 3 → "2", 0.7 → index 1 → "0.5"
+    assert "3.0000" not in table
+    df = pd.DataFrame({"catalyst_conc_mM": [0.0, 3.0, 4.0], "temperature_C": [40.0, 60.0, 80.0], "yield": [1, 2, 3]})
+    phys = a._physical_frame(df, LEVELS)
+    assert phys["catalyst_conc_mM"].tolist() == [0.1, 2.0, 5.0]
+    assert a._decode_point({"catalyst_conc_mM": 4.0, "temperature_C": 80.0}, LEVELS) == {"catalyst_conc_mM": 5.0, "temperature_C": 80.0}
+    # non-numeric levels stay strings
+    assert a._physical_frame(pd.DataFrame({"solvent": [0.0, 1.0]}), {"solvent": ["water", "DMSO"]})["solvent"].tolist() == ["water", "DMSO"]
+
+
+def test_stage_hands_the_planner_physical_inputs_and_keeps_codes_downstream():
+    seen = {}
+
+    def planner(**kw):
+        seen.update(kw)
+        return [{"catalyst_conc_mM": 3.0, "temperature_C": 75.0}], {"coverage_summary": "ok"}, None
+
+    a = SimpleNamespace(_summarize_acquisition_landscape=lambda **kw: seen.setdefault("landscape_kw", kw) and "L",
+                        _plan_constrained_batch=planner, _log_action=lambda **kw: None, _run_seed=None)
+    a._physical_frame = types.MethodType(BOAgent._physical_frame, a)
+    a._decode_point = types.MethodType(BOAgent._decode_point, a)
+    a._level_of = BOAgent._level_of
+    a._norm_level_label = BOAgent._norm_level_label
+    c = SimpleNamespace(
+        input_cols=["catalyst_conc_mM", "temperature_C"], target_cols=["yield"],
+        X=np.array([[0.0, 40.0], [3.0, 60.0]]), y=np.array([[0.4], [0.9]]), optimizer=object(),
+        minimize_mask=[], is_moo=False, input_bounds=[[0.0, 4.0], [40.0, 80.0]], objective_text="o",
+        budget_ctx={"budget_phase": "unlimited"}, batch_size=1, physical_constraints="stocks",
+        unconstrained_recommendations=[{"catalyst_conc_mM": 2.0, "temperature_C": 82.0}],
+        constrained_metadata=None, next_x_batch=None, recommendations=None, input_levels=LEVELS,
+        df=pd.DataFrame({"catalyst_conc_mM": [0.0, 3.0], "temperature_C": [40.0, 60.0], "yield": [0.4, 0.9]}),
+        valid_config={"acquisition_strategy": {"type": "log_ei"}, "model_config": {}}, plot_path="p",
+        inspection={}, acq_plot_path=None, acq_data_path=None, candidate_pool_info=None, data_path="d",
+        experimental_budget=None, save_acq=False, plot_acq=False, cat_dims=[0], output_dir="/tmp/x")
+    BOAgent._stage_constrained_batch(a, c)
+    # the planner saw physical values: current best 2 mM (code 3), unconstrained pick 1 mM (code 2)
+    assert seen["current_best"] == {"catalyst_conc_mM": 2.0, "temperature_C": 60.0}
+    assert seen["unconstrained_recommendations"] == [{"catalyst_conc_mM": 1.0, "temperature_C": 82.0}]
+    assert seen["input_levels"] == LEVELS and seen["landscape_kw"]["input_levels"] == LEVELS
+    assert "0.1" in seen["data_summary_str"] or "0.1" in str(seen["data_summary_str"])
+    # downstream stays in code space (the orchestrator decodes once)
+    assert c.recommendations == [{"catalyst_conc_mM": 3.0, "temperature_C": 75.0}]
+    assert c.selection_method == "constrained_planner"
+    res = BOAgent._stage_output(a, c)
+    assert res["acqf_optimum"] == {"catalyst_conc_mM": 2.0, "temperature_C": 82.0}  # codes, as the recommendation

--- a/tests/test_bo_selection_method.py
+++ b/tests/test_bo_selection_method.py
@@ -3,6 +3,7 @@
 deliberate, constraint-aware deviation chosen by the LLM planner), and a
 planner-chosen point carries the optimum it deviated from. Exercises the
 two stages directly with a stub agent, no LLM."""
+import types
 from types import SimpleNamespace
 
 import numpy as np
@@ -10,9 +11,9 @@ import numpy as np
 from scilink.agents.planning_agents.bo_agent import BOAgent
 
 
-class _Frame:
-    def describe(self):
-        return SimpleNamespace(to_markdown=lambda: "| stats |")
+def _Frame():
+    import pandas as pd
+    return pd.DataFrame({"T": [1.0, 3.0], "pH": [2.0, 4.0], "yield": [0.5, 0.9]})
 
 
 def _ctx(batch_size=1, constraints=None):
@@ -40,6 +41,9 @@ def _agent(planner):
         _log_action=lambda **kw: None,
         _run_seed=None,
     )
+    # the stage renders the planner's inputs in physical terms (#579)
+    a._physical_frame = types.MethodType(BOAgent._physical_frame, a)
+    a._decode_point = types.MethodType(BOAgent._decode_point, a)
     return a
 
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1143,3 +1143,13 @@ def test_skills_catalog_view_and_upload(client, tmp_path):
     session.agent = SimpleNamespace()
     assert client.get(f"{base}/skills").json()["skills_supported"] is False
     assert client.post(f"{base}/skills", files=[("files", ("a.md", b"# a"))]).status_code == 400
+
+
+def test_server_forces_a_headless_matplotlib_backend(tmp_path):
+    """Agents plot on worker threads; macOS's GUI backend refuses that, so
+    creating the app must leave matplotlib on Agg (and set MPLBACKEND for
+    any subprocess the agents spawn)."""
+    import matplotlib
+    create_app(tmp_path, serve_frontend=False)
+    assert matplotlib.get_backend().lower() == "agg"
+    assert os.environ.get("MPLBACKEND") == "Agg"


### PR DESCRIPTION
Closes #579.

## Summary

When a BO input is categorical (a set of stock concentrations, a choice of solvents) and physical constraints are given, the constrained planner used to see index-encoded bounds next to data in physical units, could invent exclusions like "the 5.0 mM stock exceeds the 4.0 upper bound", and its physical answer was then decoded as a level index, so the reported recommendation could name a different level than the one it chose. The planner now reasons entirely in physical terms — it sees each categorical input as its list of allowed levels, the acquisition landscape, data summary, current best and unconstrained picks in level names — and everything it returns is mapped back to the optimizer's codes before the orchestrator decodes it once. A second fix found on the way: the web server now forces a headless matplotlib backend at startup, so a plan session's BO step no longer fails at its diagnostics plot on macOS when no image preview happened to switch the backend first.

## Technical description

- `bo_agent.run_optimization_loop(..., input_levels=None)`: the orchestrator passes its `level_maps`. In `_stage_constrained_batch` the acquisition-landscape table renders categorical region centres as level names (`_summarize_acquisition_landscape(input_levels=...)`), the data summary comes from `_physical_frame` (codes → level names, numeric levels as numbers), and current best / Pareto front / unconstrained recommendations go through `_decode_point`. `_plan_constrained_batch(input_levels=...)` renders a categorical input's bounds line as `CATEGORICAL — one of [...]` and, on validation, maps each returned value to a code via `_code_of` (exact level name with numeric-looking values compared as numbers, or the nearest numeric level within 1 % of the level spacing; anything else is a validation error naming the levels). Recommendations, `next_x_batch`, `acqf_optimum` and `bo_history` stay in code space; the orchestrator's existing `_decode_categorical_recs` is now applied to codes only.
- `scilink/server/cli.py` / `app.py`: `_headless_matplotlib()` sets `MPLBACKEND=Agg` and `matplotlib.use("Agg")` before any agent imports pyplot (also from `create_app`, for embedders and tests).
- Tests: `tests/test_bo_categorical_planner_space.py` (5): code/level mapping incl. snapping tolerance and string levels; the planner prompt shows levels and its physical answer becomes a code; an off-level answer is rejected with the level list; level names in the landscape table and data frame; the stage hands the planner physical inputs and keeps codes downstream. `test_web_server.py`: the app leaves matplotlib on Agg. BO suites: 55 pass.

### Live matrix (Bedrock, Opus 4.8, plan sessions)

- Original repro (8 rows, five stock levels, constraint text, batch 1): planner chose 1.0 mM at 80 °C; `bo_history` holds code 2.0, the tool response decodes it to `"1"`, the narration says 1.0 mM — one answer everywhere, and the planner's trade-offs no longer mention a fabricated bound.
- Same data, unconstrained: `acqf_optimizer`, code 3.0 → `"2"` mM, consistent.
- Same data, batch of 4 sharing one stock: all four at code 3.0 → `"2"` mM with four temperatures.
- String levels (solvent water/ethanol/DMSO, ethanol banned, batch 2): planner returned DMSO and water; codes 0 and 2; ethanol excluded; decoded names correct.
- The first attempt of this matrix failed on the matplotlib GUI-backend error on all four sessions, which is what led to the server fix.