### PR TITLE
Treat a parameter pinned at its bound as a degenerate fit

### DIFF
--- a/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
+++ b/scilink/agents/exp_agents/controllers/curve_fitting_controllers.py
@@ -3064,6 +3064,10 @@ class UnifiedSeriesProcessingController:
     """
     
     MAX_ATTEMPTS = 5
+    # Bound-relaxation refits per spectrum (#592): one relaxation is the
+    # remedy; a fit that still pins afterwards is kept, stamped and flagged
+    # rather than fed back through the whole ladder.
+    MAX_PINNED_RETRIES = 1
     DEFAULT_R2_THRESHOLD = 0.95
     DEFAULT_MAX_MODEL_RETRIES = 1
     DEFAULT_OUTLIER_SIGMA = 2.0
@@ -3775,6 +3779,7 @@ Your guidance: '''
         script_errors: list[dict] = []
         consecutive_timeouts = 0
         used_timeout_escalation = False
+        pinned_retries = 0
 
         for attempt in range(1, self.MAX_ATTEMPTS + 1):
             try:
@@ -3858,6 +3863,28 @@ Your guidance: '''
                         if has_fit_results else False
 
                     if has_fit_results and has_parameters and has_visualization:
+                        # A fit with a parameter pinned at a bound (#592) is
+                        # degenerate even when R² clears the gate: another
+                        # parameter absorbs the misfit and the extracted value
+                        # is wrong. Route it through the correction ladder,
+                        # which relaxes exactly those bounds; if the last
+                        # attempt still pins, the result is kept but stamped
+                        # and flagged rather than silently accepted.
+                        from ...skills._shared.curve_fitting_tools import (
+                            validate_bound_pinning, describe_pinned, PINNED_BOUND_FIX)
+                        _fr = _parse_script_markers(run["stdout"])
+                        _pins = validate_bound_pinning(_fr.get("parameters"), _fr.get("bounds"))
+                        if (_pins and attempt < self.MAX_ATTEMPTS
+                                and pinned_retries < self.MAX_PINNED_RETRIES):
+                            pinned_retries += 1
+                            last_error = (
+                                "DEGENERATE FIT — parameter(s) pinned at a bound: "
+                                + describe_pinned(_pins) + ". " + PINNED_BOUND_FIX)
+                            self.logger.warning(
+                                f"    ⚠️ Attempt {attempt}: pinned at bound — "
+                                f"{describe_pinned(_pins)}; relaxing bounds and refitting")
+                            consecutive_timeouts = 0
+                            continue
                         break
                     else:
                         missing = []
@@ -3937,11 +3964,31 @@ Your guidance: '''
             self.logger.warning(
                 "    ⚠️ Absence contract: %s", "; ".join(_acv))
 
+        # Pinned-at-bound degeneracy that survived the correction ladder
+        # (#592): stamp it so the series flags the spectrum and the verifier
+        # / synthesis see it, independent of R².
+        from ...skills._shared.curve_fitting_tools import (
+            validate_bound_pinning, describe_pinned, PINNED_BOUND_FIX)
+        pinned = validate_bound_pinning(
+            fit_results.get("parameters"), fit_results.get("bounds"))
+        if pinned:
+            script_errors.append({
+                "error": "degenerate fit — parameter(s) pinned at a bound: "
+                         + describe_pinned(pinned),
+                "diagnosis": PINNED_BOUND_FIX,
+                "kind": "pinned_bound",
+            })
+            self.logger.warning(
+                "    ⚠️ Pinned at bound after relaxation — kept and flagged: %s",
+                describe_pinned(pinned))
+
         # Best-effort residual diagnostics from the saved fitted curve (vision aid):
         # reliable per-region structure metrics the verifier can reason over instead
         # of eyeballing a dynamic-range-crushed plot. Skipped silently if fit.npy
         # is absent (older/refit scripts) so this never breaks the fit path.
         fit_quality = dict(fit_results.get("fit_quality", {}) or {})
+        if pinned:
+            fit_quality["pinned_at_bound"] = pinned
         residual_diag = None
         residual_zoom_panels = []
         try:
@@ -4025,6 +4072,14 @@ Your guidance: '''
             "script": script,
             "script_errors": script_errors,
         }
+        if fit_results.get("bounds"):
+            result["bounds"] = fit_results["bounds"]
+        if pinned:
+            result["pinned_at_bound"] = pinned
+            result["quality_warning"] = (
+                "Degenerate fit: " + describe_pinned(pinned)
+                + " — the extracted value is not trustworthy; the bound must "
+                  "be made data-relative and the spectrum refitted.")
         if used_timeout_escalation:
             # Provenance: this fit came from the last-resort model
             # restructure after persistent timeouts — the executed script,
@@ -6352,6 +6407,17 @@ Return JSON with:
             state["locked_fitting_config"] = original_config
             return best_result, best_r2
 
+    @staticmethod
+    def _reuse_blocked_by_regimes(state: dict) -> bool:
+        """Locked-script reuse is incompatible with a series plan that splits
+        the run into MORE THAN ONE regime (each regime derives its own model).
+        A single-regime plan is the normal case and must not block reuse —
+        it did, because the guard tested for the presence of per-spectrum
+        regime configs, which every planned series has (#592)."""
+        plan = state.get("series_analysis_plan") or {}
+        regimes = plan.get("regimes") or []
+        return len(regimes) > 1
+
     def _detect_outliers(self, series_results: List[dict], gate=None) -> List[dict]:
         # Score each fit by the GATE's metric, not always global R². For a
         # non-R² goodness-of-fit gate (e.g. peak_region_r2) a correct low-SNR
@@ -6402,6 +6468,23 @@ Return JSON with:
                 continue
 
             r2 = self._score_fn(r)
+            # A pinned-at-bound fit is flagged regardless of its R² (#592):
+            # the gate metric can stay high while the extracted value is
+            # wrong, which is exactly how the degeneracy hid before.
+            pins = (r.get("fit_quality") or {}).get("pinned_at_bound")
+            if pins:
+                from ...skills._shared.curve_fitting_tools import describe_pinned
+                flagged.append({
+                    "index": r["index"], "name": r["name"], "reason": "pinned_at_bound",
+                    "r_squared": float(r2) if r2 is not None else None,
+                    "series_mean": median_r2, "series_std": robust_scale,
+                    "deviation_sigma": None,
+                    "recommendation": ("Degenerate fit: " + describe_pinned(pins)
+                                       + ". R² is not evidence here — another parameter absorbed "
+                                         "the misfit. Refit with that bound made data-relative "
+                                         "(e.g. 2 × max(y)) before trusting the extracted values."),
+                })
+                continue
             if r2 is None:
                 continue
 
@@ -6609,7 +6692,7 @@ Return JSON with:
             cs = state["_cold_start_reuse"]
             reuse_script = cs.get("script")
             reuse_source = f"script_bank:{cs.get('id')}"
-        if reuse_script and regime_configs:
+        if reuse_script and self._reuse_blocked_by_regimes(state):
             # script_edits made it past entry validation, but the series
             # plan split this run into regimes, which disables reuse — the
             # caller's explicitly requested edits would be silently dropped

--- a/scilink/agents/exp_agents/instruct.py
+++ b/scilink/agents/exp_agents/instruct.py
@@ -2543,6 +2543,11 @@ plan as specified and let the retry pipeline handle actual runtime failures.
    (e.g. fitting one peak while ignoring real signal elsewhere) unless there is a
    clear physics reason or the user explicitly requested it; report R² over the
    full domain you are modelling, not a hand-picked sub-region.
+   **Bounds are data-relative, never constants read off this spectrum.** The
+   script is reused VERBATIM on other spectra whose features may be larger, so an
+   amplitude / intensity / area / scale bound must be an expression of the loaded
+   data (e.g. `2 * np.max(y)`, `np.ptp(y)`) or unbounded. A parameter that ends at
+   its bound is a degenerate fit, not a converged one, and is rejected downstream.
 4. Compute R² and RMSE
 5. Save `visualization.png` (in the current working directory): data + fit + residuals (show individual components if multiple peaks).
    **Make the residual diagnosable** (the reviewer reads this plot): put residuals
@@ -2593,6 +2598,7 @@ instead of losing exactly the points that prove the transition completed.
 results = {{
     "model_type": "description",
     "parameters": {{"peak_1": {{"center": val, "center_err": err, ...}}, ...}},
+    "bounds": {{"peak_1": {{"amplitude": [lo, hi], "center": [lo, hi], ...}}, ...}},  # the bounds actually used, mirroring `parameters` (null for an unbounded side); omit a parameter you did not bound
     "fit_quality": {{"r_squared": val, "rmse": val}},
     "deviation_note": ""  # empty if plan was followed; else one line on process-level deviations only
 }}
@@ -2629,6 +2635,7 @@ never as missing keys.
 
 **CRITICAL:** Fix only the execution error. Do NOT change the fitting model, its parameters, the fit domain/window, or the overall analysis approach — and never narrow the window or truncate the data to raise R². The model is locked for series consistency.
 **Narrow exception — timeout errors ONLY:** if the error says the script timed out, the script is too slow, not wrong. You may change the COMPUTATIONAL strategy — vectorize loops, reduce optimizer restarts/iterations, replace brute-force search with an efficient optimizer — but every rule above still holds: same model, same parameters, same fit domain/window, and ALL of the data.
+**Narrow exception — a parameter PINNED AT ITS BOUND:** if the error names parameters that ended at a bound, the fit is degenerate (the optimizer wanted to go further). You MUST widen exactly those bounds — an amplitude/scale ceiling to a data-relative expression (e.g. `2 * np.max(y)`) or unbounded, a position/width window far enough to contain the feature — and keep everything else (model, components, fit domain, initial-guess logic) unchanged. Report the bounds you use in the results' `"bounds"` field.
 
 **I/O contract (do not deviate):** the data is `data.npy` in the current working directory — load it with `np.load` (do NOT look for .csv/.txt/.dat or glob for other files); save the plot to `visualization.png`; print one line `FIT_RESULTS_JSON:{{...}}` with the fit results. Missing any of these fails the run. Also keep saving `fit.npy` (1-D fitted curve at the `data.npy` x-points, length N) if the script you are fixing already did — it feeds the reviewer's residual diagnostics.
 

--- a/scilink/skills/_shared/curve_fitting_tools.py
+++ b/scilink/skills/_shared/curve_fitting_tools.py
@@ -64,6 +64,78 @@ ABSENT_COMPONENT_FIX = (
 )
 
 
+_FRACTION_KEYS = ("eta", "fraction", "mixing", "weight", "ratio")
+
+PINNED_BOUND_FIX = (
+    "A parameter that ends at its bound is a degenerate fit, not a converged "
+    "one: the bound was a constant baked from the anchor spectrum and this "
+    "spectrum's feature is larger. Widen exactly the named bounds to "
+    "data-relative expressions (e.g. an amplitude ceiling of 2 * np.max(y), "
+    "or unbounded), keep the model, components and fit domain unchanged, "
+    "and report the bounds used in the results' 'bounds' field."
+)
+
+
+def validate_bound_pinning(parameters, bounds, rel_tol: float = 0.01) -> list:
+    """Deterministic pinned-at-bound check (#592).
+
+    ``bounds`` mirrors ``parameters``: ``{component: {param: [lo, hi]}}`` with
+    ``None`` / non-finite for an unbounded side. A parameter is pinned when
+    it sits within ``rel_tol`` of the bound span (or of the bound's own
+    magnitude when the other side is open) of a finite bound.
+
+    Deliberately narrow, so a parameter that legitimately rests on a bound
+    is never called degenerate: a lower bound of ZERO is a physical floor
+    (a vanished component, a zero slope or offset) and is not reported;
+    a fraction-like parameter (eta, fraction, mixing, weight, ratio) is
+    exempt on both sides — a pseudo-Voigt at eta = 1 is a Lorentzian, not
+    a failed fit. What remains is the failure mode this guards against: a
+    feature larger than a ceiling baked from another spectrum, or a
+    position / width driven to the edge of its window.
+    Returns ``[{component, parameter, value, bound, side}]``; empty when
+    compliant or when no bounds were reported. Never raises.
+    """
+    import math
+    out = []
+    if not isinstance(parameters, dict) or not isinstance(bounds, dict):
+        return out
+
+    def _num(v):
+        return v if isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v) else None
+
+    for comp, pb in bounds.items():
+        pv = parameters.get(comp)
+        if not isinstance(pb, dict) or not isinstance(pv, dict):
+            continue
+        for name, lohi in pb.items():
+            if not isinstance(lohi, (list, tuple)) or len(lohi) != 2:
+                continue
+            v = _num(pv.get(name))
+            if v is None:
+                continue
+            lo, hi = _num(lohi[0]), _num(lohi[1])
+            if lo is None and hi is None:
+                continue
+            if lo is not None and hi is not None:
+                tol = rel_tol * abs(hi - lo)
+            else:
+                tol = rel_tol * abs(lo if hi is None else hi)
+            tol = max(tol, 1e-12)
+            if any(f in str(name).lower() for f in _FRACTION_KEYS):
+                continue
+            if hi is not None and v >= hi - tol:
+                out.append({"component": comp, "parameter": name, "value": v, "bound": hi, "side": "upper"})
+            elif lo is not None and lo != 0 and v <= lo + tol:
+                out.append({"component": comp, "parameter": name, "value": v, "bound": lo, "side": "lower"})
+    return out
+
+
+def describe_pinned(pins) -> str:
+    """``peak_2.amplitude = 0.45 at its upper bound 0.45; ...``"""
+    return "; ".join(f"{p['component']}.{p['parameter']} = {p['value']:.6g} at its "
+                     f"{p['side']} bound {p['bound']:.6g}" for p in pins)
+
+
 def validate_absent_component_contract(parameters) -> list:
     """Deterministic check of the absence-as-value results contract.
 

--- a/tests/test_pinned_bound_degeneracy.py
+++ b/tests/test_pinned_bound_degeneracy.py
@@ -1,0 +1,123 @@
+"""#592 — a parameter pinned at its bound is a degeneracy, independent of R².
+The validator reads the script's reported bounds; the fit loop routes a
+pinned fit through the correction ladder (which relaxes exactly those
+bounds); a fit that still pins is stamped and the series flags it."""
+import json
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from scilink.skills._shared.curve_fitting_tools import validate_bound_pinning, describe_pinned, PINNED_BOUND_FIX
+from scilink.agents.exp_agents.controllers import curve_fitting_controllers as cc
+
+PARAMS = {"peak_1": {"amplitude": 0.31, "center": 445.0, "sigma": 30.0},
+          "peak_2": {"amplitude": 0.45, "amplitude_err": 0.0, "center": 560.0, "sigma": 60.0},
+          "baseline": {"intercept": 0.43, "slope": 0.0}}
+BOUNDS = {"peak_1": {"amplitude": [0, None], "center": [400, 445.0], "sigma": [5, 80]},
+          "peak_2": {"amplitude": [0, 0.45], "center": [500, 620], "sigma": [10, 120]},
+          "baseline": {"intercept": [None, None]}}
+
+
+def test_validator_names_the_pinned_parameters_only():
+    pins = validate_bound_pinning(PARAMS, BOUNDS)
+    assert [(p["component"], p["parameter"], p["side"]) for p in pins] == [
+        ("peak_1", "center", "upper"), ("peak_2", "amplitude", "upper")]
+    assert "peak_2.amplitude = 0.45 at its upper bound 0.45" in describe_pinned(pins)
+    # 1 % of the span: 0.446 pins, 0.44 does not
+    assert validate_bound_pinning({"p": {"a": 0.446}}, {"p": {"a": [0, 0.45]}})
+    assert not validate_bound_pinning({"p": {"a": 0.44}}, {"p": {"a": [0, 0.45]}})
+    # an open-sided bound uses the bound's own magnitude for the tolerance
+    assert validate_bound_pinning({"p": {"c": 99.5}}, {"p": {"c": [None, 100]}})
+    # a zero lower bound is a physical floor (vanished component, zero slope): never reported
+    assert not validate_bound_pinning({"p": {"amplitude": 0.0}}, {"p": {"amplitude": [0, 5]}})
+    assert not validate_bound_pinning({"b": {"slope": 0.0}}, {"b": {"slope": [0, 1]}})
+    # a non-zero floor is a window edge: reported
+    assert validate_bound_pinning({"p": {"sigma": 5.0}}, {"p": {"sigma": [5, 80]}})[0]["side"] == "lower"
+    # fraction-like parameters legitimately sit at 0 or 1 (a pseudo-Voigt at eta=1 is a Lorentzian)
+    assert not validate_bound_pinning({"p": {"eta": 1.0, "fraction": 0.0}}, {"p": {"eta": [0, 1], "fraction": [0, 1]}})
+    # nothing reported → nothing to check; garbage never raises
+    assert validate_bound_pinning(PARAMS, None) == [] and validate_bound_pinning(PARAMS, {"peak_2": "x"}) == []
+    assert validate_bound_pinning({"p": {"a": "nan"}}, {"p": {"a": [0, 1]}}) == []
+
+
+def _controller(tmp_path, runs, corrections):
+    c = cc.UnifiedSeriesProcessingController.__new__(cc.UnifiedSeriesProcessingController)
+    c.logger = logging.getLogger("t592"); c.output_dir = Path(tmp_path); c.executor = object()
+    c._extract_extra_operands = lambda state, p: None
+    c._extra_operand_block = lambda state: ""
+    c._compute_statistics = lambda cd: {"n": len(cd)}
+    c._should_escalate_timeout_model = lambda *a, **k: False
+    c._correct_script = lambda state, script, err: (corrections.append(err) or (script + "\n# relaxed", "widened the bound"))
+    return c
+
+
+def _run(stdout):
+    return {"status": "success", "stdout": stdout, "visualization_path": "viz.png",
+            "visualization_bytes": b"", "exec": {}}
+
+
+def _stdout(params, bounds):
+    return "FIT_RESULTS_JSON:" + json.dumps({"model_type": "2G+lin", "parameters": params, "bounds": bounds,
+                                             "fit_quality": {"r_squared": 0.963}})
+
+
+def test_a_pinned_locked_script_is_corrected_and_the_relaxed_fit_is_kept(tmp_path, monkeypatch):
+    corrections = []
+    relaxed_params = {**PARAMS, "peak_2": {**PARAMS["peak_2"], "amplitude": 1.21}, "baseline": {"intercept": 0.01, "slope": 0.0}}
+    relaxed_bounds = {**BOUNDS, "peak_1": {"amplitude": [0, None], "center": [400, 460], "sigma": [5, 80]},
+                      "peak_2": {**BOUNDS["peak_2"], "amplitude": [0, 2.8]}}
+    runs = iter([_run(_stdout(PARAMS, BOUNDS)), _run(_stdout(relaxed_params, relaxed_bounds))])
+    monkeypatch.setattr(cc, "stage_and_run_adaptive", lambda *a, **k: next(runs))
+    c = _controller(tmp_path, runs, corrections)
+    data = np.column_stack([np.linspace(400, 700, 50), np.ones(50)])
+    res = c._fit_single_spectrum({}, data, "s7.csv", "s7", 7, base_script="ub = [inf, 445.0, 0.45]")
+    assert res["success"] and "pinned_at_bound" not in res and "pinned_at_bound" not in res["fit_quality"]
+    assert res["parameters"]["peak_2"]["amplitude"] == 1.21 and res["script"].endswith("# relaxed")
+    assert res["bounds"] == relaxed_bounds
+    # the correction was asked for exactly the bound relaxation
+    assert len(corrections) == 1 and "peak_2.amplitude = 0.45 at its upper bound 0.45" in corrections[0]
+    assert PINNED_BOUND_FIX in corrections[0]
+    assert res["script_errors"][0]["error"].startswith("DEGENERATE FIT")
+
+
+def test_a_fit_that_still_pins_after_the_ladder_is_stamped(tmp_path, monkeypatch):
+    corrections = []
+    monkeypatch.setattr(cc, "stage_and_run_adaptive", lambda *a, **k: _run(_stdout(PARAMS, BOUNDS)))
+    c = _controller(tmp_path, None, corrections)
+    c.MAX_ATTEMPTS = 3
+    data = np.column_stack([np.linspace(400, 700, 50), np.ones(50)])
+    res = c._fit_single_spectrum({}, data, "s8.csv", "s8", 8, base_script="ub = [inf, 445.0, 0.45]")
+    assert res["success"] and len(corrections) == 1                      # one relaxation, then kept and stamped
+    assert [p["parameter"] for p in res["pinned_at_bound"]] == ["center", "amplitude"]
+    assert res["fit_quality"]["pinned_at_bound"] == res["pinned_at_bound"]
+    assert res["quality_warning"].startswith("Degenerate fit:")
+    assert res["script_errors"][-1]["kind"] == "pinned_bound"
+
+
+def test_series_flags_a_pinned_fit_regardless_of_r2(tmp_path):
+    c = cc.UnifiedSeriesProcessingController.__new__(cc.UnifiedSeriesProcessingController)
+    c.logger = logging.getLogger("t592"); c.r2_threshold = 0.95; c.outlier_sigma = 2.0
+    def r(i, r2, pins=None):
+        fq = {"r_squared": r2}
+        if pins: fq["pinned_at_bound"] = pins
+        return {"index": i, "name": f"s{i}", "success": True, "fit_quality": fq}
+    pins = [{"component": "peak_2", "parameter": "amplitude", "value": 0.45, "bound": 0.45, "side": "upper"}]
+    results = [r(0, 0.99), r(1, 0.985), r(2, 0.99), r(3, 0.963, pins), r(4, 0.988)]
+    flagged = c._detect_outliers(results)
+    assert [(f["index"], f["reason"]) for f in flagged] == [(3, "pinned_at_bound")]
+    assert "R² is not evidence here" in flagged[0]["recommendation"] and "peak_2.amplitude" in flagged[0]["recommendation"]
+
+
+def test_codegen_contract_carries_the_rule_and_the_bounds_field():
+    from scilink.agents.exp_agents import instruct
+    assert "Bounds are data-relative, never constants read off this spectrum" in instruct.FITTING_SCRIPT_INSTRUCTIONS
+    assert '"bounds": {{"peak_1"' in instruct.FITTING_SCRIPT_INSTRUCTIONS
+    assert "PINNED AT ITS BOUND" in instruct.FITTING_SCRIPT_CORRECTION_INSTRUCTIONS
+
+
+def test_single_regime_plan_does_not_block_locked_script_reuse():
+    blocked = cc.UnifiedSeriesProcessingController._reuse_blocked_by_regimes
+    assert blocked({"series_analysis_plan": {"regimes": [{"spectrum_indices": [0, 1, 2]}]}, "regime_configs": {0: {}, 1: {}, 2: {}}}) is False
+    assert blocked({"series_analysis_plan": {"regimes": [{"spectrum_indices": [0, 1]}, {"spectrum_indices": [2]}]}}) is True
+    assert blocked({}) is False


### PR DESCRIPTION
Closes #592.

## Summary

A locked fitting script that carried a numeric amplitude ceiling read off its first spectrum pinned at that ceiling on later, stronger spectra. The baseline absorbed the misfit, R² still passed the gate, and a wrong value was recorded as a success. Three changes, each general rather than tied to that trace:

- **Generated scripts use data-relative bounds** (an expression of the loaded data, or unbounded) and report the bounds they used.
- **A fit with a parameter at its bound is caught deterministically**, independent of R². The run relaxes exactly that bound once and refits; if it still pins, the fit is kept but stamped and flagged in the series so it cannot pass silently.
- **Locked-script reuse now engages for a single-regime series.** It was skipped for any planned series, which also kept the reuse path from being exercised; only a plan with more than one regime blocks it.

The check is deliberately narrow so it never calls a legitimate fit degenerate: a zero lower bound (a vanished component, a zero slope) and fraction-like parameters at 0 or 1 (a pseudo-Voigt at `eta = 1`) are not reported. Scripts that report no bounds behave exactly as before.

## Technical description

- `instruct.py`: `FITTING_SCRIPT_INSTRUCTIONS` step 3 states the data-relative-bounds principle and the results JSON gains `bounds` mirroring `parameters` (null for an open side); `FITTING_SCRIPT_CORRECTION_INSTRUCTIONS` gets a narrow exception permitting (and requiring) widening of the named bounds only.
- `curve_fitting_tools.validate_bound_pinning(parameters, bounds, rel_tol=0.01)` → `[{component, parameter, value, bound, side}]`; `describe_pinned`; `PINNED_BOUND_FIX`. Exemptions: lower bound of 0, fraction-like names (`_FRACTION_KEYS`), open-both-sides bounds.
- `_fit_single_spectrum`: after a successful run the parsed markers are checked; a pinned fit sets a `DEGENERATE FIT` error and continues to `_correct_script` (at most `MAX_PINNED_RETRIES = 1` per spectrum, within the existing attempt ladder). A fit that still pins carries `fit_quality.pinned_at_bound`, `pinned_at_bound`, `quality_warning` and a `script_errors` entry of kind `pinned_bound` (which the verifier context already consumes). `bounds` is passed through on the result.
- `_detect_outliers`: a successful result with `pinned_at_bound` is flagged with reason `pinned_at_bound` regardless of the gate metric; existing consumers already guard `r_squared`/`deviation_sigma` for None and the adaptive-refit selector keys on its own reason list, so nothing downstream changes for other reasons.
- `_reuse_blocked_by_regimes(state)`: true only when the series plan has more than one regime (the old guard tested `regime_configs`, which a single-regime plan also populates).
- Tests (`tests/test_pinned_bound_degeneracy.py`, 6): validator rules and exemptions; a pinned locked script corrected once and the relaxed fit kept with its reported bounds; a fit that still pins stamped after one relaxation; series flagging regardless of R²; the prompt contract; the regime guard. Full suite: identical failure set to main (56 failed / 34 errors pre-existing, 2607 passed).

### Live check (Bedrock)

A prior run whose script hardcodes `ub = [..., 0.45, ...]` for the product amplitude was reused on a four-spectrum series with true product amplitudes 0.2, 0.4, 0.8, 1.2.

- Control, script as-is with no agent: at a true amplitude of 0.5 it reports 0.450, the intercept inflates to 0.039 and R² is 0.990, so the old gate passed it.
- With the fix, reuse engaged (`reuse_validity: good`); spectra 2 and 3 pinned on attempt 1 (`product.amplitude = 0.45 at its upper bound 0.45`), the correction changed the ceiling to `2.0 * np.max(y)`, and the refits reported 0.799 and 1.199 with R² 0.9996 and 0.9998. Run twice with the final code, same outcome.
- A fresh anchor generated under the new prompt (earlier run) used `3.0 * yr` ceilings and reported its bounds.