### PR TITLE
Ground, audit and fully propagate the plan-mode TEA; accept multi-file data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,25 @@ remembering: every pass that re-emits a plan edits the shim, so
 `resync_portfolio` (called from `_stamp_campaign`) makes the nested copy
 authoritative — otherwise a refined portfolio serves stale directions.
 
+**TEA is a grounded, audited step, and the whole assessment travels.**
+`run_economic_analysis` authors under two instruction tiers — strict (KB /
+literature only) and fallback (general benchmarks, entered only when the
+model reports insufficient economic context) — and the result records which
+one produced it (`grounding.mode`, mirrored as `generation_mode` on
+`latest_tea_results`). A TEA critic (`critique_tea`) then audits every
+`(Quantitative)` claim against the same evidence the author saw and stores
+advisory `critic_findings`; the evidence itself is written to
+`tea_analysis.grounding.md`. Downstream, `_tea_context_block` renders the
+full assessment — cost drivers, risks, comparison, **data gaps**, provenance,
+caveats — as one block that plan authoring, refinement, portfolio and
+technical-document calls all inject; nothing reads the summary sentence
+alone. `primary_data_set` takes several tables at once (folder or comma
+list), each summarised under its own name, because a TEA routinely needs a
+composition, a price list and measured yields together. A TEA-first run is
+iteration 0; a TEA run mid-campaign keeps the current iteration (stage
+`TEA Update`) and never resets the counter, and the report keys cards on
+(iteration, kind) so a TEA and the plan it assesses both render.
+
 ## Plan-mode capability boundaries
 
 Two settled conventions on where capability lives in plan mode:

--- a/scilink/agents/planning_agents/html_generator.py
+++ b/scilink/agents/planning_agents/html_generator.py
@@ -266,12 +266,82 @@ class HTMLReportGenerator:
         """
 
     def _render_tea(self, plan: Dict[str, Any]) -> str:
-        assess = plan.get('technoeconomic_assessment', {})
+        assess = plan.get('technoeconomic_assessment') or {}
+        if not isinstance(assess, dict):
+            assess = {"summary": str(assess)}
+
+        def _as_list(key):
+            # The model may hand back None, a bare string or a scalar where a
+            # list was asked for; a string must become ONE item, not its chars.
+            v = assess.get(key)
+            if v is None or v == "":
+                return []
+            if isinstance(v, (list, tuple)):
+                return [x for x in v if x is not None and str(x).strip()]
+            return [v]
+
         def list_to_html(key, css_class):
-            return "".join(f"<li class='{css_class}'>{html.escape(str(x))}</li>" for x in assess.get(key, []))
-        
+            return "".join(f"<li class='{css_class}'>{html.escape(str(x))}</li>"
+                           for x in _as_list(key))
+
         # Summary might contain tables
-        summary_html = self._markdown_to_html(assess.get('summary', ''))
+        summary_html = self._markdown_to_html(str(assess.get('summary') or ''))
+
+        # Provenance: the one line a reader needs before trusting a figure.
+        grounding = plan.get("grounding") or {}
+        mode = grounding.get("mode") or plan.get("generation_mode")  # None: legacy record
+        sources = [str(x) for x in _as_list("source_documents")]
+        files = grounding.get("primary_data_files") or []
+        if mode == "fallback":
+            prov_html = (
+                '<div style="margin-top:12px;padding:10px 14px;background:#fef3c7;'
+                'border-left:4px solid #f59e0b;border-radius:6px;color:#92400e;">'
+                '<strong>⚠️ Fallback tier — general benchmarks.</strong> The knowledge '
+                'base and literature held no usable economic data, so the figures '
+                'below are model estimates from industry norms, not sourced values.'
+                '</div>')
+        elif mode is None:
+            prov_html = (
+                '<div style="margin-top:12px;padding:10px 14px;background:#f1f5f9;'
+                'border-left:4px solid #94a3b8;border-radius:6px;color:#334155;">'
+                '<strong>ℹ️ Provenance not recorded.</strong> This assessment predates '
+                'tier tracking; whether its figures are sourced or estimated is unknown.'
+                '</div>')
+        else:
+            src_txt = (", ".join(html.escape(x) for x in sources)
+                       if sources else "retrieved knowledge-base / literature context")
+            prov_html = (
+                '<div style="margin-top:12px;padding:10px 14px;background:#ecfdf5;'
+                'border-left:4px solid #10b981;border-radius:6px;color:#065f46;">'
+                f'<strong>✅ Grounded (strict tier).</strong> Sources: {src_txt}.'
+                '</div>')
+        if files:
+            prov_html += ('<div class="meta" style="margin-top:6px;">Primary data: '
+                          + ", ".join(html.escape(f) for f in files) + '</div>')
+
+        comparison = str(assess.get("comparison_to_alternatives") or "").strip()
+        comparison_html = (
+            f'<div style="margin-top:15px;"><strong>⚖️ Comparison to Alternatives:</strong>'
+            f'<div>{self._markdown_to_html(comparison)}</div></div>'
+            if comparison else "")
+        gaps_html = list_to_html('data_gaps_for_quantitative_analysis', 'gap')
+        gaps_block = (
+            '<div style="margin-top:15px;padding:12px 14px;background:#eff6ff;'
+            'border-left:4px solid #3b82f6;border-radius:6px;">'
+            '<strong style="color:#1d4ed8">🔍 Data Gaps for a Quantitative TEA</strong>'
+            '<div class="meta">What to measure or source next to turn this into numbers.</div>'
+            f'<ul class="tea-list" style="margin-top:8px;">{gaps_html}</ul></div>'
+            if gaps_html else "")
+
+        caveat_lines = format_caveats(plan.get('critic_findings'))
+        caveats_html = ""
+        if caveat_lines:
+            items = "".join(f"<li>{html.escape(c)}</li>" for c in caveat_lines)
+            caveats_html = (
+                '<div class="caveats" style="margin-top:18px;padding:14px 16px;'
+                'background:#fef3c7;border-left:4px solid #f59e0b;border-radius:6px;">'
+                '<strong style="color:#b45309">⚠️ Critic Caveats on this Assessment</strong>'
+                f'<ul style="margin:8px 0 0;color:#92400e">{items}</ul></div>')
 
         return f"""
         <div class="exp-block" style="border-left-color: #10b981;">
@@ -279,11 +349,15 @@ class HTMLReportGenerator:
                 <strong>💰 Executive Summary:</strong><br>
                 {summary_html}
             </div>
+            {prov_html}
             <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 20px;">
                 <div><strong>💸 Key Cost Drivers:</strong><ul class="tea-list">{list_to_html('key_cost_drivers', 'cost')}</ul></div>
                 <div><strong>📈 Potential Benefits:</strong><ul class="tea-list">{list_to_html('potential_benefits_or_revenue', 'benefit')}</ul></div>
             </div>
             <div style="margin-top: 15px;"><strong>⚠️ Economic Risks:</strong><ul>{list_to_html('economic_risks', '')}</ul></div>
