### PR TITLE
Guard scout overlay labels against present-but-None metadata

### DIFF
--- a/scilink/utils/curve_preview.py
+++ b/scilink/utils/curve_preview.py
@@ -50,9 +50,11 @@ def render_curve_overlay(
         color = cmap(i / max(n - 1, 1))
         ax.plot(x, y, color=color, linewidth=1.2, label=entry["label"])
 
-    ax.set_xlabel(system_info.get("xlabel", "X"))
-    ax.set_ylabel(system_info.get("ylabel", "Y"))
-    ax.set_title(system_info.get("title", "Data") + title_suffix)
+    # `or`, not a .get default: metadata often carries the key with a None
+    # value, and None + title_suffix was a TypeError that cost the overlay.
+    ax.set_xlabel(system_info.get("xlabel") or "X")
+    ax.set_ylabel(system_info.get("ylabel") or "Y")
+    ax.set_title(str(system_info.get("title") or "Data") + title_suffix)
     ax.legend(fontsize=8, loc="best")
     fig.tight_layout()
 
@@ -72,9 +74,9 @@ def render_curve_single(curve_data: np.ndarray, system_info: dict | None = None)
 
     fig, ax = plt.subplots(figsize=(10, 6))
     ax.plot(x, y, color="steelblue", linewidth=1.4)
-    ax.set_xlabel(system_info.get("xlabel", "X"))
-    ax.set_ylabel(system_info.get("ylabel", "Y"))
-    ax.set_title(system_info.get("title", "Data"))
+    ax.set_xlabel(system_info.get("xlabel") or "X")
+    ax.set_ylabel(system_info.get("ylabel") or "Y")
+    ax.set_title(str(system_info.get("title") or "Data"))
     fig.tight_layout()
 
     buf = io.BytesIO()

--- a/tests/test_curve_preview_none_metadata.py
+++ b/tests/test_curve_preview_none_metadata.py
@@ -1,0 +1,45 @@
+"""#587 — a metadata dict that carries title/xlabel/ylabel keys with None
+values renders with the defaults instead of crashing on None + str."""
+import numpy as np
+import pytest
+
+from scilink.utils.curve_preview import render_curve_overlay, render_curve_single
+
+CURVES = [{"label": f"s{i}", "curve_data": np.column_stack([np.linspace(0, 1, 20), np.sin(np.linspace(0, 1, 20) + i)])}
+          for i in range(3)]
+NONE_META = {"title": None, "xlabel": None, "ylabel": None}
+
+
+@pytest.fixture(autouse=True)
+def _agg():
+    import matplotlib
+    matplotlib.use("Agg", force=True)
+
+
+def _texts(monkeypatch):
+    seen = {}
+    import matplotlib.axes
+    monkeypatch.setattr(matplotlib.axes.Axes, "set_title", lambda self, t, *a, **k: seen.__setitem__("title", t))
+    monkeypatch.setattr(matplotlib.axes.Axes, "set_xlabel", lambda self, t, *a, **k: seen.__setitem__("xlabel", t))
+    monkeypatch.setattr(matplotlib.axes.Axes, "set_ylabel", lambda self, t, *a, **k: seen.__setitem__("ylabel", t))
+    return seen
+
+
+def test_overlay_with_present_but_none_metadata_uses_the_defaults(monkeypatch):
+    seen = _texts(monkeypatch)
+    png = render_curve_overlay(CURVES, NONE_META)
+    assert png[:8] == b"\x89PNG\r\n\x1a\n"
+    assert seen == {"title": "Data — Scout Overlay", "xlabel": "X", "ylabel": "Y"}
+
+
+def test_overlay_keeps_populated_metadata(monkeypatch):
+    seen = _texts(monkeypatch)
+    render_curve_overlay(CURVES, {"title": "XPS C 1s", "xlabel": "BE (eV)", "ylabel": "counts"})
+    assert seen == {"title": "XPS C 1s — Scout Overlay", "xlabel": "BE (eV)", "ylabel": "counts"}
+
+
+def test_single_curve_with_none_metadata(monkeypatch):
+    seen = _texts(monkeypatch)
+    png = render_curve_single(CURVES[0]["curve_data"], NONE_META)
+    assert png[:8] == b"\x89PNG\r\n\x1a\n"
+    assert seen == {"title": "Data", "xlabel": "X", "ylabel": "Y"}


### PR DESCRIPTION
Closes #587.

## Summary

When a series run's metadata carried a `title` key with no value, the scout overlay figure failed to render and the run logged "Failed to create overlay plot: unsupported operand type(s) for +: 'NoneType' and 'str'". The run still completed, but the scouts were compared without the overlay figure. The overlay and single-curve renderers now treat an empty title, x-label or y-label the same as a missing one and fall back to the defaults.

## Technical description

- `scilink/utils/curve_preview.py`: `render_curve_overlay` and `render_curve_single` use `system_info.get(key) or default` for title/xlabel/ylabel; the title is wrapped in `str()` before the suffix is appended. `dict.get(key, default)` only substitutes when the key is absent, so a present-but-`None` value reached `None + title_suffix`. The axis labels did not crash (matplotlib accepts `None`) but rendered blank instead of the intended default.
- Test `tests/test_curve_preview_none_metadata.py`: both renderers with all three keys set to `None` produce a PNG whose title/labels are the defaults; populated metadata still wins.

### Live check (Bedrock, Opus)

A six-spectrum series analysed with `system_info={"title": None, "xlabel": None, "ylabel": None, ...}`. Control: the pre-fix module from `main` loaded from git raises `TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'` on the same metadata. On this branch the scout logged "Generated overlay comparison plot" followed by "Scouted 3 of 6 spectra", and the captured overlay is a valid PNG.