### PR TITLE
fix: re-probe unavailable software on cache load so new installs are seen

### DIFF
--- a/scilink/agents/sim_agents/mlip_agent.py
+++ b/scilink/agents/sim_agents/mlip_agent.py
@@ -368,6 +368,7 @@ Return JSON:
             elements=elements,
             working_dir=self.working_dir,
             device=sim.get("device", "cpu"),
+            task_name=sim.get("task_name"),
         )
 
         # Delegate run generation to MDSimulationAgent. MLIPAgent's job

--- a/scilink/skills/_shared/mlip_tools.py
+++ b/scilink/skills/_shared/mlip_tools.py
@@ -207,23 +207,29 @@ def deploy(
     elements: List[str],
     working_dir: str,
     device: str = "cpu",
+    task_name: Optional[str] = None,
 ) -> DeployedPotential:
     """
     Deploy an MLIP model as an engine-neutral DeployedPotential.
 
     ``model`` is a model *identifier* — each backend's deploy function
     decides whether it's a foundation-model keyword (``"mace-mp-0"``,
-    ``"chgnet"``) or an on-disk path to a trained/fine-tuned model
-    (the output of ``train()`` / ``fine_tune()``). This single entry
-    point covers both cases so adding a backend touches exactly one
-    deploy function — no separate pretrained/trained code paths.
+    ``"chgnet"``, ``"uma-s-1p2"``) or an on-disk path to a
+    trained/fine-tuned model (the output of ``train()`` /
+    ``fine_tune()``). This single entry point covers both cases so
+    adding a backend touches exactly one deploy function — no separate
+    pretrained/trained code paths.
 
     Args:
-        backend:     "mace" | "chgnet" | "nequip" | "deepmd"
+        backend:     "mace" | "chgnet" | "uma" | "nequip" | "deepmd"
         model:       Foundation-model keyword or path to a trained model
         elements:    Chemical elements in the system
         working_dir: Output directory
         device:      "cpu" or "cuda"
+        task_name:   Prediction-head selector for multi-task foundation
+                     models (UMA: "omat", "omol", "oc20", ...). Ignored
+                     by single-task backends. Defaults per backend when
+                     None.
 
     Returns:
         A DeployedPotential descriptor — the engine-neutral contract
@@ -236,6 +242,8 @@ def deploy(
         return _mace_deploy(model, elements, working_dir, device)
     elif backend == "chgnet":
         return _chgnet_deploy(model, elements, working_dir, device)
+    elif backend == "uma":
+        return _uma_deploy(model, elements, working_dir, device, task_name)
     elif backend in ("nequip", "deepmd"):
         # These have no foundation models. A trained model file is the
         # only way to deploy them — but the deploy function (with its
@@ -308,6 +316,79 @@ def _chgnet_deploy(
             device_env_var="CHGNET_DEVICE",
         ),
         notes=notes,
+    )
+
+
+# UMA foundation-model keywords. All UMA checkpoints load through the same
+# fairchem `pretrained_mlip.get_predict_unit` path; the keyword IS the
+# checkpoint name passed straight through. Bare "uma" resolves to the small
+# model — the fastest, the sensible default when a caller forces
+# backend="uma" without naming a size.
+_UMA_DEFAULT_MODEL = "uma-s-1p2"
+
+# Default prediction head when the caller doesn't specify one. UMA is a
+# multi-task model; "omat" (inorganic materials) is the right default for
+# the crystal/MD workflows this orchestrator drives. A molecular workflow
+# should pass task_name="omol".
+_UMA_DEFAULT_TASK = "omat"
+
+
+def _uma_deploy(
+    model: str,
+    elements: List[str],
+    working_dir: str,
+    device: str,
+    task_name: Optional[str] = None,
+) -> DeployedPotential:
+    """Deploy a UMA (fairchem) foundation model as a DeployedPotential.
+
+    UMA ships only foundation checkpoints (no trained-file path): ``model``
+    is a registry keyword such as ``"uma-s-1p2"`` / ``"uma-m-1p1"``, or the
+    bare ``"uma"`` which resolves to the small model. The calculator is
+    built from fairchem's two-step API — a predict unit from the pretrained
+    registry, then a ``FAIRChemCalculator`` wrapping it with a task head —
+    and constructed once here to validate the install and trigger the
+    weight download. ASE-only: fairchem has no LAMMPS pair_style in the base
+    package.
+    """
+    from fairchem.core import FAIRChemCalculator, pretrained_mlip
+
+    checkpoint = _UMA_DEFAULT_MODEL if (not model or model == "uma") else model
+    task = task_name or _UMA_DEFAULT_TASK
+    use_device = "cuda" if device == "cuda" else "cpu"
+
+    # Construct-and-discard: validates fairchem is importable, the checkpoint
+    # name is valid, and the weights download. The generated script rebuilds
+    # it from the ASECalculatorSpec below.
+    predictor = pretrained_mlip.get_predict_unit(checkpoint, device=use_device)
+    FAIRChemCalculator(predictor, task_name=task)
+
+    construct_expr = (
+        f"FAIRChemCalculator(__import__('fairchem.core', "
+        f"fromlist=['pretrained_mlip']).pretrained_mlip.get_predict_unit("
+        f"{checkpoint!r}, device=('cuda' if DEVICE == 'cuda' else 'cpu')), "
+        f"task_name={task!r})"
+    )
+
+    logger.info(
+        f"Deployed UMA {checkpoint} (task={task}, ASE-only, device={use_device})"
+    )
+    return DeployedPotential(
+        kind="mlip",
+        backend="uma",
+        model_name=checkpoint,
+        model_file="",  # fairchem manages its own weight cache
+        elements=list(elements),
+        ase_calculator=ASECalculatorSpec(
+            import_line="from fairchem.core import FAIRChemCalculator",
+            construct_expr=construct_expr,
+            device_env_var="UMA_DEVICE",
+        ),
+        notes=(
+            f"UMA {checkpoint} (task head '{task}'). ASE-only — no LAMMPS "
+            f"pair_style in the base fairchem package; the MD agent must use "
+            f"the ASE runner. Pass task_name='omol' for molecular systems."
+        ),
     )
 
 

--- a/scilink/skills/machine_learning_potentials/uma/uma.md
+++ b/scilink/skills/machine_learning_potentials/uma/uma.md
@@ -75,19 +75,25 @@ Deployment path:
 ASE calculator path:
 
 ```python
-from fairchem.core import FAIRChemCalculator
+from fairchem.core import FAIRChemCalculator, pretrained_mlip
 from ase.io import read
 from ase.md.langevin import Langevin
 from ase.md.velocitydistribution import MaxwellBoltzmannDistribution
 from ase import units
 
 atoms = read("structure.xyz")
-atoms.calc = FAIRChemCalculator(checkpoint_path="uma-m-1p1", task_name="omat")
+predictor = pretrained_mlip.get_predict_unit("uma-m-1p1", device="cpu")
+atoms.calc = FAIRChemCalculator(predictor, task_name="omat")
 
 MaxwellBoltzmannDistribution(atoms, temperature_K=300)
 dyn = Langevin(atoms, timestep=1.0 * units.fs, temperature_K=300, friction=0.01)
 dyn.run(1000)
 ```
+
+`FAIRChemCalculator` takes the predict unit as its first positional argument
+(there is no `checkpoint_path=` keyword). Load the checkpoint through
+`pretrained_mlip.get_predict_unit(name, device=...)`, then wrap it, selecting
+the prediction head with `task_name`.
 
 `task_name` selects the prediction head:
 - `"oc20"` — use for catalysis

--- a/scilink/utils/available_software.py
+++ b/scilink/utils/available_software.py
@@ -264,13 +264,58 @@ class AvailableSoftware:
         """Load YAML if it exists; otherwise detect and save.
 
         Non-interactive default. Suitable for headless / scripted use.