+            {comparison_html}
+            {gaps_block}
+            {caveats_html}
         </div>
         """
 
@@ -395,10 +469,16 @@ class HTMLReportGenerator:
         # Filter out superseded plans - they stay in JSON for transparency
         active_plans = [p for p in full_history if p.get('status') != 'superseded']
 
+        # One card per (iteration, kind): a TEA run mid-campaign shares its
+        # iteration number with the plan it assesses and must not replace it
+        # (keying on iteration alone silently dropped one of the two). Within
+        # an iteration the TEA renders first; the latest entry of a kind wins.
         finalized_plans = {}
         for plan in active_plans:
             iter_idx = plan.get('iteration', 0)
-            finalized_plans[iter_idx] = plan
+            is_tea = ("technoeconomic_assessment" in plan
+                      or plan.get("type") == "technoeconomic_analysis")
+            finalized_plans[(iter_idx, 0 if is_tea else 1)] = plan
 
         sorted_plans = [finalized_plans[k] for k in sorted(finalized_plans.keys())]
         results = self.state.get('experimental_results', [])

--- a/scilink/agents/planning_agents/instruct.py
+++ b/scilink/agents/planning_agents/instruct.py
@@ -57,7 +57,7 @@ You MUST respond with a single JSON object containing a key "proposed_experiment
 """
 
 TEA_INSTRUCTIONS = """
-You are an expert technoeconomic analyst specializing in scientific and engineering fields. Your primary goal is to provide a preliminary technoeconfig assessment (TEA) of a proposed technology, process, or material *based strictly on the provided knowledge base context*.
+You are an expert technoeconomic analyst specializing in scientific and engineering fields. Your primary goal is to provide a preliminary technoeconomic assessment (TEA) of a proposed technology, process, or material *based strictly on the provided knowledge base context*.
 
 **Input:**
 1.  **Objective:** The specific technology, process, or material to be assessed economically.
@@ -71,7 +71,7 @@ Your response format depends on the quality and relevance of the retrieved conte
 - **IF** the retrieved context contains little to no economic information (e.g., costs, prices, market size, efficiency comparisons, manufacturing challenges related to cost) relevant to the objective:
     - You **MUST NOT** invent economic data or use your general knowledge of typical costs.
     - Instead, you **MUST** respond with a JSON object containing an "error" key.
-    - Example: `{"error": "Insufficient economic context provided to perform a meaningful technoeconfig assessment for [objective topic]. Context focuses primarily on technical aspects."}`
+    - Example: `{"error": "Insufficient economic context provided to perform a meaningful technoeconomic assessment for [objective topic]. Context focuses primarily on technical aspects."}`
 - **ELSE** (if the context provides *some* relevant economic indicators, even if qualitative):
     - Proceed with the task below, relying *only* on the information given.
 

--- a/scilink/agents/planning_agents/orchestrator_tools.py
+++ b/scilink/agents/planning_agents/orchestrator_tools.py
@@ -21,6 +21,7 @@ def _natural_sort_key(s):
     return [int(c) if c.isdigit() else c.lower() for c in re.split(r'(\d+)', str(s))]
 
 from .parser_utils import write_experiments_to_disk
+from .user_interface import format_caveats
 from .instruct import (
     BO_OBJECTIVE_DISTILL_PROMPT,
     KNOWLEDGE_QUERY_CODEGEN_PROMPT,
@@ -629,6 +630,77 @@ class OrchestratorTools:
             # resolver skipped the campaign's most relevant corpus).
             return text
         return ""
+
+    _TEA_LIST_CAP = 8
+
+    def _tea_context_block(self, heading: bool = True) -> Optional[str]:
+        """The stored TEA as ONE markdown block for downstream prompts.
+
+        Every consumer — plan authoring, refinement, portfolio, technical
+        document — reads the same rendering (``heading=False`` drops the
+        leading ``##`` line for a caller that supplies its own). Until this existed only the
+        one-sentence ``summary`` travelled: cost drivers, risks, the
+        comparison to alternatives and above all the DATA GAPS (the list
+        that tells a planner which measurement would retire the largest
+        economic uncertainty) were computed and then dropped on the floor.
+
+        Carries the provenance line too, so an author sees whether the
+        figures are KB-sourced (strict) or benchmark estimates (fallback).
+        Lists are capped so the block stays a grounding aid, not a second
+        document. Returns None when no TEA has run.
+        """
+        tea = getattr(self.orch, "latest_tea_results", None)
+        if not tea or not isinstance(tea, dict):   # absent, or a damaged checkpoint
+            return None
+        full = tea.get("full_analysis") or {}
+        if not isinstance(full, dict):
+            full = {"summary": str(full)}
+        cap = self._TEA_LIST_CAP
+
+        def _items(key):
+            raw = full.get(key)
+            if raw is None or raw == "":
+                raw = []
+            elif not isinstance(raw, (list, tuple)):
+                raw = [raw]                   # a bare string is ONE item, not its chars
+            vals = [str(v) for v in raw if v is not None and str(v).strip()]
+            more = len(vals) - cap
+            lines = [f"- {v}" for v in vals[:cap]]
+            if more > 0:
+                lines.append(f"- (+{more} more in tea_analysis.json)")
+            return "\n".join(lines)
+
+        mode = tea.get("generation_mode")
+        if mode == "strict":
+            prov = "KB/literature-sourced (strict mode)"
+        elif mode == "fallback":
+            prov = ("GENERAL BENCHMARKS — the knowledge base held no usable "
+                    "economic data, so figures are model estimates, not "
+                    "sourced values (fallback mode)")
+        else:  # TEA restored from a checkpoint that predates tier tracking
+            prov = "not recorded (assessment predates provenance tracking)"
+        parts = (["## Techno-Economic Assessment (prior TEA step)"] if heading else []) + [
+                 f"Provenance: {prov}.",
+                 f"Summary: {tea.get('summary') or full.get('summary') or ''}".strip()]
+        for key, title in (("key_cost_drivers", "Key cost drivers"),
+                           ("potential_benefits_or_revenue", "Potential benefits / revenue"),
+                           ("economic_risks", "Economic risks")):
+            body = _items(key)
+            if body:
+                parts.append(f"{title}:\n{body}")
+        cmp_ = str(full.get("comparison_to_alternatives") or "").strip()
+        if cmp_:
+            parts.append(f"Comparison to alternatives: {cmp_}")
+        gaps = _items("data_gaps_for_quantitative_analysis")
+        if gaps:
+            parts.append("Data gaps for a quantitative TEA (an experiment that "
+                         "closes one of these is worth more than one that does "
+                         "not):\n" + gaps)
+        caveats = format_caveats(tea.get("critic_findings"))
+        if caveats:
+            parts.append("Critic caveats on the assessment:\n"
+                         + "\n".join(f"- {c}" for c in caveats[:cap]))
+        return "\n\n".join(parts)
 
     @staticmethod
     def _resolve_context_text(value) -> Optional[str]:
@@ -1367,6 +1439,64 @@ class OrchestratorTools:
                 f"later when more data is collected."
             ),
         }
+
+    _TABULAR_EXTS = ("*.csv", "*.xlsx", "*.xls")
+    # Every table is summarised INTO the prompt (small ones verbatim), so a
+    # folder of dozens would silently swamp the objective. Past this many the
+    # caller is asked to name the tables that matter instead.
+    _TABULAR_MAX_FILES = 10
+
+    def _resolve_tabular_inputs(self, spec: str):
+        """Resolve a comma-separated spec of files and/or folders to a list
+        of ``{"file_path": ...}`` entries — every tabular file in a folder,
+        in natural order, de-duplicated, each path run through
+        ``_resolve_data_path`` (typo / session / extension recovery).
+
+        Returns ``(entries, None)`` or ``(None, error_json)``.
+        """
+        entries, seen = [], set()
+        for raw in str(spec).split(","):
+            raw = raw.strip()
+            if not raw:
+                continue
+            resolved, error = self._resolve_data_path(raw)
+            if error:
+                return None, error
+            path = Path(resolved)
+            if path.is_dir():
+                files = []
+                for ext in self._TABULAR_EXTS:
+                    files.extend(path.glob(ext))
+                if not files:
+                    return None, json.dumps({
+                        "status": "error",
+                        "message": f"No data files (.csv, .xlsx, .xls) found in: {raw}",
+                        "hint": "Add data files to the folder or specify a different path"
+                    })
+                files = sorted(files, key=lambda f: _natural_sort_key(f.name))
+            else:
+                files = [path]
+            for f in files:
+                key = str(f.resolve())
+                if key not in seen:
+                    seen.add(key)
+                    entries.append({"file_path": str(f)})
+        if not entries:
+            return None, json.dumps({
+                "status": "error",
+                "message": f"No data files resolved from: {spec}"})
+        if len(entries) > self._TABULAR_MAX_FILES:
+            names = [Path(e["file_path"]).name for e in entries]
+            return None, json.dumps({
+                "status": "error",
+                "message": (f"{len(entries)} data files resolved from '{spec}', more than "
+                            f"the {self._TABULAR_MAX_FILES} a single assessment can take "
+                            f"in its prompt."),
+                "available_files": names,
+                "hint": ("Pass a comma-separated list of the tables that bear on the "
+                         "economics (composition, prices, yields, ...) instead of the "
+                         "whole folder.")})
+        return entries, None
 
     def _resolve_data_path(self, path_input: str) -> tuple[str, str]:
         """
@@ -2368,15 +2498,22 @@ class OrchestratorTools:
                 context_parts.append(f"User Requirements: {additional_context}")
                 print(f"    ℹ️  User context: {additional_context[:60]}...")
             
-            # Auto-include TEA results
-            if self.orch.latest_tea_results:
-                tea_summary = self.orch.latest_tea_results.get('summary', '')
-                context_parts.append(f"Economic Analysis Results: {tea_summary}")
-                print(f"    💰 Including TEA results in context")
-            
             context_dict = None
             if context_parts:
                 context_dict = {"user_context": "\n\n".join(context_parts)}
+
+            # Auto-include the TEA — the whole assessment, not just its
+            # summary sentence (see _tea_context_block) — under its OWN
+            # heading. It must not sit inside user_context: that block is
+            # the user's hard constraints, which the author is told to map
+            # step-by-step, and an economic assessment is grounding, not a
+            # constraint list.
+            tea_block = self._tea_context_block(heading=False)
+            if tea_block:
+                context_dict = context_dict or {}
+                context_dict["Techno-Economic Assessment (prior TEA step)"] = tea_block
+                print(f"    💰 Including TEA results in context "
+                      f"({self.orch.latest_tea_results.get('generation_mode') or 'unknown'} tier)")
             
             # Resolve skill: use provided value or fall back to orchestrator's active skill
             effective_skill = skill or getattr(self.orch, '_active_skill', None)
@@ -3041,51 +3178,21 @@ class OrchestratorTools:
             if knowledge_list:
                 print(f"    📚 Knowledge sources: {knowledge_list}")
 
-            # Parse primary dataset
+            # Parse primary dataset(s): comma-separated paths; a folder
+            # contributes EVERY tabular file it holds. A TEA routinely needs
+            # a composition table AND a price list AND measured yields, so
+            # the single-file contract (which errored on a folder with two
+            # files) forced the rest through the KB as unstructured prose.
             primary_dataset = None
             if primary_data_set:
-                # Try to resolve the path
-                resolved_path, error = self._resolve_data_path(primary_data_set)
-                
+                primary_dataset, error = self._resolve_tabular_inputs(primary_data_set)
                 if error:
-                    return error  # Return the error JSON with suggestions
-                
-                path = Path(resolved_path)
-                
-                # Now handle resolved path
-                if path.is_file():
-                    primary_dataset = {"file_path": str(path)}
-                    print(f"    📊 Primary data: {path.name}")
-                    
-                elif path.is_dir():
-                    # Directory - check how many data files
-                    all_files = []
-                    for ext in ['*.csv', '*.xlsx', '*.xls']:
-                        all_files.extend(path.glob(ext))
-                    
-                    if not all_files:
-                        return json.dumps({
-                            "status": "error",
-                            "message": f"No data files (.csv, .xlsx, .xls) found in: {primary_data_set}",
-                            "hint": "Add data files to the folder or specify a different path"
-                        })
-                    
-                    elif len(all_files) == 1:
-                        # Only one file - use it automatically
-                        primary_dataset = {"file_path": str(all_files[0])}
-                        print(f"    📊 Primary data (auto-selected): {all_files[0].name}")
-                        
-                    else:
-                        # Multiple files - require user to specify
-                        file_list = sorted([f.name for f in all_files], key=_natural_sort_key)
-                        return json.dumps({
-                            "status": "error",
-                            "message": f"Multiple data files found in '{primary_data_set}'",
-                            "available_files": file_list,
-                            "file_count": len(file_list),
-                            "hint": f"Please specify which file to use. Example: primary_data_set='./experimental_results/{file_list[0]}'"
-                        })
-            
+                    return error
+                names = [Path(e["file_path"]).name for e in primary_dataset]
+                print(f"    📊 Primary data ({len(names)} file(s)): {', '.join(names)}")
+                if len(primary_dataset) == 1:
+                    primary_dataset = primary_dataset[0]
+
             try:
                 # Resolve literature context
                 ext_ctx = None
@@ -3100,7 +3207,8 @@ class OrchestratorTools:
                     knowledge_paths=knowledge_list,
                     primary_data_set=primary_dataset,
                     output_json_path=str(self._output_dir() / "tea_analysis.json"),
-                    external_context=ext_ctx
+                    external_context=ext_ctx,
+                    additional_context=additional_context,
                 )
                 
                 if res.get("error"):
@@ -3109,23 +3217,48 @@ class OrchestratorTools:
                         "message": res.get("error")
                     })
                 
-                summary = res.get('technoeconomic_assessment', {}).get('summary', 'No summary')
+                assess = res.get('technoeconomic_assessment', {}) or {}
+                summary = assess.get('summary', 'No summary')
+                mode = (res.get("grounding") or {}).get("mode") or res.get("generation_mode") or "strict"
+                findings = res.get("critic_findings") or []
                 
-                # Store TEA results in orchestrator state
+                # Store TEA results in orchestrator state — the full
+                # assessment plus its provenance, which every downstream
+                # consumer reads through _tea_context_block.
                 self.orch.latest_tea_results = {
                     "summary": summary,
-                    "full_analysis": res.get('technoeconomic_assessment'),
+                    "full_analysis": assess,
+                    "generation_mode": mode,
+                    "critic_findings": findings,
+                    "source_documents": assess.get("source_documents") or [],
+                    "primary_data_files": (res.get("grounding") or {}).get("primary_data_files") or [],
                     "timestamp": datetime.now().isoformat()
                 }
                 print(f"    ✅ TEA results stored for future planning")
                 
-                return json.dumps({
+                out = {
                     "status": "success",
+                    "generation_mode": mode,
                     "summary": summary,
+                    "data_gaps_for_quantitative_analysis":
+                        assess.get("data_gaps_for_quantitative_analysis") or [],
+                    "caveats": format_caveats(findings),
                     "output_path": str(self._output_dir() / "tea_analysis.json"),
+                    "grounding_record": str(self._output_dir() / "tea_analysis.grounding.md"),
                     "html_report": str(self._output_dir() / "tea_analysis.html"),
-                    "hint": "These results will automatically inform future generate_initial_plan calls"
-                })
+                    "hint": ("The full assessment (cost drivers, risks, data gaps, "
+                             "provenance) is automatically included in later "
+                             "generate_initial_plan / refine / document calls.")
+                }
+                if mode == "fallback":
+                    out["warning"] = (
+                        "FALLBACK tier: the knowledge base and literature held no "
+                        "usable economic data, so every figure is a general "
+                        "benchmark estimated by the model, not a sourced value. "
+                        "Tell the user this explicitly; add economic sources "
+                        "(price tables, TEA reports) or run search_literature("
+                        "search_type='economic_data') to ground it.")
+                return json.dumps(out)
                 
             except Exception as e:
                 logging.error(f"TEA error: {e}", exc_info=True)
