### PR TITLE
Judge completion against the request as stated

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -332,6 +332,10 @@ examine_data returns data_type:
    - `run_dft_workflow` — build VASP-ready inputs for one of the recommended structures.
 
 **BEHAVIOR:**
+- Judge completion against the request AS STATED: never invent a deliverable, format,
+  or acceptance criterion the user did not ask for and then work to satisfy it — a phrase
+  describing a result's granularity ("per-unit-cell", "per-spectrum") is not a request for
+  a table of it. An extra artifact is produced only when explicitly requested.
 - If disambiguation_needed=true in examine_data result, ASK the user before selecting agent
 - NEVER pass a `raw_instrument` container (or any file whose sidecar forbids generic
   routing) to run_analysis; prepare it first with `prepare_data`.

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -333,6 +333,10 @@ rather than fabricate a result).
   would contradict the optimizer's output.
 
 **RESPONSE STYLE:**
+- Judge a specialist's result against the user's request AS STATED: do not
+  invent a deliverable, format, or acceptance criterion the user did not ask
+  for and then delegate follow-ups to satisfy it. An extra artifact is
+  produced only when explicitly requested.
 - Do not dump raw tool JSON back to the user — synthesize it into plain
   language.
 - Make clear which specialist produced which result.

--- a/tests/test_verify_against_request.py
+++ b/tests/test_verify_against_request.py
@@ -1,0 +1,19 @@
+"""#598 — completion is judged against the request as stated: both the
+analysis orchestrator and the meta carry the one-sentence principle, so a
+self-review cannot invent a deliverable and then chase it."""
+from scilink.agents.exp_agents import analysis_orchestrator as ao
+from scilink.agents.meta_agent import meta_orchestrator as mo
+
+
+def test_analysis_prompt_anchors_completion_to_the_stated_request():
+    body = ao._SYSTEM_PROMPT_BODY_POST
+    assert "Judge completion against the request AS STATED" in body
+    assert "is not a request for\n  a table of it" in body
+    assert "produced only when explicitly requested" in body
+
+
+def test_meta_prompt_carries_the_same_principle():
+    import inspect
+    src = inspect.getsource(mo)
+    assert "Judge a specialist's result against the user's request AS STATED" in src
+    assert "delegate follow-ups to satisfy it" in src


### PR DESCRIPTION
Closes #598.

## Summary

An analysis self-review could upgrade the user's ask into a stricter deliverable it was never given (a phrase describing a result's granularity read as a demand for a table of it), judge its own correct output insufficient, and then run unrequested follow-up analyses to satisfy the phantom requirement. Both the analysis orchestrator and the meta now carry the principle as a single behavioral rule: judge completion against the request as stated, never invent a deliverable, format or acceptance criterion beyond it, and produce an extra artifact only when explicitly requested.

## Technical description

- `analysis_orchestrator.py`: first item of the **BEHAVIOR** list in `_SYSTEM_PROMPT_BODY_POST`.
- `meta_orchestrator.py`: first item of **RESPONSE STYLE** in the meta prompt, phrased for the reviewer of a specialist's result (no follow-up delegations to satisfy an invented criterion).
- One sentence each, stating the principle rather than enumerating output types, per the prompt-patch convention. Test: `tests/test_verify_against_request.py` pins both.

A live check of the trigger scenario is reported with the companion PR for #599, which adds the lightweight derive step the chase mis-routed through.