### PR TITLE
Portable tool schemas on the internal-proxy path too

### DIFF
--- a/scilink/agents/exp_agents/analysis_orchestrator.py
+++ b/scilink/agents/exp_agents/analysis_orchestrator.py
@@ -1720,12 +1720,15 @@ class AnalysisOrchestratorAgent:
     def _handle_openai_chat(self, user_input: str) -> str:
         """Handle chat with OpenAI-compatible models with manual function calling loop."""
         from openai import OpenAI
-        
-        client = OpenAI(
+        from ...wrappers.tool_schema import portable_openai_client
+
+        # Portable tool schemas + gpt-5 reasoning rule on the proxy path too (#606)
+        client = portable_openai_client(OpenAI(
             api_key=self.model.api_key,
             base_url=self.model.base_url,
             timeout=120.0  # 2 minute timeout
-        )
+        ), self.model.model)
+        self.client = client
         
         # Repair any tool_use left unanswered by a mid-run user Stop
         # (or a trim slicing a pair apart) before extending history.

--- a/scilink/agents/meta_agent/meta_orchestrator.py
+++ b/scilink/agents/meta_agent/meta_orchestrator.py
@@ -2154,12 +2154,13 @@ class MetaOrchestratorAgent:
     def _handle_openai_chat(self, user_input: str) -> str:
         """Handle chat with OpenAI-compatible models — manual tool-calling loop."""
         from openai import OpenAI
+        from ...wrappers.tool_schema import portable_openai_client
 
-        client = OpenAI(
+        client = portable_openai_client(OpenAI(
             api_key=self.model.api_key,
             base_url=self.model.base_url,
             timeout=120.0,
-        )
+        ), self.model.model)   # portable tool schemas on the proxy path (#606)
 
         # Repair any tool_use left unanswered by a mid-run user Stop
         # (or a trim slicing a pair apart) before extending history.

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -1721,11 +1721,12 @@ class PlanningOrchestratorAgent:
     def _handle_openai_chat(self, user_input: str) -> str:
         """Handle chat with OpenAI-compatible models with manual function calling loop."""
         from openai import OpenAI
-        
-        client = OpenAI(
+        from ...wrappers.tool_schema import portable_openai_client
+
+        client = portable_openai_client(OpenAI(
             api_key=self.model.api_key,
             base_url=self.model.base_url
-        )
+        ), self.model.model)   # portable tool schemas on the proxy path (#606)
         
         # Repair any tool_use left unanswered by a mid-run user Stop
         # (or a trim slicing a pair apart) before extending history.

--- a/scilink/agents/sim_agents/simulation_orchestrator.py
+++ b/scilink/agents/sim_agents/simulation_orchestrator.py
@@ -884,12 +884,13 @@ class SimulationOrchestratorAgent:
     def _handle_openai_chat(self, user_input: str) -> str:
         """Chat with OpenAI-compatible models with manual function calling loop."""
         from openai import OpenAI
+        from ...wrappers.tool_schema import portable_openai_client
 
-        client = OpenAI(
+        client = portable_openai_client(OpenAI(
             api_key=self.model.api_key,
             base_url=self.model.base_url,
             timeout=120.0,
-        )
+        ), self.model.model)   # portable tool schemas on the proxy path (#606)
 
         # Repair any tool_use left unanswered by a mid-run user Stop
         # (or a trim slicing a pair apart) before extending history.

--- a/scilink/agents/sim_agents/structure_agent.py
+++ b/scilink/agents/sim_agents/structure_agent.py
@@ -297,7 +297,8 @@ class StructureGenerator:
                                   *, api_key, base_url, model_name):
         """Tool-call loop using the OpenAI Python SDK (internal-proxy path)."""
         from openai import OpenAI