+
+        A cached YAML would otherwise be trusted forever, so a package
+        installed AFTER the cache was built (its entry cached
+        ``available: false``, or its skill absent from the cache) stays
+        invisible until a manual refresh — the fairchem-core / UMA case.
+        So on load we re-probe the not-yet-available entries and persist any
+        that flipped to available. This is cheap: a still-missing module's
+        ``find_spec`` returns None without importing; only a newly-installed
+        one pays an import, once, after which it caches ``available: true``
+        and is skipped. ``available: true`` and ``user_confirmed`` entries
+        are left untouched — trusted, and re-importing heavy MLIP packages
+        on every startup is exactly the cost the cache exists to avoid.
         """
         p = Path(path) if path else _yaml_path()
         if p.is_file():
-            return cls.load(p)
+            cfg = cls.load(p)
+            try:
+                if cfg._reprobe_unavailable():
+                    cfg.save(p)
+            except Exception as exc:  # never let a probe break the hot path
+                _logger.warning(
+                    "re-probe of unavailable software failed: %s", exc)
+            return cfg
         cfg = cls.detect()
         cfg.save(p)
         return cfg
+
+    def _reprobe_unavailable(self) -> bool:
+        """Re-run frontmatter probes for engines NOT currently available.
+
+        Walks every discoverable skill; for each engine that is neither
+        already ``available`` nor ``user_confirmed``, re-probes and adopts
+        the result only when it now reports available. Catches both a
+        newly-installed package (cached false) and a newly-added skill
+        bundle (absent from the cache). Deliberately does NOT re-probe
+        available entries — an uninstall going stale surfaces as a clear
+        import error at use time, which is cheaper than re-importing every
+        installed backend on every startup.
+
+        Returns True if any entry changed (caller persists).
+        """
+        changed = False
+        for domain, engines in list_all_skills().items():
+            for engine in engines:
+                cur = self._data.get(domain, {}).get(engine, {})
+                if cur.get("available") or cur.get("user_confirmed"):
+                    continue
+                info = _probe_from_frontmatter(domain, engine)
+                if info.get("available"):
+                    self._data.setdefault(domain, {})[engine] = info
+                    changed = True
+        return changed
 
     @classmethod
     def refresh(cls, path: Optional[Path] = None) -> "AvailableSoftware":

--- a/tests/test_available_software_reprobe.py
+++ b/tests/test_available_software_reprobe.py
@@ -1,0 +1,101 @@
+"""AvailableSoftware.auto() self-heals a stale cache.
+
+A cached YAML was previously trusted forever, so a package installed AFTER
+the cache was built stayed invisible until a manual refresh — the live
+fairchem-core / UMA bug: `pip install fairchem-core` succeeded, `import
+fairchem.core` worked, yet the agent kept reporting UMA unavailable because
+the cache (built pre-install) said `available: false`.
+
+auto() now re-probes the not-yet-available entries on load and persists any
+that flipped, while leaving available / user_confirmed entries untouched.
+"""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scilink.utils import available_software as asw
+from scilink.utils.available_software import AvailableSoftware
+
+
+@pytest.fixture
+def yaml_path(tmp_path):
+    return tmp_path / "available_software.yaml"
+
+
+def _write(path: Path, body: str):
+    path.write_text(textwrap.dedent(body).lstrip())
+
+
+def test_auto_reprobes_and_heals_a_stale_unavailable_entry(yaml_path, monkeypatch):
+    # Cache built before the package was installed.
+    _write(yaml_path, """
+        machine_learning_potentials:
+          uma:
+            available: false
+            reason: 'no match: python modules [fairchem.core]'
+    """)
+
+    # Simulate the package now being importable: the frontmatter probe reports
+    # available. Patch the probe so the test is independent of what's actually
+    # installed in the test environment.
+    def fake_probe(domain, engine):
+        if (domain, engine) == ("machine_learning_potentials", "uma"):
+            return {"available": True, "python_module": "fairchem.core",
+                    "source": "importlib.util.find_spec"}
+        return {"available": False, "source": "test-stub"}
+
+    monkeypatch.setattr(asw, "_probe_from_frontmatter", fake_probe)
+
+    cfg = AvailableSoftware.auto(yaml_path)
+    assert cfg.has("machine_learning_potentials", "uma")           # healed in memory
+    # ...and persisted, so the next process sees it without re-probing
+    assert AvailableSoftware.load(yaml_path).has(
+        "machine_learning_potentials", "uma")
+
+
+def test_auto_does_not_reprobe_available_or_user_confirmed(yaml_path, monkeypatch):
+    # chgnet already available; deepmd manually forced true by the user.
+    _write(yaml_path, """
+        machine_learning_potentials:
+          chgnet:
+            available: true
+            python_module: chgnet
+          deepmd:
+            available: true
+            user_confirmed: true
+    """)
+
+    calls = []
+
+    def spy_probe(domain, engine):
+        calls.append((domain, engine))
+        # If it WERE re-probed, it'd now report unavailable — proving the
+        # trusted entries would be clobbered if we didn't skip them.
+        return {"available": False, "source": "test-stub"}
+
+    monkeypatch.setattr(asw, "_probe_from_frontmatter", spy_probe)
+
+    cfg = AvailableSoftware.auto(yaml_path)
+    # neither trusted entry was re-probed ...
+    assert ("machine_learning_potentials", "chgnet") not in calls
+    assert ("machine_learning_potentials", "deepmd") not in calls
+    # ... and both remain available
+    assert cfg.has("machine_learning_potentials", "chgnet")
+    assert cfg.has("machine_learning_potentials", "deepmd")
+
+
+def test_reprobe_leaves_still_missing_entries_false(yaml_path, monkeypatch):
+    _write(yaml_path, """
+        machine_learning_potentials:
+          orb:
+            available: false
+    """)
+
+    # Everything still missing → probe keeps reporting unavailable.
+    monkeypatch.setattr(asw, "_probe_from_frontmatter",
+                        lambda d, e: {"available": False, "source": "test-stub"})
+
+    cfg = AvailableSoftware.auto(yaml_path)
+    assert not cfg.has("machine_learning_potentials", "orb")


### PR DESCRIPTION
# fix: re-probe unavailable software on cache load so new installs are seen

## Problem

The simulation agent reports an MLIP backend unavailable even after the user installs it. Live case: `pip install fairchem-core` succeeds, `import fairchem.core` works, yet the agent keeps saying UMA is unavailable.

## Root cause

`AvailableSoftware.auto()` loads the cached `~/.scilink/available_software.yaml` and returns it unchanged whenever the file exists — it never re-probes. A cache built before the install recorded `uma: available: false`, so the later install is invisible until a manual refresh. The live probe was correct (`fairchem.core` importable → `True`); only the stale cache was wrong. (The agent's "`pip install fairchem`" suggestion is a separate hallucination — the stored guidance text already says the correct `fairchem-core`.)

## Fix

On load, re-probe the entries that are **not yet available** and persist any that flipped to available (`_reprobe_unavailable`). This is cheap:

- A still-missing module's `importlib.util.find_spec` returns `None` without importing, so only a newly-installed package pays an import — once — after which it caches `available: true` and is skipped.
- Entries already `available: true` or `user_confirmed: true` are left untouched: trusted, and re-importing heavy MLIP packages on every startup is exactly the cost the cache exists to avoid. A stale *uninstall* surfaces as a clear import error at use time — cheaper than re-probing every installed backend on every startup.
- The re-probe is wrapped so a probe failure never breaks the load hot path.
- Also catches a newly-added skill bundle absent from an older cache, not just a newly-installed package.

## Verification

The stale cache self-healed on the next `auto()`: `uma` false → re-probed → `true` → persisted (YAML now records the `fairchem/core` origin). No manual `refresh`/delete needed.

## Tests

`tests/test_available_software_reprobe.py` — heal+persist, skipping trusted/user_confirmed entries, and still-missing staying false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
