### PR TITLE
Make the BO step index campaign-level and monotonic

### DIFF
--- a/scilink/agents/planning_agents/bo_agent.py
+++ b/scilink/agents/planning_agents/bo_agent.py
@@ -241,6 +241,37 @@ class OptimizationAgent(BaseAgent):
         history.append(entry)
         with open(self.history_file, 'w', encoding="utf-8") as f: json.dump(history, f, indent=2)
 
+    def _backup_history_files(self) -> List[Path]:
+        """Every ``bo_history.json.backup*`` next to the live history —
+        the histories a reset set aside (#593)."""
+        return sorted(self.output_dir.glob(self.history_file.name + ".backup*"))
+
+    @staticmethod
+    def _last_step_in(history) -> int:
+        steps = [h.get("step") for h in (history or []) if isinstance(h, dict)]
+        steps = [int(x) for x in steps if isinstance(x, (int, float))]
+        return max(steps) if steps else len(history or [])
+
+    def _next_step_number(self, history: List[Dict]) -> int:
+        """Campaign-level monotonic step index (#593).
+
+        The next step continues from the highest step recorded in the live
+        history, or — when the history was set aside by a reset — from the
+        highest step in any ``bo_history.json.backup*``. A step therefore
+        never restarts at 1 while earlier ``step_N.*`` artifacts exist, so an
+        iteration cannot overwrite the previous iteration's plots.
+        """
+        if history:
+            return self._last_step_in(history) + 1
+        last = 0
+        for path in self._backup_history_files():
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    last = max(last, self._last_step_in(json.load(f)))
+            except Exception:  # noqa: BLE001 - an unreadable backup is ignored
+                continue
+        return last + 1
+
     def _validate_config(self, config: Dict, fidelity_declared: bool = False,
                          extra_surrogates: Optional[set] = None,
                          extra_acquisitions: Optional[set] = None) -> Dict:
@@ -1295,9 +1326,13 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
         history = self._load_history()
 
         is_retry = history and history[-1].get("data_points") == len(df)
+        c.step_override = None
         if is_retry:
             print(f"  - 🔄 Re-run detected (same {len(df)} data points). Replacing previous step.")
-            history.pop()
+            replaced = history.pop()
+            # The replacement keeps the replaced step's number (#593): its
+            # artifacts are overwritten on purpose, nothing else's.
+            c.step_override = replaced.get("step") if isinstance(replaced, dict) else None
             with open(self.history_file, 'w', encoding="utf-8") as f:
                 json.dump(history, f, indent=2)
 
@@ -1597,7 +1632,7 @@ zone is around each center (per parameter). Wider spread = more forgiving placem
         optimizer = c.optimizer
         output_dir = c.output_dir
 
-        step_num = len(history) + 1
+        step_num = getattr(c, "step_override", None) or self._next_step_number(history)
         n_initial = history[0]["data_points"] if history and "data_points" in history[0] else len(df)
         plot_path = f"{output_dir}/step_{step_num}.png"
         sensitivity_data = {}

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -4666,22 +4666,41 @@ class OrchestratorTools:
                 except Exception as e:
                     logging.warning(f"Could not delete analyzed_files.json: {e}")
             
+            def _set_aside(path: Path) -> Path:
+                """``<name>.backup``, then ``.backup.2``, ``.3`` … — a reset
+                never clobbers the backup an earlier reset made (#593)."""
+                dest = path.with_name(path.name + ".backup")
+                n = 2
+                while dest.exists():
+                    dest = path.with_name(f"{path.name}.backup.{n}")
+                    n += 1
+                path.rename(dest)
+                return dest
+
             if self.orch.bo_data_path.exists():
-                backup_path = self.orch.bo_data_path.with_suffix('.csv.backup')
-                self.orch.bo_data_path.rename(backup_path)
+                backup_path = _set_aside(self.orch.bo_data_path)
                 print(f"    ⚠️  Old data backed up to: {backup_path.name}")
 
             bo_history = self.orch.bo.history_file
+            next_step = None
             if bo_history.exists():
-                backup = bo_history.with_suffix('.json.backup')
-                bo_history.rename(backup)
+                backup = _set_aside(bo_history)
                 print(f"    ⚠️  BO history backed up to: {backup.name}")
+                # The campaign step index is monotonic across resets: the
+                # next run_optimization_loop continues the numbering, so
+                # its step_N artifacts do not overwrite earlier iterations.
+                next_step = self.orch.bo._next_step_number([])
+                print(f"    ℹ️  BO step numbering continues at step {next_step}")
 