-        client = OpenAI(api_key=api_key, base_url=base_url, timeout=60.0)
+        from ...wrappers.tool_schema import portable_openai_client
+        client = portable_openai_client(OpenAI(api_key=api_key, base_url=base_url, timeout=60.0), model_name)
 
         for _ in range(MAX_MP_RESOLVER_ITERATIONS):
             resp = client.chat.completions.create(

--- a/scilink/wrappers/litellm_wrapper.py
+++ b/scilink/wrappers/litellm_wrapper.py
@@ -32,7 +32,7 @@ import base64
 import json
 import logging
 import time
-from .tool_schema import normalize_tools
+from .tool_schema import normalize_tools, openai_tools_need_no_reasoning as _openai_tools_need_no_reasoning
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Union
 
@@ -238,21 +238,6 @@ def _check_litellm():
     logging.getLogger("litellm").setLevel(logging.WARNING)
 
     litellm.suppress_debug_info = True
-
-
-def _openai_tools_need_no_reasoning(model: str) -> bool:
-    """True for OpenAI gpt-5 family models on chat completions, which reject
-    function tools unless ``reasoning_effort`` is ``"none"`` (observed live:
-    "Function tools with reasoning_effort are not supported for gpt-5.6-sol
-    in /v1/chat/completions ... set reasoning_effort to 'none'")."""
-    m = str(model or "").lower()
-    if "/" in m:
-        provider, _, name = m.partition("/")
-        if provider != "openai":
-            return False
-    else:
-        name = m
-    return name.startswith("gpt-5")
 
 
 def _scope_drop_params(model) -> None:

--- a/scilink/wrappers/openai_wrapper.py
+++ b/scilink/wrappers/openai_wrapper.py
@@ -1,4 +1,5 @@
 import io
+from .tool_schema import portable_openai_client
 import re
 import time
 import base64
@@ -89,8 +90,8 @@ class OpenAIAsGenerativeModel:
         self.timeout = timeout or self.DEFAULT_TIMEOUT
 
         # Works with OpenAI and any OpenAI-compatible endpoint
-        self.client = openai.OpenAI(api_key=api_key, base_url=base_url,
-                                    timeout=self.timeout)
+        self.client = portable_openai_client(
+            openai.OpenAI(api_key=api_key, base_url=base_url, timeout=self.timeout), model)
 
     # ---------------------- public API ----------------------
     def generate_content(self, contents, generation_config=None, safety_settings=None):

--- a/scilink/wrappers/openai_wrapper_tools.py
+++ b/scilink/wrappers/openai_wrapper_tools.py
@@ -1,5 +1,5 @@
 import io
-from .tool_schema import normalize_tools
+from .tool_schema import normalize_tools, portable_openai_client
 import re
 import base64
 from types import SimpleNamespace
@@ -28,7 +28,7 @@ class OpenAIAsGenerativeModel:
 
     def __init__(self, model: str, api_key: str | None = None, base_url: str | None = None):
         # Works with OpenAI and any OpenAI-compatible endpoint 
-        self.client = openai.OpenAI(api_key=api_key, base_url=base_url)
+        self.client = portable_openai_client(openai.OpenAI(api_key=api_key, base_url=base_url), model)
         self.model = model
 
     # ---------------------- public API ----------------------

--- a/scilink/wrappers/tool_schema.py
+++ b/scilink/wrappers/tool_schema.py
@@ -196,3 +196,72 @@ def tool_schema_problems(tools: Optional[List[Any]]) -> List[str]:
             out.append(f"{name}: parameters.type must be 'object'")
         out += [f"{name}: {p}" for p in gemini_schema_problems(params)]
     return out
+
+
+# ── the OpenAI-compatible (internal proxy) path ───────────────────────────
+def openai_tools_need_no_reasoning(model: str) -> bool:
+    """True for OpenAI's gpt-5 family, which refuses function tools on chat
+    completions unless ``reasoning_effort`` is ``"none"`` (observed live:
+    "Function tools with reasoning_effort are not supported for gpt-5.6-sol
+    in /v1/chat/completions ... set reasoning_effort to 'none'"). Accepts a
+    LiteLLM-prefixed name (``openai/gpt-5.6-sol``) or the bare model id an
+    OpenAI-compatible proxy exposes (``gpt-5.6-sol``); any other provider
+    prefix is never a match."""
+    m = str(model or "").lower()
+    if "/" in m:
+        provider, _, name = m.partition("/")
+        if provider != "openai":
+            return False
+    else:
+        name = m
+    return name.startswith("gpt-5")
+
+
+class _PortableCompletions:
+    def __init__(self, raw_completions, default_model):
+        self._raw = raw_completions
+        self._default_model = default_model
+
+    def create(self, *args, **kwargs):
+        tools = kwargs.get("tools")
+        if tools:
+            kwargs["tools"] = normalize_tools(tools)
+            model = kwargs.get("model") or self._default_model
+            if openai_tools_need_no_reasoning(model) and "reasoning_effort" not in kwargs:
+                kwargs["reasoning_effort"] = "none"
+        return self._raw.create(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._raw, name)
+
+
+class _PortableChat:
+    def __init__(self, raw_chat, default_model):
+        self._raw = raw_chat
+        self.completions = _PortableCompletions(raw_chat.completions, default_model)
+
+    def __getattr__(self, name):
+        return getattr(self._raw, name)
+
+
+class PortableOpenAIClient:
+    """An ``openai.OpenAI`` client whose ``chat.completions.create`` sends
+    normalized tool schemas and turns reasoning off for gpt-5 tool calls;
+    everything else (embeddings, models, ...) is the wrapped client's. Every
+    internal-proxy call site builds its client through
+    :func:`portable_openai_client`, so an OpenAI-compatible proxy in front
+    of Gemini or a gpt-5 model gets the same portable declarations as the
+    direct LiteLLM path."""
+
+    def __init__(self, raw_client, default_model=None):
+        self._raw = raw_client
+        self.chat = _PortableChat(raw_client.chat, default_model)
+
+    def __getattr__(self, name):
+        return getattr(self._raw, name)
+
+
+def portable_openai_client(raw_client, default_model=None):
+    if isinstance(raw_client, PortableOpenAIClient):
+        return raw_client
+    return PortableOpenAIClient(raw_client, default_model)

--- a/tests/test_tool_schema_portability.py
+++ b/tests/test_tool_schema_portability.py
@@ -150,3 +150,51 @@ def test_wrapper_normalizes_tools_and_sets_reasoning_off_for_openai_gpt5():
     assert "reasoning_effort" not in m._build_params(None, tools)
     assert not _openai_tools_need_no_reasoning("gpt-4o") and _openai_tools_need_no_reasoning("gpt-5.6-sol")
     assert m._build_params(None, None).get("tools") is None
+
+
+# ── the OpenAI-compatible (internal proxy) path ─────────────────────────
+
+class _RawCompletions:
+    def __init__(self): self.calls = []
+    def create(self, **kw): self.calls.append(kw); return {"ok": True}
+class _RawClient:
+    def __init__(self):
+        from types import SimpleNamespace
+        self.chat = SimpleNamespace(completions=_RawCompletions()); self.embeddings = "emb"
+
+
+def test_portable_openai_client_normalizes_tools_and_applies_the_reasoning_rule():
+    from scilink.wrappers.tool_schema import portable_openai_client, openai_tools_need_no_reasoning, PortableOpenAIClient
+    raw = _RawClient(); c = portable_openai_client(raw, "gpt-5.6-sol")
+    tools = [{"type": "function", "function": {"name": "f", "parameters": {"type": "object", "properties": {"p": {"type": ["string", "array"], "items": {"type": "string"}}}}}}]
+    assert c.chat.completions.create(model="gpt-5.6-sol", messages=[], tools=tools) == {"ok": True}
+    kw = raw.chat.completions.calls[-1]
+    assert "anyOf" in kw["tools"][0]["function"]["parameters"]["properties"]["p"] and kw["reasoning_effort"] == "none"
+    assert "anyOf" not in tools[0]["function"]["parameters"]["properties"]["p"]        # caller's list untouched
+    c.chat.completions.create(model="gemini-3.8-flash", messages=[], tools=tools)
+    assert "reasoning_effort" not in raw.chat.completions.calls[-1]
+    c.chat.completions.create(model="gpt-5.6-sol", messages=[], tools=tools, reasoning_effort="low")
+    assert raw.chat.completions.calls[-1]["reasoning_effort"] == "low"                  # explicit value wins
+    c.chat.completions.create(messages=[], tools=tools)                                  # default model applies
+    assert raw.chat.completions.calls[-1]["reasoning_effort"] == "none"
+    c.chat.completions.create(model="gpt-5.6-sol", messages=[])                          # no tools: nothing added
+    assert "reasoning_effort" not in raw.chat.completions.calls[-1]
+    assert c.embeddings == "emb" and portable_openai_client(c) is c and isinstance(c, PortableOpenAIClient)
+    assert openai_tools_need_no_reasoning("gpt-5.6-sol") and openai_tools_need_no_reasoning("openai/gpt-5-mini")
+    assert not openai_tools_need_no_reasoning("gemini-3.8-flash") and not openai_tools_need_no_reasoning("bedrock/gpt-5") and not openai_tools_need_no_reasoning("gpt-4o")
+
+
+def test_every_internal_proxy_client_is_built_portable():
+    """Each proxy-path call site wraps its OpenAI client; a raw client would
+    send the authored schemas straight to the proxy's backend."""
+    import re
+    root = Path(__file__).resolve().parents[1] / "scilink"
+    sites = ["agents/exp_agents/analysis_orchestrator.py", "agents/planning_agents/planning_orchestrator.py",
+             "agents/meta_agent/meta_orchestrator.py", "agents/sim_agents/simulation_orchestrator.py",
+             "agents/sim_agents/structure_agent.py", "wrappers/openai_wrapper.py", "wrappers/openai_wrapper_tools.py"]
+    for rel in sites:
+        src = (root / rel).read_text()
+        raw = [m.start() for m in re.finditer(r"(?<![\w.])(?:openai\.)?OpenAI\(", src)]
+        assert raw, rel
+        for pos in raw:
+            assert "portable_openai_client(" in src[max(0, pos - 200):pos + 10], f"{rel}: raw OpenAI( client at {pos}"


### PR DESCRIPTION
Follow-up to #609 (issue #606).

## Summary

The first fix normalized tool schemas in the LiteLLM wrapper, but the internal-proxy path (a `base_url` pointing at an OpenAI-compatible proxy) never goes through it: each orchestrator's proxy chat loop builds its own OpenAI client and sends the authored schemas as written. A proxy in front of Gemini therefore still rejected plan/BO mode, and a proxy in front of a gpt-5 model refused function tools everywhere. Every proxy-path client is now built through one wrapper that applies the same normalization and the same gpt-5 reasoning rule, so both paths send identical, portable declarations.

## Technical description

- `tool_schema.portable_openai_client(raw, default_model)` → `PortableOpenAIClient`: `chat.completions.create` normalizes `tools` and sets `reasoning_effort="none"` for gpt-5 models when tools are present and the caller gave no value; all other attributes delegate to the wrapped client; wrapping is idempotent. `openai_tools_need_no_reasoning` moves here (accepts bare proxy model ids and LiteLLM-prefixed names) and the LiteLLM wrapper imports it.
- Wired at every proxy-path client: the analysis, planning, meta and simulation chat loops, the structure agent's resolver loop, and both `OpenAIAsGenerativeModel` wrappers. The analysis loop's empty-answer follow-up referenced `self.client`, which was never assigned; it is now the same portable client.
- Tests (2 new, 13 total in `tests/test_tool_schema_portability.py`): the wrapper on a fake client, and a static check that no proxy call site builds a raw client. Full suite: identical failure set to main.

### Live checks through a local OpenAI-compatible proxy

A minimal FastAPI proxy forwarding `/v1/chat/completions` verbatim to Gemini (`gemini-3.8-flash`), OpenAI (`gpt-5.6-sol`) and Bedrock (Opus 4.8).

- Control with the raw SDK, each orchestrator's real tool set: the planning set rejected by Gemini with the #606 error, every set rejected by the gpt-5 model. With the wrapper: 12/12 accepted.
- End to end on the proxy path, autonomous: BO in plan mode to Gemini, OpenAI and Bedrock (`run_optimization` success, history written); the meta delegating BO to Gemini; analysis mode to Gemini and OpenAI; simulate mode to Gemini.