### PR TITLE
Native TLS for scilink serve (SSE) and scilink-web

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -70,6 +70,18 @@ scilink serve --print-mcp-json                        # ready-to-paste client co
 mission control itself as a single delegation tool. See
 [connecting_agent_clients.md](connecting_agent_clients.md).
 
+The SSE transport is plain HTTP by default, meant to sit behind a
+TLS-terminating reverse proxy when exposed off-box. To serve HTTPS directly:
+
+```bash
+scilink serve --transport sse --host 0.0.0.0 --port 8000 \
+    --ssl-certfile /etc/scilink/cert.pem --ssl-keyfile /etc/scilink/key.pem
+# clients use: {"type": "sse", "url": "https://host:8000/sse"}
+```
+
+(`--ssl-keyfile-password` for an encrypted key; `--print-mcp-json` reflects
+the scheme.) `scilink-web` takes the same three flags.
+
 ## In-session slash commands
 
 Chat sessions accept slash commands alongside natural language. Common set:

--- a/docs/connecting_agent_clients.md
+++ b/docs/connecting_agent_clients.md
@@ -65,6 +65,11 @@ scilink serve --mode both --transport sse --host 127.0.0.1 --port 8000 \
 # clients use: {"type": "sse", "url": "http://127.0.0.1:8000/sse"}
 ```
 
+Off-box, put a TLS-terminating reverse proxy in front (the same Caddy /
+nginx shape as the [web UI](react_web_ui.md#https)), or serve HTTPS
+directly with `--ssl-certfile cert.pem --ssl-keyfile key.pem` — the
+endpoint is then `https://host:8000/sse`.
+
 `scilink serve --print-mcp-json --transport sse --port 8000` prints that
 client entry too.
 

--- a/docs/react_web_ui.md
+++ b/docs/react_web_ui.md
@@ -73,7 +73,9 @@ What a shared server changes, and only a shared server:
   server for everyone);
 - cookie sessions live in memory, so a restart signs everyone out.
 
-TLS is the reverse proxy's job. Caddy:
+### HTTPS
+
+TLS is normally the reverse proxy's job. Caddy:
 
 ```
 scilink.lab.example.org {
@@ -95,6 +97,17 @@ location / {
     client_max_body_size 2g;
 }
 ```
+
+Without a proxy, the server terminates TLS itself with the same flags
+`scilink serve` takes:
+
+```bash
+scilink-web --host 0.0.0.0 --port 8422 --users users.json \
+    --ssl-certfile /etc/scilink/cert.pem --ssl-keyfile /etc/scilink/key.pem
+```
+
+The sign-in cookie is `Secure` either way (the server reads its own scheme
+or `X-Forwarded-Proto`).
 
 If the proxy itself authenticates every request (SSO, mTLS), run with
 `--insecure-no-auth` behind it. Not covered yet: per-user LLM credentials

--- a/scilink/cli/serve.py
+++ b/scilink/cli/serve.py
@@ -7,6 +7,7 @@ Usage::
     scilink serve --mode analyze                       # analysis tools only
     scilink serve --autonomy co-pilot                  # require approval
     scilink serve --transport sse --port 8000           # SSE transport