-            return json.dumps({
+            out = {
                 "status": "success",
                 "message": "Analysis logic reset. All files will be reprocessed fresh on next analyze_file call.",
                 "hint": "Previous optimization data was backed up"
-            })
+            }
+            if next_step is not None:
+                out["next_bo_step"] = next_step
+                out["hint"] += f"; the next BO step is numbered {next_step} (earlier step artifacts are kept)"
+            return json.dumps(out)
         
         self._register_tool(
             func=reset_analysis_logic,

--- a/tests/test_bo_step_counter.py
+++ b/tests/test_bo_step_counter.py
@@ -1,0 +1,81 @@
+"""#593 — the BO step index is campaign-level and monotonic. A reset sets
+the history aside as a backup; the next step continues the numbering, so
+iteration N never overwrites iteration N-1's step_* artifacts. A same-data
+re-run replaces the step it repeats, keeping that step's number."""
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+
+from scilink.agents.planning_agents.bo_agent import BOAgent
+
+
+def _agent(tmp_path):
+    a = BOAgent.__new__(BOAgent)
+    a.output_dir = Path(tmp_path)
+    a.history_file = a.output_dir / "bo_history.json"
+    return a
+
+
+def test_next_step_continues_from_the_live_history(tmp_path):
+    a = _agent(tmp_path)
+    assert a._next_step_number([]) == 1
+    assert a._next_step_number([{"step": 1}, {"step": 2}]) == 3
+    assert a._next_step_number([{"step": 4}]) == 5             # gaps are preserved, not re-packed
+    assert a._next_step_number([{"data_points": 9}]) == 2      # legacy entry without a step
+
+
+def test_next_step_continues_from_a_reset_backup(tmp_path):
+    a = _agent(tmp_path)
+    (tmp_path / "bo_history.json.backup").write_text(json.dumps([{"step": 1}, {"step": 2}]))
+    (tmp_path / "bo_history.json.backup.2").write_text(json.dumps([{"step": 3}]))
+    (tmp_path / "bo_history.json.backup.3").write_text("not json")
+    assert a._next_step_number([]) == 4
+
+
+def _ctx(history, override=None):
+    df = pd.DataFrame({"x": [0.0, 1.0, 2.0], "y": [1.0, 2.0, 3.0]})
+    written = {}
+    optimizer = SimpleNamespace(generate_diagnostics=lambda *a, **k: written.setdefault("plot", k.get("save_path")) and {})
+    return SimpleNamespace(history=history, df=df, optimizer=optimizer, output_dir="/tmp/bo593",
+                           is_moo=False, target_cols=["y"], next_x_batch=np.array([[1.5]]),
+                           plot_acq=False, save_acq=False, step_override=override), written
+
+
+def test_diagnostics_number_the_step_after_the_backup(tmp_path):
+    a = _agent(tmp_path)
+    (tmp_path / "bo_history.json.backup").write_text(json.dumps([{"step": 1, "data_points": 9}]))
+    c, written = _ctx([])
+    BOAgent._stage_diagnostics(a, c)
+    assert c.step_num == 2 and c.plot_path.endswith("step_2.png") and written["plot"].endswith("step_2.png")
+
+
+def test_a_same_data_rerun_keeps_the_replaced_step_number(tmp_path):
+    a = _agent(tmp_path)
+    c, _ = _ctx([{"step": 1}, {"step": 2}], override=3)
+    BOAgent._stage_diagnostics(a, c)
+    assert c.step_num == 3
+
+
+def test_reset_sets_the_history_aside_without_clobbering_and_reports_the_next_step(tmp_path):
+    from scilink.agents.planning_agents.orchestrator_tools import OrchestratorTools
+    bo = _agent(tmp_path / "bo_artifacts"); bo.output_dir.mkdir()
+    orch = SimpleNamespace(base_dir=tmp_path, planner=SimpleNamespace(), bo=bo,
+                           active_scalarizer_script="s", expected_input_columns=["x"],
+                           expected_target_columns=["y"], analyzed_files={"f": 1},
+                           analyzed_files_path=tmp_path / "analyzed_files.json",
+                           bo_data_path=tmp_path / "optimization_data.csv")
+    t = OrchestratorTools(orch)
+    bo.history_file.write_text(json.dumps([{"step": 1, "data_points": 9}]))
+    orch.bo_data_path.write_text("x,y\n1,2\n")
+    out = json.loads(t.functions_map["reset_analysis_logic"]())
+    assert out["next_bo_step"] == 2 and "numbered 2" in out["hint"]
+    assert (bo.output_dir / "bo_history.json.backup").exists() and not bo.history_file.exists()
+    # a second reset after another iteration keeps BOTH backups
+    bo.history_file.write_text(json.dumps([{"step": 2, "data_points": 10}]))
+    out = json.loads(t.functions_map["reset_analysis_logic"]())
+    assert out["next_bo_step"] == 3
+    assert (bo.output_dir / "bo_history.json.backup.2").exists()
+    assert json.loads((bo.output_dir / "bo_history.json.backup").read_text())[0]["step"] == 1


### PR DESCRIPTION
Closes #593.

## Summary

In a multi-iteration optimization campaign each iteration numbered its own step from 1, so iteration 2 was reported as step 1 and its diagnostic plots overwrote iteration 1's. The step index is now campaign-level: it continues from the last recorded step, including one set aside by a reset, so iteration 2 writes `step_2.png` and the earlier files stay. A reset no longer overwrites an earlier reset's backup and tells the agent which step comes next.

## Technical description

- `BOAgent._next_step_number(history)`: max recorded `step` in the live history + 1; with no live history, max step across `bo_history.json.backup*` + 1; else 1. `_stage_diagnostics` uses it instead of `len(history) + 1`, so all `step_N` artifacts (diagnostics plot, acquisition plot and data, batch CSV) and the history entry share the campaign index.
- A same-data re-run still pops the last entry and now keeps that entry's step number (`c.step_override`) so the replacement overwrites only the step it repeats.
- `reset_analysis_logic`: `optimization_data.csv` and `bo_history.json` are set aside as `.backup`, `.backup.2`, ... (never clobbering), and the response carries `next_bo_step`.
- Tests (`tests/test_bo_step_counter.py`, 5): continuation from live history and from backups (including an unreadable one), diagnostics naming after a backup, re-run override, and the reset tool's non-clobbering backups and reported next step. BO suites: 59 pass.

### Live check (Bedrock, real planning orchestrator)

Iteration 1 on nine points wrote `step_1.png`, `acq_step_1.png`, `acq_data_step_1.npz`. The `reset_analysis_logic` tool reported next step 2. Iteration 2 on ten points wrote the `step_2` trio; iteration 1's three files were byte-identical afterwards, the history held step 2 and the backup held step 1.