### PR TITLE
Web UI: smaller landing-page mode picker; readable code panes in light mode

### DIFF
--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -117,7 +117,7 @@ label.field > span { display: block; margin-bottom: 4px; }
 }
 .welcome .logo-big { width: 380px; }
 .welcome .mode-desc {
-  font-size: 15px; color: var(--text-dim); margin: 0;
+  font-size: 14px; color: var(--text-dim); margin: 0;
   max-width: 520px;
 }
 
@@ -125,8 +125,8 @@ label.field > span { display: block; margin-bottom: 4px; }
    shows once beneath the trigger. */
 .mode-select { position: relative; }
 .mode-trigger {
-  display: flex; align-items: center; gap: 12px;
-  font-size: 18px; padding: 12px 20px; min-width: 300px;
+  display: flex; align-items: center; gap: 10px;
+  font-size: 15px; padding: 8px 16px; min-width: 260px;
   border-radius: 10px;
 }
 .mode-trigger .mode-name { flex: 1; text-align: left; }
@@ -135,7 +135,7 @@ label.field > span { display: block; margin-bottom: 4px; }
   transform: rotate(90deg); transition: transform 0.15s;
 }
 .mode-trigger[aria-expanded="true"] .mode-caret { transform: rotate(-90deg); }
-.mode-emoji { font-size: 22px; line-height: 1; flex: none; }
+.mode-emoji { font-size: 18px; line-height: 1; flex: none; }
 .mode-name { font-weight: 600; white-space: nowrap; }
 
 .mode-menu {
@@ -148,9 +148,9 @@ label.field > span { display: block; margin-bottom: 4px; }
   display: flex; flex-direction: column; gap: 2px;
 }
 .mode-option {
-  display: flex; align-items: center; gap: 14px;
-  text-align: left; padding: 12px 14px; border: 1px solid transparent;
-  background: none; border-radius: 8px; font-size: 15px;
+  display: flex; align-items: center; gap: 12px;
+  text-align: left; padding: 8px 12px; border: 1px solid transparent;
+  background: none; border-radius: 8px; font-size: 14px;
 }
 .mode-option:hover:not(:disabled) { background: var(--bg-panel); border-color: var(--border); }
 .mode-option.selected { border-color: var(--accent); }
@@ -762,7 +762,7 @@ details.card iframe { width: 100%; height: 600px; border: none; background: #fff
 .tel-row.open td { background: var(--bg-panel); border-bottom: none; }
 .tel-row-detail td { padding: 4px 8px 12px 24px; }
 .tel-shape { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; color: var(--text-dim); word-break: break-word; }
-.tel-json { margin: 0; padding: 8px 10px; max-height: 320px; overflow: auto; font-size: 12px; white-space: pre-wrap; word-break: break-word; background: var(--code-bg); border: 1px solid var(--code-border); border-radius: 4px; }
+.tel-json { margin: 0; padding: 8px 10px; max-height: 320px; overflow: auto; font-size: 12px; white-space: pre-wrap; word-break: break-word; background: var(--code-bg); color: var(--code-text); border: 1px solid var(--code-border); border-radius: 4px; }
 .tel-status { font-size: 12px; padding: 1px 7px; border-radius: 10px; border: 1px solid var(--border); color: var(--text-dim); white-space: nowrap; }
 .tel-status.status-success, .tel-status.status-ok, .tel-status.status-completed { color: #3fb950; border-color: #3fb95055; }
 .tel-status.status-error, .tel-status.status-failed { color: #f85149; border-color: #f8514955; }
@@ -833,7 +833,7 @@ details.card iframe { width: 100%; height: 600px; border: none; background: #fff
 @keyframes mem-spin { to { transform: rotate(360deg); } }
 .mem-review { margin-top: 10px; padding: 8px 10px; border: 1px solid var(--border-strong); border-radius: 6px; font-size: 13px; }
 .mem-editor { width: 100%; box-sizing: border-box; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; margin: 6px 0; }
-.mem-diff { margin: 6px 0; padding: 8px 10px; max-height: 360px; overflow: auto; font-size: 12px; background: var(--code-bg); border: 1px solid var(--code-border); border-radius: 4px; white-space: pre; }
+.mem-diff { margin: 6px 0; padding: 8px 10px; max-height: 360px; overflow: auto; font-size: 12px; background: var(--code-bg); color: var(--code-text); border: 1px solid var(--code-border); border-radius: 4px; white-space: pre; }
 .mem-diff .add { color: #3fb950; }
 .mem-diff .del { color: #f85149; }
 .mem-diff .hunk { color: #58a6ff; }


### PR DESCRIPTION
## Summary

Two cosmetic fixes. The Mission Control / Analyze / Plan picker on the landing page was a size too large; it is now 15 px with tighter padding and the option rows 14 px. In light mode the Telemetry tab's Arguments and Result blocks (and the memory panel's diff) were unreadable because the dark code pane inherited the page's dark text; they now use the code-pane text color in both themes.

## Technical description

`webui/src/app.css` only: `.mode-trigger` 18 → 15 px, padding 12/20 → 8/16, min-width 300 → 260; `.mode-option` 15 → 14 px, padding 12/14 → 8/12; `.mode-emoji` 22 → 18 px; `.welcome .mode-desc` 15 → 14 px. `.tel-json` and `.mem-diff` gain `color: var(--code-text)` (the tokens keep code panes dark in both themes, so the text color must be explicit). Verified in Chrome in light mode: the expanded tool row shows its arguments and result; the mode picker at the new sizes.