@@ -3152,7 +3285,12 @@ class OrchestratorTools:
                 },
                 "primary_data_set": {
                     "type": "string",
-                    "description": "Path to experimental data file or folder"
+                    "description": (
+                        "Tabular data (.csv/.xlsx/.xls) for the assessment: "
+                        "one path, a comma-separated list of paths, or a folder "
+                        "(ALL tabular files in it are used). Pass every table "
+                        "that bears on the economics — feedstock composition, "
+                        "price list, measured yields — in one call.")
                 },
                 "additional_context": {
                     "type": "string",
@@ -3230,6 +3368,12 @@ class OrchestratorTools:
             if additional_context:
                 ext_parts.append(f"## Additional Context\n{additional_context}")
                 print(f"    ℹ️  Additional context provided")
+            # The TEA rides along as its own block (NOT as literature, so
+            # provenance stamping never mistakes it for a search result).
+            tea_block = self._tea_context_block()
+            if tea_block:
+                ext_parts.append(tea_block)
+                print("    💰 Including TEA results in refinement context")
             ext_ctx = "\n\n".join(ext_parts) if ext_parts else None
 
             try:
@@ -7980,7 +8124,9 @@ class OrchestratorTools:
                     generation_config=planner.generation_config,
                     external_context=lit,
                     source_documents=("\n\n".join(sources) if sources else None),
-                    additional_context=date_note,
+                    additional_context=("\n\n".join(
+                        x for x in (date_note, self._tea_context_block()) if x)
+                        or None),
                     skill_context=planner._build_skill_context("planning"),
                     revise_document=current,
                     style="memo" if memo else "report",

--- a/scilink/agents/planning_agents/planning_agent.py
+++ b/scilink/agents/planning_agents/planning_agent.py
@@ -46,6 +46,7 @@ from .planning_rag import (
     refine_code_with_feedback,
     verify_plan_relevance,
     critique_plan,
+    critique_tea,
     generate_plan_candidates,
     judge_plan_candidates
 )
@@ -2556,11 +2557,12 @@ Select the most appropriate strategy:
 
     def perform_technoeconomic_analysis(self, objective: str,
                                         knowledge_paths: Optional[List[str]] = None,
-                                        primary_data_set: Optional[Union[str, Dict[str, str]]] = None,
+                                        primary_data_set: Optional[Any] = None,
                                         image_paths: Optional[List[str]] = None,
                                         image_descriptions: Optional[List[str]] = None,
                                         output_json_path: Optional[str] = None,
-                                        external_context: Optional[str] = None) -> Dict[str, Any]:
+                                        external_context: Optional[str] = None,
+                                        additional_context: Optional[str] = None) -> Dict[str, Any]:
         """
         Performs technoeconomic analysis (TEA) using Dual-KB retrieval.
 
@@ -2601,9 +2603,12 @@ Select the most appropriate strategy:
                 and Excel/CSV.
                 Example: ["./market_reports/", "./critical_materials_report.pdf"]
 
-            primary_data_set: Main dataset for analysis.
-                Can contain composition, concentration, or yield data.
-                Example: {"file_path": "./feedstock_composition.xlsx"}
+            primary_data_set: Main dataset(s) for analysis — a path, a
+                ``{"file_path": ...}`` dict, or a LIST of either. A TEA
+                usually wants several tables at once (a feedstock
+                composition, a price list, measured yields); every file
+                is summarised under its own name in the prompt.
+                Example: ["./feedstock_composition.xlsx", "./prices.csv"]
 
             image_paths: Images to support TEA analysis.
                 Examples: criticality matrices, supply chain diagrams, cost breakdowns.
@@ -2613,8 +2618,16 @@ Select the most appropriate strategy:
 
             output_json_path: Path to save TEA results.
                 Saves results to {output_json_path}, state to
-                {output_json_path}.state.json, and HTML report to
+                {output_json_path}.state.json, the evidence the author saw
+                to {stem}.grounding.md, and HTML report to
                 {output_json_path}.html.
+
+            external_context: External literature text (from the
+                orchestrator's economic_data literature search).
+
+            additional_context: Free-text constraints / requirements from
+                the user (plant scale, target market, budget ceiling, ...),
+                injected as the prompt's Additional Context block.
 
         Returns:
             Dict[str, Any]: Technoeconomic analysis results containing
@@ -2641,8 +2654,14 @@ Select the most appropriate strategy:
             ... )
         """
         
-        # 0a. Resolve Primary Data
-        primary_data_set = resolve_primary_data_path(primary_data_set)
+        # 0a. Resolve Primary Data — one file or several (metadata sidecars
+        # are auto-discovered per file, exactly as for a single one).
+        if isinstance(primary_data_set, list):
+            primary_data_set = [r for r in
+                                (resolve_primary_data_path(e) for e in primary_data_set)
+                                if r] or None
+        else:
+            primary_data_set = resolve_primary_data_path(primary_data_set)
         # 0b. Resolve image paths
         # Images explicitly specified by user undr image_paths (will be deprecated in the future)
         manual_images = image_paths or []
@@ -2662,8 +2681,18 @@ Select the most appropriate strategy:
                 image_descriptions=image_descriptions
             )
 
-        #  TEA is always step 0 (pre-planning)
-        self.state["iteration_index"] = 0
+        # TEA-first is step 0 (pre-planning). A TEA run MID-campaign must not
+        # reset the iteration counter: the next plan would be numbered 1 again,
+        # colliding with the existing iteration-1 plan (refine's executed-plan
+        # lookup and the report's per-iteration cards both key on it). It is
+        # stamped with the CURRENT iteration instead, alongside the plan it
+        # assesses.
+        _has_plans = any(
+            (h or {}).get("type") != "technoeconomic_analysis"
+            for h in (self.state.get("plan_history") or []))
+        if not _has_plans:
+            self.state["iteration_index"] = 0
+        _tea_iteration = self.state.get("iteration_index", 0)
 
         # 2. Build KB if needed
         if not self._ensure_kb_is_ready(knowledge_paths, code_paths=None):
@@ -2685,7 +2714,11 @@ Select the most appropriate strategy:
         # Build skill context for TEA (overview section if relevant)
         skill_tea_context = self._build_skill_context("overview")
 
-        res = perform_science_rag(
+        # return_context + mode_key: keep the evidence the author saw and the
+        # instruction tier that produced the result. Without them a TEA card
+        # could not say whether "the KB said this" or "the model estimated
+        # this" — and the fallback tier explicitly licenses estimates.
+        res, author_context = perform_science_rag(
             objective=objective,
             instructions=TEA_INSTRUCTIONS,
             task_name="Technoeconomic Analysis",
@@ -2696,18 +2729,55 @@ Select the most appropriate strategy:
             image_paths=all_image_paths,
             image_descriptions=image_descriptions,
             external_context=lit_context,
-            skill_context=skill_tea_context
+            additional_context=additional_context,
+            skill_context=skill_tea_context,
+            return_context=True,
+            mode_key="generation_mode",
         )
 
         if lit_context:
             res["literature_search"] = lit_context
 
-        # 5. Commit to State
+        # 5. Provenance + advisory critic, then commit to State
         if not res.get("error"):
+            tier = res.get("generation_mode") or "strict"
+            _files = ([Path(e["file_path"]).name for e in primary_data_set]
+                      if isinstance(primary_data_set, list)
+                      else [Path(primary_data_set["file_path"]).name]
+                      if primary_data_set else [])
+            res["grounding"] = {
+                "mode": tier,
+                "retrieved_context_chars": len(author_context.get("retrieved_context") or ""),
+                "has_primary_data": bool(author_context.get("primary_data")),
+                "primary_data_files": _files,
+                "has_external_literature": bool(lit_context),
+            }
+            if tier == "fallback":
+                print("    ⚠️  TEA authored in FALLBACK mode — the knowledge base "
+                      "held no usable economic data, so figures are general "
+                      "benchmarks, not sourced values.")
+            verdict = critique_tea(
+                objective, res, self.model, self.generation_config,
+                retrieved_context=author_context.get("retrieved_context"),
+                primary_data=author_context.get("primary_data"),
+                tier=tier,
+                skill_context=skill_tea_context,
+            )
+            findings = verdict.get("findings", [])
+            if findings:
+                _order = {"critical": 0, "minor": 1}
+                findings = sorted(findings, key=lambda f: _order.get(f.get("severity"), 1))
+                res["critic_findings"] = findings
+                self._log_action(
+                    action="tea_critic_review",
+                    input_ctx={"findings": findings},
+                    result=res,
+                    rationale="Advisory caveats recorded; assessment not modified."
+                )
             # Tags for the HTML Generator
             res["type"] = "technoeconomic_analysis"
-            res["stage"] = "TEA Initial"
-            res["iteration"] = 0 # TEA is step 0 (pre-planning)
+            res["stage"] = "TEA Initial" if _tea_iteration == 0 else "TEA Update"
+            res["iteration"] = _tea_iteration
             # Append copy to history
             self.state["plan_history"].append(self._stamp_campaign(res).copy())
      
@@ -2717,7 +2787,8 @@ Select the most appropriate strategy:
                 "objective": objective,
                 "knowledge_paths": knowledge_paths,
                 "has_primary_data": primary_data_set is not None,
-                "has_literature": bool(lit_context)
+                "has_literature": bool(lit_context),
+                "has_additional_context": bool(additional_context),
             },
             result=res,
             rationale=res.get("technoeconomic_assessment", {}).get("summary") if not res.get("error") else None
@@ -2727,7 +2798,25 @@ Select the most appropriate strategy:
         if output_json_path:
             self._save_results_to_json(res, output_json_path)
             self._save_state_to_json(output_json_path + ".state.json")
-            
+            # The evidence the author saw, as a sidecar: auditable without
+            # bloating the result JSON that rides into every later prompt.
+            if not res.get("error"):
+                try:
+                    _gp = Path(output_json_path).with_suffix(".grounding.md")
+                    _g = res.get("grounding", {})
+                    _gp.write_text(
+                        "# TEA grounding record\n\n"
+                        f"- generation mode: **{_g.get('mode')}**\n"
+                        f"- primary data files: {', '.join(_g.get('primary_data_files') or []) or 'none'}\n"
+                        f"- external literature: {'yes' if _g.get('has_external_literature') else 'no'}\n\n"
+                        "## Primary data summary\n\n"
+                        f"{author_context.get('primary_data') or '(none)'}\n\n"
+                        "## Retrieved context\n\n"
+                        f"{author_context.get('retrieved_context') or '(none)'}\n",
+                        encoding="utf-8")
+                except Exception as e:  # noqa: BLE001 - record-keeping must not fail the TEA
+                    logging.warning(f"Could not write TEA grounding record: {e}")
+
             # Trigger HTML Generation (will show TEA card)
             self._generate_html_report(output_json_path)
 