+    scilink serve --transport sse --ssl-certfile cert.pem --ssl-keyfile key.pem   # HTTPS
 """
 
 import argparse
@@ -39,10 +40,13 @@ def _print_mcp_json(args) -> int:
     if args.session_dir:
         serve_args += ["--session-dir", args.session_dir]
     if args.transport == "sse":
-        entry = {"type": "sse", "url": f"http://{args.host}:{args.port}/sse"}
+        scheme = "https" if (args.ssl_certfile or args.ssl_keyfile) else "http"
+        entry = {"type": "sse", "url": f"{scheme}://{args.host}:{args.port}/sse"}
+        tls_flags = (f" --ssl-certfile {args.ssl_certfile} --ssl-keyfile {args.ssl_keyfile}"
+                     if scheme == "https" else "")
         note = (f"# Start the server yourself:\n"
                 f"#   scilink serve {' '.join(serve_args[1:])} "
-                f"--transport sse --host {args.host} --port {args.port}")
+                f"--transport sse --host {args.host} --port {args.port}{tls_flags}")
     elif shutil.which("uvx"):
         entry = {"command": "uvx",
                  "args": ["--from",
@@ -142,6 +146,8 @@ def main():
         default=8000,
         help="Bind port for SSE transport (default: 8000)",
     )
+    from scilink.server.tls import add_tls_arguments, tls_kwargs
+    add_tls_arguments(parser, "the SSE transport")
     parser.add_argument(
         "--futurehouse-key",
         type=str,
@@ -161,6 +167,10 @@ def main():
     )
 
     args = parser.parse_args()
+    tls = tls_kwargs(args) if args.transport == "sse" else {}
+    if args.transport != "sse" and (args.ssl_certfile or args.ssl_keyfile):
+        print("Note: --ssl-* flags apply to --transport sse only; ignored for stdio.",
+              file=sys.stderr)
 
     if args.print_mcp_json:
         return _print_mcp_json(args)
@@ -219,7 +229,7 @@ def main():
           file=sys.stderr)
     server.eager_init()
 
-    transport_label = (f"SSE on http://{args.host}:{args.port}/sse"
+    transport_label = (f"SSE on {'https' if tls else 'http'}://{args.host}:{args.port}/sse"
                        if args.transport == "sse" else "stdio")
     print(f"SciLink MCP server ready ({transport_label}). "
           f"Waiting for MCP client connections...",
@@ -228,7 +238,7 @@ def main():
     sys.stderr.flush()
 
     if args.transport == "sse":
-        run_sse(server, host=args.host, port=args.port)
+        run_sse(server, host=args.host, port=args.port, **tls)
     else:
         import asyncio
         asyncio.run(run_stdio(server, real_stdout=_real_stdout))

--- a/scilink/mcp_server.py
+++ b/scilink/mcp_server.py
@@ -2100,7 +2100,9 @@ async def run_stdio(server: Server, real_stdout=None) -> None:
         )
 
 
-def run_sse(server: Server, host: str = "127.0.0.1", port: int = 8000) -> None:
+def run_sse(server: Server, host: str = "127.0.0.1", port: int = 8000,
+            ssl_certfile: Optional[str] = None, ssl_keyfile: Optional[str] = None,
+            ssl_keyfile_password: Optional[str] = None) -> None:
     """Run the MCP server over SSE (Server-Sent Events) transport.
 
     Starts an HTTP server with two endpoints:
@@ -2112,6 +2114,10 @@ def run_sse(server: Server, host: str = "127.0.0.1", port: int = 8000) -> None:
         server: The configured MCP Server.
         host: Bind address (default: ``127.0.0.1``).
         port: Bind port (default: ``8000``).
+        ssl_certfile / ssl_keyfile / ssl_keyfile_password: serve HTTPS
+            directly (#611); both files together, or neither. Without them
+            the endpoint is plain HTTP, meant to sit behind a TLS-terminating
+            reverse proxy when exposed off-box.
     """
     _require_mcp()
 
@@ -2157,5 +2163,13 @@ def run_sse(server: Server, host: str = "127.0.0.1", port: int = 8000) -> None:
         ],
     )
 
-    logging.info(f"SciLink MCP server (SSE) at http://{host}:{port}/sse")
-    uvicorn.run(app, host=host, port=port, log_level="warning")
+    tls = {}
+    if ssl_certfile or ssl_keyfile:
+        if not (ssl_certfile and ssl_keyfile):
+            raise ValueError("ssl_certfile and ssl_keyfile must be given together")
+        tls = {"ssl_certfile": ssl_certfile, "ssl_keyfile": ssl_keyfile}
+        if ssl_keyfile_password:
+            tls["ssl_keyfile_password"] = ssl_keyfile_password
+    scheme = "https" if tls else "http"
+    logging.info(f"SciLink MCP server (SSE) at {scheme}://{host}:{port}/sse")
+    uvicorn.run(app, host=host, port=port, log_level="warning", **tls)

--- a/scilink/server/cli.py
+++ b/scilink/server/cli.py
@@ -18,6 +18,8 @@ import argparse
 import sys
 from pathlib import Path
 
+from .tls import add_tls_arguments, tls_kwargs
+
 
 def _headless_matplotlib() -> None:
     """Force a non-interactive backend before any agent imports pyplot.
@@ -59,7 +61,9 @@ def main(argv=None) -> int:
                         help="Allow a non-loopback --host WITHOUT any auth "
                              "(only behind a reverse proxy that "
                              "authenticates for you).")
