### PR TITLE
Web UI: syntax highlighting for source files and fenced code

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "scilink-webui",
       "version": "0.0.1",
       "dependencies": {
+        "highlight.js": "^11.12.0",
         "katex": "^0.16.11",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -806,9 +807,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -917,9 +915,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -934,9 +929,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -951,9 +943,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -968,9 +957,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -985,9 +971,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1002,9 +985,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1019,9 +999,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1036,9 +1013,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1053,9 +1027,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1070,9 +1041,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1087,9 +1055,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1104,9 +1069,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1121,9 +1083,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1892,6 +1851,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.12.0.tgz",
+      "integrity": "sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/html-url-attributes": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -8,9 +8,11 @@
     "build": "tsc -b && vite build",
     "build:package": "npm run build && rsync -a --delete dist/ ../scilink/server/static/",
     "preview": "vite preview",
-    "check:graph": "node --experimental-strip-types scripts/graph_check.ts"
+    "check:graph": "node --experimental-strip-types scripts/graph_check.ts",
+    "check:highlight": "node --experimental-strip-types scripts/highlight_check.ts"
   },
   "dependencies": {
+    "highlight.js": "^11.12.0",
     "katex": "^0.16.11",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/webui/scripts/highlight_check.ts
+++ b/webui/scripts/highlight_check.ts
@@ -1,0 +1,35 @@
+/** Headless check of the syntax highlighter (#605): language mapping,
+ * tokenization of the common languages, escaping, and the size cutoff.
+ * Run: npm run check:highlight */
+import { highlightCode, languageForExtension, resolveLanguage, HIGHLIGHT_MAX_CHARS } from "../src/highlight.ts";
+
+let failures = 0;
+function check(name: string, cond: boolean, detail = "") {
+  console.log(`  [${cond ? "PASS" : "FAIL"}] ${name}${detail && !cond ? " — " + detail : ""}`);
+  if (!cond) failures++;
+}
+
+check("py → python", languageForExtension("py") === "python");
+check("yml → yaml, toml → ini, jsonl → json, md → markdown", languageForExtension("yml") === "yaml" && languageForExtension("toml") === "ini" && languageForExtension("jsonl") === "json" && languageForExtension("md") === "markdown");
+check("unknown extension → null", languageForExtension("cif") === null && languageForExtension("") === null);
+check("fence tags resolve case-insensitively with aliases", resolveLanguage("Python") === "python" && resolveLanguage("sh") === "bash" && resolveLanguage("py") === "python");
+check("unregistered fence tag → null", resolveLanguage("fortran") === null && resolveLanguage("") === null);
+
+const py = 'import numpy as np\n\ndef fit(x, y):\n    """Fit."""  # comment\n    return np.polyfit(x, y, 2) * 3.5\n';
+const hp = highlightCode(py, "python");
+check("python: keyword / string / number / comment tokens", hp.language === "python" && /hljs-keyword/.test(hp.html) && /hljs-string/.test(hp.html) && /hljs-number/.test(hp.html) && /hljs-comment/.test(hp.html), hp.html.slice(0, 200));
+check("python: function name is a title token", /hljs-title[^>]*>fit</.test(hp.html));
+check("json tokens", /hljs-attr/.test(highlightCode('{"a": 1, "b": [true, "x"]}', "json").html));
+check("bash tokens", /hljs-built_in|hljs-keyword/.test(highlightCode("export X=1\nfor f in *.py; do echo $f; done\n", "bash").html));
+check("yaml tokens", /hljs-attr/.test(highlightCode("name: eels\nsections:\n  - planning\n", "yaml").html));
+check("markdown tokens", /hljs-section/.test(highlightCode("# Title\n\nsome *text*\n", "markdown").html));
+
+const plain = highlightCode("<b>x</b> & y", null);
+check("no language → escaped plain text", plain.language === null && plain.html === "&lt;b&gt;x&lt;/b&gt; &amp; y");
+check("plaintext language → escaped plain text", highlightCode("a < b", "plaintext").language === null);
+const big = highlightCode("x = 1\n".repeat(HIGHLIGHT_MAX_CHARS / 6 + 10), "python");
+check("oversized input skips highlighting", big.language === null && !big.html.includes("<span"));
+check("html in code is escaped, never injected", !highlightCode('s = "<script>alert(1)</script>"', "python").html.includes("<script>"));
+
+console.log(failures ? `\n${failures} check(s) FAILED` : "\nall highlight checks passed");
+process.exit(failures ? 1 : 0);

--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -853,3 +853,21 @@ button.primary.small { padding: 4px 10px; font-size: 13px; width: auto; }
 .mem-stage-fold > .mem-stage { border-top: none; margin-top: 0; padding-top: 0; }
 .mem-stage-lead { margin: 2px 0 6px; font-size: 12px; color: var(--text-dim); }
 
+
+/* ── syntax highlighting (#605) ─────────────────────────────── */
+code.hljs { color: inherit; background: transparent; padding: 0; }   /* the pane (pre) keeps its own surface */
+.hljs-keyword, .hljs-selector-tag, .hljs-literal, .hljs-doctag, .hljs-tag .hljs-name { color: var(--hl-keyword); }
+.hljs-built_in, .hljs-type { color: var(--hl-builtin); }
+.hljs-string, .hljs-regexp, .hljs-quote, .hljs-template-tag { color: var(--hl-string); }
+.hljs-number, .hljs-symbol, .hljs-bullet, .hljs-link { color: var(--hl-number); }
+.hljs-comment { color: var(--hl-comment); font-style: italic; }
+.hljs-title, .hljs-title.function_, .hljs-section { color: var(--hl-function); }
+.hljs-title.class_, .hljs-title.class_.inherited__, .hljs-selector-class, .hljs-selector-id { color: var(--hl-class); }
+.hljs-attr, .hljs-attribute, .hljs-variable, .hljs-template-variable, .hljs-property { color: var(--hl-attr); }
+.hljs-meta, .hljs-meta .hljs-keyword, .hljs-params .hljs-keyword { color: var(--hl-meta); }
+.hljs-punctuation, .hljs-operator, .hljs-params { color: var(--hl-punct); }
+.hljs-addition { color: var(--hl-addition); }
+.hljs-deletion { color: var(--hl-deletion); }
+.hljs-emphasis { font-style: italic; }
+.hljs-strong { font-weight: 600; }
+.hljs-section { font-weight: 600; }

--- a/webui/src/components/CodeBlock.tsx
+++ b/webui/src/components/CodeBlock.tsx
@@ -1,0 +1,31 @@
+import { useMemo } from "react";
+import { highlightCode } from "../highlight";
+
+/** A source / code block: tokenized when the language is known, plain
+ * otherwise. `className` lets callers keep their existing pane styling
+ * (`text-preview` in the file explorer). */
+export function CodeBlock({
+  code,
+  language,
+  className = "text-preview",
+}: {
+  code: string;
+  language: string | null | undefined;
+  className?: string;
+}) {
+  const hl = useMemo(() => highlightCode(code, language), [code, language]);
+  if (!hl.language) return <pre className={className}>{code}</pre>;
+  return (
+    <pre className={`${className} hljs`} data-language={hl.language}>
+      <code className={`hljs language-${hl.language}`} dangerouslySetInnerHTML={{ __html: hl.html }} />
+    </pre>
+  );
+}
+
+/** The `<code>` inside a markdown fenced block (react-markdown renders the
+ * surrounding `<pre>` itself). */
+export function HighlightedCode({ code, language }: { code: string; language: string | null }) {
+  const hl = useMemo(() => highlightCode(code, language), [code, language]);
+  if (!hl.language) return <code>{code}</code>;
+  return <code className={`hljs language-${hl.language}`} dangerouslySetInnerHTML={{ __html: hl.html }} />;
+}

--- a/webui/src/components/FilePreview.tsx
+++ b/webui/src/components/FilePreview.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
+import { CodeBlock } from "./CodeBlock";
+import { languageForExtension } from "../highlight";
 import {
   api,
   type ProvenanceEvent,
@@ -99,9 +101,10 @@ function PreviewBody({
     return <iframe className="preview-frame" src={url} title={path} sandbox="allow-scripts" />;
   if (e === "pdf")
     return <iframe className="preview-frame tall" src={url} title={path} />;
-  if (e === "json") return <TextPreview url={url} pretty />;
+  if (e === "json") return <TextPreview url={url} pretty language="json" />;
   // code, extension-less files (POSCAR/INCAR/...), and anything text-ish
-  if (CODE_EXTS.includes(e) || e === "") return <TextPreview url={url} />;
+  if (CODE_EXTS.includes(e) || e === "")
+    return <TextPreview url={url} language={languageForExtension(e)} />;
   return (
     <p className="caption">
       No inline preview for .{e} — use Download.
@@ -319,13 +322,21 @@ function MdPreview({ sessionId, path }: { sessionId: string; path: string }) {
           }
         />
       ) : (
-        <pre className="text-preview">{text}</pre>
+        <CodeBlock code={text} language="markdown" />
       )}
     </div>
   );
 }
 
-function TextPreview({ url, pretty = false }: { url: string; pretty?: boolean }) {
+function TextPreview({
+  url,
+  pretty = false,
+  language = null,
+}: {
+  url: string;
+  pretty?: boolean;
+  language?: string | null;
+}) {
   const [text, setText] = useState<string | null>(null);
   useEffect(() => {
     setText(null);
@@ -344,5 +355,5 @@ function TextPreview({ url, pretty = false }: { url: string; pretty?: boolean })
       .catch((err) => setText(`Could not load: ${err}`));
   }, [url, pretty]);
   if (text === null) return <p className="caption">Loading…</p>;
-  return <pre className="text-preview">{text}</pre>;
+  return <CodeBlock code={text} language={language} />;
 }

--- a/webui/src/components/MarkdownBody.tsx
+++ b/webui/src/components/MarkdownBody.tsx
@@ -30,6 +30,13 @@ export function demoteHeadings(text: string): string {
 }
 
 import { isFileToken } from "../filelink";
+import { HighlightedCode } from "./CodeBlock";
+
+/** react-markdown puts ```lang on the code element as `language-lang`. */
+function fenceLanguage(className?: string): string | null {
+  const m = /language-([\w+-]+)/.exec(className ?? "");
+  return m ? m[1] : null;
+}
 
 export function MarkdownBody({
   text,
@@ -51,27 +58,30 @@ export function MarkdownBody({
       <img src={src ? transformImageUri(src) : undefined} alt={alt ?? ""} />
     );
   }
-  if (onFileClick) {
-    components.code = (props: {
-      className?: string;
-      children?: React.ReactNode;
-    }) => {
-      const raw = String(props.children ?? "");
-      // Inline code only (fenced blocks carry a language class / newlines).
-      if (!props.className && !raw.includes("\n") && isFileToken(raw)) {
-        return (
-          <code
-            className="file-link"
-            title="Open in Files"
-            onClick={() => onFileClick(raw)}
-          >
-            {props.children}
-          </code>
-        );
-      }
-      return <code className={props.className}>{props.children}</code>;
-    };
-  }
+  components.code = (props: {
+    className?: string;
+    children?: React.ReactNode;
+  }) => {
+    const raw = String(props.children ?? "");
+    const lang = fenceLanguage(props.className);
+    // A fenced block (language class, or multi-line) is highlighted (#605).
+    if (lang || raw.includes("\n")) {
+      return <HighlightedCode code={raw.replace(/\n$/, "")} language={lang} />;
+    }
+    // Inline code that looks like a file path opens it in the explorer.
+    if (onFileClick && isFileToken(raw)) {
+      return (
+        <code
+          className="file-link"
+          title="Open in Files"
+          onClick={() => onFileClick(raw)}
+        >
+          {props.children}
+        </code>
+      );
+    }
+    return <code className={props.className}>{props.children}</code>;
+  };
   return (
     <div className="md-body">
       <ReactMarkdown

--- a/webui/src/highlight.ts
+++ b/webui/src/highlight.ts
@@ -1,0 +1,88 @@
+/** Syntax highlighting (#605): highlight.js core with a curated language
+ * set, so generated scripts, skill snippets and session files render as
+ * tokens instead of plain text. Colors come from CSS tokens (`--hl-*`), so
+ * the palette follows the app theme. */
+import hljs from "highlight.js/lib/core";
+import python from "highlight.js/lib/languages/python";
+import javascript from "highlight.js/lib/languages/javascript";
+import typescript from "highlight.js/lib/languages/typescript";
+import json from "highlight.js/lib/languages/json";
+import bash from "highlight.js/lib/languages/bash";
+import yaml from "highlight.js/lib/languages/yaml";
+import ini from "highlight.js/lib/languages/ini";
+import markdown from "highlight.js/lib/languages/markdown";
+import xml from "highlight.js/lib/languages/xml";
+import css from "highlight.js/lib/languages/css";
+import diff from "highlight.js/lib/languages/diff";
+import plaintext from "highlight.js/lib/languages/plaintext";
+
+const LANGS: Record<string, unknown> = {
+  python, javascript, typescript, json, bash, yaml, ini, markdown, xml, css, diff, plaintext,
+};
+for (const [name, def] of Object.entries(LANGS)) {
+  hljs.registerLanguage(name, def as Parameters<typeof hljs.registerLanguage>[1]);
+}
+hljs.registerAliases(["py", "python3"], { languageName: "python" });
+hljs.registerAliases(["js", "jsx", "mjs"], { languageName: "javascript" });
+hljs.registerAliases(["ts", "tsx"], { languageName: "typescript" });
+hljs.registerAliases(["sh", "shell", "zsh", "console"], { languageName: "bash" });
+hljs.registerAliases(["yml"], { languageName: "yaml" });
+hljs.registerAliases(["toml", "cfg", "conf"], { languageName: "ini" });
+hljs.registerAliases(["md"], { languageName: "markdown" });
+hljs.registerAliases(["html", "htm", "svg"], { languageName: "xml" });
+hljs.registerAliases(["jsonl"], { languageName: "json" });
+hljs.registerAliases(["txt", "text", "log"], { languageName: "plaintext" });
+
+/** File extension → registered language name (null: leave plain). */
+const EXT_LANG: Record<string, string> = {
+  py: "python", js: "javascript", ts: "typescript", tsx: "typescript", jsx: "javascript",
+  json: "json", jsonl: "json", sh: "bash", bash: "bash", zsh: "bash",
+  yaml: "yaml", yml: "yaml", toml: "ini", ini: "ini", cfg: "ini",
+  md: "markdown", html: "xml", htm: "xml", xml: "xml", svg: "xml", css: "css", diff: "diff", patch: "diff",
+};
+
+export function languageForExtension(ext: string): string | null {
+  return EXT_LANG[ext.toLowerCase()] ?? null;
+}
+
+/** Fence tags and their aliases → the registered (canonical) language. */
+const ALIASES: Record<string, string> = {
+  py: "python", python3: "python", js: "javascript", jsx: "javascript", mjs: "javascript",
+  ts: "typescript", tsx: "typescript", sh: "bash", shell: "bash", zsh: "bash", console: "bash",
+  yml: "yaml", toml: "ini", cfg: "ini", conf: "ini", md: "markdown", html: "xml", htm: "xml", svg: "xml",
+  jsonl: "json", txt: "plaintext", text: "plaintext", log: "plaintext",
+};
+
+/** Normalize a fenced-block language tag (```python, ```py, ```Python) to the
+ * canonical registered language, or null when unknown / not registered. */
+export function resolveLanguage(tag: string | null | undefined): string | null {
+  if (!tag) return null;
+  const name = tag.toLowerCase().trim();
+  const canonical = ALIASES[name] ?? name;
+  return canonical in LANGS ? canonical : null;
+}
+
+/** Highlighting is skipped above this size — a 200 000-character log would
+ * take longer to tokenize than to read. */
+export const HIGHLIGHT_MAX_CHARS = 120_000;
+
+export type Highlighted = { html: string; language: string | null };
+
+/** Highlighted HTML for `code`; `language` null or plaintext returns the
+ * escaped text unchanged (as `html`) with `language: null`. Never throws. */
+export function highlightCode(code: string, language: string | null | undefined): Highlighted {
+  const lang = resolveLanguage(language);
+  if (!lang || lang === "plaintext" || code.length > HIGHLIGHT_MAX_CHARS) {
+    return { html: escapeHtml(code), language: null };
+  }
+  try {
+    const res = hljs.highlight(code, { language: lang, ignoreIllegals: true });
+    return { html: res.value, language: lang };
+  } catch {
+    return { html: escapeHtml(code), language: null };
+  }
+}
+
+export function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/webui/src/tokens.css
+++ b/webui/src/tokens.css
@@ -30,6 +30,22 @@
   --code-border: #333333;
   --code-text: #e0e0e0;
 
+  /* syntax-highlighting palette (#605). Code panes are dark in both themes
+     (--code-bg is not overridden by the light theme), so one palette serves
+     both; a theme that lightens the panes overrides these in its block. */
+  --hl-keyword: #c792ea;
+  --hl-builtin: #82aaff;
+  --hl-string: #c3e88d;
+  --hl-number: #f78c6c;
+  --hl-comment: #7f8c99;
+  --hl-function: #82aaff;
+  --hl-class: #ffcb6b;
+  --hl-attr: #ffcb6b;
+  --hl-meta: #89ddff;
+  --hl-punct: #bfc7d5;
+  --hl-addition: #a6e3a1;
+  --hl-deletion: #f38ba8;
+
   /* narration colors (app.py:_log_to_html) */
   --thought-meta: #6ec1e4;
   --thought-specialist: #c9a06a;


### PR DESCRIPTION
Closes #605.

## Summary

Generated scripts, skill snippets and any fenced code in the web UI rendered as plain text. Source files opened in the file explorer and fenced code blocks in markdown (skill previews, reports, chat replies) are now syntax-highlighted for the common languages, with colors that follow the app's design tokens. Everything else in those views is unchanged: tables, images, inline file links and the plain-text fallback for unknown file types.

## Technical description

- `webui/src/highlight.ts`: highlight.js core (11.12) with python, javascript, typescript, json, bash, yaml, ini (toml), markdown, xml (html), css, diff and plaintext registered; extension → language map; fence-tag aliases resolved to the canonical language; `highlightCode` returns escaped text for unknown/plaintext languages or inputs over 120k characters and never throws.
- `CodeBlock.tsx`: `CodeBlock` (the file explorer's text preview and the markdown Source view, keeping the `text-preview` pane class) and `HighlightedCode` (the `<code>` inside a react-markdown fence).
- `MarkdownBody.tsx`: the `code` component now always exists; fenced/multi-line code is highlighted, inline code keeps the file-link click behaviour.
- `FilePreview.tsx`: `TextPreview` takes a `language` (from the extension; `json` for the pretty-printed JSON path); the markdown Source view highlights as markdown.
- `tokens.css` / `app.css`: `--hl-*` palette tokens and the `.hljs-*` class mapping; `code.hljs` is transparent so the pane keeps its surface (the panes are dark in both themes by design).
- `npm run check:highlight` (`scripts/highlight_check.ts`): mapping, tokenization per language, escaping, oversized-input cutoff, script-tag escaping. `tsc -b` and `vite build` clean; bundle 778 kB (gzip 238 kB).

### Verified in Chrome (resumed session on the test server)

Python `trend_analysis.py` in the file explorer highlighted (345 tokens); `analysis_results.json` highlighted (153 tokens, 34 keys); the EPR skill preview's python fence highlighted (81 tokens); light theme keeps the dark pane with readable tokens; a CSV still renders as a table; inline file links in chat still work.