### PR TITLE
Web UI polish: session-relative paths, readable graph, tab order, memory folds, log stand-down

### DIFF
--- a/scilink/agents/meta_agent/telemetry.py
+++ b/scilink/agents/meta_agent/telemetry.py
@@ -157,6 +157,23 @@ def _analysis_reports(base_dir: Path) -> List[Dict[str, Any]]:
     return reports
 
 
+def relativize(obj: Any, root: Optional[str]) -> Any:
+    """Strings (recursively, through dicts and lists) with the session root
+    prefix removed — a tool argument or result that names
+    ``<root>/analysis/results/x.png`` reads ``analysis/results/x.png``.
+    The root itself becomes ``.``. Anything else is returned unchanged."""
+    if not root:
+        return obj
+    root = str(root).rstrip("/")
+    if isinstance(obj, str):
+        return obj.replace(root + "/", "").replace(root, ".")
+    if isinstance(obj, list):
+        return [relativize(v, root) for v in obj]
+    if isinstance(obj, dict):
+        return {k: relativize(v, root) for k, v in obj.items()}
+    return obj
+
+
 def _maybe_json(value: Any) -> Any:
     """Parse a JSON string into a dict/list; leave anything else as-is.
 
@@ -346,6 +363,7 @@ def collect_session_telemetry(meta_agent: Any) -> Dict[str, Any]:
             if a["name"] not in names:
                 names.append(a["name"])
 
+        root = str(base_dir_raw) if base_dir_raw else None
         return {
             "meta": {
                 "meta_mode": meta_mode_str,
@@ -354,10 +372,12 @@ def collect_session_telemetry(meta_agent: Any) -> Dict[str, Any]:
                 "delegations": delegations,
             },
             "specialists": _specialists(meta_agent),
-            "agents": agents,
+            # Session-relative paths throughout: absolute roots tripled the
+            # width of every argument / result row in the Telemetry tab.
+            "agents": relativize(agents, root),
             "sub_agents": sub_agents,
-            "analysis_reports": analysis_reports,
-            "tool_sequence": tool_sequence,
+            "analysis_reports": relativize(analysis_reports, root),
+            "tool_sequence": relativize(tool_sequence, root),
         }
     except Exception as e:  # noqa: BLE001 - telemetry must never break the UI
         logger.warning(f"telemetry collection failed: {e}")

--- a/scilink/server/delegations.py
+++ b/scilink/server/delegations.py
@@ -56,6 +56,16 @@ def _rel(path: Any, session_dir: Optional[str]) -> str:
         return p
 
 
+def _rel_text(text: Any, session_dir: Optional[str]) -> str:
+    """Text with absolute session-root paths shortened to session-relative
+    ones (the ledger records the ACTUAL task sent, full paths included)."""
+    s = "" if text is None else str(text)
+    if not session_dir:
+        return s
+    root = str(Path(session_dir).resolve()).rstrip("/")
+    return s.replace(root + "/", "").replace(root, ".")
+
+
 def _sub_agents(session_dir: Optional[str]) -> Dict[str, List[str]]:
     """Which worker agents each specialist used, from the ``*_state.json``
     files the workers persist (same source as the telemetry reader, but
@@ -108,7 +118,7 @@ def delegation_view(agent: Any, session_dir: Optional[str] = None
                 "mode": e.get("mode") or "?",
                 "label": (e.get("label") or "").strip()
                 or _clip(e.get("task"), 60),
-                "task": _clip(e.get("task"), _TASK_MAX),
+                "task": _clip(_rel_text(e.get("task"), session_dir), _TASK_MAX),
                 "status": e.get("status") or "running",
                 "context_from": [int(x) for x in (e.get("context_from") or [])
                                  if str(x).isdigit()],
@@ -122,13 +132,13 @@ def delegation_view(agent: Any, session_dir: Optional[str] = None
                 "labels": list(e.get("labels") or []),   # fusion inputs
                 "timestamp": e.get("timestamp"),
                 "completed_at": e.get("completed_at"),
-                "summary": _clip(e.get("summary"), _SUMMARY_MAX),
-                "key_findings": [str(k) for k in
+                "summary": _clip(_rel_text(e.get("summary"), session_dir), _SUMMARY_MAX),
+                "key_findings": [_rel_text(k, session_dir) for k in
                                  (e.get("key_findings") or [])[:_FINDINGS_MAX]],
                 "files_produced": [_rel(p, session_dir) for p in
                                    (e.get("files_produced") or [])[:_FILES_MAX]],
                 "n_feature_tables": len(e.get("feature_tables") or []),
-                "warnings": [str(w) for w in
+                "warnings": [_rel_text(w, session_dir) for w in
                              (e.get("warnings") or [])[:_WARNINGS_MAX]],
                 "error": (str(e.get("error")) if e.get("error") else None),
                 "timed_out": bool(e.get("timed_out")),

--- a/scilink/server/memory_api.py
+++ b/scilink/server/memory_api.py
@@ -144,7 +144,7 @@ def memory_overview() -> Dict[str, Any]:
     return {
         "enabled": enabled,
         "env_override": env or None,
-        "home": str(loader.scilink_home()),
+        "home": _tilde(loader.scilink_home()),
         "consolidate_min_n": need,
         "proven_n": proven_n,
         "pipeline": {
@@ -165,6 +165,13 @@ def memory_overview() -> Dict[str, Any]:
             "shadows_builtin": _shadows_builtin(s.get("domain"), s.get("name")),
         } for s in skills],
     }
+
+
+def _tilde(path) -> str:
+    """``~/.scilink`` rather than the absolute home path, for display."""
+    s = str(path)
+    home = str(Path.home())
+    return "~" + s[len(home):] if s.startswith(home) else s
 
 
 def _shadows_builtin(domain: Optional[str], name: Optional[str]) -> bool:

--- a/tests/test_meta_telemetry_reader.py
+++ b/tests/test_meta_telemetry_reader.py
@@ -58,3 +58,13 @@ def test_worker_rows_for_image_and_hyperspectral_state_files(tmp_path):
     assert (img["specialist"], img["name"], img["action_count"]) == ("analysis", "Image Analysis", 1)
     assert img["actions"][0]["status"] == "running"
     assert (hs["name"], hs["action_count"], hs["outcomes"]["success"]) == ("Hyperspectral Analysis", 2, 1)
+
+
+def test_relativize_strips_the_session_root_everywhere():
+    from scilink.agents.meta_agent.telemetry import relativize
+    root = "/tmp/sess"
+    obj = {"path": "/tmp/sess/analysis/results/x.png", "dir": "/tmp/sess",
+           "nested": [{"f": "/tmp/sess/uploads/a.csv"}, "plain", 3]}
+    assert relativize(obj, root) == {"path": "analysis/results/x.png", "dir": ".",
+                                     "nested": [{"f": "uploads/a.csv"}, "plain", 3]}
+    assert relativize(obj, None) == obj

--- a/tests/test_web_memory.py
+++ b/tests/test_web_memory.py
@@ -113,6 +113,7 @@ def test_memory_overview_switch_and_records(mem_client, tmp_path):
     c = mem_client
     ov = c.get("/api/v1/memory").json()
     assert ov["enabled"] is False and ov["env_override"] is None
+    assert not ov["home"].startswith(str(Path.home())) or ov["home"].startswith("~")
     assert ov["pipeline"] == {"bank_total": 2, "bank_proven": 1, "inbox_total": 3,
                               "inbox_ready": 1, "skills_total": 1, "skills_provisional": 1}
     bank = {d["domain"]: d for d in ov["bank"]}["curve_fitting"]

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -937,9 +937,14 @@ def test_delegation_view_shapes_the_ledger(tmp_path):
         dict(_ledger_entry(4, "analysis", "success", context_from=[1]),
              fanout=True, parallel_group="fanout_4"),
     ])
+    agent._delegation_ledger[0]["task"] = f"Analyze {tmp_path}/uploads/spectra (two files)"
+    agent._delegation_ledger[0]["key_findings"].append(f"see {tmp_path}/analysis/results/fit.png")
     view = delegation_view(agent, str(tmp_path))
     rows = view["delegations"]
     assert [r["index"] for r in rows] == [1, 2, 3, 4]
+    # paths under the session root read session-relative in task and findings
+    assert rows[0]["task"] == "Analyze uploads/spectra (two files)"
+    assert rows[0]["key_findings"][-1] == "see analysis/results/fit.png"
     assert rows[3]["fanout"] is True and rows[3]["fanout_group"] == "fanout_4"
     assert rows[0]["fanout"] is False and rows[0]["fanout_group"] is None
     assert rows[0]["files_produced"] == ["analysis/results/fit.png", "/elsewhere/x.csv"]

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -29,6 +29,9 @@ interface SessionState {
   status: "idle" | "running" | "awaiting_input";
   messages: ChatMessage[];
   liveLog: string;
+  // The turn's answer has arrived: log chunks that trail it (the capture
+  // buffer's final flush) are dropped instead of showing under the reply.
+  answered: boolean;
   pendingQuestion: PresentedQuestion | null;
   name: string | null;
   lastError: string | null;
@@ -51,6 +54,7 @@ const emptyState: SessionState = {
   status: "idle",
   messages: [],
   liveLog: "",
+  answered: false,
   pendingQuestion: null,
   name: null,
   lastError: null,
@@ -87,6 +91,7 @@ function reducer(state: SessionState, action: Action): SessionState {
         ...state,
         status: "running",
         liveLog: "",
+        answered: false,
         lastError: null,
         liveImages: [], // fresh turn → fresh filmstrip
         messages: [...state.messages, { role: "user", content: action.content }],
@@ -97,6 +102,7 @@ function reducer(state: SessionState, action: Action): SessionState {
       const ev = action.event;
       switch (ev.type) {
         case "log":
+          if (state.answered) return state;
           return { ...state, liveLog: state.liveLog + ev.chunk };
         case "status":
           return {
@@ -105,6 +111,7 @@ function reducer(state: SessionState, action: Action): SessionState {
             // Turn over: the completion message carries the figures/report,
             // so the live log and the figure inset both stand down.
             ...(ev.status === "idle" ? { liveLog: "", liveImages: [] } : {}),
+            ...(ev.status === "running" ? { answered: false } : {}),
           };
         case "question":
           return { ...state, pendingQuestion: ev.question };
@@ -115,7 +122,8 @@ function reducer(state: SessionState, action: Action): SessionState {
           // Reconnect replay can re-deliver the last message; de-dup on content.
           if (last?.role === "assistant" && last.content === ev.message.content)
             return state;
-          return { ...state, messages: [...state.messages, ev.message] };
+          return { ...state, messages: [...state.messages, ev.message],
+                   liveLog: "", answered: true };
         }
         case "session_named":
           return { ...state, name: ev.name };
@@ -530,6 +538,15 @@ export default function App() {
               >
                 Files
               </button>
+              {mode === "meta" && (
+                <button
+                  className={tab === "telemetry" ? "active" : ""}
+                  onClick={() => setTab("telemetry")}
+                  title="Delegation details, tool sequence, worker agents (the sidebar tree is the live overview)"
+                >
+                  Telemetry
+                </button>
+              )}
               <button
                 className={tab === "skills" ? "active" : ""}
                 onClick={() => setTab("skills")}
@@ -544,15 +561,6 @@ export default function App() {
               >
                 MCP
               </button>
-              {mode === "meta" && (
-                <button
-                  className={tab === "telemetry" ? "active" : ""}
-                  onClick={() => setTab("telemetry")}
-                  title="Delegation details, tool sequence, worker agents (the sidebar tree is the live overview)"
-                >
-                  Telemetry
-                </button>
-              )}
             </div>
             {/* Both tab bodies stay MOUNTED and toggle visibility: switching
                 tabs must not destroy the hero's upload/objective state, a

--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -776,7 +776,9 @@ details.card iframe { width: 100%; height: 600px; border: none; background: #fff
 
 /* Delegation dependency graph (SVG twin of the Streamlit graphviz chart) */
 .deleg-graph-wrap { margin: 4px 0 18px; overflow-x: auto; }
-.deleg-graph { display: block; max-width: 100%; height: auto; }
+.deleg-graph { display: block; }
+.deleg-graph.fit { max-width: 100%; height: auto; }
+.deleg-graph-fit { display: block; margin: 0 0 4px auto; }
 .deleg-graph-node:hover rect { filter: brightness(1.12); }
 .deleg-graph-halo { fill: var(--bg-app); opacity: 0.85; }
 .link-btn[download] { text-decoration: none; }
@@ -802,7 +804,7 @@ details.card iframe { width: 100%; height: 600px; border: none; background: #fff
 .mem-panel h4 { font-size: 14px; margin: 18px 0 4px; }
 .mem-switch { display: flex; align-items: center; gap: 8px; margin: 8px 0; font-size: 13px; flex-wrap: wrap; }
 .mem-info { padding: 8px 10px; border-left: 3px solid var(--border-strong); background: var(--bg-panel); border-radius: 4px; }
-.mem-pipeline { font-size: 13px; margin: 8px 0 4px; color: var(--text); }
+.mem-pipeline { font-size: 14px; font-weight: 600; margin: 10px 0 6px; color: var(--text); }
 .mem-notice { display: flex; align-items: center; gap: 8px; font-size: 13px; padding: 6px 10px; border-radius: 6px; border: 1px solid var(--border); margin: 8px 0; }
 .mem-notice.ok { border-color: #3fb95055; color: #3fb950; }
 .mem-notice.warn { border-color: #d2992255; color: #d29922; }
@@ -842,4 +844,12 @@ details.card iframe { width: 100%; height: 600px; border: none; background: #fff
 .link-btn.danger { color: var(--danger); }
 .link-btn.armed { font-weight: 600; text-decoration: underline; }
 button.primary.small { padding: 4px 10px; font-size: 13px; width: auto; }
+
+/* UI polish batch: sidebar credential hint, memory stage folds */
+.cred-hint { display: block; margin-top: 4px; }
+.cred-hint code { display: block; font-size: 11px; word-break: break-all; margin-top: 2px; }
+.mem-stage-fold { margin-top: 8px; padding-top: 6px; border-top: 1px solid var(--border); }
+.mem-stage-fold > summary { cursor: pointer; font-size: 14px; font-weight: 600; margin: 6px 0 2px; }
+.mem-stage-fold > .mem-stage { border-top: none; margin-top: 0; padding-top: 0; }
+.mem-stage-lead { margin: 2px 0 6px; font-size: 12px; color: var(--text-dim); }
 

--- a/webui/src/components/DelegationGraph.tsx
+++ b/webui/src/components/DelegationGraph.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { DelegationRow } from "../api";
 import { computeGraph, groupStatus, NODE_H, NODE_W } from "../delegationGraph";
 
@@ -42,7 +42,11 @@ export function DelegationGraph({
   onSelect: (index: number) => void;
 }) {
   const g = useMemo(() => computeGraph(rows), [rows]);
+  // A wide ledger scaled to the panel became unreadable; past this width
+  // the graph keeps its natural size and scrolls, with a fit toggle.
+  const [fit, setFit] = useState<boolean | null>(null);
   if (rows.length === 0) return null;
+  const fitted = fit ?? g.width <= 1100;
   const { placed, root, width, height, edges, nodeOfIndex } = g;
   const selectedId = selected == null ? null : nodeOfIndex.get(selected) ?? null;
   const modeLabel = metaMode
@@ -52,8 +56,13 @@ export function DelegationGraph({
 
   return (
     <div className="deleg-graph-wrap">
+      {g.width > 1100 && (
+        <button type="button" className="link-btn deleg-graph-fit" onClick={() => setFit(!fitted)}>
+          {fitted ? "Actual size" : "Fit to width"}
+        </button>
+      )}
       <svg
-        className="deleg-graph"
+        className={`deleg-graph${fitted ? " fit" : ""}`}
         viewBox={`0 0 ${width} ${height}`}
         width={width}
         height={height}

--- a/webui/src/components/MemoryPanel.tsx
+++ b/webui/src/components/MemoryPanel.tsx
@@ -138,6 +138,12 @@ export function MemoryPanel({ sessionId, active }: { sessionId: string; active: 
   const notify = useCallback((kind: "ok" | "warn", text: string) => {
     setNotice({ kind, text });
   }, []);
+  // A success notice fades on its own; a warning stays until dismissed.
+  useEffect(() => {
+    if (!notice || notice.kind !== "ok") return;
+    const t = setTimeout(() => setNotice(null), 6000);
+    return () => clearTimeout(t);
+  }, [notice]);
 
   if (error) {
     return (
@@ -210,8 +216,16 @@ export function MemoryPanel({ sessionId, active }: { sessionId: string; active: 
         </p>
       )}
 
-      <BankSection ov={ov} onChange={refresh} notify={notify} />
-      <InboxSection ov={ov} sessionId={sessionId} onChange={refresh} notify={notify} />
+      {/* Stages 1 and 2 are the working area only while something waits
+          for review; with an empty inbox they start collapsed. */}
+      <details className="mem-stage-fold" open={p.inbox_total > 0}>
+        <summary>1 · Script bank <span className="caption">({p.bank_total}{p.bank_proven ? `, ★${p.bank_proven} proven` : ""})</span></summary>
+        <BankSection ov={ov} onChange={refresh} notify={notify} />
+      </details>
+      <details className="mem-stage-fold" open={p.inbox_total > 0}>
+        <summary>2 · Review inbox <span className="caption">({p.inbox_total}{p.inbox_ready ? `, ${p.inbox_ready} ready` : ""})</span></summary>
+        <InboxSection ov={ov} sessionId={sessionId} onChange={refresh} notify={notify} />
+      </details>
       <SkillsSection ov={ov} onChange={refresh} notify={notify} />
     </section>
   );
@@ -249,7 +263,7 @@ function BankSection({
 
   return (
     <div className="mem-stage">
-      <h4>1 · Script bank <span className="caption">— every success, recorded automatically</span></h4>
+      <p className="mem-stage-lead">Every success, recorded automatically.</p>
       <p className="caption">
         Each approved analysis banks its working script with a fingerprint of the data it solved;
         later runs retrieve the closest match as a starting point. Records that keep succeeding
@@ -400,7 +414,7 @@ function InboxSection({
 }) {
   return (
     <div className="mem-stage">
-      <h4>2 · Review inbox <span className="caption">— lessons awaiting your call</span></h4>
+      <p className="mem-stage-lead">Lessons awaiting your call.</p>
       <p className="caption">
         Three knowledge streams converge here: 📜 script nominations, 🐛 error lessons, 💬 your
         feedback. Select records and distill them into a <strong>new</strong> skill or into an{" "}

--- a/webui/src/components/Sidebar.tsx
+++ b/webui/src/components/Sidebar.tsx
@@ -159,7 +159,7 @@ export function Sidebar({
   const envCaption = (field: string) => {
     const c = cred(field);
     return c?.is_set && c.env_var ? (
-      <span className="caption">✓ available from {c.env_var}</span>
+      <span className="caption cred-hint">✓ available from <code>{c.env_var}</code></span>
     ) : null;
   };
 


### PR DESCRIPTION
## Summary

A batch of small usability fixes across the web UI:

- **Paths read session-relative everywhere.** Telemetry arguments and results, worker actions, analysis reports, and the delegation tasks, summaries and findings no longer print the absolute session root; the memory panel shows its store as `~/.scilink`.
- **The delegation graph stays legible.** Past 1100 px it keeps its natural size and scrolls, with a "Fit to width" / "Actual size" toggle.
- **Sidebar credential hint** puts the environment variable in monospace on its own line.
- **Tab order** is Chat, Files, Telemetry, Skills, MCP.
- **Memory panel**: the script-bank and review-inbox stages start collapsed when nothing waits for review; the pipeline strip is weighted; success notices fade on their own.
- **The verbose log no longer lingers under a fresh answer.** The last log flush arrived a moment after the reply and showed beneath it until the idle status followed; the client now stands the log down on the answer itself.

## Technical description

- `telemetry.py`: `relativize(obj, root)` walks dicts/lists/strings; applied to `agents`, `analysis_reports` and `tool_sequence`. `delegations.py`: `_rel_text` on task/summary/findings/warnings, applied before `_clip` so a clipped path keeps a whole prefix. `memory_api.py`: `_tilde` for `home`.
- `DelegationGraph.tsx`: `fit` state (default: width ≤ 1100), `.deleg-graph.fit` carries the max-width scaling, a `.deleg-graph-fit` link toggles it.
- `Sidebar.tsx` / CSS: `.cred-hint code` as a block. `App.tsx`: Telemetry button moved before Skills.
- `MemoryPanel.tsx`: `<details class="mem-stage-fold" open={inbox_total > 0}>` around stages 1 and 2 (stage headings become summaries, the old h4s become lead lines); a `useEffect` fades `ok` notices after 6 s. CSS: `.mem-pipeline` 14 px / 600.
- `App.tsx` reducer: new `answered` flag — set with `liveLog: ""` on `assistant_message`, cleared on `user_message` and on `status: running`; `log` chunks are ignored while answered.
- Tests: `relativize` (telemetry reader), session-relative task/findings (delegation view), tilde home (memory). Web suites: 53 pass.

### Verified in Chrome

Tab order and the two-line credential hint; the 45-delegation graph at natural size with the toggle; the memory folds and weighted strip; telemetry args such as `uploads/spectrum.npy` and a delegation task naming `uploads/spectrum.json` in place of absolute paths; and, on a real tool-using turn, a DOM probe recorded the live log pane present at 0.6 s and gone in the same 100 ms sample in which the assistant message appeared at 11.0 s.