--- a/scilink/agents/planning_agents/planning_orchestrator.py
+++ b/scilink/agents/planning_agents/planning_orchestrator.py
@@ -61,7 +61,9 @@ _CO_PILOT_DIRECTIVE = """
 
 **POST-TEA PAUSE RULE:**
 After `run_economic_analysis` completes, ALWAYS stop and present the TEA results to the
-user. Then ask what experimental system, equipment, and constraints they want to use
+user — including its `generation_mode` (a FALLBACK result is benchmark estimates, not
+sourced figures, and must be described that way) and its data gaps. Then ask what
+experimental system, equipment, and constraints they want to use
 before calling `generate_initial_plan`. Do NOT proceed directly to plan generation
 unless the user's original objective already contained detailed experimental setup
 information (specific equipment names, plate formats, measurement techniques, etc.).
@@ -274,8 +276,10 @@ to `generate_initial_plan` or `refine_plan_with_results`.
 **TEA-FIRST RULE:** Run `run_economic_analysis` BEFORE `generate_initial_plan` when the
 objective or subject implies economic relevance — e.g., critical materials recovery,
 process scale-up, cost optimization, resource extraction, manufacturing, market-driven
-material selection, or any goal where viability/profitability matters. TEA results are
-automatically injected into the plan, producing a more grounded strategy.
+material selection, or any goal where viability/profitability matters. The full TEA
+(cost drivers, risks, data gaps, provenance) is automatically injected into later plan,
+refinement and document calls. Pass EVERY relevant table (composition, prices, yields)
+to `primary_data_set` in one call; report the result's `generation_mode` to the user.
 Do NOT run TEA for purely scientific exploration (e.g., "study phase transitions",
 "characterize this sample", "explore structure-property relationships").
 
@@ -1552,8 +1556,26 @@ class PlanningOrchestratorAgent:
         for col in self.expected_target_columns or []:
             direction = self.target_directions.get(col, "optimize")
             key_findings.append(f"Optimization target: {col} ({direction}).")
-        if self.latest_tea_results:
-            key_findings.append("Techno-economic analysis results are available.")
+        if isinstance(self.latest_tea_results, dict) and self.latest_tea_results:
+            _tea = self.latest_tea_results
+            _mode = _tea.get("generation_mode")
+            _full = _tea.get("full_analysis")
+            _gaps = (_full.get("data_gaps_for_quantitative_analysis") or []
+                     if isinstance(_full, dict) else [])
+            if not isinstance(_gaps, list):
+                _gaps = [_gaps]
+            key_findings.append(
+                "Techno-economic analysis results are available "
+                + ("(KB/literature-grounded)." if _mode == "strict" else
+                   "(FALLBACK tier: figures are general benchmarks, not "
+                   "sourced values)." if _mode == "fallback" else
+                   "(provenance not recorded).")
+            )
+            if _tea.get("summary"):
+                key_findings.append(f"TEA summary: {_tea['summary']}")
+            for _g in _gaps[:5]:
+                if _g is not None and str(_g).strip():
+                    key_findings.append(f"TEA data gap: {_g}")
 
         # Heuristic: collected BO data with no further direction is a natural
         # cue to propose the next experiment batch.

--- a/scilink/agents/planning_agents/planning_rag.py
+++ b/scilink/agents/planning_agents/planning_rag.py
@@ -422,13 +422,185 @@ If the plan is clean, return {{"findings": []}}.
         return {"findings": []}
 
 
+def critique_tea(objective: str,
+                 result: Dict[str, Any],
+                 model: Any,
+                 generation_config: Any,
+                 retrieved_context: Optional[str] = None,
+                 primary_data: Optional[str] = None,
+                 tier: str = "strict",
+                 skill_context: Optional[str] = None) -> Dict[str, Any]:
+    """Advisory critic for a technoeconomic assessment.
+
+    The TEA counterpart of ``critique_plan``: a separate LLM call over the
+    finished assessment and the SAME evidence the author saw, returning
+    caveats it never acts on. Where the plan critic checks physics, this one
+    checks GROUNDING — a TEA's failure mode is a confident cost figure the
+    evidence never stated. Two things the author could not police itself:
+
+    * every ``(Quantitative)`` claim must trace to a number in the evidence;
+      a claim tagged quantitative with no supporting figure, or a figure
+      the evidence gives with different units or for a different system, is
+      flagged;
+    * on the fallback tier (``tier="fallback"``) the author was LICENSED to
+      use general knowledge, so the critic marks which numeric claims are
+      benchmarks rather than sourced values — that is what lets the card
+      say "the model estimated this" instead of "the KB said this".
+
+    Returns ``{"findings": [{"dimension","severity","claim","issue"}, ...]}``
+    with ``dimension`` in {grounding, quantification, consistency, scope}.
+    Fails open (``{"findings": []}``) so a critic crash never blocks the TEA.
+    """
+    assess = result.get("technoeconomic_assessment") or {}
+    if not assess:
+        return {"findings": []}
+
+    evidence_parts = []
+    if primary_data:
+        evidence_parts.append(f"## 📊 Primary Data:\n{primary_data}")
+    if retrieved_context:
+        evidence_parts.append(
+            f"## Retrieved Context (KB + literature):\n{retrieved_context}")
+    if skill_context:
+        evidence_parts.append(skill_context)
+    evidence_section = ("\n".join(evidence_parts) if evidence_parts
+                        else "(No evidence was available to the author.)")
+
+    tier_note = (
+        "The author ran in FALLBACK mode: the evidence held no usable economic "
+        "data, so it was told to estimate from general engineering economics "
+        "and industry benchmarks. Treat every figure as a benchmark unless the "
+        "evidence below states it; report each such figure under 'grounding' "
+        "so the reader knows it is an estimate, not a sourced value."
+        if tier == "fallback" else
+        "The author ran in STRICT mode: it was told to use ONLY the evidence "
+        "below and to invent nothing. A figure or claim the evidence does not "
+        "support is a defect."
+    )
+
+    eval_prompt = f"""
+You are auditing a preliminary technoeconomic assessment (TEA) the way a reviewer
+audits a feasibility memo: does each claim trace to the evidence the author had?
+
+OBJECTIVE: "{objective}"
+
+{tier_note}
+
+THE ASSESSMENT:
+{json.dumps(assess, indent=2)}
+
+────────────────────────────────────
+EVIDENCE THE AUTHOR USED:
+{evidence_section}
+────────────────────────────────────
+
+Try to break the assessment on these axes:
+  • grounding      — a claim (especially one tagged "(Quantitative)") with no
+                     supporting figure or statement anywhere in the evidence; a
+                     source listed under source_documents that the evidence does
+                     not contain.
+  • quantification — a figure copied with the wrong units, scale or system; a
+                     number the evidence gives as a range or projection reported
+                     as a point value; an arithmetic step the evidence does not
+                     support.
+  • consistency    — a cost driver that contradicts a listed benefit; a summary
+                     verdict the listed risks do not support; a data gap listed
+                     for data the evidence actually provides.
+  • scope          — the assessment evaluates a different process, scale or
+                     product than the objective names; the primary data was
+                     available but not used where it bears on a claim.
+Report only a flaw you can name concretely, quoting the claim. Do NOT invent
+problems to appear thorough. At most 8 findings, most material first.
+
+SEVERITY:
+  • critical — the claim would mislead a go/no-go decision.
+  • minor    — worth noting; the assessment still stands.
+
+OUTPUT — a single JSON object:
+{{"findings": [
+   {{"dimension": "grounding|quantification|consistency|scope",
+     "severity": "critical|minor",
+     "claim": "<the assessment text at issue, abbreviated>",
+     "issue": "<one concrete sentence>"}}
+]}}
+If the assessment is clean, return {{"findings": []}}.
+"""
+    try:
+        response = model.generate_content([eval_prompt],
+                                          generation_config=generation_config)
+        verdict, _ = parse_json_from_response(response)
+        findings = (verdict or {}).get("findings", []) or []
+        findings = [f for f in findings if isinstance(f, dict) and f.get("issue")]
+        crit = [f for f in findings if f.get("severity") == "critical"]
+        if crit:
+            print(f"    - ⚠️  TEA critic noted {len(crit)} significant caveat(s).")
+        else:
+            print(f"    - ✅ TEA critic: {len(findings)} minor caveat(s).")
+        return {"findings": findings}
+    except Exception as e:  # noqa: BLE001 - advisory; never block the TEA
+        logging.error(f"TEA critic step failed: {e}")
+        return {"findings": []}
+
+
+def summarize_primary_data(primary_data_set: Any) -> Optional[str]:
+    """Summarise one or several tabular primary-data files for a prompt.
+
+    Accepts ``None``, one ``{"file_path", "metadata_path"}`` dict, or a list
+    of them. A single file keeps the historical output byte-for-byte (the
+    bare summary text). Several files are each summarised and joined under
+    a ``## Data file i of N: <filename>`` heading so the author can tell a composition table
+    from a price table — the previous single-dict contract forced a TEA to
+    pick ONE of them and push the rest through the KB as prose.
+
+    A file that fails to parse is reported and skipped; the others still
+    reach the prompt.
+    """
+    if not primary_data_set:
+        return None
+    entries = (primary_data_set if isinstance(primary_data_set, list)
+               else [primary_data_set])
+    entries = [e for e in entries if e and e.get("file_path")]
+    if not entries:
+        return None
+
+    def _one(entry: Dict[str, Any]) -> Optional[str]:
+        try:
+            chunks = parse_adaptive_excel(
+                entry["file_path"], entry.get("metadata_path")
+            )
+        except Exception as e:  # noqa: BLE001 - one bad file must not drop the rest
+            print(f"  - ⚠️ Warning: Failed to parse primary data set "
+                  f"{Path(entry['file_path']).name}: {e}")
+            return None
+        if not chunks:
+            return None
+        summary = next(
+            (c for c in chunks if c["metadata"].get("content_type")
+             in ("dataset_summary", "dataset_package")),
+            chunks[0],
+        )
+        return summary["text"]
+
+    if len(entries) == 1:
+        return _one(entries[0])
+
+    # The per-file summary already opens with its own '### Experiment Data'
+    # heading, so the file label sits one level ABOVE it.
+    parts, n = [], len(entries)
+    for i, entry in enumerate(entries, 1):
+        text = _one(entry)
+        if text:
+            parts.append(f"## Data file {i} of {n}: {Path(entry['file_path']).name}\n{text}")
+    return "\n\n".join(parts) if parts else None
+
+
 def perform_science_rag(objective: str,
                         instructions: str,
                         task_name: str,
                         kb_docs: Any,  # Pass the KB object here
                         model: Any,    # Pass the LLM object here
                         generation_config: Any,
-                        primary_data_set: Optional[Dict[str, str]] = None,
+                        primary_data_set: Optional[Any] = None,
                         image_paths: Optional[List[str]] = None,
                         image_descriptions: Optional[List[str]] = None,
                         additional_context: Optional[str] = None,
@@ -440,6 +612,11 @@ def perform_science_rag(objective: str,
     """
     Executes the Scientific/TEA RAG loop over the Docs KnowledgeBase.
 
+    ``primary_data_set`` is one ``{"file_path", "metadata_path"}`` dict or a
+    list of them; several files are summarised one after another, each
+    under its own filename, so a TEA can read a composition table and a
+    price table in the same call (see ``summarize_primary_data``).
+
     Thin planning-side wrapper over the shared ``scilink.knowledge.run_rag``
     engine: it resolves planning's primary-data Excel summary and selects the
     matching fallback instruction set, then delegates retrieval + generation.