+    add_tls_arguments(parser, "the web UI")
     args = parser.parse_args(argv)
+    tls = tls_kwargs(args)
 
     try:
         import uvicorn
@@ -112,8 +116,9 @@ def main(argv=None) -> int:
     # Pasted local folder paths only make sense when the browser and the
     # server share a machine.
     app = create_app(session_root, auth=auth, local_files=loopback)
-    url = f"http://127.0.0.1:{args.port}"
-    print(f"SciLink web backend on http://{args.host}:{args.port} "
+    scheme = "https" if tls else "http"
+    url = f"{scheme}://127.0.0.1:{args.port}"
+    print(f"SciLink web backend on {scheme}://{args.host}:{args.port} "
           f"(sessions in {session_root})")
     if auth is not None:
         who = (f"{len(auth.users)} users, per-user session roots"
@@ -131,7 +136,7 @@ def main(argv=None) -> int:
         import webbrowser
 
         threading.Timer(1.0, lambda: webbrowser.open(url)).start()
-    uvicorn.run(app, host=args.host, port=args.port, log_level="warning")
+    uvicorn.run(app, host=args.host, port=args.port, log_level="warning", **tls)
     return 0
 
 

--- a/scilink/server/tls.py
+++ b/scilink/server/tls.py
@@ -1,0 +1,45 @@
+"""Native TLS for the servers SciLink runs itself (#611).
+
+Both ``scilink serve --transport sse`` and ``scilink-web`` bind an HTTP
+port; a reverse proxy terminating TLS in front of it is the recommended
+deployment (see docs), but when no proxy is available the same flags on
+both commands hand a certificate and key straight to uvicorn.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Optional
+
+
+def add_tls_arguments(parser: argparse.ArgumentParser, what: str) -> None:
+    g = parser.add_argument_group(
+        "TLS", f"Serve {what} over HTTPS directly (when no reverse proxy terminates TLS).")
+    g.add_argument("--ssl-certfile", default=None, metavar="PEM",
+                   help="TLS certificate chain (PEM). Requires --ssl-keyfile.")
+    g.add_argument("--ssl-keyfile", default=None, metavar="PEM",
+                   help="TLS private key (PEM). Requires --ssl-certfile.")
+    g.add_argument("--ssl-keyfile-password", default=None, metavar="PASSWORD",
+                   help="Password of an encrypted private key (optional).")
+
+
+def tls_kwargs(args: argparse.Namespace) -> dict:
+    """The uvicorn keyword arguments for the parsed TLS flags — an empty
+    dict for plain HTTP. Raises ``SystemExit(2)`` with a message when the
+    flags are inconsistent or a file is missing."""
+    cert, key = args.ssl_certfile, args.ssl_keyfile
+    if not cert and not key:
+        return {}
+    if not (cert and key):
+        raise SystemExit("--ssl-certfile and --ssl-keyfile must be given together.")
+    for label, path in (("--ssl-certfile", cert), ("--ssl-keyfile", key)):
+        if not Path(path).is_file():
+            raise SystemExit(f"{label}: file not found: {path}")
+    out = {"ssl_certfile": cert, "ssl_keyfile": key}
+    if args.ssl_keyfile_password:
+        out["ssl_keyfile_password"] = args.ssl_keyfile_password
+    return out
+
+
+def scheme(tls: Optional[dict]) -> str:
+    return "https" if tls else "http"

--- a/tests/test_tls_flags.py
+++ b/tests/test_tls_flags.py
@@ -1,0 +1,79 @@
+"""#611 — native TLS for the servers SciLink runs itself: the same three
+flags on `scilink serve --transport sse` and `scilink-web`, validated
+together, threaded into uvicorn, and reflected in the printed URLs."""
+import argparse
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scilink.server.tls import add_tls_arguments, tls_kwargs
+
+
+def _ns(**kw):
+    base = {"ssl_certfile": None, "ssl_keyfile": None, "ssl_keyfile_password": None}
+    base.update(kw); return SimpleNamespace(**base)
+
+
+def test_tls_kwargs_validation(tmp_path):
+    cert = tmp_path / "c.pem"; key = tmp_path / "k.pem"; cert.write_text("c"); key.write_text("k")
+    assert tls_kwargs(_ns()) == {}
+    assert tls_kwargs(_ns(ssl_certfile=str(cert), ssl_keyfile=str(key))) == {"ssl_certfile": str(cert), "ssl_keyfile": str(key)}
+    assert tls_kwargs(_ns(ssl_certfile=str(cert), ssl_keyfile=str(key), ssl_keyfile_password="pw"))["ssl_keyfile_password"] == "pw"
+    with pytest.raises(SystemExit, match="together"):
+        tls_kwargs(_ns(ssl_certfile=str(cert)))
+    with pytest.raises(SystemExit, match="not found"):
+        tls_kwargs(_ns(ssl_certfile=str(cert), ssl_keyfile=str(tmp_path / "missing.pem")))
+    p = argparse.ArgumentParser(); add_tls_arguments(p, "x")
+    a = p.parse_args(["--ssl-certfile", str(cert), "--ssl-keyfile", str(key)])
+    assert tls_kwargs(a)["ssl_certfile"] == str(cert)
+
+
+def test_run_sse_threads_tls_into_uvicorn(monkeypatch):
+    import uvicorn
+    from scilink import mcp_server
+    seen = {}
+    monkeypatch.setattr(uvicorn, "run", lambda app, **kw: seen.update(kw))
+    server = SimpleNamespace(run=None, create_initialization_options=lambda: None)
+    mcp_server.run_sse(server, host="0.0.0.0", port=8443, ssl_certfile="c.pem", ssl_keyfile="k.pem")
+    assert seen["ssl_certfile"] == "c.pem" and seen["ssl_keyfile"] == "k.pem" and seen["port"] == 8443
+    seen.clear(); mcp_server.run_sse(server)
+    assert "ssl_certfile" not in seen
+    with pytest.raises(ValueError, match="together"):
+        mcp_server.run_sse(server, ssl_certfile="c.pem")
+
+
+def test_serve_print_mcp_json_reflects_https(tmp_path, monkeypatch, capsys):
+    from scilink.cli import serve
+    cert = tmp_path / "c.pem"; key = tmp_path / "k.pem"; cert.write_text("c"); key.write_text("k")
+    monkeypatch.setattr(sys, "argv", ["scilink serve", "--print-mcp-json", "--transport", "sse", "--host", "0.0.0.0",
+                                      "--port", "8443", "--ssl-certfile", str(cert), "--ssl-keyfile", str(key)])
+    assert serve.main() == 0
+    out = capsys.readouterr()
+    assert json.loads(out.out)["mcpServers"]["scilink"]["url"] == "https://0.0.0.0:8443/sse"
+    assert "--ssl-certfile" in out.err
+    monkeypatch.setattr(sys, "argv", ["scilink serve", "--print-mcp-json", "--transport", "sse"])
+    assert serve.main() == 0
+    assert json.loads(capsys.readouterr().out)["mcpServers"]["scilink"]["url"] == "http://127.0.0.1:8000/sse"
+    monkeypatch.setattr(sys, "argv", ["scilink serve", "--transport", "sse", "--ssl-certfile", str(cert)])
+    with pytest.raises(SystemExit, match="together"):
+        serve.main()
+
+
+def test_web_cli_threads_tls_into_uvicorn_and_prints_https(tmp_path, monkeypatch, capsys):
+    import uvicorn
+    from scilink.server import cli
+    cert = tmp_path / "c.pem"; key = tmp_path / "k.pem"; cert.write_text("c"); key.write_text("k")
+    seen = {}
+    monkeypatch.setattr(uvicorn, "run", lambda app, **kw: seen.update(kw))
+    rc = cli.main(["--port", "8499", "--session-root", str(tmp_path), "--no-open",
+                   "--ssl-certfile", str(cert), "--ssl-keyfile", str(key)])
+    assert rc == 0 and seen["ssl_certfile"] == str(cert) and seen["ssl_keyfile"] == str(key)
+    assert "https://127.0.0.1:8499" in capsys.readouterr().out
+    seen.clear()
+    assert cli.main(["--port", "8499", "--session-root", str(tmp_path), "--no-open"]) == 0
+    assert "ssl_certfile" not in seen and "http://127.0.0.1:8499" in capsys.readouterr().out
+    with pytest.raises(SystemExit, match="together"):
+        cli.main(["--session-root", str(tmp_path), "--no-open", "--ssl-keyfile", str(key)])


### PR DESCRIPTION
Closes #611.

## Summary

`scilink serve --transport sse` and `scilink-web` only spoke plain HTTP, so an off-box bind was unencrypted unless a reverse proxy terminated TLS. Both options from the issue are now in place: the reverse-proxy pattern is the documented, recommended deployment, and when no proxy is available both commands accept a certificate and key and serve HTTPS themselves. Client configs printed by `--print-mcp-json` show the right scheme.

## Technical description

- `scilink/server/tls.py`: `add_tls_arguments` (the same `--ssl-certfile` / `--ssl-keyfile` / `--ssl-keyfile-password` group on both parsers) and `tls_kwargs` (both files or neither, files must exist; returns uvicorn keyword arguments).
- `mcp_server.run_sse` takes `ssl_certfile` / `ssl_keyfile` / `ssl_keyfile_password` and passes them to `uvicorn.run`; `scilink serve` parses the flags for the SSE transport (a note is printed if given with stdio), reflects the scheme in the ready banner and in `--print-mcp-json` (URL and the start command hint).
- `scilink-web`: same flags, same threading; the printed URL uses the scheme. The sign-in cookie already reads `request.url.scheme` (or `X-Forwarded-Proto`), so it is `Secure` on native TLS with no change.
- Docs: `cli_reference.md` (flags and the proxy note), `connecting_agent_clients.md` (off-box SSE), `react_web_ui.md` (an HTTPS section with the Caddy/nginx pattern and the native flags).
- Tests (`tests/test_tls_flags.py`, 4): flag validation, `run_sse` threading and its pair check, `--print-mcp-json` scheme, and the web CLI threading and URL.

### Live check (self-signed certificate)

- `scilink serve --transport sse --ssl-certfile … --ssl-keyfile …`: an MCP client trusting the CA initialized over `https://127.0.0.1:8600/sse` and listed 40 tools; a client not trusting it failed with certificate verification; plain HTTP on the port is refused.
- `scilink-web --ssl-certfile … --ssl-keyfile … --token …`: the SPA and API served over HTTPS, the login response set the session cookie with `Secure`, an untrusting client failed verification (curl exit 60), plain HTTP refused.