@@ -450,22 +627,8 @@ def perform_science_rag(objective: str,
     against the same material. Default False preserves the result-only return.
     """
 
-    # --- Resolve primary data (Excel) into a summary string ---
-    primary_data_str = None
-    if primary_data_set:
-        try:
-            chunks = parse_adaptive_excel(
-                primary_data_set['file_path'], primary_data_set['metadata_path']
-            )
-            if chunks:
-                summary = next(
-                    (c for c in chunks if c['metadata'].get('content_type')
-                     in ('dataset_summary', 'dataset_package')),
-                    chunks[0],
-                )
-                primary_data_str = summary['text']
-        except Exception as e:
-            print(f"  - ⚠️ Warning: Failed to parse primary data set: {e}")
+    # --- Resolve primary data (Excel / CSV, one file or several) ---
+    primary_data_str = summarize_primary_data(primary_data_set)
 
     # Literature context crowds out the less glamorous constraints: plans stay
     # on-topic but silently drop individual requirements, and the misses are
@@ -473,7 +636,11 @@ def perform_science_rag(objective: str,
     # mapping restores coverage at no measurable cost to plan quality. Scoped
     # to the condition it was measured in — constraints AND literature both
     # present; a constraints-only run already complies.
-    if additional_context and external_context:
+    # Not for a TEA: its additional_context is the user's economic framing,
+    # and the note's "named experimental step" demand has no referent there.
+    # Every other instruction set keeps the note exactly as before.
+    if (additional_context and external_context
+            and not instructions.startswith(TEA_INSTRUCTIONS)):
         additional_context = f"{additional_context}\n{CONSTRAINT_COVERAGE_NOTE}"
 
     # --- Select the fallback instruction set matching the planning task ---

--- a/scilink/agents/planning_agents/user_interface.py
+++ b/scilink/agents/planning_agents/user_interface.py
@@ -172,7 +172,11 @@ def format_caveats(findings: Optional[List[Dict[str, Any]]]) -> List[str]:
     both the console summary and ``run_task`` warnings.
     """
     lines: List[str] = []
-    for f in findings or []:
+    if not isinstance(findings, list):
+        findings = []          # a damaged record (dict / string) is no caveat
+    for f in findings:
+        if not isinstance(f, dict):
+            continue
         dim = f.get("dimension", "")
         issue = (f.get("issue") or "").strip()
         if not issue:

--- a/tests/test_tea_grounding.py
+++ b/tests/test_tea_grounding.py
@@ -1,0 +1,747 @@
+"""Offline tests for the TEA grounding / provenance / multi-file work.
+
+Pins three contracts:
+
+1. The WHOLE technoeconomic assessment reaches downstream prompts (plan
+   authoring, refinement, technical documents) — cost drivers, risks, the
+   comparison to alternatives, the data gaps and a provenance line — not
+   only the one-sentence summary.
+2. A TEA records which instruction tier produced it (``generation_mode``),
+   writes the evidence the author saw to a ``.grounding.md`` sidecar, and
+   runs an advisory critic whose findings ride on the result as
+   ``critic_findings`` (fail-open).
+3. ``primary_data_set`` accepts several tabular files at once — a folder
+   contributes every file it holds, a comma list resolves each path — and
+   the prompt carries each file under its own name.
+
+All LLM traffic is a scripted mock; no network.
+"""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from scilink.agents.planning_agents import planning_rag as pr
+from scilink.agents.planning_agents.planning_agent import PlanningAgent
+from scilink.agents.planning_agents.base_agent import BaseAgent
+from scilink.agents.planning_agents import orchestrator_tools as ot
+from scilink.agents.planning_agents.orchestrator_tools import OrchestratorTools
+from scilink.agents.planning_agents.html_generator import HTMLReportGenerator
+
+
+# ---------------------------------------------------------------- helpers
+
+class ScriptedModel:
+    """Returns canned responses in order; records every prompt it saw."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def generate_content(self, prompt_parts, generation_config=None):
+        if isinstance(prompt_parts, str):
+            prompt_parts = [prompt_parts]
+        self.calls.append("\n".join(p for p in prompt_parts if isinstance(p, str)))
+        if not self.responses:
+            raise AssertionError("ScriptedModel exhausted — unexpected extra LLM call")
+        return SimpleNamespace(text=self.responses.pop(0))
+
+
+def make_agent(tmp_path, model):
+    agent = PlanningAgent.__new__(PlanningAgent)
+    BaseAgent.__init__(agent, str(tmp_path))
+    agent.agent_type = "planning"
+    agent.model = model
+    agent.generation_config = None
+    agent.kb_docs = None
+    agent.kb_code = None
+    agent.lit_agent = None
+    agent._ensure_kb_is_ready = lambda *a, **k: True
+    return agent
+
+
+def _csv(path: Path, **cols):
+    pd.DataFrame(cols).to_csv(path, index=False)
+    # a metadata sidecar keeps resolve_primary_data_path from prompting
+    path.with_suffix(".json").write_text(json.dumps(
+        {"title": path.stem, "objective": f"{path.stem} table"}))
+    return path
+
+
+def _two_tables(d: Path):
+    comp = _csv(d / "feedstock.csv",
+                Element=["Nd", "Dy", "Fe"], Concentration_Percent=[24.5, 1.2, 58.0])
+    price = _csv(d / "prices.csv",
+                 Element=["Nd", "Dy"], Market_Value_USD_kg=[120, 350])
+    return comp, price
+
+
+ASSESSMENT = {
+    "summary": "Context suggests viability; Dy price volatility is the main risk.",
+    "key_cost_drivers": ["(Quantitative) HCl consumption at 4 M",
+                         "(Qualitative) Energy for calcination"],
+    "potential_benefits_or_revenue": ["(Quantitative) Nd at $120/kg"],
+    "economic_risks": ["(Qualitative) Dy price volatility"],
+    "comparison_to_alternatives": "Hydrometallurgy cheaper than pyrometallurgy per context.",
+    "data_gaps_for_quantitative_analysis": ["Reagent cost per kg feed",
+                                            "Plant CAPEX at 1 kt/yr"],
+    "source_documents": ["market_report.txt"],
+}
+
+
+def tea_json(assess=ASSESSMENT):
+    return json.dumps({"technoeconomic_assessment": assess})
+
+
+def critic_json(findings):
+    return json.dumps({"findings": findings})
+
+
+FINDINGS = [
+    {"dimension": "grounding", "severity": "minor",
+     "claim": "HCl consumption at 4 M", "issue": "No HCl price in the evidence."},
+    {"dimension": "quantification", "severity": "critical",
+     "claim": "Nd at $120/kg", "issue": "Evidence gives a 2023 range, not a point."},
+]
+
+
+# --------------------------------------------- 3. multi-file primary data
+
+def test_single_file_summary_is_unchanged(tmp_path):
+    comp, _ = _two_tables(tmp_path)
+    one = pr.summarize_primary_data({"file_path": str(comp), "metadata_path": None})
+    assert one and "Concentration_Percent" in one
+    assert "Data file 1 of" not in one          # bare text, as before
+
+
+def test_multi_file_summary_labels_each_file(tmp_path):
+    comp, price = _two_tables(tmp_path)
+    out = pr.summarize_primary_data([
+        {"file_path": str(comp), "metadata_path": None},
+        {"file_path": str(price), "metadata_path": None},
+    ])
+    assert "## Data file 1 of 2: feedstock.csv" in out
+    assert "## Data file 2 of 2: prices.csv" in out
+    assert "Concentration_Percent" in out and "Market_Value_USD_kg" in out
+    assert out.index("feedstock.csv") < out.index("prices.csv")
+
+
+def test_multi_file_summary_skips_unparseable_and_keeps_the_rest(tmp_path):
+    comp, _ = _two_tables(tmp_path)
+    out = pr.summarize_primary_data([
+        {"file_path": str(tmp_path / "missing.csv")},
+        {"file_path": str(comp)},
+    ])
+    assert out and "Concentration_Percent" in out
+    assert "missing.csv" not in out
+
+
+def test_summary_handles_empty_inputs():
+    assert pr.summarize_primary_data(None) is None
+    assert pr.summarize_primary_data([]) is None
+    assert pr.summarize_primary_data([{}]) is None
+
+
+# ------------------------------------- 2. provenance, sidecar, TEA critic
+
+def test_tea_records_strict_tier_evidence_and_critic(tmp_path):
+    comp, price = _two_tables(tmp_path)
+    model = ScriptedModel([tea_json(), critic_json(FINDINGS)])
+    agent = make_agent(tmp_path, model)
+    out = tmp_path / "out" / "tea_analysis.json"
+    out.parent.mkdir()
+
+    res = agent.perform_technoeconomic_analysis(
+        objective="Recover Nd from NdFeB magnets",
+        primary_data_set=[str(comp), str(price)],
+        external_context="Nd spot price ~$120/kg (2023 range 100-140).",
+        additional_context="Target plant: 1 kt/yr.",
+        output_json_path=str(out),
+    )
+
+    assert not res.get("error")
+    assert res["generation_mode"] == "strict"
+    g = res["grounding"]
+    assert g["mode"] == "strict"
+    assert g["primary_data_files"] == ["feedstock.csv", "prices.csv"]
+    assert g["has_primary_data"] and g["has_external_literature"]
+    assert g["retrieved_context_chars"] > 0
+
+    # critic ran on the same evidence the author saw, strict framing
+    assert len(model.calls) == 2
+    author, critic = model.calls
+    assert "Data file 1 of 2: feedstock.csv" in author and "Data file 2 of 2: prices.csv" in author
+    assert "Target plant: 1 kt/yr." in author
+    assert "STRICT mode" in critic
+    assert "Nd spot price ~$120/kg" in critic and "Data file 2 of 2: prices.csv" in critic
+    # findings recorded, critical first, assessment untouched
+    assert [f["severity"] for f in res["critic_findings"]] == ["critical", "minor"]
+    assert res["technoeconomic_assessment"] == ASSESSMENT
+
+    # sidecar: auditable evidence record next to the JSON
+    rec = (out.parent / "tea_analysis.grounding.md").read_text()
+    assert "generation mode: **strict**" in rec
+    assert "feedstock.csv, prices.csv" in rec
+    assert "Nd spot price ~$120/kg" in rec
+    saved = json.loads(out.read_text())
+    assert saved["grounding"]["mode"] == "strict"
+    assert saved["critic_findings"]
+    # history snapshot carries the TEA kind
+    assert agent.state["plan_history"][-1]["type"] == "technoeconomic_analysis"
+
+
+def test_tea_fallback_tier_is_recorded_and_critic_told(tmp_path):
+    model = ScriptedModel([
+        json.dumps({"error": "Insufficient economic context provided."}),
+        tea_json(),
+        critic_json([]),
+    ])
+    agent = make_agent(tmp_path, model)
+    out = tmp_path / "tea_analysis.json"
+    res = agent.perform_technoeconomic_analysis(
+        objective="Recover Nd from NdFeB magnets", output_json_path=str(out))
+    assert res["generation_mode"] == "fallback"
+    assert res["grounding"]["mode"] == "fallback"
+    assert "FALLBACK mode" in model.calls[-1]
+    assert "critic_findings" not in res           # clean critic -> no key
+    assert "generation mode: **fallback**" in (tmp_path / "tea_analysis.grounding.md").read_text()
+
+
+def test_tea_critic_failure_fails_open(tmp_path):
+    model = ScriptedModel([tea_json(), "this is not json at all"])
+    agent = make_agent(tmp_path, model)
+    res = agent.perform_technoeconomic_analysis(objective="obj")
+    assert not res.get("error")
+    assert res["technoeconomic_assessment"] == ASSESSMENT
+    assert "critic_findings" not in res
+
+
+def test_tea_prompt_never_gets_the_plan_constraint_coverage_note(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(pr, "run_rag", lambda **kw: (seen.update(kw), {})[1])
+    pr.perform_science_rag(objective="o", instructions=pr.TEA_INSTRUCTIONS, task_name="t",
+                           kb_docs=None, model=None, generation_config=None,
+                           additional_context="1 kt/yr plant", external_context="lit")
+    assert "MANDATORY CONSTRAINT COVERAGE" not in seen["additional_context"]
+    # ...while a plan author with both still gets it (unchanged behaviour)
+    pr.perform_science_rag(objective="o", instructions=pr.HYPOTHESIS_GENERATION_INSTRUCTIONS,
+                           task_name="t", kb_docs=None, model=None, generation_config=None,
+                           additional_context="constraint", external_context="lit")
+    assert "MANDATORY CONSTRAINT COVERAGE" in seen["additional_context"]
+
+
+def test_critique_tea_skips_when_no_assessment():
+    model = ScriptedModel([])
+    assert pr.critique_tea("o", {"error": "x"}, model, None) == {"findings": []}
+    assert model.calls == []
+
+
+# ---------------------------------- 1. the full TEA reaches downstream prompts
+
+def _tools(base: Path, planner=None, **orch_attrs):
+    orch = SimpleNamespace(base_dir=base, planner=planner or SimpleNamespace(),
+                           objective="Recover Nd from NdFeB magnets",
+                           knowledge_dir=None, latest_tea_results=None,
+                           _active_output_subdir=None)
+    for k, v in orch_attrs.items():
+        setattr(orch, k, v)
+    return OrchestratorTools(orch)
+
+
+def _stored_tea(mode="strict", findings=None, n_gaps=2):
+    assess = dict(ASSESSMENT)
+    assess["data_gaps_for_quantitative_analysis"] = [f"gap {i}" for i in range(n_gaps)]
+    return {"summary": assess["summary"], "full_analysis": assess,
+            "generation_mode": mode, "critic_findings": findings or [],
+            "source_documents": assess["source_documents"], "timestamp": "t"}
+
+
+def test_tea_context_block_is_none_without_a_tea(tmp_path):
+    assert _tools(tmp_path)._tea_context_block() is None
+
+
+def test_tea_context_block_carries_the_whole_assessment(tmp_path):
+    t = _tools(tmp_path, latest_tea_results=_stored_tea(findings=FINDINGS))
+    block = t._tea_context_block()
+    assert block.startswith("## Techno-Economic Assessment")
+    assert "Provenance: KB/literature-sourced (strict mode)" in block
+    assert ASSESSMENT["summary"] in block
+    assert "HCl consumption at 4 M" in block                  # cost driver
+    assert "Dy price volatility" in block                      # risk
+    assert "Hydrometallurgy cheaper" in block                  # comparison
+    assert "Data gaps for a quantitative TEA" in block and "gap 1" in block
+    assert "[quantification] Evidence gives a 2023 range" in block   # caveat
+    assert "Minor: [grounding]" in block
+
+
+def test_tea_context_block_marks_legacy_records_without_a_tier(tmp_path):
+    legacy = {"summary": "s", "full_analysis": ASSESSMENT, "timestamp": "t"}
+    block = _tools(tmp_path, latest_tea_results=legacy)._tea_context_block()
+    assert "Provenance: not recorded" in block
+    assert "strict" not in block.split("Summary:")[0]
+
+
+def test_tea_context_block_flags_fallback_and_caps_lists(tmp_path):
+    t = _tools(tmp_path, latest_tea_results=_stored_tea(mode="fallback", n_gaps=11))
+    block = t._tea_context_block()
+    assert "GENERAL BENCHMARKS" in block and "fallback mode" in block
+    assert "gap 7" in block and "gap 8" not in block
+    assert "(+3 more in tea_analysis.json)" in block
+
+
+def test_generate_initial_plan_threads_the_full_tea_block(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_generate_plan(**kw):
+        seen.update(kw)
+        return {"proposed_experiments": [{"experiment_name": "E1"}], "iteration": 1}
+
+    planner = SimpleNamespace(generate_plan=fake_generate_plan, state=None,
+                              _build_skill_context=lambda *a, **k: None)
+    t = _tools(tmp_path, planner=planner,
+               latest_tea_results=_stored_tea(findings=FINDINGS))
+    # keep the test about context threading, not report rendering / ledgers
+    monkeypatch.setattr(t, "_emit_plan_report", lambda *a, **k: None)
+    monkeypatch.setattr(t, "_adopt_literature", lambda *a, **k: None)
+    monkeypatch.setattr(ot, "resolve_n_candidates", lambda *a, **k: 1, raising=False)
+
+    out = json.loads(t.functions_map["generate_initial_plan"](
+        specific_objective="Leach Nd from NdFeB", n_candidates=1,
+        additional_context="Only 50 mL reactors available."))
+    assert out["status"] == "success", out
+    assert out["tea_context_included"] is True
+    assert seen["additional_context"]["user_context"] == \
+        "User Requirements: Only 50 mL reactors available."
+    del seen["additional_context"]["user_context"]
+    ctx_dict = seen["additional_context"]
+    # the TEA rides under its OWN heading, never inside the user's constraints
+    assert "user_context" not in ctx_dict
+    ctx = ctx_dict["Techno-Economic Assessment (prior TEA step)"]
+    assert not ctx.startswith("## ")
+    # the WHOLE assessment, not just the summary sentence
+    assert "Data gaps for a quantitative TEA" in ctx
+    assert "gap 0" in ctx and "Hydrometallurgy cheaper" in ctx
+    assert "Provenance: KB/literature-sourced" in ctx
+    assert "Evidence gives a 2023 range" in ctx
+
+
+def test_refine_plan_threads_tea_as_its_own_block_not_literature(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_refine(**kw):
+        seen.update(kw)
+        return {"proposed_experiments": [{"experiment_name": "E1"}], "iteration": 2}
+
+    planner = SimpleNamespace(refine_plan=fake_refine, state=None)
+    t = _tools(tmp_path, planner=planner, latest_tea_results=_stored_tea())
+    monkeypatch.setattr(t, "_emit_plan_report", lambda *a, **k: None)
+    monkeypatch.setattr(t, "_adopt_literature", lambda *a, **k: None)
+    monkeypatch.setattr(t, "_load_campaign_literature", lambda *a, **k: None)
+    monkeypatch.setattr(t, "_collect_scalarizer_context", lambda *a, **k: [])
+
+    out = json.loads(t.functions_map["refine_plan_with_results"](
+        result_data="Yield was 12%."))
+    assert out["status"] == "success", out
+    assert "Data gaps for a quantitative TEA" in seen["external_context"]
+    assert seen["literature_text"] is None          # provenance stays honest
+
+
+def test_technical_document_threads_the_tea(tmp_path, monkeypatch):
+    seen = {}
+
+    def fake_author(**kw):
+        seen.update(kw)
+        return {"sections": [{"heading": "Scope", "content": "Body."}]}
+
+    monkeypatch.setattr(ot, "author_technical_document", fake_author)
+    planner = SimpleNamespace(kb_docs=None, model=None, generation_config=None,
+                              _build_skill_context=lambda *a, **k: None, state=None)
+    t = _tools(tmp_path, planner=planner, latest_tea_results=_stored_tea())
+    monkeypatch.setattr(t, "_load_campaign_literature", lambda *a, **k: None)
+
+    out = json.loads(t.functions_map["write_technical_document"](
+        request="Write a one-page roadmap", filename="roadmap.md"))
+    assert out.get("status") == "success", out
+    assert "Data gaps for a quantitative TEA" in (seen["additional_context"] or "")
+
+
+# ------------------------------------ 3b. run_economic_analysis multi-file
+
+def _planner_recording_tea(result_extra=None):
+    seen = {}
+
+    def fake_tea(**kw):
+        seen.update(kw)
+        res = {"technoeconomic_assessment": ASSESSMENT,
+               "grounding": {"mode": "strict", "primary_data_files": []},
+               "generation_mode": "strict"}
+        res.update(result_extra or {})
+        return res
+
+    return SimpleNamespace(perform_technoeconomic_analysis=fake_tea), seen
+
+
+def test_run_economic_analysis_folder_uses_every_table(tmp_path):
+    data = tmp_path / "data"; data.mkdir()
+    _two_tables(data)
+    planner, seen = _planner_recording_tea()
+    t = _tools(tmp_path, planner=planner)
+    out = json.loads(t.functions_map["run_economic_analysis"](
+        focus_topic="NdFeB recycling", primary_data_set=str(data)))
+    assert out["status"] == "success", out
+    names = [Path(e["file_path"]).name for e in seen["primary_data_set"]]
+    assert names == ["feedstock.csv", "prices.csv"]
+    assert seen["additional_context"] is None
+
+
+def test_run_economic_analysis_comma_list_and_single_file(tmp_path):
+    comp, price = _two_tables(tmp_path)
+    planner, seen = _planner_recording_tea()
+    t = _tools(tmp_path, planner=planner)
+    t.functions_map["run_economic_analysis"](
+        primary_data_set=f"{comp}, {price}", additional_context="1 kt/yr plant")
+    assert [Path(e["file_path"]).name for e in seen["primary_data_set"]] == \
+        ["feedstock.csv", "prices.csv"]
+    assert seen["additional_context"] == "1 kt/yr plant"
+    # a single file keeps the historical dict shape
+    t.functions_map["run_economic_analysis"](primary_data_set=str(comp))
+    assert isinstance(seen["primary_data_set"], dict)
+    assert Path(seen["primary_data_set"]["file_path"]).name == "feedstock.csv"
+
+
+def test_run_economic_analysis_empty_folder_errors(tmp_path):
+    empty = tmp_path / "empty"; empty.mkdir()
+    planner, _ = _planner_recording_tea()
+    t = _tools(tmp_path, planner=planner)
+    out = json.loads(t.functions_map["run_economic_analysis"](primary_data_set=str(empty)))
+    assert out["status"] == "error" and "No data files" in out["message"]
+
+
+def test_run_economic_analysis_result_carries_tier_gaps_and_caveats(tmp_path):
+    planner, _ = _planner_recording_tea({
+        "grounding": {"mode": "fallback", "primary_data_files": []},
+        "generation_mode": "fallback",
+        "critic_findings": FINDINGS})
+    t = _tools(tmp_path, planner=planner)
+    out = json.loads(t.functions_map["run_economic_analysis"](focus_topic="x"))
+    assert out["generation_mode"] == "fallback"
+    assert "FALLBACK tier" in out["warning"]
+    assert out["data_gaps_for_quantitative_analysis"] == ASSESSMENT["data_gaps_for_quantitative_analysis"]
+    # caveats are the planner's (already ordered) findings, rendered
+    assert set(out["caveats"]) == {"Minor: [grounding] No HCl price in the evidence.",
+                                   "[quantification] Evidence gives a 2023 range, not a point."}
+    assert out["grounding_record"].endswith("tea_analysis.grounding.md")
+    stored = t.orch.latest_tea_results
+    assert stored["generation_mode"] == "fallback"
+    assert stored["critic_findings"] == FINDINGS
+    assert stored["full_analysis"] == ASSESSMENT
+    # and the downstream block now says so
+    assert "GENERAL BENCHMARKS" in t._tea_context_block()
+
+
+# ---------------------------------------------------------- HTML card
+
+def test_tea_card_shows_gaps_comparison_provenance_and_caveats():
+    gen = HTMLReportGenerator.__new__(HTMLReportGenerator)
+    plan = {"technoeconomic_assessment": ASSESSMENT,
+            "grounding": {"mode": "strict", "primary_data_files": ["prices.csv"]},
+            "critic_findings": FINDINGS}
+    card = gen._render_tea(plan)
+    assert "Data Gaps for a Quantitative TEA" in card and "Plant CAPEX at 1 kt/yr" in card
+    assert "Comparison to Alternatives" in card and "Hydrometallurgy cheaper" in card
+    assert "Grounded (strict tier)" in card and "market_report.txt" in card
+    assert "Primary data: prices.csv" in card
+    assert "Critic Caveats" in card and "Evidence gives a 2023 range" in card
+
+    fb = gen._render_tea({"technoeconomic_assessment": ASSESSMENT,
+                          "grounding": {"mode": "fallback"}})
+    assert "Fallback tier" in fb and "Grounded (strict tier)" not in fb
+    assert "Critic Caveats" not in fb
+
+
+# =============================================================== stress / edge
+
+def test_critic_output_is_sanitised_and_sorted(tmp_path):
+    """Malformed findings (non-dicts, missing issue, unknown severity) are
+    dropped or ranked as minor — never a crash, never a blank caveat line."""
+    messy = json.dumps({"findings": [
+        "just a string", 42, {"severity": "critical"},             # no issue -> dropped
+        {"dimension": "scope", "issue": "no severity given"},      # unknown -> after critical
+        {"dimension": "grounding", "severity": "critical", "issue": "Unsupported $ figure."},
+        {"dimension": "consistency", "severity": "bogus", "issue": "Odd severity."},
+    ]})
+    model = ScriptedModel([tea_json(), messy])
+    agent = make_agent(tmp_path, model)
+    res = agent.perform_technoeconomic_analysis(objective="o")
+    f = res["critic_findings"]
+    assert [x["issue"] for x in f] == ["Unsupported $ figure.", "no severity given", "Odd severity."]
+    assert all(isinstance(x, dict) for x in f)
+    # findings returned as a dict instead of a list -> treated as clean
+    model = ScriptedModel([tea_json(), json.dumps({"findings": {"a": 1}})])
+    res = make_agent(tmp_path / "b", model).perform_technoeconomic_analysis(objective="o")
+    assert "critic_findings" not in res
+
+
+def test_non_string_and_null_assessment_fields_do_not_crash(tmp_path):
+    weird = {"summary": None, "key_cost_drivers": [{"k": 1}, 3.5, "", None],
+             "potential_benefits_or_revenue": None, "economic_risks": "not a list",
+             "comparison_to_alternatives": None,
+             "data_gaps_for_quantitative_analysis": [], "source_documents": None}
+    tea = {"summary": None, "full_analysis": weird, "generation_mode": "strict",
+           "critic_findings": [{"issue": "x"}]}           # no dimension / severity
+    block = _tools(tmp_path, latest_tea_results=tea)._tea_context_block()
+    assert "{'k': 1}" in block and "3.5" in block
+    assert "- not a list" in block and "- n\n" not in block  # string field = one item
+    assert "[] x" in block                                   # format_caveats tolerates it
+    card = HTMLReportGenerator.__new__(HTMLReportGenerator)._render_tea(
+        {"technoeconomic_assessment": weird, "grounding": {"mode": "strict"}})
+    assert "Data Gaps" not in card                          # empty list -> section omitted
+    assert "Grounded (strict tier)" in card
+    assert card.count("<li class=''>") == 1                  # 'not a list' -> one risk item
+    # assessment that is not even a dict
+    assert "oops" in HTMLReportGenerator.__new__(HTMLReportGenerator)._render_tea(
+        {"technoeconomic_assessment": "oops"})
+    # full_analysis missing entirely
+    assert _tools(tmp_path, latest_tea_results={"summary": "s"})._tea_context_block()
+
+
+def test_legacy_tea_record_renders_neutral_provenance():
+    card = HTMLReportGenerator.__new__(HTMLReportGenerator)._render_tea(
+        {"technoeconomic_assessment": ASSESSMENT})        # no grounding, no mode
+    assert "Provenance not recorded" in card
+    assert "Grounded (strict tier)" not in card and "Fallback tier" not in card
+
+
+def test_resolve_tabular_inputs_edge_cases(tmp_path):
+    data = tmp_path / "data"; data.mkdir()
+    comp, price = _two_tables(data)
+    pd.DataFrame({"a": [1]}).to_excel(data / "book.xlsx", index=False)
+    (data / "notes.txt").write_text("not a table")
+    (data / "meta.json").write_text("{}")
+    t = _tools(tmp_path)
+    # folder with trailing slash + mixed types: tabular only, natural order
+    entries, err = t._resolve_tabular_inputs(str(data) + "/")
+    assert err is None
+    assert [Path(e["file_path"]).name for e in entries] == ["feedstock.csv", "prices.csv", "book.xlsx"] \
+        or sorted(Path(e["file_path"]).name for e in entries) == ["book.xlsx", "feedstock.csv", "prices.csv"]
+    # duplicates (folder + a file inside it + same file twice) collapse
+    entries, _ = t._resolve_tabular_inputs(f"{data}, {comp}, {comp}")
+    assert len(entries) == 3
+    # whitespace-only spec
+    entries, err = t._resolve_tabular_inputs("  ,  ")
+    assert entries is None and "No data files resolved" in json.loads(err)["message"]
+    # a missing path surfaces _resolve_data_path's error (with suggestions)
+    entries, err = t._resolve_tabular_inputs(f"{comp}, {data / 'nope.csv'}")
+    assert entries is None and json.loads(err)["status"] == "error"
+    # folder of only non-tabular files
+    other = tmp_path / "other"; other.mkdir(); (other / "a.txt").write_text("x")
+    entries, err = t._resolve_tabular_inputs(str(other))
+    assert entries is None and "No data files" in json.loads(err)["message"]
+
+
+def test_too_many_tables_is_refused_with_the_list(tmp_path):
+    data = tmp_path / "many"; data.mkdir()
+    for i in range(12):
+        pd.DataFrame({"x": [i]}).to_csv(data / f"t{i}.csv", index=False)
+    t = _tools(tmp_path)
+    entries, err = t._resolve_tabular_inputs(str(data))
+    assert entries is None
+    e = json.loads(err)
+    assert "12 data files" in e["message"] and len(e["available_files"]) == 12
+    assert "comma-separated" in e["hint"]
+    # exactly the cap is fine
+    (data / "t11.csv").unlink(); (data / "t10.csv").unlink()
+    entries, err = t._resolve_tabular_inputs(str(data))
+    assert err is None and len(entries) == 10
+
+
+def test_header_only_and_garbage_files_are_tolerated(tmp_path):
+    good, _ = _two_tables(tmp_path)
+    (tmp_path / "empty.csv").write_text("a,b\n")
+    (tmp_path / "garbage.csv").write_bytes(b"\xff\xfe\x00\x00binary\x00junk")
+    out = pr.summarize_primary_data([
+        {"file_path": str(tmp_path / "empty.csv")},
+        {"file_path": str(tmp_path / "garbage.csv")},
+        {"file_path": str(good)},
+    ])
+    assert out and "Concentration_Percent" in out
+    # the garbage file never poisons the good one
+    assert "feedstock.csv" in out
+
+
+def test_tea_with_only_missing_data_files_runs_without_data(tmp_path):
+    model = ScriptedModel([tea_json(), critic_json([])])
+    agent = make_agent(tmp_path, model)
+    res = agent.perform_technoeconomic_analysis(
+        objective="o", primary_data_set=[str(tmp_path / "a.csv"), str(tmp_path / "b.csv")])
+    assert not res.get("error")
+    assert res["grounding"]["primary_data_files"] == []
+    assert res["grounding"]["has_primary_data"] is False
+    assert "Primary Experimental Data" not in model.calls[0]
+
+
+def test_tea_author_error_short_circuits_provenance_and_critic(tmp_path):
+    model = ScriptedModel([json.dumps({"error": "Model refused for some other reason"})])
+    agent = make_agent(tmp_path, model)
+    out = tmp_path / "tea.json"
+    res = agent.perform_technoeconomic_analysis(objective="o", output_json_path=str(out))
+    assert res.get("error")
+    assert "grounding" not in res and "critic_findings" not in res
+    assert len(model.calls) == 1                         # no critic call
+    assert not (tmp_path / "tea.grounding.md").exists()
+    assert not agent.state["plan_history"]
+
+
+def test_tea_first_then_plan_keeps_iterations_distinct(tmp_path):
+    """TEA-first numbering is unchanged: TEA is iteration 0, the first plan 1."""
+    model = ScriptedModel([tea_json(), critic_json([])])
+    agent = make_agent(tmp_path, model)
+    agent.perform_technoeconomic_analysis(objective="o")
+    assert agent.state["iteration_index"] == 0
+    assert agent.state["plan_history"][-1]["iteration"] == 0
+    assert agent.state["plan_history"][-1]["stage"] == "TEA Initial"
+
+
+def test_tea_mid_campaign_does_not_reset_the_iteration_counter(tmp_path):
+    """Regression guard: a TEA run AFTER a plan used to set iteration_index
+    back to 0, so the next plan was numbered 1 again and overwrote the
+    existing iteration-1 card in the report."""
+    model = ScriptedModel([tea_json(), critic_json([])])
+    agent = make_agent(tmp_path, model)
+    agent.state = agent._initialize_state(objective="o", knowledge_paths=None, code_paths=None,
+                                          primary_data_set=None, image_paths=[], image_descriptions=None)
+    agent.state["iteration_index"] = 2
+    agent.state["plan_history"] = [
+        {"type": "lab", "iteration": 1, "proposed_experiments": [{"experiment_name": "E1"}]},
+        {"type": "lab", "iteration": 2, "proposed_experiments": [{"experiment_name": "E2"}]},
+    ]
+    agent.perform_technoeconomic_analysis(objective="o")
+    assert agent.state["iteration_index"] == 2
+    tea = agent.state["plan_history"][-1]
+    assert tea["iteration"] == 2 and tea["stage"] == "TEA Update"
+
+
+def test_full_report_renders_tea_and_plan_cards_without_collision(tmp_path):
+    state = {
+        "session_id": "s", "objective": "obj", "start_time": "2026-09-12T00:00:00",
+        "plan_history": [
+            {"type": "technoeconomic_analysis", "iteration": 0, "stage": "TEA Initial",
+             "technoeconomic_assessment": ASSESSMENT,
+             "grounding": {"mode": "fallback"}, "critic_findings": FINDINGS},
+            {"type": "lab", "iteration": 1, "proposed_experiments": [
+                {"experiment_name": "E1", "hypothesis": "H", "experimental_steps": ["s1"],
+                 "required_equipment": ["x"], "expected_outcome": "o", "justification": "j"}],
+             "critic_findings": [{"dimension": "physics", "severity": "minor", "issue": "plan caveat"}]},
+            # a mid-campaign TEA sharing iteration 1 with the plan
+            {"type": "technoeconomic_analysis", "iteration": 1, "stage": "TEA Update",
+             "technoeconomic_assessment": dict(ASSESSMENT, summary="Updated TEA"),
+             "grounding": {"mode": "strict"}},
+        ],
+        "experimental_results": [],
+    }
+    out = tmp_path / "plan.html"
+    HTMLReportGenerator(state).generate(str(out))
+    h = out.read_text()
+    assert h.count("TECHNO-ECONOMIC ANALYSIS") == 2 and h.count("EXPERIMENTAL STRATEGY") == 1
+    assert "Updated TEA" in h and "Fallback tier" in h and "Grounded (strict tier)" in h
+    assert "Critic Caveats on this Assessment" in h          # TEA caveats
+    assert "plan caveat" in h                                  # plan caveats still render
+    assert h.count("Evidence gives a 2023 range") == 1         # rendered once, not duplicated
+    # the TEA precedes the plan it shares an iteration with
+    assert h.index("Updated TEA") < h.index("plan caveat")
+
+
+def test_context_block_with_empty_assessment_still_yields_provenance(tmp_path):
+    t = _tools(tmp_path, latest_tea_results={"summary": "", "full_analysis": {},
+                                             "generation_mode": "fallback"})
+    block = t._tea_context_block()
+    assert "GENERAL BENCHMARKS" in block
+    assert "Data gaps" not in block and "Key cost drivers" not in block
+
+
+def test_run_economic_analysis_planner_error_and_exception(tmp_path):
+    planner = SimpleNamespace(perform_technoeconomic_analysis=lambda **kw: {"error": "KB Init Failed"})
+    t = _tools(tmp_path, planner=planner)
+    out = json.loads(t.functions_map["run_economic_analysis"](focus_topic="x"))
+    assert out == {"status": "error", "message": "KB Init Failed"}
+    assert t.orch.latest_tea_results is None               # nothing stored on failure
+
+    def boom(**kw):
+        raise RuntimeError("model exploded")
+    t = _tools(tmp_path, planner=SimpleNamespace(perform_technoeconomic_analysis=boom))
+    out = json.loads(t.functions_map["run_economic_analysis"](focus_topic="x"))
+    assert out["status"] == "error" and "model exploded" in out["message"]
+
+
+def test_run_economic_analysis_inline_literature_text_and_folder_slash(tmp_path):
+    data = tmp_path / "data"; data.mkdir(); _two_tables(data)
+    planner, seen = _planner_recording_tea()
+    t = _tools(tmp_path, planner=planner)
+    out = json.loads(t.functions_map["run_economic_analysis"](
+        primary_data_set=str(data) + "/", literature_context="Nd price is $120/kg (inline text)."))
+    assert out["status"] == "success"
+    assert seen["external_context"] == "Nd price is $120/kg (inline text)."
+    assert len(seen["primary_data_set"]) == 2
+
+
+def test_unicode_and_html_are_escaped_in_card_and_survive_block(tmp_path):
+    assess = dict(ASSESSMENT, summary="Coût ≈ 12 €/kg <b>bold</b>",
+                  key_cost_drivers=["<script>alert(1)</script>"])
+    card = HTMLReportGenerator.__new__(HTMLReportGenerator)._render_tea(
+        {"technoeconomic_assessment": assess, "grounding": {"mode": "strict"}})
+    assert "&lt;script&gt;" in card and "<script>alert" not in card
+    block = _tools(tmp_path, latest_tea_results={"summary": assess["summary"],
+                                                 "full_analysis": assess,
+                                                 "generation_mode": "strict"})._tea_context_block()
+    assert "Coût ≈ 12 €/kg" in block
+
+
+def test_damaged_tea_state_never_crashes_downstream(tmp_path):
+    """A corrupted checkpoint can hand back a string, a list or a dict with
+    the wrong shapes; plan generation and the run_task summary must shrug."""
+    from scilink.agents.planning_agents.user_interface import format_caveats
+    for bad in ("a string", ["list"], 42, {"full_analysis": "str", "critic_findings": {"x": 1}},
+                {"full_analysis": {"data_gaps_for_quantitative_analysis": "one gap"},
+                 "critic_findings": ["str", None, {"issue": "ok"}]}):
+        t = _tools(tmp_path, latest_tea_results=bad)
+        block = t._tea_context_block()          # None or a string, never an exception
+        assert block is None or isinstance(block, str)
+    assert format_caveats({"x": 1}) == [] and format_caveats("nope") == []
+    assert format_caveats(["str", None, {"issue": "ok"}]) == ["[] ok"]
+
+
+def test_run_task_key_findings_surface_tea_tier_summary_and_gaps(tmp_path, monkeypatch):
+    """The meta agent reads a planning delegation through run_task; the TEA's
+    tier, summary and (up to five) data gaps must be in key_findings, and a
+    damaged record must not break the summary."""
+    from scilink.agents.planning_agents.planning_orchestrator import (
+        PlanningOrchestratorAgent, AutonomyLevel)
+    (tmp_path / "data").mkdir()
+    try:
+        o = PlanningOrchestratorAgent(objective="x", base_dir=str(tmp_path / "s"), api_key=None,
+                                      model_name="bedrock/us.anthropic.claude-opus-4-8",
+                                      autonomy_level=AutonomyLevel.AUTONOMOUS,
+                                      data_dir=str(tmp_path / "data"))
+    except Exception as e:  # noqa: BLE001 - constructor needs an installed LLM stack
+        pytest.skip(f"orchestrator not constructible here: {e}")
+    monkeypatch.setattr(o, "chat", lambda prompt: "done")
+    o.latest_tea_results = {"summary": "Conditionally viable.",
+                            "full_analysis": {"data_gaps_for_quantitative_analysis":
+                                              [f"gap {i}" for i in range(7)]},
+                            "generation_mode": "fallback", "critic_findings": []}
+    r = o.run_task("summarise")
+    kf = r["key_findings"]
+    assert any("FALLBACK tier" in k for k in kf)
+    assert "TEA summary: Conditionally viable." in kf
+    assert sum(k.startswith("TEA data gap:") for k in kf) == 5
+    # legacy record without a tier
+    o.latest_tea_results = {"summary": "s", "full_analysis": {}}
+    assert any("provenance not recorded" in k for k in o.run_task("x")["key_findings"])
+    # damaged record
+    o.latest_tea_results = {"full_analysis": "oops", "generation_mode": "strict"}
+    assert any("KB/literature-grounded" in k for k in o.run_task("x")["key_findings"])
+    o.latest_tea_results = "corrupt"
+    assert not any("Techno-economic" in k for k in o.run_task("x")["key_findings"])


### PR DESCRIPTION
## Summary

For a scientist using plan mode, the techno-economic analysis (TEA) now behaves like a real feasibility step instead of a one-line opinion:

- **Everything the TEA found reaches the plan.** Cost drivers, risks, the comparison to alternatives and, most importantly, the **data gaps** (what you would need to measure to make the economics quantitative) are handed to plan generation, refinement, portfolios and technical documents. Live, the first bench experiment the planner proposed targeted a listed TEA data gap.
- **You can see whether the numbers are real.** Every TEA now says whether it was grounded in your documents and literature (**strict**) or estimated from general industry benchmarks because your sources held no economic data (**fallback**). A fallback result is flagged in the chat reply, the HTML report, and every downstream prompt. An independent critic audits each quantitative claim against the evidence and lists its caveats. Live, it caught the author mixing a user price list with a literature price snapshot and comparing undiscounted oxide value against cost.
- **Give it all your tables at once.** `primary_data_set` accepts a folder or a comma-separated list, so a composition table, a price list and measured yields go into one assessment.
- A TEA run **after** a plan no longer resets the campaign's iteration counter or overwrites the plan card in the report.

## Technical description

### Design

- `OrchestratorTools._tea_context_block(heading=True)` is the single renderer of the stored `latest_tea_results` for downstream prompts (lists capped at 8, provenance line, critic caveats). `generate_initial_plan` injects it under its **own** `additional_context` key, never inside `user_context`, because that block is the user's hard constraints and the mandatory constraint-coverage note tells the author to map every item to a step. `refine_plan_with_results` appends it to `external_context` (not `literature_text`, so provenance stamping stays honest); `refine_portfolio` and `generate_ideation_portfolio` inherit via forwarding; `write_technical_document` passes it as `additional_context`.
- `PlanningAgent.perform_technoeconomic_analysis` calls `perform_science_rag(..., return_context=True, mode_key="generation_mode")`, stamps `res["grounding"]` (`mode`, `retrieved_context_chars`, `has_primary_data`, `primary_data_files`, `has_external_literature`), runs `planning_rag.critique_tea` (advisory, fail-open, dimensions `grounding|quantification|consistency|scope`, told which tier authored the result), stores sorted `critic_findings`, and writes `<stem>.grounding.md` next to the JSON. New `additional_context` parameter threads the previously ignored tool argument.
- `planning_rag.summarize_primary_data` accepts a dict or a list of dicts; one file keeps the byte-identical historical summary, several are joined under `## Data file i of N: <name>` headings (the per-file summary already opens with `### Experiment Data`). `perform_science_rag` skips the constraint-coverage note only for `TEA_INSTRUCTIONS`; every other caller is unchanged (existing test pins that).
- `OrchestratorTools._resolve_tabular_inputs` resolves comma lists and folders through `_resolve_data_path` (typo / session / extension recovery), de-duplicates, natural-sorts, refuses more than `_TABULAR_MAX_FILES = 10` with the file list. A single file still reaches the planner as a dict.
- `run_economic_analysis` stores `generation_mode`, `critic_findings`, `source_documents`, `primary_data_files` on `latest_tea_results` and returns `generation_mode`, `data_gaps_for_quantitative_analysis`, `caveats`, `grounding_record`, plus a `warning` on fallback. `run_task` `key_findings` carry the tier, the summary and up to five gaps (a record without a tier reads "provenance not recorded").
- `html_generator._render_tea` adds the comparison, data gaps, a provenance banner (strict / fallback / not recorded) and critic caveats; fields are coerced (`None`, bare strings, scalars) so a malformed assessment cannot crash the report. `generate()` keys cards on `(iteration, kind)`.
- Mid-campaign TEA: `perform_technoeconomic_analysis` only zeroes `iteration_index` when no plan exists; otherwise the TEA is stamped at the current iteration with stage `TEA Update`.
- Hardening: `format_caveats` tolerates non-list / non-dict findings; the block and run_task summary tolerate a non-dict `latest_tea_results` / `full_analysis`.
- Orchestrator prompt: POST-TEA PAUSE and TEA-FIRST rules now ask the agent to report `generation_mode` and pass every relevant table. CLAUDE.md gains a paragraph recording the contract.

### Files

`planning_rag.py` (summariser, critic, note scoping), `planning_agent.py` (TEA method), `orchestrator_tools.py` (block, tabular resolver, tool, consumers), `planning_orchestrator.py` (prompt, run_task findings), `html_generator.py`, `user_interface.py` (`format_caveats` guard), `instruct.py` (typo), `CLAUDE.md`, `tests/test_tea_grounding.py` (38 offline tests).

### Verification

- Offline: 38 new tests (multi-file summaries, tier recording, sidecar, critic on strict/fallback and fail-open, malformed critic output, context threading into plan/refine/document, tabular resolver edge cases and cap, header-only/binary files, author-error short-circuit, TEA-first vs mid-campaign numbering, full report with colliding iterations, damaged state, HTML escaping, run_task summary). Full offline suite diffed against an order-matched run on `main`: **zero branch-only failures** (the 59 shared failures are environmental).
- Live on `bedrock/us.anthropic.claude-opus-4-8` with FutureHouse literature search, credentials via environment only:
  - A strict tier, three tables, economic literature → plan → memo → refine: 31/32 (the miss was a test assumption; restore verified separately).
  - B fallback tier flagged end to end: 7/7.
  - C chat-driven autonomous TEA → plan; the model passed all three tables as a comma list unprompted: 5/6 (regex miss; reply named the tier and described the gaps).
  - D heading split verified in the actual author prompt: 9/9.
  - E1 portfolio with TEA 5/5, E2 run_task + restore 7/7, E3 TEA after plan + refine 9/9, E4 fallback TEA → plan 4/4, E5 image in knowledge folder 4/4.

### Not changed

`generate_initial_plan`'s own single-file `primary_data_set` handling; `refine_plan`'s literature stamping; the experiment-plan critic; every non-TEA `perform_science_rag` caller; MCP / CLI / web UI (no reader of the assessment shape exists outside `planning_agents`). Each TEA now costs one extra LLM call (the critic).
